### PR TITLE
Add Affinity field prints in describing Pod and Pod template

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -5727,12 +5727,14 @@ func TestDescribeClusterCIDR(t *testing.T) {
 Labels:       <none>
 Annotations:  <none>
 NodeSelector:
-  NodeSelector Terms:
-    Term 0:       foo in [bar]
-PerNodeHostBits:  8
-IPv4:             10.1.0.0/16
-IPv6:             fd00:1:1::/64
-Events:           <none>` + "\n",
+  NodeSelector Terms:  
+    Term 0:
+      Match Expressions:  foo in [bar]
+      Match Fields:       <none>
+PerNodeHostBits:          8
+IPv4:                     10.1.0.0/16
+IPv6:                     fd00:1:1::/64
+Events:                   <none>` + "\n",
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Xiaodong Ye <yeahdongcn@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

The `Affinity` field is missing in describing pod and deployment/daemonset/etc. (with pod template). This PR adds extra prints in `describePod` and `DescribePodTemplate` in `staging/src/k8s.io/kubectl/pkg/describe/describe.go`.

Tests were done against the following pod manifests (from the official documentation):

1. [pod-with-affinity-anti-affinity.yaml](https://github.com/kubernetes/website/blob/main/content/en/examples/pods/pod-with-affinity-anti-affinity.yaml)
  ```bash
  ❯ ./kubectl describe pod with-affinity-anti-affinity | grep -C 10 Affinity
  Node:             gcc-pc-01/192.168.5.229
  Start Time:       Tue, 03 Jan 2023 09:06:12 +0800
  Labels:           <none>
  Annotations:      cni.projectcalico.org/containerID: 53f0bd62e9e8e931f4376a40475b8d5f99f959fea18bab0ed4fcc80d00f52eec
                    cni.projectcalico.org/podIP: 10.244.3.157/32
                    cni.projectcalico.org/podIPs: 10.244.3.157/32
  Status:           Running
  IP:               10.244.3.157
  IPs:
    IP:  10.244.3.157
  Affinity:
    Node Affinity:     
      Required Terms:  
        Term 0:
          Match Expressions:  kubernetes.io/os in [linux]
          Match Fields:       <none>
      Preferred Terms:        
        Term 0:
          Weight 1:
          Preference:           
            Match Expressions:  label-1 in [key-1]
            Match Fields:       <none>
        Term 1:
          Weight 50:
          Preference:           
            Match Expressions:  label-2 in [key-2]
            Match Fields:       <none>
    Pod Affinity:               <none>
    Pod Anti-affinity:          <none>
  Containers:
    with-node-affinity:
      Container ID:   containerd://70729f33167c6dacde027940ebaa38ac53f79db099320269c83323546f5eaeb4
      Image:          registry.k8s.io/pause:2.0
      Image ID:       sha256:5de2169ecc98c9854e95ca8f965b0755a04674351b9a3bddc47375a9b63f5bd6
      Port:           <none>
      Host Port:      <none>
      State:          Waiting
        Reason:       CrashLoopBackOff
  ```
2. [pod-with-node-affinity.yaml](https://github.com/kubernetes/website/blob/main/content/en/examples/pods/pod-with-node-affinity.yaml)
  ```bash
  ❯ ./kubectl describe pod with-node-affinity | grep -C 10 Affinity
  Name:             with-node-affinity
  Namespace:        default
  Priority:         0
  Service Account:  default
  Node:             <none>
  Labels:           <none>
  Annotations:      <none>
  Status:           Pending
  IP:               
  IPs:              <none>
  Affinity:
    Node Affinity:     
      Required Terms:  
        Term 0:
          Match Expressions:  topology.kubernetes.io/zone in [antarctica-east1, antarctica-west1]
          Match Fields:       <none>
      Preferred Terms:        
        Term 0:
          Weight 1:
          Preference:           
            Match Expressions:  another-node-label-key in [another-node-label-value]
            Match Fields:       <none>
    Pod Affinity:               <none>
    Pod Anti-affinity:          <none>
  Containers:
    with-node-affinity:
      Image:        registry.k8s.io/pause:2.0
      Port:         <none>
      Host Port:    <none>
      Environment:  <none>
      Mounts:
        /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-s7vfb (ro)
  Conditions:
  ```
3. [pod-with-pod-affinity.yaml](https://github.com/kubernetes/website/blob/main/content/en/examples/pods/pod-with-pod-affinity.yaml)
  ```bash
  ❯ ./kubectl describe pod with-pod-affinity | grep -C 10 Affinity
  Name:             with-pod-affinity
  Namespace:        default
  Priority:         0
  Service Account:  default
  Node:             <none>
  Labels:           <none>
  Annotations:      <none>
  Status:           Pending
  IP:               
  IPs:              <none>
  Affinity:
    Node Affinity:     <none>
    Pod Affinity:      
      Required Terms:  
        Term 0:
          Label Selector:      security in (S1)
          Namespaces:          []
          Topology Key:        topology.kubernetes.io/zone
          Namespace Selector:  <none>
      Preferred Terms:         <none>
    Pod Anti-affinity:         
      Required Terms:          <none>
      Preferred Terms:         
        Term 0:
          Weight:                100
          Pod Affinity Term:     
            Label Selector:      security in (S2)
            Namespaces:          []
            Topology Key:        topology.kubernetes.io/zone
            Namespace Selector:  <none>
  Containers:
    with-pod-affinity:
      Image:        registry.k8s.io/pause:2.0
      Port:         <none>
      Host Port:    <none>
      Environment:  <none>
  ```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
One function (`printNodeSelectorMultilineWithIndent`) is extracted to reduce code duplication and `describeClusterCIDRV1alpha1` && `describePersistentVolume` are affected as well.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Print the Affinity field in kubectl describe pod/deployment/daemonset/etc.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
