### PR TITLE
Remove  `volume.beta.kubernetes.io/storage-provisioner` annotation

### DIFF
--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -475,7 +475,7 @@ func newClaim(name, claimUID, capacity, boundToVolume string, phase v1.Persisten
 		claim.Annotations = make(map[string]string)
 		for _, a := range annotations {
 			switch a {
-			case storagehelpers.AnnBetaStorageProvisioner, storagehelpers.AnnStorageProvisioner:
+			case storagehelpers.AnnStorageProvisioner:
 				claim.Annotations[a] = mockPluginName
 			default:
 				claim.Annotations[a] = "yes"

--- a/pkg/controller/volume/persistentvolume/provision_test.go
+++ b/pkg/controller/volume/persistentvolume/provision_test.go
@@ -181,7 +181,7 @@ func TestProvisionSync(t *testing.T) {
 			expectedVolumes: volumesWithFinalizers(newVolumeArray("pvc-uid11-1", "1Gi", "uid11-1", "claim11-1", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classGold, volume.AnnBoundByController, volume.AnnDynamicallyProvisioned), []string{volume.PVDeletionInTreeProtectionFinalizer}),
 			// Binding will be completed in the next syncClaim
 			initialClaims:  newClaimArray("claim11-1", "uid11-1", "1Gi", "", v1.ClaimPending, &classGold),
-			expectedClaims: newClaimArray("claim11-1", "uid11-1", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner, volume.AnnBetaStorageProvisioner),
+			expectedClaims: newClaimArray("claim11-1", "uid11-1", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner),
 			expectedEvents: []string{"Normal ProvisioningSucceeded"},
 			errors:         noerrors,
 			test:           wrapTestWithProvisionCalls([]provisionCall{provision1Success}, testSyncClaim),
@@ -203,7 +203,7 @@ func TestProvisionSync(t *testing.T) {
 			initialVolumes:  novolumes,
 			expectedVolumes: novolumes,
 			initialClaims:   newClaimArray("claim11-3", "uid11-3", "1Gi", "", v1.ClaimPending, &classGold),
-			expectedClaims:  newClaimArray("claim11-3", "uid11-3", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner, volume.AnnBetaStorageProvisioner),
+			expectedClaims:  newClaimArray("claim11-3", "uid11-3", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner),
 			expectedEvents:  []string{"Warning ProvisioningFailed"},
 			errors:          noerrors,
 			test:            wrapTestWithProvisionCalls([]provisionCall{}, testSyncClaim),
@@ -214,7 +214,7 @@ func TestProvisionSync(t *testing.T) {
 			initialVolumes:  novolumes,
 			expectedVolumes: novolumes,
 			initialClaims:   newClaimArray("claim11-4", "uid11-4", "1Gi", "", v1.ClaimPending, &classGold),
-			expectedClaims:  newClaimArray("claim11-4", "uid11-4", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner, volume.AnnBetaStorageProvisioner),
+			expectedClaims:  newClaimArray("claim11-4", "uid11-4", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner),
 			expectedEvents:  []string{"Warning ProvisioningFailed"},
 			errors:          noerrors,
 			test:            wrapTestWithProvisionCalls([]provisionCall{provision1Error}, testSyncClaim),
@@ -240,7 +240,7 @@ func TestProvisionSync(t *testing.T) {
 			expectedVolumes: newVolumeArray("pvc-uid11-7", "1Gi", "uid11-7", "claim11-7", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classGold, volume.AnnBoundByController, volume.AnnDynamicallyProvisioned),
 			initialClaims:   newClaimArray("claim11-7", "uid11-7", "1Gi", "", v1.ClaimPending, &classGold),
 			// The claim would be bound in next syncClaim
-			expectedClaims: newClaimArray("claim11-7", "uid11-7", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner, volume.AnnBetaStorageProvisioner),
+			expectedClaims: newClaimArray("claim11-7", "uid11-7", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner),
 			expectedEvents: noevents,
 			errors:         noerrors,
 			test: wrapTestWithInjectedOperation(wrapTestWithProvisionCalls([]provisionCall{}, testSyncClaim), func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor) {
@@ -258,7 +258,7 @@ func TestProvisionSync(t *testing.T) {
 			expectedVolumes: volumesWithFinalizers(newVolumeArray("pvc-uid11-8", "1Gi", "uid11-8", "claim11-8", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classGold, volume.AnnBoundByController, volume.AnnDynamicallyProvisioned), []string{volume.PVDeletionInTreeProtectionFinalizer}),
 			initialClaims:   newClaimArray("claim11-8", "uid11-8", "1Gi", "", v1.ClaimPending, &classGold),
 			// Binding will be completed in the next syncClaim
-			expectedClaims: newClaimArray("claim11-8", "uid11-8", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner, volume.AnnBetaStorageProvisioner),
+			expectedClaims: newClaimArray("claim11-8", "uid11-8", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner),
 			expectedEvents: []string{"Normal ProvisioningSucceeded"},
 			errors: []pvtesting.ReactorError{
 				// Inject error to the first
@@ -275,7 +275,7 @@ func TestProvisionSync(t *testing.T) {
 			initialVolumes:  novolumes,
 			expectedVolumes: novolumes,
 			initialClaims:   newClaimArray("claim11-9", "uid11-9", "1Gi", "", v1.ClaimPending, &classGold),
-			expectedClaims:  newClaimArray("claim11-9", "uid11-9", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner, volume.AnnBetaStorageProvisioner),
+			expectedClaims:  newClaimArray("claim11-9", "uid11-9", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner),
 			expectedEvents:  []string{"Warning ProvisioningFailed"},
 			errors: []pvtesting.ReactorError{
 				// Inject error to five kubeclient.PersistentVolumes.Create()
@@ -300,7 +300,7 @@ func TestProvisionSync(t *testing.T) {
 			initialVolumes:  novolumes,
 			expectedVolumes: novolumes,
 			initialClaims:   newClaimArray("claim11-10", "uid11-10", "1Gi", "", v1.ClaimPending, &classGold),
-			expectedClaims:  newClaimArray("claim11-10", "uid11-10", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner, volume.AnnBetaStorageProvisioner),
+			expectedClaims:  newClaimArray("claim11-10", "uid11-10", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner),
 			expectedEvents:  []string{"Warning ProvisioningFailed", "Warning ProvisioningCleanupFailed"},
 			errors: []pvtesting.ReactorError{
 				// Inject error to five kubeclient.PersistentVolumes.Create()
@@ -321,7 +321,7 @@ func TestProvisionSync(t *testing.T) {
 			initialVolumes:  novolumes,
 			expectedVolumes: novolumes,
 			initialClaims:   newClaimArray("claim11-11", "uid11-11", "1Gi", "", v1.ClaimPending, &classGold),
-			expectedClaims:  newClaimArray("claim11-11", "uid11-11", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner, volume.AnnBetaStorageProvisioner),
+			expectedClaims:  newClaimArray("claim11-11", "uid11-11", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner),
 			expectedEvents:  []string{"Warning ProvisioningFailed", "Warning ProvisioningCleanupFailed"},
 			errors: []pvtesting.ReactorError{
 				// Inject error to five kubeclient.PersistentVolumes.Create()
@@ -351,7 +351,7 @@ func TestProvisionSync(t *testing.T) {
 			initialVolumes:  novolumes,
 			expectedVolumes: novolumes,
 			initialClaims:   newClaimArray("claim11-12", "uid11-12", "1Gi", "", v1.ClaimPending, &classGold),
-			expectedClaims:  newClaimArray("claim11-12", "uid11-12", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner, volume.AnnBetaStorageProvisioner),
+			expectedClaims:  newClaimArray("claim11-12", "uid11-12", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner),
 			expectedEvents:  []string{"Warning ProvisioningFailed"},
 			errors: []pvtesting.ReactorError{
 				// Inject error to five kubeclient.PersistentVolumes.Create()
@@ -379,7 +379,7 @@ func TestProvisionSync(t *testing.T) {
 			expectedVolumes: volumesWithFinalizers(newVolumeArray("pvc-uid11-13", "1Gi", "uid11-13", "claim11-13", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classSilver, volume.AnnBoundByController, volume.AnnDynamicallyProvisioned), []string{volume.PVDeletionInTreeProtectionFinalizer}),
 			initialClaims:   newClaimArray("claim11-13", "uid11-13", "1Gi", "", v1.ClaimPending, &classSilver),
 			// Binding will be completed in the next syncClaim
-			expectedClaims: newClaimArray("claim11-13", "uid11-13", "1Gi", "", v1.ClaimPending, &classSilver, volume.AnnStorageProvisioner, volume.AnnBetaStorageProvisioner),
+			expectedClaims: newClaimArray("claim11-13", "uid11-13", "1Gi", "", v1.ClaimPending, &classSilver, volume.AnnStorageProvisioner),
 			expectedEvents: []string{"Normal ProvisioningSucceeded"},
 			errors:         noerrors,
 			test:           wrapTestWithProvisionCalls([]provisionCall{provision2Success}, testSyncClaim),
@@ -423,9 +423,8 @@ func TestProvisionSync(t *testing.T) {
 			initialVolumes:  novolumes,
 			expectedVolumes: novolumes,
 			initialClaims:   newClaimArray("claim11-17", "uid11-17", "1Gi", "", v1.ClaimPending, &classExternal),
-			expectedClaims: claimWithAnnotation(volume.AnnBetaStorageProvisioner, "vendor.com/my-volume",
-				claimWithAnnotation(volume.AnnStorageProvisioner, "vendor.com/my-volume",
-					newClaimArray("claim11-17", "uid11-17", "1Gi", "", v1.ClaimPending, &classExternal))),
+			expectedClaims: claimWithAnnotation(volume.AnnStorageProvisioner, "vendor.com/my-volume",
+				newClaimArray("claim11-17", "uid11-17", "1Gi", "", v1.ClaimPending, &classExternal)),
 			expectedEvents: []string{"Normal ExternalProvisioning"},
 			errors:         noerrors,
 			test:           wrapTestWithProvisionCalls([]provisionCall{}, testSyncClaim),
@@ -456,7 +455,7 @@ func TestProvisionSync(t *testing.T) {
 			// end of the test is empty.
 			novolumes,
 			newClaimArray("claim11-19", "uid11-19", "1Gi", "", v1.ClaimPending, &classGold),
-			newClaimArray("claim11-19", "uid11-19", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner, volume.AnnBetaStorageProvisioner),
+			newClaimArray("claim11-19", "uid11-19", "1Gi", "", v1.ClaimPending, &classGold, volume.AnnStorageProvisioner),
 			noevents,
 			[]pvtesting.ReactorError{
 				// Inject errors to simulate crashed API server during
@@ -477,7 +476,7 @@ func TestProvisionSync(t *testing.T) {
 			initialVolumes:  novolumes,
 			expectedVolumes: novolumes,
 			initialClaims:   newClaimArray("claim11-20", "uid11-20", "1Gi", "", v1.ClaimPending, &classUnsupportedMountOptions),
-			expectedClaims:  newClaimArray("claim11-20", "uid11-20", "1Gi", "", v1.ClaimPending, &classUnsupportedMountOptions, volume.AnnStorageProvisioner, volume.AnnBetaStorageProvisioner),
+			expectedClaims:  newClaimArray("claim11-20", "uid11-20", "1Gi", "", v1.ClaimPending, &classUnsupportedMountOptions, volume.AnnStorageProvisioner),
 			// Expect event to be prefixed with "Mount options" because saving PV will fail anyway
 			expectedEvents: []string{"Warning ProvisioningFailed Mount options"},
 			errors:         noerrors,
@@ -493,9 +492,8 @@ func TestProvisionSync(t *testing.T) {
 				annotateClaim(
 					newClaim("claim11-21", "uid11-21", "1Gi", "", v1.ClaimPending, &classGold),
 					map[string]string{
-						volume.AnnStorageProvisioner:     "vendor.com/MockCSIDriver",
-						volume.AnnBetaStorageProvisioner: "vendor.com/MockCSIDriver",
-						volume.AnnMigratedTo:             "vendor.com/MockCSIDriver",
+						volume.AnnStorageProvisioner: "vendor.com/MockCSIDriver",
+						volume.AnnMigratedTo:         "vendor.com/MockCSIDriver",
 					}),
 			},
 			expectedEvents: []string{"Normal ExternalProvisioning"},
@@ -525,7 +523,7 @@ func TestProvisionSync(t *testing.T) {
 			claimWithAnnotation(volume.AnnSelectedNode, "node1",
 				newClaimArray("claim11-23", "uid11-23", "1Gi", "", v1.ClaimPending, &classCopper)),
 			claimWithAnnotation(volume.AnnSelectedNode, "node1",
-				newClaimArray("claim11-23", "uid11-23", "1Gi", "", v1.ClaimPending, &classCopper, volume.AnnStorageProvisioner, volume.AnnBetaStorageProvisioner)),
+				newClaimArray("claim11-23", "uid11-23", "1Gi", "", v1.ClaimPending, &classCopper, volume.AnnStorageProvisioner)),
 			[]string{"Normal ProvisioningSucceeded"},
 			noerrors,
 			wrapTestWithInjectedOperation(wrapTestWithProvisionCalls([]provisionCall{provision1Success}, testSyncClaim),
@@ -543,10 +541,9 @@ func TestProvisionSync(t *testing.T) {
 			expectedVolumes: newVolumeArray("volume11-24", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimDelete, classExternalWait),
 			initialClaims: claimWithAnnotation(volume.AnnSelectedNode, "node1",
 				newClaimArray("claim11-24", "uid11-24", "1Gi", "", v1.ClaimPending, &classExternalWait)),
-			expectedClaims: claimWithAnnotation(volume.AnnBetaStorageProvisioner, "vendor.com/my-volume-wait",
-				claimWithAnnotation(volume.AnnStorageProvisioner, "vendor.com/my-volume-wait",
-					claimWithAnnotation(volume.AnnSelectedNode, "node1",
-						newClaimArray("claim11-24", "uid11-24", "1Gi", "", v1.ClaimPending, &classExternalWait)))),
+			expectedClaims: claimWithAnnotation(volume.AnnStorageProvisioner, "vendor.com/my-volume-wait",
+				claimWithAnnotation(volume.AnnSelectedNode, "node1",
+					newClaimArray("claim11-24", "uid11-24", "1Gi", "", v1.ClaimPending, &classExternalWait))),
 			expectedEvents: []string{"Normal ExternalProvisioning"},
 			errors:         noerrors,
 			test:           testSyncClaim,
@@ -604,7 +601,7 @@ func TestProvisionMultiSync(t *testing.T) {
 			initialVolumes:  novolumes,
 			expectedVolumes: newVolumeArray("pvc-uid12-1", "1Gi", "uid12-1", "claim12-1", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classGold, volume.AnnBoundByController, volume.AnnDynamicallyProvisioned),
 			initialClaims:   newClaimArray("claim12-1", "uid12-1", "1Gi", "", v1.ClaimPending, &classGold),
-			expectedClaims:  newClaimArray("claim12-1", "uid12-1", "1Gi", "pvc-uid12-1", v1.ClaimBound, &classGold, volume.AnnBoundByController, volume.AnnBindCompleted, volume.AnnStorageProvisioner, volume.AnnBetaStorageProvisioner),
+			expectedClaims:  newClaimArray("claim12-1", "uid12-1", "1Gi", "pvc-uid12-1", v1.ClaimBound, &classGold, volume.AnnBoundByController, volume.AnnBindCompleted, volume.AnnStorageProvisioner),
 			expectedEvents:  noevents,
 			errors:          noerrors,
 			test:            wrapTestWithProvisionCalls([]provisionCall{provision1Success}, testSyncClaim),
@@ -615,9 +612,8 @@ func TestProvisionMultiSync(t *testing.T) {
 			initialVolumes:  novolumes,
 			expectedVolumes: newVolumeArray("pvc-uid12-2", "1Gi", "uid12-2", "claim12-2", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classExternal, volume.AnnBoundByController),
 			initialClaims:   newClaimArray("claim12-2", "uid12-2", "1Gi", "", v1.ClaimPending, &classExternal),
-			expectedClaims: claimWithAnnotation(volume.AnnBetaStorageProvisioner, "vendor.com/my-volume",
-				claimWithAnnotation(volume.AnnStorageProvisioner, "vendor.com/my-volume",
-					newClaimArray("claim12-2", "uid12-2", "1Gi", "pvc-uid12-2", v1.ClaimBound, &classExternal, volume.AnnBoundByController, volume.AnnBindCompleted))),
+			expectedClaims: claimWithAnnotation(volume.AnnStorageProvisioner, "vendor.com/my-volume",
+				newClaimArray("claim12-2", "uid12-2", "1Gi", "pvc-uid12-2", v1.ClaimBound, &classExternal, volume.AnnBoundByController, volume.AnnBindCompleted)),
 			expectedEvents: []string{"Normal ExternalProvisioning"},
 			errors:         noerrors,
 			test: wrapTestWithInjectedOperation(wrapTestWithProvisionCalls([]provisionCall{}, testSyncClaim), func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor) {
@@ -641,9 +637,8 @@ func TestProvisionMultiSync(t *testing.T) {
 			initialVolumes:  novolumes,
 			expectedVolumes: novolumes,
 			initialClaims:   newClaimArray("claim12-3", "uid12-3", "1Gi", "", v1.ClaimPending, &classExternal),
-			expectedClaims: claimWithAnnotation(volume.AnnBetaStorageProvisioner, "vendor.com/my-volume",
-				claimWithAnnotation(volume.AnnStorageProvisioner, "vendor.com/my-volume",
-					newClaimArray("claim12-3", "uid12-3", "1Gi", "", v1.ClaimPending, &classExternal))),
+			expectedClaims: claimWithAnnotation(volume.AnnStorageProvisioner, "vendor.com/my-volume",
+				newClaimArray("claim12-3", "uid12-3", "1Gi", "", v1.ClaimPending, &classExternal)),
 			expectedEvents: []string{"Normal ExternalProvisioning"},
 			errors:         noerrors,
 			test:           wrapTestWithProvisionCalls([]provisionCall{provision1Success}, testSyncClaim),
@@ -654,9 +649,8 @@ func TestProvisionMultiSync(t *testing.T) {
 			initialVolumes:  novolumes,
 			expectedVolumes: newVolumeArray("pvc-uid12-4", "1Gi", "uid12-4", "claim12-4", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classExternal, volume.AnnBoundByController),
 			initialClaims:   newClaimArray("claim12-4", "uid12-4", "1Gi", "", v1.ClaimPending, &classExternal),
-			expectedClaims: claimWithAnnotation(volume.AnnBetaStorageProvisioner, "vendor.com/my-volume",
-				claimWithAnnotation(volume.AnnStorageProvisioner, "vendor.com/my-volume",
-					newClaimArray("claim12-4", "uid12-4", "1Gi", "pvc-uid12-4", v1.ClaimBound, &classExternal, volume.AnnBoundByController, volume.AnnBindCompleted))),
+			expectedClaims: claimWithAnnotation(volume.AnnStorageProvisioner, "vendor.com/my-volume",
+				newClaimArray("claim12-4", "uid12-4", "1Gi", "pvc-uid12-4", v1.ClaimBound, &classExternal, volume.AnnBoundByController, volume.AnnBindCompleted)),
 			expectedEvents: []string{"Normal ExternalProvisioning"},
 			errors:         noerrors,
 			test: wrapTestWithInjectedOperation(wrapTestWithProvisionCalls([]provisionCall{}, testSyncClaim), func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor) {

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -457,16 +457,8 @@ func updateMigrationAnnotations(cmpm CSIMigratedPluginManager, translator CSINam
 	}
 	provisioner, ok := ann[provisionerKey]
 	if !ok {
-		if claim {
-			// Also check beta AnnStorageProvisioner annontation to make sure
-			provisioner, ok = ann[storagehelpers.AnnBetaStorageProvisioner]
-			if !ok {
-				return false
-			}
-		} else {
-			// Volume Statically provisioned.
-			return false
-		}
+		// Volume Statically provisioned.
+		return false
 	}
 
 	migratedToDriver := ann[storagehelpers.AnnMigratedTo]
@@ -641,8 +633,6 @@ func (ctrl *PersistentVolumeController) setClaimProvisioner(ctx context.Context,
 	// The volume from method args can be pointing to watcher cache. We must not
 	// modify these, therefore create a copy.
 	claimClone := claim.DeepCopy()
-	// TODO: remove the beta storage provisioner anno after the deprecation period
-	metav1.SetMetaDataAnnotation(&claimClone.ObjectMeta, storagehelpers.AnnBetaStorageProvisioner, provisionerName)
 	metav1.SetMetaDataAnnotation(&claimClone.ObjectMeta, storagehelpers.AnnStorageProvisioner, provisionerName)
 	updateMigrationAnnotations(ctrl.csiMigratedPluginManager, ctrl.translator, claimClone.Annotations, true)
 	newClaim, err := ctrl.kubeClient.CoreV1().PersistentVolumeClaims(claim.Namespace).Update(context.TODO(), claimClone, metav1.UpdateOptions{})

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -518,13 +518,6 @@ func TestAnnealMigrationAnnotations(t *testing.T) {
 			expClaimAnnotations:  map[string]string{volume.AnnStorageProvisioner: migratedPlugin, volume.AnnMigratedTo: migratedDriver},
 		},
 		{
-			name:                 "migration on with Beta storage provisioner annontation",
-			volumeAnnotations:    map[string]string{volume.AnnDynamicallyProvisioned: migratedPlugin},
-			expVolumeAnnotations: map[string]string{volume.AnnDynamicallyProvisioned: migratedPlugin, volume.AnnMigratedTo: migratedDriver},
-			claimAnnotations:     map[string]string{volume.AnnBetaStorageProvisioner: migratedPlugin},
-			expClaimAnnotations:  map[string]string{volume.AnnBetaStorageProvisioner: migratedPlugin, volume.AnnMigratedTo: migratedDriver},
-		},
-		{
 			name:                 "migration off",
 			volumeAnnotations:    map[string]string{volume.AnnDynamicallyProvisioned: nonmigratedPlugin},
 			expVolumeAnnotations: map[string]string{volume.AnnDynamicallyProvisioned: nonmigratedPlugin},
@@ -537,13 +530,6 @@ func TestAnnealMigrationAnnotations(t *testing.T) {
 			expVolumeAnnotations: map[string]string{volume.AnnDynamicallyProvisioned: nonmigratedPlugin},
 			claimAnnotations:     map[string]string{volume.AnnStorageProvisioner: nonmigratedPlugin, volume.AnnMigratedTo: nonmigratedDriver},
 			expClaimAnnotations:  map[string]string{volume.AnnStorageProvisioner: nonmigratedPlugin},
-		},
-		{
-			name:                 "migration off removes migrated to (rollback) with Beta storage provisioner annontation",
-			volumeAnnotations:    map[string]string{volume.AnnDynamicallyProvisioned: nonmigratedPlugin, volume.AnnMigratedTo: nonmigratedDriver},
-			expVolumeAnnotations: map[string]string{volume.AnnDynamicallyProvisioned: nonmigratedPlugin},
-			claimAnnotations:     map[string]string{volume.AnnBetaStorageProvisioner: nonmigratedPlugin, volume.AnnMigratedTo: nonmigratedDriver},
-			expClaimAnnotations:  map[string]string{volume.AnnBetaStorageProvisioner: nonmigratedPlugin},
 		},
 		{
 			name:                 "migration on, other plugin not affected",

--- a/staging/src/k8s.io/component-helpers/storage/volume/pv_helpers.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/pv_helpers.go
@@ -70,9 +70,7 @@ const (
 	// AnnStorageProvisioner annotation is added to a PVC that is supposed to be dynamically
 	// provisioned. Its value is name of volume plugin that is supposed to provision
 	// a volume for this PVC.
-	// TODO: remove beta anno once deprecation period ends
-	AnnStorageProvisioner     = "volume.kubernetes.io/storage-provisioner"
-	AnnBetaStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
+	AnnStorageProvisioner = "volume.kubernetes.io/storage-provisioner"
 
 	//PVDeletionProtectionFinalizer is the finalizer added by the external-provisioner on the PV
 	PVDeletionProtectionFinalizer = "external-provisioner.volume.kubernetes.io/finalizer"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The `volume.beta.kubernetes.io/storage-provisioner` annotation has been deprecated since v1.23 and uses `volume.kubernetes.io/storage-provisioner` instead.
- https://github.com/kubernetes/kubernetes/pull/104590

Now we can remove beta annotation because the deprecation period has ended(more than a year and 3 minor releases).
see https://kubernetes.io/docs/reference/using-api/deprecation-policy/#deprecating-parts-of-the-api for more deprecation details. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref:  
- https://github.com/kubernetes/kubernetes/issues/104760
- https://github.com/kubernetes/kubernetes/issues/102357

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Action required: Remove the `volume.beta.kubernetes.io/storage-provisioner` annotation, deprecated since v1.23, and use `volume.kubernetes.io/storage-provisioner` instead.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig storage

/cc @jsafrane @msau42 @Jiawei0227 