### PR TITLE
Allow node addresses to be used as loadBalancer addresses for proxy-mode=ipvs

### DIFF
--- a/pkg/proxy/ipvs/netlink.go
+++ b/pkg/proxy/ipvs/netlink.go
@@ -40,4 +40,9 @@ type NetLinkHandle interface {
 	// Only the addresses of the current family are returned.
 	// IPv6 link-local and loopback addresses are excluded.
 	GetLocalAddresses(dev string) (sets.Set[string], error)
+	// GetAllLocalAddressesExcept return all local addresses on the node, except from the passed dev.
+	// This is not the same as to take the diff between GetAllLocalAddresses and GetLocalAddresses
+	// since an address can be assigned to many interfaces. This problem raised
+	// https://github.com/kubernetes/kubernetes/issues/114815
+	GetAllLocalAddressesExcept(dev string) (sets.Set[string], error)
 }

--- a/pkg/proxy/ipvs/netlink_unsupported.go
+++ b/pkg/proxy/ipvs/netlink_unsupported.go
@@ -71,6 +71,11 @@ func (h *netlinkHandle) GetLocalAddresses(dev string) (sets.Set[string], error) 
 	return nil, fmt.Errorf("netlink is not supported in this platform")
 }
 
+// GetAllLocalAddressesExcept is part of interface.
+func (h *netlinkHandle) GetAllLocalAddressesExcept(dev string) (sets.Set[string], error) {
+	return nil, fmt.Errorf("netlink is not supported in this platform")
+}
+
 // Must match the one in proxier_test.go
 func (h *netlinkHandle) isValidForSet(ip net.IP) bool {
 	return false

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -990,11 +990,10 @@ func (proxier *Proxier) syncProxyRules() {
 		klog.ErrorS(err, "Error listing addresses binded to dummy interface")
 	}
 	// nodeAddressSet All addresses *except* those on the dummy interface
-	nodeAddressSet, err := proxier.netlinkHandle.GetAllLocalAddresses()
+	nodeAddressSet, err := proxier.netlinkHandle.GetAllLocalAddressesExcept(defaultDummyDevice)
 	if err != nil {
 		klog.ErrorS(err, "Error listing node addresses")
 	}
-	nodeAddressSet = nodeAddressSet.Difference(alreadyBoundAddrs)
 
 	hasNodePort := false
 	for _, svc := range proxier.svcPortMap {

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1169,9 +1169,13 @@ func (proxier *Proxier) syncProxyRules() {
 			if proxier.ipvsScheduler == "mh" {
 				serv.Flags |= utilipvs.FlagSourceHash
 			}
-			if err := proxier.syncService(svcPortNameString, serv, true, alreadyBoundAddrs); err == nil {
+			// We must not add the address to the dummy device if it exist on another interface
+			shouldBind := !nodeAddressSet.Has(serv.Address.String())
+			if err := proxier.syncService(svcPortNameString, serv, shouldBind, alreadyBoundAddrs); err == nil {
 				activeIPVSServices.Insert(serv.String())
-				activeBindAddrs.Insert(serv.Address.String())
+				if shouldBind {
+					activeBindAddrs.Insert(serv.Address.String())
+				}
 				if err := proxier.syncEndpoint(svcPortName, svcInfo.ExternalPolicyLocal(), serv); err != nil {
 					klog.ErrorS(err, "Failed to sync endpoint for service", "servicePortName", svcPortName, "virtualServer", serv)
 				}
@@ -1272,9 +1276,13 @@ func (proxier *Proxier) syncProxyRules() {
 			if proxier.ipvsScheduler == "mh" {
 				serv.Flags |= utilipvs.FlagSourceHash
 			}
-			if err := proxier.syncService(svcPortNameString, serv, true, alreadyBoundAddrs); err == nil {
+			// We must not add the address to the dummy device if it exist on another interface
+			shouldBind := !nodeAddressSet.Has(serv.Address.String())
+			if err := proxier.syncService(svcPortNameString, serv, shouldBind, alreadyBoundAddrs); err == nil {
 				activeIPVSServices.Insert(serv.String())
-				activeBindAddrs.Insert(serv.Address.String())
+				if shouldBind {
+					activeBindAddrs.Insert(serv.Address.String())
+				}
 				if err := proxier.syncEndpoint(svcPortName, svcInfo.ExternalPolicyLocal(), serv); err != nil {
 					klog.ErrorS(err, "Failed to sync endpoint for service", "servicePortName", svcPortName, "virtualServer", serv)
 				}

--- a/pkg/proxy/ipvs/testing/fake.go
+++ b/pkg/proxy/ipvs/testing/fake.go
@@ -140,6 +140,21 @@ func (h *FakeNetlinkHandle) GetAllLocalAddresses() (sets.Set[string], error) {
 	return res, nil
 }
 
+func (h *FakeNetlinkHandle) GetAllLocalAddressesExcept(dev string) (sets.Set[string], error) {
+	res := sets.New[string]()
+	for linkName := range h.localAddresses {
+		if linkName == dev {
+			continue
+		}
+		for _, addr := range h.localAddresses[linkName] {
+			if h.isValidForSet(addr) {
+				res.Insert(addr)
+			}
+		}
+	}
+	return res, nil
+}
+
 // SetLocalAddresses set IP addresses to the given interface device.  It's not part of interface.
 func (h *FakeNetlinkHandle) SetLocalAddresses(dev string, ips ...string) error {
 	if h.localAddresses == nil {

--- a/pkg/proxy/ipvs/testing/fake_test.go
+++ b/pkg/proxy/ipvs/testing/fake_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/ipvs"
 )
 
+// (I am unsure if this test has any value since it only tests the fake implementation)
 func TestSetGetLocalAddresses(t *testing.T) {
 	fake := NewFakeNetlinkHandle(false)
 	_ = ipvs.NetLinkHandle(fake) // Ensure that the interface is honored
@@ -43,9 +44,14 @@ func TestSetGetLocalAddresses(t *testing.T) {
 	if !addr.Equal(expected) {
 		t.Errorf("Unexpected mismatch, expected: %v, got: %v", expected, addr)
 	}
-	fake.SetLocalAddresses("kube-ipvs0", "4.3.2.1")
+	fake.SetLocalAddresses("kube-ipvs0", "1.2.3.4", "4.3.2.1")
 	addr, _ = fake.GetAllLocalAddresses()
 	expected = sets.New("1.2.3.4", "4.3.2.1")
+	if !addr.Equal(expected) {
+		t.Errorf("Unexpected mismatch, expected: %v, got: %v", expected, addr)
+	}
+	addr, _ = fake.GetAllLocalAddressesExcept("kube-ipvs0")
+	expected = sets.New("1.2.3.4")
 	if !addr.Equal(expected) {
 		t.Errorf("Unexpected mismatch, expected: %v, got: %v", expected, addr)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig network
/area kube-proxy
/area ipvs

#### What this PR does / why we need it:

To use node-addresses as loadBalancerIP works with proxy-mode=iptables and did work before K8s v1.23 for proxy-mode=ipvs.

A problem with kernel versions and netlink fixed in PR https://github.com/kubernetes/kubernetes/pull/101429 caused the problem reported in #114815. The addresses assigned for NodePort became `AllAddresses - addresses(kube-ipvs0)`, but the the node-address is a loadBalancerIP it is assigned (also) to kube-ipvs0 and is thus excluded.

The security fix in https://github.com/kubernetes/kubernetes/pull/108460 prevents access to ports on the node (like ssh) to be accesible via loadBalancerIPs and clusterIPs, but if a loadBalancerIPs is also a node-ip, then **access to the node will be blocked**.

Both these problems must be taken care of in this PR.


#### Which issue(s) this PR fixes:

Fixes #114815, #117613

#### Special notes for your reviewer:

**NOTE** I am splitting this PR into one for the cleanup https://github.com/kubernetes/kubernetes/pull/115073 and will re-build this PR on top of that.



#### Does this PR introduce a user-facing change?

```release-note
Fixes a 1.26 regression in kube-proxy ipvs mode
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
