### PR TITLE
Fix wait test timeout

### DIFF
--- a/test/cmd/wait.sh
+++ b/test/cmd/wait.sh
@@ -86,7 +86,7 @@ EOF
     len_sec=$((end_sec-start_sec))
     set -o errexit
     kube::test::if_has_string "${output_message}" 'timed out waiting for the condition '
-    kube::test::if_has_string "${len_sec}" '1'
+    test $len_sec -ge 1 && test $len_sec -le 2
 
     # Clean deployment
     kubectl delete deployment dtest


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:
This test was introduced in https://github.com/kubernetes/kubernetes/pull/114574 but it's not reliable enough, since it's requires the timeout to be exactly 1, when sometimes it can be 2.

See failures which started earlier today https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-integration

#### Which issue(s) this PR fixes:
Fixes #114610

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
