### PR TITLE
kubelet/cm/cpumanager: Improving test coverage

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -68,6 +68,17 @@ func (spt staticPolicyTest) PseudoClone() staticPolicyTest {
 	}
 }
 
+func TestSMTAlignmentError(t *testing.T) {
+	smtErr := SMTAlignmentError{RequestedCPUs: 3, CpusPerCore: 2}
+
+	if err := smtErr.Error(); err != "SMT Alignment Error: requested 3 cpus not multiple cpus per core = 2" {
+		t.Errorf("expected: SMT Alignment Error: requested 3 cpus not multiple cpus per core = 2, but got: %s", err)
+	}
+	if typ := smtErr.Type(); typ != "SMTAlignmentError" {
+		t.Errorf("expected: SMTAlignmentError but got: %s", typ)
+	}
+}
+
 func TestStaticPolicyName(t *testing.T) {
 	policy, _ := NewStaticPolicy(topoSingleSocketHT, 1, cpuset.New(), topologymanager.NewFakeManager(), nil)
 
@@ -971,7 +982,6 @@ func TestStaticPolicyStartWithResvList(t *testing.T) {
 }
 
 func TestStaticPolicyAddWithResvList(t *testing.T) {
-
 	testCases := []staticPolicyTestWithResvList{
 		{
 			description:     "GuPodSingleCore, SingleSocketHT, ExpectError",

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -358,10 +358,17 @@ func TestCheckpointStateHelpers(t *testing.T) {
 					if cpus, _ := state.GetCPUSet(pod, container); !cpus.Equals(set) {
 						t.Fatalf("state inconsistent, got %q instead of %q", set, cpus)
 					}
+					if cpus := state.GetCPUSetOrDefault(pod, container); !cpus.Equals(set) {
+						t.Fatalf("state inconsistent, got %q instead of %q", set, cpus)
+					}
 
 					state.Delete(pod, container)
 					if _, ok := state.GetCPUSet(pod, container); ok {
 						t.Fatal("deleted container still existing in state")
+					}
+
+					if !state.GetCPUSetOrDefault(pod, container).Equals(tc.defaultCPUset) {
+						t.Fatal("deleted container, should have returned default cpu set")
 					}
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

If applied this commit will increase the unit tests code coverage of `pkg/kubelet/cm/cpumanager`.

- Initial unit tests code coverage

<img width="733" alt="Screenshot 2023-01-02 at 20 34 22" src="https://user-images.githubusercontent.com/9576370/210363360-b1588b26-b89b-4dfa-a388-b515cb9fb935.png">

- After Changes

<img width="732" alt="Screenshot 2023-01-03 at 14 07 09" src="https://user-images.githubusercontent.com/9576370/210363396-5229a00d-8788-4a87-9359-8ac241de05cc.png">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
