### PR TITLE
e2e storage: define local PersistentVolume tests in deterministic order

### DIFF
--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -108,6 +109,19 @@ var setupLocalVolumeMap = map[localVolumeType]utils.LocalVolumeType{
 	BlockFsWithoutFormatLocalVolumeType:     utils.LocalVolumeBlock, // block device in Filesystem mode (default in this test suite)
 }
 
+// setupLocalVolumeMapKeys returns all keys in a sorted slice. This is needed
+// to define tests in a deterministic order.
+func setupLocalVolumeMapKeys() []localVolumeType {
+	var keys []localVolumeType
+	for key := range setupLocalVolumeMap {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i] < keys[j]
+	})
+	return keys
+}
+
 type localTestVolume struct {
 	// Local test resource
 	ltr *utils.LocalTestResource
@@ -181,7 +195,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 		}
 	})
 
-	for tempTestVolType := range setupLocalVolumeMap {
+	for _, tempTestVolType := range setupLocalVolumeMapKeys() {
 
 		// New variable required for gingko test closures
 		testVolType := tempTestVolType


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Ginkgo relies on all workers defining all tests in exactly the same order. This wasn't guaranteed for these tests, with the result that some tests might have been executed more than once and others not at all when running in parallel.

This was noticed when some of these tests started to flake and then were reported both as failure and success, as if they had been retried.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @onsi @aojea 