### PR TITLE
Fix verify-license cleanup

### DIFF
--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -135,10 +135,6 @@ done < "${KUBE_TEMP}"/licenses.csv
 awk '{ printf "%-100s : %-20s : %s\n", $1, $2, $3 }' "${KUBE_TEMP}"/approved_licenses.dump
 
 
-# cleanup
-git remote remove licenses
-
-
 if [[ ${#packages_url_missing[@]} -gt 0 ]]; then
 	echo -e '\n[ERROR] The following go-packages in the project have unknown or unreachable license URL:'
 	awk '{ printf "%-100s :  %-20s : %s\n", $1, $2, $3 }' "${KUBE_TEMP}"/approved_licenses_with_missing_urls.dump


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/kubernetes/pull/114826 to green up https://prow.k8s.io/?job=kubernetes-verify-go-licenses-periodical

The script worked locally once when I tried it on the previous PR because I had a `licenses` remote hanging around 🤦 

```release-note
NONE
```

/assign @dims