### PR TITLE
Add metrics for the type of authenticator used.

### DIFF
--- a/pkg/serviceaccount/jwt.go
+++ b/pkg/serviceaccount/jwt.go
@@ -319,6 +319,7 @@ func (j *jwtTokenAuthenticator) AuthenticateToken(ctx context.Context, tokenData
 	return &authenticator.Response{
 		User:      sa.UserInfo(),
 		Audiences: auds,
+		Type:      authenticator.ServiceAccount,
 	}, true, nil
 }
 

--- a/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap.go
+++ b/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap.go
@@ -147,5 +147,6 @@ func (t *TokenAuthenticator) AuthenticateToken(ctx context.Context, token string
 			Name:   bootstrapapi.BootstrapUserPrefix + string(id),
 			Groups: groups,
 		},
+		Type: authenticator.Bootstrap,
 	}, true, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/interfaces.go
@@ -62,4 +62,19 @@ type Response struct {
 	Audiences Audiences
 	// User is the UserInfo associated with the authentication context.
 	User user.Info
+	// Type is the type of the authenticator that produced the response.
+	Type Type
 }
+
+type Type string
+
+const (
+	Anonymous      = Type("anonymous")
+	Bootstrap      = Type("bootstrap")
+	Proxy          = Type("proxy")
+	ServiceAccount = Type("service-account")
+	TokenFile      = Type("token-file")
+	X509           = Type("x509")
+	Webhook        = Type("webhook")
+	Oidc           = Type("oidc")
+)

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous.go
@@ -38,6 +38,7 @@ func NewAuthenticator() authenticator.Request {
 				Groups: []string{unauthenticatedGroup},
 			},
 			Audiences: auds,
+			Type:      authenticator.Anonymous,
 		}, true, nil
 	})
 }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
@@ -181,6 +181,7 @@ func (a *requestHeaderAuthRequestHandler) AuthenticateRequest(req *http.Request)
 			Groups: groups,
 			Extra:  extra,
 		},
+		Type: authenticator.Proxy,
 	}, true, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
