### PR TITLE
Ipvs: remove the scheduler validation

### DIFF
--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -218,48 +218,6 @@ const (
 	LocalModeInterfaceNamePrefix LocalMode = "InterfaceNamePrefix"
 )
 
-// IPVSSchedulerMethod is the algorithm for allocating TCP connections and
-// UDP datagrams to real servers. Scheduling algorithms are implemented as kernel modules.
-// Ten are shipped with the Linux Virtual Server.
-type IPVSSchedulerMethod string
-
-const (
-	// RoundRobin distributes jobs equally amongst the available real servers.
-	RoundRobin IPVSSchedulerMethod = "rr"
-	// WeightedRoundRobin assigns jobs to real servers proportionally to their real servers' weight.
-	// Servers with higher weights receive new jobs first and get more jobs than servers with lower weights.
-	// Servers with equal weights get an equal distribution of new jobs.
-	WeightedRoundRobin IPVSSchedulerMethod = "wrr"
-	// LeastConnection assigns more jobs to real servers with fewer active jobs.
-	LeastConnection IPVSSchedulerMethod = "lc"
-	// WeightedLeastConnection assigns more jobs to servers with fewer jobs and
-	// relative to the real servers' weight(Ci/Wi).
-	WeightedLeastConnection IPVSSchedulerMethod = "wlc"
-	// LocalityBasedLeastConnection assigns jobs destined for the same IP address to the same server if
-	// the server is not overloaded and available; otherwise assigns jobs to servers with fewer jobs,
-	// and keep it for future assignment.
-	LocalityBasedLeastConnection IPVSSchedulerMethod = "lblc"
-	// LocalityBasedLeastConnectionWithReplication with Replication assigns jobs destined for the same IP address to the
-	// least-connection node in the server set for the IP address. If all the node in the server set are overloaded,
-	// it picks up a node with fewer jobs in the cluster and adds it to the sever set for the target.
-	// If the server set has not been modified for the specified time, the most loaded node is removed from the server set,
-	// in order to avoid high degree of replication.
-	LocalityBasedLeastConnectionWithReplication IPVSSchedulerMethod = "lblcr"
-	// SourceHashing assigns jobs to servers through looking up a statically assigned hash table
-	// by their source IP addresses.
-	SourceHashing IPVSSchedulerMethod = "sh"
-	// DestinationHashing assigns jobs to servers through looking up a statically assigned hash table
-	// by their destination IP addresses.
-	DestinationHashing IPVSSchedulerMethod = "dh"
-	// ShortestExpectedDelay assigns an incoming job to the server with the shortest expected delay.
-	// The expected delay that the job will experience is (Ci + 1) / Ui if sent to the ith server, in which
-	// Ci is the number of jobs on the ith server and Ui is the fixed service rate (weight) of the ith server.
-	ShortestExpectedDelay IPVSSchedulerMethod = "sed"
-	// NeverQueue assigns an incoming job to an idle server if there is, instead of waiting for a fast one;
-	// if all the servers are busy, it adopts the ShortestExpectedDelay policy to assign the job.
-	NeverQueue IPVSSchedulerMethod = "nq"
-)
-
 func (m *ProxyMode) Set(s string) error {
 	*m = ProxyMode(s)
 	return nil

--- a/pkg/proxy/apis/config/validation/validation.go
+++ b/pkg/proxy/apis/config/validation/validation.go
@@ -143,7 +143,6 @@ func validateKubeProxyIPVSConfiguration(config kubeproxyconfig.KubeProxyIPVSConf
 	}
 
 	allErrs = append(allErrs, validateIPVSTimeout(config, fldPath)...)
-	allErrs = append(allErrs, validateIPVSSchedulerMethod(kubeproxyconfig.IPVSSchedulerMethod(config.Scheduler), fldPath.Child("Scheduler"))...)
 	allErrs = append(allErrs, validateIPVSExcludeCIDRs(config.ExcludeCIDRs, fldPath.Child("ExcludeCidrs"))...)
 
 	return allErrs
@@ -231,36 +230,6 @@ func validateHostPort(input string, fldPath *field.Path) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(fldPath, port, "must be a valid port"))
 	}
 
