### PR TITLE
Promote e2e test for SubjectAccessReview & createAuthorizationV1NamespacedLocalSubjectAccessReview +2 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1119,6 +1119,18 @@
     it MUST succeed and the field MUST equal the new value.
   release: v1.26
   file: test/e2e/auth/service_accounts.go
+- testname: SubjectReview, API Operations
+  codename: '[sig-auth] SubjectReview should support SubjectReview API operations
+    [Conformance]'
+  description: A ServiceAccount is created which MUST succeed. A clientset is created
+    to impersonate the ServiceAccount. A SubjectAccessReview is created for the ServiceAccount
+    which MUST succeed. The allowed status for the SubjectAccessReview MUST match
+    the expected allowed for the impersonated client call. A LocalSubjectAccessReviews
+    is created for the ServiceAccount which MUST succeed. The allowed status for the
+    LocalSubjectAccessReview MUST match the expected allowed for the impersonated
+    client call.
+  release: v1.27
+  file: test/e2e/auth/subjectreviews.go
 - testname: Kubectl, guestbook application
   codename: '[sig-cli] Kubectl client Guestbook application should create and stop
     a working application  [Conformance]'

--- a/test/e2e/auth/subjectreviews.go
+++ b/test/e2e/auth/subjectreviews.go
@@ -35,7 +35,19 @@ import (
 var _ = SIGDescribe("SubjectReview", func() {
 	f := framework.NewDefaultFramework("subjectreview")
 
-	ginkgo.It("should support SubjectReview API operations", func() {
+	/*
+		Release: v1.27
+		Testname: SubjectReview, API Operations
+		Description: A ServiceAccount is created which MUST succeed.
+		A clientset is created to impersonate the ServiceAccount.
+		A SubjectAccessReview is created for the ServiceAccount which
+		MUST succeed. The allowed status for the SubjectAccessReview
+		MUST match the expected allowed for the impersonated client
+		call. A LocalSubjectAccessReviews is created for the ServiceAccount
+		which MUST succeed. The allowed status for the LocalSubjectAccessReview
+		MUST match the expected allowed for the impersonated client call.
+	*/
+	framework.ConformanceIt("should support SubjectReview API operations", func() {
 
 		AuthClient := f.ClientSet.AuthorizationV1()
 		ns := f.Namespace.Name


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- SubjectAccessReview 
- createAuthorizationV1NamespacedLocalSubjectAccessReview

**Which issue(s) this PR fixes:**
Fixes #114344

**Testgrid Link:** 
[testgrid-link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.support.SubjectReview.API.operations)

**Special notes for your reviewer:**
Adds +2 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance
