### PR TITLE
fieldmanager: remove dependencies on internal

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/admission.go
@@ -22,7 +22,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apiserver/pkg/admission"
-	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal"
 	"k8s.io/apiserver/pkg/warning"
 )
 
@@ -71,7 +70,7 @@ func (admit *managedFieldsValidatingAdmissionController) Admit(ctx context.Conte
 		return err
 	}
 	managedFieldsAfterAdmission := objectMeta.GetManagedFields()
-	if _, err := internal.DecodeManagedFields(managedFieldsAfterAdmission); err != nil {
+	if err := ValidateManagedFields(managedFieldsAfterAdmission); err != nil {
 		objectMeta.SetManagedFields(managedFieldsBeforeAdmission)
 		warning.AddWarning(ctx, "",
 			fmt.Sprintf(InvalidManagedFieldsAfterMutatingAdmissionWarningFormat,

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/admission_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
-	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
@@ -36,7 +35,9 @@ func TestAdmission(t *testing.T) {
 	ac := fieldmanager.NewManagedFieldsValidatingAdmissionController(wrap)
 	now := metav1.Now()
 
-	validFieldsV1, err := internal.SetToFields(*fieldpath.NewSet(fieldpath.MakePathOrDie("metadata", "labels", "test-label")))
+	validFieldsV1 := metav1.FieldsV1{}
+	var err error
+	validFieldsV1.Raw, err = fieldpath.NewSet(fieldpath.MakePathOrDie("metadata", "labels", "test-label")).ToJSON()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Remove dependencies on internal fieldmanager for admission things. This is preparing for moving fieldmanager out, but the admission part will stay here, so it can't depend directly on internal.

/assign @alexzielenski 

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```