### PR TITLE
pkg/apis: Replace deprecated pointer function

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -2569,7 +2569,7 @@ func TestValidateKeyToPath(t *testing.T) {
 			ok: true,
 		},
 		{
-			kp: core.KeyToPath{Key: "k", Path: "p", Mode: utilpointer.Int32Ptr(0644)},
+			kp: core.KeyToPath{Key: "k", Path: "p", Mode: utilpointer.Int32(0644)},
 			ok: true,
 		},
 		{
@@ -2603,12 +2603,12 @@ func TestValidateKeyToPath(t *testing.T) {
 			errtype: field.ErrorTypeInvalid,
 		},
 		{
-			kp:      core.KeyToPath{Key: "k", Path: "p", Mode: utilpointer.Int32Ptr(01000)},
+			kp:      core.KeyToPath{Key: "k", Path: "p", Mode: utilpointer.Int32(01000)},
 			ok:      false,
 			errtype: field.ErrorTypeInvalid,
 		},
 		{
-			kp:      core.KeyToPath{Key: "k", Path: "p", Mode: utilpointer.Int32Ptr(-1)},
+			kp:      core.KeyToPath{Key: "k", Path: "p", Mode: utilpointer.Int32(-1)},
 			ok:      false,
 			errtype: field.ErrorTypeInvalid,
 		},
@@ -3686,7 +3686,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					Secret: &core.SecretVolumeSource{
 						SecretName:  "my-secret",
-						DefaultMode: utilpointer.Int32Ptr(0644),
+						DefaultMode: utilpointer.Int32(0644),
 					},
 				},
 			},
@@ -3701,7 +3701,7 @@ func TestValidateVolumes(t *testing.T) {
 						Items: []core.KeyToPath{{
 							Key:  "key",
 							Path: "filename",
-							Mode: utilpointer.Int32Ptr(0644),
+							Mode: utilpointer.Int32(0644),
 						}},
 					},
 				},
@@ -3777,7 +3777,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					Secret: &core.SecretVolumeSource{
 						SecretName:  "s",
-						DefaultMode: utilpointer.Int32Ptr(01000),
+						DefaultMode: utilpointer.Int32(01000),
 					},
 				},
 			},
@@ -3793,7 +3793,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					Secret: &core.SecretVolumeSource{
 						SecretName:  "s",
-						DefaultMode: utilpointer.Int32Ptr(-1),
+						DefaultMode: utilpointer.Int32(-1),
 					},
 				},
 			},
@@ -3825,7 +3825,7 @@ func TestValidateVolumes(t *testing.T) {
 						LocalObjectReference: core.LocalObjectReference{
 							Name: "my-cfgmap",
 						},
-						DefaultMode: utilpointer.Int32Ptr(0644),
+						DefaultMode: utilpointer.Int32(0644),
 					},
 				},
 			},
@@ -3841,7 +3841,7 @@ func TestValidateVolumes(t *testing.T) {
 						Items: []core.KeyToPath{{
 							Key:  "key",
 							Path: "filename",
-							Mode: utilpointer.Int32Ptr(0644),
+							Mode: utilpointer.Int32(0644),
 						}},
 					},
 				},
@@ -3918,7 +3918,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					ConfigMap: &core.ConfigMapVolumeSource{
 						LocalObjectReference: core.LocalObjectReference{Name: "c"},
-						DefaultMode:          utilpointer.Int32Ptr(01000),
+						DefaultMode:          utilpointer.Int32(01000),
 					},
 				},
 			},
@@ -3934,7 +3934,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					ConfigMap: &core.ConfigMapVolumeSource{
 						LocalObjectReference: core.LocalObjectReference{Name: "c"},
-						DefaultMode:          utilpointer.Int32Ptr(-1),
+						DefaultMode:          utilpointer.Int32(-1),
 					},
 				},
 			},
@@ -4354,7 +4354,7 @@ func TestValidateVolumes(t *testing.T) {
 				Name: "downapi",
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
-						DefaultMode: utilpointer.Int32Ptr(0644),
+						DefaultMode: utilpointer.Int32(0644),
 					},
 				},
 			},
@@ -4366,7 +4366,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
 						Items: []core.DownwardAPIVolumeFile{{
-							Mode: utilpointer.Int32Ptr(0644),
+							Mode: utilpointer.Int32(0644),
 							Path: "path",
 							FieldRef: &core.ObjectFieldSelector{
 								APIVersion: "v1",
@@ -4384,7 +4384,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
 						Items: []core.DownwardAPIVolumeFile{{
-							Mode: utilpointer.Int32Ptr(01000),
+							Mode: utilpointer.Int32(01000),
 							Path: "path",
 							FieldRef: &core.ObjectFieldSelector{
 								APIVersion: "v1",
@@ -4406,7 +4406,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
 						Items: []core.DownwardAPIVolumeFile{{
-							Mode: utilpointer.Int32Ptr(-1),
+							Mode: utilpointer.Int32(-1),
 							Path: "path",
 							FieldRef: &core.ObjectFieldSelector{
 								APIVersion: "v1",
@@ -4561,7 +4561,7 @@ func TestValidateVolumes(t *testing.T) {
 				Name: "downapi",
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
-						DefaultMode: utilpointer.Int32Ptr(01000),
+						DefaultMode: utilpointer.Int32(01000),
 					},
 				},
 			},
@@ -4576,7 +4576,7 @@ func TestValidateVolumes(t *testing.T) {
 				Name: "downapi",
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
-						DefaultMode: utilpointer.Int32Ptr(-1),
+						DefaultMode: utilpointer.Int32(-1),
 					},
 				},
 			},
@@ -4593,7 +4593,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{"some_wwn"},
-						Lun:        utilpointer.Int32Ptr(1),
+						Lun:        utilpointer.Int32(1),
 						FSType:     "ext4",
 						ReadOnly:   false,
 					},
@@ -4620,7 +4620,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{},
-						Lun:        utilpointer.Int32Ptr(1),
+						Lun:        utilpointer.Int32(1),
 						WWIDs:      []string{},
 						FSType:     "ext4",
 						ReadOnly:   false,
@@ -4640,7 +4640,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{"some_wwn"},
-						Lun:        utilpointer.Int32Ptr(1),
+						Lun:        utilpointer.Int32(1),
 						WWIDs:      []string{"some_wwid"},
 						FSType:     "ext4",
 						ReadOnly:   false,
@@ -4679,7 +4679,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{"wwn"},
-						Lun:        utilpointer.Int32Ptr(256),
+						Lun:        utilpointer.Int32(256),
 						FSType:     "ext4",
 						ReadOnly:   false,
 					},
@@ -7655,7 +7655,7 @@ func TestValidateContainers(t *testing.T) {
 								Port: intstr.FromInt(80),
 							},
 						},
-						TerminationGracePeriodSeconds: utilpointer.Int64Ptr(10),
+						TerminationGracePeriodSeconds: utilpointer.Int64(10),
 					},
 					ImagePullPolicy:          "IfNotPresent",
 					TerminationMessagePolicy: "File",
@@ -7759,7 +7759,7 @@ func TestValidateContainers(t *testing.T) {
 						PeriodSeconds:                 -1,
 						SuccessThreshold:              -1,
 						FailureThreshold:              -1,
-						TerminationGracePeriodSeconds: utilpointer.Int64Ptr(-1),
+						TerminationGracePeriodSeconds: utilpointer.Int64(-1),
 					},
 					ImagePullPolicy:          "IfNotPresent",
 					TerminationMessagePolicy: "File",
@@ -7793,7 +7793,7 @@ func TestValidateContainers(t *testing.T) {
 						PeriodSeconds:                 -1,
 						SuccessThreshold:              -1,
 						FailureThreshold:              -1,
-						TerminationGracePeriodSeconds: utilpointer.Int64Ptr(-1),
+						TerminationGracePeriodSeconds: utilpointer.Int64(-1),
 					},
 					ImagePullPolicy:          "IfNotPresent",
 					TerminationMessagePolicy: "File",
@@ -7830,7 +7830,7 @@ func TestValidateContainers(t *testing.T) {
 						PeriodSeconds:                 -1,
 						SuccessThreshold:              -1,
 						FailureThreshold:              -1,
-						TerminationGracePeriodSeconds: utilpointer.Int64Ptr(-1),
+						TerminationGracePeriodSeconds: utilpointer.Int64(-1),
 					},
 					ImagePullPolicy:          "IfNotPresent",
 					TerminationMessagePolicy: "File",
@@ -8285,7 +8285,7 @@ func TestValidateInitContainers(t *testing.T) {
 						PeriodSeconds:                 -1,
 						SuccessThreshold:              -1,
 						FailureThreshold:              -1,
-						TerminationGracePeriodSeconds: utilpointer.Int64Ptr(-1),
+						TerminationGracePeriodSeconds: utilpointer.Int64(-1),
 					},
 				},
 			},
