### PR TITLE
Fix failure(context canceled) in scheduler_perf benchmark

### DIFF
--- a/test/integration/scheduler_perf/main_test.go
+++ b/test/integration/scheduler_perf/main_test.go
@@ -17,11 +17,18 @@ limitations under the License.
 package benchmark
 
 import (
+	"flag"
 	"testing"
 
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
 func TestMain(m *testing.M) {
+	// Run with -v=2, this is the default log level in production.
+	ktesting.DefaultConfig = ktesting.NewConfig(ktesting.Verbosity(2))
+	ktesting.DefaultConfig.AddFlags(flag.CommandLine)
+	flag.Parse()
+
 	framework.EtcdMain(m.Run)
 }

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -691,7 +691,7 @@ func runWorkload(b *testing.B, tc *testCase, w *workload) []DataItem {
 				b.Fatalf("op %d: %v", opIndex, err)
 			}
 			b.Cleanup(func() {
-				_ = nodePreparer.CleanupNodes(ctx)
+				_ = nodePreparer.CleanupNodes(context.Background())
 			})
 			nextNodeIndex += concreteOp.Count
 

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -584,10 +584,14 @@ func BenchmarkPerfScheduling(b *testing.B) {
 		b.Run(tc.Name, func(b *testing.B) {
 			for _, w := range tc.Workloads {
 				b.Run(w.Name, func(b *testing.B) {
+					// 30 minutes should be plenty enough even for the 5000-node tests.
+					ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Minute)
+					b.Cleanup(cancel)
+
 					for feature, flag := range tc.FeatureGates {
 						defer featuregatetesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, feature, flag)()
 					}
-					dataItems.DataItems = append(dataItems.DataItems, runWorkload(b, tc, w)...)
+					dataItems.DataItems = append(dataItems.DataItems, runWorkload(ctx, b, tc, w)...)
 					// Reset metrics to prevent metrics generated in current workload gets
 					// carried over to the next workload.
 					legacyregistry.Reset()
@@ -639,10 +643,7 @@ func unrollWorkloadTemplate(b *testing.B, wt []op, w *workload) []op {
 	return unrolled
 }
 
-func runWorkload(b *testing.B, tc *testCase, w *workload) []DataItem {
-	// 30 minutes should be plenty enough even for the 5000-node tests.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-	defer cancel()
+func runWorkload(ctx context.Context, b *testing.B, tc *testCase, w *workload) []DataItem {
 	var cfg *config.KubeSchedulerConfiguration
 	var err error
 	if tc.SchedulerConfigPath != nil {
@@ -654,7 +655,7 @@ func runWorkload(b *testing.B, tc *testCase, w *workload) []DataItem {
 			b.Fatalf("validate scheduler config file failed: %v", err)
 		}
 	}
-	finalFunc, podInformer, client, dynClient := mustSetupScheduler(b, cfg)
+	finalFunc, podInformer, client, dynClient := mustSetupScheduler(ctx, b, cfg)
 	b.Cleanup(finalFunc)
 
 	var mu sync.Mutex
@@ -665,7 +666,7 @@ func runWorkload(b *testing.B, tc *testCase, w *workload) []DataItem {
 	numPodsScheduledPerNamespace := make(map[string]int)
 	b.Cleanup(func() {
 		for namespace := range numPodsScheduledPerNamespace {
-			if err := client.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{}); err != nil {
+			if err := client.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{}); err != nil {
 				b.Errorf("Deleting Namespace in numPodsScheduledPerNamespace: %v", err)
 			}
 		}
@@ -691,7 +692,7 @@ func runWorkload(b *testing.B, tc *testCase, w *workload) []DataItem {
 				b.Fatalf("op %d: %v", opIndex, err)
 			}
 			b.Cleanup(func() {
-				if err := nodePreparer.CleanupNodes(context.Background()); err != nil {
+				if err := nodePreparer.CleanupNodes(ctx); err != nil {
 					b.Fatalf("failed to clean up nodes, error: %v", err)
 				}
 			})
@@ -702,8 +703,8 @@ func runWorkload(b *testing.B, tc *testCase, w *workload) []DataItem {
 			if err != nil {
 				b.Fatalf("op %d: %v", opIndex, err)
 			}
-			if err := nsPreparer.prepare(); err != nil {
-				nsPreparer.cleanup()
+			if err := nsPreparer.prepare(ctx); err != nil {
+				nsPreparer.cleanup(ctx)
 				b.Fatalf("op %d: %v", opIndex, err)
 			}
 			for _, n := range nsPreparer.namespaces() {
@@ -987,6 +988,7 @@ func waitUntilPodsScheduledInNamespace(ctx context.Context, b *testing.B, podInf
 			return false, err
 		}
 		if len(scheduled) >= wantCount {
+			b.Logf("scheduling succeed")
 			return true, nil
 		}
 		b.Logf("namespace: %s, pods: want %d, got %d", namespace, wantCount, len(scheduled))
@@ -1197,7 +1199,7 @@ func (p *namespacePreparer) namespaces() []string {
 }
 
 // prepare creates the namespaces.
-func (p *namespacePreparer) prepare() error {
+func (p *namespacePreparer) prepare(ctx context.Context) error {
 	base := &v1.Namespace{}
 	if p.spec != nil {
 		base = p.spec
@@ -1207,7 +1209,7 @@ func (p *namespacePreparer) prepare() error {
 		n := base.DeepCopy()
 		n.Name = fmt.Sprintf("%s-%d", p.prefix, i)
 		if err := testutils.RetryWithExponentialBackOff(func() (bool, error) {
-			_, err := p.client.CoreV1().Namespaces().Create(context.Background(), n, metav1.CreateOptions{})
+			_, err := p.client.CoreV1().Namespaces().Create(ctx, n, metav1.CreateOptions{})
 			return err == nil || apierrors.IsAlreadyExists(err), nil
 		}); err != nil {
 			return err
@@ -1217,11 +1219,11 @@ func (p *namespacePreparer) prepare() error {
 }
 
 // cleanup deletes existing test namespaces.
-func (p *namespacePreparer) cleanup() error {
+func (p *namespacePreparer) cleanup(ctx context.Context) error {
 	var errRet error
 	for i := 0; i < p.count; i++ {
 		n := fmt.Sprintf("%s-%d", p.prefix, i)
-		if err := p.client.CoreV1().Namespaces().Delete(context.Background(), n, metav1.DeleteOptions{}); err != nil {
+		if err := p.client.CoreV1().Namespaces().Delete(ctx, n, metav1.DeleteOptions{}); err != nil {
 			p.t.Errorf("Deleting Namespace: %v", err)
 			errRet = err
 		}

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -691,7 +691,9 @@ func runWorkload(b *testing.B, tc *testCase, w *workload) []DataItem {
 				b.Fatalf("op %d: %v", opIndex, err)
 			}
 			b.Cleanup(func() {
-				_ = nodePreparer.CleanupNodes(context.Background())
+				if err := nodePreparer.CleanupNodes(context.Background()); err != nil {
+					b.Fatalf("failed to clean up nodes, error: %v", err)
+				}
 			})
 			nextNodeIndex += concreteOp.Count
 


### PR DESCRIPTION
Scheduler-perf benchmark tests are always failed due to the cancelled context when tearing down

Signed-off-by: Kante Yin <kerthcet@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/sig scheduling
/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

scheduler-perf benchmarks are always failed due to the error:
```
E0105 04:27:16.047290   27011 perf_utils.go:129] Error while deleting Node: client rate limiter Wait returned an error: context canceled
```

see testgrid: https://testgrid.k8s.io/sig-scalability-benchmarks#scheduler-perf

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
