### PR TITLE
logs: add AddGoFlags

### DIFF
--- a/staging/src/k8s.io/component-base/logs/api/v1/options_test.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/options_test.go
@@ -32,23 +32,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func TestFlags(t *testing.T) {
-	c := NewLoggingConfiguration()
-	fs := pflag.NewFlagSet("addflagstest", pflag.ContinueOnError)
-	output := bytes.Buffer{}
-	AddFlags(c, fs)
-	fs.SetOutput(&output)
-	fs.PrintDefaults()
-	want := `      --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
-      --logging-format string          Sets the log format. Permitted formats: "text". (default "text")
-  -v, --v Level                        number for the log level verbosity
-      --vmodule pattern=N,...          comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
-`
-	if !assert.Equal(t, want, output.String()) {
-		t.Errorf("Wrong list of flags. expect %q, got %q", want, output.String())
-	}
-}
-
 func TestOptions(t *testing.T) {
 	newOptions := NewLoggingConfiguration()
 	testcases := []struct {

--- a/staging/src/k8s.io/component-base/logs/api/v1/options_test.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/options_test.go
@@ -152,6 +152,33 @@ $`, buffer.String())
 $`, buffer.String())
 	})
 
+	t.Run("AddGoFlags", func(t *testing.T) {
+		newOptions := NewLoggingConfiguration()
+		var fs flag.FlagSet
+		var buffer bytes.Buffer
+		AddGoFlags(newOptions, &fs)
+		fs.SetOutput(&buffer)
+		fs.PrintDefaults()
+		// In contrast to copying through VisitAll, the type of some options is now
+		// known:
+		// -log-flush-frequency duration
+		//   	Maximum number of seconds between log flushes (default 5s)
+		// -logging-format string
+		//   	Sets the log format. Permitted formats: "text". (default "text")
+		// -v value
+		//   	number for the log level verbosity
+		// -vmodule value
+		//   	comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
+		assert.Regexp(t, `^.*-log-flush-frequency.*duration.*
+.*default 5s.*
+.*-logging-format.*string.*
+.*default.*text.*
+.*-v.*
+.*
+.*-vmodule.*
+.*
+$`, buffer.String())
+	})
 }
 
 func TestContextualLogging(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This makes it possible to use logging command line flags with a flag.FlagSet, without having to copy values from a pflag.FlagSet.

#### Does this PR introduce a user-facing change?
```release-note
k8s.io/component-base/logs now also supports adding command line flags to a flag.FlagSet.
```
