### PR TITLE
kubelet/cm/containermap: Improving test coverage

### DIFF
--- a/pkg/kubelet/cm/containermap/container_map_test.go
+++ b/pkg/kubelet/cm/containermap/container_map_test.go
@@ -62,26 +62,25 @@ func TestContainerMap(t *testing.T) {
 
 		// Remove all entries from the containerMap, checking proper removal of
 		// each along the way.
-		for i := range tc.containerNames {
-			cm.RemoveByContainerID(tc.containerIDs[i])
-			containerID, err := cm.GetContainerID(tc.podUID, tc.containerNames[i])
+		cm.Visit(func(podUID string, containerName string, containerID string) {
+			cm.RemoveByContainerID(containerID)
+			containerID, err := cm.GetContainerID(podUID, containerName)
 			if err == nil {
 				t.Errorf("unexpected retrieval of containerID after removal: %v", containerID)
 			}
 
-			cm.Add(tc.podUID, tc.containerNames[i], tc.containerIDs[i])
+			cm.Add(podUID, containerName, containerID)
 
-			cm.RemoveByContainerRef(tc.podUID, tc.containerNames[i])
-			podUID, containerName, err := cm.GetContainerRef(tc.containerIDs[i])
+			cm.RemoveByContainerRef(podUID, containerName)
+			id, cn, err := cm.GetContainerRef(containerID)
 			if err == nil {
-				t.Errorf("unexpected retrieval of container reference after removal: (%v, %v)", podUID, containerName)
+				t.Errorf("unexpected retrieval of container reference after removal: (%v, %v)", id, cn)
 			}
-		}
+		})
 
 		// Verify containerMap now empty.
 		if len(cm) != 0 {
 			t.Errorf("unexpected entries still in containerMap: %v", cm)
 		}
-
 	}
 }


### PR DESCRIPTION
Signed-off-by: TommyStarK <thomasmilox@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If applied this commit will increase the unit tests code coverage of `pkg/kubelet/cm/containermap`.

- Initial unit tests code coverage

<img width="731" alt="Screenshot 2023-01-02 at 14 43 03" src="https://user-images.githubusercontent.com/9576370/210239461-d910b8c2-329b-401d-853a-faa21e08e087.png">

- After changes

<img width="730" alt="Screenshot 2023-01-02 at 14 42 16" src="https://user-images.githubusercontent.com/9576370/210239494-a000a267-8475-4b7c-b908-1ff33d442b16.png">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
