### PR TITLE
Improve vendor verification works for each staging repo

### DIFF
--- a/hack/verify-vendor.sh
+++ b/hack/verify-vendor.sh
@@ -92,5 +92,17 @@ if [[ ${ret} -gt 0 ]]; then
   exit ${ret}
 fi
 
+# Ensure we can tidy every repo using only its recorded versions
+for repo in $(kube::util::list_staging_repos); do
+  pushd "${_kubetmp}/staging/src/k8s.io/${repo}" >/dev/null 2>&1
+    echo "Tidying k8s.io/${repo}..."
+    GODEBUG=gocacheverify=1 go mod tidy
+  popd >/dev/null 2>&1
+done
+pushd "${_kubetmp}" >/dev/null 2>&1
+  echo "Tidying k8s.io/kubernetes..."
+  GODEBUG=gocacheverify=1 go mod tidy
+popd >/dev/null 2>&1
+
 echo "Vendor Verified."
 # ex: ts=2 sw=2 et filetype=sh


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds a check to presubmit to ensure we don't merge vendor updates that break tidy when run in isolation on a staging repo with a clean go cache. This has bitten us in post-merge with ambiguous module versions / imports before.

This passes on master, and fails like the following on a PR that made staging references ambiguous:

```
Tidying k8s.io/api...
Tidying k8s.io/apiextensions-apiserver...
k8s.io/apiextensions-apiserver/pkg/apiserver imports
	k8s.io/apiserver/pkg/registry/generic imports
	k8s.io/apiserver/pkg/storage/storagebackend/factory imports
	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc tested by
	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc.test imports
	google.golang.org/grpc/interop imports
	golang.org/x/oauth2/google imports
	cloud.google.com/go/compute/metadata: ambiguous import: found package cloud.google.com/go/compute/metadata in multiple modules:
	cloud.google.com/go v0.65.0 (/Users/liggitt/go/pkg/mod/cloud.google.com/go@v0.65.0/compute/metadata)
	cloud.google.com/go/compute v1.7.0 (/Users/liggitt/go/pkg/mod/cloud.google.com/go/compute@v1.7.0/metadata)
```


cc @dims @nikhita 

```release-note
NONE
```