### PR TITLE
Do not log errors when ServiceHealthServer is closed normally

### DIFF
--- a/pkg/proxy/healthcheck/common.go
+++ b/pkg/proxy/healthcheck/common.go
@@ -39,6 +39,7 @@ type httpServerFactory interface {
 // It is designed so that http.Server satisfies this interface,
 type httpServer interface {
 	Serve(listener net.Listener) error
+	Close() error
 }
 
 // Implement listener in terms of net.Listen.

--- a/pkg/proxy/healthcheck/healthcheck_test.go
+++ b/pkg/proxy/healthcheck/healthcheck_test.go
@@ -104,6 +104,10 @@ func (fake *fakeHTTPServer) Serve(listener net.Listener) error {
 	return nil // Cause the goroutine to return
 }
 
+func (fake *fakeHTTPServer) Close() error {
+	return nil
+}
+
 func mknsn(ns, name string) types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: ns,

--- a/pkg/proxy/healthcheck/service_health.go
+++ b/pkg/proxy/healthcheck/service_health.go
@@ -150,7 +150,6 @@ type hcInstance struct {
 	nsn  types.NamespacedName
 	port uint16
 
-	listeners   []net.Listener
 	httpServers []httpServer
 
 	endpoints int // number of local endpoints for a service
@@ -162,7 +161,6 @@ func (hcI *hcInstance) listenAndServeAll(hcs *server) error {
 	var listener net.Listener
 
 	addresses := hcs.nodeAddresses.List()
-	hcI.listeners = make([]net.Listener, 0, len(addresses))
 	hcI.httpServers = make([]httpServer, 0, len(addresses))
 
 	// for each of the node addresses start listening and serving
@@ -181,16 +179,15 @@ func (hcI *hcInstance) listenAndServeAll(hcs *server) error {
 
 		// start serving
 		go func(hcI *hcInstance, listener net.Listener, httpSrv httpServer) {
-			// Serve() will exit when the listener is closed.
+			// Serve() will exit and return ErrServerClosed when the http server is closed.
 			klog.V(3).InfoS("Starting goroutine for healthcheck", "service", hcI.nsn, "address", listener.Addr())
-			if err := httpSrv.Serve(listener); err != nil {
+			if err := httpSrv.Serve(listener); err != nil && err != http.ErrServerClosed {
 				klog.ErrorS(err, "Healthcheck closed", "service", hcI.nsn)
 				return
 			}
 			klog.V(3).InfoS("Healthcheck closed", "service", hcI.nsn, "address", listener.Addr())
 		}(hcI, listener, httpSrv)
 
-		hcI.listeners = append(hcI.listeners, listener)
 		hcI.httpServers = append(hcI.httpServers, httpSrv)
 	}
 
@@ -199,9 +196,9 @@ func (hcI *hcInstance) listenAndServeAll(hcs *server) error {
 
 func (hcI *hcInstance) closeAll() error {
 	errors := []error{}
-	for _, listener := range hcI.listeners {
-		if err := listener.Close(); err != nil {
-			klog.ErrorS(err, "Error closing listener for health check service", "service", hcI.nsn, "address", listener.Addr())
+	for _, server := range hcI.httpServers {
+		if err := server.Close(); err != nil {
+			klog.ErrorS(err, "Error closing server for health check service", "service", hcI.nsn)
 			errors = append(errors, err)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

Server.Serve() always returns a non-nil error. If it exits because the http server is closed, it will return ErrServerClosed. To differentiate the error, this patch changes to close the http server instead of the listener when the Service is deleted. Closing http server automatically closes the listener, there is no need to cache the listeners any more.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #114723

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
