### PR TITLE
test/integration: Replace deprecated pointer function

### DIFF
--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -325,8 +325,8 @@ func TestNodeAuthorizer(t *testing.T) {
 					Name: "node1",
 				},
 				Spec: coordination.LeaseSpec{
-					HolderIdentity:       pointer.StringPtr("node1"),
-					LeaseDurationSeconds: pointer.Int32Ptr(node1LeaseDurationSeconds),
+					HolderIdentity:       pointer.String("node1"),
+					LeaseDurationSeconds: pointer.Int32(node1LeaseDurationSeconds),
 					RenewTime:            &metav1.MicroTime{Time: time.Now()},
 				},
 			}

--- a/test/integration/controlplane/apiserver_identity_test.go
+++ b/test/integration/controlplane/apiserver_identity_test.go
@@ -196,8 +196,8 @@ func newTestLease(acquireTime time.Time, namespace string) *coordinationv1.Lease
 			},
 		},
 		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity:       pointer.StringPtr(testLeaseName),
-			LeaseDurationSeconds: pointer.Int32Ptr(3600),
+			HolderIdentity:       pointer.String(testLeaseName),
+			LeaseDurationSeconds: pointer.Int32(3600),
 			AcquireTime:          &metav1.MicroTime{Time: acquireTime},
 			RenewTime:            &metav1.MicroTime{Time: acquireTime},
 		},

