### PR TITLE
Make the warning about pod name clearer

### DIFF
--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -114,7 +114,7 @@ func (podStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []s
 	newPod := obj.(*api.Pod)
 	var warnings []string
 	if msgs := utilvalidation.IsDNS1123Label(newPod.Name); len(msgs) != 0 {
-		warnings = append(warnings, fmt.Sprintf("metadata.name: this is used in Pod names and hostnames, which can result in surprising behavior; a DNS label is recommended: %v", msgs))
+		warnings = append(warnings, fmt.Sprintf("metadata.name: this is used in the Pod's hostname, which can result in surprising behavior; a DNS label is recommended: %v", msgs))
 	}
 	warnings = append(warnings, podutil.GetWarningsForPod(ctx, newPod, nil)...)
 	return warnings


### PR DESCRIPTION
Previously this was cut-paste from deployment.  It didn't make much sense for pod.

/kind cleanup

```release-note
NONE
```
