### PR TITLE
Reuse generic Watch test for watchcache

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -659,11 +659,6 @@ func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptio
 		return c.storage.GetList(ctx, key, opts, listObj)
 	}
 
-	match := opts.ResourceVersionMatch
-	if match != metav1.ResourceVersionMatchNotOlderThan && match != "" {
-		return fmt.Errorf("unknown ResourceVersionMatch value: %v", match)
-	}
-
 	// If resourceVersion is specified, serve it from cache.
 	// It's guaranteed that the returned value is at least that
 	// fresh as the given resourceVersion.

--- a/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
@@ -298,23 +298,16 @@ func verifyWatchEvent(t *testing.T, w watch.Interface, eventType watch.EventType
 	}
 }
 
-type injectListError struct {
-	errors int
-	storage.Interface
-}
-
-func (self *injectListError) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
-	if self.errors > 0 {
-		self.errors--
-		return fmt.Errorf("injected error")
-	}
-	return self.Interface.GetList(ctx, key, opts, listObj)
-}
-
 func TestWatch(t *testing.T) {
+	ctx, cacher, terminate := testSetup(t)
+	t.Cleanup(terminate)
+	storagetesting.RunTestWatch(ctx, t, cacher)
+}
+
+// TODO(wojtek-t): We should extend the generic RunTestWatch test to cover the
+// scenarios that are not yet covered by it and get rid of this test.
+func TestWatchDeprecated(t *testing.T) {
 	server, etcdStorage := newEtcdTestStorage(t, etcd3testing.PathPrefix())
-	// Inject one list error to make sure we test the relist case.
-	etcdStorage = &injectListError{errors: 1, Interface: etcdStorage}
 	defer server.Terminate(t)
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	cacher, _, err := newTestCacherWithClock(etcdStorage, fakeClock)
@@ -884,8 +877,14 @@ func testSetup(t *testing.T, opts ...setupOption) (context.Context, *cacherstora
 	}
 
 	server, etcdStorage := newEtcdTestStorage(t, etcd3testing.PathPrefix())
+	// Inject one list error to make sure we test the relist case.
+	wrappedStorage := &storagetesting.StorageInjectingListErrors{
+		Interface: etcdStorage,
+		Errors:    1,
+	}
+
 	config := cacherstorage.Config{
-		Storage:        etcdStorage,
+		Storage:        wrappedStorage,
 		Versioner:      storage.APIObjectVersioner{},
 		GroupResource:  schema.GroupResource{Resource: "pods"},
 		ResourcePrefix: setupOpts.resourcePrefix,
@@ -904,6 +903,12 @@ func testSetup(t *testing.T, opts ...setupOption) (context.Context, *cacherstora
 	terminate := func() {
 		cacher.Stop()
 		server.Terminate(t)
+	}
+
+	// Since some tests depend on the fact that GetList shouldn't fail,
+	// we wait until the error from the underlying storage is consumed.
+	if err := wait.PollInfinite(100*time.Millisecond, wrappedStorage.ErrorsConsumed); err != nil {
+		t.Fatalf("Failed to inject list errors: %v", err)
 	}
 
 	return ctx, cacher, terminate


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/109831

```release-note
NONE
```

/kind cleanup
/priority important-longterm
/sig api-machinery

/assign @stevekuznetsov 