### PR TITLE
Polish error message in transformDecodeError()

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -3277,7 +3277,7 @@ func TestCreateChecksDecode(t *testing.T) {
 	b, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
-	} else if !strings.Contains(string(b), "cannot be handled as a Simple") {
+	} else if !strings.Contains(string(b), "cannot be handled as a(n) Simple") {
 		t.Errorf("unexpected response: %s", string(b))
 	}
 }
@@ -3554,7 +3554,7 @@ func TestUpdateChecksDecode(t *testing.T) {
 	b, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
-	} else if !strings.Contains(string(b), "cannot be handled as a Simple") {
+	} else if !strings.Contains(string(b), "cannot be handled as a(n) Simple") {
 		t.Errorf("unexpected response: %s", string(b))
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -252,7 +252,7 @@ func transformDecodeError(typer runtime.ObjectTyper, baseErr error, into runtime
 	}
 	objGVK := objGVKs[0]
 	if gvk != nil && len(gvk.Kind) > 0 {
-		return errors.NewBadRequest(fmt.Sprintf("%s in version %q cannot be handled as a %s: %v", gvk.Kind, gvk.Version, objGVK.Kind, baseErr))
+		return errors.NewBadRequest(fmt.Sprintf("%s in version %q cannot be handled as a(n) %s: %v", gvk.Kind, gvk.Version, objGVK.Kind, baseErr))
 	}
 	summary := summarizeData(body, 30)
 	return errors.NewBadRequest(fmt.Sprintf("the object provided is unrecognized (must be of type %s): %v (%s)", objGVK.Kind, baseErr, summary))


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When `objGVK.Kind` is starting with a vowel like "Ingress", the syntax of the error message is incorrect as follows:

```
...cannot be handled as a Ingress...
```

This PR fixes it as follows:

```
...cannot be handled as a(n) Ingress...
```

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
