### PR TITLE
expose prometheus.Registerer so that we can hook into this from exter…

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/registry.go
@@ -157,6 +157,10 @@ type KubeRegistry interface {
 	Reset()
 	// RegisterMetaMetrics registers metrics about the number of registered metrics.
 	RegisterMetaMetrics()
+	// Registerer exposes the underlying prometheus registerer
+	Registerer() prometheus.Registerer
+	// Gatherer exposes the underlying prometheus gatherer
+	Gatherer() prometheus.Gatherer
 }
 
 // kubeRegistry is a wrapper around a prometheus registry-type object. Upon initialization
@@ -186,6 +190,16 @@ func (kr *kubeRegistry) Register(c Registerable) error {
 
 	kr.trackHiddenCollector(c)
 	return nil
+}
+
+// Registerer exposes the underlying prometheus.Registerer
+func (kr *kubeRegistry) Registerer() prometheus.Registerer {
+	return kr.PromRegistry
+}
+
+// Gatherer exposes the underlying prometheus.Gatherer
+func (kr *kubeRegistry) Gatherer() prometheus.Gatherer {
+	return kr.PromRegistry
 }
 
 // MustRegister works like Register but registers any number of


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

We need to be able to pass in metrics and register native prometheus metrics from vendored in libraries. This exposes Registerer so that we can pass this to a external function to register metrics.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Note that this was reverted during 1.26 Test Freeze (https://github.com/kubernetes/kubernetes/pull/114309).