### PR TITLE
kubeadm: fix the nil pointer dereference in testcase

### DIFF
--- a/cmd/kubeadm/app/cmd/certs_test.go
+++ b/cmd/kubeadm/app/cmd/certs_test.go
@@ -464,11 +464,11 @@ kubernetesVersion: %s`,
 			err := config.load()
 			if test.expectErr {
 				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
 			}
-			for _, assertFunc := range test.assertions {
-				assertFunc(t, config)
+			if !test.expectErr && assert.NoError(t, err) {
+				for _, assertFunc := range test.assertions {
+					assertFunc(t, config)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
`genCSRConfig.kubeadmConfig` is possible to be nil if there any error from the config loading, so access the field should only be done if there is no error in the previous step.

Signed-off-by: Dave Chen <dave.chen@arm.com>


ref: https://github.com/kubernetes/kubernetes/issues/113936

more context:
- a nil `kubeadmapiv1.InitConfiguration` is returned when some error was found, e.g.  client version cannot be parsed correctly.
https://github.com/kubernetes/kubernetes/blob/ca2f095cc7a69b2cb24569cd3e45a33cd37ff1be/cmd/kubeadm/app/util/config/initconfiguration.go#L242-L244

- Debug the testcase show that `config.kubeadmConfig` is nil if `test.expectErr` is true.
```bash
(dlv) p config.kubeadmConfig
*k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm.InitConfiguration nil
```

- The nil pointer dereference error msg should be like this.
https://github.com/kubernetes/kubernetes/issues/113936#issuecomment-1370551435
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