-	return allErrs
-}
-
-func validateIPVSSchedulerMethod(scheduler kubeproxyconfig.IPVSSchedulerMethod, fldPath *field.Path) field.ErrorList {
-	supportedMethod := []kubeproxyconfig.IPVSSchedulerMethod{
-		kubeproxyconfig.RoundRobin,
-		kubeproxyconfig.WeightedRoundRobin,
-		kubeproxyconfig.LeastConnection,
-		kubeproxyconfig.WeightedLeastConnection,
-		kubeproxyconfig.LocalityBasedLeastConnection,
-		kubeproxyconfig.LocalityBasedLeastConnectionWithReplication,
-		kubeproxyconfig.SourceHashing,
-		kubeproxyconfig.DestinationHashing,
-		kubeproxyconfig.ShortestExpectedDelay,
-		kubeproxyconfig.NeverQueue,
-		"",
-	}
-	allErrs := field.ErrorList{}
-	var found bool
-	for i := range supportedMethod {
-		if scheduler == supportedMethod[i] {
-			found = true
-			break
-		}
-	}
-	// Not found
-	if !found {
-		errMsg := fmt.Sprintf("must be in %v, blank means the default algorithm method (currently rr)", supportedMethod)
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("Scheduler"), string(scheduler), errMsg))
-	}
 	return allErrs
 }
 

--- a/pkg/proxy/apis/config/validation/validation_test.go
+++ b/pkg/proxy/apis/config/validation/validation_test.go
@@ -828,52 +828,6 @@ func TestValidateHostPort(t *testing.T) {
 	}
 }
 
-func TestValidateIPVSSchedulerMethod(t *testing.T) {
-	newPath := field.NewPath("KubeProxyConfiguration")
-
-	successCases := []kubeproxyconfig.IPVSSchedulerMethod{
-		kubeproxyconfig.RoundRobin,
-		kubeproxyconfig.WeightedRoundRobin,
-		kubeproxyconfig.LeastConnection,
-		kubeproxyconfig.WeightedLeastConnection,
-		kubeproxyconfig.LocalityBasedLeastConnection,
-		kubeproxyconfig.LocalityBasedLeastConnectionWithReplication,
-		kubeproxyconfig.SourceHashing,
-		kubeproxyconfig.DestinationHashing,
-		kubeproxyconfig.ShortestExpectedDelay,
-		kubeproxyconfig.NeverQueue,
-		"",
-	}
-
-	for _, successCase := range successCases {
-		if errs := validateIPVSSchedulerMethod(successCase, newPath.Child("Scheduler")); len(errs) != 0 {
-			t.Errorf("expected success: %v", errs)
-		}
-	}
-
-	errorCases := map[string]struct {
-		mode         kubeproxyconfig.IPVSSchedulerMethod
-		expectedErrs field.ErrorList
-	}{
-		"non-existent scheduler method": {
-			mode:         kubeproxyconfig.IPVSSchedulerMethod("non-existing"),
-			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("ProxyMode.Scheduler"), "non-existing", "must be in [rr wrr lc wlc lblc lblcr sh dh sed nq ], blank means the default algorithm method (currently rr)")},
-		},
-	}
-
-	for _, errorCase := range errorCases {
-		errs := validateIPVSSchedulerMethod(errorCase.mode, newPath.Child("ProxyMode"))
-		if len(errorCase.expectedErrs) != len(errs) {
-			t.Fatalf("Expected %d errors, got %d errors: %v", len(errorCase.expectedErrs), len(errs), errs)
-		}
-		for i, err := range errs {
-			if err.Error() != errorCase.expectedErrs[i].Error() {
-				t.Fatalf("Expected error: %s, got %s", errorCase.expectedErrs[i], err.Error())
-			}
-		}
-	}
-}
-
 func TestValidateKubeProxyNodePortAddress(t *testing.T) {
 	newPath := field.NewPath("KubeProxyConfiguration")
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `ipvs` scheduler was restricted to the ones existing in the kernel when proxy-mode=ipvs was implemented. However, new schedulers have been added since then and yet new ones may be implemented. It is also possible for a user to write their own ipvs scheduler.

This PR removes the scheduler validation and thus allow any current, future or own developed schedulers.

The validation of the configured scheduler is done by trying to use it, as implemented in PR https://github.com/kubernetes/kubernetes/pull/114669. From user perspective this should not be worse than to validate the strings, the `kube-proxy` will fail to start in both cases.

#### Which issue(s) this PR fixes:

Fixes #114619

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
IPVS: Any ipvs scheduler can now be configured. If a un-usable scheduler is configured `kube-proxy` will re-start and the logs must be checked (same as before but different log printouts).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```

