### PR TITLE
e2e framework: consolidate timeouts and intervals

### DIFF
--- a/test/e2e/cloud/gcp/resize_nodes.go
+++ b/test/e2e/cloud/gcp/resize_nodes.go
@@ -126,7 +126,7 @@ var _ = SIGDescribe("Nodes [Disruptive]", func() {
 
 			ginkgo.By("waiting 2 minutes for the watch in the podGC to catch up, remove any pods scheduled on " +
 				"the now non-existent node and the RC to recreate it")
-			time.Sleep(framework.NewTimeoutContext().PodStartShort)
+			time.Sleep(f.Timeouts.PodStartShort)
 
 			ginkgo.By("verifying whether the pods from the removed node are recreated")
 			err = e2epod.VerifyPods(ctx, c, ns, name, true, originalNodeCount)

--- a/test/e2e/cloud/gcp/resize_nodes.go
+++ b/test/e2e/cloud/gcp/resize_nodes.go
@@ -126,7 +126,7 @@ var _ = SIGDescribe("Nodes [Disruptive]", func() {
 
 			ginkgo.By("waiting 2 minutes for the watch in the podGC to catch up, remove any pods scheduled on " +
 				"the now non-existent node and the RC to recreate it")
-			time.Sleep(framework.NewTimeoutContextWithDefaults().PodStartShort)
+			time.Sleep(framework.NewTimeoutContext().PodStartShort)
 
 			ginkgo.By("verifying whether the pods from the removed node are recreated")
 			err = e2epod.VerifyPods(ctx, c, ns, name, true, originalNodeCount)

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -27,6 +27,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"reflect"
 	"strings"
 	"time"
 
@@ -144,10 +145,19 @@ type Options struct {
 	GroupVersion *schema.GroupVersion
 }
 
-// NewFrameworkWithCustomTimeouts makes a framework with with custom timeouts.
+// NewFrameworkWithCustomTimeouts makes a framework with custom timeouts.
+// For timeout values that are zero the normal default value continues to
+// be used.
 func NewFrameworkWithCustomTimeouts(baseName string, timeouts *TimeoutContext) *Framework {
 	f := NewDefaultFramework(baseName)
-	f.Timeouts = timeouts
+	in := reflect.ValueOf(timeouts).Elem()
+	out := reflect.ValueOf(f.Timeouts).Elem()
+	for i := 0; i < in.NumField(); i++ {
+		value := in.Field(i)
+		if !value.IsZero() {
+			out.Field(i).Set(value)
+		}
+	}
 	return f
 }
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -179,7 +179,7 @@ func NewFramework(baseName string, options Options, client clientset.Interface) 
 		BaseName:  baseName,
 		Options:   options,
 		ClientSet: client,
-		Timeouts:  NewTimeoutContextWithDefaults(),
+		Timeouts:  NewTimeoutContext(),
 	}
 
 	// The order is important here: if the extension calls ginkgo.BeforeEach

--- a/test/e2e/framework/internal/unittests/framework_test.go
+++ b/test/e2e/framework/internal/unittests/framework_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func TestNewFrameworkWithCustomTimeouts(t *testing.T) {
+	defaultF := framework.NewDefaultFramework("test")
+	customTimeouts := &framework.TimeoutContext{
+		PodStart:  5 * time.Second,
+		PodDelete: time.Second,
+	}
+	customF := framework.NewFrameworkWithCustomTimeouts("test", customTimeouts)
+
+	defaultF.Timeouts.PodStart = customTimeouts.PodStart
+	defaultF.Timeouts.PodDelete = customTimeouts.PodDelete
+	assert.Equal(t, customF.Timeouts, defaultF.Timeouts)
+}
+
+func TestNewFramework(t *testing.T) {
+	f := framework.NewDefaultFramework("test")
+
+	timeouts := reflect.ValueOf(f.Timeouts).Elem()
+	for i := 0; i < timeouts.NumField(); i++ {
+		value := timeouts.Field(i)
+		if value.IsZero() {
+			t.Errorf("%s in Framework.Timeouts was not set.", reflect.TypeOf(*f.Timeouts).Field(i).Name)
+		}
+	}
+}

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/types"
+	"github.com/onsi/gomega"
 	gomegaformat "github.com/onsi/gomega/format"
 
 	restclient "k8s.io/client-go/rest"
@@ -471,6 +472,15 @@ func AfterReadingAllFlags(t *TestContextType) {
 		}
 		os.Exit(0)
 	}
+
+	// Reconfigure gomega defaults. The poll interval should be suitable
+	// for most tests. The timeouts are more subjective and tests may want
+	// to override them, but these defaults are still better for E2E than the
+	// ones from Gomega (1s timeout, 10ms interval).
+	gomega.SetDefaultEventuallyPollingInterval(t.timeouts.Poll)
+	gomega.SetDefaultConsistentlyPollingInterval(t.timeouts.Poll)
+	gomega.SetDefaultEventuallyTimeout(t.timeouts.PodStart)
+	gomega.SetDefaultConsistentlyDuration(t.timeouts.PodStartShort)
 
 	// Only set a default host if one won't be supplied via kubeconfig
 	if len(t.Host) == 0 && len(t.KubeConfig) == 0 {

--- a/test/e2e/framework/timeouts.go
+++ b/test/e2e/framework/timeouts.go
@@ -35,6 +35,9 @@ var defaultTimeouts = TimeoutContext{
 	SnapshotCreate:            5 * time.Minute,
 	SnapshotDelete:            5 * time.Minute,
 	SnapshotControllerMetrics: 5 * time.Minute,
+	SystemPodsStartup:         10 * time.Minute,
+	NodeSchedulable:           30 * time.Minute,
+	SystemDaemonsetStartup:    5 * time.Minute,
 }
 
 // TimeoutContext contains timeout settings for several actions.
@@ -88,12 +91,23 @@ type TimeoutContext struct {
 
 	// SnapshotControllerMetrics is how long to wait for snapshot controller metrics.
 	SnapshotControllerMetrics time.Duration
+
+	// SystemPodsStartup is how long to wait for system pods to be running.
+	SystemPodsStartup time.Duration
+
+	// NodeSchedulable is how long to wait for all nodes to be schedulable.
+	NodeSchedulable time.Duration
+
+	// SystemDaemonsetStartup is how long to wait for all system daemonsets to be ready.
+	SystemDaemonsetStartup time.Duration
 }
 
-// NewTimeoutContextWithDefaults returns a TimeoutContext with default values.
-func NewTimeoutContextWithDefaults() *TimeoutContext {
-	// Make a copy, otherwise the caller would have the ability to
-	// modify the defaults
-	copy := defaultTimeouts
+// NewTimeoutContext returns a TimeoutContext with all values set either to
+// hard-coded defaults or a value that was configured when running the E2E
+// suite. Should be called after command line parsing.
+func NewTimeoutContext() *TimeoutContext {
+	// Make a copy, otherwise the caller would have the ability to modify
+	// the original values.
+	copy := TestContext.timeouts
 	return &copy
 }

--- a/test/e2e/framework/timeouts.go
+++ b/test/e2e/framework/timeouts.go
@@ -47,10 +47,12 @@ type TimeoutContext struct {
 	Poll time.Duration
 
 	// PodStart is how long to wait for the pod to be started.
+	// This value is the default for gomega.Eventually.
 	PodStart time.Duration
 
 	// PodStartShort is same as `PodStart`, but shorter.
 	// Use it in a case-by-case basis, mostly when you are sure pod start will not be delayed.
+	// This value is the default for gomega.Consistently.
 	PodStartShort time.Duration
 
 	// PodStartSlow is same as `PodStart`, but longer.
@@ -118,6 +120,8 @@ func NewTimeoutContext() *TimeoutContext {
 
 // PollInterval defines how long to wait between API server queries while
 // waiting for some condition.
+//
+// This value is the default for gomega.Eventually and gomega.Consistently.
 func PollInterval() time.Duration {
 	return TestContext.timeouts.Poll
 }

--- a/test/e2e/framework/timeouts.go
+++ b/test/e2e/framework/timeouts.go
@@ -19,6 +19,7 @@ package framework
 import "time"
 
 var defaultTimeouts = TimeoutContext{
+	Poll:                      2 * time.Second, // from the former e2e/framework/pod poll interval
 	PodStart:                  5 * time.Minute,
 	PodStartShort:             2 * time.Minute,
 	PodStartSlow:              15 * time.Minute,
@@ -42,6 +43,9 @@ var defaultTimeouts = TimeoutContext{
 
 // TimeoutContext contains timeout settings for several actions.
 type TimeoutContext struct {
+	// Poll is how long to wait between API calls when waiting for some condition.
+	Poll time.Duration
+
 	// PodStart is how long to wait for the pod to be started.
 	PodStart time.Duration
 
@@ -110,4 +114,10 @@ func NewTimeoutContext() *TimeoutContext {
 	// the original values.
 	copy := TestContext.timeouts
 	return &copy
+}
+
+// PollInterval defines how long to wait between API server queries while
+// waiting for some condition.
+func PollInterval() time.Duration {
+	return TestContext.timeouts.Poll
 }

--- a/test/e2e/framework/timeouts.go
+++ b/test/e2e/framework/timeouts.go
@@ -18,25 +18,24 @@ package framework
 
 import "time"
 
-const (
-	// Default timeouts to be used in TimeoutContext
-	podStartTimeout                  = 5 * time.Minute
-	podStartShortTimeout             = 2 * time.Minute
-	podStartSlowTimeout              = 15 * time.Minute
-	podDeleteTimeout                 = 5 * time.Minute
-	claimProvisionTimeout            = 5 * time.Minute
-	claimProvisionShortTimeout       = 1 * time.Minute
-	dataSourceProvisionTimeout       = 5 * time.Minute
-	claimBoundTimeout                = 3 * time.Minute
-	pvReclaimTimeout                 = 3 * time.Minute
-	pvBoundTimeout                   = 3 * time.Minute
-	pvCreateTimeout                  = 3 * time.Minute
-	pvDeleteTimeout                  = 5 * time.Minute
-	pvDeleteSlowTimeout              = 20 * time.Minute
-	snapshotCreateTimeout            = 5 * time.Minute
-	snapshotDeleteTimeout            = 5 * time.Minute
-	snapshotControllerMetricsTimeout = 5 * time.Minute
-)
+var defaultTimeouts = TimeoutContext{
+	PodStart:                  5 * time.Minute,
+	PodStartShort:             2 * time.Minute,
+	PodStartSlow:              15 * time.Minute,
+	PodDelete:                 5 * time.Minute,
+	ClaimProvision:            5 * time.Minute,
+	ClaimProvisionShort:       1 * time.Minute,
+	DataSourceProvision:       5 * time.Minute,
+	ClaimBound:                3 * time.Minute,
+	PVReclaim:                 3 * time.Minute,
+	PVBound:                   3 * time.Minute,
+	PVCreate:                  3 * time.Minute,
+	PVDelete:                  5 * time.Minute,
+	PVDeleteSlow:              20 * time.Minute,
+	SnapshotCreate:            5 * time.Minute,
+	SnapshotDelete:            5 * time.Minute,
+	SnapshotControllerMetrics: 5 * time.Minute,
+}
 
 // TimeoutContext contains timeout settings for several actions.
 type TimeoutContext struct {
@@ -93,22 +92,8 @@ type TimeoutContext struct {
 
 // NewTimeoutContextWithDefaults returns a TimeoutContext with default values.
 func NewTimeoutContextWithDefaults() *TimeoutContext {
-	return &TimeoutContext{
-		PodStart:                  podStartTimeout,
-		PodStartShort:             podStartShortTimeout,
-		PodStartSlow:              podStartSlowTimeout,
-		PodDelete:                 podDeleteTimeout,
-		ClaimProvision:            claimProvisionTimeout,
-		ClaimProvisionShort:       claimProvisionShortTimeout,
-		DataSourceProvision:       dataSourceProvisionTimeout,
-		ClaimBound:                claimBoundTimeout,
-		PVReclaim:                 pvReclaimTimeout,
-		PVBound:                   pvBoundTimeout,
-		PVCreate:                  pvCreateTimeout,
-		PVDelete:                  pvDeleteTimeout,
-		PVDeleteSlow:              pvDeleteSlowTimeout,
-		SnapshotCreate:            snapshotCreateTimeout,
-		SnapshotDelete:            snapshotDeleteTimeout,
-		SnapshotControllerMetrics: snapshotControllerMetricsTimeout,
-	}
+	// Make a copy, otherwise the caller would have the ability to
+	// modify the defaults
+	copy := defaultTimeouts
+	return &copy
 }

--- a/test/e2e/network/dns_scale_records.go
+++ b/test/e2e/network/dns_scale_records.go
@@ -47,7 +47,7 @@ var _ = common.SIGDescribe("[Feature:PerformanceDNS][Serial]", func() {
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, f.Timeouts.NodeSchedulable))
 		e2enode.WaitForTotalHealthy(ctx, f.ClientSet, time.Minute)
 
 		err := framework.CheckTestingNSDeletedExcept(ctx, f.ClientSet, f.Namespace.Name)

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1967,7 +1967,7 @@ func (v *azureFileVolume) DeleteVolume(ctx context.Context) {
 }
 
 func (a *azureDiskDriver) GetTimeouts() *framework.TimeoutContext {
-	timeouts := framework.NewTimeoutContextWithDefaults()
+	timeouts := framework.NewTimeoutContext()
 	timeouts.PodStart = time.Minute * 15
 	timeouts.PodDelete = time.Minute * 15
 	timeouts.PVDelete = time.Minute * 20

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -311,7 +311,7 @@ func (d *driverDefinition) GetDynamicProvisionStorageClass(ctx context.Context, 
 }
 
 func (d *driverDefinition) GetTimeouts() *framework.TimeoutContext {
-	timeouts := framework.NewTimeoutContextWithDefaults()
+	timeouts := framework.NewTimeoutContext()
 	if d.Timeouts == nil {
 		return timeouts
 	}

--- a/test/e2e/storage/flexvolume_mounted_volume_resize.go
+++ b/test/e2e/storage/flexvolume_mounted_volume_resize.go
@@ -69,7 +69,7 @@ var _ = utils.SIGDescribe("[Feature:Flexvolumes] Mounted flexvolume expand[Slow]
 		e2eskipper.SkipUnlessSSHKeyPresent()
 		c = f.ClientSet
 		ns = f.Namespace.Name
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, c, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, c, f.Timeouts.NodeSchedulable))
 
 		node, err = e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 		framework.ExpectNoError(err)

--- a/test/e2e/storage/flexvolume_online_resize.go
+++ b/test/e2e/storage/flexvolume_online_resize.go
@@ -63,7 +63,7 @@ var _ = utils.SIGDescribe("[Feature:Flexvolumes] Mounted flexvolume volume expan
 		e2eskipper.SkipUnlessSSHKeyPresent()
 		c = f.ClientSet
 		ns = f.Namespace.Name
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, c, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, c, f.Timeouts.NodeSchedulable))
 		var err error
 
 		node, err = e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)

--- a/test/e2e/storage/framework/testdriver.go
+++ b/test/e2e/storage/framework/testdriver.go
@@ -141,7 +141,7 @@ func GetDriverTimeouts(driver TestDriver) *framework.TimeoutContext {
 	if d, ok := driver.(CustomTimeoutsTestDriver); ok {
 		return d.GetTimeouts()
 	}
-	return framework.NewTimeoutContextWithDefaults()
+	return framework.NewTimeoutContext()
 }
 
 // Capability represents a feature that a volume plugin supports

--- a/test/e2e/storage/mounted_volume_resize.go
+++ b/test/e2e/storage/mounted_volume_resize.go
@@ -62,7 +62,7 @@ var _ = utils.SIGDescribe("Mounted volume expand [Feature:StorageProvider]", fun
 		e2eskipper.SkipUnlessProviderIs("aws", "gce")
 		c = f.ClientSet
 		ns = f.Namespace.Name
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, c, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, c, f.Timeouts.NodeSchedulable))
 
 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 		framework.ExpectNoError(err)

--- a/test/e2e/storage/pv_protection.go
+++ b/test/e2e/storage/pv_protection.go
@@ -54,7 +54,7 @@ var _ = utils.SIGDescribe("PV Protection", func() {
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		client = f.ClientSet
 		nameSpace = f.Namespace.Name
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, client, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, client, f.Timeouts.NodeSchedulable))
 
 		// Enforce binding only within test space via selector labels
 		volLabel = labels.Set{e2epv.VolumeSelectorKey: nameSpace}

--- a/test/e2e/storage/pvc_protection.go
+++ b/test/e2e/storage/pvc_protection.go
@@ -75,7 +75,7 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		client = f.ClientSet
 		nameSpace = f.Namespace.Name
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, client, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, client, f.Timeouts.NodeSchedulable))
 
 		ginkgo.By("Creating a PVC")
 		prefix := "pvc-protection"

--- a/test/e2e/storage/regional_pd.go
+++ b/test/e2e/storage/regional_pd.go
@@ -110,7 +110,7 @@ func testVolumeProvisioning(ctx context.Context, c clientset.Interface, t *frame
 			Name:           "HDD Regional PD on GCE/GKE",
 			CloudProviders: []string{"gce", "gke"},
 			Provisioner:    "kubernetes.io/gce-pd",
-			Timeouts:       framework.NewTimeoutContextWithDefaults(),
+			Timeouts:       framework.NewTimeoutContext(),
 			Parameters: map[string]string{
 				"type":             "pd-standard",
 				"zones":            strings.Join(cloudZones, ","),
@@ -133,7 +133,7 @@ func testVolumeProvisioning(ctx context.Context, c clientset.Interface, t *frame
 			Name:           "HDD Regional PD with auto zone selection on GCE/GKE",
 			CloudProviders: []string{"gce", "gke"},
 			Provisioner:    "kubernetes.io/gce-pd",
-			Timeouts:       framework.NewTimeoutContextWithDefaults(),
+			Timeouts:       framework.NewTimeoutContext(),
 			Parameters: map[string]string{
 				"type":             "pd-standard",
 				"replication-type": "regional-pd",
@@ -173,7 +173,7 @@ func testZonalFailover(ctx context.Context, c clientset.Interface, ns string) {
 	testSpec := testsuites.StorageClassTest{
 		Name:           "Regional PD Failover on GCE/GKE",
 		CloudProviders: []string{"gce", "gke"},
-		Timeouts:       framework.NewTimeoutContextWithDefaults(),
+		Timeouts:       framework.NewTimeoutContext(),
 		Provisioner:    "kubernetes.io/gce-pd",
 		Parameters: map[string]string{
 			"type":             "pd-standard",
@@ -331,7 +331,7 @@ func testRegionalDelayedBinding(ctx context.Context, c clientset.Interface, ns s
 		Client:      c,
 		Name:        "Regional PD storage class with waitForFirstConsumer test on GCE",
 		Provisioner: "kubernetes.io/gce-pd",
-		Timeouts:    framework.NewTimeoutContextWithDefaults(),
+		Timeouts:    framework.NewTimeoutContext(),
 		Parameters: map[string]string{
 			"type":             "pd-standard",
 			"replication-type": "regional-pd",
@@ -369,7 +369,7 @@ func testRegionalAllowedTopologies(ctx context.Context, c clientset.Interface, n
 	test := testsuites.StorageClassTest{
 		Name:        "Regional PD storage class with allowedTopologies test on GCE",
 		Provisioner: "kubernetes.io/gce-pd",
-		Timeouts:    framework.NewTimeoutContextWithDefaults(),
+		Timeouts:    framework.NewTimeoutContext(),
 		Parameters: map[string]string{
 			"type":             "pd-standard",
 			"replication-type": "regional-pd",
@@ -397,7 +397,7 @@ func testRegionalAllowedTopologies(ctx context.Context, c clientset.Interface, n
 func testRegionalAllowedTopologiesWithDelayedBinding(ctx context.Context, c clientset.Interface, ns string, pvcCount int) {
 	test := testsuites.StorageClassTest{
 		Client:      c,
-		Timeouts:    framework.NewTimeoutContextWithDefaults(),
+		Timeouts:    framework.NewTimeoutContext(),
 		Name:        "Regional PD storage class with allowedTopologies and waitForFirstConsumer test on GCE",
 		Provisioner: "kubernetes.io/gce-pd",
 		Parameters: map[string]string{

--- a/test/e2e/storage/vsphere/pv_reclaimpolicy.go
+++ b/test/e2e/storage/vsphere/pv_reclaimpolicy.go
@@ -50,7 +50,7 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:vsphere][Feature:ReclaimPo
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		c = f.ClientSet
 		ns = f.Namespace.Name
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, c, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, c, f.Timeouts.NodeSchedulable))
 	})
 
 	ginkgo.Describe("persistentvolumereclaim:vsphere [Feature:vsphere]", func() {

--- a/test/e2e/storage/vsphere/pvc_label_selector.go
+++ b/test/e2e/storage/vsphere/pvc_label_selector.go
@@ -69,7 +69,7 @@ var _ = utils.SIGDescribe("PersistentVolumes [Feature:vsphere][Feature:LabelSele
 		ns = f.Namespace.Name
 		Bootstrap(f)
 		nodeInfo = GetReadySchedulableRandomNodeInfo(ctx)
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, c, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, c, f.Timeouts.NodeSchedulable))
 		ssdlabels = make(map[string]string)
 		ssdlabels["volume-type"] = "ssd"
 		vvollabels = make(map[string]string)

--- a/test/e2e/storage/vsphere/vsphere_volume_master_restart.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_master_restart.go
@@ -120,7 +120,7 @@ var _ = utils.SIGDescribe("Volume Attach Verify [Feature:vsphere][Serial][Disrup
 		Bootstrap(f)
 		client = f.ClientSet
 		namespace = f.Namespace.Name
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, client, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, client, f.Timeouts.NodeSchedulable))
 
 		nodes, err := e2enode.GetReadySchedulableNodes(ctx, client)
 		framework.ExpectNoError(err)

--- a/test/e2e/storage/vsphere/vsphere_volume_node_delete.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_node_delete.go
@@ -46,7 +46,7 @@ var _ = utils.SIGDescribe("Node Unregister [Feature:vsphere] [Slow] [Disruptive]
 		Bootstrap(f)
 		client = f.ClientSet
 		namespace = f.Namespace.Name
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, client, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, client, f.Timeouts.NodeSchedulable))
 		framework.ExpectNoError(err)
 		workingDir = GetAndExpectStringEnvVar("VSPHERE_WORKING_DIR")
 	})

--- a/test/e2e/storage/vsphere/vsphere_volume_node_poweroff.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_node_poweroff.go
@@ -58,7 +58,7 @@ var _ = utils.SIGDescribe("Node Poweroff [Feature:vsphere] [Slow] [Disruptive]",
 		Bootstrap(f)
 		client = f.ClientSet
 		namespace = f.Namespace.Name
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, client, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, client, f.Timeouts.NodeSchedulable))
 		nodeList, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
 		framework.ExpectNoError(err)
 		if len(nodeList.Items) < 2 {

--- a/test/e2e/storage/vsphere/vsphere_volume_placement.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_placement.go
@@ -59,7 +59,7 @@ var _ = utils.SIGDescribe("Volume Placement [Feature:vsphere]", func() {
 		Bootstrap(f)
 		c = f.ClientSet
 		ns = f.Namespace.Name
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, c, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, c, f.Timeouts.NodeSchedulable))
 		node1Name, node1KeyValueLabel, node2Name, node2KeyValueLabel = testSetupVolumePlacement(ctx, c, ns)
 		ginkgo.DeferCleanup(func() {
 			if len(node1KeyValueLabel) > 0 {

--- a/test/e2e/storage/vsphere/vsphere_volume_vpxd_restart.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_vpxd_restart.go
@@ -80,7 +80,7 @@ var _ = utils.SIGDescribe("Verify Volume Attach Through vpxd Restart [Feature:vs
 		Bootstrap(f)
 		client = f.ClientSet
 		namespace = f.Namespace.Name
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, client, framework.TestContext.NodeSchedulableTimeout))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, client, f.Timeouts.NodeSchedulable))
 
 		nodes, err := e2enode.GetReadySchedulableNodes(ctx, client)
 		framework.ExpectNoError(err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Some timeouts were defined in TestContext, others in TimeoutContext. Some were constants in source code. The long-term goal is to move all of those durations into TimeoutContext and provide a uniform configuration mechanism for them. This PR is a first step towards that.

### Special notes for your reviewer:

This was motivated by https://github.com/kubernetes/community/pull/7021#discussion_r1060376259

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

