### PR TITLE
update publishing rules to use go1.19.5

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -6,22 +6,22 @@ rules:
       branch: master
       dir: staging/src/k8s.io/code-generator
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/code-generator
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/code-generator
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/code-generator
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     source: 
       branch: release-1.26
       dir: staging/src/k8s.io/code-generator
@@ -32,22 +32,22 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     source: 
       branch: release-1.26
       dir: staging/src/k8s.io/apimachinery
@@ -62,7 +62,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/api
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -70,7 +70,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/api
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -78,7 +78,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/api
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -86,7 +86,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/api
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -110,7 +110,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -124,7 +124,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -138,7 +138,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -152,7 +152,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -180,7 +180,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/component-base
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -192,7 +192,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-base
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -204,7 +204,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-base
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -216,7 +216,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-base
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -242,7 +242,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -254,7 +254,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -266,7 +266,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -278,7 +278,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -301,7 +301,7 @@ rules:
     - repository: apimachinery
       branch: master
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/kms
@@ -323,7 +323,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apiserver
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -337,7 +337,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/apiserver
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -351,7 +351,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/apiserver
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -365,7 +365,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/apiserver
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -403,7 +403,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -421,7 +421,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -439,7 +439,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -457,7 +457,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -503,7 +503,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -526,7 +526,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -549,7 +549,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -572,7 +572,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -617,7 +617,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -636,7 +636,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -655,7 +655,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -674,7 +674,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -716,7 +716,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -736,7 +736,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -756,7 +756,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -776,7 +776,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -813,7 +813,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/metrics
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -827,7 +827,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/metrics
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -841,7 +841,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/metrics
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -855,7 +855,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/metrics
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -883,7 +883,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.23
@@ -895,7 +895,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.24
@@ -907,7 +907,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.25
@@ -919,7 +919,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.26
@@ -947,7 +947,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.23
@@ -961,7 +961,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.24
@@ -975,7 +975,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.25
@@ -989,7 +989,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1018,7 +1018,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1032,7 +1032,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1046,7 +1046,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1060,7 +1060,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1090,7 +1090,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kubelet
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1104,7 +1104,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubelet
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1118,7 +1118,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubelet
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1132,7 +1132,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubelet
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1162,7 +1162,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1176,7 +1176,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1190,7 +1190,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1204,7 +1204,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1238,7 +1238,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1254,7 +1254,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1270,7 +1270,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1286,7 +1286,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1328,7 +1328,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1348,7 +1348,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1368,7 +1368,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1388,7 +1388,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1436,7 +1436,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1458,7 +1458,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1480,7 +1480,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1502,7 +1502,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1538,7 +1538,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.23
@@ -1548,7 +1548,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1558,7 +1558,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1568,7 +1568,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1590,7 +1590,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1600,7 +1600,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1610,7 +1610,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1620,7 +1620,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1637,22 +1637,22 @@ rules:
       branch: master
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/mount-utils
@@ -1685,7 +1685,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1711,7 +1711,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1737,7 +1737,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1763,7 +1763,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1798,22 +1798,22 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cri-api
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     source:
       branch: release-1.23
       dir: staging/src/k8s.io/cri-api
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/cri-api
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/cri-api
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/cri-api
@@ -1842,7 +1842,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kubectl
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1864,7 +1864,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/kubectl
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1886,7 +1886,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubectl
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1908,7 +1908,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubectl
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1950,7 +1950,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.23
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.23
@@ -1966,7 +1966,7 @@ rules:
       branch: release-1.23
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.24
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1982,7 +1982,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.25
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1998,7 +1998,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2034,7 +2034,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
-    go: 1.19.4
+    go: 1.19.5
     dependencies:
       - repository: apimachinery
         branch: release-1.26


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- update publishing rules to use go1.19.5

/assign @nikhita @dims @liggitt @saschagrunert 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