@@ -254,5 +254,6 @@ var CommonNameUserConversion = UserConversionFunc(func(chain []*x509.Certificate
 			Name:   chain[0].Subject.CommonName,
 			Groups: chain[0].Subject.Organization,
 		},
+		Type: authenticator.X509,
 	}, true, nil
 })

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/tokenfile.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/tokenfile.go
@@ -95,5 +95,8 @@ func (a *TokenAuthenticator) AuthenticateToken(ctx context.Context, value string
 	if !ok {
 		return nil, false, nil
 	}
-	return &authenticator.Response{User: user}, true, nil
+	return &authenticator.Response{
+		User: user,
+		Type: authenticator.TokenFile,
+	}, true, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/metrics_test.go
@@ -48,15 +48,16 @@ func TestMetrics(t *testing.T) {
 			desc: "auth ok",
 			response: &authenticator.Response{
 				User: &user.DefaultInfo{Name: "admin"},
+				Type: authenticator.Proxy,
 			},
 			status: true,
 			want: `
 				# HELP authenticated_user_requests [ALPHA] Counter of authenticated requests broken out by username.
 				# TYPE authenticated_user_requests counter
-				authenticated_user_requests{username="admin"} 1
+				authenticated_user_requests{authenticator="proxy",username="admin"} 1
         # HELP authentication_attempts [ALPHA] Counter of authenticated attempts.
         # TYPE authentication_attempts counter
-        authentication_attempts{result="success"} 1
+        authentication_attempts{authenticator="proxy",result="success"} 1
 				`,
 		},
 		{
@@ -65,7 +66,7 @@ func TestMetrics(t *testing.T) {
 			want: `
         # HELP authentication_attempts [ALPHA] Counter of authenticated attempts.
         # TYPE authentication_attempts counter
-        authentication_attempts{result="error"} 1
+        authentication_attempts{authenticator="",result="error"} 1
 				`,
 		},
 		{
@@ -73,7 +74,7 @@ func TestMetrics(t *testing.T) {
 			want: `
         # HELP authentication_attempts [ALPHA] Counter of authenticated attempts.
         # TYPE authentication_attempts counter
-        authentication_attempts{result="failure"} 1
+        authentication_attempts{authenticator="",result="failure"} 1
 				`,
 		},
 		{
@@ -81,29 +82,31 @@ func TestMetrics(t *testing.T) {
 			response: &authenticator.Response{
 				User:      &user.DefaultInfo{Name: "admin"},
 				Audiences: authenticator.Audiences{"audience-x"},
+				Type:      authenticator.Proxy,
 			},
 			status:      true,
 			apiAudience: authenticator.Audiences{"audience-y"},
 			want: `
         # HELP authentication_attempts [ALPHA] Counter of authenticated attempts.
         # TYPE authentication_attempts counter
-        authentication_attempts{result="error"} 1
+        authentication_attempts{authenticator="proxy",result="error"} 1
 				`,
 		},
 		{
 			desc: "audiences not supplied in the response",
 			response: &authenticator.Response{
 				User: &user.DefaultInfo{Name: "admin"},
+				Type: authenticator.Proxy,
 			},
 			status:      true,
 			apiAudience: authenticator.Audiences{"audience-y"},
 			want: `
         # HELP authenticated_user_requests [ALPHA] Counter of authenticated requests broken out by username.
 				# TYPE authenticated_user_requests counter
-				authenticated_user_requests{username="admin"} 1
+				authenticated_user_requests{authenticator="proxy",username="admin"} 1
         # HELP authentication_attempts [ALPHA] Counter of authenticated attempts.
         # TYPE authentication_attempts counter
-        authentication_attempts{result="success"} 1
+        authentication_attempts{authenticator="proxy",result="success"} 1
 				`,
 		},
 		{
@@ -111,15 +114,16 @@ func TestMetrics(t *testing.T) {
 			response: &authenticator.Response{
 				User:      &user.DefaultInfo{Name: "admin"},
 				Audiences: authenticator.Audiences{"audience-x"},
+				Type:      authenticator.Proxy,
 			},
 			status: true,
 			want: `
         # HELP authenticated_user_requests [ALPHA] Counter of authenticated requests broken out by username.
 				# TYPE authenticated_user_requests counter
-				authenticated_user_requests{username="admin"} 1
+				authenticated_user_requests{authenticator="proxy",username="admin"} 1
         # HELP authentication_attempts [ALPHA] Counter of authenticated attempts.
         # TYPE authentication_attempts counter
-        authentication_attempts{result="success"} 1
+        authentication_attempts{authenticator="proxy",result="success"} 1
 				`,
 		},
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -638,7 +638,10 @@ func (a *Authenticator) AuthenticateToken(ctx context.Context, token string) (*a
 		}
 	}
 
-	return &authenticator.Response{User: info}, true, nil
+	return &authenticator.Response{
+		User: info,
+		Type: authenticator.Oidc,
+	}, true, nil
 }
 
 // getClaimJWT gets a distributed claim JWT from url, using the supplied access

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook.go
@@ -191,6 +191,7 @@ func (w *WebhookTokenAuthenticator) AuthenticateToken(ctx context.Context, token
 			Extra:  extra,
 		},
 		Audiences: auds,
+		Type:      authenticator.Webhook,
 	}, true, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Since a typical cluster today uses multiple types of authentications, it is important to classify authentication related metrics based on the type, for example, x509 vs bearer token.

#### Special notes for your reviewer:
This PR has been created by using and refactoring the code from #98454

#### Does this PR introduce a user-facing change?
```release-note
A new label `authenticator` has been added to the following three metrics:
  * authenticated_user_requests
  * authentication_attempts
  * authentication_duration_seconds
The label can be "anonymous", "bootstrap", "proxy", "service-account", "token-file", "x509", "webhook", "oidc", etc.
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

-->
```docs

```
