### PR TITLE
E2e context informers

### DIFF
--- a/test/e2e/apps/daemon_restart.go
+++ b/test/e2e/apps/daemon_restart.go
@@ -245,12 +245,12 @@ var _ = SIGDescribe("DaemonRestart [Disruptive]", func() {
 			&cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 					options.LabelSelector = labelSelector.String()
-					obj, err := f.ClientSet.CoreV1().Pods(ns).List(backgroundCtx, options)
+					obj, err := f.ClientSet.CoreV1().Pods(ns).List(context.Background(), options)
 					return runtime.Object(obj), err
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 					options.LabelSelector = labelSelector.String()
-					return f.ClientSet.CoreV1().Pods(ns).Watch(backgroundCtx, options)
+					return f.ClientSet.CoreV1().Pods(ns).Watch(context.Background(), options)
 				},
 			},
 			&v1.Pod{},

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -756,12 +756,12 @@ func newInformerWatchPod(ctx context.Context, c clientset.Interface, podNamespac
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.FieldSelector = fields.SelectorFromSet(fields.Set{"metadata.name": podName}).String()
-				obj, err := c.CoreV1().Pods(podNamespace).List(ctx, options)
+				obj, err := c.CoreV1().Pods(podNamespace).List(context.Background(), options)
 				return runtime.Object(obj), err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.FieldSelector = fields.SelectorFromSet(fields.Set{"metadata.name": podName}).String()
-				return c.CoreV1().Pods(podNamespace).Watch(ctx, options)
+				return c.CoreV1().Pods(podNamespace).Watch(context.Background(), options)
 			},
 		},
 		&v1.Pod{},

--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -256,12 +256,12 @@ var _ = SIGDescribe("Pods", func() {
 		lw := &cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.LabelSelector = selector.String()
-				podList, err := podClient.List(ctx, options)
+				podList, err := podClient.List(context.Background(), options)
 				return podList, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.LabelSelector = selector.String()
-				return podClient.Watch(ctx, options)
+				return podClient.Watch(context.Background(), options)
 			},
 		}
 		_, informer, w, _ := watchtools.NewIndexerInformerWatcher(lw, &v1.Pod{})

--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -366,12 +366,12 @@ func (j *TestJig) waitForAvailableEndpoint(ctx context.Context, timeout time.Dur
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.FieldSelector = endpointSelector.String()
-				obj, err := j.Client.CoreV1().Endpoints(j.Namespace).List(ctx, options)
+				obj, err := j.Client.CoreV1().Endpoints(j.Namespace).List(context.Background(), options)
 				return runtime.Object(obj), err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.FieldSelector = endpointSelector.String()
-				return j.Client.CoreV1().Endpoints(j.Namespace).Watch(ctx, options)
+				return j.Client.CoreV1().Endpoints(j.Namespace).Watch(context.Background(), options)
 			},
 		},
 		&v1.Endpoints{},
