### PR TITLE
apiserver cluster egress metrics: backport to release-1.25

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
@@ -35,7 +35,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/apis/apiserver"
 	egressmetrics "k8s.io/apiserver/pkg/server/egressselector/metrics"
-	compbasemetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 	utiltrace "k8s.io/utils/trace"
 	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
@@ -44,7 +44,7 @@ import (
 var directDialer utilnet.DialFunc = http.DefaultTransport.(*http.Transport).DialContext
 
 func init() {
-	client.Metrics.RegisterMetrics(compbasemetrics.NewKubeRegistry().Registerer())
+	client.Metrics.RegisterMetrics(legacyregistry.Registerer())
 }
 
 // EgressSelector is the map of network context type to context dialer, for network egress.

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
@@ -35,12 +35,17 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/apis/apiserver"
 	egressmetrics "k8s.io/apiserver/pkg/server/egressselector/metrics"
+	compbasemetrics "k8s.io/component-base/metrics"
 	"k8s.io/klog/v2"
 	utiltrace "k8s.io/utils/trace"
 	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
 )
 
 var directDialer utilnet.DialFunc = http.DefaultTransport.(*http.Transport).DialContext
+
+func init() {
+	client.Metrics.RegisterMetrics(compbasemetrics.NewKubeRegistry().Registerer())
+}
 
 // EgressSelector is the map of network context type to context dialer, for network egress.
 type EgressSelector struct {

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
@@ -245,6 +245,7 @@ func (d *dialerCreator) createDialer() utilnet.DialFunc {
 		trace := utiltrace.New(fmt.Sprintf("Proxy via %s protocol over %s", d.options.protocol, d.options.transport), utiltrace.Field{Key: "address", Value: addr})
 		defer trace.LogIfLong(500 * time.Millisecond)
 		start := egressmetrics.Metrics.Clock().Now()
+		egressmetrics.Metrics.ObserveDialStart(d.options.protocol, d.options.transport)
 		proxier, err := d.connector.connect(ctx)
 		if err != nil {
 			egressmetrics.Metrics.ObserveDialFailure(d.options.protocol, d.options.transport, egressmetrics.StageConnect)

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
@@ -201,6 +201,16 @@ func TestMetrics(t *testing.T) {
 		metrics      []string
 		want         string
 	}{
+		"connect to proxy server start": {
+			connectorErr: true,
+			proxierErr:   true,
+			metrics:      []string{"apiserver_egress_dialer_dial_start_total"},
+			want: `
+	# HELP apiserver_egress_dialer_dial_start_total [ALPHA] Dial starts, labeled by the protocol (http-connect or grpc) and transport (tcp or uds).
+	# TYPE apiserver_egress_dialer_dial_start_total counter
+	apiserver_egress_dialer_dial_start_total{protocol="fake_protocol",transport="fake_transport"} 1
+`,
+		},
 		"connect to proxy server error": {
 			connectorErr: true,
 			proxierErr:   false,

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
@@ -18,6 +18,7 @@ package egressselector
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -31,6 +32,9 @@ import (
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/metrics/testutil"
 	testingclock "k8s.io/utils/clock/testing"
+	clientmetrics "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics"
+	ccmetrics "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/common/metrics"
+	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
 )
 
 type fakeEgressSelection struct {
@@ -272,5 +276,70 @@ func TestMetrics(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestKonnectivityClientMetrics(t *testing.T) {
+	testcases := []struct {
+		name    string
+		metrics []string
+		trigger func()
+		want    string
+	}{
+		{
+			name:    "stream packets",
+			metrics: []string{"konnectivity_network_proxy_client_stream_packets_total"},
+			trigger: func() {
+				clientmetrics.Metrics.ObservePacket(ccmetrics.SegmentFromClient, client.PacketType_DIAL_REQ)
+			},
+			want: `
+# HELP konnectivity_network_proxy_client_stream_packets_total Count of packets processed, by segment and packet type (example: from_client, DIAL_REQ)
+# TYPE konnectivity_network_proxy_client_stream_packets_total counter
+konnectivity_network_proxy_client_stream_packets_total{packet_type="DIAL_REQ",segment="from_client"} 1
+`,
+		},
+		{
+			name:    "stream errors",
+			metrics: []string{"konnectivity_network_proxy_client_stream_errors_total"},
+			trigger: func() {
+				clientmetrics.Metrics.ObserveStreamError(ccmetrics.SegmentToClient, errors.New("example"), client.PacketType_DIAL_RSP)
+			},
+			want: `
+# HELP konnectivity_network_proxy_client_stream_errors_total Count of gRPC stream errors, by segment, grpc Code, packet type. (example: from_agent, Code.Unavailable, DIAL_RSP)
+# TYPE konnectivity_network_proxy_client_stream_errors_total counter
+konnectivity_network_proxy_client_stream_errors_total{code="Unknown",packet_type="DIAL_RSP",segment="to_client"} 1
+`,
+		},
+		{
+			name:    "dial failure",
+			metrics: []string{"konnectivity_network_proxy_client_dial_failure_total"},
+			trigger: func() {
+				clientmetrics.Metrics.ObserveDialFailure(clientmetrics.DialFailureTimeout)
+			},
+			want: `
+# HELP konnectivity_network_proxy_client_dial_failure_total Number of dial failures observed, by reason (example: remote endpoint error)
+# TYPE konnectivity_network_proxy_client_dial_failure_total counter
+konnectivity_network_proxy_client_dial_failure_total{reason="timeout"} 1
+`,
+		},
+		{
+			name:    "client connections",
+			metrics: []string{"konnectivity_network_proxy_client_client_connections"},
+			trigger: func() {
+				clientmetrics.Metrics.GetClientConnectionsMetric().WithLabelValues("dialing").Inc()
+			},
+			want: `
+# HELP konnectivity_network_proxy_client_client_connections Number of open client connections, by status (Example: dialing)
+# TYPE konnectivity_network_proxy_client_client_connections gauge
+konnectivity_network_proxy_client_client_connections{status="dialing"} 1
+`,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.trigger()
+			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tc.want), tc.metrics...); err != nil {
+				t.Errorf("GatherAndCompare error: %v", err)
+			}
+		})
+	}
 }

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
@@ -41,6 +41,9 @@ var (
 
 	// Register registers a collectable metric but uses the global registry
 	Register = defaultRegistry.Register
+
+	// Registerer exposes the global registerer
+	Registerer = defaultRegistry.Registerer
 )
 
 func init() {

--- a/staging/src/k8s.io/component-base/metrics/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/registry.go
@@ -129,6 +129,10 @@ type KubeRegistry interface {
 	// Reset invokes the Reset() function on all items in the registry
 	// which are added as resettables.
 	Reset()
+	// Registerer exposes the underlying prometheus registerer
+	Registerer() prometheus.Registerer
+	// Gatherer exposes the underlying prometheus gatherer
+	Gatherer() prometheus.Gatherer
 }
 
 // kubeRegistry is a wrapper around a prometheus registry-type object. Upon initialization
@@ -158,6 +162,16 @@ func (kr *kubeRegistry) Register(c Registerable) error {
 
 	kr.trackHiddenCollector(c)
 	return nil
+}
+
+// Registerer exposes the underlying prometheus.Registerer
+func (kr *kubeRegistry) Registerer() prometheus.Registerer {
+	return kr.PromRegistry
+}
+
+// Gatherer exposes the underlying prometheus.Gatherer
+func (kr *kubeRegistry) Gatherer() prometheus.Gatherer {
+	return kr.PromRegistry
 }
 
 // MustRegister works like Register but registers any number of


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

1. Backport apiserver metric related to cluster egress, to improve observability.

apiserver_egress_dialer_dial_start_total

2. Register  (related) new metrics added in konnectivity-client https://github.com/kubernetes/kubernetes/pull/114929

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

UPDATED on 2023-01-27

* All merge conflicts were imports only.
* These commits are present in master branch.
* This now includes the fix #115327


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
