### PR TITLE
Ignore api-resources not found error until it's ready

### DIFF
--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -159,7 +159,7 @@ __EOF__
   local tries=5
   for i in $(seq 1 $tries); do
       local output
-      output=$(kubectl "${kube_flags[@]:?}" api-resources --api-group mygroup.example.com -oname)
+      output=$(kubectl "${kube_flags[@]:?}" api-resources --api-group mygroup.example.com -oname || true)
       if kube::test::if_has_string "$output" resources.mygroup.example.com; then
           break
       fi

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -512,7 +512,7 @@ __EOF__
   local tries=5
   for i in $(seq 1 $tries); do
       local output
-      output=$(kubectl "${kube_flags[@]:?}" api-resources --api-group example.com -oname)
+      output=$(kubectl "${kube_flags[@]:?}" api-resources --api-group example.com -oname || true)
       if kube::test::if_has_string "$output" deprecated.example.com; then
           break
       fi


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind flake
/kind failing-test

#### What this PR does / why we need it:
Some test-cmd tests are failing[1][2] due to same reason in that issue https://github.com/kubernetes/kubernetes/issues/113677.

This PR ignores the error during retry like it is done in this fix https://github.com/kubernetes/kubernetes/pull/113708

[1] https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/114623/pull-kubernetes-integration/1605361968200290304
[2] https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/114622/pull-kubernetes-integration/1605358715735642112

#### Does this PR introduce a user-facing change?
```release-note
NONE
```