### PR TITLE
fix path for not approved licenses

### DIFF
--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -128,7 +128,7 @@ do
 			echo "${GO_PACKAGE}  ${LICENSE_NAME}  ${LICENSE_URL}" >> "${KUBE_TEMP}"/approved_licenses.dump
 		fi
 	else
-		echo "${GO_PACKAGE}  ${LICENSE_NAME}  ${LICENSE_URL}" >> "${KUBE_TEMP}"notapproved_licenses.dump
+		echo "${GO_PACKAGE}  ${LICENSE_NAME}  ${LICENSE_URL}" >> "${KUBE_TEMP}"/notapproved_licenses.dump
 		packages_flagged+=("${GO_PACKAGE}")
 	fi
 done < "${KUBE_TEMP}"/licenses.csv


### PR DESCRIPTION
This builds on https://github.com/kubernetes/kubernetes/pull/114826 to fix the path on not approved licenses dump.


Signed-off-by: Alex Pana <8968914+acpana@users.noreply.github.com>


/kind bug
/kind cleanup
/kind failing-test

```release-note
NONE
```