### PR TITLE
staging/src/k8s.io/client-go/rest/request: Log latency for failed requests

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -605,10 +605,10 @@ func (r *Request) tryThrottleWithInfo(ctx context.Context, retryInfo string) err
 	now := time.Now()
 
 	err := r.rateLimiter.Wait(ctx)
-	if err != nil {
-		err = fmt.Errorf("client rate limiter Wait returned an error: %w", err)
-	}
 	latency := time.Since(now)
+	if err != nil {
+		err = fmt.Errorf("client rate limiter Wait returned an error after %v: %w", latency, err)
+	}
 
 	var message string
 	switch {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Before this commit, this line could generate errors like:

    client rate limiter Wait returned an error: context deadline exceeded

This commit adds the latency to the error message, to match some of the non-error logging that had already included the latency.  It should help debug some failure modes, such as when client-side rate limiting is given an absurdly short or already expired Context deadline.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```