### PR TITLE
Enhanced logic to identify eligible preemption node

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -49,6 +49,7 @@ const Name = names.DefaultPreemption
 // DefaultPreemption is a PostFilter plugin implements the preemption logic.
 type DefaultPreemption struct {
 	fh        framework.Handle
+	fts       feature.Features
 	args      config.DefaultPreemptionArgs
 	podLister corelisters.PodLister
 	pdbLister policylisters.PodDisruptionBudgetLister
@@ -72,6 +73,7 @@ func New(dpArgs runtime.Object, fh framework.Handle, fts feature.Features) (fram
 	}
 	pl := DefaultPreemption{
 		fh:        fh,
+		fts:       fts,
 		args:      *args,
 		podLister: fh.SharedInformerFactory().Core().V1().Pods().Lister(),
 		pdbLister: getPDBLister(fh.SharedInformerFactory()),
@@ -250,7 +252,7 @@ func (pl *DefaultPreemption) PodEligibleToPreemptOthers(pod *v1.Pod, nominatedNo
 		if nodeInfo, _ := nodeInfos.Get(nomNodeName); nodeInfo != nil {
 			podPriority := corev1helpers.PodPriority(pod)
 			for _, p := range nodeInfo.Pods {
-				if p.Pod.DeletionTimestamp != nil && corev1helpers.PodPriority(p.Pod) < podPriority {
+				if corev1helpers.PodPriority(p.Pod) < podPriority && podTerminatingByPreemption(p.Pod, pl.fts.EnablePodDisruptionConditions) {
 					// There is a terminating pod on the nominated node.
 					return false, "not eligible due to a terminating pod on the nominated node."
 				}
@@ -258,6 +260,25 @@ func (pl *DefaultPreemption) PodEligibleToPreemptOthers(pod *v1.Pod, nominatedNo
 		}
 	}
 	return true, ""
+}
+
+// podTerminatingByPreemption returns the pod's terminating state if feature PodDisruptionConditions is not enabled.
+// Otherwise, it additionally checks if the termination state is caused by scheduler preemption.
+func podTerminatingByPreemption(p *v1.Pod, enablePodDisruptionConditions bool) bool {
+	if p.DeletionTimestamp == nil {
+		return false
+	}
+
+	if !enablePodDisruptionConditions {
+		return true
+	}
+
+	for _, condition := range p.Status.Conditions {
+		if condition.Type == v1.DisruptionTarget {
+			return condition.Status == v1.ConditionTrue && condition.Reason == v1.PodReasonPreemptionByKubeScheduler
+		}
+	}
+	return false
 }
 
 // filterPodsWithPDBViolation groups the given "pods" into two groups of "violatingPods"

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -275,7 +275,7 @@ func podTerminatingByPreemption(p *v1.Pod, enablePodDisruptionConditions bool) b
 
 	for _, condition := range p.Status.Conditions {
 		if condition.Type == v1.DisruptionTarget {
-			return condition.Status == v1.ConditionTrue && condition.Reason == v1.PodReasonPreemptionByKubeScheduler
+			return condition.Status == v1.ConditionTrue && condition.Reason == v1.PodReasonPreemptionByScheduler
 		}
 	}
 	return false

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -1445,7 +1445,7 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 			fts:  feature.Features{EnablePodDisruptionConditions: true},
 			pod:  st.MakePod().Name("p_with_nominated_node").UID("p").Priority(highPriority).NominatedNodeName("node1").Obj(),
 			pods: []*v1.Pod{st.MakePod().Name("p1").UID("p1").Priority(lowPriority).Node("node1").Terminating().
-				Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByKubeScheduler).Obj()},
+				Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Obj()},
 			nodes:    []string{"node1"},
 			expected: false,
 		},
@@ -1462,7 +1462,7 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 			fts:  feature.Features{EnablePodDisruptionConditions: false},
 			pod:  st.MakePod().Name("p_with_nominated_node").UID("p").Priority(highPriority).NominatedNodeName("node1").Obj(),
 			pods: []*v1.Pod{st.MakePod().Name("p1").UID("p1").Priority(lowPriority).Node("node1").Terminating().
-				Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByKubeScheduler).Obj()},
+				Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Obj()},
 			nodes:    []string{"node1"},
 			expected: false,
 		},

--- a/pkg/scheduler/framework/plugins/feature/feature.go
+++ b/pkg/scheduler/framework/plugins/feature/feature.go
@@ -27,4 +27,5 @@ type Features struct {
 	EnableNodeInclusionPolicyInPodTopologySpread bool
 	EnableMatchLabelKeysInPodTopologySpread      bool
 	EnablePodSchedulingReadiness                 bool
+	EnablePodDisruptionConditions                bool
 }

