### PR TITLE
staging/publishing: remove rules for 1.22

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -5,11 +5,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/code-generator
-  - name: release-1.22
-    go: 1.16.15
-    source:
-      branch: release-1.22
-      dir: staging/src/k8s.io/code-generator
   - name: release-1.23
     go: 1.19.4
     source:
@@ -35,11 +30,6 @@ rules:
   - name: master
     source:
       branch: master
-      dir: staging/src/k8s.io/apimachinery
-  - name: release-1.22
-    go: 1.16.15
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.23
     go: 1.19.4
@@ -70,14 +60,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/api
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.22
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/api
   - name: release-1.23
     go: 1.19.4
@@ -122,20 +104,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/client-go
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod ./...
-      go test -mod=mod ./...
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: api
-      branch: release-1.22
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/client-go
     smoke-test: |
       # assumes GO111MODULE=on
@@ -211,18 +179,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/component-base
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: api
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    source:
-      branch: release-1.22
-      dir: staging/src/k8s.io/component-base
   - name: release-1.23
     go: 1.19.4
     dependencies:
@@ -284,18 +240,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/component-helpers
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: api
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.23
     go: 1.19.4
@@ -378,20 +322,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/apiserver
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: api
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    - repository: component-base
-      branch: release-1.22
-    source:
-      branch: release-1.22
-      dir: staging/src/k8s.io/apiserver
   - name: release-1.23
     go: 1.19.4
     dependencies:
@@ -471,24 +401,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-aggregator
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: api
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    - repository: apiserver
-      branch: release-1.22
-    - repository: component-base
-      branch: release-1.22
-    - repository: code-generator
-      branch: release-1.22
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.23
     go: 1.19.4
@@ -584,29 +496,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/sample-apiserver
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: api
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    - repository: apiserver
-      branch: release-1.22
-    - repository: code-generator
-      branch: release-1.22
-    - repository: component-base
-      branch: release-1.22
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/sample-apiserver
     required-packages:
     - k8s.io/code-generator
@@ -727,25 +616,6 @@ rules:
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: api
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    - repository: code-generator
-      branch: release-1.22
-    source:
-      branch: release-1.22
-      dir: staging/src/k8s.io/sample-controller
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
   - name: release-1.23
     go: 1.19.4
     dependencies:
@@ -842,26 +712,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    required-packages:
-    - k8s.io/code-generator
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: api
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    - repository: apiserver
-      branch: release-1.22
-    - repository: code-generator
-      branch: release-1.22
-    - repository: component-base
-      branch: release-1.22
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
@@ -962,20 +812,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/metrics
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: api
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    - repository: code-generator
-      branch: release-1.22
-    source:
-      branch: release-1.22
-      dir: staging/src/k8s.io/metrics
   - name: release-1.23
     go: 1.19.4
     dependencies:
@@ -1046,18 +882,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/cli-runtime
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: api
-      branch: release-1.22
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    source:
-      branch: release-1.22
-      dir: staging/src/k8s.io/cli-runtime
   - name: release-1.23
     go: 1.19.4
     dependencies:
@@ -1121,20 +945,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/sample-cli-plugin
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: api
-      branch: release-1.22
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: cli-runtime
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.23
     go: 1.19.4
@@ -1206,20 +1016,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-proxy
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: component-base
-      branch: release-1.22
-    - repository: api
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.23
     go: 1.19.4
@@ -1293,20 +1089,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/kubelet
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: api
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    - repository: component-base
-      branch: release-1.22
-    source:
-      branch: release-1.22
-      dir: staging/src/k8s.io/kubelet
   - name: release-1.23
     go: 1.19.4
     dependencies:
@@ -1378,20 +1160,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-scheduler
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: component-base
-      branch: release-1.22
-    - repository: api
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.23
     go: 1.19.4
@@ -1468,22 +1236,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/controller-manager
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: api
-      branch: release-1.22
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    - repository: component-base
-      branch: release-1.22
-    - repository: apiserver
-      branch: release-1.22
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.23
     go: 1.19.4
@@ -1574,26 +1326,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/cloud-provider
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: api
-      branch: release-1.22
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: apiserver
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    - repository: component-base
-      branch: release-1.22
-    - repository: controller-manager
-      branch: release-1.22
-    - repository: component-helpers
-      branch: release-1.22
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.23
     go: 1.19.4
@@ -1703,28 +1435,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/kube-controller-manager
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: apiserver
-      branch: release-1.22
-    - repository: component-base
-      branch: release-1.22
-    - repository: api
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    - repository: controller-manager
-      branch: release-1.22
-    - repository: cloud-provider
-      branch: release-1.22
-    - repository: component-helpers
-      branch: release-1.22
-    source:
-      branch: release-1.22
-      dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.23
     go: 1.19.4
     dependencies:
@@ -1827,16 +1537,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/cluster-bootstrap
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: api
-      branch: release-1.22
-    source:
-      branch: release-1.22
-      dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.23
     go: 1.19.4
     dependencies:
@@ -1889,16 +1589,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/csi-translation-lib
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: api
-      branch: release-1.22
-    - repository: apimachinery
-      branch: release-1.22
-    source:
-      branch: release-1.22
-      dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.23
     go: 1.19.4
     dependencies:
@@ -1945,11 +1635,6 @@ rules:
   - name: master
     source:
       branch: master
-      dir: staging/src/k8s.io/mount-utils
-  - name: release-1.22
-    go: 1.16.15
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.23
     go: 1.19.4
@@ -1998,32 +1683,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/legacy-cloud-providers
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: api
-      branch: release-1.22
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    - repository: cloud-provider
-      branch: release-1.22
-    - repository: csi-translation-lib
-      branch: release-1.22
-    - repository: apiserver
-      branch: release-1.22
-    - repository: component-base
-      branch: release-1.22
-    - repository: controller-manager
-      branch: release-1.22
-    - repository: mount-utils
-      branch: release-1.22
-    - repository: component-helpers
-      branch: release-1.22
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.23
     go: 1.19.4
@@ -2138,11 +1797,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/cri-api
-  - name: release-1.22
-    go: 1.16.15
-    source:
-      branch: release-1.22
-      dir: staging/src/k8s.io/cri-api
   - name: release-1.23
     go: 1.19.4
     source:
@@ -2186,28 +1840,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kubectl
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: api
-      branch: release-1.22
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: cli-runtime
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    - repository: code-generator
-      branch: release-1.22
-    - repository: component-base
-      branch: release-1.22
-    - repository: component-helpers
-      branch: release-1.22
-    - repository: metrics
-      branch: release-1.22
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/kubectl
   - name: release-1.23
     go: 1.19.4
@@ -2316,22 +1948,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/pod-security-admission
-  - name: release-1.22
-    go: 1.16.15
-    dependencies:
-    - repository: api
-      branch: release-1.22
-    - repository: apimachinery
-      branch: release-1.22
-    - repository: apiserver
-      branch: release-1.22
-    - repository: client-go
-      branch: release-1.22
-    - repository: component-base
-      branch: release-1.22
-    source:
-      branch: release-1.22
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.23
     go: 1.19.4


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

1.22 is not supported anymore.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
