### PR TITLE
unit tests: Disable rate limiting before doing doNoExecuteTaintingPass

### DIFF
--- a/pkg/controller/nodelifecycle/scheduler/rate_limited_queue.go
+++ b/pkg/controller/nodelifecycle/scheduler/rate_limited_queue.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"container/heap"
+	"math"
 	"sync"
 	"time"
 
@@ -290,6 +291,8 @@ func (q *RateLimitedTimedQueue) SwapLimiter(newQPS float32) {
 	var newLimiter flowcontrol.RateLimiter
 	if newQPS <= 0 {
 		newLimiter = flowcontrol.NewFakeNeverRateLimiter()
+	} else if newQPS == math.MaxFloat32 {
+		newLimiter = flowcontrol.NewFakeAlwaysRateLimiter()
 	} else {
 		newLimiter = flowcontrol.NewTokenBucketRateLimiter(newQPS, EvictionRateLimiterBurst)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake
/sig windows
/sig testing

/priority important-soon
/milestone v1.27

#### What this PR does / why we need it:

Some of the ``pkg/controller/nodelifecycle`` unit tests are calling ``doNoExecuteTainingPass`` and expect certain taints to be set appropriately.

However, the tainter works are rate limited, meaning that they may not process all the nodes in the queue if not enough times elapses, resulting in potential flaky tests.

This issue is even more obvious on Windows nodes where time keeping is less precise (2 consecutive ``time.Now()`` calls may return the same timestamp if called within a ~1-15ms window), meaning that the rate limiter will have fewer necessary tokens to process all the queued nodes.

This commit adds the possibility to disable the rate limiter and disables the rate limiter for tests in which ``doNoExecuteTaintingPass`` is called.

[1] Windows clock resolution issue: https://github.com/golang/go/issues/8687

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related: https://github.com/kubernetes/kubernetes/issues/51540

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
