### PR TITLE
Remove Overly Permissive File Modes 2/5

### DIFF
--- a/pkg/volume/fc/fc_util.go
+++ b/pkg/volume/fc/fc_util.go
@@ -127,7 +127,7 @@ func removeFromScsiSubsystem(deviceName string, io ioHandler) {
 	fileName := "/sys/block/" + deviceName + "/device/delete"
 	klog.V(4).Infof("fc: remove device from scsi-subsystem: path: %s", fileName)
 	data := []byte("1")
-	io.WriteFile(fileName, data, 0666)
+	io.WriteFile(fileName, data, 0644)
 }
 
 // rescan scsi bus
@@ -137,7 +137,7 @@ func scsiHostRescan(io ioHandler) {
 		for _, f := range dirs {
 			name := scsiPath + f.Name() + "/scan"
 			data := []byte("- - -")
-			io.WriteFile(name, data, 0666)
+			io.WriteFile(name, data, 0644)
 		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR updates the overly permissive file modes from 0666 to 0644 in the `removeFromScsiSubsystem`  and `scsiHostRescan` functions in `pkg/volume/fc/fc_util.go`.
#### Which issue(s) this PR fixes:

Contributes to: https://github.com/kubernetes/kubernetes/issues/81116

#### Does this PR introduce a user-facing change?
Change file creation permission from 660 to 644

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

