### PR TITLE
Embed context deadline exceeded in error to let errors.Is can work

### DIFF
--- a/staging/src/k8s.io/client-go/tools/watch/until.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until.go
@@ -136,7 +136,7 @@ func UntilWithSync(ctx context.Context, lw cache.ListerWatcher, objType runtime.
 
 	if precondition != nil {
 		if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
-			return nil, fmt.Errorf("UntilWithSync: unable to sync caches: %v", ctx.Err())
+			return nil, fmt.Errorf("UntilWithSync: unable to sync caches: %w", ctx.Err())
 		}
 
 		done, err := precondition(indexer)

--- a/staging/src/k8s.io/client-go/tools/watch/until_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until_test.go
@@ -19,6 +19,7 @@ package watch
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -227,7 +228,7 @@ func TestUntilWithSync(t *testing.T) {
 			conditionFunc: func(e watch.Event) (bool, error) {
 				return true, nil
 			},
-			expectedErr:   errors.New("UntilWithSync: unable to sync caches: context deadline exceeded"),
+			expectedErr:   fmt.Errorf("UntilWithSync: unable to sync caches: %w", context.DeadlineExceeded),
 			expectedEvent: nil,
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Currently, watch package embeds context deadlineexceeded error in it's own error using `%v`, as can be seen in here;

`fmt.Errorf("UntilWithSync: unable to sync caches: %v", ctx.Err())`

However, consumers of this function can not use
`errors.Is(err, context.DeadlineExceeded)` due this `%v`.

To let consumers can distinguish context deadlineexceeded errors, this PR changes error embedding format to `%w`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```