### PR TITLE
Skip .metadata.manageFields when describing unkown resources

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -295,7 +295,8 @@ func (g *genericDescriber) Describe(namespace, name string, describerSettings De
 		w.Write(LEVEL_0, "Namespace:\t%s\n", obj.GetNamespace())
 		printLabelsMultiline(w, "Labels", obj.GetLabels())
 		printAnnotationsMultiline(w, "Annotations", obj.GetAnnotations())
-		printUnstructuredContent(w, LEVEL_0, obj.UnstructuredContent(), "", ".metadata.name", ".metadata.namespace", ".metadata.labels", ".metadata.annotations")
+		printUnstructuredContent(w, LEVEL_0, obj.UnstructuredContent(), "", ".metadata.managedFields", ".metadata.name",
+			".metadata.namespace", ".metadata.labels", ".metadata.annotations")
 		if events != nil {
 			DescribeEvents(events, w)
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup
/sig cli

#### What this PR does / why we need it:
Currently if you try to describe a CR or any other resource that does not have Desriber defined you'll notice that it'll show ManagedFields:
```
$ kubectl describe schedulers.config.openshift.io/cluster 
Name:         cluster
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  config.openshift.io/v1
Kind:         Scheduler
Metadata:
  Creation Timestamp:  2022-12-18T02:04:54Z
  Generation:          1
  Managed Fields:
    API Version:  config.openshift.io/v1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:mastersSchedulable:
        f:policy:
          .:
          f:name:
    Manager:      cluster-bootstrap
    Operation:    Update
...
```
In https://github.com/kubernetes/kubernetes/pull/96878 we hid the managed fields behind a flag for `kubectl get` command. This PR hides the managed fields from `kubectl describe` entirely, to provide more user-friendly output:
```
$ kubectl describe schedulers.config.openshift.io/cluster 
Name:         cluster
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  config.openshift.io/v1
Kind:         Scheduler
Metadata:
  Creation Timestamp:  2022-12-18T02:04:54Z
  Generation:          1
  Resource Version:    542
  UID:                 3e8d233c-583c-4854-afd8-d4f27b1d176e
Spec:
  Masters Schedulable:  false

```

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
Hide .metadata.managedFields when describing CRs
```
