### PR TITLE
replace deprecated sets.String to sets.Set

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -149,7 +149,7 @@ func NewKubeletFlags() *KubeletFlags {
 
 // ValidateKubeletFlags validates Kubelet's configuration flags and returns an error if they are invalid.
 func ValidateKubeletFlags(f *KubeletFlags) error {
-	unknownLabels := sets.NewString()
+	unknownLabels := sets.New[string]()
 	invalidLabelErrs := make(map[string][]string)
 	for k, v := range f.NodeLabels {
 		if isKubernetesLabel(k) && !kubeletapis.IsKubeletLabel(k) {
@@ -164,7 +164,7 @@ func ValidateKubeletFlags(f *KubeletFlags) error {
 		}
 	}
 	if len(unknownLabels) > 0 {
-		return fmt.Errorf("unknown 'kubernetes.io' or 'k8s.io' labels specified with --node-labels: %v\n--node-labels in the 'kubernetes.io' namespace must begin with an allowed prefix (%s) or be in the specifically allowed set (%s)", unknownLabels.List(), strings.Join(kubeletapis.KubeletLabelNamespaces(), ", "), strings.Join(kubeletapis.KubeletLabels(), ", "))
+		return fmt.Errorf("unknown 'kubernetes.io' or 'k8s.io' labels specified with --node-labels: %v\n--node-labels in the 'kubernetes.io' namespace must begin with an allowed prefix (%s) or be in the specifically allowed set (%s)", sets.List(unknownLabels), strings.Join(kubeletapis.KubeletLabelNamespaces(), ", "), strings.Join(kubeletapis.KubeletLabels(), ", "))
 	}
 	if len(invalidLabelErrs) > 0 {
 		labelErrs := []string{}

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -737,7 +737,7 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 				NodeAllocatableConfig: cm.NodeAllocatableConfig{
 					KubeReservedCgroupName:   s.KubeReservedCgroup,
 					SystemReservedCgroupName: s.SystemReservedCgroup,
-					EnforceNodeAllocatable:   sets.NewString(s.EnforceNodeAllocatable...),
+					EnforceNodeAllocatable:   sets.New(s.EnforceNodeAllocatable...),
 					KubeReserved:             kubeReserved,
 					SystemReserved:           systemReserved,
 					ReservedSystemCPUs:       reservedSystemCPUs,

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -30,11 +30,11 @@ func TestKubeletConfigurationPathFields(t *testing.T) {
 	if i := kubeletConfigurationPathFieldPaths.Intersection(kubeletConfigurationNonPathFieldPaths); len(i) > 0 {
 		t.Fatalf("expect the intersection of kubeletConfigurationPathFieldPaths and "+
 			"KubeletConfigurationNonPathFields to be empty, got:\n%s",
-			strings.Join(i.List(), "\n"))
+			strings.Join(sets.List(i), "\n"))
 	}
 
 	// ensure that kubeletConfigurationPathFields U kubeletConfigurationNonPathFields == allPrimitiveFieldPaths(KubeletConfiguration)
-	expect := sets.NewString().Union(kubeletConfigurationPathFieldPaths).Union(kubeletConfigurationNonPathFieldPaths)
+	expect := sets.New[string]().Union(kubeletConfigurationPathFieldPaths).Union(kubeletConfigurationNonPathFieldPaths)
 	result := allPrimitiveFieldPaths(t, expect, reflect.TypeOf(&KubeletConfiguration{}), nil)
 	if !expect.Equal(result) {
 		// expected fields missing from result
@@ -46,38 +46,38 @@ func TestKubeletConfigurationPathFields(t *testing.T) {
 				"If the field has been removed, please remove it from the kubeletConfigurationPathFieldPaths set "+
 				"and the KubeletConfigurationPathRefs function, "+
 				"or remove it from the kubeletConfigurationNonPathFieldPaths set, as appropriate:\n%s",
-				strings.Join(missing.List(), "\n"))
+				strings.Join(sets.List(missing), "\n"))
 		}
 		if len(unexpected) > 0 {
 			t.Errorf("the following fields were in the result, but unexpected. "+
 				"If the field is new, please add it to the kubeletConfigurationPathFieldPaths set "+
 				"and the KubeletConfigurationPathRefs function, "+
 				"or add it to the kubeletConfigurationNonPathFieldPaths set, as appropriate:\n%s",
-				strings.Join(unexpected.List(), "\n"))
+				strings.Join(sets.List(unexpected), "\n"))
 		}
 	}
 }
 
 // allPrimitiveFieldPaths returns the set of field paths in type `tp`, rooted at `path`.
 // It recursively descends into the definition of type `tp` accumulating paths to primitive leaf fields or paths in `skipRecurseList`.
-func allPrimitiveFieldPaths(t *testing.T, skipRecurseList sets.String, tp reflect.Type, path *field.Path) sets.String {
+func allPrimitiveFieldPaths(t *testing.T, skipRecurseList sets.Set[string], tp reflect.Type, path *field.Path) sets.Set[string] {
 	// if the current field path is in the list of paths we should not recurse into,
 	// return here rather than descending and accumulating child field paths
 	if pathStr := path.String(); len(pathStr) > 0 && skipRecurseList.Has(pathStr) {
-		return sets.NewString(pathStr)
+		return sets.New[string](pathStr)
 	}
 
-	paths := sets.NewString()
+	paths := sets.New[string]()
 	switch tp.Kind() {
 	case reflect.Pointer:
-		paths.Insert(allPrimitiveFieldPaths(t, skipRecurseList, tp.Elem(), path).List()...)
+		paths.Insert(sets.List(allPrimitiveFieldPaths(t, skipRecurseList, tp.Elem(), path))...)
 	case reflect.Struct:
 		for i := 0; i < tp.NumField(); i++ {
 			field := tp.Field(i)
-			paths.Insert(allPrimitiveFieldPaths(t, skipRecurseList, field.Type, path.Child(field.Name)).List()...)
+			paths.Insert(sets.List(allPrimitiveFieldPaths(t, skipRecurseList, field.Type, path.Child(field.Name)))...)
 		}
 	case reflect.Map, reflect.Slice:
-		paths.Insert(allPrimitiveFieldPaths(t, skipRecurseList, tp.Elem(), path.Key("*")).List()...)
+		paths.Insert(sets.List(allPrimitiveFieldPaths(t, skipRecurseList, tp.Elem(), path.Key("*")))...)
 	case reflect.Interface:
 		t.Fatalf("unexpected interface{} field %s", path.String())
 	default:
@@ -115,7 +115,7 @@ type bar struct {
 }
 
 func TestAllPrimitiveFieldPaths(t *testing.T) {
-	expect := sets.NewString(
+	expect := sets.New[string](
 		"str",
 		"strptr",
 		"ints[*]",
@@ -140,17 +140,17 @@ func TestAllPrimitiveFieldPaths(t *testing.T) {
 		unexpected := result.Difference(expect)
 
 		if len(missing) > 0 {
-			t.Errorf("the following fields were expected, but missing from the result:\n%s", strings.Join(missing.List(), "\n"))
+			t.Errorf("the following fields were expected, but missing from the result:\n%s", strings.Join(sets.List(missing), "\n"))
 		}
 		if len(unexpected) > 0 {
-			t.Errorf("the following fields were in the result, but unexpected:\n%s", strings.Join(unexpected.List(), "\n"))
+			t.Errorf("the following fields were in the result, but unexpected:\n%s", strings.Join(sets.List(unexpected), "\n"))
 		}
 	}
 }
 
 var (
 	// KubeletConfiguration fields that contain file paths. If you update this, also update KubeletConfigurationPathRefs!
-	kubeletConfigurationPathFieldPaths = sets.NewString(
+	kubeletConfigurationPathFieldPaths = sets.New[string](
 		"StaticPodPath",
 		"Authentication.X509.ClientCAFile",
 		"TLSCertFile",
@@ -159,7 +159,7 @@ var (
 	)
 
 	// KubeletConfiguration fields that do not contain file paths.
-	kubeletConfigurationNonPathFieldPaths = sets.NewString(
+	kubeletConfigurationNonPathFieldPaths = sets.New[string](
 		"Address",
 		"AllowedUnsafeSysctls[*]",
 		"Authentication.Anonymous.Enabled",

--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -245,7 +245,7 @@ func (m *cgroupManagerImpl) Validate(name CgroupName) error {
 		}
 		difference := neededControllers.Difference(enabledControllers)
 		if difference.Len() > 0 {
-			return fmt.Errorf("cgroup %q has some missing controllers: %v", name, strings.Join(difference.List(), ", "))
+			return fmt.Errorf("cgroup %q has some missing controllers: %v", name, strings.Join(sets.List(difference), ", "))
 		}
 		return nil // valid V2 cgroup
 	}
@@ -259,7 +259,7 @@ func (m *cgroupManagerImpl) Validate(name CgroupName) error {
 	// scoped to the set control groups it understands.  this is being discussed
 	// in https://github.com/opencontainers/runc/issues/1440
 	// once resolved, we can remove this code.
-	allowlistControllers := sets.NewString("cpu", "cpuacct", "cpuset", "memory", "systemd", "pids")
+	allowlistControllers := sets.New[string]("cpu", "cpuacct", "cpuset", "memory", "systemd", "pids")
 
 	if _, ok := m.subsystems.MountPoints["hugetlb"]; ok {
 		allowlistControllers.Insert("hugetlb")
@@ -321,24 +321,24 @@ func getCPUWeight(cpuShares *uint64) uint64 {
 }
 
 // readUnifiedControllers reads the controllers available at the specified cgroup
-func readUnifiedControllers(path string) (sets.String, error) {
+func readUnifiedControllers(path string) (sets.Set[string], error) {
 	controllersFileContent, err := os.ReadFile(filepath.Join(path, "cgroup.controllers"))
 	if err != nil {
 		return nil, err
 	}
 	controllers := strings.Fields(string(controllersFileContent))
-	return sets.NewString(controllers...), nil
+	return sets.New(controllers...), nil
 }
 
 var (
 	availableRootControllersOnce sync.Once
-	availableRootControllers     sets.String
+	availableRootControllers     sets.Set[string]
 )
 
 // getSupportedUnifiedControllers returns a set of supported controllers when running on cgroup v2
-func getSupportedUnifiedControllers() sets.String {
+func getSupportedUnifiedControllers() sets.Set[string] {
 	// This is the set of controllers used by the Kubelet
-	supportedControllers := sets.NewString("cpu", "cpuset", "memory", "hugetlb", "pids")
+	supportedControllers := sets.New[string]("cpu", "cpuset", "memory", "hugetlb", "pids")
 	// Memoize the set of controllers that are present in the root cgroup
 	availableRootControllersOnce.Do(func() {
 		var err error
@@ -406,7 +406,7 @@ func (m *cgroupManagerImpl) maybeSetHugetlb(resourceConfig *ResourceConfig, reso
 	}
 
 	// For each page size enumerated, set that value.
-	pageSizes := sets.NewString()
+	pageSizes := sets.New[string]()
 	for pageSize, limit := range resourceConfig.HugePageLimit {
 		sizeString, err := v1helper.HugePageUnitSizeFromByteSize(pageSize)
 		if err != nil {
@@ -484,7 +484,7 @@ func (m *cgroupManagerImpl) Pids(name CgroupName) []int {
 	cgroupFsName := m.Name(name)
 
 	// Get a list of processes that we need to kill
-	pidsToKill := sets.NewInt()
+	pidsToKill := sets.New[int]()
 	var pids []int
 	for _, val := range m.subsystems.MountPoints {
 		dir := path.Join(val, cgroupFsName)
@@ -525,7 +525,7 @@ func (m *cgroupManagerImpl) Pids(name CgroupName) []int {
 			klog.V(4).InfoS("Cgroup manager encountered error scanning pids for directory", "path", dir, "err", err)
 		}
 	}
-	return pidsToKill.List()
+	return sets.List(pidsToKill)
 }
 
 // ReduceCPULimits reduces the cgroup's cpu shares to the lowest possible value

--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -163,7 +163,7 @@ type NodeAllocatableConfig struct {
 	KubeReservedCgroupName   string
 	SystemReservedCgroupName string
 	ReservedSystemCPUs       cpuset.CPUSet
-	EnforceNodeAllocatable   sets.String
+	EnforceNodeAllocatable   sets.Set[string]
 	KubeReserved             v1.ResourceList
 	SystemReserved           v1.ResourceList
 	HardEvictionThresholds   []evictionapi.Threshold

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -162,7 +162,7 @@ func validateSystemRequirements(mountUtil mount.Interface) (features, error) {
 		return f, nil
 	}
 
-	expectedCgroups := sets.NewString("cpu", "cpuacct", "cpuset", "memory")
+	expectedCgroups := sets.New[string]("cpu", "cpuacct", "cpuset", "memory")
 	for _, mountPoint := range mountPoints {
 		if mountPoint.Type == cgroupMountType {
 			for _, opt := range mountPoint.Opts {
@@ -177,7 +177,7 @@ func validateSystemRequirements(mountUtil mount.Interface) (features, error) {
 	}
 
 	if expectedCgroups.Len() > 0 {
-		return f, fmt.Errorf("%s - Following Cgroup subsystem not mounted: %v", localErr, expectedCgroups.List())
+		return f, fmt.Errorf("%s - Following Cgroup subsystem not mounted: %v", localErr, sets.List(expectedCgroups))
 	}
 
 	// Check if cpu quota is available.

--- a/pkg/kubelet/cm/cpumanager/policy_options.go
+++ b/pkg/kubelet/cm/cpumanager/policy_options.go
@@ -35,14 +35,14 @@ const (
 )
 
 var (
-	alphaOptions = sets.NewString(
+	alphaOptions = sets.New[string](
 		DistributeCPUsAcrossNUMAOption,
 		AlignBySocketOption,
 	)
-	betaOptions = sets.NewString(
+	betaOptions = sets.New[string](
 		FullPCPUsOnlyOption,
 	)
-	stableOptions = sets.NewString()
+	stableOptions = sets.New[string]()
 )
 
 // CheckPolicyOptionAvailable verifies if the given option can be used depending on the Feature Gate Settings.

--- a/pkg/kubelet/cm/devicemanager/checkpoint/checkpoint.go
+++ b/pkg/kubelet/cm/devicemanager/checkpoint/checkpoint.go
@@ -62,9 +62,9 @@ func NewDevicesPerNUMA() DevicesPerNUMA {
 }
 
 // Devices is a function that returns all device ids for all NUMA nodes
-// and represent it as sets.String
-func (dev DevicesPerNUMA) Devices() sets.String {
-	result := sets.NewString()
+// and represent it as sets.Set[string]
+func (dev DevicesPerNUMA) Devices() sets.Set[string] {
+	result := sets.New[string]()
 
 	for _, devs := range dev {
 		result.Insert(devs...)

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -73,13 +73,13 @@ type ManagerImpl struct {
 	allDevices ResourceDeviceInstances
 
 	// healthyDevices contains all of the registered healthy resourceNames and their exported device IDs.
-	healthyDevices map[string]sets.String
+	healthyDevices map[string]sets.Set[string]
 
 	// unhealthyDevices contains all of the unhealthy devices and their exported device IDs.
-	unhealthyDevices map[string]sets.String
+	unhealthyDevices map[string]sets.Set[string]
 
 	// allocatedDevices contains allocated deviceIds, keyed by resourceName.
-	allocatedDevices map[string]sets.String
+	allocatedDevices map[string]sets.Set[string]
 
 	// podDevices contains pod to allocated device mapping.
 	podDevices        *podDevices
@@ -107,7 +107,7 @@ type endpointInfo struct {
 type sourcesReadyStub struct{}
 
 // PodReusableDevices is a map by pod name of devices to reuse.
-type PodReusableDevices map[string]map[string]sets.String
+type PodReusableDevices map[string]map[string]sets.Set[string]
 
 func (s *sourcesReadyStub) AddSource(source string) {}
 func (s *sourcesReadyStub) AllReady() bool          { return true }
@@ -133,9 +133,9 @@ func newManagerImpl(socketPath string, topology []cadvisorapi.Node, topologyAffi
 		endpoints: make(map[string]endpointInfo),
 
 		allDevices:            NewResourceDeviceInstances(),
-		healthyDevices:        make(map[string]sets.String),
-		unhealthyDevices:      make(map[string]sets.String),
-		allocatedDevices:      make(map[string]sets.String),
+		healthyDevices:        make(map[string]sets.Set[string]),
+		unhealthyDevices:      make(map[string]sets.Set[string]),
+		allocatedDevices:      make(map[string]sets.Set[string]),
 		podDevices:            newPodDevices(),
 		numaNodes:             numaNodes,
 		topologyAffinityStore: topologyAffinityStore,
@@ -247,8 +247,8 @@ func (m *ManagerImpl) PluginListAndWatchReceiver(resourceName string, resp *plug
 
 func (m *ManagerImpl) genericDeviceUpdateCallback(resourceName string, devices []pluginapi.Device) {
 	m.mutex.Lock()
-	m.healthyDevices[resourceName] = sets.NewString()
-	m.unhealthyDevices[resourceName] = sets.NewString()
+	m.healthyDevices[resourceName] = sets.New[string]()
+	m.unhealthyDevices[resourceName] = sets.New[string]()
 	m.allDevices[resourceName] = make(map[string]pluginapi.Device)
 	for _, dev := range devices {
 		m.allDevices[resourceName][dev.ID] = dev
@@ -307,7 +307,7 @@ func (m *ManagerImpl) Allocate(pod *v1.Pod, container *v1.Container) error {
 	m.setPodPendingAdmission(pod)
 
 	if _, ok := m.devicesToReuse[string(pod.UID)]; !ok {
-		m.devicesToReuse[string(pod.UID)] = make(map[string]sets.String)
+		m.devicesToReuse[string(pod.UID)] = make(map[string]sets.Set[string])
 	}
 	// If pod entries to m.devicesToReuse other than the current pod exist, delete them.
 	for podUID := range m.devicesToReuse {
@@ -349,13 +349,13 @@ func (m *ManagerImpl) UpdatePluginResources(node *schedulerframework.NodeInfo, a
 
 func (m *ManagerImpl) markResourceUnhealthy(resourceName string) {
 	klog.V(2).InfoS("Mark all resources Unhealthy for resource", "resourceName", resourceName)
-	healthyDevices := sets.NewString()
+	healthyDevices := sets.New[string]()
 	if _, ok := m.healthyDevices[resourceName]; ok {
 		healthyDevices = m.healthyDevices[resourceName]
-		m.healthyDevices[resourceName] = sets.NewString()
+		m.healthyDevices[resourceName] = sets.New[string]()
 	}
 	if _, ok := m.unhealthyDevices[resourceName]; !ok {
-		m.unhealthyDevices[resourceName] = sets.NewString()
+		m.unhealthyDevices[resourceName] = sets.New[string]()
 	}
 	m.unhealthyDevices[resourceName] = m.unhealthyDevices[resourceName].Union(healthyDevices)
 }
@@ -376,7 +376,7 @@ func (m *ManagerImpl) GetCapacity() (v1.ResourceList, v1.ResourceList, []string)
 	needsUpdateCheckpoint := false
 	var capacity = v1.ResourceList{}
 	var allocatable = v1.ResourceList{}
-	deletedResources := sets.NewString()
+	deletedResources := sets.New[string]()
 	m.mutex.Lock()
 	for resourceName, devices := range m.healthyDevices {
 		eI, ok := m.endpoints[resourceName]
@@ -476,8 +476,8 @@ func (m *ManagerImpl) readCheckpoint() error {
 	for resource := range registeredDevs {
 		// During start up, creates empty healthyDevices list so that the resource capacity
 		// will stay zero till the corresponding device plugin re-registers.
-		m.healthyDevices[resource] = sets.NewString()
-		m.unhealthyDevices[resource] = sets.NewString()
+		m.healthyDevices[resource] = sets.New[string]()
+		m.unhealthyDevices[resource] = sets.New[string]()
 		m.endpoints[resource] = endpointInfo{e: newStoppedEndpointImpl(resource), opts: nil}
 	}
 	return nil
@@ -520,15 +520,16 @@ func (m *ManagerImpl) UpdateAllocatedDevices() {
 	if len(podsToBeRemoved) <= 0 {
 		return
 	}
-	klog.V(3).InfoS("Pods to be removed", "podUIDs", podsToBeRemoved.List())
-	m.podDevices.delete(podsToBeRemoved.List())
+	podsRemovedList := sets.List(podsToBeRemoved)
+	klog.V(3).InfoS("Pods to be removed", "podUIDs", podsRemovedList)
+	m.podDevices.delete(podsRemovedList)
 	// Regenerated allocatedDevices after we update pod allocation information.
 	m.allocatedDevices = m.podDevices.devices()
 }
 
 // Returns list of device Ids we need to allocate with Allocate rpc call.
 // Returns empty list in case we don't need to issue the Allocate rpc call.
-func (m *ManagerImpl) devicesToAllocate(podUID, contName, resource string, required int, reusableDevices sets.String) (sets.String, error) {
+func (m *ManagerImpl) devicesToAllocate(podUID, contName, resource string, required int, reusableDevices sets.Set[string]) (sets.Set[string], error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	needed := required
@@ -536,7 +537,7 @@ func (m *ManagerImpl) devicesToAllocate(podUID, contName, resource string, requi
 	// This can happen if a container restarts for example.
 	devices := m.podDevices.containerDevices(podUID, contName, resource)
 	if devices != nil {
-		klog.V(3).InfoS("Found pre-allocated devices for resource on pod", "resourceName", resource, "containerName", contName, "podUID", string(podUID), "devices", devices.List())
+		klog.V(3).InfoS("Found pre-allocated devices for resource on pod", "resourceName", resource, "containerName", contName, "podUID", string(podUID), "devices", sets.List(devices))
 		needed = needed - devices.Len()
 		// A pod's resource is not expected to change once admitted by the API server,
 		// so just fail loudly here. We can revisit this part if this no longer holds.
@@ -556,11 +557,11 @@ func (m *ManagerImpl) devicesToAllocate(podUID, contName, resource string, requi
 
 	// Declare the list of allocated devices.
 	// This will be populated and returned below.
-	allocated := sets.NewString()
+	allocated := sets.New[string]()
 
 	// Create a closure to help with device allocation
 	// Returns 'true' once no more devices need to be allocated.
-	allocateRemainingFrom := func(devices sets.String) bool {
+	allocateRemainingFrom := func(devices sets.Set[string]) bool {
 		for device := range devices.Difference(allocated) {
 			m.allocatedDevices[resource].Insert(device)
 			allocated.Insert(device)
@@ -574,7 +575,7 @@ func (m *ManagerImpl) devicesToAllocate(podUID, contName, resource string, requi
 
 	// Needs to allocate additional devices.
 	if m.allocatedDevices[resource] == nil {
-		m.allocatedDevices[resource] = sets.NewString()
+		m.allocatedDevices[resource] = sets.New[string]()
 	}
 
 	// Allocates from reusableDevices list first.
@@ -643,22 +644,22 @@ func (m *ManagerImpl) devicesToAllocate(podUID, contName, resource string, requi
 	return nil, fmt.Errorf("unexpectedly allocated less resources than required. Requested: %d, Got: %d", required, required-needed)
 }
 
-func (m *ManagerImpl) filterByAffinity(podUID, contName, resource string, available sets.String) (sets.String, sets.String, sets.String) {
+func (m *ManagerImpl) filterByAffinity(podUID, contName, resource string, available sets.Set[string]) (sets.Set[string], sets.Set[string], sets.Set[string]) {
 	// If alignment information is not available, just pass the available list back.
 	hint := m.topologyAffinityStore.GetAffinity(podUID, contName)
 	if !m.deviceHasTopologyAlignment(resource) || hint.NUMANodeAffinity == nil {
-		return sets.NewString(), sets.NewString(), available
+		return sets.New[string](), sets.New[string](), available
 	}
 
 	// Build a map of NUMA Nodes to the devices associated with them. A
 	// device may be associated to multiple NUMA nodes at the same time. If an
 	// available device does not have any NUMA Nodes associated with it, add it
 	// to a list of NUMA Nodes for the fake NUMANode -1.
-	perNodeDevices := make(map[int]sets.String)
+	perNodeDevices := make(map[int]sets.Set[string])
 	for d := range available {
 		if m.allDevices[resource][d].Topology == nil || len(m.allDevices[resource][d].Topology.Nodes) == 0 {
 			if _, ok := perNodeDevices[nodeWithoutTopology]; !ok {
-				perNodeDevices[nodeWithoutTopology] = sets.NewString()
+				perNodeDevices[nodeWithoutTopology] = sets.New[string]()
 			}
 			perNodeDevices[nodeWithoutTopology].Insert(d)
 			continue
@@ -666,7 +667,7 @@ func (m *ManagerImpl) filterByAffinity(podUID, contName, resource string, availa
 
 		for _, node := range m.allDevices[resource][d].Topology.Nodes {
 			if _, ok := perNodeDevices[int(node.ID)]; !ok {
-				perNodeDevices[int(node.ID)] = sets.NewString()
+				perNodeDevices[int(node.ID)] = sets.New[string]()
 			}
 			perNodeDevices[int(node.ID)].Insert(d)
 		}
@@ -737,14 +738,14 @@ func (m *ManagerImpl) filterByAffinity(podUID, contName, resource string, availa
 	}
 
 	// Return all three lists containing the full set of devices across them.
-	return sets.NewString(fromAffinity...), sets.NewString(notFromAffinity...), sets.NewString(withoutTopology...)
+	return sets.New[string](fromAffinity...), sets.New[string](notFromAffinity...), sets.New[string](withoutTopology...)
 }
 
 // allocateContainerResources attempts to allocate all of required device
 // plugin resources for the input container, issues an Allocate rpc request
 // for each new device resource requirement, processes their AllocateResponses,
 // and updates the cached containerDevices on success.
-func (m *ManagerImpl) allocateContainerResources(pod *v1.Pod, container *v1.Container, devicesToReuse map[string]sets.String) error {
+func (m *ManagerImpl) allocateContainerResources(pod *v1.Pod, container *v1.Container, devicesToReuse map[string]sets.Set[string]) error {
 	podUID := string(pod.UID)
 	contName := container.Name
 	allocatedDevicesUpdated := false
@@ -927,7 +928,7 @@ func (m *ManagerImpl) callPreStartContainerIfNeeded(podUID, contName, resource s
 
 // callGetPreferredAllocationIfAvailable issues GetPreferredAllocation grpc
 // call for device plugin resource with GetPreferredAllocationAvailable option set.
-func (m *ManagerImpl) callGetPreferredAllocationIfAvailable(podUID, contName, resource string, available, mustInclude sets.String, size int) (sets.String, error) {
+func (m *ManagerImpl) callGetPreferredAllocationIfAvailable(podUID, contName, resource string, available, mustInclude sets.Set[string], size int) (sets.Set[string], error) {
 	eI, ok := m.endpoints[resource]
 	if !ok {
 		return nil, fmt.Errorf("endpoint not found in cache for a registered resource: %s", resource)
@@ -946,9 +947,9 @@ func (m *ManagerImpl) callGetPreferredAllocationIfAvailable(podUID, contName, re
 		return nil, fmt.Errorf("device plugin GetPreferredAllocation rpc failed with err: %v", err)
 	}
 	if resp != nil && len(resp.ContainerResponses) > 0 {
-		return sets.NewString(resp.ContainerResponses[0].DeviceIDs...), nil
+		return sets.New[string](resp.ContainerResponses[0].DeviceIDs...), nil
 	}
-	return sets.NewString(), nil
+	return sets.New[string](), nil
 }
 
 // sanitizeNodeAllocatable scans through allocatedDevices in the device manager

--- a/pkg/kubelet/cm/devicemanager/pod_devices.go
+++ b/pkg/kubelet/cm/devicemanager/pod_devices.go
@@ -48,10 +48,10 @@ func newPodDevices() *podDevices {
 	return &podDevices{devs: make(map[string]containerDevices)}
 }
 
-func (pdev *podDevices) pods() sets.String {
+func (pdev *podDevices) pods() sets.Set[string] {
 	pdev.RLock()
 	defer pdev.RUnlock()
-	ret := sets.NewString()
+	ret := sets.New[string]()
 	for k := range pdev.devs {
 		ret.Insert(k)
 	}
@@ -96,11 +96,11 @@ func (pdev *podDevices) delete(pods []string) {
 
 // Returns list of device Ids allocated to the given pod for the given resource.
 // Returns nil if we don't have cached state for the given <podUID, resource>.
-func (pdev *podDevices) podDevices(podUID, resource string) sets.String {
+func (pdev *podDevices) podDevices(podUID, resource string) sets.Set[string] {
 	pdev.RLock()
 	defer pdev.RUnlock()
 
-	ret := sets.NewString()
+	ret := sets.New[string]()
 	for contName := range pdev.devs[podUID] {
 		ret = ret.Union(pdev.containerDevices(podUID, contName, resource))
 	}
@@ -109,7 +109,7 @@ func (pdev *podDevices) podDevices(podUID, resource string) sets.String {
 
 // Returns list of device Ids allocated to the given container for the given resource.
 // Returns nil if we don't have cached state for the given <podUID, contName, resource>.
-func (pdev *podDevices) containerDevices(podUID, contName, resource string) sets.String {
+func (pdev *podDevices) containerDevices(podUID, contName, resource string) sets.Set[string] {
 	pdev.RLock()
 	defer pdev.RUnlock()
 	if _, podExists := pdev.devs[podUID]; !podExists {
@@ -126,7 +126,7 @@ func (pdev *podDevices) containerDevices(podUID, contName, resource string) sets
 }
 
 // Populates allocatedResources with the device resources allocated to the specified <podUID, contName>.
-func (pdev *podDevices) addContainerAllocatedResources(podUID, contName string, allocatedResources map[string]sets.String) {
+func (pdev *podDevices) addContainerAllocatedResources(podUID, contName string, allocatedResources map[string]sets.Set[string]) {
 	pdev.RLock()
 	defer pdev.RUnlock()
 	containers, exists := pdev.devs[podUID]
@@ -143,7 +143,7 @@ func (pdev *podDevices) addContainerAllocatedResources(podUID, contName string, 
 }
 
 // Removes the device resources allocated to the specified <podUID, contName> from allocatedResources.
-func (pdev *podDevices) removeContainerAllocatedResources(podUID, contName string, allocatedResources map[string]sets.String) {
+func (pdev *podDevices) removeContainerAllocatedResources(podUID, contName string, allocatedResources map[string]sets.Set[string]) {
 	pdev.RLock()
 	defer pdev.RUnlock()
 	containers, exists := pdev.devs[podUID]
@@ -160,15 +160,15 @@ func (pdev *podDevices) removeContainerAllocatedResources(podUID, contName strin
 }
 
 // Returns all of devices allocated to the pods being tracked, keyed by resourceName.
-func (pdev *podDevices) devices() map[string]sets.String {
-	ret := make(map[string]sets.String)
+func (pdev *podDevices) devices() map[string]sets.Set[string] {
+	ret := make(map[string]sets.Set[string])
 	pdev.RLock()
 	defer pdev.RUnlock()
 	for _, containerDevices := range pdev.devs {
 		for _, resources := range containerDevices {
 			for resource, devices := range resources {
 				if _, exists := ret[resource]; !exists {
-					ret[resource] = sets.NewString()
+					ret[resource] = sets.New[string]()
 				}
 				if devices.allocResp != nil {
 					ret[resource] = ret[resource].Union(devices.deviceIds.Devices())
@@ -389,9 +389,9 @@ func (rdev ResourceDeviceInstances) Clone() ResourceDeviceInstances {
 	return clone
 }
 
-// Filter takes a condition set expressed as map[string]sets.String and returns a new
+// Filter takes a condition set expressed as map[string]sets.Set[string] and returns a new
 // ResourceDeviceInstances with only the devices matching the condition set.
-func (rdev ResourceDeviceInstances) Filter(cond map[string]sets.String) ResourceDeviceInstances {
+func (rdev ResourceDeviceInstances) Filter(cond map[string]sets.Set[string]) ResourceDeviceInstances {
 	filtered := NewResourceDeviceInstances()
 	for resourceName, filterIDs := range cond {
 		if _, exists := rdev[resourceName]; !exists {

--- a/pkg/kubelet/cm/devicemanager/pod_devices_test.go
+++ b/pkg/kubelet/cm/devicemanager/pod_devices_test.go
@@ -56,7 +56,7 @@ func TestGetContainerDevices(t *testing.T) {
 
 func TestResourceDeviceInstanceFilter(t *testing.T) {
 	var expected string
-	var cond map[string]sets.String
+	var cond map[string]sets.Set[string]
 	var resp ResourceDeviceInstances
 	devs := ResourceDeviceInstances{
 		"foo": DeviceInstances{
@@ -94,40 +94,40 @@ func TestResourceDeviceInstanceFilter(t *testing.T) {
 		},
 	}
 
-	resp = devs.Filter(map[string]sets.String{})
+	resp = devs.Filter(map[string]sets.Set[string]{})
 	expected = `{}`
 	expectResourceDeviceInstances(t, resp, expected)
 
-	cond = map[string]sets.String{
-		"foo": sets.NewString("dev-foo1", "dev-foo2"),
-		"bar": sets.NewString("dev-bar1"),
+	cond = map[string]sets.Set[string]{
+		"foo": sets.New[string]("dev-foo1", "dev-foo2"),
+		"bar": sets.New[string]("dev-bar1"),
 	}
 	resp = devs.Filter(cond)
 	expected = `{"bar":{"dev-bar1":{"ID":"bar1"}},"foo":{"dev-foo1":{"ID":"foo1"},"dev-foo2":{"ID":"foo2"}}}`
 	expectResourceDeviceInstances(t, resp, expected)
 
-	cond = map[string]sets.String{
-		"foo": sets.NewString("dev-foo1", "dev-foo2", "dev-foo3"),
-		"bar": sets.NewString("dev-bar1", "dev-bar2", "dev-bar3"),
-		"baz": sets.NewString("dev-baz1", "dev-baz2", "dev-baz3"),
+	cond = map[string]sets.Set[string]{
+		"foo": sets.New[string]("dev-foo1", "dev-foo2", "dev-foo3"),
+		"bar": sets.New[string]("dev-bar1", "dev-bar2", "dev-bar3"),
+		"baz": sets.New[string]("dev-baz1", "dev-baz2", "dev-baz3"),
 	}
 	resp = devs.Filter(cond)
 	expected = `{"bar":{"dev-bar1":{"ID":"bar1"},"dev-bar2":{"ID":"bar2"},"dev-bar3":{"ID":"bar3"}},"baz":{"dev-baz1":{"ID":"baz1"},"dev-baz2":{"ID":"baz2"},"dev-baz3":{"ID":"baz3"}},"foo":{"dev-foo1":{"ID":"foo1"},"dev-foo2":{"ID":"foo2"},"dev-foo3":{"ID":"foo3"}}}`
 	expectResourceDeviceInstances(t, resp, expected)
 
-	cond = map[string]sets.String{
-		"foo": sets.NewString("dev-foo1", "dev-foo2", "dev-foo3", "dev-foo4"),
-		"bar": sets.NewString("dev-bar1", "dev-bar2", "dev-bar3", "dev-bar4"),
-		"baz": sets.NewString("dev-baz1", "dev-baz2", "dev-baz3", "dev-bar4"),
+	cond = map[string]sets.Set[string]{
+		"foo": sets.New[string]("dev-foo1", "dev-foo2", "dev-foo3", "dev-foo4"),
+		"bar": sets.New[string]("dev-bar1", "dev-bar2", "dev-bar3", "dev-bar4"),
+		"baz": sets.New[string]("dev-baz1", "dev-baz2", "dev-baz3", "dev-bar4"),
 	}
 	resp = devs.Filter(cond)
 	expected = `{"bar":{"dev-bar1":{"ID":"bar1"},"dev-bar2":{"ID":"bar2"},"dev-bar3":{"ID":"bar3"}},"baz":{"dev-baz1":{"ID":"baz1"},"dev-baz2":{"ID":"baz2"},"dev-baz3":{"ID":"baz3"}},"foo":{"dev-foo1":{"ID":"foo1"},"dev-foo2":{"ID":"foo2"},"dev-foo3":{"ID":"foo3"}}}`
 	expectResourceDeviceInstances(t, resp, expected)
 
-	cond = map[string]sets.String{
-		"foo": sets.NewString("dev-foo1", "dev-foo4", "dev-foo7"),
-		"bar": sets.NewString("dev-bar1", "dev-bar4", "dev-bar7"),
-		"baz": sets.NewString("dev-baz1", "dev-baz4", "dev-baz7"),
+	cond = map[string]sets.Set[string]{
+		"foo": sets.New[string]("dev-foo1", "dev-foo4", "dev-foo7"),
+		"bar": sets.New[string]("dev-bar1", "dev-bar4", "dev-bar7"),
+		"baz": sets.New[string]("dev-baz1", "dev-baz4", "dev-baz7"),
 	}
 	resp = devs.Filter(cond)
 	expected = `{"bar":{"dev-bar1":{"ID":"bar1"}},"baz":{"dev-baz1":{"ID":"baz1"}},"foo":{"dev-foo1":{"ID":"foo1"}}}`

--- a/pkg/kubelet/cm/devicemanager/topology_hints.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints.go
@@ -63,7 +63,7 @@ func (m *ManagerImpl) GetTopologyHints(pod *v1.Pod, container *v1.Container) map
 				continue
 			}
 			klog.InfoS("Regenerating TopologyHints for resource already allocated to pod", "resource", resource, "pod", klog.KObj(pod), "containerName", container.Name)
-				deviceHints[resource] = m.generateDeviceTopologyHints(resource, allocated, sets.Set[string]{}, requested)
+			deviceHints[resource] = m.generateDeviceTopologyHints(resource, allocated, sets.Set[string]{}, requested)
 			continue
 		}
 

--- a/pkg/kubelet/cm/devicemanager/topology_hints.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints.go
@@ -63,7 +63,7 @@ func (m *ManagerImpl) GetTopologyHints(pod *v1.Pod, container *v1.Container) map
 				continue
 			}
 			klog.InfoS("Regenerating TopologyHints for resource already allocated to pod", "resource", resource, "pod", klog.KObj(pod), "containerName", container.Name)
-			deviceHints[resource] = m.generateDeviceTopologyHints(resource, allocated, sets.String{}, requested)
+				deviceHints[resource] = m.generateDeviceTopologyHints(resource, allocated, sets.Set[string]{}, requested)
 			continue
 		}
 
@@ -118,7 +118,7 @@ func (m *ManagerImpl) GetPodTopologyHints(pod *v1.Pod) map[string][]topologymana
 				continue
 			}
 			klog.InfoS("Regenerating TopologyHints for resource already allocated to pod", "resource", resource, "pod", klog.KObj(pod))
-			deviceHints[resource] = m.generateDeviceTopologyHints(resource, allocated, sets.String{}, requested)
+			deviceHints[resource] = m.generateDeviceTopologyHints(resource, allocated, sets.Set[string]{}, requested)
 			continue
 		}
 
@@ -132,7 +132,7 @@ func (m *ManagerImpl) GetPodTopologyHints(pod *v1.Pod) map[string][]topologymana
 
 		// Generate TopologyHints for this resource given the current
 		// request size and the list of available devices.
-		deviceHints[resource] = m.generateDeviceTopologyHints(resource, available, sets.String{}, requested)
+		deviceHints[resource] = m.generateDeviceTopologyHints(resource, available, sets.Set[string]{}, requested)
 	}
 
 	return deviceHints
@@ -148,12 +148,12 @@ func (m *ManagerImpl) deviceHasTopologyAlignment(resource string) bool {
 	return false
 }
 
-func (m *ManagerImpl) getAvailableDevices(resource string) sets.String {
+func (m *ManagerImpl) getAvailableDevices(resource string) sets.Set[string] {
 	// Strip all devices in use from the list of healthy ones.
 	return m.healthyDevices[resource].Difference(m.allocatedDevices[resource])
 }
 
-func (m *ManagerImpl) generateDeviceTopologyHints(resource string, available sets.String, reusable sets.String, request int) []topologymanager.TopologyHint {
+func (m *ManagerImpl) generateDeviceTopologyHints(resource string, available sets.Set[string], reusable sets.Set[string], request int) []topologymanager.TopologyHint {
 	// Initialize minAffinitySize to include all NUMA Nodes
 	minAffinitySize := len(m.numaNodes)
 

--- a/pkg/kubelet/cm/internal_container_lifecycle_linux.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_linux.go
@@ -20,6 +20,7 @@ limitations under the License.
 package cm
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
 	"strconv"
 	"strings"
 
@@ -39,7 +40,7 @@ func (i *internalContainerLifecycleImpl) PreCreateContainer(pod *v1.Pod, contain
 		numaNodes := i.memoryManager.GetMemoryNUMANodes(pod, container)
 		if numaNodes.Len() > 0 {
 			var affinity []string
-			for _, numaNode := range numaNodes.List() {
+			for _, numaNode := range sets.List(numaNodes) {
 				affinity = append(affinity, strconv.Itoa(numaNode))
 			}
 			containerConfig.Linux.Resources.CpusetMems = strings.Join(affinity, ",")

--- a/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
@@ -50,7 +50,7 @@ func (m *fakeManager) AddContainer(pod *v1.Pod, container *v1.Container, contain
 	klog.InfoS("Add container", "pod", klog.KObj(pod), "containerName", container.Name, "containerID", containerID)
 }
 
-func (m *fakeManager) GetMemoryNUMANodes(pod *v1.Pod, container *v1.Container) sets.Int {
+func (m *fakeManager) GetMemoryNUMANodes(pod *v1.Pod, container *v1.Container) sets.Set[int] {
 	klog.InfoS("Get MemoryNUMANodes", "pod", klog.KObj(pod), "containerName", container.Name)
 	return nil
 }

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -83,7 +83,7 @@ type Manager interface {
 	GetPodTopologyHints(*v1.Pod) map[string][]topologymanager.TopologyHint
 
 	// GetMemoryNUMANodes provides NUMA nodes that are used to allocate the container memory
-	GetMemoryNUMANodes(pod *v1.Pod, container *v1.Container) sets.Int
+	GetMemoryNUMANodes(pod *v1.Pod, container *v1.Container) sets.Set[int]
 
 	// GetAllocatableMemory returns the amount of allocatable memory for each NUMA node
 	GetAllocatableMemory() []state.Block
@@ -213,9 +213,9 @@ func (m *manager) AddContainer(pod *v1.Pod, container *v1.Container, containerID
 }
 
 // GetMemoryNUMANodes provides NUMA nodes that used to allocate the container memory
-func (m *manager) GetMemoryNUMANodes(pod *v1.Pod, container *v1.Container) sets.Int {
+func (m *manager) GetMemoryNUMANodes(pod *v1.Pod, container *v1.Container) sets.Set[int] {
 	// Get NUMA node affinity of blocks assigned to the container during Allocate()
-	numaNodes := sets.NewInt()
+	numaNodes := sets.New[int]()
 	for _, block := range m.state.GetMemoryBlocks(string(pod.UID), container.Name) {
 		for _, nodeID := range block.NUMAAffinity {
 			// avoid nodes duplication when hugepages and memory blocks pinned to the same NUMA node

--- a/pkg/kubelet/cm/topologymanager/policy_options.go
+++ b/pkg/kubelet/cm/topologymanager/policy_options.go
@@ -30,11 +30,11 @@ const (
 )
 
 var (
-	alphaOptions = sets.NewString(
+	alphaOptions = sets.New[string](
 		PreferClosestNUMANodes,
 	)
-	betaOptions   = sets.NewString()
-	stableOptions = sets.NewString()
+	betaOptions   = sets.New[string]()
+	stableOptions = sets.New[string]()
 )
 
 func CheckPolicyOptionAvailable(option string) error {

--- a/pkg/kubelet/cm/topologymanager/policy_options_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_options_test.go
@@ -82,7 +82,7 @@ func TestNewTopologyManagerOptions(t *testing.T) {
 		},
 	}
 
-	betaOptions = sets.NewString(fancyBetaOption)
+	betaOptions = sets.New[string](fancyBetaOption)
 
 	for _, tcase := range testCases {
 		t.Run(tcase.description, func(t *testing.T) {

--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -68,7 +68,7 @@ type PodConfig struct {
 
 	// contains the list of all configured sources
 	sourcesLock sync.Mutex
-	sources     sets.String
+	sources     sets.Set[string]
 }
 
 // NewPodConfig creates an object that can merge many configuration sources into a stream
@@ -80,7 +80,7 @@ func NewPodConfig(mode PodConfigNotificationMode, recorder record.EventRecorder,
 		pods:    storage,
 		mux:     config.NewMux(storage),
 		updates: updates,
-		sources: sets.String{},
+		sources: sets.Set[string]{},
 	}
 	return podConfig
 }
@@ -96,14 +96,14 @@ func (c *PodConfig) Channel(ctx context.Context, source string) chan<- interface
 
 // SeenAllSources returns true if seenSources contains all sources in the
 // config, and also this config has received a SET message from each source.
-func (c *PodConfig) SeenAllSources(seenSources sets.String) bool {
+func (c *PodConfig) SeenAllSources(seenSources sets.Set[string]) bool {
 	if c.pods == nil {
 		return false
 	}
 	c.sourcesLock.Lock()
 	defer c.sourcesLock.Unlock()
-	klog.V(5).InfoS("Looking for sources, have seen", "sources", c.sources.List(), "seenSources", seenSources)
-	return seenSources.HasAll(c.sources.List()...) && c.pods.seenSources(c.sources.List()...)
+	klog.V(5).InfoS("Looking for sources, have seen", "sources", sets.List(c.sources), "seenSources", seenSources)
+	return seenSources.HasAll(sets.List(c.sources)...) && c.pods.seenSources(sets.List(c.sources)...)
 }
 
 // Updates returns a channel of updates to the configuration, properly denormalized.
@@ -133,7 +133,7 @@ type podStorage struct {
 
 	// contains the set of all sources that have sent at least one SET
 	sourcesSeenLock sync.RWMutex
-	sourcesSeen     sets.String
+	sourcesSeen     sets.Set[string]
 
 	// the EventRecorder to use
 	recorder record.EventRecorder
@@ -149,7 +149,7 @@ func newPodStorage(updates chan<- kubetypes.PodUpdate, mode PodConfigNotificatio
 		pods:               make(map[string]map[types.UID]*v1.Pod),
 		mode:               mode,
 		updates:            updates,
-		sourcesSeen:        sets.String{},
+		sourcesSeen:        sets.Set[string]{},
 		recorder:           recorder,
 		startupSLIObserver: startupSLIObserver,
 	}
@@ -332,7 +332,7 @@ func (s *podStorage) seenSources(sources ...string) bool {
 }
 
 func filterInvalidPods(pods []*v1.Pod, source string, recorder record.EventRecorder) (filtered []*v1.Pod) {
-	names := sets.String{}
+	names := sets.Set[string]{}
 	for i, pod := range pods {
 		// Pods from each source are assumed to have passed validation individually.
 		// This function only checks if there is any naming conflict.

--- a/pkg/kubelet/config/config_test.go
+++ b/pkg/kubelet/config/config_test.go
@@ -466,7 +466,7 @@ func TestPodUpdateLabels(t *testing.T) {
 func TestPodConfigRace(t *testing.T) {
 	eventBroadcaster := record.NewBroadcaster()
 	config := NewPodConfig(PodConfigNotificationIncremental, eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "kubelet"}), &mockPodStartupSLIObserver{})
-	seenSources := sets.NewString(TestSource)
+	seenSources := sets.New[string](TestSource)
 	var wg sync.WaitGroup
 	const iterations = 100
 	wg.Add(2)

--- a/pkg/kubelet/config/sources.go
+++ b/pkg/kubelet/config/sources.go
@@ -24,7 +24,7 @@ import (
 )
 
 // SourcesReadyFn is function that returns true if the specified sources have been seen.
-type SourcesReadyFn func(sourcesSeen sets.String) bool
+type SourcesReadyFn func(sourcesSeen sets.Set[string]) bool
 
 // SourcesReady tracks the set of configured sources seen by the kubelet.
 type SourcesReady interface {
@@ -37,7 +37,7 @@ type SourcesReady interface {
 // NewSourcesReady returns a SourcesReady with the specified function.
 func NewSourcesReady(sourcesReadyFn SourcesReadyFn) SourcesReady {
 	return &sourcesImpl{
-		sourcesSeen:    sets.NewString(),
+		sourcesSeen:    sets.New[string](),
 		sourcesReadyFn: sourcesReadyFn,
 	}
 }
@@ -47,7 +47,7 @@ type sourcesImpl struct {
 	// lock protects access to sources seen.
 	lock sync.RWMutex
 	// set of sources seen.
-	sourcesSeen sets.String
+	sourcesSeen sets.Set[string]
 	// sourcesReady is a function that evaluates if the sources are ready.
 	sourcesReadyFn SourcesReadyFn
 }

--- a/pkg/kubelet/configmap/configmap_manager.go
+++ b/pkg/kubelet/configmap/configmap_manager.go
@@ -98,8 +98,8 @@ func (c *configMapManager) UnregisterPod(pod *v1.Pod) {
 	c.manager.UnregisterPod(pod)
 }
 
-func getConfigMapNames(pod *v1.Pod) sets.String {
-	result := sets.NewString()
+func getConfigMapNames(pod *v1.Pod) sets.Set[string] {
+	result := sets.New[string]()
 	podutil.VisitPodConfigmapNames(pod, func(name string) bool {
 		result.Insert(name)
 		return true

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -172,7 +172,7 @@ func ExpandContainerCommandOnlyStatic(containerCommand []string, envs []v1.EnvVa
 func ExpandContainerVolumeMounts(mount v1.VolumeMount, envs []EnvVar) (string, error) {
 
 	envmap := envVarsToMap(envs)
-	missingKeys := sets.NewString()
+	missingKeys := sets.New[string]()
 	expanded := expansion.Expand(mount.SubPathExpr, func(key string) string {
 		value, ok := envmap[key]
 		if !ok || len(value) == 0 {
@@ -182,7 +182,7 @@ func ExpandContainerVolumeMounts(mount v1.VolumeMount, envs []EnvVar) (string, e
 	})
 
 	if len(missingKeys) > 0 {
-		return "", fmt.Errorf("missing value for %s", strings.Join(missingKeys.List(), ", "))
+		return "", fmt.Errorf("missing value for %s", strings.Join(sets.List(missingKeys), ", "))
 	}
 	return expanded, nil
 }

--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -211,8 +211,8 @@ func (im *realImageGCManager) GetImageList() ([]container.Image, error) {
 	return im.imageCache.get(), nil
 }
 
-func (im *realImageGCManager) detectImages(ctx context.Context, detectTime time.Time) (sets.String, error) {
-	imagesInUse := sets.NewString()
+func (im *realImageGCManager) detectImages(ctx context.Context, detectTime time.Time) (sets.Set[string], error) {
+	imagesInUse := sets.New[string]()
 
 	// Always consider the container runtime pod sandbox image in use
 	imageRef, err := im.runtime.GetImageRef(ctx, container.ImageSpec{Image: im.sandboxImage})
@@ -239,7 +239,7 @@ func (im *realImageGCManager) detectImages(ctx context.Context, detectTime time.
 
 	// Add new images and record those being used.
 	now := time.Now()
-	currentImages := sets.NewString()
+	currentImages := sets.New[string]()
 	im.imageRecordsLock.Lock()
 	defer im.imageRecordsLock.Unlock()
 	for _, image := range images {
@@ -423,7 +423,7 @@ func (ev byLastUsedAndDetected) Less(i, j int) bool {
 	return ev[i].lastUsed.Before(ev[j].lastUsed)
 }
 
-func isImageUsed(imageID string, imagesInUse sets.String) bool {
+func isImageUsed(imageID string, imagesInUse sets.Set[string]) bool {
 	// Check the image ID.
 	if _, ok := imagesInUse[imageID]; ok {
 		return true

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2057,7 +2057,7 @@ func (kl *Kubelet) SyncTerminatedPod(ctx context.Context, pod *v1.Pod, podStatus
 func (kl *Kubelet) getPodsToSync() []*v1.Pod {
 	allPods := kl.podManager.GetPods()
 	podUIDs := kl.workQueue.GetWork()
-	podUIDSet := sets.NewString()
+	podUIDSet := sets.New[string]()
 	for _, podUID := range podUIDs {
 		podUIDSet.Insert(string(podUID))
 	}

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -127,7 +127,7 @@ func (kl *Kubelet) tryRegisterWithAPIServer(node *v1.Node) bool {
 // reconcileHugePageResource will update huge page capacity for each page size and remove huge page sizes no longer supported
 func (kl *Kubelet) reconcileHugePageResource(initialNode, existingNode *v1.Node) bool {
 	requiresUpdate := updateDefaultResources(initialNode, existingNode)
-	supportedHugePageResources := sets.String{}
+	supportedHugePageResources := sets.New[string]()
 
 	for resourceName := range initialNode.Status.Capacity {
 		if !v1helper.IsHugePageResourceName(resourceName) {

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -527,7 +527,7 @@ func (kl *Kubelet) GenerateRunContainerOptions(ctx context.Context, pod *v1.Pod,
 	return opts, cleanupAction, nil
 }
 
-var masterServices = sets.NewString("kubernetes")
+var masterServices = sets.New[string]("kubernetes")
 
 // getServiceEnvVarMap makes a map[string]string of env vars for services a
 // pod in namespace ns should see.

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -209,7 +209,7 @@ func newTestKubeletWithImageList(
 	if err := os.MkdirAll(kubelet.rootDirectory, 0750); err != nil {
 		t.Fatalf("can't mkdir(%q): %v", kubelet.rootDirectory, err)
 	}
-	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.String) bool { return true })
+	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
 	kubelet.serviceLister = testServiceLister{}
 	kubelet.serviceHasSynced = func() bool { return true }
 	kubelet.nodeHasSynced = func() bool { return true }
@@ -715,7 +715,7 @@ func TestHandlePodRemovesWhenSourcesAreReady(t *testing.T) {
 		{Pod: fakePod},
 	}
 	kubelet := testKubelet.kubelet
-	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.String) bool { return ready })
+	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.Set[string]) bool { return ready })
 
 	kubelet.HandlePodRemoves(pods)
 	time.Sleep(2 * time.Second)

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -167,7 +167,7 @@ func (kl *Kubelet) removeOrphanedPodVolumeDirs(uid types.UID) []error {
 // cleanupOrphanedPodDirs removes the volumes of pods that should not be
 // running and that have no containers running.  Note that we roll up logs here since it runs in the main loop.
 func (kl *Kubelet) cleanupOrphanedPodDirs(pods []*v1.Pod, runningPods []*kubecontainer.Pod) error {
-	allPods := sets.NewString()
+	allPods := sets.New[string]()
 	for _, pod := range pods {
 		allPods.Insert(string(pod.UID))
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -791,7 +791,7 @@ func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(ctx context.Con
 func (m *kubeGenericRuntimeManager) pruneInitContainersBeforeStart(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus) {
 	// only the last execution of each init container should be preserved, and only preserve it if it is in the
 	// list of init containers to keep.
-	initContainerNames := sets.NewString()
+	initContainerNames := sets.New[string]()
 	for _, container := range pod.Spec.InitContainers {
 		initContainerNames.Insert(container.Name)
 	}
@@ -825,7 +825,7 @@ func (m *kubeGenericRuntimeManager) pruneInitContainersBeforeStart(ctx context.C
 // of the container because it assumes all init containers have been stopped
 // before the call happens.
 func (m *kubeGenericRuntimeManager) purgeInitContainers(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus) {
-	initContainerNames := sets.NewString()
+	initContainerNames := sets.New[string]()
 	for _, container := range pod.Spec.InitContainers {
 		initContainerNames.Insert(container.Name)
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_gc.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc.go
@@ -285,7 +285,7 @@ func (cgc *containerGC) evictSandboxes(ctx context.Context, evictNonDeletedPods 
 	}
 
 	// collect all the PodSandboxId of container
-	sandboxIDs := sets.NewString()
+	sandboxIDs := sets.New[string]()
 	for _, container := range containers {
 		sandboxIDs.Insert(container.PodSandboxId)
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
@@ -73,17 +73,17 @@ func TestListImages(t *testing.T) {
 	assert.NoError(t, err)
 
 	images := []string{"1111", "2222", "3333"}
-	expected := sets.NewString(images...)
+	expected := sets.New[string](images...)
 	fakeImageService.SetFakeImages(images)
 
 	actualImages, err := fakeManager.ListImages(ctx)
 	assert.NoError(t, err)
-	actual := sets.NewString()
+	actual := sets.New[string]()
 	for _, i := range actualImages {
 		actual.Insert(i.ID)
 	}
 
-	assert.Equal(t, expected.List(), actual.List())
+	assert.Equal(t, sets.List(expected), sets.List(actual))
 }
 
 func TestListImagesWithError(t *testing.T) {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -244,8 +244,8 @@ func verifyPods(a, b []*kubecontainer.Pod) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-func verifyFakeContainerList(fakeRuntime *apitest.FakeRuntimeService, expected sets.String) (sets.String, bool) {
-	actual := sets.NewString()
+func verifyFakeContainerList(fakeRuntime *apitest.FakeRuntimeService, expected sets.Set[string]) (sets.Set[string], bool) {
+	actual := sets.New[string]()
 	for _, c := range fakeRuntime.Containers {
 		actual.Insert(c.Id)
 	}
@@ -739,7 +739,7 @@ func TestPruneInitContainers(t *testing.T) {
 	assert.NoError(t, err)
 
 	m.pruneInitContainersBeforeStart(ctx, pod, podStatus)
-	expectedContainers := sets.NewString(fakes[0].Id, fakes[2].Id)
+	expectedContainers := sets.New[string](fakes[0].Id, fakes[2].Id)
 	if actual, ok := verifyFakeContainerList(fakeRuntime, expectedContainers); !ok {
 		t.Errorf("expected %v, got %v", expectedContainers, actual)
 	}

--- a/pkg/kubelet/metrics/collectors/volume_stats.go
+++ b/pkg/kubelet/metrics/collectors/volume_stats.go
@@ -107,7 +107,7 @@ func (collector *volumeStatsCollector) CollectWithStability(ch chan<- metrics.Me
 		lv = append([]string{pvcRef.Namespace, pvcRef.Name}, lv...)
 		ch <- metrics.NewLazyConstMetric(desc, metrics.GaugeValue, v, lv...)
 	}
-	allPVCs := sets.String{}
+	allPVCs := sets.Set[string]{}
 	for _, podStat := range podStats {
 		if podStat.VolumeStats == nil {
 			continue

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -105,7 +105,7 @@ func TestParseResolvConf(t *testing.T) {
 			require.NoError(t, err)
 			assert.EqualValues(t, tc.nameservers, ns, "test case [%d]: name servers", i)
 			assert.EqualValues(t, tc.searches, srch, "test case [%d] searches", i)
-			assert.EqualValues(t, sets.NewString(tc.options...), sets.NewString(opts...), "test case [%d] options", i)
+			assert.EqualValues(t, sets.New[string](tc.options...), sets.New[string](opts...), "test case [%d] options", i)
 		} else {
 			require.Error(t, err, "tc.searches %v", tc.searches)
 		}
@@ -343,7 +343,7 @@ func TestMergeDNSOptions(t *testing.T) {
 	for _, tc := range testCases {
 		options := mergeDNSOptions(tc.existingDNSConfigOptions, tc.dnsConfigOptions)
 		// Options order may be changed after conversion.
-		if !sets.NewString(options...).Equal(sets.NewString(tc.expectedOptions...)) {
+		if !sets.New[string](options...).Equal(sets.New[string](tc.expectedOptions...)) {
 			t.Errorf("%s: mergeDNSOptions(%v, %v)=%v, want %v", tc.desc, tc.existingDNSConfigOptions, tc.dnsConfigOptions, options, tc.expectedOptions)
 		}
 	}
@@ -741,7 +741,7 @@ func dnsConfigsAreEqual(resConfig, expectedConfig *runtimeapi.DNSConfig) bool {
 		}
 	}
 	// Options order may be changed after conversion.
-	return sets.NewString(resConfig.Options...).Equal(sets.NewString(expectedConfig.Options...))
+	return sets.New[string](resConfig.Options...).Equal(sets.New[string](expectedConfig.Options...))
 }
 
 func newTestPods(count int) []*v1.Pod {

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -361,7 +361,7 @@ func (g *GenericPLEG) Relist() {
 }
 
 func getContainersFromPods(pods ...*kubecontainer.Pod) []*kubecontainer.Container {
-	cidSet := sets.NewString()
+	cidSet := sets.New[string]()
 	var containers []*kubecontainer.Container
 	fillCidSet := func(cs []*kubecontainer.Container) {
 		for _, c := range cs {

--- a/pkg/kubelet/pluginmanager/plugin_manager_test.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager_test.go
@@ -131,7 +131,7 @@ func TestPluginRegistration(t *testing.T) {
 	stopChan := make(chan struct{})
 	defer close(stopChan)
 	go func() {
-		sourcesReady := config.NewSourcesReady(func(_ sets.String) bool { return true })
+		sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
 		pluginManager.Run(sourcesReady, stopChan)
 	}()
 

--- a/pkg/kubelet/pod/testing/fake_mirror_client.go
+++ b/pkg/kubelet/pod/testing/fake_mirror_client.go
@@ -29,14 +29,14 @@ type FakeMirrorClient struct {
 	mirrorPodLock sync.RWMutex
 	// Note that a real mirror manager does not store the mirror pods in
 	// itself. This fake manager does this to track calls.
-	mirrorPods   sets.String
+	mirrorPods   sets.Set[string]
 	createCounts map[string]int
 	deleteCounts map[string]int
 }
 
 func NewFakeMirrorClient() *FakeMirrorClient {
 	m := FakeMirrorClient{}
-	m.mirrorPods = sets.NewString()
+	m.mirrorPods = sets.New[string]()
 	m.createCounts = make(map[string]int)
 	m.deleteCounts = make(map[string]int)
 	return &m
@@ -75,7 +75,7 @@ func (fmc *FakeMirrorClient) NumOfPods() int {
 func (fmc *FakeMirrorClient) GetPods() []string {
 	fmc.mirrorPodLock.RLock()
 	defer fmc.mirrorPodLock.RUnlock()
-	return fmc.mirrorPods.List()
+	return sets.List(fmc.mirrorPods)
 }
 
 func (fmc *FakeMirrorClient) GetCounts(podFullName string) (int, int) {

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -214,10 +214,10 @@ func (q *fakeQueue) Items() []FakeQueueItem {
 	return append(make([]FakeQueueItem, 0, len(q.queue)), q.queue...)
 }
 
-func (q *fakeQueue) Set() sets.String {
+func (q *fakeQueue) Set() sets.Set[string] {
 	q.lock.Lock()
 	defer q.lock.Unlock()
-	work := sets.NewString()
+	work := sets.New[string]()
 	for _, item := range q.queue[q.currentStart:] {
 		work.Insert(string(item.UID))
 	}
@@ -470,7 +470,7 @@ func drainWorkers(podWorkers *podWorkers, numPods int) {
 }
 
 func drainWorkersExcept(podWorkers *podWorkers, uids ...types.UID) {
-	set := sets.NewString()
+	set := sets.New[string]()
 	for _, uid := range uids {
 		set.Insert(string(uid))
 	}
@@ -958,8 +958,8 @@ func TestUpdatePodDoesNotForgetSyncPodKill(t *testing.T) {
 	}
 }
 
-func newUIDSet(uids ...types.UID) sets.String {
-	set := sets.NewString()
+func newUIDSet(uids ...types.UID) sets.Set[string] {
+	set := sets.New[string]()
 	for _, uid := range uids {
 		set.Insert(string(uid))
 	}
@@ -969,7 +969,7 @@ func newUIDSet(uids ...types.UID) sets.String {
 type terminalPhaseSync struct {
 	lock     sync.Mutex
 	fn       syncPodFnType
-	terminal sets.String
+	terminal sets.Set[string]
 }
 
 func (s *terminalPhaseSync) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType, pod *v1.Pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, error) {
@@ -994,7 +994,7 @@ func (s *terminalPhaseSync) SetTerminal(uid types.UID) {
 func newTerminalPhaseSync(fn syncPodFnType) *terminalPhaseSync {
 	return &terminalPhaseSync{
 		fn:       fn,
-		terminal: sets.NewString(),
+		terminal: sets.New[string](),
 	}
 }
 
@@ -1147,7 +1147,7 @@ func TestStaticPodExclusion(t *testing.T) {
 		t.Fatalf("unexpected waiting static pods: %s", cmp.Diff(e, a))
 	}
 	// verify all are enqueued
-	if e, a := sets.NewString("1-normal", "2-static", "4-static", "3-static"), podWorkers.workQueue.(*fakeQueue).Set(); !e.Equal(a) {
+	if e, a := sets.New[string]("1-normal", "2-static", "4-static", "3-static"), podWorkers.workQueue.(*fakeQueue).Set(); !e.Equal(a) {
 		t.Fatalf("unexpected queued items: %s", cmp.Diff(e, a))
 	}
 
@@ -1167,7 +1167,7 @@ func TestStaticPodExclusion(t *testing.T) {
 		t.Fatalf("unexpected waiting static pods: %s", cmp.Diff(e, a))
 	}
 	// the queue should include a single item for 3-static (indicating we need to retry later)
-	if e, a := sets.NewString("3-static"), newUIDSet(podWorkers.workQueue.GetWork()...); !reflect.DeepEqual(e, a) {
+	if e, a := sets.New[string]("3-static"), newUIDSet(podWorkers.workQueue.GetWork()...); !reflect.DeepEqual(e, a) {
 		t.Fatalf("unexpected queued items: %s", cmp.Diff(e, a))
 	}
 
@@ -1185,7 +1185,7 @@ func TestStaticPodExclusion(t *testing.T) {
 		t.Fatalf("unexpected pod state: %#v", pod3)
 	}
 	// the queue should be empty because the worker is now done
-	if e, a := sets.NewString(), newUIDSet(podWorkers.workQueue.GetWork()...); !reflect.DeepEqual(e, a) {
+	if e, a := sets.New[string](), newUIDSet(podWorkers.workQueue.GetWork()...); !reflect.DeepEqual(e, a) {
 		t.Fatalf("unexpected queued items: %s", cmp.Diff(e, a))
 	}
 	// 2-static is still running

--- a/pkg/kubelet/secret/secret_manager.go
+++ b/pkg/kubelet/secret/secret_manager.go
@@ -99,8 +99,8 @@ func (s *secretManager) UnregisterPod(pod *v1.Pod) {
 	s.manager.UnregisterPod(pod)
 }
 
-func getSecretNames(pod *v1.Pod) sets.String {
-	result := sets.NewString()
+func getSecretNames(pod *v1.Pod) sets.Set[string] {
+	result := sets.New[string]()
 	podutil.VisitPodSecretNames(pod, func(name string) bool {
 		result.Insert(name)
 		return true

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -106,8 +106,8 @@ type Server struct {
 	auth                 AuthInterface
 	host                 HostInterface
 	restfulCont          containerInterface
-	metricsBuckets       sets.String
-	metricsMethodBuckets sets.String
+	metricsBuckets       sets.Set[string]
+	metricsMethodBuckets sets.Set[string]
 	resourceAnalyzer     stats.ResourceAnalyzer
 }
 
@@ -267,8 +267,8 @@ func NewServer(
 		resourceAnalyzer:     resourceAnalyzer,
 		auth:                 auth,
 		restfulCont:          &filteringContainer{Container: restful.NewContainer()},
-		metricsBuckets:       sets.NewString(),
-		metricsMethodBuckets: sets.NewString("OPTIONS", "GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "CONNECT"),
+		metricsBuckets:       sets.New[string](),
+		metricsMethodBuckets: sets.New("OPTIONS", "GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "CONNECT"),
 	}
 	if auth != nil {
 		server.InstallAuthFilter()

--- a/pkg/kubelet/userns_manager.go
+++ b/pkg/kubelet/userns_manager.go
@@ -439,7 +439,7 @@ func (m *usernsManager) CleanupOrphanedPodUsernsAllocations(pods []*v1.Pod, runn
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	allPods := sets.NewString()
+	allPods := sets.New[string]()
 	for _, pod := range pods {
 		allPods.Insert(string(pod.UID))
 	}
@@ -447,7 +447,7 @@ func (m *usernsManager) CleanupOrphanedPodUsernsAllocations(pods []*v1.Pod, runn
 		allPods.Insert(string(pod.ID))
 	}
 
-	allFound := sets.NewString()
+	allFound := sets.New[string]()
 	found, err := m.kl.listPodsFromDisk()
 	if err != nil {
 		return err

--- a/pkg/kubelet/util/manager/cache_based_manager.go
+++ b/pkg/kubelet/util/manager/cache_based_manager.go
@@ -210,7 +210,7 @@ func (s *objectStore) Get(namespace, name string) (runtime.Object, error) {
 // (e.g. ttl-based implementation vs watch-based implementation).
 type cacheBasedManager struct {
 	objectStore          Store
-	getReferencedObjects func(*v1.Pod) sets.String
+	getReferencedObjects func(*v1.Pod) sets.Set[string]
 
 	lock           sync.Mutex
 	registeredPods map[objectKey]*v1.Pod
@@ -265,7 +265,7 @@ func (c *cacheBasedManager) UnregisterPod(pod *v1.Pod) {
 //   - every GetObject() call tries to fetch the value from local cache; if it is
 //     not there, invalidated or too old, we fetch it from apiserver and refresh the
 //     value in cache; otherwise it is just fetched from cache
-func NewCacheBasedManager(objectStore Store, getReferencedObjects func(*v1.Pod) sets.String) Manager {
+func NewCacheBasedManager(objectStore Store, getReferencedObjects func(*v1.Pod) sets.Set[string]) Manager {
 	return &cacheBasedManager{
 		objectStore:          objectStore,
 		getReferencedObjects: getReferencedObjects,

--- a/pkg/kubelet/util/manager/cache_based_manager_test.go
+++ b/pkg/kubelet/util/manager/cache_based_manager_test.go
@@ -73,8 +73,8 @@ func newSecretStore(fakeClient clientset.Interface, clock clock.Clock, getTTL Ge
 	}
 }
 
-func getSecretNames(pod *v1.Pod) sets.String {
-	result := sets.NewString()
+func getSecretNames(pod *v1.Pod) sets.Set[string] {
+	result := sets.New[string]()
 	podutil.VisitPodSecretNames(pod, func(name string) bool {
 		result.Insert(name)
 		return true

--- a/pkg/kubelet/util/manager/watch_based_manager.go
+++ b/pkg/kubelet/util/manager/watch_based_manager.go
@@ -379,7 +379,7 @@ func NewWatchBasedManager(
 	isImmutable isImmutableFunc,
 	groupResource schema.GroupResource,
 	resyncInterval time.Duration,
-	getReferencedObjects func(*v1.Pod) sets.String) Manager {
+	getReferencedObjects func(*v1.Pod) sets.Set[string]) Manager {
 
 	// If a configmap/secret is used as a volume, the volumeManager will visit the objectCacheItem every resyncInterval cycle,
 	// We just want to stop the objectCacheItem referenced by environment variables,

--- a/pkg/kubelet/util/queue/work_queue_test.go
+++ b/pkg/kubelet/util/queue/work_queue_test.go
@@ -37,16 +37,16 @@ func newTestBasicWorkQueue() (*basicWorkQueue, *testingclock.FakeClock) {
 }
 
 func compareResults(t *testing.T, expected, actual []types.UID) {
-	expectedSet := sets.NewString()
+	expectedSet := sets.New[string]()
 	for _, u := range expected {
 		expectedSet.Insert(string(u))
 	}
-	actualSet := sets.NewString()
+	actualSet := sets.New[string]()
 	for _, u := range actual {
 		actualSet.Insert(string(u))
 	}
 	if !expectedSet.Equal(actualSet) {
-		t.Errorf("Expected %#v, got %#v", expectedSet.List(), actualSet.List())
+		t.Errorf("Expected %#v, got %#v", sets.List(expectedSet), sets.List(actualSet))
 	}
 }
 

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
@@ -150,7 +150,7 @@ func NewDesiredStateOfWorld(volumePluginMgr *volume.VolumePluginMgr, seLinuxTran
 	return &desiredStateOfWorld{
 		volumesToMount:    make(map[v1.UniqueVolumeName]volumeToMount),
 		volumePluginMgr:   volumePluginMgr,
-		podErrors:         make(map[types.UniquePodName]sets.String),
+		podErrors:         make(map[types.UniquePodName]sets.Set[string]),
 		seLinuxTranslator: seLinuxTranslator,
 	}
 }
@@ -165,7 +165,7 @@ type desiredStateOfWorld struct {
 	// plugin objects.
 	volumePluginMgr *volume.VolumePluginMgr
 	// podErrors are errors caught by desiredStateOfWorldPopulator about volumes for a given pod.
-	podErrors map[types.UniquePodName]sets.String
+	podErrors map[types.UniquePodName]sets.Set[string]
 	// seLinuxTranslator translates v1.SELinuxOptions to a file SELinux label.
 	seLinuxTranslator util.SELinuxLabelTranslator
 
@@ -605,7 +605,7 @@ func (dsw *desiredStateOfWorld) AddErrorToPod(podName types.UniquePodName, err s
 		}
 		return
 	}
-	dsw.podErrors[podName] = sets.NewString(err)
+	dsw.podErrors[podName] = sets.New[string](err)
 }
 
 func (dsw *desiredStateOfWorld) PopPodErrors(podName types.UniquePodName) []string {
@@ -614,7 +614,7 @@ func (dsw *desiredStateOfWorld) PopPodErrors(podName types.UniquePodName) []stri
 
 	if errs, found := dsw.podErrors[podName]; found {
 		delete(dsw.podErrors, podName)
-		return errs.List()
+		return sets.List(errs)
 	}
 	return []string{}
 }

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -444,7 +444,7 @@ func (dswp *desiredStateOfWorldPopulator) deleteProcessedPod(
 // specified volume. It dereference any PVC to get PV objects, if needed.
 // Returns an error if unable to obtain the volume at this time.
 func (dswp *desiredStateOfWorldPopulator) createVolumeSpec(
-	podVolume v1.Volume, pod *v1.Pod, mounts, devices sets.String) (*v1.PersistentVolumeClaim, *volume.Spec, string, error) {
+	podVolume v1.Volume, pod *v1.Pod, mounts, devices sets.Set[string]) (*v1.PersistentVolumeClaim, *volume.Spec, string, error) {
 	pvcSource := podVolume.VolumeSource.PersistentVolumeClaim
 	isEphemeral := pvcSource == nil && podVolume.VolumeSource.Ephemeral != nil
 	if isEphemeral {

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct_new_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct_new_test.go
@@ -128,12 +128,12 @@ func TestReconstructVolumes(t *testing.T) {
 				t.Errorf("Expected volumesNeedReportedInUse:\n%v\n got:\n%v", expectedVolumes, rcInstance.volumesNeedReportedInUse)
 			}
 
-			volumesFailedReconstruction := sets.NewString()
+			volumesFailedReconstruction := sets.New[string]()
 			for _, vol := range rcInstance.volumesFailedReconstruction {
 				volumesFailedReconstruction.Insert(vol.volumeSpecName)
 			}
-			if !reflect.DeepEqual(volumesFailedReconstruction.List(), tc.expectedVolumesFailedReconstruction) {
-				t.Errorf("Expected volumesFailedReconstruction:\n%v\n got:\n%v", tc.expectedVolumesFailedReconstruction, volumesFailedReconstruction.List())
+			if !reflect.DeepEqual(sets.List(volumesFailedReconstruction), tc.expectedVolumesFailedReconstruction) {
+				t.Errorf("Expected volumesFailedReconstruction:\n%v\n got:\n%v", tc.expectedVolumesFailedReconstruction, sets.List(volumesFailedReconstruction))
 			}
 
 			if tc.verifyFunc != nil {

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -318,7 +318,7 @@ func (vm *volumeManager) GetPossiblyMountedVolumesForPod(podName types.UniquePod
 
 func (vm *volumeManager) GetExtraSupplementalGroupsForPod(pod *v1.Pod) []int64 {
 	podName := util.GetUniquePodName(pod)
-	supplementalGroups := sets.NewString()
+	supplementalGroups := sets.New[string]()
 
 	for _, mountedVolume := range vm.actualStateOfWorld.GetMountedVolumesForPod(podName) {
 		if mountedVolume.VolumeGidValue != "" {
@@ -327,7 +327,7 @@ func (vm *volumeManager) GetExtraSupplementalGroupsForPod(pod *v1.Pod) []int64 {
 	}
 
 	result := make([]int64, 0, supplementalGroups.Len())
-	for _, group := range supplementalGroups.List() {
+	for _, group := range sets.List(supplementalGroups) {
 		iGroup, extra := getExtraSupplementalGid(group, pod)
 		if !extra {
 			continue
@@ -471,7 +471,7 @@ func (vm *volumeManager) WaitForUnmount(pod *v1.Pod) error {
 }
 
 func (vm *volumeManager) getVolumesNotInDSW(uniquePodName types.UniquePodName, expectedVolumes []string) []string {
-	volumesNotInDSW := sets.NewString(expectedVolumes...)
+	volumesNotInDSW := sets.New[string](expectedVolumes...)
 
 	for _, volumeToMount := range vm.desiredStateOfWorld.GetVolumesToMount() {
 		if volumeToMount.PodName == uniquePodName {
@@ -479,7 +479,7 @@ func (vm *volumeManager) getVolumesNotInDSW(uniquePodName types.UniquePodName, e
 		}
 	}
 
-	return volumesNotInDSW.List()
+	return sets.List(volumesNotInDSW)
 }
 
 // getUnattachedVolumes returns a list of the volumes that are expected to be attached but
@@ -524,7 +524,7 @@ func (vm *volumeManager) verifyVolumesUnmountedFunc(podName types.UniquePodName)
 // expectedVolumes. It returns a list of unmounted volumes.
 // The list also includes volume that may be mounted in uncertain state.
 func (vm *volumeManager) getUnmountedVolumes(podName types.UniquePodName, expectedVolumes []string) []string {
-	mountedVolumes := sets.NewString()
+	mountedVolumes := sets.New[string]()
 	for _, mountedVolume := range vm.actualStateOfWorld.GetMountedVolumesForPod(podName) {
 		mountedVolumes.Insert(mountedVolume.OuterVolumeSpecName)
 	}
@@ -533,7 +533,7 @@ func (vm *volumeManager) getUnmountedVolumes(podName types.UniquePodName, expect
 
 // filterUnmountedVolumes adds each element of expectedVolumes that is not in
 // mountedVolumes to a list of unmountedVolumes and returns it.
-func filterUnmountedVolumes(mountedVolumes sets.String, expectedVolumes []string) []string {
+func filterUnmountedVolumes(mountedVolumes sets.Set[string], expectedVolumes []string) []string {
 	unmountedVolumes := []string{}
 	for _, expectedVolume := range expectedVolumes {
 		if !mountedVolumes.Has(expectedVolume) {

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -524,7 +524,7 @@ func runVolumeManager(manager VolumeManager) chan struct{} {
 	stopCh := make(chan struct{})
 	//readyCh := make(chan bool, 1)
 	//readyCh <- true
-	sourcesReady := config.NewSourcesReady(func(_ sets.String) bool { return true })
+	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
 	go manager.Run(sourcesReady, stopCh)
 	return stopCh
 }

--- a/pkg/kubelet/winstats/network_stats.go
+++ b/pkg/kubelet/winstats/network_stats.go
@@ -180,7 +180,7 @@ func (n *networkCounter) mergeCollectedData(packetsReceivedPerSecondData,
 	packetsReceivedErrorsData,
 	packetsOutboundDiscardedData,
 	packetsOutboundErrorsData map[string]uint64) {
-	adapters := sets.NewString()
+	adapters := sets.New[string]()
 
 	// merge the collected data and list of adapters.
 	adapters.Insert(n.mergePacketsReceivedPerSecondData(packetsReceivedPerSecondData)...)

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -617,9 +617,9 @@ func GetLocalPersistentVolumeNodeNames(pv *v1.PersistentVolume) []string {
 // GetPodVolumeNames returns names of volumes that are used in a pod,
 // either as filesystem mount or raw block device, together with list
 // of all SELinux contexts of all containers that use the volumes.
-func GetPodVolumeNames(pod *v1.Pod) (mounts sets.String, devices sets.String, seLinuxContainerContexts map[string][]*v1.SELinuxOptions) {
-	mounts = sets.NewString()
-	devices = sets.NewString()
+func GetPodVolumeNames(pod *v1.Pod) (mounts sets.Set[string], devices sets.Set[string], seLinuxContainerContexts map[string][]*v1.SELinuxOptions) {
+	mounts = sets.New[string]()
+	devices = sets.New[string]()
 	seLinuxContainerContexts = make(map[string][]*v1.SELinuxOptions)
 
 	podutil.VisitContainers(&pod.Spec, podutil.AllFeatureEnabledContainers(), func(container *v1.Container, containerType podutil.ContainerType) bool {

--- a/pkg/volume/util/util_test.go
+++ b/pkg/volume/util/util_test.go
@@ -622,8 +622,8 @@ func TestGetPodVolumeNames(t *testing.T) {
 	tests := []struct {
 		name                    string
 		pod                     *v1.Pod
-		expectedMounts          sets.String
-		expectedDevices         sets.String
+		expectedMounts          sets.Set[string]
+		expectedDevices         sets.Set[string]
 		expectedSELinuxContexts map[string][]*v1.SELinuxOptions
 	}{
 		{
@@ -631,8 +631,8 @@ func TestGetPodVolumeNames(t *testing.T) {
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{},
 			},
-			expectedMounts:  sets.NewString(),
-			expectedDevices: sets.NewString(),
+			expectedMounts:  sets.New[string](),
+			expectedDevices: sets.New[string](),
 		},
 		{
 			name: "pod with volumes",
@@ -675,8 +675,8 @@ func TestGetPodVolumeNames(t *testing.T) {
 					},
 				},
 			},
-			expectedMounts:  sets.NewString("vol1", "vol2"),
-			expectedDevices: sets.NewString("vol3", "vol4"),
+			expectedMounts:  sets.New("vol1", "vol2"),
+			expectedDevices: sets.New("vol3", "vol4"),
 		},
 		{
 			name: "pod with init containers",
@@ -719,8 +719,8 @@ func TestGetPodVolumeNames(t *testing.T) {
 					},
 				},
 			},
-			expectedMounts:  sets.NewString("vol1", "vol2"),
-			expectedDevices: sets.NewString("vol3", "vol4"),
+			expectedMounts:  sets.New("vol1", "vol2"),
+			expectedDevices: sets.New("vol3", "vol4"),
 		},
 		{
 			name: "pod with multiple containers",
@@ -778,8 +778,8 @@ func TestGetPodVolumeNames(t *testing.T) {
 					},
 				},
 			},
-			expectedMounts:  sets.NewString("vol1", "vol3"),
-			expectedDevices: sets.NewString("vol2", "vol4"),
+			expectedMounts:  sets.New("vol1", "vol3"),
+			expectedDevices: sets.New("vol2", "vol4"),
 		},
 		{
 			name: "pod with ephemeral containers",
@@ -820,8 +820,8 @@ func TestGetPodVolumeNames(t *testing.T) {
 					},
 				},
 			},
-			expectedMounts:  sets.NewString("vol1", "vol2"),
-			expectedDevices: sets.NewString(),
+			expectedMounts:  sets.New("vol1", "vol2"),
+			expectedDevices: sets.New[string](),
 		},
 		{
 			name: "pod with SELinuxOptions",
@@ -893,7 +893,7 @@ func TestGetPodVolumeNames(t *testing.T) {
 					},
 				},
 			},
-			expectedMounts: sets.NewString("vol1", "vol2", "vol3"),
+			expectedMounts: sets.New[string]("vol1", "vol2", "vol3"),
 			expectedSELinuxContexts: map[string][]*v1.SELinuxOptions{
 				"vol1": {
 					{
@@ -929,10 +929,10 @@ func TestGetPodVolumeNames(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			mounts, devices, contexts := GetPodVolumeNames(test.pod)
 			if !mounts.Equal(test.expectedMounts) {
-				t.Errorf("Expected mounts: %q, got %q", mounts.List(), test.expectedMounts.List())
+				t.Errorf("Expected mounts: %q, got %q", sets.List(mounts), sets.List(test.expectedMounts))
 			}
 			if !devices.Equal(test.expectedDevices) {
-				t.Errorf("Expected devices: %q, got %q", devices.List(), test.expectedDevices.List())
+				t.Errorf("Expected devices: %q, got %q", sets.List(devices), sets.List(test.expectedDevices))
 			}
 			if len(contexts) == 0 {
 				contexts = nil


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
`sets.Set` is newly implemented, and `sets.String` got marked as deprecated.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