@@ -8902,13 +8902,13 @@ func TestValidatePodSpec(t *testing.T) {
 			Containers:       []core.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
 			RestartPolicy:    core.RestartPolicyAlways,
 			DNSPolicy:        core.DNSClusterFirst,
-			RuntimeClassName: utilpointer.StringPtr("valid-sandbox"),
+			RuntimeClassName: utilpointer.String("valid-sandbox"),
 		},
 		"populate Overhead": {
 			Containers:       []core.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
 			RestartPolicy:    core.RestartPolicyAlways,
 			DNSPolicy:        core.DNSClusterFirst,
-			RuntimeClassName: utilpointer.StringPtr("valid-sandbox"),
+			RuntimeClassName: utilpointer.String("valid-sandbox"),
 			Overhead:         core.ResourceList{},
 		},
 		"populate DNSPolicy": {
@@ -9106,7 +9106,7 @@ func TestValidatePodSpec(t *testing.T) {
 			Containers:       []core.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
 			RestartPolicy:    core.RestartPolicyAlways,
 			DNSPolicy:        core.DNSClusterFirst,
-			RuntimeClassName: utilpointer.StringPtr("invalid/sandbox"),
+			RuntimeClassName: utilpointer.String("invalid/sandbox"),
 		},
 		"bad empty fsGroupchangepolicy": {
 			Containers: []core.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
@@ -9598,7 +9598,7 @@ func TestValidatePod(t *testing.T) {
 				SecurityContext: &core.PodSecurityContext{
 					SeccompProfile: &core.SeccompProfile{
 						Type:             core.SeccompProfileTypeLocalhost,
-						LocalhostProfile: utilpointer.StringPtr("filename.json"),
+						LocalhostProfile: utilpointer.String("filename.json"),
 					},
 				},
 			},
@@ -9613,7 +9613,7 @@ func TestValidatePod(t *testing.T) {
 					SecurityContext: &core.SecurityContext{
 						SeccompProfile: &core.SeccompProfile{
 							Type:             core.SeccompProfileTypeLocalhost,
-							LocalhostProfile: utilpointer.StringPtr("filename.json"),
+							LocalhostProfile: utilpointer.String("filename.json"),
 						},
 					},
 				}},
@@ -11693,7 +11693,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					Name: "foo",
 				},
 				Spec: core.PodSpec{
-					TerminationGracePeriodSeconds: utilpointer.Int64Ptr(1),
+					TerminationGracePeriodSeconds: utilpointer.Int64(1),
 				},
 			},
 			old: core.Pod{
@@ -11701,7 +11701,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					Name: "foo",
 				},
 				Spec: core.PodSpec{
-					TerminationGracePeriodSeconds: utilpointer.Int64Ptr(-1),
+					TerminationGracePeriodSeconds: utilpointer.Int64(-1),
 				},
 			},
 			err:  "",
@@ -11713,7 +11713,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					Name: "foo",
 				},
 				Spec: core.PodSpec{
-					TerminationGracePeriodSeconds: utilpointer.Int64Ptr(0),
+					TerminationGracePeriodSeconds: utilpointer.Int64(0),
 				},
 			},
 			old: core.Pod{
@@ -11721,7 +11721,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					Name: "foo",
 				},
 				Spec: core.PodSpec{
-					TerminationGracePeriodSeconds: utilpointer.Int64Ptr(-1),
+					TerminationGracePeriodSeconds: utilpointer.Int64(-1),
 				},
 			},
 			err:  "spec: Forbidden: pod updates",
@@ -13073,7 +13073,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.Ports[0].Protocol = "UDP"
 			},
 			numErrs: 0,
@@ -13083,7 +13083,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.Ports[0] = core.ServicePort{Name: "q", Port: 12345, Protocol: "UDP", TargetPort: intstr.FromInt(12345)}
 			},
 			numErrs: 0,
@@ -13093,7 +13093,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "UDP", TargetPort: intstr.FromInt(12345)})
 			},
 			numErrs: 0,
@@ -13148,7 +13148,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 			},
 			numErrs: 0,
 		},
@@ -13157,7 +13157,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(false)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
 			},
 			numErrs: 0,
 		},
@@ -13174,7 +13174,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt(12345)})
 			},
 			numErrs: 0,
@@ -13184,7 +13184,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt(12345)})
 			},
 			numErrs: 0,
@@ -13249,7 +13249,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 			},
 			numErrs: 0,
 		},
@@ -13258,7 +13258,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt(12345)})
 			},
 			numErrs: 0,
@@ -13268,7 +13268,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", NodePort: 12345, TargetPort: intstr.FromInt(12345)})
 			},
 			numErrs: 0,
@@ -13322,7 +13322,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt(12345)})
 			},
 			numErrs: 0,
@@ -13334,7 +13334,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "kubelet", Port: 10250, Protocol: "TCP", TargetPort: intstr.FromInt(12345)})
 			},
 			numErrs: 1,
@@ -13344,7 +13344,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Annotations[core.AnnotationLoadBalancerSourceRangesKey] = "1.2.3.4/8,  5.6.7.8/16"
 			},
 			numErrs: 0,
@@ -13354,7 +13354,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Annotations[core.AnnotationLoadBalancerSourceRangesKey] = ""
 			},
 			numErrs: 0,
@@ -13371,7 +13371,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Annotations[core.AnnotationLoadBalancerSourceRangesKey] = "1.2.3.4/33"
 			},
 			numErrs: 1,
@@ -13388,7 +13388,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.LoadBalancerSourceRanges = []string{"1.2.3.4/8", "5.6.7.8/16"}
 			},
 			numErrs: 0,
@@ -13398,7 +13398,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.LoadBalancerSourceRanges = []string{"   "}
 			},
 			numErrs: 1,
@@ -13408,7 +13408,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.LoadBalancerSourceRanges = []string{"foo.bar"}
 			},
 			numErrs: 1,
@@ -13464,7 +13464,7 @@ func TestValidateServiceCreate(t *testing.T) {
 				s.Spec.ClusterIPs = []string{"None"}
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 			},
 			numErrs: 1,
 		},
@@ -13484,7 +13484,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "invalid externalTraffic field",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.ExternalTrafficPolicy = "invalid"
 			},
 			numErrs: 1,
