### PR TITLE
kubelet: correctly propagate status of static pod readiness probes on termination

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2252,7 +2252,7 @@ func (kl *Kubelet) syncLoopIteration(ctx context.Context, configCh <-chan kubety
 		}
 	case update := <-kl.readinessManager.Updates():
 		ready := update.Result == proberesults.Success
-		kl.statusManager.SetContainerReadiness(update.PodUID, update.ContainerID, ready)
+		kl.statusManager.SetContainerReadiness(update.Pod, update.ContainerID, ready)
 
 		status := ""
 		if ready {
@@ -2261,7 +2261,7 @@ func (kl *Kubelet) syncLoopIteration(ctx context.Context, configCh <-chan kubety
 		handleProbeSync(kl, update, handler, "readiness", status)
 	case update := <-kl.startupManager.Updates():
 		started := update.Result == proberesults.Success
-		kl.statusManager.SetContainerStartup(update.PodUID, update.ContainerID, started)
+		kl.statusManager.SetContainerStartup(update.Pod, update.ContainerID, started)
 
 		status := "unhealthy"
 		if started {
@@ -2291,7 +2291,7 @@ func (kl *Kubelet) syncLoopIteration(ctx context.Context, configCh <-chan kubety
 
 func handleProbeSync(kl *Kubelet, update proberesults.Update, handler SyncHandler, probe, status string) {
 	// We should not use the pod from manager, because it is never updated after initialization.
-	pod, ok := kl.podManager.GetPodByUID(update.PodUID)
+	pod, ok := kl.podManager.GetPodByUID(update.Pod.UID)
 	if !ok {
 		// If the pod no longer exists, ignore the update.
 		klog.V(4).InfoS("SyncLoop (probe): ignore irrelevant update", "probe", probe, "status", status, "update", update)

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1034,13 +1034,16 @@ func (kl *Kubelet) isAdmittedPodTerminal(pod *v1.Pod) bool {
 
 // removeOrphanedPodStatuses removes obsolete entries in podStatus where
 // the pod is no longer considered bound to this node.
-func (kl *Kubelet) removeOrphanedPodStatuses(pods []*v1.Pod, mirrorPods []*v1.Pod) {
+func (kl *Kubelet) removeOrphanedPodStatuses(pods []*v1.Pod, mirrorPods []*v1.Pod, possiblyRunningPods map[types.UID]sets.Empty) {
 	podUIDs := make(map[types.UID]bool)
 	for _, pod := range pods {
 		podUIDs[pod.UID] = true
 	}
 	for _, pod := range mirrorPods {
 		podUIDs[pod.UID] = true
+	}
+	for uid := range possiblyRunningPods {
+		podUIDs[uid] = true
 	}
 	kl.statusManager.RemoveOrphanedStatuses(podUIDs)
 }
@@ -1165,7 +1168,7 @@ func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 
 	// Remove orphaned pod statuses not in the total list of known config pods
 	klog.V(3).InfoS("Clean up orphaned pod statuses")
-	kl.removeOrphanedPodStatuses(allPods, mirrorPods)
+	kl.removeOrphanedPodStatuses(allPods, mirrorPods, possiblyRunningPods)
 	// Note that we just killed the unwanted pods. This may not have reflected
 	// in the cache. We need to bypass the cache to get the latest set of
 	// running pods to clean up the volumes.

--- a/pkg/kubelet/pod/mirror_client.go
+++ b/pkg/kubelet/pod/mirror_client.go
@@ -103,6 +103,7 @@ func (mc *basicMirrorClient) CreateMirrorPod(pod *v1.Pod) error {
 			return nil
 		}
 	}
+	klog.V(2).InfoS("Created mirror pod", "static_pod", klog.KObj(pod), "static_pod_uid", pod.UID, "mirror_pod", klog.KObj(apiPod), "mirror_pod_uid", apiPod.UID)
 	return err
 }
 

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -320,7 +320,7 @@ func (m *manager) extractedReadinessHandling() {
 	update := <-m.readinessManager.Updates()
 	// This code corresponds to an extract from kubelet.syncLoopIteration()
 	ready := update.Result == results.Success
-	m.statusManager.SetContainerReadiness(update.PodUID, update.ContainerID, ready)
+	m.statusManager.SetContainerReadiness(update.Pod, update.ContainerID, ready)
 }
 
 func TestUpdateReadiness(t *testing.T) {

--- a/pkg/kubelet/prober/results/results_manager.go
+++ b/pkg/kubelet/prober/results/results_manager.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
@@ -80,7 +79,7 @@ func (r Result) ToPrometheusType() float64 {
 type Update struct {
 	ContainerID kubecontainer.ContainerID
 	Result      Result
-	PodUID      types.UID
+	Pod         *v1.Pod
 }
 
 // Manager implementation.
@@ -112,7 +111,7 @@ func (m *manager) Get(id kubecontainer.ContainerID) (Result, bool) {
 
 func (m *manager) Set(id kubecontainer.ContainerID, result Result, pod *v1.Pod) {
 	if m.setInternal(id, result) {
-		m.updates <- Update{id, result, pod.UID}
+		m.updates <- Update{id, result, pod}
 	}
 }
 

--- a/pkg/kubelet/prober/results/results_manager_test.go
+++ b/pkg/kubelet/prober/results/results_manager_test.go
@@ -78,10 +78,10 @@ func TestUpdates(t *testing.T) {
 
 	// New result should always push an update.
 	m.Set(fooID, Success, pod)
-	expectUpdate(Update{fooID, Success, pod.UID}, "new success")
+	expectUpdate(Update{fooID, Success, pod}, "new success")
 
 	m.Set(barID, Failure, pod)
-	expectUpdate(Update{barID, Failure, pod.UID}, "new failure")
+	expectUpdate(Update{barID, Failure, pod}, "new failure")
 
 	// Unchanged results should not send an update.
 	m.Set(fooID, Success, pod)
@@ -92,8 +92,8 @@ func TestUpdates(t *testing.T) {
 
 	// Changed results should send an update.
 	m.Set(fooID, Failure, pod)
-	expectUpdate(Update{fooID, Failure, pod.UID}, "changed foo")
+	expectUpdate(Update{fooID, Failure, pod}, "changed foo")
 
 	m.Set(barID, Success, pod)
-	expectUpdate(Update{barID, Success, pod.UID}, "changed bar")
+	expectUpdate(Update{barID, Success, pod}, "changed bar")
 }

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -455,7 +455,7 @@ func TestLivenessProbeDisabledByStarted(t *testing.T) {
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
 	// setting started state
-	m.statusManager.SetContainerStartup(w.pod.UID, w.containerID, true)
+	m.statusManager.SetContainerStartup(w.pod, w.containerID, true)
 	// livenessProbe fails
 	m.prober.exec = fakeExecProber{probe.Failure, nil}
 	msg = "Started, probe failure, result failure"
@@ -479,7 +479,7 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
 	// setting started state
-	m.statusManager.SetContainerStartup(w.pod.UID, w.containerID, true)
+	m.statusManager.SetContainerStartup(w.pod, w.containerID, true)
 	// startupProbe fails, but is disabled
 	m.prober.exec = fakeExecProber{probe.Failure, nil}
 	msg = "Started, probe failure, result success"

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -115,11 +115,11 @@ type Manager interface {
 
 	// SetContainerReadiness updates the cached container status with the given readiness, and
 	// triggers a status update.
-	SetContainerReadiness(podUID types.UID, containerID kubecontainer.ContainerID, ready bool)
+	SetContainerReadiness(pod *v1.Pod, containerID kubecontainer.ContainerID, ready bool)
 
 	// SetContainerStartup updates the cached container status with the given startup, and
 	// triggers a status update.
-	SetContainerStartup(podUID types.UID, containerID kubecontainer.ContainerID, started bool)
+	SetContainerStartup(pod *v1.Pod, containerID kubecontainer.ContainerID, started bool)
 
 	// TerminatePod resets the container status for the provided pod to terminated and triggers
 	// a status update.
@@ -220,15 +220,9 @@ func (m *manager) SetPodStatus(pod *v1.Pod, status v1.PodStatus) {
 	m.updateStatusInternal(pod, status, pod.DeletionTimestamp != nil)
 }
 
-func (m *manager) SetContainerReadiness(podUID types.UID, containerID kubecontainer.ContainerID, ready bool) {
+func (m *manager) SetContainerReadiness(pod *v1.Pod, containerID kubecontainer.ContainerID, ready bool) {
 	m.podStatusesLock.Lock()
 	defer m.podStatusesLock.Unlock()
-
-	pod, ok := m.podManager.GetPodByUID(podUID)
-	if !ok {
-		klog.V(4).InfoS("Pod has been deleted, no need to update readiness", "podUID", string(podUID))
-		return
-	}
 
 	oldStatus, found := m.podStatuses[pod.UID]
 	if !found {
@@ -281,10 +275,11 @@ func (m *manager) SetContainerReadiness(podUID types.UID, containerID kubecontai
 	m.updateStatusInternal(pod, status, false)
 }
 
-func (m *manager) SetContainerStartup(podUID types.UID, containerID kubecontainer.ContainerID, started bool) {
+func (m *manager) SetContainerStartup(pod *v1.Pod, containerID kubecontainer.ContainerID, started bool) {
 	m.podStatusesLock.Lock()
 	defer m.podStatusesLock.Unlock()
 
+	podUID := pod.UID
 	pod, ok := m.podManager.GetPodByUID(podUID)
 	if !ok {
 		klog.V(4).InfoS("Pod has been deleted, no need to update startup", "podUID", string(podUID))
@@ -699,17 +694,6 @@ func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
 			"podUID", uid,
 			"pod", klog.KRef(status.podNamespace, status.podName),
 			"err", err)
-		return
-	}
-
-	translatedUID := m.podManager.TranslatePodUID(pod.UID)
-	// Type convert original uid just for the purpose of comparison.
-	if len(translatedUID) > 0 && translatedUID != kubetypes.ResolvedPodUID(uid) {
-		klog.V(2).InfoS("Pod was deleted and then recreated, skipping status update",
-			"pod", klog.KObj(pod),
-			"oldPodUID", uid,
-			"podUID", translatedUID)
-		m.deletePodStatus(uid)
 		return
 	}
 

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -323,6 +323,7 @@ func TestSyncPodChecksMismatchedUID(t *testing.T) {
 	pod.UID = "first"
 	syncer.podManager.AddPod(pod)
 	differentPod := getTestPod()
+	differentPod.Name = "second pod"
 	differentPod.UID = "second"
 	syncer.podManager.AddPod(differentPod)
 	syncer.kubeClient = fake.NewSimpleClientset(pod)
@@ -363,7 +364,7 @@ func TestSyncPodNoDeadlock(t *testing.T) {
 	ret.UID = "other_pod"
 	err = nil
 	m.SetPodStatus(pod, getRandomPodStatus())
-	verifyActions(t, m, []core.Action{getAction()})
+	verifyActions(t, m, []core.Action{getAction(), patchAction()})
 
 	t.Logf("Pod not deleted (success case).")
 	ret = getTestPod()
@@ -1042,7 +1043,7 @@ func TestSetContainerReadiness(t *testing.T) {
 	m.podManager.AddPod(pod)
 
 	t.Log("Setting readiness before status should fail.")
-	m.SetContainerReadiness(pod.UID, cID1, true)
+	m.SetContainerReadiness(pod, cID1, true)
 	verifyUpdates(t, m, 0)
 	if status, ok := m.GetPodStatus(pod.UID); ok {
 		t.Errorf("Unexpected PodStatus: %+v", status)
@@ -1055,25 +1056,25 @@ func TestSetContainerReadiness(t *testing.T) {
 	verifyReadiness("initial", &status, false, false, false)
 
 	t.Log("Setting unchanged readiness should do nothing.")
-	m.SetContainerReadiness(pod.UID, cID1, false)
+	m.SetContainerReadiness(pod, cID1, false)
 	verifyUpdates(t, m, 0)
 	status = expectPodStatus(t, m, pod)
 	verifyReadiness("unchanged", &status, false, false, false)
 
 	t.Log("Setting container readiness should generate update but not pod readiness.")
-	m.SetContainerReadiness(pod.UID, cID1, true)
+	m.SetContainerReadiness(pod, cID1, true)
 	verifyUpdates(t, m, 1)
 	status = expectPodStatus(t, m, pod)
 	verifyReadiness("c1 ready", &status, true, false, false)
 
 	t.Log("Setting both containers to ready should update pod readiness.")
-	m.SetContainerReadiness(pod.UID, cID2, true)
+	m.SetContainerReadiness(pod, cID2, true)
 	verifyUpdates(t, m, 1)
 	status = expectPodStatus(t, m, pod)
 	verifyReadiness("all ready", &status, true, true, true)
 
 	t.Log("Setting non-existent container readiness should fail.")
-	m.SetContainerReadiness(pod.UID, kubecontainer.ContainerID{Type: "test", ID: "foo"}, true)
+	m.SetContainerReadiness(pod, kubecontainer.ContainerID{Type: "test", ID: "foo"}, true)
 	verifyUpdates(t, m, 0)
 	status = expectPodStatus(t, m, pod)
 	verifyReadiness("ignore non-existent", &status, true, true, true)
@@ -1126,7 +1127,7 @@ func TestSetContainerStartup(t *testing.T) {
 	m.podManager.AddPod(pod)
 
 	t.Log("Setting startup before status should fail.")
-	m.SetContainerStartup(pod.UID, cID1, true)
+	m.SetContainerStartup(pod, cID1, true)
 	verifyUpdates(t, m, 0)
 	if status, ok := m.GetPodStatus(pod.UID); ok {
 		t.Errorf("Unexpected PodStatus: %+v", status)
@@ -1139,25 +1140,25 @@ func TestSetContainerStartup(t *testing.T) {
 	verifyStartup("initial", &status, false, false, false)
 
 	t.Log("Setting unchanged startup should do nothing.")
-	m.SetContainerStartup(pod.UID, cID1, false)
+	m.SetContainerStartup(pod, cID1, false)
 	verifyUpdates(t, m, 1)
 	status = expectPodStatus(t, m, pod)
 	verifyStartup("unchanged", &status, false, false, false)
 
 	t.Log("Setting container startup should generate update but not pod startup.")
-	m.SetContainerStartup(pod.UID, cID1, true)
+	m.SetContainerStartup(pod, cID1, true)
 	verifyUpdates(t, m, 1) // Started = nil to false
 	status = expectPodStatus(t, m, pod)
 	verifyStartup("c1 ready", &status, true, false, false)
 
 	t.Log("Setting both containers to ready should update pod startup.")
-	m.SetContainerStartup(pod.UID, cID2, true)
+	m.SetContainerStartup(pod, cID2, true)
 	verifyUpdates(t, m, 1)
 	status = expectPodStatus(t, m, pod)
 	verifyStartup("all ready", &status, true, true, true)
 
 	t.Log("Setting non-existent container startup should fail.")
-	m.SetContainerStartup(pod.UID, kubecontainer.ContainerID{Type: "test", ID: "foo"}, true)
+	m.SetContainerStartup(pod, kubecontainer.ContainerID{Type: "test", ID: "foo"}, true)
 	verifyUpdates(t, m, 0)
 	status = expectPodStatus(t, m, pod)
 	verifyStartup("ignore non-existent", &status, true, true, true)

--- a/pkg/kubelet/status/testing/mock_pod_status_provider.go
+++ b/pkg/kubelet/status/testing/mock_pod_status_provider.go
@@ -216,27 +216,27 @@ func (mr *MockManagerMockRecorder) RemoveOrphanedStatuses(podUIDs interface{}) *
 }
 
 // SetContainerReadiness mocks base method.
-func (m *MockManager) SetContainerReadiness(podUID types.UID, containerID container.ContainerID, ready bool) {
+func (m *MockManager) SetContainerReadiness(pod *v1.Pod, containerID container.ContainerID, ready bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetContainerReadiness", podUID, containerID, ready)
+	m.ctrl.Call(m, "SetContainerReadiness", pod, containerID, ready)
 }
 
 // SetContainerReadiness indicates an expected call of SetContainerReadiness.
-func (mr *MockManagerMockRecorder) SetContainerReadiness(podUID, containerID, ready interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) SetContainerReadiness(pod, containerID, ready interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContainerReadiness", reflect.TypeOf((*MockManager)(nil).SetContainerReadiness), podUID, containerID, ready)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContainerReadiness", reflect.TypeOf((*MockManager)(nil).SetContainerReadiness), pod, containerID, ready)
 }
 
 // SetContainerStartup mocks base method.
-func (m *MockManager) SetContainerStartup(podUID types.UID, containerID container.ContainerID, started bool) {
+func (m *MockManager) SetContainerStartup(pod *v1.Pod, containerID container.ContainerID, started bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetContainerStartup", podUID, containerID, started)
+	m.ctrl.Call(m, "SetContainerStartup", pod, containerID, started)
 }
 
 // SetContainerStartup indicates an expected call of SetContainerStartup.
-func (mr *MockManagerMockRecorder) SetContainerStartup(podUID, containerID, started interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) SetContainerStartup(pod, containerID, started interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContainerStartup", reflect.TypeOf((*MockManager)(nil).SetContainerStartup), podUID, containerID, started)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContainerStartup", reflect.TypeOf((*MockManager)(nil).SetContainerStartup), pod, containerID, started)
 }
 
 // SetPodStatus mocks base method.

--- a/test/e2e_node/mirror_pod_readiness_test.go
+++ b/test/e2e_node/mirror_pod_readiness_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = SIGDescribe("MirrorPod", func() {
+	f := framework.NewDefaultFramework("mirror-pod")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
+	ginkgo.Context("when create a mirror pod check readiness ", func() {
+		var ns, podPath, staticPodName, mirrorPodName string
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			ns = f.Namespace.Name
+			staticPodName = "static-pod-" + string(uuid.NewUUID())
+			mirrorPodName = staticPodName + "-" + framework.TestContext.NodeName
+
+			podPath = framework.TestContext.KubeletConfig.StaticPodPath
+
+			ginkgo.By("create the static pod")
+			err := createStaticPodWithReadiness(podPath, staticPodName, ns,
+				imageutils.GetE2EImage(imageutils.Perl), v1.RestartPolicyAlways)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("wait for the mirror pod to be running")
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				return checkMirrorPodRunning(ctx, f.ClientSet, mirrorPodName, ns)
+			}, 2*time.Minute, time.Second*4).Should(gomega.BeNil())
+
+			ginkgo.By("wait for pod to be ready")
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				pod, err := f.ClientSet.CoreV1().Pods(ns).Get(ctx, mirrorPodName, metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("expected the mirror pod %q to be present: %v", mirrorPodName, err)
+				}
+				for _, c := range pod.Status.Conditions {
+					if c.Type == v1.PodReady && c.Status == v1.ConditionTrue {
+						return nil
+					}
+				}
+				return errors.New("pod needs to be ready")
+			}, 2*time.Minute, time.Second*4).Should(gomega.BeNil())
+		})
+		/*
+			Testname: Mirror Pod, readiness
+			Description: checks the readiness of a pod on termination
+		*/
+		ginkgo.It("should be unready with readiness probe failure on termination [NodeConformance]", func(ctx context.Context) {
+			// remove the static pod, pod should go unready
+			err := deleteStaticPod(podPath, staticPodName, ns)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("wait for the mirror pod to be not ready")
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				pod, err := f.ClientSet.CoreV1().Pods(ns).Get(ctx, mirrorPodName, metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("expected the mirror pod %q to be present: %v", mirrorPodName, err)
+				}
+				for _, c := range pod.Status.Conditions {
+					if c.Type == v1.PodReady && c.Status == v1.ConditionFalse {
+						return nil
+					}
+				}
+				return errors.New("pod needs to be unready")
+			}, 2*time.Minute, time.Second*4).Should(gomega.BeNil())
+		})
+	})
+})
+
+func createStaticPodWithReadiness(dir, name, namespace, image string, restart v1.RestartPolicy) error {
+	template := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  containers:
+  - name: test
+    image: %s
+    restartPolicy: %s
+    command:
+      - bash
+      - -c
+      - "_term() { rm -f /tmp/ready ; sleep 10; exit 0; } ; trap _term SIGTERM; touch /tmp/ready ; while true; do echo \"hello\"; sleep 10; done"
+    readinessProbe:
+      exec:
+        command:
+        - cat
+        - /tmp/ready
+      failureThreshold: 1
+      initialDelaySeconds: 5
+      periodSeconds: 2
+`
+	file := staticPodPath(dir, name, namespace)
+	podYaml := fmt.Sprintf(template, name, namespace, image, string(restart))
+
+	f, err := os.OpenFile(file, os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(podYaml)
+	return err
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
It is important for pods to propagate readiness to the API server on termination. Readiness allows for load balancers, Kubernetes Endpoints, and other services to gracefully remove services without throwing 500's and other errors.  https://github.com/kubernetes/kubernetes/pull/110191 re-enabled readiness probes on probe termination; however, there is a bug in propagating status back to the API. This PR fixes the status propagation for static pods back to the API server.

The following fixes are implemented:

* removeOrphanedPodStatuses did not account for pods that are terminating. We are now mixing in the "possiblyRunningPods" to allow not cleanup the pod statuses too early.
* Added a log message (level 2) to print the static pod and mirror pod UIDs. This will aid in external programs to cross reference the static pod uid to the mirror pod UID.
* SetContainerReadiness was originally written to *not* propagate readiness statuses. The PR removes this limitation.
* syncPod has a stanza to delete the pod status when it detects a recreated pod (mostly for static pods). We don't need this check anymore to allow for readiness updates during termination.
* Updated the tests and mocks.

- [x] Code Fix
- [x] e2e_node Test

Note: https://github.com/kubernetes/kubernetes/pull/110191 is a fix that merged to enable readiness probes on termination. This PR fixes an issue within the Kubelet where probes might not be running during termination due to how the kubelet handles the state.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubelet fix to status updates for readiness on terminating static pods.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
