### PR TITLE
Remove support for seccomp annotations when determining whether a container update should trigger a policy evaluation

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/admission/admission.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/admission.go
@@ -638,12 +638,12 @@ func isSignificantPodUpdate(pod, oldPod *corev1.Pod) bool {
 		return true
 	}
 	for i := 0; i < len(pod.Spec.Containers); i++ {
-		if isSignificantContainerUpdate(&pod.Spec.Containers[i], &oldPod.Spec.Containers[i], pod.Annotations, oldPod.Annotations) {
+		if isSignificantContainerUpdate(&pod.Spec.Containers[i], &oldPod.Spec.Containers[i]) {
 			return true
 		}
 	}
 	for i := 0; i < len(pod.Spec.InitContainers); i++ {
-		if isSignificantContainerUpdate(&pod.Spec.InitContainers[i], &oldPod.Spec.InitContainers[i], pod.Annotations, oldPod.Annotations) {
+		if isSignificantContainerUpdate(&pod.Spec.InitContainers[i], &oldPod.Spec.InitContainers[i]) {
 			return true
 		}
 	}
@@ -658,7 +658,7 @@ func isSignificantPodUpdate(pod, oldPod *corev1.Pod) bool {
 		if oldC == nil {
 			return true // EphemeralContainer added
 		}
-		if isSignificantContainerUpdate((*corev1.Container)(&c.EphemeralContainerCommon), oldC, pod.Annotations, oldPod.Annotations) {
+		if isSignificantContainerUpdate((*corev1.Container)(&c.EphemeralContainerCommon), oldC) {
 			return true
 		}
 	}
@@ -666,13 +666,8 @@ func isSignificantPodUpdate(pod, oldPod *corev1.Pod) bool {
 }
 
 // isSignificantContainerUpdate determines whether a container update should trigger a policy evaluation.
-func isSignificantContainerUpdate(container, oldContainer *corev1.Container, annotations, oldAnnotations map[string]string) bool {
-	if container.Image != oldContainer.Image {
-		return true
-	}
-	// TODO(saschagrunert): Remove this logic in 1.27.
-	seccompKey := corev1.SeccompContainerAnnotationKeyPrefix + container.Name
-	return annotations[seccompKey] != oldAnnotations[seccompKey]
+func isSignificantContainerUpdate(container, oldContainer *corev1.Container) bool {
+	return container.Image != oldContainer.Image
 }
 
 func (a *Admission) exemptNamespace(namespace string) bool {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Followup #109819, since the seccomp fields are immutable, so we can just drop them in 1.27

https://github.com/kubernetes/kubernetes/pull/109819#discussion_r868578042
> container-level seccomp annotations could still influence 1.23 and 1.24 kubelets (which still honor them over pod level fields), so this is still a relevant change. keep this and leave a comment explaining why and a TODO to drop this in 1.27

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref #95171

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
