### PR TITLE
WIP: client-go OIDC auth provider integration testing

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc.go
@@ -111,12 +111,12 @@ func (c *clientCache) setClient(clusterAddress, issuer, clientID string, client 
 func newOIDCAuthProvider(clusterAddress string, cfg map[string]string, persister restclient.AuthProviderConfigPersister) (restclient.AuthProvider, error) {
 	issuer := cfg[cfgIssuerURL]
 	if issuer == "" {
-		return nil, fmt.Errorf("Must provide %s", cfgIssuerURL)
+		return nil, fmt.Errorf("must provide %s", cfgIssuerURL)
 	}
 
 	clientID := cfg[cfgClientID]
 	if clientID == "" {
-		return nil, fmt.Errorf("Must provide %s", cfgClientID)
+		return nil, fmt.Errorf("must provide %s", cfgClientID)
 	}
 
 	// Check cache for existing provider.
@@ -125,7 +125,7 @@ func newOIDCAuthProvider(clusterAddress string, cfg map[string]string, persister
 	}
 
 	if len(cfg[cfgExtraScopes]) > 0 {
-		klog.V(2).Infof("%s auth provider field depricated, refresh request don't send scopes",
+		klog.V(2).Infof("%s auth provider field deprecated, scopes will not get sent with a token refresh request",
 			cfgExtraScopes)
 	}
 

--- a/test/integration/auth/oidc_test.go
+++ b/test/integration/auth/oidc_test.go
@@ -1,0 +1,149 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
+	"k8s.io/kubernetes/test/integration/auth/oidcserver"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestOIDCClients(t *testing.T) {
+	oidcServer := oidcserver.RunOIDCMockServer(t)
+
+	_, kubeConfig, tearDownFn := framework.StartTestServer(t, framework.TestServerSetup{
+		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
+			opts.Authentication.Anonymous = &kubeoptions.AnonymousAuthenticationOptions{Allow: false}
+			opts.Authentication.APIAudiences = []string{oidcserver.KubeAudience}
+			opts.Authentication.OIDC = oidcServer.OIDCConfig()
+			opts.Authorization.Modes = []string{"AlwaysAllow"}
+			opts.Authentication.TokenSuccessCacheTTL = -1
+			opts.Authentication.TokenFailureCacheTTL = -1
+		},
+	})
+	defer tearDownFn()
+
+	// FIXME: should do at least two rountrips to retrieve the id-token in order
+	// to attempt a token refresh with a new refresh-token (refresh token is currently
+	// rotated with every /token request)
+	for _, tt := range []struct {
+		name                     string
+		configToken              oidcserver.TokensType
+		serverToken              oidcserver.TokensType
+		expectUnauthorized       bool
+		expectTokenRetrieveError bool
+	}{
+		{
+			name:        "no init token, valid token from server",
+			configToken: oidcserver.TokensNone,
+			serverToken: oidcserver.TokensValid,
+		},
+		{
+			name:               "no init token, expired token from server",
+			configToken:        oidcserver.TokensNone,
+			serverToken:        oidcserver.TokensExpired,
+			expectUnauthorized: true,
+		},
+		{
+			name:               "no init token, improperly signed token from server",
+			configToken:        oidcserver.TokensNone,
+			serverToken:        oidcserver.TokensInvalidSignature,
+			expectUnauthorized: true,
+		},
+		{
+			name:                     "no init token, no id-token from the server",
+			configToken:              oidcserver.TokensNone,
+			serverToken:              oidcserver.TokensNone,
+			expectTokenRetrieveError: true, // TODO: if the received token is empty (id_token: "" in token response, not `omitempty`` on id_token, the empty string is accepted as the token - and rightfully fails with Unauthorized afterwards)
+		},
+		{
+			name:        "valid init token",
+			configToken: oidcserver.TokensValid,
+			serverToken: oidcserver.TokensValid,
+		},
+		{
+			name:        "expired init token, valid token from server",
+			configToken: oidcserver.TokensExpired,
+			serverToken: oidcserver.TokensValid,
+		},
+		{
+			name:        "improperly signed init token, valid token from server",
+			configToken: oidcserver.TokensInvalidSignature,
+			serverToken: oidcserver.TokensValid,
+			// TODO: since we've got the refresh token - should the client try to fix our id-token instead of failing?
+			expectUnauthorized: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			expectError := tt.expectTokenRetrieveError || tt.expectUnauthorized
+
+			configToken, err := oidcServer.MintIDToken(tt.configToken)
+			if err != nil {
+				t.Fatalf("failed to create token: %v", err)
+			}
+			oidcServer.SetMintedTokensType(tt.serverToken)
+
+			userConfig := rest.AnonymousClientConfig(kubeConfig)
+			userConfig.AuthProvider = withIDToken(oidcServer.AuthConfig(), configToken)
+			recorder := httprecorder{t: t}
+			userConfig.Wrap(recorder.Wrap)
+
+			userClient, err := kubernetes.NewForConfig(userConfig)
+			if err != nil {
+				t.Fatalf("failed to setup user client: %v", err)
+			}
+
+			_, err = userClient.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+			if (err != nil) != expectError {
+				t.Errorf("expected unauthorized (%v) or token retrieval (%v), got %v", tt.expectUnauthorized, tt.expectTokenRetrieveError, err)
+			}
+
+			if err != nil {
+				if tt.expectUnauthorized && !apierrors.IsUnauthorized(err) {
+					t.Errorf("expected unauthorized err, got %v", err)
+				}
+
+				if tt.expectTokenRetrieveError &&
+					!strings.Contains(err.Error(),
+						"token response did not contain an id_token, either the scope \"openid\" wasn't requested upon login, or the provider doesn't support id_tokens as part of the refresh response",
+					) {
+					t.Errorf("expected token retrieval error, got %v", err)
+				}
+			}
+		})
+	}
+}
+
+type httprecorder struct {
+	delegate http.RoundTripper
+	t        *testing.T
+}
+
+func (r *httprecorder) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqDump, _ := httputil.DumpRequestOut(req, false)
+	r.t.Logf("request:\n%s", reqDump)
+	resp, err := r.delegate.RoundTrip(req)
+	respDump, _ := httputil.DumpResponse(resp, false)
+	r.t.Logf("response:\n%s", respDump)
+	return resp, err
+}
+
+func (r *httprecorder) Wrap(rt http.RoundTripper) http.RoundTripper {
+	r.delegate = rt
+	return r
+}
+
+func withIDToken(authConfig *clientcmdapi.AuthProviderConfig, token string) *clientcmdapi.AuthProviderConfig {
+	authConfig.Config["id-token"] = token
+	return authConfig
+}

