### PR TITLE
WIP - Add resourceVersion precondition to GC controller deletions

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -620,7 +620,7 @@ func (gc *GarbageCollector) attemptToDeleteItem(ctx context.Context, item *node)
 		// FinalizerDeletingDependents from the item, resulting in the final
 		// deletion of the item.
 		policy := metav1.DeletePropagationForeground
-		return gc.deleteObject(item.identity, &policy)
+		return gc.deleteObject(item.identity, latest.ResourceVersion, latest.OwnerReferences, &policy)
 	default:
 		// item doesn't have any solid owner, so it needs to be garbage
 		// collected. Also, none of item's owners is waiting for the deletion of
@@ -641,7 +641,7 @@ func (gc *GarbageCollector) attemptToDeleteItem(ctx context.Context, item *node)
 			"item", item.identity,
 			"propagationPolicy", policy,
 		)
-		return gc.deleteObject(item.identity, &policy)
+		return gc.deleteObject(item.identity, latest.ResourceVersion, latest.OwnerReferences, &policy)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds a resourceVersion precondition to GC deletion so that we only delete the exact version of objects whose ownerReferences we inspected.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/114603

#### Special notes for your reviewer:

/hold for tests of precondition functionality

This also introduces the possibility of rapid updates of unrelated fields in an object pre-empting deletion by the GC controller possibly perpetually. I think this is worth it to be sure we're deleting the exact owner references we inspected, but it is a risk.

#### Does this PR introduce a user-facing change?
```release-note
The garbage collection controller no longer races with changes to ownerReferences when deleting orphaned objects.
```

/assign @deads2k 