@@ -13547,7 +13547,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "negative healthCheckNodePort field",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyLocal
 				s.Spec.HealthCheckNodePort = -1
 			},
@@ -13557,7 +13557,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "negative healthCheckNodePort field",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyLocal
 				s.Spec.HealthCheckNodePort = 31100
 			},
@@ -13571,7 +13571,7 @@ func TestValidateServiceCreate(t *testing.T) {
 				s.Spec.SessionAffinity = core.ServiceAffinityClientIP
 				s.Spec.SessionAffinityConfig = &core.SessionAffinityConfig{
 					ClientIP: &core.ClientIPConfig{
-						TimeoutSeconds: utilpointer.Int32Ptr(-1),
+						TimeoutSeconds: utilpointer.Int32(-1),
 					},
 				}
 			},
@@ -13582,11 +13582,11 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.SessionAffinity = core.ServiceAffinityNone
 				s.Spec.SessionAffinityConfig = &core.SessionAffinityConfig{
 					ClientIP: &core.ClientIPConfig{
-						TimeoutSeconds: utilpointer.Int32Ptr(90),
+						TimeoutSeconds: utilpointer.Int32(90),
 					},
 				}
 			},
@@ -13977,7 +13977,7 @@ func TestValidateServiceCreate(t *testing.T) {
 					Port:        12345,
 					TargetPort:  intstr.FromInt(12345),
 					Protocol:    "TCP",
-					AppProtocol: utilpointer.StringPtr("HTTP"),
+					AppProtocol: utilpointer.String("HTTP"),
 				}}
 			},
 			numErrs: 0,
@@ -13989,7 +13989,7 @@ func TestValidateServiceCreate(t *testing.T) {
 					Port:        12345,
 					TargetPort:  intstr.FromInt(12345),
 					Protocol:    "TCP",
-					AppProtocol: utilpointer.StringPtr("example.com/protocol"),
+					AppProtocol: utilpointer.String("example.com/protocol"),
 				}}
 			},
 			numErrs: 0,
@@ -14001,7 +14001,7 @@ func TestValidateServiceCreate(t *testing.T) {
 					Port:        12345,
 					TargetPort:  intstr.FromInt(12345),
 					Protocol:    "TCP",
-					AppProtocol: utilpointer.StringPtr("example.com/protocol_with{invalid}[characters]"),
+					AppProtocol: utilpointer.String("example.com/protocol_with{invalid}[characters]"),
 				}}
 			},
 			numErrs: 1,
@@ -14027,7 +14027,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		{
 			name: "Use AllocateLoadBalancerNodePorts when type is not LoadBalancer",
 			tweakSvc: func(s *core.Service) {
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 			},
 			numErrs: 1,
 		},
@@ -14036,8 +14036,8 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
-				s.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-load-balancer-class")
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				s.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
 			},
 			numErrs: 0,
 		},
@@ -14046,8 +14046,8 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
-				s.Spec.LoadBalancerClass = utilpointer.StringPtr("Bad/LoadBalancerClass")
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				s.Spec.LoadBalancerClass = utilpointer.String("Bad/LoadBalancerClass")
 			},
 			numErrs: 1,
 		},
@@ -14055,7 +14055,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "invalid: set LoadBalancerClass when type is not LoadBalancer",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeClusterIP
-				s.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-load-balancer-class")
+				s.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
 			},
 			numErrs: 1,
 		},
@@ -14086,7 +14086,7 @@ func TestValidateServiceExternalTrafficPolicy(t *testing.T) {
 			name: "valid loadBalancer service with externalTrafficPolicy and healthCheckNodePort set",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyLocal
 				s.Spec.HealthCheckNodePort = 34567
 			},
@@ -14111,7 +14111,7 @@ func TestValidateServiceExternalTrafficPolicy(t *testing.T) {
 			name: "cannot set healthCheckNodePort field on loadBalancer service with externalTrafficPolicy!=Local",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
-				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 				s.Spec.HealthCheckNodePort = 34567
 			},
@@ -15628,7 +15628,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				newSvc.Spec.SessionAffinity = "ClientIP"
 				newSvc.Spec.SessionAffinityConfig = &core.SessionAffinityConfig{
 					ClientIP: &core.ClientIPConfig{
-						TimeoutSeconds: utilpointer.Int32Ptr(90),
+						TimeoutSeconds: utilpointer.Int32(90),
 					},
 				}
 			},
@@ -15646,7 +15646,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 			},
 			numErrs: 0,
 		},
@@ -15669,10 +15669,10 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "add loadBalancerSourceRanges",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				newSvc.Spec.LoadBalancerSourceRanges = []string{"10.0.0.0/8"}
 			},
 			numErrs: 0,
@@ -15681,11 +15681,11 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "update loadBalancerSourceRanges",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				oldSvc.Spec.LoadBalancerSourceRanges = []string{"10.0.0.0/8"}
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				newSvc.Spec.LoadBalancerSourceRanges = []string{"10.100.0.0/16"}
 			},
 			numErrs: 0,
@@ -15697,7 +15697,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				newSvc.Spec.ClusterIPs = []string{"None"}
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 			},
 			numErrs: 1,
 		},
@@ -15801,7 +15801,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeClusterIP
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 
 				oldSvc.Spec.ClusterIP = "1.2.3.4"
 				oldSvc.Spec.ClusterIPs = []string{"1.2.3.4"}
@@ -15817,7 +15817,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeClusterIP
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 
 				oldSvc.Spec.ClusterIP = ""
 				oldSvc.Spec.ClusterIPs = nil
@@ -15831,10 +15831,10 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type can change its AllocateLoadBalancerNodePorts from true to false",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(false)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
 			},
 			numErrs: 0,
 		},
@@ -15842,10 +15842,10 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type can change its AllocateLoadBalancerNodePorts from false to true",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(false)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 			},
 			numErrs: 0,
 		},
@@ -15913,7 +15913,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 
 				oldSvc.Spec.ClusterIP = "1.2.3.4"
 				oldSvc.Spec.ClusterIPs = []string{"1.2.3.4"}
@@ -15929,7 +15929,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 
 				oldSvc.Spec.ClusterIP = ""
 				oldSvc.Spec.ClusterIPs = nil
@@ -15943,10 +15943,10 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type cannot change its set ClusterIP",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 
 				oldSvc.Spec.ClusterIP = "1.2.3.4"
 				oldSvc.Spec.ClusterIPs = []string{"1.2.3.4"}
@@ -15960,10 +15960,10 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type can change its empty ClusterIP",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 
 				oldSvc.Spec.ClusterIP = ""
 				oldSvc.Spec.ClusterIPs = nil
@@ -15977,7 +15977,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type cannot change its set ClusterIP when changing type to ClusterIP",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				newSvc.Spec.Type = core.ServiceTypeClusterIP
 
 				oldSvc.Spec.ClusterIP = "1.2.3.4"
@@ -15992,7 +15992,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type can change its empty ClusterIP when changing type to ClusterIP",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				newSvc.Spec.Type = core.ServiceTypeClusterIP
 
 				oldSvc.Spec.ClusterIP = ""
@@ -16007,7 +16007,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type cannot change its set ClusterIP when changing type to NodePort",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				newSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 
@@ -16023,7 +16023,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "Service with LoadBalancer type can change its empty ClusterIP when changing type to NodePort",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				newSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 
@@ -16494,7 +16494,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "update to valid app protocol",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP"}}
-				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP", AppProtocol: utilpointer.StringPtr("https")}}
+				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP", AppProtocol: utilpointer.String("https")}}
 			},
 			numErrs: 0,
 		},
