### PR TITLE
handle event errors caused due to terminating namespaces

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -276,6 +276,8 @@ func recordEvent(sink EventSink, event *v1.Event, patch []byte, updateExistingEv
 	case *errors.StatusError:
 		if errors.IsAlreadyExists(err) {
 			klog.V(5).Infof("Server rejected event '%#v': '%v' (will not retry!)", event, err)
+		} else if errors.HasStatusCause(err, v1.NamespaceTerminatingCause) {
+			klog.V(5).Infof("Server rejected event '%#v': '%v' (will not retry!)", event, err)
 		} else {
 			klog.Errorf("Server rejected event '%#v': '%v' (will not retry!)", event, err)
 		}

--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -274,9 +274,7 @@ func recordEvent(sink EventSink, event *v1.Event, patch []byte, updateExistingEv
 		klog.Errorf("Unable to construct event '%#v': '%v' (will not retry!)", event, err)
 		return true
 	case *errors.StatusError:
-		if errors.IsAlreadyExists(err) {
-			klog.V(5).Infof("Server rejected event '%#v': '%v' (will not retry!)", event, err)
-		} else if errors.HasStatusCause(err, v1.NamespaceTerminatingCause) {
+		if errors.IsAlreadyExists(err) || errors.HasStatusCause(err, v1.NamespaceTerminatingCause) {
 			klog.V(5).Infof("Server rejected event '%#v': '%v' (will not retry!)", event, err)
 		} else {
 			klog.Errorf("Server rejected event '%#v': '%v' (will not retry!)", event, err)


### PR DESCRIPTION
Signed-off-by: Sunil Shivanand <sunil.shivanand@statnett.no>

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Create events are forbidden in terminating namespaces, use info instead of error to log the failed event.

#### Which issue(s) this PR fixes:
Fixes [#1208](https://github.com/kubernetes/client-go/issues/1208)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Users will no longer see an error for failed events caused due to terminating namespace.
```
