### PR TITLE
Give TypeConverter to TestFieldManager

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/capmanagers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/capmanagers_test.go
@@ -48,7 +48,7 @@ func (*fakeManager) Apply(_, _ runtime.Object, _ fieldmanager.Managed, _ string,
 }
 
 func TestCapManagersManagerMergesEntries(t *testing.T) {
-	f := fieldmanagertest.NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"),
+	f := fieldmanagertest.NewTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "Pod"),
 		"",
 		func(m fieldmanager.Manager) fieldmanager.Manager {
 			return fieldmanager.NewCapManagersManager(m, 3)
@@ -114,7 +114,7 @@ func TestCapManagersManagerMergesEntries(t *testing.T) {
 }
 
 func TestCapUpdateManagers(t *testing.T) {
-	f := fieldmanagertest.NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"),
+	f := fieldmanagertest.NewTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "Pod"),
 		"",
 		func(m fieldmanager.Manager) fieldmanager.Manager {
 			return fieldmanager.NewCapManagersManager(m, 3)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedmanager_test.go
@@ -44,7 +44,7 @@ type testArgs struct {
 // created with the client-side apply last-applied annotation
 // will not give conflicts
 func TestApplyUsingLastAppliedAnnotation(t *testing.T) {
-	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("apps/v1", "Deployment"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("apps/v1", "Deployment"))
 
 	tests := []testArgs{
 		{
@@ -564,7 +564,7 @@ spec:
 }
 
 func TestServiceApply(t *testing.T) {
-	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "Service"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "Service"))
 
 	tests := []testArgs{
 		{
@@ -675,7 +675,7 @@ spec:
 }
 
 func TestReplicationControllerApply(t *testing.T) {
-	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ReplicationController"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "ReplicationController"))
 
 	tests := []testArgs{
 		{
@@ -738,7 +738,7 @@ spec:
 }
 
 func TestPodApply(t *testing.T) {
-	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "Pod"))
 
 	tests := []testArgs{
 		{

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedupdater_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/lastappliedupdater_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestLastAppliedUpdater(t *testing.T) {
-	f := fieldmanagertest.NewTestFieldManager(schema.FromAPIVersionAndKind("apps/v1", "Deployment"),
+	f := fieldmanagertest.NewTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("apps/v1", "Deployment"),
 		"",
 		func(m fieldmanager.Manager) fieldmanager.Manager {
 			return fieldmanager.NewLastAppliedUpdater(m)
@@ -189,7 +189,7 @@ func TestLargeLastApplied(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			f := fieldmanagertest.NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"),
+			f := fieldmanagertest.NewTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "ConfigMap"),
 				"",
 				func(m fieldmanager.Manager) fieldmanager.Manager {
 					return fieldmanager.NewLastAppliedUpdater(m)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/managedfieldsupdater_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/managedfieldsupdater_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestManagedFieldsUpdateDoesModifyTime(t *testing.T) {
 	var err error
-	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = updateObject(&f, "fieldmanager_test", []byte(`{
 		"apiVersion": "v1",
@@ -77,7 +77,7 @@ func TestManagedFieldsUpdateDoesModifyTime(t *testing.T) {
 
 func TestManagedFieldsApplyDoesModifyTime(t *testing.T) {
 	var err error
-	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = applyObject(&f, "fieldmanager_test", []byte(`{
 		"apiVersion": "v1",
@@ -118,7 +118,7 @@ func TestManagedFieldsApplyDoesModifyTime(t *testing.T) {
 
 func TestManagedFieldsUpdateWithoutChangesDoesNotModifyTime(t *testing.T) {
 	var err error
-	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = updateObject(&f, "fieldmanager_test", []byte(`{
 		"apiVersion": "v1",
@@ -159,7 +159,7 @@ func TestManagedFieldsUpdateWithoutChangesDoesNotModifyTime(t *testing.T) {
 
 func TestManagedFieldsApplyWithoutChangesDoesNotModifyTime(t *testing.T) {
 	var err error
-	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = applyObject(&f, "fieldmanager_test", []byte(`{
 		"apiVersion": "v1",
@@ -200,7 +200,7 @@ func TestManagedFieldsApplyWithoutChangesDoesNotModifyTime(t *testing.T) {
 
 func TestNonManagedFieldsUpdateDoesNotModifyTime(t *testing.T) {
 	var err error
-	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = updateObject(&f, "fieldmanager_a_test", []byte(`{
 		"apiVersion": "v1",
@@ -263,7 +263,7 @@ func TestNonManagedFieldsUpdateDoesNotModifyTime(t *testing.T) {
 
 func TestNonManagedFieldsApplyDoesNotModifyTime(t *testing.T) {
 	var err error
-	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = applyObject(&f, "fieldmanager_a_test", []byte(`{
 		"apiVersion": "v1",
@@ -326,7 +326,7 @@ func TestNonManagedFieldsApplyDoesNotModifyTime(t *testing.T) {
 
 func TestTakingOverManagedFieldsDuringUpdateDoesNotModifyPreviousManagerTime(t *testing.T) {
 	var err error
-	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = updateObject(&f, "fieldmanager_a_test", []byte(`{
 		"apiVersion": "v1",
@@ -377,7 +377,7 @@ func TestTakingOverManagedFieldsDuringUpdateDoesNotModifyPreviousManagerTime(t *
 
 func TestTakingOverManagedFieldsDuringApplyDoesNotModifyPreviousManagerTime(t *testing.T) {
 	var err error
-	f := fieldmanagertest.NewDefaultTestFieldManager(schema.FromAPIVersionAndKind("v1", "ConfigMap"))
+	f := fieldmanagertest.NewDefaultTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "ConfigMap"))
 
 	err = applyObject(&f, "fieldmanager_a_test", []byte(`{
 		"apiVersion": "v1",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/skipnonapplied_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/skipnonapplied_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestNoUpdateBeforeFirstApply(t *testing.T) {
-	f := fieldmanagertest.NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m fieldmanager.Manager) fieldmanager.Manager {
+	f := fieldmanagertest.NewTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m fieldmanager.Manager) fieldmanager.Manager {
 		return fieldmanager.NewSkipNonAppliedManager(
 			m,
 			fieldmanagertest.NewFakeObjectCreater(),
@@ -70,7 +70,7 @@ func TestNoUpdateBeforeFirstApply(t *testing.T) {
 }
 
 func TestUpdateBeforeFirstApply(t *testing.T) {
-	f := fieldmanagertest.NewTestFieldManager(schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m fieldmanager.Manager) fieldmanager.Manager {
+	f := fieldmanagertest.NewTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m fieldmanager.Manager) fieldmanager.Manager {
 		return fieldmanager.NewSkipNonAppliedManager(
 			m,
 			fieldmanagertest.NewFakeObjectCreater(),


### PR DESCRIPTION
This is mostly because the path, even for built-in, can change from test to test, so it's easier to make the whole thing configurable anyway.

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Continues to clean-up the fieldmanager package, in preparation for it to move to a place where it can be easily imported.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
