### PR TITLE
Resource Claims must be a map type, not set

### DIFF
--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -6249,7 +6249,10 @@
               "default": {}
             },
             "type": "array",
-            "x-kubernetes-list-type": "set"
+            "x-kubernetes-list-map-keys": [
+              "name"
+            ],
+            "x-kubernetes-list-type": "map"
           },
           "limits": {
             "additionalProperties": {

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -4057,7 +4057,10 @@
               "default": {}
             },
             "type": "array",
-            "x-kubernetes-list-type": "set"
+            "x-kubernetes-list-map-keys": [
+              "name"
+            ],
+            "x-kubernetes-list-type": "map"
           },
           "limits": {
             "additionalProperties": {

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -3231,7 +3231,10 @@
               "default": {}
             },
             "type": "array",
-            "x-kubernetes-list-type": "set"
+            "x-kubernetes-list-map-keys": [
+              "name"
+            ],
+            "x-kubernetes-list-type": "map"
           },
           "limits": {
             "additionalProperties": {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -25052,7 +25052,10 @@ func schema_k8sio_api_core_v1_ResourceRequirements(ref common.ReferenceCallback)
 					"claims": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -4517,7 +4517,8 @@ message ResourceRequirements {
   //
   // This field is immutable.
   //
-  // +listType=set
+  // +listType=map
+  // +listMapKey=name
   // +featureGate=DynamicResourceAllocation
   // +optional
   repeated ResourceClaim claims = 3;

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2321,7 +2321,8 @@ type ResourceRequirements struct {
 	//
 	// This field is immutable.
 	//
-	// +listType=set
+	// +listType=map
+	// +listMapKey=name
 	// +featureGate=DynamicResourceAllocation
 	// +optional
 	Claims []ResourceClaim `json:"claims,omitempty" protobuf:"bytes,3,opt,name=claims"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -6553,6 +6553,8 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             namedType: io.k8s.api.core.v1.ResourceClaim
           elementRelationship: associative
+          keys:
+          - name
     - name: limits
       type:
         map:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind api-change


#### What this PR does / why we need it:

This PR adds the `structType` to the `ResourceClaim` struct within the `corev1` API group.

When the `structType` is not set, it defaults to granular (out of a choice of granular or atomic).
Granular structs are not compatible with being used in a `listType=set` slice.
This type was introduced for the `Claims` member of `ResourceRequirements` which has the `listType=set` semantic.

Without this fix, CRD schemas generated, including the `ResourceRequirements` struct are not valid and produce an error when installed into a cluster.

#### Which issue(s) this PR fixes:

Currently, if you import the `corev1.ResourceRequirements` type into a custom resource definition, the generator generates an invalid schema, which results in errors such as below when you attempt to create the CRD.
```
unable to create CRD instances: unable to create CRD \"configs.imageregistry.operator.openshift.io\": CustomResourceDefinition.apiextensions.k8s.io \"configs.imageregistry.operator.openshift.io\" is invalid: spec.validation.openAPIV3Schema.properties[spec].properties[resources].properties[claims].items.x-kubernetes-map-type: Invalid value: \"null\": must be atomic as item of a list with x-kubernetes-list-type=set
```

#### Special notes for your reviewer:

The validation error we are hitting is [this piece of code](https://github.com/kubernetes/apiextensions-apiserver/blob/4511d97c244205b3a7e1e5590d5566227e334d4a/pkg/apis/apiextensions/validation/validation.go#L944-L947).

It was introduced by @sttts in https://github.com/kubernetes/kubernetes/commit/e4e1c2cd80e896a03e1ac93ffa0b7a3951efd2f2, and we are specifically hitting the `object` case here. Looking at the PR, seems @apelisse may be the expert on why this validation was introduced and may be able to help ascertain that this is the correct fix.

This validation sets a requirement that any `struct` used as the underlying type of a slice, must be an atomic struct when the slice itself is a set.

The `ResourceRequirements` was recently updated to [add the new field Claims](https://github.com/kubernetes/kubernetes/blob/e6926831c1551bc99522daec2c187e41f4ced4ec/staging/src/k8s.io/api/core/v1/types.go#L2327) in https://github.com/kubernetes/kubernetes/pull/111023 which then introduced this bug. CC @pohly. Tthis is a very obscure bug and I have no idea how anyone would know to set the struct tag correctly.

I noticed while search k/k that there are many instances of this throughout the codebase where we have invalid combinations of `listType=set` and no `structType` set. We may want to fix the other instances too.

CC @deads2k

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a 1.26 regression in the published openapi of Pod types caused by an incorrect list-type of the alpha resourceClaims field. This fix modifies that field list type from "set" to "map", resolving an incompatibility with use of this schema in CustomResourceDefinitions and with server-side apply.
```