@@ -16502,14 +16502,14 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "update to invalid app protocol",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP"}}
-				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP", AppProtocol: utilpointer.StringPtr("~https")}}
+				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP", AppProtocol: utilpointer.String("~https")}}
 			},
 			numErrs: 1,
 		},
 		{
 			name: "Set AllocateLoadBalancerNodePorts when type is not LoadBalancer",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 			},
 			numErrs: 1,
 		},
@@ -16517,13 +16517,13 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "update LoadBalancer type of service without change LoadBalancerClass",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-old")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-old")
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
-				newSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-old")
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-old")
 			},
 			numErrs: 0,
 		},
@@ -16531,13 +16531,13 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "invalid: change LoadBalancerClass when update service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-old")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-old")
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
-				newSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-new")
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-new")
 			},
 			numErrs: 1,
 		},
@@ -16545,12 +16545,12 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "invalid: unset LoadBalancerClass when update service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-old")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-old")
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				newSvc.Spec.LoadBalancerClass = nil
 			},
 			numErrs: 1,
@@ -16559,13 +16559,13 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "invalid: set LoadBalancerClass when update service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				oldSvc.Spec.LoadBalancerClass = nil
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
-				newSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-new")
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-new")
 			},
 			numErrs: 1,
 		},
@@ -16576,8 +16576,8 @@ func TestValidateServiceUpdate(t *testing.T) {
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
-				newSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-load-balancer-class")
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
 			},
 			numErrs: 0,
 		},
@@ -16588,7 +16588,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 				newSvc.Spec.LoadBalancerClass = nil
 			},
 			numErrs: 0,
@@ -16600,8 +16600,8 @@ func TestValidateServiceUpdate(t *testing.T) {
 
 				newSvc.Spec.Type = core.ServiceTypeLoadBalancer
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
-				newSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("Bad/LoadBalancerclass")
+				newSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				newSvc.Spec.LoadBalancerClass = utilpointer.String("Bad/LoadBalancerclass")
 			},
 			numErrs: 2,
 		},
@@ -16611,7 +16611,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeClusterIP
 
 				newSvc.Spec.Type = core.ServiceTypeClusterIP
-				newSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
 			},
 			numErrs: 2,
 		},
@@ -16621,7 +16621,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = core.ServiceTypeExternalName
 
 				newSvc.Spec.Type = core.ServiceTypeExternalName
-				newSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
 			},
 			numErrs: 3,
 		},
@@ -16632,7 +16632,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 
 				newSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
 			},
 			numErrs: 2,
 		},
@@ -16640,11 +16640,11 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "invalid: set LoadBalancerClass when update from LoadBalancer service to non LoadBalancer type of service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-load-balancer-class")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
 
 				newSvc.Spec.Type = core.ServiceTypeClusterIP
-				newSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
 			},
 			numErrs: 2,
 		},
@@ -16652,11 +16652,11 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "invalid: set LoadBalancerClass when update from LoadBalancer service to non LoadBalancer type of service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-load-balancer-class")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
 
 				newSvc.Spec.Type = core.ServiceTypeExternalName
-				newSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
 			},
 			numErrs: 3,
 		},
@@ -16664,12 +16664,12 @@ func TestValidateServiceUpdate(t *testing.T) {
 			name: "invalid: set LoadBalancerClass when update from LoadBalancer service to non LoadBalancer type of service",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
 				oldSvc.Spec.Type = core.ServiceTypeLoadBalancer
-				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
-				oldSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-load-balancer-class")
+				oldSvc.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
+				oldSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
 
 				newSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				newSvc.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test-load-balancer-class")
+				newSvc.Spec.LoadBalancerClass = utilpointer.String("test.com/test-load-balancer-class")
 			},
 			numErrs: 2,
 		},
@@ -18192,7 +18192,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				Subsets: []core.EndpointSubset{
 					{
 						Addresses: []core.EndpointAddress{{IP: "10.10.1.1"}},
-						Ports:     []core.EndpointPort{{Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.StringPtr("HTTP")}},
+						Ports:     []core.EndpointPort{{Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.String("HTTP")}},
 					},
 				},
 			},
@@ -18386,7 +18386,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				Subsets: []core.EndpointSubset{
 					{
 						Addresses: []core.EndpointAddress{{IP: "10.10.1.1"}},
-						Ports:     []core.EndpointPort{{Name: "p", Port: 93, Protocol: "TCP", AppProtocol: utilpointer.StringPtr("lots-of[invalid]-{chars}")}},
+						Ports:     []core.EndpointPort{{Name: "p", Port: 93, Protocol: "TCP", AppProtocol: utilpointer.String("lots-of[invalid]-{chars}")}},
 					},
 				},
 			},
@@ -18422,7 +18422,7 @@ func TestValidateEndpointsUpdate(t *testing.T) {
 				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP"}}
 			},
 			tweakNewEndpoints: func(ep *core.Endpoints) {
-				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.StringPtr("https")}}
+				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.String("https")}}
 			},
 			numExpectedErrors: 0,
 		},
@@ -18431,7 +18431,7 @@ func TestValidateEndpointsUpdate(t *testing.T) {
 				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP"}}
 			},
 			tweakNewEndpoints: func(ep *core.Endpoints) {
-				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.StringPtr("~https")}}
+				ep.Subsets[0].Ports = []core.EndpointPort{{Name: "a", Port: 8675, Protocol: "TCP", AppProtocol: utilpointer.String("~https")}}
 			},
 			numExpectedErrors: 1,
 		},
@@ -18820,7 +18820,7 @@ func TestValidateTLSSecret(t *testing.T) {
 func TestValidateLinuxSecurityContext(t *testing.T) {
 	runAsUser := int64(1)
 	validLinuxSC := &core.SecurityContext{
-		Privileged: utilpointer.BoolPtr(false),
+		Privileged: utilpointer.Bool(false),
 		Capabilities: &core.Capabilities{
 			Add:  []core.Capability{"foo"},
 			Drop: []core.Capability{"bar"},
@@ -18874,7 +18874,7 @@ func TestValidateSecurityContext(t *testing.T) {
 	runAsUser := int64(1)
 	fullValidSC := func() *core.SecurityContext {
 		return &core.SecurityContext{
-			Privileged: utilpointer.BoolPtr(false),
+			Privileged: utilpointer.Bool(false),
 			Capabilities: &core.Capabilities{
 				Add:  []core.Capability{"foo"},
 				Drop: []core.Capability{"bar"},
@@ -18919,19 +18919,19 @@ func TestValidateSecurityContext(t *testing.T) {
 	}
 
 	privRequestWithGlobalDeny := fullValidSC()
-	privRequestWithGlobalDeny.Privileged = utilpointer.BoolPtr(true)
+	privRequestWithGlobalDeny.Privileged = utilpointer.Bool(true)
 
 	negativeRunAsUser := fullValidSC()
 	negativeUser := int64(-1)
 	negativeRunAsUser.RunAsUser = &negativeUser
 
 	privWithoutEscalation := fullValidSC()
-	privWithoutEscalation.Privileged = utilpointer.BoolPtr(true)
-	privWithoutEscalation.AllowPrivilegeEscalation = utilpointer.BoolPtr(false)
+	privWithoutEscalation.Privileged = utilpointer.Bool(true)
+	privWithoutEscalation.AllowPrivilegeEscalation = utilpointer.Bool(false)
 
 	capSysAdminWithoutEscalation := fullValidSC()
 	capSysAdminWithoutEscalation.Capabilities.Add = []core.Capability{"CAP_SYS_ADMIN"}
-	capSysAdminWithoutEscalation.AllowPrivilegeEscalation = utilpointer.BoolPtr(false)
+	capSysAdminWithoutEscalation.AllowPrivilegeEscalation = utilpointer.Bool(false)
 
 	errorCases := map[string]struct {
 		sc           *core.SecurityContext
@@ -19479,17 +19479,17 @@ func TestValidateOrSetClientIPAffinityConfig(t *testing.T) {
 	successCases := map[string]*core.SessionAffinityConfig{
 		"non-empty config, valid timeout: 1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32Ptr(1),
+				TimeoutSeconds: utilpointer.Int32(1),
 			},
 		},
 		"non-empty config, valid timeout: core.MaxClientIPServiceAffinitySeconds-1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32Ptr(core.MaxClientIPServiceAffinitySeconds - 1),
+				TimeoutSeconds: utilpointer.Int32(core.MaxClientIPServiceAffinitySeconds - 1),
 			},
 		},
 		"non-empty config, valid timeout: core.MaxClientIPServiceAffinitySeconds": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32Ptr(core.MaxClientIPServiceAffinitySeconds),
+				TimeoutSeconds: utilpointer.Int32(core.MaxClientIPServiceAffinitySeconds),
 			},
 		},
 	}
@@ -19512,17 +19512,17 @@ func TestValidateOrSetClientIPAffinityConfig(t *testing.T) {
 		},
 		"non-empty config, invalid timeout: core.MaxClientIPServiceAffinitySeconds+1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32Ptr(core.MaxClientIPServiceAffinitySeconds + 1),
+				TimeoutSeconds: utilpointer.Int32(core.MaxClientIPServiceAffinitySeconds + 1),
 			},
 		},
 		"non-empty config, invalid timeout: -1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32Ptr(-1),
+				TimeoutSeconds: utilpointer.Int32(-1),
 			},
 		},
 		"non-empty config, invalid timeout: 0": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: utilpointer.Int32Ptr(0),
