### PR TITLE
Fixed Unsafe defer of os.Close

### DIFF
--- a/staging/src/k8s.io/client-go/util/testing/fake_openapi_handler.go
+++ b/staging/src/k8s.io/client-go/util/testing/fake_openapi_handler.go
@@ -63,13 +63,12 @@ func NewFakeOpenAPIV3Server(specsPath string) (*FakeOpenAPIServer, error) {
 	grouped := make(map[string][]byte)
 	var testV3Specs = make(map[string]*spec3.OpenAPI)
 
-	addSpec := func(path string) {
+	addSpec := func(path string) error {
 		file, err := os.Open(path)
 		if err != nil {
 			panic(err)
 		}
 
-		defer file.Close()
 		vals, err := io.ReadAll(file)
 		if err != nil {
 			panic(err)
@@ -79,6 +78,7 @@ func NewFakeOpenAPIV3Server(specsPath string) (*FakeOpenAPIServer, error) {
 		if err == nil {
 			grouped[rel[:(len(rel)-len(filepath.Ext(rel)))]] = vals
 		}
+		return file.Close()
 	}
 
 	filepath.WalkDir(specsPath, func(path string, d fs.DirEntry, err error) error {

--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/parser.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/parser.go
@@ -62,11 +62,11 @@ func rewriteFile(name string, header []byte, rewriteFn func(*token.FileSet, *ast
 	if err != nil {
 		return err
 	}
-
+	defer f.close()
 	if _, err := f.Write(body); err != nil {
 		return err
 	}
-	return f.Close()
+	return f.Sync()
 }
 
 // ExtractFunc extracts information from the provided TypeSpec and returns true if the type should be

--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/parser.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/parser.go
@@ -62,7 +62,7 @@ func rewriteFile(name string, header []byte, rewriteFn func(*token.FileSet, *ast
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+
 	if _, err := f.Write(body); err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/parser.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/parser.go
@@ -62,7 +62,7 @@ func rewriteFile(name string, header []byte, rewriteFn func(*token.FileSet, *ast
 	if err != nil {
 		return err
 	}
-	defer f.close()
+	defer f.Close()
 	if _, err := f.Write(body); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
``` removed the **defer file.close()** and used **return file.close()** to fix potenial data loss. ```
files [parser.go](https://github.com/nishantsikarwar/kubernetes/blob/eccb3921e31f8370b521131fd582994cf0d8e8eb/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/parser.go#L65) 
[here](https://github.com/nishantsikarwar/kubernetes/blob/eccb3921e31f8370b521131fd582994cf0d8e8eb/staging/src/k8s.io/client-go/util/testing/fake_openapi_handler.go#L72)



#### Which issue(s) this PR fixes:

``` Calling os.Close on an io.Closer may return an error, and ignoring the same might result in a data loss.```

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
    NONE 

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```