### PR TITLE
cleanup(scheduler_perf): remove all removed feature gates

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -98,7 +98,6 @@
 
 - name: SchedulingMigratedInTreePVs
   featureGates:
-    CSIMigration: true
     CSIMigrationAWS: true
   workloadTemplate:
   - opcode: createNodes
@@ -491,8 +490,6 @@
 
 - name: SchedulingRequiredPodAntiAffinityWithNSSelector
   defaultPodTemplatePath: config/pod-anti-affinity-ns-selector.yaml
-  featureGates:
-    PodAffinityNamespaceSelector: true
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -526,8 +523,6 @@
 
 - name: SchedulingPreferredAntiAffinityWithNSSelector
   defaultPodTemplatePath: config/pod-preferred-anti-affinity-ns-selector.yaml
-  featureGates:
-    PodAffinityNamespaceSelector: true
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -561,8 +556,6 @@
 
 - name: SchedulingRequiredPodAffinityWithNSSelector
   defaultPodTemplatePath: config/pod-affinity-ns-selector.yaml
-  featureGates:
-    PodAffinityNamespaceSelector: true
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -597,8 +590,6 @@
 
 - name: SchedulingPreferredAffinityWithNSSelector
   defaultPodTemplatePath: config/pod-preferred-affinity-ns-selector.yaml
-  featureGates:
-    PodAffinityNamespaceSelector: true
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Remove removed feature gates from scheduler_perf's config.

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-benchmark-scheduler-perf-master/1609847120766963712

```
BenchmarkPerfScheduling/SchedulingMigratedInTreePVs/500Nodes
panic: feature "CSIMigration" is not registered in FeatureGate "k8s.io/apiserver/pkg/util/feature/feature_gate.go:28"
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #114795

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
