### PR TITLE
Fix range allocator hotloop

### DIFF
--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -39,7 +39,6 @@ import (
 	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/kubernetes/pkg/controller/nodeipam/ipam/cidrset"
 	controllerutil "k8s.io/kubernetes/pkg/controller/util/node"
-	utiltaints "k8s.io/kubernetes/pkg/util/taints"
 )
 
 type rangeAllocator struct {
@@ -150,13 +149,6 @@ func NewCIDRRangeAllocator(client clientset.Interface, nodeInformer informers.No
 			// state is correct.
 			// Restart of NC fixes the issue.
 			if len(newNode.Spec.PodCIDRs) == 0 {
-				return ra.AllocateOrOccupyCIDR(newNode)
-			}
-			// Even if PodCIDR is assigned, but NetworkUnavailable condition is
-			// set to true, we need to process the node to set the condition.
-			networkUnavailableTaint := &v1.Taint{Key: v1.TaintNodeNetworkUnavailable, Effect: v1.TaintEffectNoSchedule}
-			_, cond := nodeutil.GetNodeCondition(&newNode.Status, v1.NodeNetworkUnavailable)
-			if cond == nil || cond.Status != v1.ConditionFalse || utiltaints.TaintExists(newNode.Spec.Taints, networkUnavailableTaint) {
 				return ra.AllocateOrOccupyCIDR(newNode)
 			}
 			return nil

--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -191,18 +191,18 @@ func (r *rangeAllocator) worker(stopChan <-chan struct{}) {
 				return
 			}
 			if err := r.updateCIDRsAllocation(workItem); err == nil {
-				klog.V(3).Infof("Updated CIDR for %q", workItem)
+				klog.V(3).Infof("Updated CIDR for %q", workItem.nodeName)
 			} else {
-				klog.Errorf("Error updating CIDR for %q: %v", workItem, err)
+				klog.Errorf("Error updating CIDR for %q: %v", workItem.nodeName, err)
 				if canRetry, timeout := r.retryParams(workItem.nodeName); canRetry {
-					klog.V(2).Infof("Retrying update for %q after %v", workItem, timeout)
+					klog.V(2).Infof("Retrying update for %q after %v", workItem.nodeName, timeout)
 					time.AfterFunc(timeout, func() {
 						// Requeue the failed node for update again.
 						r.nodeCIDRUpdateChannel <- workItem
 					})
 					continue
 				}
-				klog.Errorf("Exceeded retry count for %q, dropping from queue", workItem)
+				klog.Errorf("Exceeded retry count for %q, dropping from queue", workItem.nodeName)
 			}
 			r.removeNodeFromProcessing(workItem.nodeName)
 		case <-stopChan:

--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
@@ -28,7 +29,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	informers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -39,6 +39,7 @@ import (
 	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/kubernetes/pkg/controller/nodeipam/ipam/cidrset"
 	controllerutil "k8s.io/kubernetes/pkg/controller/util/node"
+	utiltaints "k8s.io/kubernetes/pkg/util/taints"
 )
 
 type rangeAllocator struct {
@@ -58,7 +59,7 @@ type rangeAllocator struct {
 	recorder              record.EventRecorder
 	// Keep a set of nodes that are currently being processed to avoid races in CIDR allocation
 	lock              sync.Mutex
-	nodesInProcessing sets.String
+	nodesInProcessing map[string]*nodeProcessingInfo
 }
 
 // NewCIDRRangeAllocator returns a CIDRAllocator to allocate CIDRs for node (one from each of clusterCIDRs)
@@ -94,7 +95,7 @@ func NewCIDRRangeAllocator(client clientset.Interface, nodeInformer informers.No
 		nodeCIDRUpdateChannel: make(chan nodeReservedCIDRs, cidrUpdateQueueSize),
 		broadcaster:           eventBroadcaster,
 		recorder:              recorder,
-		nodesInProcessing:     sets.NewString(),
+		nodesInProcessing:     map[string]*nodeProcessingInfo{},
 	}
 
 	if allocatorParams.ServiceCIDR != nil {
@@ -151,6 +152,13 @@ func NewCIDRRangeAllocator(client clientset.Interface, nodeInformer informers.No
 			if len(newNode.Spec.PodCIDRs) == 0 {
 				return ra.AllocateOrOccupyCIDR(newNode)
 			}
+			// Even if PodCIDR is assigned, but NetworkUnavailable condition is
+			// set to true, we need to process the node to set the condition.
+			networkUnavailableTaint := &v1.Taint{Key: v1.TaintNodeNetworkUnavailable, Effect: v1.TaintEffectNoSchedule}
+			_, cond := nodeutil.GetNodeCondition(&newNode.Status, v1.NodeNetworkUnavailable)
+			if cond == nil || cond.Status != v1.ConditionFalse || utiltaints.TaintExists(newNode.Spec.Taints, networkUnavailableTaint) {
+				return ra.AllocateOrOccupyCIDR(newNode)
+			}
 			return nil
 		}),
 		DeleteFunc: controllerutil.CreateDeleteNodeHandler(ra.ReleaseCIDR),
@@ -190,10 +198,21 @@ func (r *rangeAllocator) worker(stopChan <-chan struct{}) {
 				klog.Warning("Channel nodeCIDRUpdateChannel was unexpectedly closed")
 				return
 			}
-			if err := r.updateCIDRsAllocation(workItem); err != nil {
-				// Requeue the failed node for update again.
-				r.nodeCIDRUpdateChannel <- workItem
+			if err := r.updateCIDRsAllocation(workItem); err == nil {
+				klog.V(3).Infof("Updated CIDR for %q", workItem)
+			} else {
+				klog.Errorf("Error updating CIDR for %q: %v", workItem, err)
+				if canRetry, timeout := r.retryParams(workItem.nodeName); canRetry {
+					klog.V(2).Infof("Retrying update for %q after %v", workItem, timeout)
+					time.AfterFunc(timeout, func() {
+						// Requeue the failed node for update again.
+						r.nodeCIDRUpdateChannel <- workItem
+					})
+					continue
+				}
+				klog.Errorf("Exceeded retry count for %q, dropping from queue", workItem)
 			}
+			r.removeNodeFromProcessing(workItem.nodeName)
 		case <-stopChan:
 			return
 		}
@@ -203,17 +222,36 @@ func (r *rangeAllocator) worker(stopChan <-chan struct{}) {
 func (r *rangeAllocator) insertNodeToProcessing(nodeName string) bool {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	if r.nodesInProcessing.Has(nodeName) {
+	if _, found := r.nodesInProcessing[nodeName]; found {
 		return false
 	}
-	r.nodesInProcessing.Insert(nodeName)
+	r.nodesInProcessing[nodeName] = &nodeProcessingInfo{}
 	return true
+}
+
+func (r *rangeAllocator) retryParams(nodeName string) (bool, time.Duration) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	entry, ok := r.nodesInProcessing[nodeName]
+	if !ok {
+		klog.Errorf("Cannot get retryParams for %q as entry does not exist", nodeName)
+		return false, 0
+	}
+
+	count := entry.retries + 1
+	if count > updateMaxRetries {
+		return false, 0
+	}
+	r.nodesInProcessing[nodeName].retries = count
+
+	return true, nodeUpdateRetryTimeout(count)
 }
 
 func (r *rangeAllocator) removeNodeFromProcessing(nodeName string) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	r.nodesInProcessing.Delete(nodeName)
+	delete(r.nodesInProcessing, nodeName)
 }
 
 // marks node.PodCIDRs[...] as used in allocator's tracked cidrSet
@@ -330,7 +368,6 @@ func (r *rangeAllocator) filterOutServiceRange(serviceCIDR *net.IPNet) {
 func (r *rangeAllocator) updateCIDRsAllocation(data nodeReservedCIDRs) error {
 	var err error
 	var node *v1.Node
-	defer r.removeNodeFromProcessing(data.nodeName)
 	cidrsString := ipnetToStringList(data.allocatedCIDRs)
 	node, err = r.nodeLister.Get(data.nodeName)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Fixes a hot loop in the IPAM range allocator. This was fixed long ago for the cloud CIDR allocator in https://github.com/kubernetes/kubernetes/pull/68084. This PR just syncs with that implementation.

#### Which issue(s) this PR fixes:
Fixes #96992

#### Special notes for your reviewer:
This PR is a continuation of #97021 which was apparently closed due to inactivity. We removed an unrelated change in the original PR and added a unit test.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```