### PR TITLE
Provide a more flexible factory to create dynamic informer

### DIFF
--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -137,21 +137,21 @@ func (f *dynamicSharedInformerFactory) Start(stopCh <-chan struct{}) {
 
 // WaitForCacheSync waits for all started informers' cache were synced.
 func (f *dynamicSharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool {
-	informers := func() map[schema.GroupVersionResource]cache.SharedIndexInformer {
+	indexInformers := func() map[schema.GroupVersionResource]cache.SharedIndexInformer {
 		f.lock.Lock()
 		defer f.lock.Unlock()
 
-		informers := map[schema.GroupVersionResource]cache.SharedIndexInformer{}
+		indexInformers := map[schema.GroupVersionResource]cache.SharedIndexInformer{}
 		for informerType, informer := range f.informers {
 			if f.startedInformers[informerType] {
-				informers[informerType] = informer.Informer()
+				indexInformers[informerType] = informer.Informer()
 			}
 		}
-		return informers
+		return indexInformers
 	}()
 
 	res := map[schema.GroupVersionResource]bool{}
-	for informType, informer := range informers {
+	for informType, informer := range indexInformers {
 		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
 	}
 	return res


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
Provide a more flexible api for client to create `DynamicSharedInformerFactory` with `NewDynamicSharedInformerFactoryWithOptions`, the design follows `NewSharedInformerFactoryWithOptions`

Right now argo-workflow need to copy the implemetation from informer factory to their code (see [here](https://github.com/argoproj/argo-workflows/blob/f4a65b11a184f7429d0615a6fa65bc2cea4cc425/workflow/util/util.go#L60)) since they needs customize indexers.


#### Special notes for your reviewer:
Hi all, I'm new to kuberenetes, if I'm doing anything wrong please let me now, big thanks to all of you!

#### Does this PR introduce a user-facing change?
```release-note
Added: a function NewDynamicSharedInformerFactoryWithOptions is added, provide a way to customize DynamicSharedInformerFactory
possible customization:  ResyncPeriod, Indexers 
```


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
