### PR TITLE
fix：error strings should not be capitalized

### DIFF
--- a/hack/conformance/check_conformance_test_requirements.go
+++ b/hack/conformance/check_conformance_test_requirements.go
@@ -56,7 +56,7 @@ func checkAllProviders(e2eFile string) error {
 		line := scanner.Text()
 		if regStartConformance.MatchString(line) {
 			if inConformanceCode {
-				return errors.New("Missed the end of previous conformance test. There might be a bug in this script.")
+				return errors.New("missed the end of previous conformance test. there might be a bug in this script")
 			}
 			inConformanceCode = true
 		}
@@ -72,10 +72,10 @@ func checkAllProviders(e2eFile string) error {
 		}
 	}
 	if inConformanceCode {
-		return errors.New("Missed the end of previous conformance test. There might be a bug in this script.")
+		return errors.New("missed the end of previous conformance test. there might be a bug in this script")
 	}
 	if checkFailed {
-		return errors.New("We need to fix the above errors.")
+		return errors.New("we need to fix the above errors")
 	}
 	return nil
 }

--- a/pkg/controller/util/selectors/bimultimap_test.go
+++ b/pkg/controller/util/selectors/bimultimap_test.go
@@ -503,16 +503,16 @@ func reverseSelect(key Key, want ...Key) expectation {
 
 func emptyMap(m *BiMultimap) error {
 	if len(m.labeledObjects) != 0 {
-		return fmt.Errorf("Found %v labeledObjects. Wanted none.", len(m.labeledObjects))
+		return fmt.Errorf("found %v labeledObjects. wanted none", len(m.labeledObjects))
 	}
 	if len(m.selectingObjects) != 0 {
-		return fmt.Errorf("Found %v selectingObjects. Wanted none.", len(m.selectingObjects))
+		return fmt.Errorf("found %v selectingObjects. wanted none", len(m.selectingObjects))
 	}
 	if len(m.labeledBySelecting) != 0 {
-		return fmt.Errorf("Found %v cached labeledBySelecting associations. Wanted none.", len(m.labeledBySelecting))
+		return fmt.Errorf("found %v cached labeledBySelecting associations. wanted none", len(m.labeledBySelecting))
 	}
 	if len(m.selectingByLabeled) != 0 {
-		return fmt.Errorf("Found %v cached selectingByLabeled associations. Wanted none.", len(m.selectingByLabeled))
+		return fmt.Errorf("found %v cached selectingByLabeled associations. wanted none", len(m.selectingByLabeled))
 	}
 	return nil
 }


### PR DESCRIPTION
According to code specification ,error strings should not be capitalized or end with punctuation or a newline

Signed-off-by: yulng <wei.yang@daocloud.io>

Thanks