### PR TITLE
Sync pkg/kubelet/cri/streaming with containerd/pkg/cri/streaming

### DIFF
--- a/pkg/kubelet/cri/streaming/portforward/httpstream.go
+++ b/pkg/kubelet/cri/streaming/portforward/httpstream.go
@@ -51,7 +51,7 @@ func handleHTTPStreams(req *http.Request, w http.ResponseWriter, portForwarder P
 	}
 	defer conn.Close()
 
-	klog.V(5).InfoS("Connection setting port forwarding streaming connection idle timeout", "connection", conn, "idleTimeout", idleTimeout)
+	klog.V(5).InfoS("Connection setting port forwarding streaming connection idle timeout", "idleTimeout", idleTimeout)
 	conn.SetIdleTimeout(idleTimeout)
 
 	h := &httpStreamHandler{
@@ -63,7 +63,7 @@ func handleHTTPStreams(req *http.Request, w http.ResponseWriter, portForwarder P
 		uid:                   uid,
 		forwarder:             portForwarder,
 	}
-	h.run()
+	h.run(req.Context()) // TODO confirm this is correct
 
 	return nil
 }
@@ -122,11 +122,11 @@ func (h *httpStreamHandler) getStreamPair(requestID string) (*httpStreamPair, bo
 	defer h.streamPairsLock.Unlock()
 
 	if p, ok := h.streamPairs[requestID]; ok {
-		klog.V(5).InfoS("Connection request found existing stream pair", "connection", h.conn, "request", requestID)
+		klog.V(5).InfoS("Connection request found existing stream pair", "request", requestID)
 		return p, false
 	}
 
-	klog.V(5).InfoS("Connection request creating new stream pair", "connection", h.conn, "request", requestID)
+	klog.V(5).InfoS("Connection request creating new stream pair", "request", requestID)
 
 	p := newPortForwardPair(requestID)
 	h.streamPairs[requestID] = p
@@ -140,11 +140,11 @@ func (h *httpStreamHandler) getStreamPair(requestID string) (*httpStreamPair, bo
 func (h *httpStreamHandler) monitorStreamPair(p *httpStreamPair, timeout <-chan time.Time) {
 	select {
 	case <-timeout:
-		err := fmt.Errorf("(conn=%v, request=%s) timed out waiting for streams", h.conn, p.requestID)
+		err := fmt.Errorf("request %q timed out waiting for streams", p.requestID)
 		utilruntime.HandleError(err)
 		p.printError(err.Error())
 	case <-p.complete:
-		klog.V(5).InfoS("Connection request successfully received error and data streams", "connection", h.conn, "request", p.requestID)
+		klog.V(5).InfoS("Connection request successfully received error and data streams", "request", p.requestID)
 	}
 	h.removeStreamPair(p.requestID)
 }
@@ -175,7 +175,7 @@ func (h *httpStreamHandler) removeStreamPair(requestID string) {
 func (h *httpStreamHandler) requestID(stream httpstream.Stream) string {
 	requestID := stream.Headers().Get(api.PortForwardRequestIDHeader)
 	if len(requestID) == 0 {
-		klog.V(5).InfoS("Connection stream received without requestID header", "connection", h.conn)
+		klog.V(5).InfoS("Connection stream received without requestID header")
 		// If we get here, it's because the connection came from an older client
 		// that isn't generating the request id header
 		// (https://github.com/kubernetes/kubernetes/blob/843134885e7e0b360eb5441e85b1410a8b1a7a0c/pkg/client/unversioned/portforward/portforward.go#L258-L287)
@@ -202,7 +202,7 @@ func (h *httpStreamHandler) requestID(stream httpstream.Stream) string {
 			requestID = strconv.Itoa(int(stream.Identifier()) - 2)
 		}
 
-		klog.V(5).InfoS("Connection automatically assigning request ID from stream type and stream ID", "connection", h.conn, "request", requestID, "streamType", streamType, "stream", stream.Identifier())
+		klog.V(5).InfoS("Connection automatically assigning request ID from stream type and stream ID", "request", requestID, "streamType", streamType, "stream", stream.Identifier())
 	}
 	return requestID
 }
@@ -210,18 +210,18 @@ func (h *httpStreamHandler) requestID(stream httpstream.Stream) string {
 // run is the main loop for the httpStreamHandler. It processes new
 // streams, invoking portForward for each complete stream pair. The loop exits
 // when the httpstream.Connection is closed.
-func (h *httpStreamHandler) run() {
-	klog.V(5).InfoS("Connection waiting for port forward streams", "connection", h.conn)
+func (h *httpStreamHandler) run(ctx context.Context) {
+	klog.V(5).InfoS("Connection waiting for port forward streams")
 Loop:
 	for {
 		select {
 		case <-h.conn.CloseChan():
-			klog.V(5).InfoS("Connection upgraded connection closed", "connection", h.conn)
+			klog.V(5).InfoS("Connection upgraded connection closed")
 			break Loop
 		case stream := <-h.streamChan:
 			requestID := h.requestID(stream)
 			streamType := stream.Headers().Get(api.StreamType)
-			klog.V(5).InfoS("Connection request received new type of stream", "connection", h.conn, "request", requestID, "streamType", streamType)
+			klog.V(5).InfoS("Connection request received new type of stream", "request", requestID, "streamType", streamType)
 
 			p, created := h.getStreamPair(requestID)
 			if created {
@@ -232,7 +232,7 @@ Loop:
 				utilruntime.HandleError(errors.New(msg))
 				p.printError(msg)
 			} else if complete {
-				go h.portForward(p)
+				go h.portForward(ctx, p)
 			}
 		}
 	}
@@ -240,17 +240,16 @@ Loop:
 
 // portForward invokes the httpStreamHandler's forwarder.PortForward
 // function for the given stream pair.
-func (h *httpStreamHandler) portForward(p *httpStreamPair) {
-	ctx := context.Background()
+func (h *httpStreamHandler) portForward(ctx context.Context, p *httpStreamPair) {
 	defer p.dataStream.Close()
 	defer p.errorStream.Close()
 
 	portString := p.dataStream.Headers().Get(api.PortHeader)
 	port, _ := strconv.ParseInt(portString, 10, 32)
 
-	klog.V(5).InfoS("Connection request invoking forwarder.PortForward for port", "connection", h.conn, "request", p.requestID, "port", portString)
+	klog.V(5).InfoS("Connection request invoking forwarder.PortForward for port", "request", p.requestID, "port", portString)
 	err := h.forwarder.PortForward(ctx, h.pod, h.uid, int32(port), p.dataStream)
-	klog.V(5).InfoS("Connection request done invoking forwarder.PortForward for port", "connection", h.conn, "request", p.requestID, "port", portString)
+	klog.V(5).InfoS("Connection request done invoking forwarder.PortForward for port", "request", p.requestID, "port", portString)
 
 	if err != nil {
 		msg := fmt.Errorf("error forwarding port %d to pod %s, uid %v: %v", port, h.pod, h.uid, err)

--- a/pkg/kubelet/cri/streaming/portforward/httpstream.go
+++ b/pkg/kubelet/cri/streaming/portforward/httpstream.go
@@ -63,7 +63,7 @@ func handleHTTPStreams(req *http.Request, w http.ResponseWriter, portForwarder P
 		uid:                   uid,
 		forwarder:             portForwarder,
 	}
-	h.run(req.Context()) // TODO confirm this is correct
+	h.run(req.Context())
 
 	return nil
 }
@@ -135,10 +135,14 @@ func (h *httpStreamHandler) getStreamPair(requestID string) (*httpStreamPair, bo
 }
 
 // monitorStreamPair waits for the pair to receive both its error and data
-// streams, or for the timeout to expire (whichever happens first), and then
+// streams, or for the timeout/ctx to expire (whichever happens first), and then
 // removes the pair.
-func (h *httpStreamHandler) monitorStreamPair(p *httpStreamPair, timeout <-chan time.Time) {
+func (h *httpStreamHandler) monitorStreamPair(ctx context.Context, p *httpStreamPair, timeout <-chan time.Time) {
 	select {
+	case <-ctx.Done():
+		err := fmt.Errorf("request %q canceled while waiting for streams", p.requestID)
+		utilruntime.HandleError(err)
+		p.printError(err.Error())
 	case <-timeout:
 		err := fmt.Errorf("request %q timed out waiting for streams", p.requestID)
 		utilruntime.HandleError(err)
@@ -215,6 +219,9 @@ func (h *httpStreamHandler) run(ctx context.Context) {
 Loop:
 	for {
 		select {
+		case <-ctx.Done():
+			klog.V(5).InfoS("Connection context closed")
+			break Loop
 		case <-h.conn.CloseChan():
 			klog.V(5).InfoS("Connection upgraded connection closed")
 			break Loop
@@ -225,7 +232,11 @@ Loop:
 
 			p, created := h.getStreamPair(requestID)
 			if created {
-				go h.monitorStreamPair(p, time.After(h.streamCreationTimeout))
+				go func() {
+					timer := time.NewTimer(h.streamCreationTimeout)
+					defer timer.Stop()
+					h.monitorStreamPair(ctx, p, timer.C)
+				}()
 			}
 			if complete, err := p.add(stream); err != nil {
 				msg := fmt.Sprintf("error processing stream for request %s: %v", requestID, err)

--- a/pkg/kubelet/cri/streaming/portforward/websocket.go
+++ b/pkg/kubelet/cri/streaming/portforward/websocket.go
@@ -142,7 +142,7 @@ func handleWebSocketStreams(req *http.Request, w http.ResponseWriter, portForwar
 		uid:         uid,
 		forwarder:   portForwarder,
 	}
-	h.run(req.Context()) // TODO confirm this is correct
+	h.run(req.Context())
 
 	return nil
 }

--- a/pkg/kubelet/cri/streaming/remotecommand/httpstream.go
+++ b/pkg/kubelet/cri/streaming/remotecommand/httpstream.go
@@ -17,6 +17,7 @@ limitations under the License.
 package remotecommand
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -116,7 +117,7 @@ func createStreams(req *http.Request, w http.ResponseWriter, opts *Options, supp
 
 	if ctx.resizeStream != nil {
 		ctx.resizeChan = make(chan remotecommand.TerminalSize)
-		go handleResizeEvents(ctx.resizeStream, ctx.resizeChan)
+		go handleResizeEvents(req.Context(), ctx.resizeStream, ctx.resizeChan)
 	}
 
 	return ctx, true
@@ -409,7 +410,7 @@ WaitForStreams:
 // supportsTerminalResizing returns false because v1ProtocolHandler doesn't support it.
 func (*v1ProtocolHandler) supportsTerminalResizing() bool { return false }
 
-func handleResizeEvents(stream io.Reader, channel chan<- remotecommand.TerminalSize) {
+func handleResizeEvents(ctx context.Context, stream io.Reader, channel chan<- remotecommand.TerminalSize) {
 	defer runtime.HandleCrash()
 	defer close(channel)
 
@@ -419,7 +420,15 @@ func handleResizeEvents(stream io.Reader, channel chan<- remotecommand.TerminalS
 		if err := decoder.Decode(&size); err != nil {
 			break
 		}
-		channel <- size
+
+		select {
+		case channel <- size:
+		case <-ctx.Done():
+			// To avoid leaking this routine, exit if the http request finishes. This path
+			// would generally be hit if starting the process fails and nothing is started to
+			// ingest these resize events.
+			return
+		}
 	}
 }
 

--- a/pkg/kubelet/cri/streaming/server.go
+++ b/pkg/kubelet/cri/streaming/server.go
@@ -149,6 +149,8 @@ func NewServer(config Config, runtime Runtime) (Server, error) {
 		Addr:      s.config.Addr,
 		Handler:   s.handler,
 		TLSConfig: s.config.TLSConfig,
+		// TODO(fuweid): allow user to configure streaming server
+		ReadHeaderTimeout: 30 * time.Minute, // Fix linter G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
 	}
 
 	return s, nil

--- a/pkg/kubelet/cri/streaming/server.go
+++ b/pkg/kubelet/cri/streaming/server.go
@@ -146,11 +146,10 @@ func NewServer(config Config, runtime Runtime) (Server, error) {
 	handler.Add(ws)
 	s.handler = handler
 	s.server = &http.Server{
-		Addr:      s.config.Addr,
-		Handler:   s.handler,
-		TLSConfig: s.config.TLSConfig,
-		// TODO(fuweid): allow user to configure streaming server
-		ReadHeaderTimeout: 30 * time.Minute, // Fix linter G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
+		Addr:              s.config.Addr,
+		Handler:           s.handler,
+		TLSConfig:         s.config.TLSConfig,
+		ReadHeaderTimeout: 30 * time.Minute,
 	}
 
 	return s, nil


### PR DESCRIPTION
This change:

- Removes all code that logs httpstream.Connection (unsafe concurrent map read and write)
- Wires the request context to code paths that launch go routines
- Sets ReadHeaderTimeout on streaming server

Signed-off-by: Monis Khan <mok@microsoft.com>

/kind bug
/assign @dims @liggitt @tallclair 

```release-note
Resources associated with CRI streaming requests are correctly reclaimed when the request is canceled.
```