### PR TITLE
fix：remove ioutil for accomodate newer Go versions

### DIFF
--- a/pkg/client/tests/remotecommand_test.go
+++ b/pkg/client/tests/remotecommand_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -336,7 +335,7 @@ func TestDial(t *testing.T) {
 		conn:          &fakeConnection{},
 		resp: &http.Response{
 			StatusCode: http.StatusSwitchingProtocols,
-			Body:       ioutil.NopCloser(&bytes.Buffer{}),
+			Body:       io.NopCloser(&bytes.Buffer{}),
 		},
 	}
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: upgrader}, "POST", &url.URL{Host: "something.com", Scheme: "https"})

--- a/pkg/credentialprovider/azure/azure_acr_helper.go
+++ b/pkg/credentialprovider/azure/azure_acr_helper.go
@@ -53,7 +53,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -185,7 +184,7 @@ func performTokenExchange(
 
 	var content []byte
 	limitedReader := &io.LimitedReader{R: exchange.Body, N: maxReadLength}
-	if content, err = ioutil.ReadAll(limitedReader); err != nil {
+	if content, err = io.ReadAll(limitedReader); err != nil {
 		return "", fmt.Errorf("Www-Authenticate: error reading response from %s", authEndpoint)
 	}
 

--- a/pkg/credentialprovider/azure/azure_credentials.go
+++ b/pkg/credentialprovider/azure/azure_credentials.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -115,7 +114,7 @@ func parseConfig(configReader io.Reader) (*auth.AzureAuthConfig, error) {
 	}
 
 	limitedReader := &io.LimitedReader{R: configReader, N: maxReadLength}
-	configContents, err := ioutil.ReadAll(limitedReader)
+	configContents, err := io.ReadAll(limitedReader)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/admission/eventratelimit/config.go
+++ b/plugin/pkg/admission/eventratelimit/config.go
@@ -19,7 +19,6 @@ package eventratelimit
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -50,7 +49,7 @@ func LoadConfiguration(config io.Reader) (*eventratelimitapi.Configuration, erro
 		return internalConfig, nil
 	}
 	// we have a config so parse it.
-	data, err := ioutil.ReadAll(config)
+	data, err := io.ReadAll(config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/admission/podtolerationrestriction/config.go
+++ b/plugin/pkg/admission/podtolerationrestriction/config.go
@@ -19,7 +19,6 @@ package podtolerationrestriction
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -51,7 +50,7 @@ func loadConfiguration(config io.Reader) (*internalapi.Configuration, error) {
 		return internalConfig, nil
 	}
 	// we have a config so parse it.
-	data, err := ioutil.ReadAll(config)
+	data, err := io.ReadAll(config)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming_test.go
@@ -19,7 +19,6 @@ package streaming
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,7 +40,7 @@ func (d *fakeDecoder) Decode(data []byte, gvk *schema.GroupVersionKind, into run
 func TestEmptyDecoder(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	d := &fakeDecoder{}
-	_, _, err := NewDecoder(ioutil.NopCloser(buf), d).Decode(nil, nil)
+	_, _, err := NewDecoder(io.NopCloser(buf), d).Decode(nil, nil)
 	if err != io.EOF {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
@@ -19,7 +19,6 @@ package versioning
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"testing"
 
@@ -112,7 +111,7 @@ func TestNestedEncode(t *testing.T) {
 		schema.GroupVersion{Group: "other"}, nil,
 		"TestNestedEncode",
 	)
-	if err := codec.Encode(n, ioutil.Discard); err != n2.nestedErr {
+	if err := codec.Encode(n, io.Discard); err != n2.nestedErr {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if n.nestedCalled || !n2.nestedCalled {
@@ -135,7 +134,7 @@ func TestNestedEncodeError(t *testing.T) {
 		schema.GroupVersion{Group: "other", Version: "v2"}, nil,
 		"TestNestedEncodeError",
 	)
-	if err := codec.Encode(n, ioutil.Discard); err != n.nestedErr {
+	if err := codec.Encode(n, io.Discard); err != n.nestedErr {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if n.GroupVersionKind() != gvk1 {
@@ -371,7 +370,7 @@ func TestDirectCodecEncode(t *testing.T) {
 		Encoder:     &serializer,
 		ObjectTyper: &typer,
 	}
-	c.Encode(&testDecodable{}, ioutil.Discard)
+	c.Encode(&testDecodable{}, io.Discard)
 	if e, a := "expected_group", serializer.encodingObjGVK.Group; e != a {
 		t.Errorf("expected group to be %v, got %v", e, a)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/framer/framer_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/framer/framer_test.go
@@ -19,7 +19,6 @@ package framer
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 )
 
@@ -34,7 +33,7 @@ func TestRead(t *testing.T) {
 		0x08,
 	}
 	b := bytes.NewBuffer(data)
-	r := NewLengthDelimitedFrameReader(ioutil.NopCloser(b))
+	r := NewLengthDelimitedFrameReader(io.NopCloser(b))
 	buf := make([]byte, 1)
 	if n, err := r.Read(buf); err != io.ErrShortBuffer && n != 1 && bytes.Equal(buf, []byte{0x01}) {
 		t.Fatalf("unexpected: %v %d %v", err, n, buf)
@@ -79,7 +78,7 @@ func TestReadLarge(t *testing.T) {
 		0x08,
 	}
 	b := bytes.NewBuffer(data)
-	r := NewLengthDelimitedFrameReader(ioutil.NopCloser(b))
+	r := NewLengthDelimitedFrameReader(io.NopCloser(b))
 	buf := make([]byte, 40)
 	if n, err := r.Read(buf); err != nil && n != 4 && bytes.Equal(buf, []byte{0x01, 0x02, 0x03, 0x04}) {
 		t.Fatalf("unexpected: %v %d %v", err, n, buf)
@@ -104,7 +103,7 @@ func TestReadInvalidFrame(t *testing.T) {
 		0x01, 0x02,
 	}
 	b := bytes.NewBuffer(data)
-	r := NewLengthDelimitedFrameReader(ioutil.NopCloser(b))
+	r := NewLengthDelimitedFrameReader(io.NopCloser(b))
 	buf := make([]byte, 1)
 	if n, err := r.Read(buf); err != io.ErrShortBuffer && n != 1 && bytes.Equal(buf, []byte{0x01}) {
 		t.Fatalf("unexpected: %v %d %v", err, n, buf)
@@ -122,7 +121,7 @@ func TestReadInvalidFrame(t *testing.T) {
 
 func TestJSONFrameReader(t *testing.T) {
 	b := bytes.NewBufferString("{\"test\":true}\n1\n[\"a\"]")
-	r := NewJSONFramedReader(ioutil.NopCloser(b))
+	r := NewJSONFramedReader(io.NopCloser(b))
 	buf := make([]byte, 20)
 	if n, err := r.Read(buf); err != nil || n != 13 || string(buf[:n]) != `{"test":true}` {
 		t.Fatalf("unexpected: %v %d %q", err, n, buf)
@@ -140,7 +139,7 @@ func TestJSONFrameReader(t *testing.T) {
 
 func TestJSONFrameReaderShortBuffer(t *testing.T) {
 	b := bytes.NewBufferString("{\"test\":true}\n1\n[\"a\"]")
-	r := NewJSONFramedReader(ioutil.NopCloser(b))
+	r := NewJSONFramedReader(io.NopCloser(b))
 	buf := make([]byte, 3)
 
 	if n, err := r.Read(buf); err != io.ErrShortBuffer || n != 3 || string(buf[:n]) != `{"t` {

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport.go
@@ -22,7 +22,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -263,7 +262,7 @@ func (t *Transport) rewriteResponse(req *http.Request, resp *http.Response) (*ht
 		return resp, err
 	}
 
-	resp.Body = ioutil.NopCloser(newContent)
+	resp.Body = io.NopCloser(newContent)
 	// Update header node with new content-length
 	// TODO: Remove any hash/signature headers here?
 	resp.Header.Del("Content-Length")

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -148,7 +147,7 @@ func (onewayRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		Status:     "200 OK",
 		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(&bytes.Buffer{}),
+		Body:       io.NopCloser(&bytes.Buffer{}),
 		Request:    req,
 	}, nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -100,7 +99,7 @@ func (s *SimpleBackendHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 	s.requestHeader = req.Header
 	s.requestMethod = req.Method
 	var err error
-	s.requestBody, err = ioutil.ReadAll(req.Body)
+	s.requestBody, err = io.ReadAll(req.Body)
 	if err != nil {
 		s.t.Errorf("Unexpected error: %v", err)
 		return
@@ -370,7 +369,7 @@ func TestServeHTTP(t *testing.T) {
 			validateHeaders(t, test.name+" backend headers", res.Header, test.expectedRespHeader, test.notExpectedRespHeader)
 
 			// Validate Body
-			responseBody, err := ioutil.ReadAll(res.Body)
+			responseBody, err := io.ReadAll(res.Body)
 			if err != nil {
 				t.Errorf("Unexpected error reading response body: %v", err)
 			}
@@ -601,7 +600,7 @@ func TestProxyUpgradeConnectionErrorResponse(t *testing.T) {
 	// Expect error response.
 	assert.True(t, responder.called)
 	assert.Equal(t, fakeStatusCode, resp.StatusCode)
-	msg, err := ioutil.ReadAll(resp.Body)
+	msg, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Contains(t, string(msg), expectedErr.Error())
 }
@@ -640,7 +639,7 @@ func TestProxyUpgradeErrorResponseTerminates(t *testing.T) {
 			// Verify we get the correct response and full message body content
 			resp, err := http.ReadResponse(bufferedReader, nil)
 			require.NoError(t, err)
-			data, err := ioutil.ReadAll(resp.Body)
+			data, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			require.Equal(t, resp.StatusCode, code)
 			require.Equal(t, data, []byte(`some data`))
@@ -790,7 +789,7 @@ func TestRejectForwardingRedirectsOption(t *testing.T) {
 			resp, err := http.ReadResponse(bufferedReader, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectStatusCode, resp.StatusCode)
-			data, err := ioutil.ReadAll(resp.Body)
+			data, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectBody, data)
 			assert.Equal(t, int64(len(tc.expectBody)), resp.ContentLength)
@@ -976,7 +975,7 @@ func TestProxyRequestContentLengthAndTransferEncoding(t *testing.T) {
 			}
 
 			// Read body
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			if err != nil {
 				t.Errorf("%s: unexpected error %v", k, err)
 			}
@@ -1039,7 +1038,7 @@ func TestProxyRequestContentLengthAndTransferEncoding(t *testing.T) {
 		}
 
 		// Read response
-		response, err := ioutil.ReadAll(conn)
+		response, err := io.ReadAll(conn)
 		if err != nil {
 			t.Errorf("%s: unexpected error %v", k, err)
 			continue

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"reflect"
 	"strings"
@@ -45,7 +44,7 @@ stuff: 1
 	}
 
 	for i, testCase := range testCases {
-		r := NewDocumentDecoder(ioutil.NopCloser(bytes.NewReader([]byte(d))))
+		r := NewDocumentDecoder(io.NopCloser(bytes.NewReader([]byte(d))))
 		b := make([]byte, testCase.bufLen)
 		n, err := r.Read(b)
 		if err != testCase.expectErr || n != testCase.expectLen {
@@ -62,7 +61,7 @@ stuff: 1
 	bufferLen := 4 * 1024
 	//  maxLen 5 M
 	dd := strings.Repeat(d, 512*1024)
-	r := NewDocumentDecoder(ioutil.NopCloser(bytes.NewReader([]byte(dd[:maxLen-1]))))
+	r := NewDocumentDecoder(io.NopCloser(bytes.NewReader([]byte(dd[:maxLen-1]))))
 	b := make([]byte, bufferLen)
 	n, err := r.Read(b)
 	if err != io.ErrShortBuffer {
@@ -73,7 +72,7 @@ stuff: 1
 	if err != nil {
 		t.Fatalf("expected nil: %d / %v", n, err)
 	}
-	r = NewDocumentDecoder(ioutil.NopCloser(bytes.NewReader([]byte(dd))))
+	r = NewDocumentDecoder(io.NopCloser(bytes.NewReader([]byte(dd))))
 	b = make([]byte, maxLen)
 	n, err = r.Read(b)
 	if err != bufio.ErrTooLong {
@@ -85,7 +84,7 @@ func TestYAMLDecoderCallsAfterErrShortBufferRestOfFrame(t *testing.T) {
 	d := `---
 stuff: 1
 	test-foo: 1`
-	r := NewDocumentDecoder(ioutil.NopCloser(bytes.NewReader([]byte(d))))
+	r := NewDocumentDecoder(io.NopCloser(bytes.NewReader([]byte(d))))
 	b := make([]byte, 12)
 	n, err := r.Read(b)
 	if err != io.ErrShortBuffer || n != 12 {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/config.go
@@ -19,7 +19,6 @@ package resourcequota
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -50,7 +49,7 @@ func LoadConfiguration(config io.Reader) (*resourcequotaapi.Configuration, error
 		return internalConfig, nil
 	}
 	// we have a config so parse it.
-	data, err := ioutil.ReadAll(config)
+	data, err := io.ReadAll(config)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/kubeconfig.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/kubeconfig.go
@@ -19,7 +19,6 @@ package config
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -47,7 +46,7 @@ func LoadConfig(configFile io.Reader) (string, error) {
 	var kubeconfigFile string
 	if configFile != nil {
 		// we have a config so parse it.
-		data, err := ioutil.ReadAll(configFile)
+		data, err := io.ReadAll(configFile)
 		if err != nil {
 			return "", err
 		}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugins.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugins.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"sort"
 	"strings"
@@ -115,7 +114,7 @@ func splitStream(config io.Reader) (io.Reader, io.Reader, error) {
 		return nil, nil, nil
 	}
 
-	configBytes, err := ioutil.ReadAll(config)
+	configBytes, err := io.ReadAll(config)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -366,7 +365,7 @@ func TestSerializeObject(t *testing.T) {
 			if !reflect.DeepEqual(result.Header, tt.wantHeaders) {
 				t.Fatal(diff.ObjectReflectDiff(tt.wantHeaders, result.Header))
 			}
-			body, _ := ioutil.ReadAll(result.Body)
+			body, _ := io.ReadAll(result.Body)
 			if !bytes.Equal(tt.wantBody, body) {
 				t.Fatalf("wanted:\n%s\ngot:\n%s", hex.Dump(tt.wantBody), hex.Dump(body))
 			}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -375,13 +374,13 @@ func summarizeData(data []byte, maxLength int) string {
 func limitedReadBody(req *http.Request, limit int64) ([]byte, error) {
 	defer req.Body.Close()
 	if limit <= 0 {
-		return ioutil.ReadAll(req.Body)
+		return io.ReadAll(req.Body)
 	}
 	lr := &io.LimitedReader{
 		R: req.Body,
 		N: limit + 1,
 	}
-	data, err := ioutil.ReadAll(lr)
+	data, err := io.ReadAll(lr)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -239,7 +238,7 @@ func TestWatchClientClose(t *testing.T) {
 	}
 
 	if response.StatusCode != http.StatusOK {
-		b, _ := ioutil.ReadAll(response.Body)
+		b, _ := io.ReadAll(response.Body)
 		t.Fatalf("Unexpected response: %#v\n%s", response, string(b))
 	}
 
@@ -283,7 +282,7 @@ func TestWatchRead(t *testing.T) {
 		}
 
 		if response.StatusCode != http.StatusOK {
-			b, _ := ioutil.ReadAll(response.Body)
+			b, _ := io.ReadAll(response.Body)
 			t.Fatalf("Unexpected response for accept: %q: %#v\n%s", accept, response, string(b))
 		}
 		return response.Body, response.Header.Get("Content-Type")
@@ -933,7 +932,7 @@ func runWatchHTTPBenchmark(b *testing.B, items []runtime.Object, contentType str
 	wg.Add(1)
 	go func() {
 		defer response.Body.Close()
-		if _, err := io.Copy(ioutil.Discard, response.Body); err != nil {
+		if _, err := io.Copy(io.Discard, response.Body); err != nil {
 			b.Error(err)
 		}
 		wg.Done()
@@ -973,7 +972,7 @@ func BenchmarkWatchWebsocket(b *testing.B) {
 	wg.Add(1)
 	go func() {
 		defer ws.Close()
-		if _, err := io.Copy(ioutil.Discard, ws); err != nil {
+		if _, err := io.Copy(io.Discard, ws); err != nil {
 			b.Error(err)
 		}
 		wg.Done()

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/response_checker.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/response_checker.go
@@ -19,7 +19,6 @@ package rest
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -47,7 +46,7 @@ type GenericHttpResponseChecker struct {
 func (checker GenericHttpResponseChecker) Check(resp *http.Response) error {
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusPartialContent {
 		defer resp.Body.Close()
-		bodyBytes, err := ioutil.ReadAll(io.LimitReader(resp.Body, maxReadLength))
+		bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxReadLength))
 		if err != nil {
 			return errors.NewInternalError(err)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -142,7 +141,7 @@ func newTestGOAWAYServer() (*httptest.Server, error) {
 		return
 	})
 	postHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		reqBody, err := ioutil.ReadAll(r.Body)
+		reqBody, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -208,7 +207,7 @@ func requestGOAWAYServer(client *http.Client, serverBaseURL, url string) (<-chan
 
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response body and status code is %d, error: %v", resp.StatusCode, err)
 		}
@@ -248,7 +247,7 @@ func requestGOAWAYServer(client *http.Client, serverBaseURL, url string) (<-chan
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body, error: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -231,7 +230,7 @@ func TestInstallAPIGroups(t *testing.T) {
 			continue
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Errorf("[%d] unexpected error reading body at path %q: %v", i, path, err)
 			continue
@@ -275,7 +274,7 @@ func TestInstallAPIGroups(t *testing.T) {
 			continue
 		}
 
-		body, err = ioutil.ReadAll(resp.Body)
+		body, err = io.ReadAll(resp.Body)
 		if err != nil {
 			t.Errorf("[%d] unexpected error reading body at path %q: %v", i, path, err)
 			continue
@@ -366,7 +365,7 @@ func TestUpdateOpenAPISpec(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(http.StatusOK, resp.StatusCode)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	assert.NoError(err)
 	assert.Equal(oldSpec, body)
 	resp.Body.Close()
@@ -385,7 +384,7 @@ func TestUpdateOpenAPISpec(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(http.StatusOK, resp.StatusCode)
 
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	assert.NoError(err)
 	assert.Equal(newSpec, body)
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/wsstream/conn_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/wsstream/conn_test.go
@@ -19,7 +19,6 @@ package wsstream
 import (
 	"encoding/base64"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -57,7 +56,7 @@ func TestRawConn(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		data, err := ioutil.ReadAll(conn.channels[0])
+		data, err := io.ReadAll(conn.channels[0])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -139,7 +138,7 @@ func TestBase64Conn(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		data, err := ioutil.ReadAll(conn.channels[0])
+		data, err := io.ReadAll(conn.channels[0])
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/util/wsstream/stream_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/wsstream/stream_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strings"
@@ -251,7 +250,7 @@ func readWebSocket(r *Reader, t *testing.T, fn func(*websocket.Conn), protocols 
 		fn(client)
 	}
 
-	data, err := ioutil.ReadAll(client)
+	data, err := io.ReadAll(client)
 	if err != nil {
 		return data, err
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/io_options.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/io_options.go
@@ -19,7 +19,6 @@ package genericclioptions
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 )
 
 // IOStreams provides the standard names for iostreams.  This is useful for embedding and for unit testing.
@@ -51,7 +50,7 @@ func NewTestIOStreamsDiscard() IOStreams {
 	in := &bytes.Buffer{}
 	return IOStreams{
 		In:     in,
-		Out:    ioutil.Discard,
-		ErrOut: ioutil.Discard,
+		Out:    io.Discard,
+		ErrOut: io.Discard,
 	}
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strings"
@@ -39,7 +38,7 @@ import (
 )
 
 func objBody(obj runtime.Object) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(corev1Codec, obj))))
+	return io.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(corev1Codec, obj))))
 }
 
 func header() http.Header {
@@ -250,7 +249,7 @@ func TestHelperCreate(t *testing.T) {
 			if tt.Req != nil && !tt.Req(client.Req) {
 				t.Errorf("%d: unexpected request: %#v", i, client.Req)
 			}
-			body, err := ioutil.ReadAll(client.Req.Body)
+			body, err := io.ReadAll(client.Req.Body)
 			if err != nil {
 				t.Fatalf("%d: unexpected error: %#v", i, err)
 			}
@@ -711,7 +710,7 @@ func TestHelperReplace(t *testing.T) {
 			if tt.Req != nil && (client.Req == nil || !tt.Req(tt.ExpectPath, client.Req)) {
 				t.Fatalf("unexpected request: %#v", client.Req)
 			}
-			body, err := ioutil.ReadAll(client.Req.Body)
+			body, err := io.ReadAll(client.Req.Body)
 			if err != nil {
 				t.Fatalf("unexpected error: %#v", err)
 			}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -22,7 +22,6 @@ package azure
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -651,7 +650,7 @@ func parseConfig(configReader io.Reader) (*Config, error) {
 		return nil, nil
 	}
 
-	configContents, err := ioutil.ReadAll(configReader)
+	configContents, err := io.ReadAll(configReader)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gcpcredential/credentialutil.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gcpcredential/credentialutil.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"k8s.io/cloud-provider/credentialconfig"
@@ -68,7 +67,7 @@ func ReadURL(url string, client *http.Client, header *http.Header) (body []byte,
 	}
 
 	limitedReader := &io.LimitedReader{R: resp.Body, N: maxReadLength}
-	contents, err := ioutil.ReadAll(limitedReader)
+	contents, err := io.ReadAll(limitedReader)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
+++ b/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -180,7 +179,7 @@ func (s *Server) HandleValidate(w http.ResponseWriter, r *http.Request) {
 
 	defer r.Body.Close()
 	limitedReader := &io.LimitedReader{R: r.Body, N: maxRequestSize}
-	if body, err = ioutil.ReadAll(limitedReader); err != nil {
+	if body, err = io.ReadAll(limitedReader); err != nil {
 		klog.ErrorS(err, "unable to read the body from the incoming request")
 		http.Error(w, "unable to read the body from the incoming request", http.StatusBadRequest)
 		return

--- a/test/e2e_node/plugins/gcp-credential-provider/main.go
+++ b/test/e2e_node/plugins/gcp-credential-provider/main.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -46,7 +45,7 @@ func getCredentials(tokenEndpoint string, r io.Reader, w io.Writer) error {
 		tokenEndpoint: tokenEndpoint,
 	}
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/test/e2e_node/plugins/gcp-credential-provider/provider.go
+++ b/test/e2e_node/plugins/gcp-credential-provider/provider.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	credentialproviderv1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1"
@@ -108,7 +107,7 @@ func readURL(url string, client *http.Client) (body []byte, err error) {
 	}
 
 	limitedReader := &io.LimitedReader{R: resp.Body, N: maxReadLength}
-	contents, err := ioutil.ReadAll(limitedReader)
+	contents, err := io.ReadAll(limitedReader)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Remove ioutil for accomodate newer Go versions
We should clean all io/util package according the url: https://go.dev/doc/go1.16#ioutil
Thanks
Signed-off-by: yulng <wei.yang@daocloud.io>