### PR TITLE
e2e ginkgo timeout fixes, II

### DIFF
--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -93,9 +93,9 @@ var _ = SIGDescribe("LimitRange", func() {
 		_, informer, w, _ := watchtools.NewIndexerInformerWatcher(lw, &v1.LimitRange{})
 		defer w.Stop()
 
-		ctx, cancelCtx := context.WithTimeout(ctx, wait.ForeverTestTimeout)
-		defer cancelCtx()
-		if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		timeoutCtx, cancel := context.WithTimeout(ctx, wait.ForeverTestTimeout)
+		defer cancel()
+		if !cache.WaitForCacheSync(timeoutCtx.Done(), informer.HasSynced) {
 			framework.Failf("Timeout while waiting for LimitRange informer to sync")
 		}
 

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -623,7 +623,6 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		*/
 		framework.ConformanceIt("runs ReplicaSets to verify preemption running path", func(ctx context.Context) {
 			podNamesSeen := []int32{0, 0, 0}
-			stopCh := make(chan struct{})
 
 			// create a pod controller to list/watch pod events from the test framework namespace
 			_, podController := cache.NewInformer(
@@ -652,8 +651,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 					},
 				},
 			)
-			go podController.Run(stopCh)
-			defer close(stopCh)
+			go podController.Run(ctx.Done())
 
 			// prepare three ReplicaSet
 			rsConfs := []pauseRSConfig{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

One commit is a simplification (removal of `stopCh`), the other restores the timeout behavior in one test to what it was before PR #112923 was merged. The later could have caused an increase in test flakes, but so far those don't seem to happen.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @aojea 