### PR TITLE
kubectl api-resources --help command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
@@ -116,7 +116,7 @@ func NewCmdAPIResources(restClientGetter genericclioptions.RESTClientGetter, ioS
 	cmd.Flags().StringSliceVar(&o.Verbs, "verbs", o.Verbs, "Limit to resources that support the specified verbs.")
 	cmd.Flags().StringVar(&o.SortBy, "sort-by", o.SortBy, "If non-empty, sort list of resources using specified field. The field can be either 'name' or 'kind'.")
 	cmd.Flags().BoolVar(&o.Cached, "cached", o.Cached, "Use the cached list of resources if available.")
-	cmd.Flags().StringSliceVar(&o.Categories, "categories", o.Categories, "Limit to resources that belong the the specified categories.")
+	cmd.Flags().StringSliceVar(&o.Categories, "categories", o.Categories, "Limit to resources that belong to the specified categories.")
 	return cmd
 }
 


### PR DESCRIPTION
The command help content resulted with a grammar error. In options, find explanation for the --categories=[]:

#### What type of PR is this?
/kind cleanup
/kind documentation

#### What this PR does / why we need it:
The command `kubectl api-resources --help` listed a grammar mistake.

#### Special notes for your reviewer:
This is not a fix, I found something off in the help content, so pushing this.

#### Does this PR introduce a user-facing change?
"NONE"