--- a/test/integration/auth/oidcserver/oidcserver.go
+++ b/test/integration/auth/oidcserver/oidcserver.go
@@ -1,0 +1,353 @@
+package oidcserver
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"gopkg.in/square/go-jose.v2"
+
+	"k8s.io/apimachinery/pkg/util/uuid"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	certutil "k8s.io/client-go/util/cert"
+	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
+)
+
+type TokensType int
+
+const (
+	TestClientID     = "testclient"
+	TestClientSecret = "veryrandomsecret"
+	KubeAudience     = "https://kubernetes.default.svc"
+)
+
+const (
+	TokensNone TokensType = iota
+	TokensValid
+	TokensExpiring // returns tokens that would expire in 2 seconds
+	TokensExpired
+	TokensInvalidSignature
+	TokensError
+)
+
+type OIDCMockServer struct {
+	server          *httptest.Server
+	signingKey      *rsa.PrivateKey
+	servingCertPath string
+
+	mintedTokensType    TokensType
+	jwks                []byte
+	currentRefreshToken string
+}
+
+func RunOIDCMockServer(t *testing.T) *OIDCMockServer {
+	certDir := t.TempDir()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		t.Fatalf("failed to generate a signing key: %v", err)
+	}
+
+	jwksBytes, err := getJWKsBytes(privateKey)
+	if err != nil {
+		t.Fatalf("failed to get JWKs for private key: %v", err)
+	}
+
+	oidcServer := &OIDCMockServer{
+		mintedTokensType:    TokensValid,
+		jwks:                jwksBytes,
+		signingKey:          privateKey,
+		currentRefreshToken: "secretrefreshtoken-",
+	}
+
+	// TODO: add logging to all endpoints
+	mux := http.NewServeMux()
+	mux.Handle("/.well-known/openid-configuration", http.HandlerFunc(oidcServer.oidcDiscoveryHandler))
+	mux.Handle("/authorization", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "AUTHZ NOT IMPLEMENTED", http.StatusTeapot)
+	}))
+	mux.Handle("/token", http.HandlerFunc(http.HandlerFunc(oidcServer.tokenHandler)))
+	mux.Handle("/jwks", http.HandlerFunc(http.HandlerFunc(oidcServer.jwksHandler)))
+
+	tlsServer := httptest.NewTLSServer(mux)
+	// TODO: maybe post the server logs on cleanup?
+	t.Cleanup(tlsServer.Close)
+
+	oidcServer.server = tlsServer
+
+	servingCertPEM, err := certutil.EncodeCertificates(tlsServer.Certificate())
+	if err != nil {
+		t.Fatalf("failed to create serving cert for the mock OIDC server: %v", err)
+	}
+
+	servingCertPath := filepath.Join(certDir, "oidc-test-serving.crt")
+	if err := certutil.WriteCert(servingCertPath, servingCertPEM); err != nil {
+		t.Fatalf("failed to write serving cert for the mock OIDC server: %v", err)
+	}
+
+	oidcServer.servingCertPath = servingCertPath
+
+	return oidcServer
+}
+
+// minimalOIDCDiscovery represents the OIDC Provider Metadata defined in
+// https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+//
+// This struct only contains the fields that are REQUIRED per the above specification.
+type minimalOIDCDiscovery struct {
+	Issuer                     string   `json:"issuer"`
+	AuthorizationEndpoint      string   `json:"authorization_endpoint"`
+	TokenEndpoint              string   `json:"token_endpoint"` // 	This is REQUIRED unless only the Implicit Flow is used.
+	JWKsURI                    string   `json:"jwks_uri"`
+	ResponseTypes              []string `json:"response_types"`                        // MUST support the `code`, `id_token`, and the `token id_token` Response Type values.
+	SubjectTypesSupported      []string `json:"subject_types_supported"`               // Valid types include pairwise and public.
+	SupportedSigningAlgorithms []string `json:"id_token_signing_alg_values_supported"` // The algorithm RS256 MUST be included.
+}
+
+func (s *OIDCMockServer) oidcDiscoveryHandler(w http.ResponseWriter, req *http.Request) {
+	resp := minimalOIDCDiscovery{
+		Issuer:                     s.server.URL,
+		AuthorizationEndpoint:      s.server.URL + "/authorization",
+		TokenEndpoint:              s.server.URL + "/token",
+		JWKsURI:                    s.server.URL + "/jwks",
+		ResponseTypes:              []string{"code", "id_token", "token id_token"},
+		SubjectTypesSupported:      []string{"public"},
+		SupportedSigningAlgorithms: []string{"RS256"},
+	}
+
+	jsonResp, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to marshal discovery response: %v", err), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Add("Content-Type", "application/json")
+	w.Write(jsonResp)
+}
+
+// minimalTokenResponse represents a successful token response as per
+// https://openid.net/specs/openid-connect-core-1_0.html#TokenResponse
+//
+// This struct only contains the fields that are REQUIRED per the above specification
+// + refresh_token
+type minimalTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	IDToken      string `json:"id_token,omitempty"`
+	TokenType    string `json:"token_type"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+}
+
+func (s *OIDCMockServer) SetMintedTokensType(tt TokensType) { s.mintedTokensType = tt }
+
+// tokenHandler only implements token minting for client auth with a refresh token,
+// using the client_secret_basic client auth.
+// It does that rather poorly but it's all good enough for test purposes.
+func (s *OIDCMockServer) tokenHandler(w http.ResponseWriter, req *http.Request) {
+	if err := req.ParseForm(); err != nil || req.Method != http.MethodPost {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write(tokenErrorResponse("invalid_request"))
+		return
+	}
+
+	username, password, ok := req.BasicAuth()
+	if !ok || username != TestClientID || password != TestClientSecret {
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("WWW-Authenticate", `Basic realm="oidc test"`)
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write(tokenErrorResponse("invalid_client"))
+		return
+	}
+
+	reqForm := req.PostForm
+	if reqForm.Get("grant_type") != "refresh_token" ||
+		len(reqForm.Get("refresh_token")) == 0 {
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write(tokenErrorResponse("invalid_request"))
+		return
+	}
+
+	if refreshToken := reqForm.Get("refresh_token"); refreshToken != s.CurrentRefreshToken() {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write(tokenErrorResponse("invalid_grant"))
+	}
+
+	token, err := s.MintIDToken(s.mintedTokensType)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to mint an ID token: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	resp := minimalTokenResponse{
+		AccessToken:  "sometoken",
+		IDToken:      token,
+		TokenType:    "Bearer",
+		RefreshToken: s.refreshedRefreshToken(),
+	}
+
+	jsonResp, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to marshal token response: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Add("Content-Type", "application/json")
+	w.Write(jsonResp)
+}
+
+func (s *OIDCMockServer) jwksHandler(w http.ResponseWriter, req *http.Request) {
+	w.Header().Add("Content-Type", "application/json")
+	w.Write(s.jwks)
+}
+
+type claimsWithUsername struct {
+	jwt.RegisteredClaims `json:",inline"`
+	Username             string `json:"username"`
+}
+
+func (c *claimsWithUsername) Valid() error {
+	return c.RegisteredClaims.Valid()
+}
+
+// MintIDToken allows retrieving the token from tests without having to go through
+// the client<->kube-apiserver<->oidc-server flow
+// Useful for setting up the initial client conditions.
+func (s *OIDCMockServer) MintIDToken(tokenType TokensType) (string, error) {
+	claims := &claimsWithUsername{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    s.server.URL,
+			Subject:   string(uuid.NewUUID()),
+			Audience:  jwt.ClaimStrings{KubeAudience, TestClientID},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
+		},
+		Username: "testuser",
+	}
+
+	var signedToken string
+	var err error
+	switch tokenType {
+	case TokensNone:
+		signedToken = ""
+	case TokensValid:
+		token := jwt.NewWithClaims(jwt.GetSigningMethod("RS256"), claims)
+		signedToken, err = token.SignedString(s.signingKey)
+	case TokensExpired:
+		claims.ExpiresAt = jwt.NewNumericDate(time.Now().Add(-1 * time.Hour))
+
+		token := jwt.NewWithClaims(jwt.GetSigningMethod("RS256"), claims)
+		signedToken, err = token.SignedString(s.signingKey)
+	case TokensExpiring:
+		claims.ExpiresAt = jwt.NewNumericDate(time.Now().Add(5 * time.Second))
+
+		token := jwt.NewWithClaims(jwt.GetSigningMethod("RS256"), claims)
+		signedToken, err = token.SignedString(s.signingKey)
+	case TokensInvalidSignature:
+		token := jwt.NewWithClaims(jwt.GetSigningMethod("RS256"), claims)
+
+		privateKey, keyErr := rsa.GenerateKey(rand.Reader, 4096)
+		if keyErr != nil {
+			return "", fmt.Errorf("failed to generate a signing key: %v", keyErr)
+		}
+		signedToken, err = token.SignedString(privateKey)
+	default:
+		panic(fmt.Sprintf("%d: not implemented", tokenType))
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("failed to sign a token: %v", err)
+	}
+
+	return signedToken, nil
+}
+
+// OIDCConfig returns configuration for the kube-apiserver
+func (s *OIDCMockServer) OIDCConfig() *kubeoptions.OIDCAuthenticationOptions {
+	return &kubeoptions.OIDCAuthenticationOptions{
+		IssuerURL:     s.server.URL,
+		ClientID:      TestClientID,
+		UsernameClaim: "username",
+		CAFile:        s.servingCertPath,
+	}
+}
+
+// AuthConfig returns configuration for the client
+func (s *OIDCMockServer) AuthConfig() *clientcmdapi.AuthProviderConfig {
+	return &clientcmdapi.AuthProviderConfig{
+		Name: "oidc",
+		Config: map[string]string{
+			"idp-issuer-url":            s.server.URL,
+			"client-id":                 TestClientID,
+			"client-secret":             TestClientSecret,
+			"refresh-token":             s.CurrentRefreshToken(),
+			"idp-certificate-authority": s.servingCertPath,
+			"id-token":                  "",
+		},
+	}
+}
+
+func (s *OIDCMockServer) CurrentRefreshToken() string {
+	return s.currentRefreshToken
+}
+
+func (s *OIDCMockServer) refreshedRefreshToken() string {
+	s.currentRefreshToken += "x"
+	return s.currentRefreshToken
+}
+
+func getJWKsBytes(privKey *rsa.PrivateKey) ([]byte, error) {
+	pubKey := &privKey.PublicKey
+	keyId, err := keyIDFromPublicKey(pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive keyId from pubkey: %v", err)
+	}
+
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{
+				Key:       pubKey,
+				KeyID:     keyId,
+				Algorithm: string(jose.RS256),
+				Use:       "sig",
+			},
+		},
+	}
+
+	jwksMarshalled, err := json.Marshal(jwks)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal token response: %v", err)
+	}
+
+	return jwksMarshalled, nil
+}
+
+func keyIDFromPublicKey(publicKey interface{}) (string, error) {
+	publicKeyDERBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize public key to DER format: %v", err)
+	}
+
+	hasher := crypto.SHA256.New()
+	hasher.Write(publicKeyDERBytes)
+	publicKeyDERHash := hasher.Sum(nil)
+
+	keyID := base64.RawURLEncoding.EncodeToString(publicKeyDERHash)
+
+	return keyID, nil
+}
+
+func tokenErrorResponse(errType string) []byte {
+	return []byte(fmt.Sprintf(`{"error": "%s" }`, errType))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind feature

chose kind=feature because there is no /kind new-test

#### What this PR does / why we need it:
This PR adds integration testing for the OIDC authentication provider of the client-go library.

It also fixes the client so that when a request to create a provider that's already cached is performed, the new supplied data override the ones the client got from automatic handling/from previous creation of the provider.

#### Which issue(s) this PR fixes:
Fixes #110782

#### Special notes for your reviewer:
TODO list of tests from the original post:
- [x] ID token not expired
- [x] ID token expired
- [ ] Refresh token does not change
- [ ] Refresh token does change
- [ ] Other aspects of the config change (i.e. client secret, CA data, etc)
- [ ] Auth config persister does not actually persist
- [x] Refresh flow does not return ID token
- [ ] ID token expires early due to JWK rotation
- [ ] Distributed claim fetching for group data


#### Does this PR introduce a user-facing change?
```release-note
client-go OIDC authentication provider will now refresh the cached provider data with the latest version it gets when the program requests to create another instance of the provider for the same (cluster,issuer,clientID).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
