### PR TITLE
Add atiratree as sig-apps reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -286,13 +286,14 @@ aliases:
     - soltysh
     - smarterclayton
   sig-apps-reviewers:
+    - alculquicondor
+    - atiratree
     - janetkuo
     - kow3ns
+    - krmayankk
     - mortent
     - smarterclayton
     - soltysh
-    - krmayankk
-    - alculquicondor
   # sig-apps-emeritus:
   # - tnozicka
 


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation
/sig apps

#### What this PR does / why we need it:
Filip has been a member of kubernetes org for [over a year](https://github.com/kubernetes/org/issues/3026) now,  but he has been actively working with sig-apps for longer than that. Initially joining our bi-weekly calls, but over time sharing opinions, reviewing and finally contributing code. By now he authored [more than 20 PRs](https://github.com/kubernetes/kubernetes/pulls/atiratree), reviewed [more than 30 PRs](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+reviewed-by%3Aatiratree+) across majority of the controllers (replica set, hpa, cronjob, daemonset, statefulset, controller revision), out of which [more than 10](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+assignee%3Aatiratree+) he was acting as the primary reviewer. Recently he has been responsible for delivering [PodHealthyPolicy for PodDisruptionBudget feature](https://github.com/kubernetes/enhancements/issues/3017). Finally, he recently graduated from [sig-apps mentoring](https://github.com/kubernetes/community/issues/6665). 

With all of the above, I can confidently promote Filip to sig-apps reviewer. 

#### Special notes for your reviewer:
/assign @janetkuo @kow3ns @dims 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
