### PR TITLE
Ipvs: remove module check

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -240,10 +240,10 @@ func newProxyServer(
 	} else if proxyMode == proxyconfigapi.ProxyModeIPVS {
 		kernelHandler := ipvs.NewLinuxKernelHandler()
 		ipsetInterface = utilipset.New(execer)
-		if err := ipvs.CanUseIPVSProxier(kernelHandler, ipsetInterface, config.IPVS.Scheduler); err != nil {
+		ipvsInterface = utilipvs.New()
+		if err := ipvs.CanUseIPVSProxier(ipvsInterface, ipsetInterface, config.IPVS.Scheduler); err != nil {
 			return nil, fmt.Errorf("can't use the IPVS proxier: %v", err)
 		}
-		ipvsInterface = utilipvs.New()
 
 		klog.InfoS("Using ipvs Proxier")
 		if dualStack {

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -665,6 +665,10 @@ func CanUseIPVSProxier(ipvs utilipvs.Interface, ipsetver IPSetVersioner, schedul
 		return fmt.Errorf("ipset version: %s is less than min required version: %s", versionString, MinIPSetCheckVersion)
 	}
 
+	if scheduler == "" {
+		scheduler = defaultScheduler
+	}
+
 	// Check is any virtual servers (vs) are configured. If any, we assume
 	// that this is a kube-proxy re-start and skip the checks.
 	vservers, err := ipvs.GetVirtualServers()

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -705,7 +705,7 @@ func CanUseIPVSProxier(ipvs utilipvs.Interface, ipsetver IPSetVersioner, schedul
 	// from documentation is not unheard of, so the restriction to not use the TEST-NET-2 range
 	// must be documented.
 	vs := utilipvs.VirtualServer{
-		Address:   net.ParseIP("198.51.100.0"),
+		Address:   netutils.ParseIPSloppy("198.51.100.0"),
 		Protocol:  "TCP",
 		Port:      20000,
 		Scheduler: scheduler,

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -770,9 +770,9 @@ func CanUseIPVSProxier(ipvs utilipvs.Interface, ipsetver IPSetVersioner, schedul
 	// from documentation is not unheard of, so the restricion to not use the TEST-NET-2 range
 	// must be documented.
 	vs := utilipvs.VirtualServer{
-		Address: net.ParseIP("198.51.100.0"),
-		Protocol: "TCP",
-		Port: 20000,
+		Address:   net.ParseIP("198.51.100.0"),
+		Protocol:  "TCP",
+		Port:      20000,
 		Scheduler: scheduler,
 	}
 	if err := ipvs.AddVirtualServer(&vs); err != nil {

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -698,7 +698,7 @@ func CanUseIPVSProxier(ipvs utilipvs.Interface, ipsetver IPSetVersioner, schedul
 	// then traffic will temporary be routed to ipvs during the probe and dropped.
 	// The later case is also and invalid configuration, but the traffic impact will be minor.
 	// This should not be a problem if users honors reserved addresses, but cut/paste
-	// from documentation is not unheard of, so the restricion to not use the TEST-NET-2 range
+	// from documentation is not unheard of, so the restriction to not use the TEST-NET-2 range
 	// must be documented.
 	vs := utilipvs.VirtualServer{
 		Address:   net.ParseIP("198.51.100.0"),

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -77,9 +77,10 @@ func (f *fakeIPGetter) BindedIPs() (sets.String, error) {
 
 // fakeIpvs implements utilipvs.Interface
 type fakeIpvs struct {
-	ipvsErr string
+	ipvsErr   string
 	vsCreated bool
 }
+
 func (f *fakeIpvs) Flush() error {
 	return nil
 }
@@ -107,7 +108,7 @@ func (f *fakeIpvs) GetVirtualServers() ([]*utilipvs.VirtualServer, error) {
 		return nil, fmt.Errorf("oops")
 	}
 	if f.vsCreated {
-		vs := []*utilipvs.VirtualServer{&utilipvs.VirtualServer{}}
+		vs := []*utilipvs.VirtualServer{{}}
 		return vs, nil
 	}
 	return nil, nil
@@ -312,48 +313,48 @@ func TestCleanupLeftovers(t *testing.T) {
 
 func TestCanUseIPVSProxier(t *testing.T) {
 	testCases := []struct {
-		name          string
-		scheduler     string
-		ipsetVersion  string
-		ipsetErr      error
-		ipvsErr       string
-		ok            bool
+		name         string
+		scheduler    string
+		ipsetVersion string
+		ipsetErr     error
+		ipvsErr      string
+		ok           bool
 	}{
 		{
-			name:          "happy days",
-			ipsetVersion:  MinIPSetCheckVersion,
-			ok:            true,
+			name:         "happy days",
+			ipsetVersion: MinIPSetCheckVersion,
+			ok:           true,
 		},
 		{
-			name:          "ipset error",
-			scheduler:     "",
-			ipsetVersion:  MinIPSetCheckVersion,
-			ipsetErr:      fmt.Errorf("oops"),
-			ok:            false,
+			name:         "ipset error",
+			scheduler:    "",
+			ipsetVersion: MinIPSetCheckVersion,
+			ipsetErr:     fmt.Errorf("oops"),
+			ok:           false,
 		},
 		{
-			name:          "ipset version too low",
-			scheduler:     "rr",
-			ipsetVersion:  "4.3.0",
-			ok:            false,
+			name:         "ipset version too low",
+			scheduler:    "rr",
+			ipsetVersion: "4.3.0",
+			ok:           false,
 		},
 		{
-			name:          "GetVirtualServers fail",
-			ipsetVersion:  MinIPSetCheckVersion,
-			ipvsErr:       "GetVirtualServers",
-			ok:            false,
+			name:         "GetVirtualServers fail",
+			ipsetVersion: MinIPSetCheckVersion,
+			ipvsErr:      "GetVirtualServers",
+			ok:           false,
 		},
 		{
-			name:          "AddVirtualServer fail",
-			ipsetVersion:  MinIPSetCheckVersion,
-			ipvsErr:       "AddVirtualServer",
-			ok:            false,
+			name:         "AddVirtualServer fail",
+			ipsetVersion: MinIPSetCheckVersion,
+			ipvsErr:      "AddVirtualServer",
+			ok:           false,
 		},
 		{
-			name:          "DeleteVirtualServer fail",
-			ipsetVersion:  MinIPSetCheckVersion,
-			ipvsErr:       "DeleteVirtualServer",
-			ok:            false,
+			name:         "DeleteVirtualServer fail",
+			ipsetVersion: MinIPSetCheckVersion,
+			ipvsErr:      "DeleteVirtualServer",
+			ok:           false,
 		},
 	}
 

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -307,14 +307,6 @@ func TestCanUseIPVSProxier(t *testing.T) {
 			ipsetVersion:  "1.1",
 			ok:            false,
 		},
-		// case 3, missing required ip_vs_* kernel modules
-		{
-			mods:          []string{"ip_vs", "a", "bc", "def"},
-			scheduler:     "sed",
-			kernelVersion: "4.19",
-			ipsetVersion:  MinIPSetCheckVersion,
-			ok:            false,
-		},
 		// case 4, ipset version too low
 		{
 			mods:          []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack"},
@@ -347,14 +339,6 @@ func TestCanUseIPVSProxier(t *testing.T) {
 			ipsetVersion:  "6.19",
 			ok:            true,
 		},
-		// case 8, not ok for sed based IPVS scheduling
-		{
-			mods:          []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack"},
-			scheduler:     "sed",
-			kernelVersion: "4.19",
-			ipsetVersion:  MinIPSetCheckVersion,
-			ok:            false,
-		},
 		// case 9, ok for dh based IPVS scheduling
 		{
 			mods:          []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack", "ip_vs_dh"},
@@ -362,14 +346,6 @@ func TestCanUseIPVSProxier(t *testing.T) {
 			kernelVersion: "4.19",
 			ipsetVersion:  MinIPSetCheckVersion,
 			ok:            true,
-		},
-		// case 10, non-existent scheduler, error due to modules not existing
-		{
-			mods:          []string{"ip_vs", "ip_vs_rr", "ip_vs_wrr", "ip_vs_sh", "nf_conntrack", "ip_vs_dh"},
-			scheduler:     "foobar",
-			kernelVersion: "4.19",
-			ipsetVersion:  MinIPSetCheckVersion,
-			ok:            false,
 		},
 	}
 

--- a/pkg/util/ipvs/ipvs.go
+++ b/pkg/util/ipvs/ipvs.go
@@ -21,8 +21,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"k8s.io/apimachinery/pkg/util/version"
 )
 
 // Interface is an injectable interface for running ipvs commands.  Implementations must be goroutine-safe.
@@ -71,22 +69,6 @@ const (
 	FlagHashed = 0x2
 )
 
-// IPVS required kernel modules.
-const (
-	// KernelModuleIPVS is the kernel module "ip_vs"
-	KernelModuleIPVS string = "ip_vs"
-	// KernelModuleIPVSRR is the kernel module "ip_vs_rr"
-	KernelModuleIPVSRR string = "ip_vs_rr"
-	// KernelModuleIPVSWRR is the kernel module "ip_vs_wrr"
-	KernelModuleIPVSWRR string = "ip_vs_wrr"
-	// KernelModuleIPVSSH is the kernel module "ip_vs_sh"
-	KernelModuleIPVSSH string = "ip_vs_sh"
-	// KernelModuleNfConntrackIPV4 is the module "nf_conntrack_ipv4"
-	KernelModuleNfConntrackIPV4 string = "nf_conntrack_ipv4"
-	// KernelModuleNfConntrack is the kernel module "nf_conntrack"
-	KernelModuleNfConntrack string = "nf_conntrack"
-)
-
 // Equal check the equality of virtual server.
 // We don't use struct == since it doesn't work because of slice.
 func (svc *VirtualServer) Equal(other *VirtualServer) bool {
@@ -120,17 +102,6 @@ func (rs *RealServer) String() string {
 func (rs *RealServer) Equal(other *RealServer) bool {
 	return rs.Address.Equal(other.Address) &&
 		rs.Port == other.Port
-}
-
-// GetRequiredIPVSModules returns the required ipvs modules for the given linux kernel version.
-func GetRequiredIPVSModules(kernelVersion *version.Version) []string {
-	// "nf_conntrack_ipv4" has been removed since v4.19
-	// see https://github.com/torvalds/linux/commit/a0ae2562c6c4b2721d9fddba63b7286c13517d9f
-	if kernelVersion.LessThan(version.MustParseGeneric("4.19")) {
-		return []string{KernelModuleIPVS, KernelModuleIPVSRR, KernelModuleIPVSWRR, KernelModuleIPVSSH, KernelModuleNfConntrackIPV4}
-	}
-	return []string{KernelModuleIPVS, KernelModuleIPVSRR, KernelModuleIPVSWRR, KernelModuleIPVSSH, KernelModuleNfConntrack}
-
 }
 
 // IsRsGracefulTerminationNeeded returns true if protocol requires graceful termination for the stale connections

--- a/pkg/util/ipvs/ipvs_test.go
+++ b/pkg/util/ipvs/ipvs_test.go
@@ -17,11 +17,8 @@ limitations under the License.
 package ipvs
 
 import (
-	"reflect"
-	"sort"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/version"
 	netutils "k8s.io/utils/net"
 )
 
@@ -385,31 +382,3 @@ func TestFrontendDestinationString(t *testing.T) {
 	}
 }
 
-func TestGetRequiredIPVSModules(t *testing.T) {
-	Tests := []struct {
-		name          string
-		kernelVersion *version.Version
-		want          []string
-	}{
-		{
-			name:          "kernel version < 4.19",
-			kernelVersion: version.MustParseGeneric("4.18"),
-			want:          []string{KernelModuleIPVS, KernelModuleIPVSRR, KernelModuleIPVSWRR, KernelModuleIPVSSH, KernelModuleNfConntrackIPV4},
-		},
-		{
-			name:          "kernel version 4.19",
-			kernelVersion: version.MustParseGeneric("4.19"),
-			want:          []string{KernelModuleIPVS, KernelModuleIPVSRR, KernelModuleIPVSWRR, KernelModuleIPVSSH, KernelModuleNfConntrack},
-		},
-	}
-	for _, test := range Tests {
-		t.Run(test.name, func(t *testing.T) {
-			got := GetRequiredIPVSModules(test.kernelVersion)
-			sort.Strings(got)
-			sort.Strings(test.want)
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("GetRequiredIPVSMods() = %v for kenel version: %s, want %v", got, test.kernelVersion, test.want)
-			}
-		})
-	}
-}

--- a/pkg/util/ipvs/ipvs_test.go
+++ b/pkg/util/ipvs/ipvs_test.go
@@ -381,4 +381,3 @@ func TestFrontendDestinationString(t *testing.T) {
 		}
 	}
 }
-


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The check of kernel modules in proxy/ipvs prevents usage with statically linked kernels. Instead the *function* should be checked.


#### Which issue(s) this PR fixes:

Fixes #108579

#### Special notes for your reviewer:

Please read https://github.com/kubernetes/kubernetes/issues/108579#issuecomment-1125675626.

Comments on individual commits below.


#### Does this PR introduce a user-facing change?

```release-note
kube-proxy with proxy-mode=ipvs can be used with statically linked kernels.
The reseved IPv4 range TEST-NET-2 in rfc5737 MUST NOT be used for ClusterIP or loadBalancerIP since address 198.51.100.0 is used for probing.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A