+				TimeoutSeconds: utilpointer.Int32(0),
 			},
 		},
 	}
@@ -20770,7 +20770,7 @@ func TestValidateSeccompAnnotationsAndFieldsMatch(t *testing.T) {
 		{
 			description:     "localhost/test.json annotation and SeccompProfileTypeLocalhost with correct profile should return empty",
 			annotationValue: "localhost/test.json",
-			seccompField:    &core.SeccompProfile{Type: core.SeccompProfileTypeLocalhost, LocalhostProfile: utilpointer.StringPtr("test.json")},
+			seccompField:    &core.SeccompProfile{Type: core.SeccompProfileTypeLocalhost, LocalhostProfile: utilpointer.String("test.json")},
 			expectedErr:     nil,
 		},
 		{
@@ -20783,7 +20783,7 @@ func TestValidateSeccompAnnotationsAndFieldsMatch(t *testing.T) {
 		{
 			description:     "localhost/test.json annotation and SeccompProfileTypeLocalhost with different profile should error",
 			annotationValue: "localhost/test.json",
-			seccompField:    &core.SeccompProfile{Type: core.SeccompProfileTypeLocalhost, LocalhostProfile: utilpointer.StringPtr("different.json")},
+			seccompField:    &core.SeccompProfile{Type: core.SeccompProfileTypeLocalhost, LocalhostProfile: utilpointer.String("different.json")},
 			fldPath:         rootFld,
 			expectedErr:     field.Forbidden(rootFld.Child("localhostProfile"), "seccomp profile in annotation and field must match"),
 		},

--- a/pkg/apis/discovery/v1beta1/conversion_test.go
+++ b/pkg/apis/discovery/v1beta1/conversion_test.go
@@ -63,7 +63,7 @@ func TestEndpointZoneConverstion(t *testing.T) {
 				DeprecatedTopology: map[string]string{
 					"key1": "val1",
 				},
-				Zone: utilpointer.StringPtr("zone1"),
+				Zone: utilpointer.String("zone1"),
 			},
 		},
 		{
@@ -74,19 +74,19 @@ func TestEndpointZoneConverstion(t *testing.T) {
 				},
 			},
 			internal: discovery.Endpoint{
-				Zone: utilpointer.StringPtr("zone1"),
+				Zone: utilpointer.String("zone1"),
 			},
 		},
 		{
 			desc: "nodeName and topology[hostname] are populated with different values",
 			external: v1beta1.Endpoint{
-				NodeName: utilpointer.StringPtr("node-1"),
+				NodeName: utilpointer.String("node-1"),
 				Topology: map[string]string{
 					corev1.LabelHostname: "node-2",
 				},
 			},
 			internal: discovery.Endpoint{
-				NodeName: utilpointer.StringPtr("node-1"),
+				NodeName: utilpointer.String("node-1"),
 				DeprecatedTopology: map[string]string{
 					corev1.LabelHostname: "node-2",
 				},
@@ -95,13 +95,13 @@ func TestEndpointZoneConverstion(t *testing.T) {
 		{
 			desc: "nodeName and topology[hostname] are populated with same values",
 			external: v1beta1.Endpoint{
-				NodeName: utilpointer.StringPtr("node-1"),
+				NodeName: utilpointer.String("node-1"),
 				Topology: map[string]string{
 					corev1.LabelHostname: "node-1",
 				},
 			},
 			internal: discovery.Endpoint{
-				NodeName: utilpointer.StringPtr("node-1"),
+				NodeName: utilpointer.String("node-1"),
 			},
 		},
 		{
@@ -120,13 +120,13 @@ func TestEndpointZoneConverstion(t *testing.T) {
 		{
 			desc: "only nodeName is populated",
 			external: v1beta1.Endpoint{
-				NodeName: utilpointer.StringPtr("node-1"),
+				NodeName: utilpointer.String("node-1"),
 				Topology: map[string]string{
 					corev1.LabelHostname: "node-1",
 				},
 			},
 			internal: discovery.Endpoint{
-				NodeName: utilpointer.StringPtr("node-1"),
+				NodeName: utilpointer.String("node-1"),
 			},
 		},
 	}

--- a/pkg/apis/discovery/validation/validation_test.go
+++ b/pkg/apis/discovery/validation/validation_test.go
@@ -44,12 +44,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.StringPtr("valid-123"),
+					Hostname:  utilpointer.String("valid-123"),
 				}},
 			},
 		},
@@ -59,12 +59,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv6,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"a00:100::4"},
-					Hostname:  utilpointer.StringPtr("valid-123"),
+					Hostname:  utilpointer.String("valid-123"),
 				}},
 			},
 		},
@@ -74,12 +74,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeFQDN,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"foo.example.com", "example.com", "example.com.", "hyphens-are-good.example.com"},
-					Hostname:  utilpointer.StringPtr("valid-123"),
+					Hostname:  utilpointer.String("valid-123"),
 				}},
 			},
 		},
@@ -89,18 +89,18 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("tcp"),
+					Name:     utilpointer.String("tcp"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}, {
-					Name:     utilpointer.StringPtr("udp"),
+					Name:     utilpointer.String("udp"),
 					Protocol: protocolPtr(api.ProtocolUDP),
 				}, {
-					Name:     utilpointer.StringPtr("sctp"),
+					Name:     utilpointer.String("sctp"),
 					Protocol: protocolPtr(api.ProtocolSCTP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.StringPtr("valid-123"),
+					Hostname:  utilpointer.String("valid-123"),
 				}},
 			},
 		},