--- a/pkg/scheduler/framework/plugins/registry.go
+++ b/pkg/scheduler/framework/plugins/registry.go
@@ -54,6 +54,7 @@ func NewInTreeRegistry() runtime.Registry {
 		EnableNodeInclusionPolicyInPodTopologySpread: feature.DefaultFeatureGate.Enabled(features.NodeInclusionPolicyInPodTopologySpread),
 		EnableMatchLabelKeysInPodTopologySpread:      feature.DefaultFeatureGate.Enabled(features.MatchLabelKeysInPodTopologySpread),
 		EnablePodSchedulingReadiness:                 feature.DefaultFeatureGate.Enabled(features.PodSchedulingReadiness),
+		EnablePodDisruptionConditions:                feature.DefaultFeatureGate.Enabled(features.PodDisruptionConditions),
 	}
 
 	registry := runtime.Registry{

--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -361,7 +361,7 @@ func (ev *Evaluator) prepareCandidate(ctx context.Context, c Candidate, pod *v1.
 				victimPodApply.Status.WithConditions(corev1apply.PodCondition().
 					WithType(v1.DisruptionTarget).
 					WithStatus(v1.ConditionTrue).
-					WithReason(v1.PodReasonPreemptionByKubeScheduler).
+					WithReason(v1.PodReasonPreemptionByScheduler).
 					WithMessage(fmt.Sprintf("Kube-scheduler: preempting to accommodate a higher priority pod: %s", klog.KObj(pod))).
 					WithLastTransitionTime(metav1.Now()),
 				)

--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -361,7 +361,7 @@ func (ev *Evaluator) prepareCandidate(ctx context.Context, c Candidate, pod *v1.
 				victimPodApply.Status.WithConditions(corev1apply.PodCondition().
 					WithType(v1.DisruptionTarget).
 					WithStatus(v1.ConditionTrue).
-					WithReason("PreemptionByKubeScheduler").
+					WithReason(v1.PodReasonPreemptionByKubeScheduler).
 					WithMessage(fmt.Sprintf("Kube-scheduler: preempting to accommodate a higher priority pod: %s", klog.KObj(pod))).
 					WithLastTransitionTime(metav1.Now()),
 				)

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2722,9 +2722,9 @@ const (
 	// is initiated by kubelet
 	PodReasonTerminationByKubelet = "TerminationByKubelet"
 
-	// PodReasonPreemptionByKubeScheduler reason in DisruptionTarget pod condition indicates that the
+	// PodReasonPreemptionByScheduler reason in DisruptionTarget pod condition indicates that the
 	// disruption was initiated by scheduler's preemption.
-	PodReasonPreemptionByKubeScheduler = "PreemptionByKubeScheduler"
+	PodReasonPreemptionByScheduler = "PreemptionByScheduler"
 )
 
 // PodCondition contains details for the current condition of this pod.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2721,6 +2721,10 @@ const (
 	// TerminationByKubelet reason in DisruptionTarget pod condition indicates that the termination
 	// is initiated by kubelet
 	PodReasonTerminationByKubelet = "TerminationByKubelet"
+
+	// PodReasonPreemptionByKubeScheduler reason in DisruptionTarget pod condition indicates that the
+	// disruption was initiated by scheduler's preemption.
+	PodReasonPreemptionByKubeScheduler = "PreemptionByKubeScheduler"
 )
 
 // PodCondition contains details for the current condition of this pod.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig scheduling

#### What this PR does / why we need it:

Scheduler preemption detects eligible node (for later preemption dryrun) by checking if there are Pods terminating:

https://github.com/kubernetes/kubernetes/blob/e218e0ede4eef31027adb6c868b3b6099b25f02b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go#L252

However, it's not smart enough as the terminating pods may not be the victims that were previously preempted. More discussion see #104266.

Given PodDisruptionConditions is in place, we have a clear API field to tell whether a terminating Pod is caused by scheduler preemption.

```console
# running in k8s 1.26
# pause2 tries to preempt pause1
⇒  k get po
NAME     READY   STATUS        RESTARTS   AGE
pause1   1/1     Terminating   0          8m47s
pause2   0/1     Pending       0          2m46s

# pause1's condition
⇒  k get po pause1 -o json | jq '.status.conditions[] | select(.type=="DisruptionTarget")'
{
  "lastProbeTime": null,
  "lastTransitionTime": "2022-12-20T22:45:55Z",
  "message": "Kube-scheduler: preempting to accommodate a higher priority pod: default/pause2",
  "reason": "PreemptionByKubeScheduler",
  "status": "True",
  "type": "DisruptionTarget"
}
```

#### Which issue(s) this PR fixes:

Fixes #104266

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- A terminating pod on a node that is not caused by preemption won't prevent kube-scheduler from preempting pods on that node
- Rename 'PreemptionByKubeScheduler' to 'PreemptionByScheduler'
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
