### PR TITLE
Automated cherry pick of #114914: Adjust DisruptionTarget condition message to do not include

### DIFF
--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -362,7 +362,7 @@ func (ev *Evaluator) prepareCandidate(ctx context.Context, c Candidate, pod *v1.
 					WithType(v1.DisruptionTarget).
 					WithStatus(v1.ConditionTrue).
 					WithReason("PreemptionByKubeScheduler").
-					WithMessage(fmt.Sprintf("Kube-scheduler: preempting to accommodate a higher priority pod: %s", klog.KObj(pod))).
+					WithMessage(fmt.Sprintf("%s: preempting to accommodate a higher priority pod", pod.Spec.SchedulerName)).
 					WithLastTransitionTime(metav1.Now()),
 				)
 


### PR DESCRIPTION
Cherry pick of #114914 on release-1.26.

#114914: Adjust DisruptionTarget condition message to do not include

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a regression in default 1.26 configurations with the PodDisruptionConditions feature enabled where preemptor pod metadata can be included in the message of DisruptionTarget condition
```