### PR TITLE
Update required golang version for 1.23

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -106,9 +106,8 @@ dependencies:
     version: 1.19
     refPaths:
     - path: build/build-image/cross/VERSION
-    # TODO(liggitt): Uncomment once images are updated to go1.19
-    #- path: hack/lib/golang.sh
-    #  match: minimum_go_version=go([0-9]+\.[0-9]+)
+    - path: hack/lib/golang.sh
+      match: minimum_go_version=go([0-9]+\.[0-9]+)
 
   - name: "golang: etcd release version"
     version: 1.16.12

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -480,8 +480,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(GOFLAGS='' go version)"
   local minimum_go_version
-  # TODO(liggitt): Need to switch this to 1.19 once we update images to newer go version
-  minimum_go_version=go1.17.0
+  minimum_go_version=go1.19.4
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     kube::log::usage_from_stdin <<EOF
 Detected go version: ${go_version[*]}.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates required minimum golang version for build scripts to 1.19

```release-note
NONE
```

/hold for post-submit CI on https://github.com/kubernetes/kubernetes/pull/113983 (and maybe the next 1.23 patch release, will discuss)

/cc @aojea @xmudrii 