### PR TITLE
egress_selector.go: register konnectivity-client metrics.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
@@ -36,12 +36,17 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/apis/apiserver"
 	egressmetrics "k8s.io/apiserver/pkg/server/egressselector/metrics"
+	compbasemetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/tracing"
 	"k8s.io/klog/v2"
 	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
 )
 
 var directDialer utilnet.DialFunc = http.DefaultTransport.(*http.Transport).DialContext
+
+func init() {
+	client.Metrics.RegisterMetrics(compbasemetrics.NewKubeRegistry().Registerer())
+}
 
 // EgressSelector is the map of network context type to context dialer, for network egress.
 type EgressSelector struct {


### PR DESCRIPTION
This registers new metrics provided by https://github.com/kubernetes/kubernetes/pull/114789.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

It can be difficult to debug Konnectivity issues inside kube-apiserver, where we have limited metrics (mainly egress_selector.go). Registering these konnectivity-client library instrumented metrics provides richer signal than before.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

This takes a dependency on https://github.com/kubernetes/kubernetes/pull/114646.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
