### PR TITLE
Automated cherry pick of #114078: Explicitly call rand.Seed() method

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_retry_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_retry_test.go
@@ -80,13 +80,17 @@ func TestJitterWithNegativeMaxFactor(t *testing.T) {
 	// jitter := duration + time.Duration(rand.Float64()*maxFactor*float64(duration))
 	// If maxFactor is 0.0 or less than 0.0, a suggested default value will be chosen.
 	// rand.Float64() returns, as a float64, a pseudo-random number in [0.0,1.0).
-	duration := time.Duration(time.Second)
+	duration := time.Second
 	maxFactor := -3.0
 	res := jitter(duration, maxFactor)
-	defaultMaxFactor := 1.0
-	expected := jitter(duration, defaultMaxFactor)
-	assert.Equal(t, expected-res >= time.Duration(0.0*float64(duration)), true)
-	assert.Equal(t, expected-res < time.Duration(1.0*float64(duration)), true)
+	// jitter with negative maxFactor should not be negative
+	assert.Equal(t, res >= duration, true)
+	assert.Equal(t, res <= 2*duration, true)
+
+	maxFactor = 2.0
+	res = jitter(duration, maxFactor)
+	assert.Equal(t, res >= duration, true)
+	assert.Equal(t, res <= 3*duration, true)
 }
 
 func TestDoExponentialBackoffRetry(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #114078 on release-1.25.

#114078: Explicitly call rand.Seed() method

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```