### PR TITLE
Automated cherry pick of #114217: Fix issues in volumesnapshot test for ephemeral storage

### DIFF
--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -252,9 +252,8 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 				}
 
 				restoredPod = StartInPodWithVolumeSource(ctx, cs, volSrc, restoredPVC.Namespace, "restored-pvc-tester", "sleep 300", config.ClientNodeSelection)
-				cleanupSteps = append(cleanupSteps, func() {
-					StopPod(ctx, cs, restoredPod)
-				})
+				ginkgo.DeferCleanup(e2epod.DeletePodWithWait, cs, restoredPod)
+
 				framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(cs, restoredPod.Name, restoredPod.Namespace, f.Timeouts.PodStartSlow))
 				if pattern.VolType != storageframework.GenericEphemeralVolume {
 					commands := e2evolume.GenerateReadFileCmd(datapath)
@@ -263,14 +262,16 @@ func (s *snapshottableTestSuite) DefineTests(driver storageframework.TestDriver,
 				}
 
 				ginkgo.By("should delete the VolumeSnapshotContent according to its deletion policy")
-
 				// Delete both Snapshot and restored Pod/PVC at the same time because different storage systems
 				// have different ordering of deletion. Some may require delete the restored PVC first before
 				// Snapshot deletion and some are opposite.
 				err = storageutils.DeleteSnapshotWithoutWaiting(dc, vs.GetNamespace(), vs.GetName())
 				framework.ExpectNoError(err)
-
+				framework.Logf("deleting restored pod %q/%q", restoredPod.Namespace, restoredPod.Name)
+				err = cs.CoreV1().Pods(restoredPod.Namespace).Delete(context.TODO(), restoredPod.Name, metav1.DeleteOptions{})
+				framework.ExpectNoError(err)
 				deleteVolumeSnapshot(f, dc, sr, pattern, vscontent)
+
 			})
 
 			ginkgo.It("should check snapshot fields, check restore correctly works after modifying source data, check deletion (persistent)", func(ctx context.Context) {


### PR DESCRIPTION
Cherry pick of #114217 on release-1.26.

#114217: Fix issues in volumesnapshot test for ephemeral storage

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```