### PR TITLE
Include head and tail of clipped test messages

### DIFF
--- a/cmd/prune-junit-xml/prunexml.go
+++ b/cmd/prune-junit-xml/prunexml.go
@@ -65,15 +65,17 @@ func pruneXML(suites *junitxml.JUnitTestSuites, maxBytes int) {
 			if testcase.SkipMessage != nil {
 				if len(testcase.SkipMessage.Message) > maxBytes {
 					fmt.Printf("clipping skip message in test case : %s\n", testcase.Name)
-					testcase.SkipMessage.Message = "[... clipped...]" +
-						testcase.SkipMessage.Message[len(testcase.SkipMessage.Message)-maxBytes:]
+					head := testcase.SkipMessage.Message[:maxBytes/2]
+					tail := testcase.SkipMessage.Message[len(testcase.SkipMessage.Message)-maxBytes/2:]
+					testcase.SkipMessage.Message = head + "[...clipped...]" + tail
 				}
 			}
 			if testcase.Failure != nil {
 				if len(testcase.Failure.Contents) > maxBytes {
 					fmt.Printf("clipping failure message in test case : %s\n", testcase.Name)
-					testcase.Failure.Contents = "[... clipped...]" +
-						testcase.Failure.Contents[len(testcase.Failure.Contents)-maxBytes:]
+					head := testcase.Failure.Contents[:maxBytes/2]
+					tail := testcase.Failure.Contents[len(testcase.Failure.Contents)-maxBytes/2:]
+					testcase.Failure.Contents = head + "[...clipped...]" + tail
 				}
 			}
 		}

--- a/cmd/prune-junit-xml/prunexml_test.go
+++ b/cmd/prune-junit-xml/prunexml_test.go
@@ -19,9 +19,10 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPruneXML(t *testing.T) {
@@ -49,10 +50,10 @@ func TestPruneXML(t *testing.T) {
 		</properties>
 		<testcase classname="k8s.io/kubernetes/test/integration/apimachinery" name="TestWatchRestartsIfTimeoutNotReached/group/InformerWatcher_survives_closed_watches" time="30.050000"></testcase>
 		<testcase classname="k8s.io/kubernetes/test/integration/apiserver" name="TestMaxResourceSize/JSONPatchType_should_handle_a_patch_just_under_the_max_limit" time="0.000000">
-			<skipped message="[... clipped...]ust_under_the_max_limit (0.00s)&#xA;"></skipped>
+			<skipped message="=== RUN   TestMa[...clipped...]x_limit (0.00s)&#xA;"></skipped>
 		</testcase>
 		<testcase classname="k8s.io/kubernetes/test/integration/apimachinery" name="TestSchedulerInformers" time="-0.000000">
-			<failure message="Failed" type="">[... clipped...]prometheus/client_metrics.go:160</failure>
+			<failure message="Failed" type="">&#xA;&#x9;/home/prow/go/[...clipped...]t_metrics.go:160</failure>
 		</testcase>
 	</testsuite>
 </testsuites>`


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates test message clipping to include both the start and end of clipped messages. Sometimes the important bit is at the top (like a data race or panic or test failure), sometimes it's at the end. This helps us see both ends of the message.

```release-note
NONE
```

/assign @dims