### PR TITLE
chore: add k8s node-role.kubernetes.io/control-plane taint

### DIFF
--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -612,11 +612,11 @@ func TestPrintNodeRole(t *testing.T) {
 			node: api.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "foo10",
-					Labels: map[string]string{"node-role.kubernetes.io/master": "", "node-role.kubernetes.io/proxy": "", "kubernetes.io/role": "node"},
+					Labels: map[string]string{"node-role.kubernetes.io/master": "", "node-role.kubernetes.io/control-plane": "", "node-role.kubernetes.io/proxy": "", "kubernetes.io/role": "node"},
 				},
 			},
 			// Columns: Name, Status, Roles, Age, KubeletVersion
-			expected: []metav1.TableRow{{Cells: []interface{}{"foo10", "Unknown", "master,node,proxy", "<unknown>", ""}}},
+			expected: []metav1.TableRow{{Cells: []interface{}{"foo10", "Unknown", "control-plane,master,node,proxy", "<unknown>", ""}}},
 		},
 		{
 			node: api.Node{

--- a/test/e2e_node/testing-manifests/sriovdp-ds.yaml
+++ b/test/e2e_node/testing-manifests/sriovdp-ds.yaml
@@ -25,6 +25,9 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       serviceAccountName: sriov-device-plugin
       containers:
       - name: kube-sriovdp


### PR DESCRIPTION
`node-role.kubernetes.io/master` has been deprecated from 1.20, and replaced by `node-role.kubernetes.io/control-plane`.

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md
<img width="1055" alt="image" src="https://user-images.githubusercontent.com/76980726/210051749-5a7ef27f-9edf-4ed9-8840-16be3dec7da7.png">

/kind cleanup