### PR TITLE
(minor) kube-proxy startup cleanup

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -165,11 +165,11 @@ func newProxyServer(
 		ipt[1] = iptInterface
 	}
 
-	for _, perFamilyIpt := range ipt {
-		if !perFamilyIpt.Present() {
-			klog.InfoS("kube-proxy running in single-stack mode, this ipFamily is not supported", "ipFamily", perFamilyIpt.Protocol())
-			dualStack = false
-		}
+	if !ipt[0].Present() {
+		return nil, fmt.Errorf("iptables is not supported for primary IP family %q", primaryProtocol)
+	} else if !ipt[1].Present() {
+		klog.InfoS("kube-proxy running in single-stack mode: secondary ipFamily is not supported", "ipFamily", ipt[1].Protocol())
+		dualStack = false
 	}
 
 	if proxyMode == proxyconfigapi.ProxyModeIPTables {

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -145,8 +145,10 @@ func newProxyServer(
 
 	klog.V(2).InfoS("DetectLocalMode", "LocalMode", string(detectLocalMode))
 
+	primaryFamily := v1.IPv4Protocol
 	primaryProtocol := utiliptables.ProtocolIPv4
 	if netutils.IsIPv6(nodeIP) {
+		primaryFamily = v1.IPv6Protocol
 		primaryProtocol = utiliptables.ProtocolIPv6
 	}
 	execer := exec.New()
@@ -216,6 +218,7 @@ func newProxyServer(
 
 			// TODO this has side effects that should only happen when Run() is invoked.
 			proxier, err = iptables.NewProxier(
+				primaryFamily,
 				iptInterface,
 				utilsysctl.New(),
 				execer,
@@ -290,6 +293,7 @@ func newProxyServer(
 			}
 
 			proxier, err = ipvs.NewProxier(
+				primaryFamily,
 				iptInterface,
 				ipvsInterface,
 				ipsetInterface,

--- a/pkg/kubemark/hollow_proxy.go
+++ b/pkg/kubemark/hollow_proxy.go
@@ -85,9 +85,14 @@ func NewHollowProxyOrDie(
 			klog.InfoS("can't determine this node's IP, assuming 127.0.0.1")
 			nodeIP = netutils.ParseIPSloppy("127.0.0.1")
 		}
+		family := v1.IPv4Protocol
+		if iptInterface.IsIPv6() {
+			family = v1.IPv6Protocol
+		}
 		// Real proxier with fake iptables, sysctl, etc underneath it.
 		//var err error
 		proxier, err = iptables.NewProxier(
+			family,
 			iptInterface,
 			sysctl,
 			execer,

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -260,13 +260,6 @@ func NewProxier(ipFamily v1.IPFamily,
 
 	serviceHealthServer := healthcheck.NewServiceHealthServer(hostname, recorder, nodePortAddresses)
 
-	ipFamilyMap := utilproxy.MapCIDRsByIPFamily(nodePortAddresses)
-	nodePortAddresses = ipFamilyMap[ipFamily]
-	// Log the IPs not matching the ipFamily
-	if ips, ok := ipFamilyMap[utilproxy.OtherIPFamily(ipFamily)]; ok && len(ips) > 0 {
-		klog.InfoS("Found node IPs of the wrong family", "ipFamily", ipFamily, "IPs", strings.Join(ips, ","))
-	}
-
 	proxier := &Proxier{
 		svcPortMap:               make(proxy.ServicePortMap),
 		serviceChanges:           proxy.NewServiceChangeTracker(newServiceInfo, ipFamily, recorder, nil),

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -459,13 +459,6 @@ func NewProxier(ipFamily v1.IPFamily,
 
 	serviceHealthServer := healthcheck.NewServiceHealthServer(hostname, recorder, nodePortAddresses)
 
-	ipFamilyMap := utilproxy.MapCIDRsByIPFamily(nodePortAddresses)
-	nodePortAddresses = ipFamilyMap[ipFamily]
-	// Log the IPs not matching the ipFamily
-	if ips, ok := ipFamilyMap[utilproxy.OtherIPFamily(ipFamily)]; ok && len(ips) > 0 {
-		klog.InfoS("Found node IPs of the wrong family", "ipFamily", ipFamily, "IPs", ips)
-	}
-
 	// excludeCIDRs has been validated before, here we just parse it to IPNet list
 	parsedExcludeCIDRs, _ := netutils.ParseCIDRs(excludeCIDRs)
 

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -2117,11 +2117,11 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 	addrs1 := []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("2001:db8::"), Mask: net.CIDRMask(64, 128)}}
 	fp.networkInterfacer.(*proxyutiltest.FakeNetwork).AddInterfaceAddr(&itf, addrs)
 	fp.networkInterfacer.(*proxyutiltest.FakeNetwork).AddInterfaceAddr(&itf1, addrs1)
-	fp.nodePortAddresses = []string{"100.101.102.0/24", "2001:db8::0/64"}
+	fp.nodePortAddresses = []string{"100.101.102.0/24"}
 
 	fp.syncProxyRules()
 
-	// Expect 2 (matching ipvs IPFamily field)  services and 1 destination
+	// Expect 2 services and 1 destination
 	epVS := &netlinktest.ExpectedVirtualServer{
 		VSNum: 2, IP: nodeIP.String(), Port: uint16(svcNodePort), Protocol: string(v1.ProtocolTCP),
 		RS: []netlinktest.ExpectedRealServer{{
@@ -2205,7 +2205,7 @@ func TestHealthCheckNodePort(t *testing.T) {
 	addrs1 := []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("2001:db8::"), Mask: net.CIDRMask(64, 128)}}
 	fp.networkInterfacer.(*proxyutiltest.FakeNetwork).AddInterfaceAddr(&itf, addrs)
 	fp.networkInterfacer.(*proxyutiltest.FakeNetwork).AddInterfaceAddr(&itf1, addrs1)
-	fp.nodePortAddresses = []string{"100.101.102.0/24", "2001:db8::0/64"}
+	fp.nodePortAddresses = []string{"100.101.102.0/24"}
 
 	fp.syncProxyRules()
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig network
/priority backlog

#### What this PR does / why we need it:
Just some minor cleanups to kube-proxy startup (as a prelude to cleaning up `--nodeport-addresses` handling)

I guess the first commit is actually a bugfix, but it's a fix for a bug no one has ever reported which would be very difficult to trigger in real usage...

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