@@ -110,25 +110,25 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:        utilpointer.StringPtr("one"),
+					Name:        utilpointer.String("one"),
 					Protocol:    protocolPtr(api.ProtocolTCP),
-					AppProtocol: utilpointer.StringPtr("HTTP"),
+					AppProtocol: utilpointer.String("HTTP"),
 				}, {
-					Name:        utilpointer.StringPtr("two"),
+					Name:        utilpointer.String("two"),
 					Protocol:    protocolPtr(api.ProtocolTCP),
-					AppProtocol: utilpointer.StringPtr("https"),
+					AppProtocol: utilpointer.String("https"),
 				}, {
-					Name:        utilpointer.StringPtr("three"),
+					Name:        utilpointer.String("three"),
 					Protocol:    protocolPtr(api.ProtocolTCP),
-					AppProtocol: utilpointer.StringPtr("my-protocol"),
+					AppProtocol: utilpointer.String("my-protocol"),
 				}, {
-					Name:        utilpointer.StringPtr("four"),
+					Name:        utilpointer.String("four"),
 					Protocol:    protocolPtr(api.ProtocolTCP),
-					AppProtocol: utilpointer.StringPtr("example.com/custom-protocol"),
+					AppProtocol: utilpointer.String("example.com/custom-protocol"),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.StringPtr("valid-123"),
+					Hostname:  utilpointer.String("valid-123"),
 				}},
 			},
 		},
@@ -138,10 +138,10 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr(""),
+					Name:     utilpointer.String(""),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}, {
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -155,7 +155,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr(strings.Repeat("a", 63)),
+					Name:     utilpointer.String(strings.Repeat("a", 63)),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -195,7 +195,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -209,7 +209,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -224,7 +224,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -243,10 +243,10 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr(""),
+					Name:     utilpointer.String(""),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}, {
-					Name:     utilpointer.StringPtr(""),
+					Name:     utilpointer.String(""),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{},
@@ -258,7 +258,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("aCapital"),
+					Name:     utilpointer.String("aCapital"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{},
@@ -270,7 +270,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("almost_valid"),
+					Name:     utilpointer.String("almost_valid"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{},
@@ -282,7 +282,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr(strings.Repeat("a", 64)),
+					Name:     utilpointer.String(strings.Repeat("a", 64)),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{},
@@ -294,7 +294,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.Protocol("foo")),
 				}},
 			},
@@ -322,7 +322,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -336,7 +336,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -350,7 +350,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -365,7 +365,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -380,12 +380,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.StringPtr("--INVALID"),
+					Hostname:  utilpointer.String("--INVALID"),
 				}},
 			},
 		},
@@ -398,12 +398,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				},
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.StringPtr("valid-123"),
+					Hostname:  utilpointer.String("valid-123"),
 				}},
 			},
 		},
@@ -413,12 +413,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"123.456.789.012"},
-					Hostname:  utilpointer.StringPtr("valid-123"),
+					Hostname:  utilpointer.String("valid-123"),
 				}},
 			},
 		},
@@ -428,12 +428,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"123.456.789.012", "2001:4860:4860::8888"},
-					Hostname:  utilpointer.StringPtr("valid-123"),
+					Hostname:  utilpointer.String("valid-123"),
 				}},
 			},
 		},
@@ -443,12 +443,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv6,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"123.456.789.012", "2001:4860:4860:defg"},
-					Hostname:  utilpointer.StringPtr("valid-123"),
+					Hostname:  utilpointer.String("valid-123"),
 				}},
 			},
 		},
@@ -458,12 +458,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeFQDN,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"foo.*", "FOO.example.com", "underscores_are_bad.example.com", "*.example.com"},
-					Hostname:  utilpointer.StringPtr("valid-123"),
+					Hostname:  utilpointer.String("valid-123"),
 				}},
 			},
 		},
@@ -473,13 +473,13 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:        utilpointer.StringPtr("http"),
+					Name:        utilpointer.String("http"),
 					Protocol:    protocolPtr(api.ProtocolTCP),
-					AppProtocol: utilpointer.StringPtr("--"),
+					AppProtocol: utilpointer.String("--"),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.StringPtr("valid-123"),
+					Hostname:  utilpointer.String("valid-123"),
 				}},
 			},
 		},
@@ -489,7 +489,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -506,7 +506,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -527,7 +527,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -558,7 +558,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -573,12 +573,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"127.0.0.1"},
-					Hostname:  utilpointer.StringPtr("valid-123"),
+					Hostname:  utilpointer.String("valid-123"),
 				}},
 			},
 		},
@@ -588,12 +588,12 @@ func TestValidateEndpointSlice(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv6,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"fe80::9656:d028:8652:66b6"},
-					Hostname:  utilpointer.StringPtr("valid-123"),
+					Hostname:  utilpointer.String("valid-123"),
 				}},
 			},
 		},
@@ -626,12 +626,12 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.StringPtr("valid-123"),
+					Hostname:  utilpointer.String("valid-123"),
 				}},
 			},
 		},
@@ -641,13 +641,13 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.StringPtr("valid-123"),
-					NodeName:  utilpointer.StringPtr("valid-node-name"),
+					Hostname:  utilpointer.String("valid-123"),
+					NodeName:  utilpointer.String("valid-node-name"),
 				}},
 			},
 		},
@@ -659,13 +659,13 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
 					Addresses: generateIPAddresses(1),
-					Hostname:  utilpointer.StringPtr("valid-123"),
-					NodeName:  utilpointer.StringPtr("INvalid-node-name"),
+					Hostname:  utilpointer.String("valid-123"),
+					NodeName:  utilpointer.String("INvalid-node-name"),
 				}},
 			},
 		},
@@ -675,7 +675,7 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressType("IP"),
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -689,7 +689,7 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressType("other"),
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr("http"),
+					Name:     utilpointer.String("http"),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -744,7 +744,7 @@ func TestValidateEndpointSliceUpdate(t *testing.T) {
 				AddressType: discovery.AddressTypeIPv4,
 				Endpoints: []discovery.Endpoint{{
 					Addresses: []string{"10.1.2.3"},
-					NodeName:  utilpointer.StringPtr("INVALID foo"),
+					NodeName:  utilpointer.String("INVALID foo"),
 				}},
 			},
 			expectedErrors: 1,
@@ -781,7 +781,7 @@ func TestValidateEndpointSliceUpdate(t *testing.T) {
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
 				Ports: []discovery.EndpointPort{{
-					Name:     utilpointer.StringPtr(""),
+					Name:     utilpointer.String(""),
 					Protocol: protocolPtr(api.Protocol("invalid")),
 				}},
 			},
@@ -809,7 +809,7 @@ func generatePorts(n int) []discovery.EndpointPort {
 	ports := []discovery.EndpointPort{}
 	for i := 0; i < n; i++ {
 		ports = append(ports, discovery.EndpointPort{
-			Name:     utilpointer.StringPtr(fmt.Sprintf("http-%d", i)),
+			Name:     utilpointer.String(fmt.Sprintf("http-%d", i)),
 			Protocol: protocolPtr(api.ProtocolTCP),
 		})
 	}

--- a/pkg/apis/networking/fuzzer/fuzzer.go
+++ b/pkg/apis/networking/fuzzer/fuzzer.go
@@ -70,7 +70,7 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 			// default Parameters to Cluster
 			if p.Spec.Parameters == nil || p.Spec.Parameters.Scope == nil {
 				p.Spec.Parameters = &networking.IngressClassParametersReference{
-					Scope: utilpointer.StringPtr(networking.IngressClassParametersReferenceScopeCluster),
+					Scope: utilpointer.String(networking.IngressClassParametersReferenceScopeCluster),
 				}
 			}
 		},

