### PR TITLE
Avoid mutation of PVC in stateful set controller shared cache

### DIFF
--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -241,6 +241,7 @@ func (spc *StatefulPodControl) UpdatePodClaimForRetentionPolicy(set *apps.Statef
 			return fmt.Errorf("Could not retrieve claim %s not found for %s when checking PVC deletion policy: %w", claimName, pod.Name, err)
 		default:
 			if !claimOwnerMatchesSetAndPod(claim, set, pod) {
+				claim = claim.DeepCopy() // Make a copy so we don't mutate the shared cache.
 				needsUpdate := updateClaimOwnerRefForSetAndPod(claim, set, pod)
 				if needsUpdate {
 					err := spc.objectMgr.UpdateClaim(claim)

--- a/pkg/controller/statefulset/stateful_pod_control_test.go
+++ b/pkg/controller/statefulset/stateful_pod_control_test.go
@@ -536,6 +536,11 @@ func TestStatefulPodControlUpdatePodClaimForRetentionPolicy(t *testing.T) {
 		fakeClient := &fake.Clientset{}
 		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 		claimLister := corelisters.NewPersistentVolumeClaimLister(indexer)
+		fakeClient.AddReactor("update", "persistentvolumeclaims", func(action core.Action) (bool, runtime.Object, error) {
+			update := action.(core.UpdateAction)
+			indexer.Update(update.GetObject())
+			return true, update.GetObject(), nil
+		})
 		set := newStatefulSet(3)
 		set.GetObjectMeta().SetUID("set-123")
 		pod := newStatefulSetPod(set, 0)


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
The code currently mutates an object in the shared informer cache. Since the e2e for this code path is guarded as a Feature, the alpha e2e tests that have the mutation detector turned on have not been run.

```release-note
None
```

/cc @liggitt 