@@ -404,12 +404,12 @@ func (j *TestJig) waitForAvailableEndpoint(ctx context.Context, timeout time.Dur
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.LabelSelector = "kubernetes.io/service-name=" + j.Name
-				obj, err := j.Client.DiscoveryV1().EndpointSlices(j.Namespace).List(ctx, options)
+				obj, err := j.Client.DiscoveryV1().EndpointSlices(j.Namespace).List(context.Background(), options)
 				return runtime.Object(obj), err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.LabelSelector = "kubernetes.io/service-name=" + j.Name
-				return j.Client.DiscoveryV1().EndpointSlices(j.Namespace).Watch(ctx, options)
+				return j.Client.DiscoveryV1().EndpointSlices(j.Namespace).Watch(context.Background(), options)
 			},
 		},
 		&discoveryv1.EndpointSlice{},

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -266,11 +266,11 @@ func waitForConfigMapInNamespace(ctx context.Context, c clientset.Interface, ns,
 	lw := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (object runtime.Object, e error) {
 			options.FieldSelector = fieldSelector
-			return c.CoreV1().ConfigMaps(ns).List(ctx, options)
+			return c.CoreV1().ConfigMaps(ns).List(context.Background(), options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
 			options.FieldSelector = fieldSelector
-			return c.CoreV1().ConfigMaps(ns).Watch(ctx, options)
+			return c.CoreV1().ConfigMaps(ns).Watch(context.Background(), options)
 		},
 	}
 	_, err := watchtools.UntilWithSync(ctx, lw, &v1.ConfigMap{}, nil, func(event watch.Event) (bool, error) {
@@ -292,11 +292,11 @@ func waitForServiceAccountInNamespace(ctx context.Context, c clientset.Interface
 	lw := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (object runtime.Object, e error) {
 			options.FieldSelector = fieldSelector
-			return c.CoreV1().ServiceAccounts(ns).List(ctx, options)
+			return c.CoreV1().ServiceAccounts(ns).List(context.Background(), options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
 			options.FieldSelector = fieldSelector
-			return c.CoreV1().ServiceAccounts(ns).Watch(ctx, options)
+			return c.CoreV1().ServiceAccounts(ns).Watch(context.Background(), options)
 		},
 	}
 	_, err := watchtools.UntilWithSync(ctx, lw, &v1.ServiceAccount{}, nil, func(event watch.Event) (bool, error) {

--- a/test/e2e/network/service_latency.go
+++ b/test/e2e/network/service_latency.go
@@ -300,11 +300,11 @@ func startEndpointWatcher(ctx context.Context, f *framework.Framework, q *endpoi
 	_, controller := cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				obj, err := f.ClientSet.CoreV1().Endpoints(f.Namespace.Name).List(ctx, options)
+				obj, err := f.ClientSet.CoreV1().Endpoints(f.Namespace.Name).List(context.Background(), options)
 				return runtime.Object(obj), err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return f.ClientSet.CoreV1().Endpoints(f.Namespace.Name).Watch(ctx, options)
+				return f.ClientSet.CoreV1().Endpoints(f.Namespace.Name).Watch(context.Background(), options)
 			},
 		},
 		&v1.Endpoints{},

--- a/test/e2e/node/taints.go
+++ b/test/e2e/node/taints.go
@@ -122,17 +122,17 @@ func createPodForTaintsTest(hasToleration bool, tolerationSeconds int, podName, 
 
 // Creates and starts a controller (informer) that watches updates on a pod in given namespace with given name. It puts a new
 // struct into observedDeletion channel for every deletion it sees.
-func createTestController(ctx context.Context, cs clientset.Interface, observedDeletions chan string, stopCh chan struct{}, podLabel, ns string) {
+func createTestController(ctx context.Context, cs clientset.Interface, observedDeletions chan string, podLabel, ns string) {
 	_, controller := cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.LabelSelector = labels.SelectorFromSet(labels.Set{"group": podLabel}).String()
-				obj, err := cs.CoreV1().Pods(ns).List(ctx, options)
+				obj, err := cs.CoreV1().Pods(ns).List(context.Background(), options)
 				return runtime.Object(obj), err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.LabelSelector = labels.SelectorFromSet(labels.Set{"group": podLabel}).String()
-				return cs.CoreV1().Pods(ns).Watch(ctx, options)
+				return cs.CoreV1().Pods(ns).Watch(context.Background(), options)
 			},
 		},
 		&v1.Pod{},
@@ -148,7 +148,7 @@ func createTestController(ctx context.Context, cs clientset.Interface, observedD
 		},
 	)
 	framework.Logf("Starting informer...")
-	go controller.Run(stopCh)
+	go controller.Run(ctx.Done())
 }
 
 const (
@@ -184,8 +184,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		podName := "taint-eviction-1"
 		pod := createPodForTaintsTest(false, 0, podName, podName, ns)
 		observedDeletions := make(chan string, 100)
-		stopCh := make(chan struct{})
-		createTestController(ctx, cs, observedDeletions, stopCh, podName, ns)
+		createTestController(ctx, cs, observedDeletions, podName, ns)
 
 		ginkgo.By("Starting pod...")
 		nodeName, err := testutils.RunPodAndGetNodeName(ctx, cs, pod, 2*time.Minute)
@@ -216,8 +215,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		podName := "taint-eviction-2"
 		pod := createPodForTaintsTest(true, 0, podName, podName, ns)
 		observedDeletions := make(chan string, 100)
-		stopCh := make(chan struct{})
-		createTestController(ctx, cs, observedDeletions, stopCh, podName, ns)
+		createTestController(ctx, cs, observedDeletions, podName, ns)
 
 		ginkgo.By("Starting pod...")
 		nodeName, err := testutils.RunPodAndGetNodeName(ctx, cs, pod, 2*time.Minute)
@@ -249,8 +247,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		podName := "taint-eviction-3"
 		pod := createPodForTaintsTest(true, kubeletPodDeletionDelaySeconds+2*additionalWaitPerDeleteSeconds, podName, podName, ns)
 		observedDeletions := make(chan string, 100)
-		stopCh := make(chan struct{})
-		createTestController(ctx, cs, observedDeletions, stopCh, podName, ns)
+		createTestController(ctx, cs, observedDeletions, podName, ns)
 
 		ginkgo.By("Starting pod...")
 		nodeName, err := testutils.RunPodAndGetNodeName(ctx, cs, pod, 2*time.Minute)
@@ -294,8 +291,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		podName := "taint-eviction-4"
 		pod := createPodForTaintsTest(true, 2*additionalWaitPerDeleteSeconds, podName, podName, ns)
 		observedDeletions := make(chan string, 100)
-		stopCh := make(chan struct{})
-		createTestController(ctx, cs, observedDeletions, stopCh, podName, ns)
+		createTestController(ctx, cs, observedDeletions, podName, ns)
 
 		// 1. Run a pod with short toleration
 		ginkgo.By("Starting pod...")
@@ -396,8 +392,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Multiple Pods [Serial]", func() {
 	ginkgo.It("only evicts pods without tolerations from tainted nodes", func(ctx context.Context) {
 		podGroup := "taint-eviction-a"
 		observedDeletions := make(chan string, 100)
-		stopCh := make(chan struct{})
-		createTestController(ctx, cs, observedDeletions, stopCh, podGroup, ns)
+		createTestController(ctx, cs, observedDeletions, podGroup, ns)
 
 		pod1 := createPodForTaintsTest(false, 0, podGroup+"1", podGroup, ns)
 		pod2 := createPodForTaintsTest(true, 0, podGroup+"2", podGroup, ns)
@@ -455,8 +450,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Multiple Pods [Serial]", func() {
 	framework.ConformanceIt("evicts pods with minTolerationSeconds [Disruptive]", func(ctx context.Context) {
 		podGroup := "taint-eviction-b"
 		observedDeletions := make(chan string, 100)
-		stopCh := make(chan struct{})
-		createTestController(ctx, cs, observedDeletions, stopCh, podGroup, ns)
+		createTestController(ctx, cs, observedDeletions, podGroup, ns)
 
 		// 1. Run two pods both with toleration; one with tolerationSeconds=5, the other with 25
 		pod1 := createPodForTaintsTest(true, additionalWaitPerDeleteSeconds, podGroup+"1", podGroup, ns)

--- a/test/e2e/scheduling/events.go
+++ b/test/e2e/scheduling/events.go
@@ -67,13 +67,13 @@ func observeEventAfterAction(ctx context.Context, c clientset.Interface, ns stri
 	_, controller := cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				ls, err := c.CoreV1().Events(ns).List(ctx, options)
+				ls, err := c.CoreV1().Events(ns).List(context.Background(), options)
 				return ls, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				// Signal parent goroutine that watching has begun.
 				defer informerStartedGuard.Do(func() { close(informerStartedChan) })
-				w, err := c.CoreV1().Events(ns).Watch(ctx, options)
+				w, err := c.CoreV1().Events(ns).Watch(context.Background(), options)
 				return w, err
 			},
 		},

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -82,12 +82,12 @@ var _ = SIGDescribe("LimitRange", func() {
 		lw := &cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.LabelSelector = selector.String()
-				limitRanges, err := f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).List(ctx, options)
+				limitRanges, err := f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).List(context.Background(), options)
 				return limitRanges, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.LabelSelector = selector.String()
-				return f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Watch(ctx, options)
+				return f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Watch(context.Background(), options)
 			},
 		}
 		_, informer, w, _ := watchtools.NewIndexerInformerWatcher(lw, &v1.LimitRange{})

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -629,11 +629,11 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			_, podController := cache.NewInformer(
 				&cache.ListWatch{
 					ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-						obj, err := f.ClientSet.CoreV1().Pods(ns).List(ctx, options)
+						obj, err := f.ClientSet.CoreV1().Pods(ns).List(context.Background(), options)
 						return runtime.Object(obj), err
 					},
 					WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-						return f.ClientSet.CoreV1().Pods(ns).Watch(ctx, options)
+						return f.ClientSet.CoreV1().Pods(ns).Watch(context.Background(), options)
 					},
 				},
 				&v1.Pod{},

--- a/test/e2e/storage/testsuites/volumeperf.go
+++ b/test/e2e/storage/testsuites/volumeperf.go
@@ -290,11 +290,11 @@ func newPVCWatch(ctx context.Context, f *framework.Framework, provisionCount int
 	_, controller := cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				obj, err := f.ClientSet.CoreV1().PersistentVolumeClaims(ns).List(ctx, metav1.ListOptions{})
+				obj, err := f.ClientSet.CoreV1().PersistentVolumeClaims(ns).List(context.Background(), metav1.ListOptions{})
 				return runtime.Object(obj), err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return f.ClientSet.CoreV1().PersistentVolumeClaims(ns).Watch(ctx, metav1.ListOptions{})
+				return f.ClientSet.CoreV1().PersistentVolumeClaims(ns).Watch(context.Background(), metav1.ListOptions{})
 			},
 		},
 		&v1.PersistentVolumeClaim{},

--- a/test/e2e/windows/density.go
+++ b/test/e2e/windows/density.go
@@ -190,12 +190,12 @@ func newInformerWatchPod(ctx context.Context, f *framework.Framework, mutex *syn
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.LabelSelector = labels.SelectorFromSet(labels.Set{"type": podType}).String()
-				obj, err := f.ClientSet.CoreV1().Pods(ns).List(ctx, options)
+				obj, err := f.ClientSet.CoreV1().Pods(ns).List(context.Background(), options)
 				return runtime.Object(obj), err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.LabelSelector = labels.SelectorFromSet(labels.Set{"type": podType}).String()
-				return f.ClientSet.CoreV1().Pods(ns).Watch(ctx, options)
+				return f.ClientSet.CoreV1().Pods(ns).Watch(context.Background(), options)
 			},
 		},
 		&v1.Pod{},


### PR DESCRIPTION

/kind cleanup
```release-note
NONE
```


    e2e context background List/WatchFunc informer
    
    Informer context only applies to the Run method, the context on the
    ListWatch only causes that current request is cancelled, but the controller
    will restart them, causing an endless loop of cancel/retries.