--- a/pkg/apis/networking/v1/defaults.go
+++ b/pkg/apis/networking/v1/defaults.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilpointer "k8s.io/utils/pointer"
@@ -47,6 +47,6 @@ func SetDefaults_NetworkPolicy(obj *networkingv1.NetworkPolicy) {
 
 func SetDefaults_IngressClass(obj *networkingv1.IngressClass) {
 	if obj.Spec.Parameters != nil && obj.Spec.Parameters.Scope == nil {
-		obj.Spec.Parameters.Scope = utilpointer.StringPtr(networkingv1.IngressClassParametersReferenceScopeCluster)
+		obj.Spec.Parameters.Scope = utilpointer.String(networkingv1.IngressClassParametersReferenceScopeCluster)
 	}
 }

--- a/pkg/apis/networking/v1/defaults_test.go
+++ b/pkg/apis/networking/v1/defaults_test.go
@@ -258,7 +258,7 @@ func TestSetDefaultsForIngressClassParametersReference(t *testing.T) {
 					Parameters: &networkingv1.IngressClassParametersReference{
 						Kind:  "k",
 						Name:  "n",
-						Scope: utilpointer.StringPtr(networkingv1.IngressClassParametersReferenceScopeCluster),
+						Scope: utilpointer.String(networkingv1.IngressClassParametersReferenceScopeCluster),
 					},
 				},
 			},
@@ -271,8 +271,8 @@ func TestSetDefaultsForIngressClassParametersReference(t *testing.T) {
 					Parameters: &networkingv1.IngressClassParametersReference{
 						Kind:      "k",
 						Name:      "n",
-						Scope:     utilpointer.StringPtr(networkingv1.IngressClassParametersReferenceScopeNamespace),
-						Namespace: utilpointer.StringPtr("foo-ns"),
+						Scope:     utilpointer.String(networkingv1.IngressClassParametersReferenceScopeNamespace),
+						Namespace: utilpointer.String("foo-ns"),
 					},
 				},
 			},
@@ -282,8 +282,8 @@ func TestSetDefaultsForIngressClassParametersReference(t *testing.T) {
 					Parameters: &networkingv1.IngressClassParametersReference{
 						Kind:      "k",
 						Name:      "n",
-						Scope:     utilpointer.StringPtr(networkingv1.IngressClassParametersReferenceScopeNamespace),
-						Namespace: utilpointer.StringPtr("foo-ns"),
+						Scope:     utilpointer.String(networkingv1.IngressClassParametersReferenceScopeNamespace),
+						Namespace: utilpointer.String("foo-ns"),
 					},
 				},
 			},

--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -599,7 +599,7 @@ func validateIngressClassParametersReference(params *networking.IngressClassPara
 	}
 
 	if params.Scope != nil || params.Namespace != nil {
-		scope := utilpointer.StringPtrDerefOr(params.Scope, "")
+		scope := utilpointer.StringDeref(params.Scope, "")
 
 		if !supportedIngressClassParametersReferenceScopes.Has(scope) {
 			allErrs = append(allErrs, field.NotSupported(fldPath.Child("scope"), scope,

--- a/pkg/apis/networking/validation/validation_test.go
+++ b/pkg/apis/networking/validation/validation_test.go
@@ -61,7 +61,7 @@ func makePort(proto *api.Protocol, port intstr.IntOrString, endPort int32) netwo
 		r.Port = &port
 	}
 	if endPort != 0 {
-		r.EndPort = utilpointer.Int32Ptr(endPort)
+		r.EndPort = utilpointer.Int32(endPort)
 	}
 	return r
 }
@@ -735,7 +735,7 @@ func TestValidateIngress(t *testing.T) {
 								Backend: networking.IngressBackend{
 									Service: serviceBackend,
 									Resource: &api.TypedLocalObjectReference{
-										APIGroup: utilpointer.StringPtr("example.com"),
+										APIGroup: utilpointer.String("example.com"),
 										Kind:     "foo",
 										Name:     "bar",
 									},
@@ -760,7 +760,7 @@ func TestValidateIngress(t *testing.T) {
 								Backend: networking.IngressBackend{
 									Service: serviceBackend,
 									Resource: &api.TypedLocalObjectReference{
-										APIGroup: utilpointer.StringPtr("example.com"),
+										APIGroup: utilpointer.String("example.com"),
 										Kind:     "foo",
 										Name:     "bar",
 									},
@@ -779,7 +779,7 @@ func TestValidateIngress(t *testing.T) {
 				ing.Spec.DefaultBackend = &networking.IngressBackend{
 					Service: serviceBackend,
 					Resource: &api.TypedLocalObjectReference{
-						APIGroup: utilpointer.StringPtr("example.com"),
+						APIGroup: utilpointer.String("example.com"),
 						Kind:     "foo",
 						Name:     "bar",
 					},
@@ -794,7 +794,7 @@ func TestValidateIngress(t *testing.T) {
 				ing.Spec.DefaultBackend = &networking.IngressBackend{
 					Service: serviceBackend,
 					Resource: &api.TypedLocalObjectReference{
-						APIGroup: utilpointer.StringPtr("example.com"),
+						APIGroup: utilpointer.String("example.com"),
 						Kind:     "foo",
 						Name:     "bar",
 					},
@@ -961,7 +961,7 @@ func TestValidateIngressCreate(t *testing.T) {
 		Service: serviceBackend,
 	}
 	resourceBackend := &api.TypedLocalObjectReference{
-		APIGroup: utilpointer.StringPtr("example.com"),
+		APIGroup: utilpointer.String("example.com"),
 		Kind:     "foo",
 		Name:     "bar",
 	}
@@ -983,7 +983,7 @@ func TestValidateIngressCreate(t *testing.T) {
 	}{
 		"class field set": {
 			tweakIngress: func(ingress *networking.Ingress) {
-				ingress.Spec.IngressClassName = utilpointer.StringPtr("bar")
+				ingress.Spec.IngressClassName = utilpointer.String("bar")
 			},
 			expectedErrs: field.ErrorList{},
 		},
@@ -995,7 +995,7 @@ func TestValidateIngressCreate(t *testing.T) {
 		},
 		"class field and annotation set": {
 			tweakIngress: func(ingress *networking.Ingress) {
-				ingress.Spec.IngressClassName = utilpointer.StringPtr("bar")
+				ingress.Spec.IngressClassName = utilpointer.String("bar")
 				ingress.Annotations = map[string]string{annotationIngressClass: "foo"}
 			},
 			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("annotations").Child(annotationIngressClass), "foo", "can not be set when the class field is also set")},
@@ -1138,7 +1138,7 @@ func TestValidateIngressUpdate(t *testing.T) {
 		Service: serviceBackend,
 	}
 	resourceBackend := &api.TypedLocalObjectReference{
-		APIGroup: utilpointer.StringPtr("example.com"),
+		APIGroup: utilpointer.String("example.com"),
 		Kind:     "foo",
 		Name:     "bar",
 	}
@@ -1159,7 +1159,7 @@ func TestValidateIngressUpdate(t *testing.T) {
 	}{
 		"class field set": {
 			tweakIngresses: func(newIngress, oldIngress *networking.Ingress) {
-				newIngress.Spec.IngressClassName = utilpointer.StringPtr("bar")
+				newIngress.Spec.IngressClassName = utilpointer.String("bar")
 			},
 			expectedErrs: field.ErrorList{},
 		},
@@ -1171,7 +1171,7 @@ func TestValidateIngressUpdate(t *testing.T) {
 		},
 		"class field and annotation set": {
 			tweakIngresses: func(newIngress, oldIngress *networking.Ingress) {
-				newIngress.Spec.IngressClassName = utilpointer.StringPtr("bar")
+				newIngress.Spec.IngressClassName = utilpointer.String("bar")
 				newIngress.Annotations = map[string]string{annotationIngressClass: "foo"}
 			},
 			expectedErrs: field.ErrorList{},
@@ -1595,44 +1595,44 @@ func TestValidateIngressClass(t *testing.T) {
 		},
 		"valid name, valid controller, valid params": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(utilpointer.StringPtr("example.com"), "foo", "bar", utilpointer.StringPtr("Cluster"), nil)),
+				setParams(makeIngressClassParams(utilpointer.String("example.com"), "foo", "bar", utilpointer.String("Cluster"), nil)),
 			),
 			expectedErrs: field.ErrorList{},
 		},
 		"valid name, valid controller, invalid params (no kind)": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(utilpointer.StringPtr("example.com"), "", "bar", utilpointer.StringPtr("Cluster"), nil)),
+				setParams(makeIngressClassParams(utilpointer.String("example.com"), "", "bar", utilpointer.String("Cluster"), nil)),
 			),
 			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec.parameters.kind"), "kind is required")},
 		},
 		"valid name, valid controller, invalid params (no name)": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(utilpointer.StringPtr("example.com"), "foo", "", utilpointer.StringPtr("Cluster"), nil)),
+				setParams(makeIngressClassParams(utilpointer.String("example.com"), "foo", "", utilpointer.String("Cluster"), nil)),
 			),
 			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec.parameters.name"), "name is required")},
 		},
 		"valid name, valid controller, invalid params (bad kind)": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo/", "bar", utilpointer.StringPtr("Cluster"), nil)),
+				setParams(makeIngressClassParams(nil, "foo/", "bar", utilpointer.String("Cluster"), nil)),
 			),
 			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec.parameters.kind"), "foo/", "may not contain '/'")},
 		},
 		"valid name, valid controller, invalid params (bad scope)": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.StringPtr("bad-scope"), nil)),
