### PR TITLE
Exports WarningPrinter field in DeleteOptions

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
@@ -63,7 +63,7 @@ type CanIOptions struct {
 	List           bool
 
 	genericclioptions.IOStreams
-	warningPrinter *printers.WarningPrinter
+	WarningPrinter *printers.WarningPrinter
 }
 
 var (
@@ -145,7 +145,10 @@ func NewCmdCanI(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 
 // Complete completes all the required options
 func (o *CanIOptions) Complete(f cmdutil.Factory, args []string) error {
-	o.warningPrinter = printers.NewWarningPrinter(o.ErrOut, printers.WarningPrinterOptions{Color: term.AllowsColorOutput(o.ErrOut)})
+	// Set default WarningPrinter if not already set.
+	if o.WarningPrinter == nil {
+		o.WarningPrinter = printers.NewWarningPrinter(o.ErrOut, printers.WarningPrinterOptions{Color: term.AllowsColorOutput(o.ErrOut)})
+	}
 
 	if o.List {
 		if len(args) != 0 {
@@ -206,8 +209,8 @@ func (o *CanIOptions) Validate() error {
 		return nil
 	}
 
-	if o.warningPrinter == nil {
-		return fmt.Errorf("warningPrinter can not be used without initialization")
+	if o.WarningPrinter == nil {
+		return fmt.Errorf("WarningPrinter can not be used without initialization")
 	}
 
 	if o.NonResourceURL != "" {
@@ -218,18 +221,18 @@ func (o *CanIOptions) Validate() error {
 			return fmt.Errorf("NonResourceURL and ResourceName can not specified together")
 		}
 		if !isKnownNonResourceVerb(o.Verb) {
-			o.warningPrinter.Print(fmt.Sprintf("verb '%s' is not a known verb\n", o.Verb))
+			o.WarningPrinter.Print(fmt.Sprintf("verb '%s' is not a known verb\n", o.Verb))
 		}
 	} else if !o.Resource.Empty() && !o.AllNamespaces && o.DiscoveryClient != nil {
 		if namespaced, err := isNamespaced(o.Resource, o.DiscoveryClient); err == nil && !namespaced {
 			if len(o.Resource.Group) == 0 {
-				o.warningPrinter.Print(fmt.Sprintf("resource '%s' is not namespace scoped\n", o.Resource.Resource))
+				o.WarningPrinter.Print(fmt.Sprintf("resource '%s' is not namespace scoped\n", o.Resource.Resource))
 			} else {
-				o.warningPrinter.Print(fmt.Sprintf("resource '%s' is not namespace scoped in group '%s'\n", o.Resource.Resource, o.Resource.Group))
+				o.WarningPrinter.Print(fmt.Sprintf("resource '%s' is not namespace scoped in group '%s'\n", o.Resource.Resource, o.Resource.Group))
 			}
 		}
 		if !isKnownResourceVerb(o.Verb) {
-			o.warningPrinter.Print(fmt.Sprintf("verb '%s' is not a known verb\n", o.Verb))
+			o.WarningPrinter.Print(fmt.Sprintf("verb '%s' is not a known verb\n", o.Verb))
 		}
 	}
 
@@ -317,9 +320,9 @@ func (o *CanIOptions) resourceFor(mapper meta.RESTMapper, resourceArg string) sc
 		if err != nil {
 			if !nonStandardResourceNames.Has(groupResource.String()) {
 				if len(groupResource.Group) == 0 {
-					o.warningPrinter.Print(fmt.Sprintf("the server doesn't have a resource type '%s'\n", groupResource.Resource))
+					o.WarningPrinter.Print(fmt.Sprintf("the server doesn't have a resource type '%s'\n", groupResource.Resource))
 				} else {
-					o.warningPrinter.Print(fmt.Sprintf("the server doesn't have a resource type '%s' in group '%s'\n", groupResource.Resource, groupResource.Group))
+					o.WarningPrinter.Print(fmt.Sprintf("the server doesn't have a resource type '%s' in group '%s'\n", groupResource.Resource, groupResource.Group))
 				}
 			}
 			return schema.GroupVersionResource{Resource: resourceArg}
@@ -331,7 +334,7 @@ func (o *CanIOptions) resourceFor(mapper meta.RESTMapper, resourceArg string) sc
 
 func (o *CanIOptions) printStatus(status authorizationv1.SubjectRulesReviewStatus) error {
 	if status.Incomplete {
-		o.warningPrinter.Print(fmt.Sprintf("the list may be incomplete: %v", status.EvaluationError))
+		o.WarningPrinter.Print(fmt.Sprintf("the list may be incomplete: %v", status.EvaluationError))
 	}
 
 	breakdownRules := []rbacv1.PolicyRule{}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani_test.go
@@ -293,7 +293,7 @@ func TestRunResourceFor(t *testing.T) {
 
 			ioStreams, _, _, buf := genericclioptions.NewTestIOStreams()
 			test.o.IOStreams = ioStreams
-			test.o.warningPrinter = printers.NewWarningPrinter(test.o.IOStreams.ErrOut, printers.WarningPrinterOptions{Color: false})
+			test.o.WarningPrinter = printers.NewWarningPrinter(test.o.IOStreams.ErrOut, printers.WarningPrinterOptions{Color: false})
 
 			restMapper, err := tf.ToRESTMapper()
 			if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -130,7 +130,7 @@ type DebugOptions struct {
 	podClient corev1client.CoreV1Interface
 
 	genericclioptions.IOStreams
-	warningPrinter *printers.WarningPrinter
+	WarningPrinter *printers.WarningPrinter
 
 	applier ProfileApplier
 }
@@ -224,8 +224,10 @@ func (o *DebugOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 	o.attachChanged = cmd.Flags().Changed("attach")
 	o.shareProcessedChanged = cmd.Flags().Changed("share-processes")
 
-	// Warning printer
-	o.warningPrinter = printers.NewWarningPrinter(o.ErrOut, printers.WarningPrinterOptions{Color: term.AllowsColorOutput(o.ErrOut)})
+	// Set default WarningPrinter
+	if o.WarningPrinter == nil {
+		o.WarningPrinter = printers.NewWarningPrinter(o.ErrOut, printers.WarningPrinterOptions{Color: term.AllowsColorOutput(o.ErrOut)})
+	}
 	o.applier, err = NewProfileApplier(o.Profile)
 	if err != nil {
 		return err
@@ -307,9 +309,9 @@ func (o *DebugOptions) Validate() error {
 		return fmt.Errorf("-i/--stdin is required for containers with -t/--tty=true")
 	}
 
-	// warningPrinter
-	if o.warningPrinter == nil {
-		return fmt.Errorf("warningPrinter can not be used without initialization")
+	// WarningPrinter
+	if o.WarningPrinter == nil {
+		return fmt.Errorf("WarningPrinter can not be used without initialization")
 	}
 
 	return nil
@@ -764,7 +766,7 @@ func (o *DebugOptions) waitForContainer(ctx context.Context, ns, podName, contai
 				return true, nil
 			}
 			if !o.Quiet && s.State.Waiting != nil && s.State.Waiting.Message != "" {
-				o.warningPrinter.Print(fmt.Sprintf("container %s: %s", containerName, s.State.Waiting.Message))
+				o.WarningPrinter.Print(fmt.Sprintf("container %s: %s", containerName, s.State.Waiting.Message))
 			}
 			return false, nil
 		})

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -1598,7 +1598,8 @@ func TestCompleteAndValidate(t *testing.T) {
 				t.Fatalf("CompleteAndValidate got error: '%v', wantError: %v", gotError, tc.wantError)
 			}
 
-			if diff := cmp.Diff(tc.wantOpts, opts, cmpFilter, cmpopts.IgnoreUnexported(DebugOptions{})); diff != "" {
+			if diff := cmp.Diff(tc.wantOpts, opts, cmpFilter, cmpopts.IgnoreFields(DebugOptions{},
+				"attachChanged", "shareProcessedChanged", "podClient", "WarningPrinter", "applier")); diff != "" {
 				t.Error("CompleteAndValidate unexpected diff in generated object: (-want +got):\n", diff)
 			}
 		})

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -133,7 +133,7 @@ type DeleteOptions struct {
 	Result        *resource.Result
 
 	genericclioptions.IOStreams
-	warningPrinter *printers.WarningPrinter
+	WarningPrinter *printers.WarningPrinter
 }
 
 func NewCmdDelete(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
@@ -226,7 +226,10 @@ func (o *DeleteOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Co
 		}
 	}
 
-	o.warningPrinter = printers.NewWarningPrinter(o.ErrOut, printers.WarningPrinterOptions{Color: term.AllowsColorOutput(o.ErrOut)})
+	// Set default WarningPrinter if not already set.
+	if o.WarningPrinter == nil {
+		o.WarningPrinter = printers.NewWarningPrinter(o.ErrOut, printers.WarningPrinterOptions{Color: term.AllowsColorOutput(o.ErrOut)})
+	}
 
 	return nil
 }
@@ -242,13 +245,13 @@ func (o *DeleteOptions) Validate() error {
 	if o.DeleteAll && len(o.FieldSelector) > 0 {
 		return fmt.Errorf("cannot set --all and --field-selector at the same time")
 	}
-	if o.warningPrinter == nil {
-		return fmt.Errorf("warningPrinter can not be used without initialization")
+	if o.WarningPrinter == nil {
+		return fmt.Errorf("WarningPrinter can not be used without initialization")
 	}
 
 	switch {
 	case o.GracePeriod == 0 && o.ForceDeletion:
-		o.warningPrinter.Print("Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.")
+		o.WarningPrinter.Print("Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.")
 	case o.GracePeriod > 0 && o.ForceDeletion:
 		return fmt.Errorf("--force and --grace-period greater than 0 cannot be specified together")
 	}
@@ -312,7 +315,7 @@ func (o *DeleteOptions) DeleteResult(r *resource.Result) error {
 		options.PropagationPolicy = &o.CascadingStrategy
 
 		if warnClusterScope && info.Mapping.Scope.Name() == meta.RESTScopeNameRoot {
-			o.warningPrinter.Print("deleting cluster-scoped resources, not scoped to the provided namespace")
+			o.WarningPrinter.Print("deleting cluster-scoped resources, not scoped to the provided namespace")
 			warnClusterScope = false
 		}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -49,7 +49,7 @@ type DrainCmdOptions struct {
 	nodeInfos []*resource.Info
 
 	genericclioptions.IOStreams
-	warningPrinter *printers.WarningPrinter
+	WarningPrinter *printers.WarningPrinter
 }
 
 var (
@@ -254,7 +254,10 @@ func (o *DrainCmdOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 		return printer.PrintObj, nil
 	}
 
-	o.warningPrinter = printers.NewWarningPrinter(o.ErrOut, printers.WarningPrinterOptions{Color: term.AllowsColorOutput(o.ErrOut)})
+	// Set default WarningPrinter if not already set.
+	if o.WarningPrinter == nil {
+		o.WarningPrinter = printers.NewWarningPrinter(o.ErrOut, printers.WarningPrinterOptions{Color: term.AllowsColorOutput(o.ErrOut)})
+	}
 
 	builder := f.NewBuilder().
 		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
@@ -336,7 +339,7 @@ func (o *DrainCmdOptions) deleteOrEvictPodsSimple(nodeInfo *resource.Info) error
 		return utilerrors.NewAggregate(errs)
 	}
 	if warnings := list.Warnings(); warnings != "" {
-		o.warningPrinter.Print(warnings)
+		o.WarningPrinter.Print(warnings)
 	}
 	if o.drainer.DryRunStrategy == cmdutil.DryRunClient {
 		for _, pod := range list.Pods() {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
@@ -130,7 +130,7 @@ type EnvOptions struct {
 	clientset              *kubernetes.Clientset
 
 	genericclioptions.IOStreams
-	warningPrinter *printers.WarningPrinter
+	WarningPrinter *printers.WarningPrinter
 }
 
 // NewEnvOptions returns an EnvOptions indicating all containers in the selected
@@ -207,7 +207,7 @@ func contains(key string, keyList []string) bool {
 func (o *EnvOptions) keyToEnvName(key string) string {
 	envName := strings.ToUpper(validEnvNameRegexp.ReplaceAllString(key, "_"))
 	if envName != key {
-		o.warningPrinter.Print(fmt.Sprintf("key %s transferred to %s", key, envName))
+		o.WarningPrinter.Print(fmt.Sprintf("key %s transferred to %s", key, envName))
 	}
 	return envName
 }
@@ -247,7 +247,10 @@ func (o *EnvOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 		return err
 	}
 	o.builder = f.NewBuilder
-	o.warningPrinter = printers.NewWarningPrinter(o.ErrOut, printers.WarningPrinterOptions{Color: term.AllowsColorOutput(o.ErrOut)})
+	// Set default WarningPrinter if not already set.
+	if o.WarningPrinter == nil {
+		o.WarningPrinter = printers.NewWarningPrinter(o.ErrOut, printers.WarningPrinterOptions{Color: term.AllowsColorOutput(o.ErrOut)})
+	}
 
 	return nil
 }
@@ -266,8 +269,8 @@ func (o *EnvOptions) Validate() error {
 	if len(o.Keys) > 0 && len(o.From) == 0 {
 		return fmt.Errorf("when specifying --keys, a configmap or secret must be provided with --from")
 	}
-	if o.warningPrinter == nil {
-		return fmt.Errorf("warningPrinter can not be used without initialization")
+	if o.WarningPrinter == nil {
+		return fmt.Errorf("WarningPrinter can not be used without initialization")
 	}
 	return nil
 }
@@ -421,7 +424,7 @@ func (o *EnvOptions) RunEnv() error {
 						}
 					}
 
-					o.warningPrinter.Print(fmt.Sprintf("%s/%s does not have any containers matching %q", objKind, objName, o.ContainerSelector))
+					o.WarningPrinter.Print(fmt.Sprintf("%s/%s does not have any containers matching %q", objKind, objName, o.ContainerSelector))
 				}
 				return nil
 			}


### PR DESCRIPTION
* Exports `WarningPrinter` field in `Options` in order to make it easier to re-use the `kubectl` code.
* Default `WarningPrinter` added in `Complete` method if not already set.
* Updates options for `delete`, `debug`, `cani`, `drain`, `set env` to make them consistent.

/kind cleanup
/sig cli
/priority important-soon

```release-note
NONE
```