### PR TITLE
Automated cherry pick of #114770: Fix clearing rate limiter in disruption controller

### DIFF
--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -645,7 +645,7 @@ func (dc *DisruptionController) processNextStalePodDisruptionWorkItem(ctx contex
 	defer dc.stalePodDisruptionQueue.Done(key)
 	err := dc.syncStalePodDisruption(ctx, key.(string))
 	if err == nil {
-		dc.queue.Forget(key)
+		dc.stalePodDisruptionQueue.Forget(key)
 		return true
 	}
 	utilruntime.HandleError(fmt.Errorf("error syncing Pod %v to clear DisruptionTarget condition, requeueing: %v", key.(string), err))


### PR DESCRIPTION
Cherry pick of #114770 on release-1.25.

#114770: Fix clearing rate limiter in disruption controller

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix clearing of rate-limiter for the queue of checks for cleaning stale pod disruption conditions. 
The bug could result in the PDB synchronization updates firing too often or the pod disruption cleanups taking too long to happen.

```