### PR TITLE
kubeadm: return the output from stdout and stderr

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/staticpods.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods.go
@@ -280,8 +280,9 @@ func performEtcdStaticPodUpgrade(certsRenewMgr *renewal.Manager, client clientse
 	// Backing up etcd data store
 	backupEtcdDir := pathMgr.BackupEtcdDir()
 	runningEtcdDir := cfg.Etcd.Local.DataDir
-	if err := kubeadmutil.CopyDir(runningEtcdDir, backupEtcdDir); err != nil {
-		return true, errors.Wrap(err, "failed to back up etcd data")
+	output, err := kubeadmutil.CopyDir(runningEtcdDir, backupEtcdDir)
+	if err != nil {
+		return true, errors.Wrapf(err, "failed to back up etcd data, output: %q", output)
 	}
 
 	// Get the desired etcd version. That's either the one specified by the user in cfg.Etcd.Local.ImageTag
@@ -531,9 +532,10 @@ func rollbackEtcdData(cfg *kubeadmapi.InitConfiguration, pathMgr StaticPodPathMa
 	backupEtcdDir := pathMgr.BackupEtcdDir()
 	runningEtcdDir := cfg.Etcd.Local.DataDir
 
-	if err := kubeadmutil.CopyDir(backupEtcdDir, runningEtcdDir); err != nil {
+	output, err := kubeadmutil.CopyDir(backupEtcdDir, runningEtcdDir)
+	if err != nil {
 		// Let the user know there we're problems, but we tried to reçover
-		return errors.Wrapf(err, "couldn't recover etcd database with error, the location of etcd backup: %s ", backupEtcdDir)
+		return errors.Wrapf(err, "couldn't recover etcd database with error, the location of etcd backup: %s, output: %q", backupEtcdDir, output)
 	}
 
 	return nil

--- a/cmd/kubeadm/app/util/copy_unix.go
+++ b/cmd/kubeadm/app/util/copy_unix.go
@@ -24,7 +24,6 @@ import (
 )
 
 // CopyDir copies the content of a folder
-func CopyDir(src string, dst string) error {
-	cmd := exec.Command("cp", "-r", src, dst)
-	return cmd.Run()
+func CopyDir(src string, dst string) ([]byte, error) {
+	return exec.Command("cp", "-r", src, dst).CombinedOutput()
 }

--- a/cmd/kubeadm/app/util/copy_windows.go
+++ b/cmd/kubeadm/app/util/copy_windows.go
@@ -24,9 +24,8 @@ import (
 )
 
 // CopyDir copies the content of a folder
-func CopyDir(src string, dst string) error {
+func CopyDir(src string, dst string) ([]byte, error) {
 	// /E Copies directories and subdirectories, including empty ones.
 	// /H Copies hidden and system files also.
-	cmd := exec.Command("xcopy", "/E", "/H", src, dst)
-	return cmd.Run()
+	return exec.Command("xcopy", "/E", "/H", src, dst).CombinedOutput()
 }


### PR DESCRIPTION
It was just saying the copy of file failed with `exit status 1`, no much details for what's going wrong.

Combine the stderr and stdout and show those info will be easier for us to fix the problem.

e.g.

It was something like 
```
exit status 1 failed to back up etcd data
```

now it will be like

```
failed to back up etcd data - exit status 1 output - "cp: cannot stat '/var/lib/kubelet2': No such file or directory" 
```



/kind cleanup

Signed-off-by: Dave Chen <dave.chen@arm.com>
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
