### PR TITLE
fix: applyconfiguration-gen fails for types with non-builtin map fields

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/refgraph.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/refgraph.go
@@ -86,6 +86,7 @@ func (t refGraph) applyConfigForType(field *types.Type) *types.Type {
 			return &types.Type{
 				Kind: types.Map,
 				Elem: t.applyConfigForType(field.Elem),
+				Key:  t.applyConfigForType(field.Key),
 			}
 		}
 		return field


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### Which issue(s) this PR fixes:

Fixes kubernetes/code-generator#144

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Apply configurations can be generated for types with non-builtin map fields
```