### PR TITLE
Removing Legacy Job Tracking Code

### DIFF
--- a/pkg/controller/job/indexed_job_utils.go
+++ b/pkg/controller/job/indexed_job_utils.go
@@ -52,17 +52,13 @@ type orderedIntervals []interval
 // empty list if this Job is not tracked with finalizers. The new list includes
 // the indexes that succeeded since the last sync.
 func calculateSucceededIndexes(job *batch.Job, pods []*v1.Pod) (orderedIntervals, orderedIntervals) {
-	var prevIntervals orderedIntervals
-	withFinalizers := hasJobTrackingAnnotation(job)
-	if withFinalizers {
-		prevIntervals = succeededIndexesFromJob(job)
-	}
+	prevIntervals := succeededIndexesFromJob(job)
 	newSucceeded := sets.NewInt()
 	for _, p := range pods {
 		ix := getCompletionIndex(p.Annotations)
 		// Succeeded Pod with valid index and, if tracking with finalizers,
 		// has a finalizer (meaning that it is not counted yet).
-		if p.Status.Phase == v1.PodSucceeded && ix != unknownCompletionIndex && ix < int(*job.Spec.Completions) && (!withFinalizers || hasJobTrackingFinalizer(p)) {
+		if p.Status.Phase == v1.PodSucceeded && ix != unknownCompletionIndex && ix < int(*job.Spec.Completions) && hasJobTrackingFinalizer(p) {
 			newSucceeded.Insert(ix)
 		}
 	}

--- a/pkg/controller/job/indexed_job_utils_test.go
+++ b/pkg/controller/job/indexed_job_utils_test.go
@@ -29,12 +29,11 @@ const noIndex = "-"
 
 func TestCalculateSucceededIndexes(t *testing.T) {
 	cases := map[string]struct {
-		prevSucceeded          string
-		pods                   []indexPhase
-		completions            int32
-		trackingWithFinalizers bool
-		wantStatusIntervals    orderedIntervals
-		wantIntervals          orderedIntervals
+		prevSucceeded       string
+		pods                []indexPhase
+		completions         int32
+		wantStatusIntervals orderedIntervals
+		wantIntervals       orderedIntervals
 	}{
 		"one index": {
 			pods:          []indexPhase{{"1", v1.PodSucceeded}},
@@ -65,19 +64,6 @@ func TestCalculateSucceededIndexes(t *testing.T) {
 			completions:   8,
 			wantIntervals: []interval{{2, 3}, {5, 7}},
 		},
-		"one interval, ignore previous": {
-			prevSucceeded: "3-5",
-			pods: []indexPhase{
-				{"0", v1.PodSucceeded},
-				{"1", v1.PodFailed},
-				{"1", v1.PodSucceeded},
-				{"2", v1.PodSucceeded},
-				{"2", v1.PodSucceeded},
-				{"3", v1.PodFailed},
-			},
-			completions:   4,
-			wantIntervals: []interval{{0, 2}},
-		},
 		"one index and one interval": {
 			pods: []indexPhase{
 				{"0", v1.PodSucceeded},
@@ -107,18 +93,16 @@ func TestCalculateSucceededIndexes(t *testing.T) {
 			wantIntervals: []interval{{0, 2}, {4, 4}},
 		},
 		"prev interval out of range": {
-			prevSucceeded:          "0-5,8-10",
-			completions:            8,
-			trackingWithFinalizers: true,
-			wantStatusIntervals:    []interval{{0, 5}},
-			wantIntervals:          []interval{{0, 5}},
+			prevSucceeded:       "0-5,8-10",
+			completions:         8,
+			wantStatusIntervals: []interval{{0, 5}},
+			wantIntervals:       []interval{{0, 5}},
 		},
 		"prev interval partially out of range": {
-			prevSucceeded:          "0-5,8-10",
-			completions:            10,
-			trackingWithFinalizers: true,
-			wantStatusIntervals:    []interval{{0, 5}, {8, 9}},
-			wantIntervals:          []interval{{0, 5}, {8, 9}},
+			prevSucceeded:       "0-5,8-10",
+			completions:         10,
+			wantStatusIntervals: []interval{{0, 5}, {8, 9}},
+			wantIntervals:       []interval{{0, 5}, {8, 9}},
 		},
 		"prev and new separate": {
 			prevSucceeded: "0,4,5,10-12",
@@ -127,8 +111,7 @@ func TestCalculateSucceededIndexes(t *testing.T) {
 				{"7", v1.PodSucceeded},
 				{"8", v1.PodSucceeded},
 			},
-			completions:            13,
-			trackingWithFinalizers: true,
+			completions: 13,
 			wantStatusIntervals: []interval{
 				{0, 0},
 				{4, 5},
@@ -149,8 +132,7 @@ func TestCalculateSucceededIndexes(t *testing.T) {
 				{"7", v1.PodSucceeded},
 				{"8", v1.PodSucceeded},
 			},
-			completions:            9,
-			trackingWithFinalizers: true,
+			completions: 9,
 			wantStatusIntervals: []interval{
 				{3, 4},
 				{6, 6},
@@ -167,8 +149,7 @@ func TestCalculateSucceededIndexes(t *testing.T) {
 				{"4", v1.PodSucceeded},
 				{"6", v1.PodSucceeded},
 			},
-			completions:            9,
-			trackingWithFinalizers: true,
+			completions: 9,
 			wantStatusIntervals: []interval{
 				{2, 2},
 				{7, 8},
@@ -186,8 +167,7 @@ func TestCalculateSucceededIndexes(t *testing.T) {
 				{"5", v1.PodSucceeded},
 				{"9", v1.PodSucceeded},
 			},
-			completions:            10,
-			trackingWithFinalizers: true,
+			completions: 10,
 			wantStatusIntervals: []interval{
 				{2, 7},
 			},
@@ -202,8 +182,7 @@ func TestCalculateSucceededIndexes(t *testing.T) {
 			pods: []indexPhase{
 				{"3", v1.PodSucceeded},
 			},
-			completions:            4,
-			trackingWithFinalizers: true,
+			completions: 4,
 			wantStatusIntervals: []interval{
 				{0, 0},
 			},
@@ -222,11 +201,6 @@ func TestCalculateSucceededIndexes(t *testing.T) {
 				Spec: batch.JobSpec{
 					Completions: pointer.Int32(tc.completions),
 				},
-			}
-			if tc.trackingWithFinalizers {
-				job.Annotations = map[string]string{
-					batch.JobTrackingFinalizer: "",
-				}
 			}
 			pods := hollowPodsWithIndexPhase(tc.pods)
 			for _, p := range pods {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind feature
#### What this PR does / why we need it:
This is part of the job finalizer KEP. We are cleaning up legacy code that is testing without finalizers.  

[Job Tracking KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/2307-job-tracking-without-lingering-pods)

#### Does this PR introduce a user-facing change?
```
The job controller ignores the annotation batch.kubernetes.io/job-tracking. The progress of all jobs is tracked using pod finalizers.
```