### PR TITLE
fix: remove case sensitive checking of probe headers

### DIFF
--- a/pkg/probe/http/request.go
+++ b/pkg/probe/http/request.go
@@ -113,7 +113,7 @@ func formatURL(scheme string, host string, port int, path string) *url.URL {
 func v1HeaderToHTTPHeader(headerList []v1.HTTPHeader) http.Header {
 	headers := make(http.Header)
 	for _, header := range headerList {
-		headers[header.Name] = append(headers[header.Name], header.Value)
+		headers.Add(header.Name, header.Value)
 	}
 	return headers
 }

--- a/pkg/probe/http/request_test.go
+++ b/pkg/probe/http/request_test.go
@@ -78,3 +78,49 @@ func Test_v1HeaderToHTTPHeader(t *testing.T) {
 		})
 	}
 }
+
+func TestHeaderConversion(t *testing.T) {
+	testCases := []struct {
+		headers  []v1.HTTPHeader
+		expected http.Header
+	}{
+		{
+			[]v1.HTTPHeader{
+				{
+					Name:  "Accept",
+					Value: "application/json",
+				},
+			},
+			http.Header{
+				"Accept": []string{"application/json"},
+			},
+		},
+		{
+			[]v1.HTTPHeader{
+				{Name: "accept", Value: "application/json"},
+			},
+			http.Header{
+				"Accept": []string{"application/json"},
+			},
+		},
+		{
+			[]v1.HTTPHeader{
+				{Name: "accept", Value: "application/json"},
+				{Name: "Accept", Value: "*/*"},
+				{Name: "pragma", Value: "no-cache"},
+				{Name: "X-forwarded-for", Value: "username"},
+			},
+			http.Header{
+				"Accept":          []string{"application/json", "*/*"},
+				"Pragma":          []string{"no-cache"},
+				"X-Forwarded-For": []string{"username"},
+			},
+		},
+	}
+	for _, test := range testCases {
+		headers := v1HeaderToHTTPHeader(test.headers)
+		if !reflect.DeepEqual(headers, test.expected) {
+			t.Errorf("Expected %v, got %v", test.expected, headers)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This fixes a bug related to the default Accept header in probes introduced in release 1.20.

When I upgraded one of our older clusters from release 1.19 to one of the latest versions some of our readiness probes didn't work anymore. So I had a look into the code and realized in release 1.20 there was a change to include a default Accept header:

Original change: https://github.com/kubernetes/kubernetes/commit/0794bf65bcde0e42fc3e5178f640bc12aec12ea0

Release notes: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md
> Changed: default "Accept: /" header added to HTTP probes. See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes (https://github.com/kubernetes/website/pull/24756) (https://github.com/kubernetes/kubernetes/pull/95641, [@fonsecas72](https://github.com/fonsecas72)) [SIG Network and Node]

After this investigation, I checked the master branch and realized, that the issue is still present. The http.Header type from the "net/http" package is not properly used and therefore handling of the casing / capitalization of headers is not correctly done. Which leads to failing probes when a custom "Accept" header is defined with lower casing like so "accept".

Location of the issue:
https://github.com/kubernetes/kubernetes/blob/05a0ce83a68d29a05b69c86e8f8b373e3e379cc4/pkg/probe/http/request.go#L113-L119

The issue can be replicated with a simple go script, as it is related to how the http.Header type from the net/http package is used:
```go
package main

import (
	"fmt"
	"net/http"
)

func main() {
	headers := http.Header{}

	// A deployment is done with a lower cased "accept" header
	headers["accept"] = append(headers["accept"], "application/json")

	// The check is not done via headers.Get() but instead via the array notation (which is case sensitive)
	if _, ok := headers["Accept"]; !ok {
		headers.Set("Accept", "*/*")
	}

	// Leading to the following misleading output.
	// In which case only the capital cased "Accept" header is then used with
	// the default value of "*/*" for the probing and because some applications
	// might enforce the specified header with a value of "application/json" the
	// probes will fail.
	fmt.Printf("headers.Get(\"Accept\"): %v\n", headers.Get("Accept"))   // Output: headers.Get("Accept"): */*
	fmt.Printf("headers.Get(\"accept\"): %v\n", headers.Get("accept"))   // Output: headers.Get("accept"): */*
	fmt.Printf("    headers[\"accept\"]: %v\n", headers["accept"])       // Output: headers["accept"]: [application/json]
}
```

<!--
#### Which issue(s) this PR fixes:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
The currently proposed solution will enforce canonical keys for all headers. For example if a deployment defines a probe header with lowercasing like so "accept-encoding" it will be converted to "Accept-Encoding" and will be send in this format to the underlying application unlike before it was stored and send as "accept-encoding". Only the special cases of "Accept" and "User-Agent" where enforced to be in the canonical standard.
/sig node
/sig network

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug that unintentionally overrides your custom Accept headers in http (live-/readiness)-probes if the header is in lower casing
```
<!--
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->