### PR TITLE
feature(scheduler_perf): distinguish result in scheduler_scheduling_attempt_duration_seconds metric result

### DIFF
--- a/pkg/scheduler/metrics/profile_metrics.go
+++ b/pkg/scheduler/metrics/profile_metrics.go
@@ -19,27 +19,27 @@ package metrics
 // This file contains helpers for metrics that are associated to a profile.
 
 var (
-	scheduledResult     = "scheduled"
-	unschedulableResult = "unschedulable"
-	errorResult         = "error"
+	ScheduledResult     = "scheduled"
+	UnschedulableResult = "unschedulable"
+	ErrorResult         = "error"
 )
 
 // PodScheduled can records a successful scheduling attempt and the duration
 // since `start`.
 func PodScheduled(profile string, duration float64) {
-	observeScheduleAttemptAndLatency(scheduledResult, profile, duration)
+	observeScheduleAttemptAndLatency(ScheduledResult, profile, duration)
 }
 
 // PodUnschedulable can records a scheduling attempt for an unschedulable pod
 // and the duration since `start`.
 func PodUnschedulable(profile string, duration float64) {
-	observeScheduleAttemptAndLatency(unschedulableResult, profile, duration)
+	observeScheduleAttemptAndLatency(UnschedulableResult, profile, duration)
 }
 
 // PodScheduleError can records a scheduling attempt that had an error and the
 // duration since `start`.
 func PodScheduleError(profile string, duration float64) {
-	observeScheduleAttemptAndLatency(errorResult, profile, duration)
+	observeScheduleAttemptAndLatency(ErrorResult, profile, duration)
 }
 
 func observeScheduleAttemptAndLatency(result, profile string, duration float64) {

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/test/integration/framework"
 	testutils "k8s.io/kubernetes/test/utils"
 	"sigs.k8s.io/yaml"
@@ -75,6 +76,7 @@ const (
 const (
 	configFile               = "config/performance-config.yaml"
 	extensionPointsLabelName = "extension_point"
+	resultLabelName          = "result"
 )
 
 var (
@@ -84,8 +86,11 @@ var (
 				label:  extensionPointsLabelName,
 				values: []string{"Filter", "Score"},
 			},
-			"scheduler_scheduling_attempt_duration_seconds": nil,
-			"scheduler_pod_scheduling_duration_seconds":     nil,
+			"scheduler_scheduling_attempt_duration_seconds": {
+				label:  resultLabelName,
+				values: []string{metrics.ScheduledResult, metrics.UnschedulableResult, metrics.ErrorResult},
+			},
+			"scheduler_pod_scheduling_duration_seconds": nil,
 		},
 	}
 )


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/issues/114509#issuecomment-1369484525

We should distinguish them so that we can notice the performance degradation on the unhappy path with scheduler_perf. 
The result will be like ↓

```
{
  "version": "v1",
  "dataItems": [
    {
      "data": {
        "Average": 162.6,
        "Perc50": 145,
        "Perc90": 271,
        "Perc95": 311,
        "Perc99": 331
      },
      "unit": "pods/s",
      "labels": {
        "Metric": "SchedulingThroughput",
        "Name": "BenchmarkPerfScheduling/Unschedulable/5000Nodes/2000InitPods/namespace-2"
      }
    },
    {
      "data": {
        "Average": 136832.44154198433,
        "Perc50": 122880,
        "Perc90": 155648.00000000003,
        "Perc95": 159744,
        "Perc99": 163020.80000000002
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_pod_scheduling_duration_seconds",
        "Name": "BenchmarkPerfScheduling/Unschedulable/5000Nodes/2000InitPods/namespace-2"
      }
    },
    {
      "data": {
        "Average": 6.979840945285685,
        "Perc50": 0.5870967741935484,
        "Perc90": 11.913967861557479,
        "Perc95": 47.95492957746479,
        "Perc99": 94.97034700315457
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/Unschedulable/5000Nodes/2000InitPods/namespace-2",
        "extension_point": "Filter"
      }
    },
    {
      "data": {
        "Average": 3.387086253799991,
        "Perc50": 0.7629764065335753,
        "Perc90": 1.5397986221515634,
        "Perc95": 2.68,
        "Perc99": 86.49937888198758
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_framework_extension_point_duration_seconds",
        "Name": "BenchmarkPerfScheduling/Unschedulable/5000Nodes/2000InitPods/namespace-2",
        "extension_point": "Score"
      }
    },
    {
      "data": {
        "Average": 15.886441675400057,
        "Perc50": 3.402131239484016,
        "Perc90": 79.40372670807454,
        "Perc95": 104.24844720496895,
        "Perc99": 124.12422360248448
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_scheduling_attempt_duration_seconds",
        "Name": "BenchmarkPerfScheduling/Unschedulable/5000Nodes/2000InitPods/namespace-2",
        "result": "scheduled"
      }
    },
    {
      "data": {
        "Average": 53.55418182849996,
        "Perc50": 29.235880398671096,
        "Perc90": 117.50399999999999,
        "Perc95": 164,
        "Perc99": 423.38461538461536
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_scheduling_attempt_duration_seconds",
        "Name": "BenchmarkPerfScheduling/Unschedulable/5000Nodes/2000InitPods/namespace-2",
        "result": "unschedulable"
      }
    }
  ]
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #https://github.com/kubernetes/kubernetes/issues/114509

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
