### PR TITLE
kubeadm: update .import-restrictions

### DIFF
--- a/cmd/kubeadm/.import-restrictions
+++ b/cmd/kubeadm/.import-restrictions
@@ -1,21 +1,5 @@
 rules:
-  - selectorRegexp: k8s[.]io/kubelet/
-    allowedPrefixes:
-      - k8s.io/kubelet/config/v1beta1
-  - selectorRegexp: k8s[.]io/kube-openapi/
-    allowedPrefixes:
-      - k8s.io/kube-openapi/pkg/util/proto
-      - k8s.io/kube-openapi/pkg/schemaconv
-      - k8s.io/kube-openapi/pkg/handler3
-      - k8s.io/kube-openapi/pkg/spec3
-  - selectorRegexp: k8s[.]io/kube-proxy/
-    allowedPrefixes:
-      - k8s.io/kube-proxy/config/v1alpha1
+  # prevent any k8s.io/kubernetes imports outside of this package
   - selectorRegexp: k8s[.]io/kubernetes
     allowedPrefixes:
       - k8s.io/kubernetes/cmd/kubeadm
-  - selectorRegexp: gopkg[.]in
-    allowedPrefixes:
-      - gopkg.in/inf.v0
-      - gopkg.in/square/go-jose.v2
-      - gopkg.in/yaml.v2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubeadm is no longer imports `k8s.io/kube-openapi` and `gopkg.in` packages.
And I believe we're only concerned about whether we're blocking the import of `k8s.io/kubernetes`.
Just like what #90600 did.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
