### PR TITLE
e2e dns don't fail if configmap does not exist

### DIFF
--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/fields"
@@ -186,7 +187,10 @@ func (t *dnsTestCommon) restoreDNSConfigMap(ctx context.Context, configMapData m
 		t.setConfigMap(ctx, &v1.ConfigMap{Data: configMapData})
 		t.deleteCoreDNSPods(ctx)
 	} else {
-		framework.ExpectNoError(t.c.CoreV1().ConfigMaps(t.ns).Delete(ctx, t.name, metav1.DeleteOptions{}))
+		err := t.c.CoreV1().ConfigMaps(t.ns).Delete(ctx, t.name, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			framework.Failf("Unexpected error deleting configmap %s/%s", t.ns, t.name)
+		}
 	}
 }
 


### PR DESCRIPTION
don't fail on cleanup if the configmap for kube-dns does not exist

Change-Id: Ia56d9f590baba374e0b687aeda71d547899b1713


/kind failing-test
/kind regression

```release-note
NONE
```