--- a/test/integration/service/loadbalancer_test.go
+++ b/test/integration/service/loadbalancer_test.go
@@ -54,7 +54,7 @@ func Test_ServiceLoadBalancerDisableAllocateNodePorts(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{
 			Type:                          corev1.ServiceTypeLoadBalancer,
-			AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(false),
+			AllocateLoadBalancerNodePorts: utilpointer.Bool(false),
 			Ports: []corev1.ServicePort{{
 				Port: int32(80),
 			}},
@@ -113,7 +113,7 @@ func Test_ServiceUpdateLoadBalancerDisableAllocateNodePorts(t *testing.T) {
 	}
 
 	service.Spec.Type = corev1.ServiceTypeLoadBalancer
-	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(false)
+	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
 	service, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("Error updating test service: %v", err)
@@ -144,7 +144,7 @@ func Test_ServiceLoadBalancerEnableThenDisableAllocatedNodePorts(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{
 			Type:                          corev1.ServiceTypeLoadBalancer,
-			AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(true),
+			AllocateLoadBalancerNodePorts: utilpointer.Bool(true),
 			Ports: []corev1.ServicePort{{
 				Port: int32(80),
 			}},
@@ -163,7 +163,7 @@ func Test_ServiceLoadBalancerEnableThenDisableAllocatedNodePorts(t *testing.T) {
 		t.Error("expected node ports but found none")
 	}
 
-	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(false)
+	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
 	service, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("Error updating test service: %v", err)
@@ -194,7 +194,7 @@ func Test_ServiceLoadBalancerDisableThenEnableAllocatedNodePorts(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{
 			Type:                          corev1.ServiceTypeLoadBalancer,
-			AllocateLoadBalancerNodePorts: utilpointer.BoolPtr(false),
+			AllocateLoadBalancerNodePorts: utilpointer.Bool(false),
 			Ports: []corev1.ServicePort{{
 				Port: int32(80),
 			}},
@@ -213,7 +213,7 @@ func Test_ServiceLoadBalancerDisableThenEnableAllocatedNodePorts(t *testing.T) {
 		t.Error("not expected node ports but found one")
 	}
 
-	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
 	service, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("Error updating test service: %v", err)
@@ -264,7 +264,7 @@ func Test_ServiceLoadBalancerEnableLoadBalancerClass(t *testing.T) {
 			Ports: []corev1.ServicePort{{
 				Port: int32(80),
 			}},
-			LoadBalancerClass: utilpointer.StringPtr("test.com/test"),
+			LoadBalancerClass: utilpointer.String("test.com/test"),
 		},
 	}
 
@@ -310,7 +310,7 @@ func Test_SetLoadBalancerClassThenUpdateLoadBalancerClass(t *testing.T) {
 			Ports: []corev1.ServicePort{{
 				Port: int32(80),
 			}},
-			LoadBalancerClass: utilpointer.StringPtr("test.com/test"),
+			LoadBalancerClass: utilpointer.String("test.com/test"),
 		},
 	}
 
@@ -319,7 +319,7 @@ func Test_SetLoadBalancerClassThenUpdateLoadBalancerClass(t *testing.T) {
 		t.Fatalf("Error creating test service: %v", err)
 	}
 
-	service.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/update")
+	service.Spec.LoadBalancerClass = utilpointer.String("test.com/update")
 	_, err = client.CoreV1().Services(ns.Name).Update(ctx, service, metav1.UpdateOptions{})
 	if err == nil {
 		t.Fatal("Error: updating test service load balancer class should throw error, field is immutable")
@@ -369,7 +369,7 @@ func Test_UpdateLoadBalancerWithLoadBalancerClass(t *testing.T) {
 		t.Fatalf("Error creating test service: %v", err)
 	}
 
-	service.Spec.LoadBalancerClass = utilpointer.StringPtr("test.com/test")
+	service.Spec.LoadBalancerClass = utilpointer.String("test.com/test")
 	_, err = client.CoreV1().Services(ns.Name).Update(ctx, service, metav1.UpdateOptions{})
 	if err == nil {
 		t.Fatal("Error: updating test service load balancer class should throw error, field is immutable")

--- a/test/integration/storageversion/gc_test.go
+++ b/test/integration/storageversion/gc_test.go
@@ -95,7 +95,7 @@ func TestStorageVersionGarbageCollection(t *testing.T) {
 			t.Errorf("unexpected storage version entry id, expected %v, got: %v",
 				expectedID, sv.Status.StorageVersions[0].APIServerID)
 		}
-		assertCommonEncodingVersion(t, kubeclient, pointer.StringPtr(idToVersion(t, idA)))
+		assertCommonEncodingVersion(t, kubeclient, pointer.String(idToVersion(t, idA)))
 		if err := kubeclient.InternalV1alpha1().StorageVersions().Delete(
 			context.TODO(), svName, metav1.DeleteOptions{}); err != nil {
 			t.Fatalf("failed to cleanup valid storage version: %v", err)
@@ -108,7 +108,7 @@ func TestStorageVersionGarbageCollection(t *testing.T) {
 		assertCommonEncodingVersion(t, kubeclient, nil)
 		deleteTestAPIServerIdentityLease(t, kubeclient, idA)
 		assertStorageVersionEntries(t, kubeclient, 1, idB)
-		assertCommonEncodingVersion(t, kubeclient, pointer.StringPtr(idToVersion(t, idB)))
+		assertCommonEncodingVersion(t, kubeclient, pointer.String(idToVersion(t, idB)))
 	})
 
 	t.Run("deleting an id should delete a storage version object that it owns entirely", func(t *testing.T) {
@@ -135,7 +135,7 @@ func createTestStorageVersion(t *testing.T, client kubernetes.Interface, ids ...
 	// every id is unique and creates a different version. We know we have a common encoding
 	// version when there is only one id. Pick it
 	if len(ids) == 1 {
-		sv.Status.CommonEncodingVersion = pointer.StringPtr(sv.Status.StorageVersions[0].EncodingVersion)
+		sv.Status.CommonEncodingVersion = pointer.String(sv.Status.StorageVersions[0].EncodingVersion)
 	}
 
 	createdSV, err := client.InternalV1alpha1().StorageVersions().Create(context.TODO(), sv, metav1.CreateOptions{})
@@ -176,8 +176,8 @@ func createTestAPIServerIdentityLease(t *testing.T, client kubernetes.Interface,
 			},
 		},
 		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity:       pointer.StringPtr(name),
-			LeaseDurationSeconds: pointer.Int32Ptr(3600),
+			HolderIdentity:       pointer.String(name),
+			LeaseDurationSeconds: pointer.Int32(3600),
 			// create fresh leases
 			AcquireTime: &metav1.MicroTime{Time: time.Now()},
 			RenewTime:   &metav1.MicroTime{Time: time.Now()},

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -505,7 +505,7 @@ func InitTestSchedulerWithNS(t *testing.T, nsPrefix string, opts ...scheduler.Op
 func InitTestDisablePreemption(t *testing.T, nsPrefix string) *TestContext {
 	cfg := configtesting.V1beta3ToInternalWithDefaults(t, v1beta3.KubeSchedulerConfiguration{
 		Profiles: []v1beta3.KubeSchedulerProfile{{
-			SchedulerName: pointer.StringPtr(v1.DefaultSchedulerName),
+			SchedulerName: pointer.String(v1.DefaultSchedulerName),
 			Plugins: &v1beta3.Plugins{
 				PostFilter: v1beta3.PluginSet{
 					Disabled: []v1beta3.Plugin{


### PR DESCRIPTION
Signed-off-by: TommyStarK <thomasmilox@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If applied this commit will replace the deprecated `StringPtr`, `Int32Ptr` and `BoolPtr` functions by `String`, `Int32` and `Bool`.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
