### PR TITLE
Fix verify-licenses script

### DIFF
--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -51,22 +51,13 @@ packages_flagged=()
 packages_url_missing=()
 exit_code=0
 
-git remote add licenses https://github.com/kubernetes/kubernetes >/dev/null 2>&1 || true
-
-
 # Install go-licenses
 echo '[INFO] Installing go-licenses...'
-pushd "${KUBE_TEMP}" >/dev/null
-    git clone https://github.com/google/go-licenses.git >/dev/null 2>&1
-    cd go-licenses
-    go build -o "${GOPATH}/bin"
-popd >/dev/null
-
+go install github.com/google/go-licenses@latest
 
 # Fetching CNCF Approved List Of Licenses
 # Refer: https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md
 curl -s 'https://spdx.org/licenses/licenses.json' -o "${KUBE_TEMP}"/licenses.json
-
 
 number_of_licenses=$(jq '.licenses | length' "${KUBE_TEMP}"/licenses.json)
 loop_index_length=$(( number_of_licenses - 1 ))
@@ -85,8 +76,7 @@ done
 
 # Scanning go-packages under the project & verifying against the CNCF approved list of licenses
 echo '[INFO] Starting license scan on go-packages...'
-go-licenses csv --git_remote licenses ./... >> "${KUBE_TEMP}"/licenses.csv 2>/dev/null
-
+go-licenses report ./... >> "${KUBE_TEMP}"/licenses.csv
 
 echo -e 'PACKAGE_NAME  LICENSE_NAME  LICENSE_URL\n' >> "${KUBE_TEMP}"/approved_licenses.dump
 while IFS=, read -r GO_PACKAGE LICENSE_URL LICENSE_NAME


### PR DESCRIPTION
fixes https://prow.k8s.io/?job=kubernetes-verify-go-licenses-periodical

The invocation was not correct at all, the job was failing with `> F0104 15:15:26.116891    1918 main.go:77] unknown flag: --git_remote`

cc @maxsmythe 