### PR TITLE
Re-add handling of rename from official image "k8s.gcr.io/coredns" to "k8s.gcr.io/coredns/coredns" to support deprecated installations

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1beta3/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta3/defaults.go
@@ -44,6 +44,8 @@ const (
 	// DefaultImageRepository defines default image registry
 	// (previously this defaulted to k8s.gcr.io)
 	DefaultImageRepository = "registry.k8s.io"
+	// OldDefaultImageRepository defines the old default image registry. This is used for migration purposes.
+	OldDefaultImageRepository = "k8s.gcr.io"
 	// DefaultManifestsDir defines default manifests directory
 	DefaultManifestsDir = "/etc/kubernetes/manifests"
 	// DefaultClusterName defines the default cluster name

--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -48,8 +48,9 @@ func GetDNSImage(cfg *kubeadmapi.ClusterConfiguration) string {
 	if cfg.DNS.ImageRepository != "" {
 		dnsImageRepository = cfg.DNS.ImageRepository
 	}
-	// Handle the renaming of the official image from "registry.k8s.io/coredns" to "registry.k8s.io/coredns/coredns
-	if dnsImageRepository == kubeadmapiv1beta3.DefaultImageRepository {
+	// Handle the renaming of the official image from "registry.k8s.io/coredns" to "registry.k8s.io/coredns/coredns"
+	// (and "k8s.gcr.io/coredns" to "k8s.gcr.io/coredns/coredns" for deprecated configurations)
+	if dnsImageRepository == kubeadmapiv1beta3.DefaultImageRepository || dnsImageRepository == kubeadmapiv1beta3.OldDefaultImageRepository {
 		dnsImageRepository = fmt.Sprintf("%s/coredns", dnsImageRepository)
 	}
 	// DNS uses an imageTag that corresponds to the DNS version matching the Kubernetes version

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -255,6 +255,13 @@ func TestGetDNSImage(t *testing.T) {
 			},
 		},
 		{
+			expected: kubeadmapiv1beta3.OldDefaultImageRepository + "/coredns/coredns:v1.10.0",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				ImageRepository: kubeadmapiv1beta3.OldDefaultImageRepository,
+				DNS:             kubeadmapi.DNS{},
+			},
+		},
+		{
 			expected: "foo.io/coredns/coredns:v1.10.0",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository: "foo.io",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

This was accidentally replaced in https://github.com/kubernetes/kubernetes/commit/50bea1dad89930ad565526910aadc314b9e9f38b (PR https://github.com/kubernetes/kubernetes/pull/109938). By re-adding it, `kubeadm join` will no longer fail with `failed to pull image k8s.gcr.io/coredns:v1.8.6` for clusters that still have `k8s.gcr.io` explicitly configured as image repository, such as CAPI-managed clusters.

Example failure that I'm facing:

- Cluster got created via CAPI for an older Kubernetes version. The default value `k8s.gcr.io` gets stored in the cluster (`kubectl get configmap -n kube-system kubeadm-config -o yaml | grep imageRepository: # prints k8s.gcr.io value`)
- Cluster upgrade to v1.23.15, or any other version that switched to `registry.k8s.io`, is performed by CAPI. This means starting a new cloud server as node, and running `kubeadm join` on it.
- kubeadm (buggy version v1.23.15) reads the in-cluster configuration, sees `ClusterConfiguration.imageRepository=k8s.gcr.io` and then fails with `failed to pull image k8s.gcr.io/coredns:v1.8.6` because the renaming logic for official images is gone

#### Which issue(s) this PR fixes:

Did not create an issue

Context:

- https://github.com/kubernetes/enhancements/tree/master/keps/sig-release/3000-artifact-distribution
- https://github.com/kubernetes/kubernetes/pull/109938

#### Special notes for your reviewer:

Maybe @dims who authored the related migration wants to have a look 😉 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix `kubeadm join` image pulls of the coredns image for installations that still use the old registry k8s.gcr.io
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