+				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.String("bad-scope"), nil)),
 			),
 			expectedErrs: field.ErrorList{field.NotSupported(field.NewPath("spec.parameters.scope"),
 				"bad-scope", []string{"Cluster", "Namespace"})},
 		},
 		"valid name, valid controller, valid Namespace scope": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.StringPtr("Namespace"), utilpointer.StringPtr("foo-ns"))),
+				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.String("Namespace"), utilpointer.String("foo-ns"))),
 			),
 			expectedErrs: field.ErrorList{},
 		},
 		"valid name, valid controller, valid scope, invalid namespace": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.StringPtr("Namespace"), utilpointer.StringPtr("foo_ns"))),
+				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.String("Namespace"), utilpointer.String("foo_ns"))),
 			),
 			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec.parameters.namespace"), "foo_ns",
 				"a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',"+
@@ -1641,27 +1641,27 @@ func TestValidateIngressClass(t *testing.T) {
 		},
 		"valid name, valid controller, valid Cluster scope": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.StringPtr("Cluster"), nil)),
+				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.String("Cluster"), nil)),
 			),
 			expectedErrs: field.ErrorList{},
 		},
 		"namespace not set when scope is Namespace": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.StringPtr("Namespace"), nil)),
+				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.String("Namespace"), nil)),
 			),
 			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec.parameters.namespace"),
 				"`parameters.scope` is set to 'Namespace'")},
 		},
 		"namespace is forbidden when scope is Cluster": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.StringPtr("Cluster"), utilpointer.StringPtr("foo-ns"))),
+				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.String("Cluster"), utilpointer.String("foo-ns"))),
 			),
 			expectedErrs: field.ErrorList{field.Forbidden(field.NewPath("spec.parameters.namespace"),
 				"`parameters.scope` is set to 'Cluster'")},
 		},
 		"empty namespace is forbidden when scope is Cluster": {
 			ingressClass: makeValidIngressClass("test123", "foo.co/bar",
-				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.StringPtr("Cluster"), utilpointer.StringPtr(""))),
+				setParams(makeIngressClassParams(nil, "foo", "bar", utilpointer.String("Cluster"), utilpointer.String(""))),
 			),
 			expectedErrs: field.ErrorList{field.Forbidden(field.NewPath("spec.parameters.namespace"),
 				"`parameters.scope` is set to 'Cluster'")},
@@ -1712,7 +1712,7 @@ func TestValidateIngressClassUpdate(t *testing.T) {
 			newIngressClass: makeValidIngressClass("test123", "foo.co/bar",
 				setResourceVersion("2"),
 				setParams(
-					makeIngressClassParams(utilpointer.StringPtr("v1"), "ConfigMap", "foo", utilpointer.StringPtr("Namespace"), utilpointer.StringPtr("bar")),
+					makeIngressClassParams(utilpointer.String("v1"), "ConfigMap", "foo", utilpointer.String("Namespace"), utilpointer.String("bar")),
 				),
 			),
 			oldIngressClass: makeValidIngressClass("test123", "foo.co/bar"),

--- a/pkg/apis/policy/validation/validation_test.go
+++ b/pkg/apis/policy/validation/validation_test.go
@@ -1064,13 +1064,13 @@ func TestValidateRuntimeClassStrategy(t *testing.T) {
 	}, {
 		name: "valid defaulting & allow all",
 		strategy: &policy.RuntimeClassStrategyOptions{
-			DefaultRuntimeClassName:  pointer.StringPtr("native"),
+			DefaultRuntimeClassName:  pointer.String("native"),
 			AllowedRuntimeClassNames: []string{"*"},
 		},
 	}, {
 		name: "valid defaulting & allow explicit",
 		strategy: &policy.RuntimeClassStrategyOptions{
-			DefaultRuntimeClassName:  pointer.StringPtr("native"),
+			DefaultRuntimeClassName:  pointer.String("native"),
 			AllowedRuntimeClassNames: []string{"foo", "native", "sandboxed"},
 		},
 	}, {
@@ -1081,20 +1081,20 @@ func TestValidateRuntimeClassStrategy(t *testing.T) {
 	}, {
 		name: "invalid default name",
 		strategy: &policy.RuntimeClassStrategyOptions{
-			DefaultRuntimeClassName: pointer.StringPtr("foo bar"),
+			DefaultRuntimeClassName: pointer.String("foo bar"),
 		},
 		expectErrors: true,
 	}, {
 		name: "disallowed default",
 		strategy: &policy.RuntimeClassStrategyOptions{
-			DefaultRuntimeClassName:  pointer.StringPtr("foo"),
+			DefaultRuntimeClassName:  pointer.String("foo"),
 			AllowedRuntimeClassNames: []string{"native", "sandboxed"},
 		},
 		expectErrors: true,
 	}, {
 		name: "nothing allowed default",
 		strategy: &policy.RuntimeClassStrategyOptions{
-			DefaultRuntimeClassName: pointer.StringPtr("foo"),
+			DefaultRuntimeClassName: pointer.String("foo"),
 		},
 		expectErrors: true,
 	}, {


### PR DESCRIPTION
Signed-off-by: TommyStarK <thomasmilox@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If applied this commit will replace the deprecated `StringPtr`, `StringPtrDerefOr`, `Int64Ptr`, `Int32Ptr`, `BoolPtr` functions by `String`, `StringDeref`, `Int64`, `Int32` and `BoolPtr`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
