### PR TITLE
WIP: wait: Refactor Kube codebase to use new PollUntilContext* methods

### DIFF
--- a/hack/refactors/poll_with_context.patch
+++ b/hack/refactors/poll_with_context.patch
@@ -1,0 +1,251 @@
+# This patch modifies client code as described in https://github.com/kubernetes/kubernetes/pull/107826
+# using github.com/uber-go/gopatch (head). It performs the most laborious changes
+#
+# Replace an unnecessarily cast to wait.ConditionFunc around some Poll calls
+@@
+var interval, timeout, condition expression
+var a, b identifier
+@@
++import "context"
+
+-wait.Poll(interval, timeout, wait.ConditionFunc(func() (a bool, b error) {...}))
++wait.PollUntilContextTimeout(context.Background(), interval, timeout, false, func(ctx context.Context) (a bool, b error) {...})
+
+# Replace wait.Poll with wait.PollUntilContextTimeout when the function can be altered
+@@
+var interval, timeout, condition expression
+@@
++import "context"
+
+-wait.Poll(interval, timeout, func() (bool, error) {...})
++wait.PollUntilContextTimeout(context.Background(), interval, timeout, false, func(ctx context.Context) (bool, error) {...})
+
+# Replace wait.Poll with wait.PollUntilContextTimeout when the function has named returns
+@@
+var interval, timeout, condition expression
+var a, b identifier
+@@
++import "context"
+
+-wait.Poll(interval, timeout, func() (a bool, b error) {...})
++wait.PollUntilContextTimeout(context.Background(), interval, timeout, false, func(ctx context.Context) (a bool, b error) {...})
+
+# Replace wait.Poll with wait.PollUntilContextTimeout
+@@
+var interval, timeout, condition expression
+@@
++import "context"
+
+-wait.Poll(interval, timeout, condition)
++wait.PollUntilContextTimeout(context.Background(), interval, timeout, false, condition)
+
+# Replace wait.PollImmediate with wait.PollUntilContextTimeout
+@@
+var interval, timeout, condition expression
+var a, b identifier
+@@
++import "context"
+
+-wait.PollImmediate(interval, timeout, func() (a bool, b error) {...})
++wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(ctx context.Context) (a bool, b error) {...})
+
+# Replace wait.PollImmediate with wait.PollUntilContextTimeout
+@@
+var interval, timeout, condition expression
+@@
++import "context"
+
+-wait.PollImmediate(interval, timeout, func() (bool, error) {...})
++wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(ctx context.Context) (bool, error) {...})
+
+# Replace wait.PollImmediate with wait.PollUntilContextTimeout
+@@
+var interval, timeout, condition expression
+@@
++import "context"
+
+-wait.PollImmediate(interval, timeout, condition)
++wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, condition)
+
+# Replace wait.PollImmediateUntilContext with wait.PollUntilContextTimeout
+@@
+var ctx, interval, timeout, condition expression
+@@
++import "context"
+
+-wait.PollImmediateUntilContext(ctx, interval, timeout, condition)
++wait.PollUntilContextTimeout(ctx, interval, timeout, true, condition)
+
+# Replace wait.PollUntilContext with wait.PollUntilContextTimeout
+@@
+var ctx, interval, timeout, condition expression
+@@
+-wait.PollUntilContext(ctx, interval, timeout, condition)
++wait.PollUntilContextTimeout(ctx, interval, timeout, false, condition)
+
+# Replace wait.PollUntil with wait.PollUntilContextTimeout with a closure
+@@
+var interval expression
+var a expression
+@@
++import "context"
+
+-wait.PollUntil(interval, func() (bool, error) {...}, a)
++wait.PollUntilContextCancel(context.Background(), interval, false, func(ctx context.Context) (bool, error) {...})
+
+# Replace wait.PollUntil with wait.PollUntilContextTimeout with a closure
+@@
+var interval expression
+var a, b, c expression
+@@
++import "context"
+
+-wait.PollUntil(interval, func() (b bool, c error) {...}, a)
++wait.PollUntilContextCancel(context.Background(), interval, false, func(ctx context.Context) (b bool, c error) {...})
+
+# Replace wait.PollUntil with wait.PollUntilContextTimeout with a named function
+@@
+var interval, condition expression
+var a expression
+@@
++import "context"
+
+-wait.PollUntil(interval, condition, a)
++wait.PollUntilContextCancel(a, interval, false, condition)
+
+# Replace wait.PollImmediateUntil with wait.PollUntilContextTimeout with a closure
+@@
+var interval expression
+var a expression
+@@
++import "context"
+
+-wait.PollImmediateUntil(interval, func() (bool, error) {...}, a)
++wait.PollUntilContextCancel(a, interval, true, func(ctx context.Context) (bool, error) {...})
+
+# Replace wait.PollImmediateUntil with wait.PollUntilContextTimeout with a closure
+@@
+var interval expression
+var a, b, c expression
+@@
++import "context"
+
+-wait.PollImmediateUntil(interval, func() (b bool, c error) {...}, a)
++wait.PollUntilContextCancel(a, interval, true, func(ctx context.Context) (b bool, c error) {...})
+
+# Replace wait.PollImmediateUntil with wait.PollUntilContextTimeout with a named function
+@@
+var interval, condition expression
+var a expression
+@@
++import "context"
+
+-wait.PollImmediateUntil(interval, condition, a)
++wait.PollUntilContextCancel(a, interval, true, condition)
+
+# Replace wait.PollImmediateWithContext with wait.PollUntilContextTimeout
+@@
+var ctx, interval, timeout, condition expression
+@@
+-wait.PollImmediateWithContext(ctx, interval, timeout, condition)
++wait.PollUntilContextTimeout(ctx, interval, timeout, true, condition)
+
+# Replace wait.PollImmediateUntilWithContext with wait.PollUntilContextCancel
+@@
+var ctx, interval, condition expression
+@@
+-wait.PollImmediateUntilWithContext(ctx, interval, condition)
++wait.PollUntilContextCancel(ctx, interval, true, condition)
+
+# Replace wait.PollUntilWithContext with wait.PollUntilContextCancel
+@@
+var ctx, interval, condition expression
+@@
+-wait.PollUntilWithContext(ctx, interval, condition)
++wait.PollUntilContextCancel(ctx, interval, false, condition)
+
+# Replace wait.PollImmediateUntilWithContext with wait.PollUntilContextCancel
+@@
+var ctx, interval, condition expression
+@@
+-wait.PollImmediateUntilWithContext(ctx, interval, condition)
++wait.PollUntilContextCancel(ctx, interval, true, condition)
+
+# Replace wait.PollInfinite with wait.PollUntilContextCancel
+@@
+var interval expression
+@@
++import "context"
+
+-wait.PollInfinite(interval, func() (bool, error) {...})
++wait.PollUntilContextCancel(context.Background(), interval, false, func(ctx context.Context) (bool, error) {...})
+
+# Replace wait.PollImmediateInfinite with wait.PollUntilContextCancel
+@@
+var interval expression
+@@
++import "context"
+
+-wait.PollImmediateInfinite(interval, func() (bool, error) {...})
++wait.PollUntilContextCancel(context.Background(), interval, true, func(ctx context.Context) (bool, error) {...})
+
+# Replace older channel constructs for context cancel with the context
+@@
+var interval, immediate, condition expression
+@@
++import "context"
+
+-wait.PollUntilContextCancel(ctx.Done(), interval, immediate, condition)
++wait.PollUntilContextCancel(ctx, interval, immediate, condition)
+
+# Replace comparisons to wait.ErrWaitTimeout with wait.Interrupted
+@@
+var err expression
+@@
+-err == wait.ErrWaitTimeout
++wait.Interrupted(err)
+
+# Replace comparisons to wait.ErrWaitTimeout with wait.Interrupted
+@@
+var err expression
+@@
+-err != wait.ErrWaitTimeout
++!wait.Interrupted(err)
+
+# Propagate wrapped ErrWaitTimeout returns instead of reduplicating them
+@@
+var err expression
+@@
+-if wait.Interrupted(err) { return ..., wait.ErrWaitTimeout }
++if wait.Interrupted(err) { return ..., err }
+
+# Replace wait.ErrWaitTimeout with wait.ErrorInterrupted(errors.New("TODO"))
+@@
+var err expression
+@@
++ import "errors"
+-wait.ErrWaitTimeout
++wait.ErrorInterrupted(errors.New("TODO"))
+
+# Replace comparisons to a constant interrupted error (after patching)
+@@
+var err expression
+@@
+-err != wait.ErrorInterrupted(errors.New("TODO"))
++!wait.Interrupted(err)
+
+# Replace simple stop channels with cancellation
+@@
+var interval, immediate, condition expression
+@@
+-err := wait.PollUntilContextCancel(stopCh, interval, immediate, condition)
++ctx, cancel := wait.ContextForChannel(stopCh)
++defer cancel()
++err := wait.PollUntilContextCancel(ctx, interval, immediate, condition)
+
+# Replace simple contexts with cancellation
+@@
+var ctx, interval, immediate, condition expression
+@@
+-err := wait.PollUntilContextCancel(ctx.Done(), interval, immediate, condition)
++err := wait.PollUntilContextCancel(ctx, interval, immediate, condition)

--- a/pkg/kubeapiserver/admission/config.go
+++ b/pkg/kubeapiserver/admission/config.go
@@ -25,7 +25,7 @@ import (
 
 	"go.opentelemetry.io/otel/trace"
 
-	utilwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/admission"
 	webhookinit "k8s.io/apiserver/pkg/admission/plugin/webhook/initializer"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -74,7 +74,7 @@ func (c *Config) New(proxyTransport *http.Transport, egressSelector *egressselec
 
 	admissionPostStartHook := func(context genericapiserver.PostStartHookContext) error {
 		discoveryRESTMapper.Reset()
-		go utilwait.Until(discoveryRESTMapper.Reset, 30*time.Second, context.StopCh)
+		go wait.Until(discoveryRESTMapper.Reset, 30*time.Second, context.StopCh)
 		return nil
 	}
 

--- a/pkg/util/iptables/monitor_test.go
+++ b/pkg/util/iptables/monitor_test.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/exec"
 )
 
@@ -284,7 +284,7 @@ func TestIPTablesMonitor(t *testing.T) {
 }
 
 func waitForChains(mfe *monitorFakeExec, canary Chain, tables []Table) error {
-	return utilwait.PollImmediate(100*time.Millisecond, time.Second, func() (bool, error) {
+	return wait.PollImmediate(100*time.Millisecond, time.Second, func() (bool, error) {
 		mfe.Lock()
 		defer mfe.Unlock()
 
@@ -307,7 +307,7 @@ func ensureNoChains(mfe *monitorFakeExec) bool {
 
 func waitForReloads(reloads *uint32, expected uint32) error {
 	if atomic.LoadUint32(reloads) < expected {
-		utilwait.PollImmediate(100*time.Millisecond, time.Second, func() (bool, error) {
+		wait.PollImmediate(100*time.Millisecond, time.Second, func() (bool, error) {
 			return atomic.LoadUint32(reloads) >= expected, nil
 		})
 	}
@@ -319,7 +319,7 @@ func waitForReloads(reloads *uint32, expected uint32) error {
 }
 
 func waitForNoReload(reloads *uint32, expected uint32) error {
-	utilwait.PollImmediate(50*time.Millisecond, 250*time.Millisecond, func() (bool, error) {
+	wait.PollImmediate(50*time.Millisecond, 250*time.Millisecond, func() (bool, error) {
 		return atomic.LoadUint32(reloads) > expected, nil
 	})
 
@@ -331,7 +331,7 @@ func waitForNoReload(reloads *uint32, expected uint32) error {
 }
 
 func waitForBlocked(mfe *monitorFakeExec) error {
-	return utilwait.PollImmediate(100*time.Millisecond, time.Second, func() (bool, error) {
+	return wait.PollImmediate(100*time.Millisecond, time.Second, func() (bool, error) {
 		blocked := mfe.getWasBlocked()
 		return blocked, nil
 	})

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -259,14 +259,14 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	// we don't want to report healthy until we can handle all CRDs that have already been registered.  Waiting for the informer
 	// to sync makes sure that the lister will be valid before we begin.  There may still be races for CRDs added after startup,
 	// but we won't go healthy until we can handle the ones already present.
-	s.GenericAPIServer.AddPostStartHookOrDie("crd-informer-synced", func(context genericapiserver.PostStartHookContext) error {
+	s.GenericAPIServer.AddPostStartHookOrDie("crd-informer-synced", func(hookContext genericapiserver.PostStartHookContext) error {
 		return wait.PollImmediateUntil(100*time.Millisecond, func() (bool, error) {
 			if s.Informers.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced() {
 				close(hasCRDInformerSyncedSignal)
 				return true, nil
 			}
 			return false, nil
-		}, context.StopCh)
+		}, hookContext.StopCh)
 	})
 
 	return s, nil

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/timer.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/timer.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+// Timer abstracts how wait functions interact with time runtime efficiently. Test
+// code may implement this interface directly but package consumers are encouraged
+// to use the Backoff type as the primary mechanism for acquiring a Timer. The
+// interface is a simplification of clock.Timer to prevent misuse. Timers are not
+// expected to be safe for calls from multiple goroutines.
+type Timer interface {
+	// C returns a channel that will receive a struct{} each time the timer fires.
+	// The channel should not be waited on after Stop() is invoked. It is allowed
+	// to cache the returned value of C() for the lifetime of the Timer.
+	C() <-chan time.Time
+	// Next is invoked by wait functions to signal timers that the next interval
+	// should begin. You may only use Next() if you have drained the channel C().
+	// You should not call Next() after Stop() is invoked.
+	Next()
+	// Stop releases the timer. It is safe to invoke if no other methods have been
+	// called.
+	Stop()
+}
+
+type noopTimer struct {
+	closedCh <-chan time.Time
+}
+
+// newNoopTimer creates a timer with a unique channel to avoid contention
+// for the channel's lock across multiple unrelated timers.
+func newNoopTimer() noopTimer {
+	ch := make(chan time.Time)
+	close(ch)
+	return noopTimer{closedCh: ch}
+}
+
+func (t noopTimer) C() <-chan time.Time {
+	return t.closedCh
+}
+func (noopTimer) Next() {}
+func (noopTimer) Stop() {}
+
+type variableTimer struct {
+	fn  DelayFunc
+	t   clock.Timer
+	new func(time.Duration) clock.Timer
+}
+
+func (t *variableTimer) C() <-chan time.Time {
+	if t.t == nil {
+		d := t.fn()
+		t.t = t.new(d)
+	}
+	return t.t.C()
+}
+func (t *variableTimer) Next() {
+	if t.t == nil {
+		return
+	}
+	d := t.fn()
+	t.t.Reset(d)
+}
+func (t *variableTimer) Stop() {
+	if t.t == nil {
+		return
+	}
+	t.t.Stop()
+	t.t = nil
+}
+
+type fixedTimer struct {
+	interval time.Duration
+	t        clock.Ticker
+	new      func(time.Duration) clock.Ticker
+}
+
+func (t *fixedTimer) C() <-chan time.Time {
+	if t.t == nil {
+		t.t = t.new(t.interval)
+	}
+	return t.t.C()
+}
+func (t *fixedTimer) Next() {
+	// no-op for fixed timers
+}
+func (t *fixedTimer) Stop() {
+	if t.t == nil {
+		return
+	}
+	t.t.Stop()
+	t.t = nil
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
@@ -794,47 +794,65 @@ func TestContextForChannel(t *testing.T) {
 	}
 }
 
-func TestExponentialBackoffManagerGetNextBackoff(t *testing.T) {
+func TestBackoffDelayWithResetExponential(t *testing.T) {
 	fc := testingclock.NewFakeClock(time.Now())
-	backoff := NewExponentialBackoffManager(1, 10, 10, 2.0, 0.0, fc)
+	backoff := Backoff{Duration: 1, Cap: 10, Factor: 2.0, Jitter: 0.0, Steps: 10}.DelayWithReset(fc, 10)
 	durations := []time.Duration{1, 2, 4, 8, 10, 10, 10}
 	for i := 0; i < len(durations); i++ {
-		generatedBackoff := backoff.(*exponentialBackoffManagerImpl).getNextBackoff()
+		generatedBackoff := backoff()
 		if generatedBackoff != durations[i] {
 			t.Errorf("unexpected %d-th backoff: %d, expecting %d", i, generatedBackoff, durations[i])
 		}
 	}
 
 	fc.Step(11)
-	resetDuration := backoff.(*exponentialBackoffManagerImpl).getNextBackoff()
+	resetDuration := backoff()
 	if resetDuration != 1 {
 		t.Errorf("after reset, backoff should be 1, but got %d", resetDuration)
 	}
 }
 
-func TestJitteredBackoffManagerGetNextBackoff(t *testing.T) {
+func TestBackoffDelayWithResetEmpty(t *testing.T) {
+	fc := testingclock.NewFakeClock(time.Now())
+	backoff := Backoff{Duration: 1, Cap: 10, Factor: 2.0, Jitter: 0.0, Steps: 10}.DelayWithReset(fc, 0)
+	durations := []time.Duration{1, 1, 1, 1, 1, 1, 1}
+	for i := 0; i < len(durations); i++ {
+		generatedBackoff := backoff()
+		if generatedBackoff != durations[i] {
+			t.Errorf("unexpected %d-th backoff: %d, expecting %d", i, generatedBackoff, durations[i])
+		}
+	}
+
+	fc.Step(11)
+	resetDuration := backoff()
+	if resetDuration != 1 {
+		t.Errorf("after reset, backoff should be 1, but got %d", resetDuration)
+	}
+}
+
+func TestBackoffDelayWithResetJitter(t *testing.T) {
 	// positive jitter
-	backoffMgr := NewJitteredBackoffManager(1, 1, testingclock.NewFakeClock(time.Now()))
+	backoff := Backoff{Duration: 1, Jitter: 1}.DelayWithReset(testingclock.NewFakeClock(time.Now()), 0)
 	for i := 0; i < 5; i++ {
-		backoff := backoffMgr.(*jitteredBackoffManagerImpl).getNextBackoff()
-		if backoff < 1 || backoff > 2 {
-			t.Errorf("backoff out of range: %d", backoff)
+		value := backoff()
+		if value < 1 || value > 2 {
+			t.Errorf("backoff out of range: %d", value)
 		}
 	}
 
 	// negative jitter, shall be a fixed backoff
-	backoffMgr = NewJitteredBackoffManager(1, -1, testingclock.NewFakeClock(time.Now()))
-	backoff := backoffMgr.(*jitteredBackoffManagerImpl).getNextBackoff()
-	if backoff != 1 {
-		t.Errorf("backoff should be 1, but got %d", backoff)
+	backoff = Backoff{Duration: 1, Jitter: -1}.DelayWithReset(testingclock.NewFakeClock(time.Now()), 0)
+	value := backoff()
+	if value != 1 {
+		t.Errorf("backoff should be 1, but got %d", value)
 	}
 }
 
-func TestJitterBackoffManagerWithRealClock(t *testing.T) {
-	backoffMgr := NewJitteredBackoffManager(1*time.Millisecond, 0, &clock.RealClock{})
+func TestBackoffDelayWithResetWithRealClockJitter(t *testing.T) {
+	backoff := Backoff{Duration: 1 * time.Millisecond, Jitter: 0}.DelayWithReset(&clock.RealClock{}, 0)
 	for i := 0; i < 5; i++ {
 		start := time.Now()
-		<-backoffMgr.Backoff().C()
+		<-RealTimer(backoff()).C()
 		passed := time.Since(start)
 		if passed < 1*time.Millisecond {
 			t.Errorf("backoff should be at least 1ms, but got %s", passed.String())
@@ -842,14 +860,14 @@ func TestJitterBackoffManagerWithRealClock(t *testing.T) {
 	}
 }
 
-func TestExponentialBackoffManagerWithRealClock(t *testing.T) {
+func TestBackoffDelayWithResetWithRealClockExponential(t *testing.T) {
 	// backoff at least 1ms, 2ms, 4ms, 8ms, 10ms, 10ms, 10ms
 	durationFactors := []time.Duration{1, 2, 4, 8, 10, 10, 10}
-	backoffMgr := NewExponentialBackoffManager(1*time.Millisecond, 10*time.Millisecond, 1*time.Hour, 2.0, 0.0, &clock.RealClock{})
+	backoff := Backoff{Duration: 1 * time.Millisecond, Cap: 10 * time.Millisecond, Factor: 2.0, Jitter: 0.0, Steps: 10}.DelayWithReset(&clock.RealClock{}, 1*time.Hour)
 
 	for i := range durationFactors {
 		start := time.Now()
-		<-backoffMgr.Backoff().C()
+		<-RealTimer(backoff()).C()
 		passed := time.Since(start)
 		if passed < durationFactors[i]*time.Millisecond {
 			t.Errorf("backoff should be at least %d ms, but got %s", durationFactors[i], passed.String())

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/preflight/checks_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/preflight/checks_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	utilwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestParseServerURIGood(t *testing.T) {
@@ -100,7 +100,7 @@ func TestCheckEtcdServers(t *testing.T) {
 }
 
 func TestPollCheckServer(t *testing.T) {
-	err := utilwait.PollImmediate(1*time.Microsecond,
+	err := wait.PollImmediate(1*time.Microsecond,
 		2*time.Microsecond,
 		EtcdConnection{ServerList: []string{""}}.CheckEtcdServers)
 	if err == nil {

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -279,7 +279,7 @@ func (r *Reflector) Run(stopCh <-chan struct{}) {
 		if err := r.ListAndWatch(stopCh); err != nil {
 			r.watchErrorHandler(r, err)
 		}
-	}, r.backoffManager, true, stopCh)
+	}, r.backoffManager.DelayFunc().Timer(r.clock), true, stopCh)
 	klog.V(3).Infof("Stopping reflector %s (%s) from %s", r.typeDescription, r.resyncPeriod, r.name)
 }
 

--- a/staging/src/k8s.io/client-go/tools/watch/until_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until_test.go
@@ -209,7 +209,7 @@ func TestUntilWithSync(t *testing.T) {
 			conditionFunc: func(e watch.Event) (bool, error) {
 				return true, nil
 			},
-			expectedErr:   errors.New("timed out waiting for the condition"),
+			expectedErr:   wait.ErrWaitTimeout,
 			expectedEvent: nil,
 		},
 		{

--- a/staging/src/k8s.io/kms/pkg/hierarchy/hierarchy.go
+++ b/staging/src/k8s.io/kms/pkg/hierarchy/hierarchy.go
@@ -163,7 +163,7 @@ func (m *LocalKEKService) run(ctx context.Context) {
 				m.isReady.Store(false)
 			}
 		}
-	}, wait.NewJitteredBackoffManager(m.pollInterval, 0, m.clock), true, ctx.Done())
+	}, wait.NewJitteredBackoffManager(m.pollInterval, 0, m.clock).Timer(), true, ctx.Done())
 }
 
 // getTransformerForEncryption returns the local KEK as localTransformer, the corresponding

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
@@ -34,6 +34,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
 	azcache "k8s.io/legacy-cloud-providers/azure/cache"
 	"k8s.io/legacy-cloud-providers/azure/clients/interfaceclient/mockinterfaceclient"
@@ -487,7 +488,7 @@ func TestNodeAddresses(t *testing.T) {
 			metadataName:        "vm1",
 			vmType:              vmTypeStandard,
 			useInstanceMetadata: true,
-			expectedErrMsg:      fmt.Errorf("timed out waiting for the condition"),
+			expectedErrMsg:      wait.ErrWaitTimeout,
 		},
 		{
 			name:                "NodeAddresses should get IP addresses from Azure API if node's name isn't equal to metadataName",

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_routes_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_routes_test.go
@@ -33,6 +33,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/legacy-cloud-providers/azure/clients/routetableclient/mockroutetableclient"
 	"k8s.io/legacy-cloud-providers/azure/mockvmsets"
@@ -226,7 +227,7 @@ func TestCreateRoute(t *testing.T) {
 			name:           "CreateRoute should report error if error occurs when invoke GetIPByNodeName",
 			routeTableName: "rt7",
 			getIPError:     fmt.Errorf("getIP error"),
-			expectedErrMsg: fmt.Errorf("timed out waiting for the condition"),
+			expectedErrMsg: wait.ErrWaitTimeout,
 		},
 		{
 			name:               "CreateRoute should add route to cloud.RouteCIDRs if node is unmanaged",

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -719,7 +719,7 @@ func TestSampleAPIServer(ctx context.Context, f *framework.Framework, aggrclient
 	framework.ExpectNoError(err, "Unable to delete apiservice %s", apiServiceName)
 
 	ginkgo.By("Confirm that the generated APIService has been deleted")
-	err = wait.PollUntilContextTimeout(context.Background(), apiServiceRetryPeriod, apiServiceRetryTimeout, true, checkApiServiceListQuantity(ctx, aggrclient, apiServiceLabelSelector, 0))
+	err = wait.PollUntilContextTimeout(context.Background(), apiServiceRetryPeriod, apiServiceRetryTimeout, true, checkApiServiceListQuantity(aggrclient, apiServiceLabelSelector, 0))
 	framework.ExpectNoError(err, "failed to count the required APIServices")
 	framework.Logf("APIService %s has been deleted.", apiServiceName)
 
@@ -765,8 +765,8 @@ func generateFlunderName(base string) string {
 	return fmt.Sprintf("%s-%d", base, id)
 }
 
-func checkApiServiceListQuantity(ctx context.Context, aggrclient *aggregatorclient.Clientset, label string, quantity int) func() (bool, error) {
-	return func() (bool, error) {
+func checkApiServiceListQuantity(aggrclient *aggregatorclient.Clientset, label string, quantity int) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
 		var err error
 
 		framework.Logf("Requesting list of APIServices to confirm quantity")

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -719,7 +719,7 @@ func TestSampleAPIServer(ctx context.Context, f *framework.Framework, aggrclient
 	framework.ExpectNoError(err, "Unable to delete apiservice %s", apiServiceName)
 
 	ginkgo.By("Confirm that the generated APIService has been deleted")
-	err = wait.PollImmediate(apiServiceRetryPeriod, apiServiceRetryTimeout, checkApiServiceListQuantity(ctx, aggrclient, apiServiceLabelSelector, 0))
+	err = wait.PollUntilContextTimeout(context.Background(), apiServiceRetryPeriod, apiServiceRetryTimeout, true, checkApiServiceListQuantity(ctx, aggrclient, apiServiceLabelSelector, 0))
 	framework.ExpectNoError(err, "failed to count the required APIServices")
 	framework.Logf("APIService %s has been deleted.", apiServiceName)
 

--- a/test/e2e/apimachinery/apiserver_identity.go
+++ b/test/e2e/apimachinery/apiserver_identity.go
@@ -147,7 +147,7 @@ var _ = SIGDescribe("kube-apiserver identity [Feature:APIServerIdentity]", func(
 			err = restartAPIServer(ctx, &node)
 			framework.ExpectNoError(err)
 
-			err = wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+			err = wait.PollUntilContextTimeout(context.Background(), time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 				lease, err = client.CoordinationV1().Leases(metav1.NamespaceSystem).Get(context.TODO(), leaseName, metav1.GetOptions{})
 				if err != nil {
 					return false, nil
@@ -165,8 +165,8 @@ var _ = SIGDescribe("kube-apiserver identity [Feature:APIServerIdentity]", func(
 				}
 
 				return true, nil
-
 			})
+
 			framework.ExpectNoError(err, "holder identity did not change after a restart")
 		}
 

--- a/test/e2e/apimachinery/chunking.go
+++ b/test/e2e/apimachinery/chunking.go
@@ -149,7 +149,7 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 		ginkgo.By("retrieving the second page until the token expires")
 		opts.Continue = firstToken
 		var inconsistentToken string
-		wait.Poll(20*time.Second, 2*storagebackend.DefaultCompactInterval, func() (bool, error) {
+		wait.PollUntilContextTimeout(context.Background(), 20*time.Second, 2*storagebackend.DefaultCompactInterval, false, func(ctx context.Context) (bool, error) {
 			_, err := client.List(ctx, opts)
 			if err == nil {
 				framework.Logf("Token %s has not expired yet", firstToken)

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -311,7 +311,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		]`), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "setting default for a to \"A\" in schema")
 
-		err = wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			u1, err := crClient.Get(ctx, name1, metav1.GetOptions{})
 			if err != nil {
 				return false, err
@@ -328,6 +328,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			}
 			return true, nil
 		})
+
 		framework.ExpectNoError(err, "waiting for CR to be defaulted on read")
 
 		// create CR with default in storage
@@ -353,7 +354,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		]`), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "setting default for b to \"B\" and remove default for a")
 
-		err = wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			u2, err := crClient.Get(ctx, name2, metav1.GetOptions{})
 			if err != nil {
 				return false, err
@@ -380,6 +381,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			}
 			return true, nil
 		})
+
 		framework.ExpectNoError(err, "waiting for CR to be defaulted on read for b and a staying the same")
 	})
 

--- a/test/e2e/apimachinery/health_handlers.go
+++ b/test/e2e/apimachinery/health_handlers.go
@@ -95,12 +95,13 @@ var (
 
 func testPath(ctx context.Context, client clientset.Interface, path string, requiredChecks sets.String) error {
 	var result restclient.Result
-	err := wait.Poll(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 		result = client.CoreV1().RESTClient().Get().RequestURI(path).Do(ctx)
 		status := 0
 		result.StatusCode(&status)
 		return status == 200, nil
 	})
+
 	if err != nil {
 		return err
 	}

--- a/test/e2e/apimachinery/openapiv3.go
+++ b/test/e2e/apimachinery/openapiv3.go
@@ -108,7 +108,7 @@ var _ = SIGDescribe("OpenAPIV3", func() {
 		c := openapi3.NewRoot(f.ClientSet.Discovery().OpenAPIV3())
 		var openAPISpec *spec3.OpenAPI
 		// Poll for the OpenAPI to be updated with the new CRD
-		wait.Poll(time.Second*1, wait.ForeverTestTimeout, func() (bool, error) {
+		wait.PollUntilContextTimeout(context.Background(), time.Second*1, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 			openAPISpec, err = c.GVSpec(gv)
 			if err == nil {
 				return true, nil
@@ -145,7 +145,7 @@ var _ = SIGDescribe("OpenAPIV3", func() {
 		gv := schema.GroupVersion{Group: "wardle.example.com", Version: "v1alpha1"}
 		var openAPISpec *spec3.OpenAPI
 		// Poll for the OpenAPI to be updated with the new aggregated apiserver.
-		wait.Poll(time.Second*1, wait.ForeverTestTimeout, func() (bool, error) {
+		wait.PollUntilContextTimeout(context.Background(), time.Second*1, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 			openAPISpec, err = c.GVSpec(gv)
 			if err == nil {
 				return true, nil

--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -1184,20 +1184,18 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		})
 		framework.ExpectNoError(err, "failed to locate ResourceQuota %q in namespace %q", patchedResourceQuota.Name, ns)
 
-		err = wait.PollImmediateWithContext(ctx, 5*time.Second, 5*time.Minute, func(ctx context.Context) (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 			resourceQuotaResult, err := rqClient.Get(ctx, rqName, metav1.GetOptions{})
 			framework.ExpectNoError(err)
-
 			if apiequality.Semantic.DeepEqual(resourceQuotaResult.Spec.Hard.Cpu(), resourceQuotaResult.Status.Hard.Cpu()) {
 				framework.ExpectEqual(*resourceQuotaResult.Status.Hard.Cpu(), resource.MustParse("1"), "Hard cpu value for ResourceQuota %q is %s not 1.", repatchedResourceQuota.Name, repatchedResourceQuota.Status.Hard.Cpu().String())
 				framework.ExpectEqual(*resourceQuotaResult.Status.Hard.Memory(), resource.MustParse("1Gi"), "Hard memory value for ResourceQuota %q is %s not 1Gi.", repatchedResourceQuota.Name, repatchedResourceQuota.Status.Hard.Memory().String())
 				framework.Logf("ResourceQuota %q Spec was unchanged and /status reset", resourceQuotaResult.Name)
-
 				return true, nil
 			}
-
 			return false, nil
 		})
+
 		framework.ExpectNoError(err)
 	})
 })

--- a/test/e2e/apimachinery/storage_version.go
+++ b/test/e2e/apimachinery/storage_version.go
@@ -68,7 +68,7 @@ var _ = SIGDescribe("StorageVersion resources [Feature:StorageVersionAPI]", func
 
 		// wait for sv to be GC'ed
 		framework.Logf("Waiting for storage version %v to be garbage collected", createdSV.Name)
-		err = wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			_, err := client.InternalV1alpha1().StorageVersions().Get(
 				ctx, createdSV.Name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
@@ -80,6 +80,7 @@ var _ = SIGDescribe("StorageVersion resources [Feature:StorageVersionAPI]", func
 			framework.Logf("The storage version %v hasn't been garbage collected yet. Retrying", createdSV.Name)
 			return false, nil
 		})
+
 		framework.ExpectNoError(err, "garbage-collecting storage version")
 	})
 })

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -424,7 +424,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "waiting for webhook configuration to be ready")
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
 			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err == nil {
@@ -449,7 +449,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Updating validating webhook configuration")
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
 			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
@@ -462,6 +462,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 			framework.ExpectNoError(err, "Deleting successfully created configMap")
 			return true, nil
 		})
+
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s to be allowed creation since webhook was updated to not validate create", f.Namespace.Name)
 
 		ginkgo.By("Patching a validating webhook configuration's rules to include the create operation")
@@ -471,7 +472,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Patching validating webhook configuration")
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
 			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err == nil {
@@ -484,6 +485,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 			}
 			return true, nil
 		})
+
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s to be denied creation by validating webhook", f.Namespace.Name)
 	})
 
@@ -526,7 +528,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Updating mutating webhook configuration")
 
 		ginkgo.By("Creating a configMap that should not be mutated")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
 			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
@@ -537,6 +539,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 			_, ok := created.Data["mutation-stage-1"]
 			return !ok, nil
 		})
+
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s this is not mutated", f.Namespace.Name)
 
 		ginkgo.By("Patching a mutating webhook configuration's rules to include the create operation")
@@ -546,7 +549,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Patching mutating webhook configuration")
 
 		ginkgo.By("Creating a configMap that should be mutated")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
 			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
@@ -557,6 +560,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 			_, ok := created.Data["mutation-stage-1"]
 			return ok, nil
 		})
+
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s to be mutated", f.Namespace.Name)
 	})
 
@@ -598,7 +602,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "waiting for webhook configuration to be ready")
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
 			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err == nil {
@@ -611,6 +615,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 			}
 			return true, nil
 		})
+
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s to be denied creation by validating webhook", f.Namespace.Name)
 
 		ginkgo.By("Deleting the collection of validation webhooks")
@@ -618,7 +623,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Deleting collection of validating webhook configurations")
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
 			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
@@ -631,6 +636,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 			framework.ExpectNoError(err, "Deleting successfully created configMap")
 			return true, nil
 		})
+
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s to be allowed creation since there are no webhooks", f.Namespace.Name)
 	})
 
@@ -672,7 +678,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "waiting for webhook configuration to be ready")
 
 		ginkgo.By("Creating a configMap that should be mutated")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
 			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
@@ -683,6 +689,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 			_, ok := created.Data["mutation-stage-1"]
 			return ok, nil
 		})
+
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s to be mutated", f.Namespace.Name)
 
 		ginkgo.By("Deleting the collection of validation webhooks")
@@ -690,7 +697,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Deleting collection of mutating webhook configurations")
 
 		ginkgo.By("Creating a configMap that should not be mutated")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
 			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
@@ -701,6 +708,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 			_, ok := created.Data["mutation-stage-1"]
 			return !ok, nil
 		})
+
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s this is not mutated", f.Namespace.Name)
 	})
 })
@@ -1589,7 +1597,7 @@ type updateConfigMapFn func(cm *v1.ConfigMap)
 
 func updateConfigMap(ctx context.Context, c clientset.Interface, ns, name string, update updateConfigMapFn) (*v1.ConfigMap, error) {
 	var cm *v1.ConfigMap
-	pollErr := wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var err error
 		if cm, err = c.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{}); err != nil {
 			return false, err
@@ -1604,6 +1612,7 @@ func updateConfigMap(ctx context.Context, c clientset.Interface, ns, name string
 		}
 		return false, nil
 	})
+
 	return cm, pollErr
 }
 
@@ -1611,7 +1620,7 @@ type updateCustomResourceFn func(cm *unstructured.Unstructured)
 
 func updateCustomResource(ctx context.Context, c dynamic.ResourceInterface, ns, name string, update updateCustomResourceFn) (*unstructured.Unstructured, error) {
 	var cr *unstructured.Unstructured
-	pollErr := wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var err error
 		if cr, err = c.Get(ctx, name, metav1.GetOptions{}); err != nil {
 			return false, err
@@ -1626,6 +1635,7 @@ func updateCustomResource(ctx context.Context, c dynamic.ResourceInterface, ns, 
 		}
 		return false, nil
 	})
+
 	return cr, pollErr
 }
 
@@ -2340,7 +2350,7 @@ func createWebhookConfigurationReadyNamespace(ctx context.Context, f *framework.
 // the webhook configuration.
 func waitWebhookConfigurationReady(ctx context.Context, f *framework.Framework, markersNamespaceName string) error {
 	cmClient := f.ClientSet.CoreV1().ConfigMaps(markersNamespaceName)
-	return wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		marker := &v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: string(uuid.NewUUID()),
@@ -2362,6 +2372,7 @@ func waitWebhookConfigurationReady(ctx context.Context, f *framework.Framework, 
 		framework.Logf("Waiting for webhook configuration to be ready...")
 		return false, nil
 	})
+
 }
 
 // newValidatingIsReadyWebhookFixture creates a validating webhook that can be added to a webhook configuration and then probed

--- a/test/e2e/apps/controller_revision.go
+++ b/test/e2e/apps/controller_revision.go
@@ -63,7 +63,7 @@ var _ = SIGDescribe("ControllerRevision [Serial]", func() {
 			for _, ds := range daemonsets.Items {
 				ginkgo.By(fmt.Sprintf("Deleting DaemonSet %q", ds.Name))
 				framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(ctx, f.ClientSet, extensionsinternal.Kind("DaemonSet"), f.Namespace.Name, ds.Name))
-				err = wait.PollImmediateWithContext(ctx, dsRetryPeriod, dsRetryTimeout, checkRunningOnNoNodes(f, &ds))
+				err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnNoNodes(f, &ds))
 				framework.ExpectNoError(err, "error waiting for daemon pod to be reaped")
 			}
 		}
@@ -132,7 +132,7 @@ var _ = SIGDescribe("ControllerRevision [Serial]", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Check that daemon pods launch on every node of the cluster.")
-		err = wait.PollImmediateWithContext(ctx, dsRetryPeriod, dsRetryTimeout, checkRunningOnAllNodes(f, testDaemonset))
+		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnAllNodes(f, testDaemonset))
 		framework.ExpectNoError(err, "error waiting for daemon pod to start")
 		err = e2edaemonset.CheckDaemonStatus(ctx, f, dsName)
 		framework.ExpectNoError(err)
@@ -189,7 +189,7 @@ var _ = SIGDescribe("ControllerRevision [Serial]", func() {
 		framework.Logf("Created ControllerRevision: %s", newControllerRevision.Name)
 
 		ginkgo.By("Confirm that there are two ControllerRevisions")
-		err = wait.PollImmediateWithContext(ctx, controllerRevisionRetryPeriod, controllerRevisionRetryTimeout, checkControllerRevisionListQuantity(f, dsLabelSelector, 2))
+		err = wait.PollUntilContextTimeout(ctx, controllerRevisionRetryPeriod, controllerRevisionRetryTimeout, true, checkControllerRevisionListQuantity(f, dsLabelSelector, 2))
 		framework.ExpectNoError(err, "failed to count required ControllerRevisions")
 
 		ginkgo.By(fmt.Sprintf("Deleting ControllerRevision %q", initialRevision.Name))
@@ -197,7 +197,7 @@ var _ = SIGDescribe("ControllerRevision [Serial]", func() {
 		framework.ExpectNoError(err, "Failed to delete ControllerRevision: %v", err)
 
 		ginkgo.By("Confirm that there is only one ControllerRevision")
-		err = wait.PollImmediateWithContext(ctx, controllerRevisionRetryPeriod, controllerRevisionRetryTimeout, checkControllerRevisionListQuantity(f, dsLabelSelector, 1))
+		err = wait.PollUntilContextTimeout(ctx, controllerRevisionRetryPeriod, controllerRevisionRetryTimeout, true, checkControllerRevisionListQuantity(f, dsLabelSelector, 1))
 		framework.ExpectNoError(err, "failed to count required ControllerRevisions")
 
 		listControllerRevisions, err := csAppsV1.ControllerRevisions(ns).List(ctx, metav1.ListOptions{})
@@ -224,7 +224,7 @@ var _ = SIGDescribe("ControllerRevision [Serial]", func() {
 		framework.ExpectNoError(err, "error patching daemon set")
 
 		ginkgo.By("Confirm that there are two ControllerRevisions")
-		err = wait.PollImmediateWithContext(ctx, controllerRevisionRetryPeriod, controllerRevisionRetryTimeout, checkControllerRevisionListQuantity(f, dsLabelSelector, 2))
+		err = wait.PollUntilContextTimeout(ctx, controllerRevisionRetryPeriod, controllerRevisionRetryTimeout, true, checkControllerRevisionListQuantity(f, dsLabelSelector, 2))
 		framework.ExpectNoError(err, "failed to count required ControllerRevisions")
 
 		updatedLabel := map[string]string{updatedControllerRevision.Name: "updated"}
@@ -235,7 +235,7 @@ var _ = SIGDescribe("ControllerRevision [Serial]", func() {
 		framework.ExpectNoError(err, "Failed to delete ControllerRevision: %v", err)
 
 		ginkgo.By("Confirm that there is only one ControllerRevision")
-		err = wait.PollImmediateWithContext(ctx, controllerRevisionRetryPeriod, controllerRevisionRetryTimeout, checkControllerRevisionListQuantity(f, dsLabelSelector, 1))
+		err = wait.PollUntilContextTimeout(ctx, controllerRevisionRetryPeriod, controllerRevisionRetryTimeout, true, checkControllerRevisionListQuantity(f, dsLabelSelector, 1))
 		framework.ExpectNoError(err, "failed to count required ControllerRevisions")
 
 		list, err := csAppsV1.ControllerRevisions(ns).List(ctx, metav1.ListOptions{})

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -19,7 +19,6 @@ package apps
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -276,7 +275,7 @@ var _ = SIGDescribe("Job", func() {
 	ginkgo.It("should not create pods when created in suspend state", func(ctx context.Context) {
 		ginkgo.By("Creating a job with suspend=true")
 		job := e2ejob.NewTestJob("succeed", "suspend-true-to-false", v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit)
-		job.Spec.Suspend = pointer.BoolPtr(true)
+		job.Spec.Suspend = pointer.Bool(true)
 		job, err := e2ejob.CreateJob(ctx, f.ClientSet, f.Namespace.Name, job)
 		framework.ExpectNoError(err, "failed to create job in namespace: %s", f.Namespace.Name)
 
@@ -287,9 +286,7 @@ var _ = SIGDescribe("Job", func() {
 				return false, err
 			}
 			return len(pods.Items) > 0, nil
-		}),
-
-			wait.ErrorInterrupted(errors.New("TODO")))
+		}), context.DeadlineExceeded)
 
 		ginkgo.By("Checking Job status to observe Suspended state")
 		job, err = e2ejob.GetJob(ctx, f.ClientSet, f.Namespace.Name, job.Name)
@@ -306,7 +303,7 @@ var _ = SIGDescribe("Job", func() {
 		}
 
 		ginkgo.By("Updating the job with suspend=false")
-		job.Spec.Suspend = pointer.BoolPtr(false)
+		job.Spec.Suspend = pointer.Bool(false)
 		job, err = e2ejob.UpdateJob(ctx, f.ClientSet, f.Namespace.Name, job)
 		framework.ExpectNoError(err, "failed to update job in namespace: %s", f.Namespace.Name)
 
@@ -734,7 +731,7 @@ var _ = SIGDescribe("Job", func() {
 		ginkgo.By("Creating a suspended job")
 		job := e2ejob.NewTestJob("succeed", jobName, v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit)
 		job.Labels = label
-		job.Spec.Suspend = pointer.BoolPtr(true)
+		job.Spec.Suspend = pointer.Bool(true)
 		job, err = e2ejob.CreateJob(ctx, f.ClientSet, ns, job)
 		framework.ExpectNoError(err, "failed to create job in namespace: %s", ns)
 
@@ -764,7 +761,7 @@ var _ = SIGDescribe("Job", func() {
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			patchedJob, err = jobClient.Get(ctx, jobName, metav1.GetOptions{})
 			framework.ExpectNoError(err, "Unable to get job %s", jobName)
-			patchedJob.Spec.Suspend = pointer.BoolPtr(false)
+			patchedJob.Spec.Suspend = pointer.Bool(false)
 			if patchedJob.Annotations == nil {
 				patchedJob.Annotations = map[string]string{}
 			}

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -19,7 +19,6 @@ package apps
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
@@ -786,7 +785,7 @@ func watchUntilWithoutRetry(ctx context.Context, watcher watch.Interface, condit
 				}
 
 			case <-ctx.Done():
-				return lastEvent, wait.ErrorInterrupted(errors.New("TODO"))
+				return lastEvent, ctx.Err()
 			}
 		}
 	}

--- a/test/e2e/apps/ttl_after_finished.go
+++ b/test/e2e/apps/ttl_after_finished.go
@@ -125,11 +125,10 @@ func finishTime(finishedJob *batchv1.Job) metav1.Time {
 func updateJobWithRetries(ctx context.Context, c clientset.Interface, namespace, name string, applyUpdate func(*batchv1.Job)) (job *batchv1.Job, err error) {
 	jobs := c.BatchV1().Jobs(namespace)
 	var updateErr error
-	pollErr := wait.PollImmediateWithContext(ctx, framework.Poll, JobTimeout, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, framework.Poll, JobTimeout, true, func(ctx context.Context) (bool, error) {
 		if job, err = jobs.Get(ctx, name, metav1.GetOptions{}); err != nil {
 			return false, err
 		}
-		// Apply the update, then attempt to push it to the apiserver.
 		applyUpdate(job)
 		if job, err = jobs.Update(ctx, job, metav1.UpdateOptions{}); err == nil {
 			framework.Logf("Updating job %s", name)
@@ -138,7 +137,10 @@ func updateJobWithRetries(ctx context.Context, c clientset.Interface, namespace,
 		updateErr = err
 		return false, nil
 	})
-	if pollErr == wait.ErrWaitTimeout {
+
+	// Apply the update, then attempt to push it to the apiserver.
+
+	if wait.Interrupted(pollErr) {
 		pollErr = fmt.Errorf("couldn't apply the provided updated to job %q: %v", name, updateErr)
 	}
 	return job, pollErr
@@ -147,11 +149,12 @@ func updateJobWithRetries(ctx context.Context, c clientset.Interface, namespace,
 // waitForJobDeleting uses c to wait for the Job jobName in namespace ns to have
 // a non-nil deletionTimestamp (i.e. being deleted).
 func waitForJobDeleting(ctx context.Context, c clientset.Interface, ns, jobName string) error {
-	return wait.PollImmediateWithContext(ctx, framework.Poll, JobTimeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, JobTimeout, true, func(ctx context.Context) (bool, error) {
 		curr, err := c.BatchV1().Jobs(ns).Get(ctx, jobName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
 		return curr.ObjectMeta.DeletionTimestamp != nil, nil
 	})
+
 }

--- a/test/e2e/auth/certificates.go
+++ b/test/e2e/auth/certificates.go
@@ -125,7 +125,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		}()
 
 		framework.Logf("approving CSR")
-		framework.ExpectNoError(wait.Poll(5*time.Second, time.Minute, func() (bool, error) {
+		framework.ExpectNoError(wait.PollUntilContextTimeout(context.Background(), 5*time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
 			csr.Status.Conditions = []certificatesv1.CertificateSigningRequestCondition{
 				{
 					Type:    certificatesv1.CertificateApproved,
@@ -144,7 +144,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		}))
 
 		framework.Logf("waiting for CSR to be signed")
-		framework.ExpectNoError(wait.Poll(5*time.Second, time.Minute, func() (bool, error) {
+		framework.ExpectNoError(wait.PollUntilContextTimeout(context.Background(), 5*time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
 			csr, err = csrClient.Get(ctx, csr.Name, metav1.GetOptions{})
 			if err != nil {
 				framework.Logf("error getting csr: %v", err)

--- a/test/e2e/auth/node_authz.go
+++ b/test/e2e/auth/node_authz.go
@@ -170,7 +170,7 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 		ginkgo.By("The node should able to access the secret")
 		itv := framework.Poll
 		dur := 1 * time.Minute
-		err = wait.Poll(itv, dur, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), itv, dur, false, func(ctx context.Context) (bool, error) {
 			_, err = c.CoreV1().Secrets(ns).Get(ctx, secret.Name, metav1.GetOptions{})
 			if err != nil {
 				framework.Logf("Failed to get secret %v, err: %v", secret.Name, err)
@@ -178,6 +178,7 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 			}
 			return true, nil
 		})
+
 		framework.ExpectNoError(err, "failed to get secret after trying every %v for %v (%s:%s)", itv, dur, ns, secret.Name)
 	})
 

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -498,7 +498,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		framework.Logf("pod is ready")
 
 		var logs string
-		if err := wait.Poll(1*time.Minute, 20*time.Minute, func() (done bool, err error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Minute, 20*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 			framework.Logf("polling logs")
 			logs, err = e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, "inclusterclient", "inclusterclient")
 			if err != nil {
@@ -618,7 +618,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 
 		// Get the logs before calling ExpectNoError, so we can debug any errors.
 		var logs string
-		if err := wait.Poll(30*time.Second, 2*time.Minute, func() (done bool, err error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 2*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 			framework.Logf("polling logs")
 			logs, err = e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
 			if err != nil {
@@ -738,7 +738,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			3. Reconciled if modified
 	*/
 	framework.ConformanceIt("should guarantee kube-root-ca.crt exist in any namespace", func(ctx context.Context) {
-		framework.ExpectNoError(wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+		framework.ExpectNoError(wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			_, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(ctx, rootCAConfigMapName, metav1.GetOptions{})
 			if err == nil {
 				return true, nil
@@ -754,7 +754,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		framework.ExpectNoError(f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, rootCAConfigMapName, metav1.DeleteOptions{GracePeriodSeconds: utilptr.Int64Ptr(0)}))
 		framework.Logf("Deleted root ca configmap in namespace %q", f.Namespace.Name)
 
-		framework.ExpectNoError(wait.Poll(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+		framework.ExpectNoError(wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 			ginkgo.By("waiting for a new root ca configmap created")
 			_, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(ctx, rootCAConfigMapName, metav1.GetOptions{})
 			if err == nil {
@@ -779,7 +779,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		framework.ExpectNoError(err)
 		framework.Logf("Updated root ca configmap in namespace %q", f.Namespace.Name)
 
-		framework.ExpectNoError(wait.Poll(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+		framework.ExpectNoError(wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 			ginkgo.By("waiting for the root ca configmap reconciled")
 			cm, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(ctx, rootCAConfigMapName, metav1.GetOptions{})
 			if err != nil {

--- a/test/e2e/autoscaling/dns_autoscaling.go
+++ b/test/e2e/autoscaling/dns_autoscaling.go
@@ -354,7 +354,7 @@ func waitForDNSReplicasSatisfied(ctx context.Context, c clientset.Interface, get
 		return true, nil
 	}
 
-	if err = wait.Poll(2*time.Second, timeout, condition); err != nil {
+	if err = wait.PollUntilContextTimeout(context.Background(), 2*time.Second, timeout, false, condition); err != nil {
 		return fmt.Errorf("err waiting for DNS replicas to satisfy %v, got %v: %w", expected, current, err)
 	}
 	framework.Logf("kube-dns reaches expected replicas: %v", expected)
@@ -371,7 +371,7 @@ func waitForDNSConfigMapCreated(ctx context.Context, c clientset.Interface, time
 		return true, nil
 	}
 
-	if err = wait.Poll(time.Second, timeout, condition); err != nil {
+	if err = wait.PollUntilContextTimeout(context.Background(), time.Second, timeout, false, condition); err != nil {
 		return nil, fmt.Errorf("err waiting for DNS autoscaling ConfigMap got re-created: %w", err)
 	}
 	return configMap, nil

--- a/test/e2e/autoscaling/dns_autoscaling.go
+++ b/test/e2e/autoscaling/dns_autoscaling.go
@@ -341,7 +341,7 @@ func waitForDNSReplicasSatisfied(ctx context.Context, c clientset.Interface, get
 	var current int
 	var expected int
 	framework.Logf("Waiting up to %v for kube-dns to reach expected replicas", timeout)
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		current, err = getDNSReplicas(ctx, c)
 		if err != nil {
 			return false, err
@@ -354,7 +354,7 @@ func waitForDNSReplicasSatisfied(ctx context.Context, c clientset.Interface, get
 		return true, nil
 	}
 
-	if err = wait.PollUntilContextTimeout(context.Background(), 2*time.Second, timeout, false, condition); err != nil {
+	if err = wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, false, condition); err != nil {
 		return fmt.Errorf("err waiting for DNS replicas to satisfy %v, got %v: %w", expected, current, err)
 	}
 	framework.Logf("kube-dns reaches expected replicas: %v", expected)
@@ -363,7 +363,7 @@ func waitForDNSReplicasSatisfied(ctx context.Context, c clientset.Interface, get
 
 func waitForDNSConfigMapCreated(ctx context.Context, c clientset.Interface, timeout time.Duration) (configMap *v1.ConfigMap, err error) {
 	framework.Logf("Waiting up to %v for DNS autoscaling ConfigMap got re-created", timeout)
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		configMap, err = fetchDNSScalingConfigMap(ctx, c)
 		if err != nil {
 			return false, nil
@@ -371,7 +371,7 @@ func waitForDNSConfigMapCreated(ctx context.Context, c clientset.Interface, time
 		return true, nil
 	}
 
-	if err = wait.PollUntilContextTimeout(context.Background(), time.Second, timeout, false, condition); err != nil {
+	if err = wait.PollUntilContextTimeout(ctx, time.Second, timeout, false, condition); err != nil {
 		return nil, fmt.Errorf("err waiting for DNS autoscaling ConfigMap got re-created: %w", err)
 	}
 	return configMap, nil

--- a/test/e2e/cloud/gcp/addon_update.go
+++ b/test/e2e/cloud/gcp/addon_update.go
@@ -364,7 +364,7 @@ func waitForReplicationControllerwithSelectorInAddonTest(ctx context.Context, c 
 
 // waitForReplicationController waits until the RC appears (exist == true), or disappears (exist == false)
 func waitForReplicationController(ctx context.Context, c clientset.Interface, namespace, name string, exist bool, interval, timeout time.Duration) error {
-	err := wait.PollImmediateWithContext(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 		_, err := c.CoreV1().ReplicationControllers(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			framework.Logf("Get ReplicationController %s in namespace %s failed (%v).", name, namespace, err)
@@ -373,6 +373,7 @@ func waitForReplicationController(ctx context.Context, c clientset.Interface, na
 		framework.Logf("ReplicationController %s in namespace %s found.", name, namespace)
 		return exist, nil
 	})
+
 	if err != nil {
 		stateMsg := map[bool]string{true: "to appear", false: "to disappear"}
 		return fmt.Errorf("error waiting for ReplicationController %s/%s %s: %w", namespace, name, stateMsg[exist], err)
@@ -383,7 +384,7 @@ func waitForReplicationController(ctx context.Context, c clientset.Interface, na
 // waitForServiceWithSelector waits until any service with given selector appears (exist == true), or disappears (exist == false)
 func waitForServiceWithSelector(ctx context.Context, c clientset.Interface, namespace string, selector labels.Selector, exist bool, interval,
 	timeout time.Duration) error {
-	err := wait.PollImmediateWithContext(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 		services, err := c.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
 		switch {
 		case len(services.Items) != 0:
@@ -400,6 +401,7 @@ func waitForServiceWithSelector(ctx context.Context, c clientset.Interface, name
 			return false, nil
 		}
 	})
+
 	if err != nil {
 		stateMsg := map[bool]string{true: "to appear", false: "to disappear"}
 		return fmt.Errorf("error waiting for service with %s in namespace %s %s: %w", selector.String(), namespace, stateMsg[exist], err)
@@ -410,7 +412,7 @@ func waitForServiceWithSelector(ctx context.Context, c clientset.Interface, name
 // waitForReplicationControllerWithSelector waits until any RC with given selector appears (exist == true), or disappears (exist == false)
 func waitForReplicationControllerWithSelector(ctx context.Context, c clientset.Interface, namespace string, selector labels.Selector, exist bool, interval,
 	timeout time.Duration) error {
-	err := wait.PollImmediateWithContext(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 		rcs, err := c.CoreV1().ReplicationControllers(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
 		switch {
 		case len(rcs.Items) != 0:
@@ -424,6 +426,7 @@ func waitForReplicationControllerWithSelector(ctx context.Context, c clientset.I
 			return false, nil
 		}
 	})
+
 	if err != nil {
 		stateMsg := map[bool]string{true: "to appear", false: "to disappear"}
 		return fmt.Errorf("error waiting for ReplicationControllers with %s in namespace %s %s: %w", selector.String(), namespace, stateMsg[exist], err)

--- a/test/e2e/cloud/gcp/common/upgrade_mechanics.go
+++ b/test/e2e/cloud/gcp/common/upgrade_mechanics.go
@@ -122,7 +122,7 @@ func checkControlPlaneVersion(ctx context.Context, c clientset.Interface, want s
 	framework.Logf("Checking control plane version")
 	var err error
 	var v *version.Info
-	waitErr := wait.PollImmediateWithContext(ctx, 5*time.Second, 2*time.Minute, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		v, err = c.Discovery().ServerVersion()
 		if err != nil {
 			traceRouteToControlPlane()
@@ -130,6 +130,7 @@ func checkControlPlaneVersion(ctx context.Context, c clientset.Interface, want s
 		}
 		return true, nil
 	})
+
 	if waitErr != nil {
 		return fmt.Errorf("CheckControlPlane() couldn't get the control plane version: %w", err)
 	}

--- a/test/e2e/common/node/node_lease.go
+++ b/test/e2e/common/node/node_lease.go
@@ -136,7 +136,7 @@ var _ = SIGDescribe("NodeLease", func() {
 			// (the same as nodeMonitorGracePeriod), or it doesn't change for at least leaseDuration
 			lastHeartbeatTime, lastStatus := getHeartbeatTimeAndStatus(ctx, f.ClientSet, nodeName)
 			lastObserved := time.Now()
-			err = wait.PollUntilContextTimeout(context.Background(), time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(ctx, time.Second, 5*time.Minute, false, func(_ context.Context) (bool, error) {
 				currentHeartbeatTime, currentStatus := getHeartbeatTimeAndStatus(ctx, f.ClientSet, nodeName)
 				currentObserved := time.Now()
 
@@ -171,7 +171,7 @@ var _ = SIGDescribe("NodeLease", func() {
 			})
 
 			// a timeout is acceptable, since it means we waited 5 minutes and didn't see any unwarranted node status updates
-			if err != nil && !wait.Interrupted(err) {
+			if err != nil && err != context.DeadlineExceeded {
 				framework.ExpectNoError(err, "error waiting for infrequent nodestatus update")
 			}
 

--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -795,7 +795,7 @@ var _ = SIGDescribe("Pods", func() {
 		})
 
 		validatePodReadiness := func(expectReady bool) {
-			err := wait.Poll(time.Second, time.Minute, func() (bool, error) {
+			err := wait.PollUntilContextTimeout(context.Background(), time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
 				pod, err := podClient.Get(ctx, podName, metav1.GetOptions{})
 				framework.ExpectNoError(err)
 				podReady := podutils.IsPodReady(pod)
@@ -805,6 +805,7 @@ var _ = SIGDescribe("Pods", func() {
 				}
 				return res, nil
 			})
+
 			framework.ExpectNoError(err)
 		}
 
@@ -883,7 +884,7 @@ var _ = SIGDescribe("Pods", func() {
 
 		// wait for all pods to be deleted
 		ginkgo.By("waiting for all pods to be deleted")
-		err = wait.PollImmediateWithContext(ctx, podRetryPeriod, f.Timeouts.PodDelete, checkPodListQuantity(f, "type=Testing", 0))
+		err = wait.PollUntilContextTimeout(ctx, podRetryPeriod, f.Timeouts.PodDelete, true, checkPodListQuantity(f, "type=Testing", 0))
 		framework.ExpectNoError(err, "found a pod(s)")
 	})
 

--- a/test/e2e/common/node/podtemplates.go
+++ b/test/e2e/common/node/podtemplates.go
@@ -161,7 +161,7 @@ var _ = SIGDescribe("PodTemplates", func() {
 
 		ginkgo.By("check that the list of pod templates matches the requested quantity")
 
-		err = wait.PollImmediate(podTemplateRetryPeriod, podTemplateRetryTimeout, checkPodTemplateListQuantity(ctx, f, "podtemplate-set=true", 0))
+		err = wait.PollUntilContextTimeout(context.Background(), podTemplateRetryPeriod, podTemplateRetryTimeout, true, checkPodTemplateListQuantity(ctx, f, "podtemplate-set=true", 0))
 		framework.ExpectNoError(err, "failed to count required pod templates")
 
 	})

--- a/test/e2e/common/node/podtemplates.go
+++ b/test/e2e/common/node/podtemplates.go
@@ -161,9 +161,8 @@ var _ = SIGDescribe("PodTemplates", func() {
 
 		ginkgo.By("check that the list of pod templates matches the requested quantity")
 
-		err = wait.PollUntilContextTimeout(context.Background(), podTemplateRetryPeriod, podTemplateRetryTimeout, true, checkPodTemplateListQuantity(ctx, f, "podtemplate-set=true", 0))
+		err = wait.PollUntilContextTimeout(ctx, podTemplateRetryPeriod, podTemplateRetryTimeout, true, checkPodTemplateListQuantity(f, "podtemplate-set=true", 0))
 		framework.ExpectNoError(err, "failed to count required pod templates")
-
 	})
 
 	/*
@@ -211,8 +210,8 @@ var _ = SIGDescribe("PodTemplates", func() {
 
 })
 
-func checkPodTemplateListQuantity(ctx context.Context, f *framework.Framework, label string, quantity int) func() (bool, error) {
-	return func() (bool, error) {
+func checkPodTemplateListQuantity(f *framework.Framework, label string, quantity int) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
 		var err error
 
 		framework.Logf("requesting list of pod templates to confirm quantity")

--- a/test/e2e/common/node/runtimeclass.go
+++ b/test/e2e/common/node/runtimeclass.go
@@ -162,7 +162,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 			framework.ExpectNoError(err, "failed to delete RuntimeClass %s", rcName)
 
 			ginkgo.By("Waiting for the RuntimeClass to disappear")
-			framework.ExpectNoError(wait.PollImmediate(framework.Poll, time.Minute, func() (bool, error) {
+			framework.ExpectNoError(wait.PollUntilContextTimeout(context.Background(), framework.Poll, time.Minute, true, func(ctx context.Context) (bool, error) {
 				_, err := rcClient.Get(ctx, rcName, metav1.GetOptions{})
 				if apierrors.IsNotFound(err) {
 					return true, nil // done

--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -192,7 +192,7 @@ func RestartNodes(c clientset.Interface, nodes []v1.Node) error {
 	// Wait for their boot IDs to change.
 	for i := range nodes {
 		node := &nodes[i]
-		if err := wait.Poll(30*time.Second, framework.RestartNodeReadyAgainTimeout, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 30*time.Second, framework.RestartNodeReadyAgainTimeout, false, func(ctx context.Context) (bool, error) {
 			newNode, err := c.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, fmt.Errorf("error getting node info after reboot: %w", err)

--- a/test/e2e/framework/events/events.go
+++ b/test/e2e/framework/events/events.go
@@ -34,7 +34,7 @@ type Action func() error
 // Please note delivery of events is not guaranteed. Asserting on events can lead to flaky tests.
 func WaitTimeoutForEvent(ctx context.Context, c clientset.Interface, namespace, eventSelector, msg string, timeout time.Duration) error {
 	interval := 2 * time.Second
-	return wait.PollImmediateWithContext(ctx, interval, timeout, eventOccurred(c, namespace, eventSelector, msg))
+	return wait.PollUntilContextTimeout(ctx, interval, timeout, true, eventOccurred(c, namespace, eventSelector, msg))
 }
 
 func eventOccurred(c clientset.Interface, namespace, eventSelector, msg string) wait.ConditionWithContextFunc {

--- a/test/e2e/framework/job/wait.go
+++ b/test/e2e/framework/job/wait.go
@@ -70,7 +70,7 @@ func WaitForJobComplete(ctx context.Context, c clientset.Interface, ns, jobName 
 
 // WaitForJobFailed uses c to wait for the Job jobName in namespace ns to fail
 func WaitForJobFailed(c clientset.Interface, ns, jobName string) error {
-	return wait.PollImmediate(framework.Poll, JobTimeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), framework.Poll, JobTimeout, true, func(ctx context.Context) (bool, error) {
 		curr, err := c.BatchV1().Jobs(ns).Get(context.TODO(), jobName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -78,6 +78,7 @@ func WaitForJobFailed(c clientset.Interface, ns, jobName string) error {
 
 		return isJobFailed(curr), nil
 	})
+
 }
 
 func isJobFailed(j *batchv1.Job) bool {
@@ -91,14 +92,14 @@ func isJobFailed(j *batchv1.Job) bool {
 
 // WaitForJobFinish uses c to wait for the Job jobName in namespace ns to finish (either Failed or Complete).
 func WaitForJobFinish(ctx context.Context, c clientset.Interface, ns, jobName string) error {
-	return wait.PollImmediateWithContext(ctx, framework.Poll, JobTimeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, JobTimeout, true, func(ctx context.Context) (bool, error) {
 		curr, err := c.BatchV1().Jobs(ns).Get(ctx, jobName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
-
 		return isJobFinished(curr), nil
 	})
+
 }
 
 func isJobFinished(j *batchv1.Job) bool {
@@ -125,11 +126,12 @@ func WaitForJobGone(ctx context.Context, c clientset.Interface, ns, jobName stri
 // WaitForAllJobPodsGone waits for all pods for the Job named jobName in namespace ns
 // to be deleted.
 func WaitForAllJobPodsGone(ctx context.Context, c clientset.Interface, ns, jobName string) error {
-	return wait.PollImmediateWithContext(ctx, framework.Poll, JobTimeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, JobTimeout, true, func(ctx context.Context) (bool, error) {
 		pods, err := GetJobPods(ctx, c, ns, jobName)
 		if err != nil {
 			return false, err
 		}
 		return len(pods.Items) == 0, nil
 	})
+
 }

--- a/test/e2e/framework/kubelet/config.go
+++ b/test/e2e/framework/kubelet/config.go
@@ -90,27 +90,25 @@ func pollConfigz(ctx context.Context, timeout time.Duration, pollInterval time.D
 	req.Header.Add("Accept", "application/json")
 
 	var respBody []byte
-	err = wait.PollImmediateWithContext(ctx, pollInterval, timeout, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
 		resp, err := client.Do(req)
 		if err != nil {
 			framework.Logf("Failed to get /configz, retrying. Error: %v", err)
 			return false, nil
 		}
 		defer resp.Body.Close()
-
 		if resp.StatusCode != 200 {
 			framework.Logf("/configz response status not 200, retrying. Response was: %+v", resp)
 			return false, nil
 		}
-
 		respBody, err = io.ReadAll(resp.Body)
 		if err != nil {
 			framework.Logf("failed to read body from /configz response, retrying. Error: %v", err)
 			return false, nil
 		}
-
 		return true, nil
 	})
+
 	framework.ExpectNoError(err, "Failed to get successful response from /configz")
 
 	return respBody

--- a/test/e2e/framework/metrics/metrics_grabber.go
+++ b/test/e2e/framework/metrics/metrics_grabber.go
@@ -239,7 +239,7 @@ func (g *Grabber) GrabFromScheduler(ctx context.Context) (SchedulerMetrics, erro
 
 	var lastMetricsFetchErr error
 	var output string
-	if metricsWaitErr := wait.PollImmediateWithContext(ctx, time.Second, time.Minute, func(ctx context.Context) (bool, error) {
+	if metricsWaitErr := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
 		output, lastMetricsFetchErr = g.getSecureMetricsFromPod(ctx, g.kubeScheduler, metav1.NamespaceSystem, kubeSchedulerPort)
 		return lastMetricsFetchErr == nil, nil
 	}); metricsWaitErr != nil {
@@ -290,7 +290,7 @@ func (g *Grabber) GrabFromControllerManager(ctx context.Context) (ControllerMana
 
 	var output string
 	var lastMetricsFetchErr error
-	if metricsWaitErr := wait.PollImmediateWithContext(ctx, time.Second, time.Minute, func(ctx context.Context) (bool, error) {
+	if metricsWaitErr := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
 		output, lastMetricsFetchErr = g.getSecureMetricsFromPod(ctx, g.kubeControllerManager, metav1.NamespaceSystem, kubeControllerManagerPort)
 		return lastMetricsFetchErr == nil, nil
 	}); metricsWaitErr != nil {
@@ -329,7 +329,7 @@ func (g *Grabber) GrabFromSnapshotController(ctx context.Context, podName string
 
 	var output string
 	var lastMetricsFetchErr error
-	if metricsWaitErr := wait.PollImmediateWithContext(ctx, time.Second, time.Minute, func(ctx context.Context) (bool, error) {
+	if metricsWaitErr := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
 		output, lastMetricsFetchErr = g.getMetricsFromPod(ctx, g.client, podName, metav1.NamespaceSystem, port)
 		return lastMetricsFetchErr == nil, nil
 	}); metricsWaitErr != nil {

--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -526,7 +526,7 @@ func (config *NetworkingTestConfig) executeCurlCmd(ctx context.Context, cmd stri
 	const retryTimeout = 30 * time.Second
 	podName := config.HostTestContainerPod.Name
 	var msg string
-	if pollErr := wait.PollImmediateWithContext(ctx, retryInterval, retryTimeout, func(ctx context.Context) (bool, error) {
+	if pollErr := wait.PollUntilContextTimeout(ctx, retryInterval, retryTimeout, true, func(ctx context.Context) (bool, error) {
 		stdout, err := e2epodoutput.RunHostCmd(config.Namespace, podName, cmd)
 		if err != nil {
 			msg = fmt.Sprintf("failed executing cmd %v in %v/%v: %v", cmd, config.Namespace, podName, err)
@@ -1172,7 +1172,7 @@ func UnblockNetwork(ctx context.Context, from string, to string) {
 
 // WaitForService waits until the service appears (exist == true), or disappears (exist == false)
 func WaitForService(ctx context.Context, c clientset.Interface, namespace, name string, exist bool, interval, timeout time.Duration) error {
-	err := wait.PollImmediateWithContext(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 		_, err := c.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
 		switch {
 		case err == nil:
@@ -1189,6 +1189,7 @@ func WaitForService(ctx context.Context, c clientset.Interface, namespace, name 
 			return false, nil
 		}
 	})
+
 	if err != nil {
 		stateMsg := map[bool]string{true: "to appear", false: "to disappear"}
 		return fmt.Errorf("error waiting for service %s/%s %s: %w", namespace, name, stateMsg[exist], err)

--- a/test/e2e/framework/node/ssh.go
+++ b/test/e2e/framework/node/ssh.go
@@ -36,8 +36,9 @@ func WaitForSSHTunnels(ctx context.Context, namespace string) {
 	defer e2ekubectl.RunKubectl(namespace, "delete", "pod", "ssh-tunnel-test")
 
 	// allow up to a minute for new ssh tunnels to establish
-	wait.PollImmediateWithContext(ctx, 5*time.Second, time.Minute, func(ctx context.Context) (bool, error) {
+	wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err := e2ekubectl.RunKubectl(namespace, "logs", "ssh-tunnel-test")
 		return err == nil, nil
 	})
+
 }

--- a/test/e2e/framework/providers/gce/firewall.go
+++ b/test/e2e/framework/providers/gce/firewall.go
@@ -410,7 +410,7 @@ func WaitForFirewallRule(ctx context.Context, gceCloud *gcecloud.Cloud, fwName s
 		return true, nil
 	}
 
-	if err := wait.PollImmediateWithContext(ctx, 5*time.Second, timeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, condition); err != nil {
 		return nil, fmt.Errorf("error waiting for firewall %v exist=%v", fwName, exist)
 	}
 	return fw, nil

--- a/test/e2e/framework/replicaset/wait.go
+++ b/test/e2e/framework/replicaset/wait.go
@@ -37,7 +37,7 @@ func WaitForReadyReplicaSet(ctx context.Context, c clientset.Interface, ns, name
 		}
 		return *(rs.Spec.Replicas) == rs.Status.Replicas && *(rs.Spec.Replicas) == rs.Status.ReadyReplicas, nil
 	})
-	if err == wait.ErrWaitTimeout {
+	if wait.Interrupted(err) {
 		err = fmt.Errorf("replicaset %q never became ready", name)
 	}
 	return err
@@ -52,14 +52,15 @@ func WaitForReplicaSetTargetAvailableReplicas(ctx context.Context, c clientset.I
 // with given timeout.
 func WaitForReplicaSetTargetAvailableReplicasWithTimeout(ctx context.Context, c clientset.Interface, replicaSet *appsv1.ReplicaSet, targetReplicaNum int32, timeout time.Duration) error {
 	desiredGeneration := replicaSet.Generation
-	err := wait.PollImmediateWithContext(ctx, framework.Poll, timeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, framework.Poll, timeout, true, func(ctx context.Context) (bool, error) {
 		rs, err := c.AppsV1().ReplicaSets(replicaSet.Namespace).Get(ctx, replicaSet.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
 		return rs.Status.ObservedGeneration >= desiredGeneration && rs.Status.AvailableReplicas == targetReplicaNum, nil
 	})
-	if err == wait.ErrWaitTimeout {
+
+	if wait.Interrupted(err) {
 		err = fmt.Errorf("replicaset %q never had desired number of .status.availableReplicas", replicaSet.Name)
 	}
 	return err

--- a/test/e2e/framework/service/util.go
+++ b/test/e2e/framework/service/util.go
@@ -44,8 +44,8 @@ func TestReachableHTTPWithRetriableErrorCodes(ctx context.Context, host string, 
 		return false, nil // caller can retry
 	}
 
-	if err := wait.PollImmediateWithContext(ctx, framework.Poll, timeout, pollfn); err != nil {
-		if err == wait.ErrWaitTimeout {
+	if err := wait.PollUntilContextTimeout(ctx, framework.Poll, timeout, true, pollfn); err != nil {
+		if wait.Interrupted(err) {
 			framework.Failf("Could not reach HTTP service through %v:%v after %v", host, port, timeout)
 		} else {
 			framework.Failf("Failed to reach HTTP service through %v:%v: %v", host, port, err)

--- a/test/e2e/framework/service/wait.go
+++ b/test/e2e/framework/service/wait.go
@@ -38,7 +38,7 @@ func WaitForServiceDeletedWithFinalizer(ctx context.Context, cs clientset.Interf
 	}
 
 	ginkgo.By("Wait for service to disappear")
-	if pollErr := wait.PollImmediateWithContext(ctx, LoadBalancerPollInterval, GetServiceLoadBalancerCreationTimeout(ctx, cs), func(ctx context.Context) (bool, error) {
+	if pollErr := wait.PollUntilContextTimeout(ctx, LoadBalancerPollInterval, GetServiceLoadBalancerCreationTimeout(ctx, cs), true, func(ctx context.Context) (bool, error) {
 		svc, err := cs.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
@@ -58,7 +58,7 @@ func WaitForServiceDeletedWithFinalizer(ctx context.Context, cs clientset.Interf
 // don't have a finalizer.
 func WaitForServiceUpdatedWithFinalizer(ctx context.Context, cs clientset.Interface, namespace, name string, hasFinalizer bool) {
 	ginkgo.By(fmt.Sprintf("Wait for service to hasFinalizer=%t", hasFinalizer))
-	if pollErr := wait.PollImmediateWithContext(ctx, LoadBalancerPollInterval, GetServiceLoadBalancerCreationTimeout(ctx, cs), func(ctx context.Context) (bool, error) {
+	if pollErr := wait.PollUntilContextTimeout(ctx, LoadBalancerPollInterval, GetServiceLoadBalancerCreationTimeout(ctx, cs), true, func(ctx context.Context) (bool, error) {
 		svc, err := cs.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/e2e/framework/ssh/ssh.go
+++ b/test/e2e/framework/ssh/ssh.go
@@ -422,15 +422,14 @@ func nodeAddresses(nodelist *v1.NodeList, addrType v1.NodeAddressType) []string 
 func waitListSchedulableNodes(ctx context.Context, c clientset.Interface) (*v1.NodeList, error) {
 	var nodes *v1.NodeList
 	var err error
-	if wait.PollImmediateWithContext(ctx, pollNodeInterval, singleCallTimeout, func(ctx context.Context) (bool, error) {
-		nodes, err = c.CoreV1().Nodes().List(ctx, metav1.ListOptions{FieldSelector: fields.Set{
-			"spec.unschedulable": "false",
-		}.AsSelector().String()})
+	if wait.PollUntilContextTimeout(ctx, pollNodeInterval, singleCallTimeout, true, func(ctx context.Context) (bool, error) {
+		nodes, err = c.CoreV1().Nodes().List(ctx, metav1.ListOptions{FieldSelector: fields.Set{"spec.unschedulable": "false"}.AsSelector().String()})
 		if err != nil {
 			return false, err
 		}
 		return true, nil
-	}) != nil {
+	}) !=
+		nil {
 		return nodes, err
 	}
 	return nodes, nil

--- a/test/e2e/instrumentation/core_events.go
+++ b/test/e2e/instrumentation/core_events.go
@@ -216,7 +216,7 @@ var _ = common.SIGDescribe("Events", func() {
 
 		ginkgo.By("check that the list of events matches the requested quantity")
 
-		err = wait.PollImmediateWithContext(ctx, eventRetryPeriod, eventRetryTimeout, checkEventListQuantity(f, "testevent-set=true", 0))
+		err = wait.PollUntilContextTimeout(ctx, eventRetryPeriod, eventRetryTimeout, true, checkEventListQuantity(f, "testevent-set=true", 0))
 		framework.ExpectNoError(err, "failed to count required events")
 	})
 

--- a/test/e2e/instrumentation/monitoring/accelerator.go
+++ b/test/e2e/instrumentation/monitoring/accelerator.go
@@ -112,8 +112,8 @@ func testStackdriverAcceleratorMonitoring(ctx context.Context, f *framework.Fram
 	framework.ExpectNoError(err)
 }
 
-func checkForAcceleratorMetrics(projectID string, gcmService *gcm.Service, start time.Time, metricsMap map[string]bool) func() (bool, error) {
-	return func() (bool, error) {
+func checkForAcceleratorMetrics(projectID string, gcmService *gcm.Service, start time.Time, metricsMap map[string]bool) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
 		counter := 0
 		for _, metric := range acceleratorMetrics {
 			metricsMap[metric] = false

--- a/test/e2e/instrumentation/monitoring/accelerator.go
+++ b/test/e2e/instrumentation/monitoring/accelerator.go
@@ -105,7 +105,7 @@ func testStackdriverAcceleratorMonitoring(ctx context.Context, f *framework.Fram
 
 	metricsMap := map[string]bool{}
 	pollingFunction := checkForAcceleratorMetrics(projectID, gcmService, time.Now(), metricsMap)
-	err = wait.Poll(pollFrequency, pollTimeout, pollingFunction)
+	err = wait.PollUntilContextTimeout(context.Background(), pollFrequency, pollTimeout, false, pollingFunction)
 	if err != nil {
 		framework.Logf("Missing metrics: %+v", metricsMap)
 	}

--- a/test/e2e/instrumentation/monitoring/stackdriver.go
+++ b/test/e2e/instrumentation/monitoring/stackdriver.go
@@ -118,8 +118,8 @@ func testStackdriverMonitoring(ctx context.Context, f *framework.Framework, pods
 	framework.ExpectNoError(err)
 }
 
-func checkForMetrics(projectID string, gcmService *gcm.Service, start time.Time, metricsMap map[string]bool, cpuUsed int, cpuLimit int64) func() (bool, error) {
-	return func() (bool, error) {
+func checkForMetrics(projectID string, gcmService *gcm.Service, start time.Time, metricsMap map[string]bool, cpuUsed int, cpuLimit int64) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
 		counter := 0
 		correctUtilization := false
 		for _, metric := range stackdriverMetrics {

--- a/test/e2e/instrumentation/monitoring/stackdriver.go
+++ b/test/e2e/instrumentation/monitoring/stackdriver.go
@@ -111,7 +111,7 @@ func testStackdriverMonitoring(ctx context.Context, f *framework.Framework, pods
 
 	metricsMap := map[string]bool{}
 	pollingFunction := checkForMetrics(projectID, gcmService, time.Now(), metricsMap, allPodsCPU, perPodCPU)
-	err = wait.Poll(pollFrequency, pollTimeout, pollingFunction)
+	err = wait.PollUntilContextTimeout(context.Background(), pollFrequency, pollTimeout, false, pollingFunction)
 	if err != nil {
 		framework.Logf("Missing metrics: %+v\n", metricsMap)
 	}

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -204,7 +204,7 @@ func cleanupKubectlInputs(fileContents string, ns string, selectors ...string) {
 // assertCleanup asserts that cleanup of a namespace wrt selectors occurred.
 func assertCleanup(ns string, selectors ...string) {
 	var e error
-	verifyCleanupFunc := func() (bool, error) {
+	verifyCleanupFunc := func(ctx context.Context) (bool, error) {
 		e = nil
 		for _, selector := range selectors {
 			resources := e2ekubectl.RunKubectlOrDie(ns, "get", "rc,svc", "-l", selector, "--no-headers")

--- a/test/e2e/lifecycle/bootstrap/util.go
+++ b/test/e2e/lifecycle/bootstrap/util.go
@@ -87,7 +87,7 @@ func TimeStringFromNow(delta time.Duration) string {
 // WaitforSignedClusterInfoByBootStrapToken waits for signed cluster info by bootstrap token.
 func WaitforSignedClusterInfoByBootStrapToken(c clientset.Interface, tokenID string) error {
 
-	return wait.Poll(framework.Poll, 2*time.Minute, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), framework.Poll, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
 		cfgMap, err := c.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(context.TODO(), bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
 		if err != nil {
 			framework.Failf("Failed to get cluster-info configMap: %v", err)
@@ -99,12 +99,13 @@ func WaitforSignedClusterInfoByBootStrapToken(c clientset.Interface, tokenID str
 		}
 		return true, nil
 	})
+
 }
 
 // WaitForSignedClusterInfoGetUpdatedByBootstrapToken waits for signed cluster info to be updated by bootstrap token.
 func WaitForSignedClusterInfoGetUpdatedByBootstrapToken(c clientset.Interface, tokenID string, signedToken string) error {
 
-	return wait.Poll(framework.Poll, 2*time.Minute, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), framework.Poll, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
 		cfgMap, err := c.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(context.TODO(), bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
 		if err != nil {
 			framework.Failf("Failed to get cluster-info configMap: %v", err)
@@ -116,12 +117,13 @@ func WaitForSignedClusterInfoGetUpdatedByBootstrapToken(c clientset.Interface, t
 		}
 		return true, nil
 	})
+
 }
 
 // WaitForSignedClusterInfoByBootstrapTokenToDisappear waits for signed cluster info to be disappeared by bootstrap token.
 func WaitForSignedClusterInfoByBootstrapTokenToDisappear(c clientset.Interface, tokenID string) error {
 
-	return wait.Poll(framework.Poll, 2*time.Minute, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), framework.Poll, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
 		cfgMap, err := c.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(context.TODO(), bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
 		if err != nil {
 			framework.Failf("Failed to get cluster-info configMap: %v", err)
@@ -133,23 +135,25 @@ func WaitForSignedClusterInfoByBootstrapTokenToDisappear(c clientset.Interface, 
 		}
 		return true, nil
 	})
+
 }
 
 // WaitForBootstrapTokenSecretToDisappear waits for bootstrap token secret to be disappeared.
 func WaitForBootstrapTokenSecretToDisappear(c clientset.Interface, tokenID string) error {
 
-	return wait.Poll(framework.Poll, 1*time.Minute, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), framework.Poll, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := c.CoreV1().Secrets(metav1.NamespaceSystem).Get(context.TODO(), bootstrapapi.BootstrapTokenSecretPrefix+tokenID, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
 		return false, nil
 	})
+
 }
 
 // WaitForBootstrapTokenSecretNotDisappear waits for bootstrap token secret not to be disappeared and takes time for the specified timeout as success path.
 func WaitForBootstrapTokenSecretNotDisappear(c clientset.Interface, tokenID string, t time.Duration) error {
-	err := wait.Poll(framework.Poll, t, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), framework.Poll, t, false, func(ctx context.Context) (bool, error) {
 		secret, err := c.CoreV1().Secrets(metav1.NamespaceSystem).Get(context.TODO(), bootstrapapi.BootstrapTokenSecretPrefix+tokenID, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, errors.New("secret not exists")
@@ -159,7 +163,8 @@ func WaitForBootstrapTokenSecretNotDisappear(c clientset.Interface, tokenID stri
 		}
 		return true, err
 	})
-	if err == wait.ErrWaitTimeout {
+
+	if wait.Interrupted(err) {
 		return nil
 	}
 	return err

--- a/test/e2e/network/conntrack.go
+++ b/test/e2e/network/conntrack.go
@@ -173,7 +173,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		// 30 seconds by default.
 		// Based on the above check if the pod receives the traffic.
 		ginkgo.By("checking client pod connected to the backend 1 on Node IP " + serverNodeInfo.nodeIP)
-		if err := wait.PollImmediateWithContext(ctx, 5*time.Second, time.Minute, logContainsFn(podBackend1, podClient)); err != nil {
+		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn(podBackend1, podClient)); err != nil {
 			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
 			framework.Logf("Pod client logs: %s", logs)
@@ -197,7 +197,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		// Check that the second pod keeps receiving traffic
 		// UDP conntrack entries timeout is 30 sec by default
 		ginkgo.By("checking client pod connected to the backend 2 on Node IP " + serverNodeInfo.nodeIP)
-		if err := wait.PollImmediateWithContext(ctx, 5*time.Second, time.Minute, logContainsFn(podBackend2, podClient)); err != nil {
+		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn(podBackend2, podClient)); err != nil {
 			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
 			framework.Logf("Pod client logs: %s", logs)
@@ -249,7 +249,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		// 30 seconds by default.
 		// Based on the above check if the pod receives the traffic.
 		ginkgo.By("checking client pod connected to the backend 1 on Node IP " + serverNodeInfo.nodeIP)
-		if err := wait.PollImmediateWithContext(ctx, 5*time.Second, time.Minute, logContainsFn(podBackend1, podClient)); err != nil {
+		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn(podBackend1, podClient)); err != nil {
 			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
 			framework.Logf("Pod client logs: %s", logs)
@@ -273,7 +273,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		// Check that the second pod keeps receiving traffic
 		// UDP conntrack entries timeout is 30 sec by default
 		ginkgo.By("checking client pod connected to the backend 2 on Node IP " + serverNodeInfo.nodeIP)
-		if err := wait.PollImmediateWithContext(ctx, 5*time.Second, time.Minute, logContainsFn(podBackend2, podClient)); err != nil {
+		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn(podBackend2, podClient)); err != nil {
 			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
 			framework.Logf("Pod client logs: %s", logs)
@@ -345,7 +345,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		// 30 seconds by default.
 		// Based on the above check if the pod receives the traffic.
 		ginkgo.By("checking client pod connected to the backend on Node IP " + serverNodeInfo.nodeIP)
-		if err := wait.PollImmediateWithContext(ctx, 5*time.Second, time.Minute, logContainsFn(podBackend1, podClient)); err != nil {
+		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn(podBackend1, podClient)); err != nil {
 			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
 			framework.Logf("Pod client logs: %s", logs)
@@ -462,7 +462,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		// so the client will receive an unexpected TCP connection and RST the connection
 		// the server will log ERROR if that happens
 		ginkgo.By("checking client pod does not RST the TCP connection because it receives an INVALID packet")
-		if err := wait.PollImmediateWithContext(ctx, 5*time.Second, time.Minute, logContainsFn("ERROR", "boom-server")); err == nil {
+		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn("ERROR", "boom-server")); err == nil {
 			logs, err := e2epod.GetPodLogs(ctx, cs, ns, "boom-server", "boom-server")
 			framework.ExpectNoError(err)
 			framework.Logf("boom-server pod logs: %s", logs)

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -532,7 +532,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		// - Custom search path is appended.
 		// - DNS query is sent to the specified server.
 		cmd = []string{"dig", "+short", "+search", testDNSNameShort}
-		digFunc := func() (bool, error) {
+		digFunc := func(ctx context.Context) (bool, error) {
 			stdout, stderr, err := e2epod.ExecWithOptions(f, e2epod.ExecOptions{
 				Command:       cmd,
 				Namespace:     f.Namespace.Name,
@@ -552,7 +552,7 @@ var _ = common.SIGDescribe("DNS", func() {
 			}
 			return true, nil
 		}
-		err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 3*time.Minute, true, digFunc)
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, digFunc)
 		framework.ExpectNoError(err, "failed to verify customized name server and search path")
 
 		// TODO: Add more test cases for other DNSPolicies.

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -552,7 +552,7 @@ var _ = common.SIGDescribe("DNS", func() {
 			}
 			return true, nil
 		}
-		err = wait.PollImmediate(5*time.Second, 3*time.Minute, digFunc)
+		err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 3*time.Minute, true, digFunc)
 		framework.ExpectNoError(err, "failed to verify customized name server and search path")
 
 		// TODO: Add more test cases for other DNSPolicies.

--- a/test/e2e/network/dual_stack.go
+++ b/test/e2e/network/dual_stack.go
@@ -235,7 +235,7 @@ var _ = common.SIGDescribe("[Feature:IPv6DualStack]", func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoint belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
@@ -281,7 +281,7 @@ var _ = common.SIGDescribe("[Feature:IPv6DualStack]", func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
@@ -326,7 +326,7 @@ var _ = common.SIGDescribe("[Feature:IPv6DualStack]", func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
@@ -371,7 +371,7 @@ var _ = common.SIGDescribe("[Feature:IPv6DualStack]", func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
@@ -416,7 +416,7 @@ var _ = common.SIGDescribe("[Feature:IPv6DualStack]", func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil

--- a/test/e2e/network/endpointslice.go
+++ b/test/e2e/network/endpointslice.go
@@ -119,7 +119,7 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 		})
 
 		// Expect Endpoints resource to be created.
-		if err := wait.PollImmediate(2*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			_, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
@@ -131,7 +131,7 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 
 		// Expect EndpointSlice resource to be created.
 		var endpointSlice discoveryv1.EndpointSlice
-		if err := wait.PollImmediate(2*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			endpointSliceList, err := cs.DiscoveryV1().EndpointSlices(svc.Namespace).List(ctx, metav1.ListOptions{
 				LabelSelector: "kubernetes.io/service-name=" + svc.Name,
 			})
@@ -163,7 +163,7 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 		framework.ExpectNoError(err, "error deleting Service")
 
 		// Expect Endpoints resource to be deleted when Service is.
-		if err := wait.PollImmediate(2*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			_, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				if apierrors.IsNotFound(err) {
@@ -180,7 +180,7 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 		// up to 90 seconds since garbage collector only polls every 30 seconds
 		// and may need to retry informer resync at some point during an e2e
 		// run.
-		if err := wait.PollImmediate(2*time.Second, 90*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 90*time.Second, true, func(ctx context.Context) (bool, error) {
 			endpointSliceList, err := cs.DiscoveryV1().EndpointSlices(svc.Namespace).List(ctx, metav1.ListOptions{
 				LabelSelector: "kubernetes.io/service-name=" + svc.Name,
 			})
@@ -306,7 +306,7 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 			},
 		})
 
-		err := wait.Poll(5*time.Second, 3*time.Minute, func() (bool, error) {
+		err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 3*time.Minute, false, func(ctx context.Context) (bool, error) {
 			var err error
 			pod1, err = podClient.Get(ctx, pod1.Name, metav1.GetOptions{})
 			if err != nil {
@@ -326,6 +326,7 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 
 			return true, nil
 		})
+
 		framework.ExpectNoError(err, "timed out waiting for Pods to have IPs assigned")
 
 		ginkgo.By("referencing a single matching pod")
@@ -739,7 +740,7 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 // the only caller of this function.
 func expectEndpointsAndSlices(ctx context.Context, cs clientset.Interface, ns string, svc *v1.Service, pods []*v1.Pod, numSubsets, numSlices int, namedPort bool) {
 	endpointSlices := []discoveryv1.EndpointSlice{}
-	if err := wait.PollImmediateWithContext(ctx, 5*time.Second, 2*time.Minute, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		endpointSlicesFound, hasMatchingSlices := hasMatchingEndpointSlices(ctx, cs, ns, svc.Name, len(pods), numSlices)
 		if !hasMatchingSlices {
 			return false, nil

--- a/test/e2e/network/endpointslicemirroring.go
+++ b/test/e2e/network/endpointslicemirroring.go
@@ -84,7 +84,7 @@ var _ = common.SIGDescribe("EndpointSliceMirroring", func() {
 			_, err := cs.CoreV1().Endpoints(f.Namespace.Name).Create(ctx, endpoints, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "Unexpected error creating Endpoints")
 
-			if err := wait.PollImmediate(2*time.Second, 12*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 12*time.Second, true, func(ctx context.Context) (bool, error) {
 				esList, err := cs.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(ctx, metav1.ListOptions{
 					LabelSelector: discoveryv1.LabelServiceName + "=" + svc.Name,
 				})
@@ -136,7 +136,7 @@ var _ = common.SIGDescribe("EndpointSliceMirroring", func() {
 			framework.ExpectNoError(err, "Unexpected error updating Endpoints")
 
 			// Expect mirrored EndpointSlice resource to be updated.
-			if err := wait.PollImmediate(2*time.Second, 12*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 12*time.Second, true, func(ctx context.Context) (bool, error) {
 				esList, err := cs.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(ctx, metav1.ListOptions{
 					LabelSelector: discoveryv1.LabelServiceName + "=" + svc.Name,
 				})
@@ -183,7 +183,7 @@ var _ = common.SIGDescribe("EndpointSliceMirroring", func() {
 			framework.ExpectNoError(err, "Unexpected error deleting Endpoints")
 
 			// Expect mirrored EndpointSlice resource to be updated.
-			if err := wait.PollImmediate(2*time.Second, 12*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 12*time.Second, true, func(ctx context.Context) (bool, error) {
 				esList, err := cs.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(ctx, metav1.ListOptions{
 					LabelSelector: discoveryv1.LabelServiceName + "=" + svc.Name,
 				})
@@ -281,7 +281,7 @@ var _ = common.SIGDescribe("EndpointSliceMirroring", func() {
 			_, err := cs.CoreV1().Endpoints(f.Namespace.Name).Create(context.TODO(), endpoints, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "Unexpected error creating Endpoints")
 
-			if err := wait.PollImmediate(2*time.Second, 12*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 12*time.Second, true, func(ctx context.Context) (bool, error) {
 				esList, err := cs.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{
 					LabelSelector: discoveryv1.LabelServiceName + "=" + svc.Name,
 				})
@@ -314,7 +314,7 @@ var _ = common.SIGDescribe("EndpointSliceMirroring", func() {
 			framework.ExpectNoError(err, "Unexpected error deleting Endpoints")
 
 			// Expect mirrored EndpointSlice resource to be updated.
-			if err := wait.PollImmediate(2*time.Second, 12*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 12*time.Second, true, func(ctx context.Context) (bool, error) {
 				esList, err := cs.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{
 					LabelSelector: discoveryv1.LabelServiceName + "=" + svc.Name,
 				})

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -255,7 +255,7 @@ func testHitNodesFromOutsideWithCount(externalIP string, httpPort int32, timeout
 	framework.Logf("Waiting up to %v for satisfying expectedHosts for %v times", timeout, countToSucceed)
 	hittedHosts := sets.NewString()
 	count := 0
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		result := e2enetwork.PokeHTTP(externalIP, int(httpPort), "/hostname", &e2enetwork.HTTPPokeParams{Timeout: 1 * time.Second})
 		if result.Status != e2enetwork.HTTPSuccess {
 			return false, nil

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -280,7 +280,7 @@ func testHitNodesFromOutsideWithCount(externalIP string, httpPort int32, timeout
 		return false, nil
 	}
 
-	if err := wait.Poll(time.Second, timeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Second, timeout, false, condition); err != nil {
 		return fmt.Errorf("error waiting for expectedHosts: %v, hittedHosts: %v, count: %v, expected count: %v",
 			expectedHosts, hittedHosts, count, countToSucceed)
 	}

--- a/test/e2e/network/funny_ips.go
+++ b/test/e2e/network/funny_ips.go
@@ -117,7 +117,7 @@ var _ = common.SIGDescribe("CVE-2021-29923", func() {
 		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
 		ip := netutils.ParseIPSloppy(clusterIPZero)
 		cmd := fmt.Sprintf("echo hostName | nc -v -t -w 2 %s %v", ip.String(), servicePort)
-		err = wait.PollImmediate(1*time.Second, e2eservice.ServiceReachabilityShortPollTimeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, e2eservice.ServiceReachabilityShortPollTimeout, true, func(ctx context.Context) (bool, error) {
 			stdout, err := e2eoutput.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
 			if err != nil {
 				framework.Logf("Service reachability failing with error: %v\nRetrying...", err)
@@ -129,6 +129,7 @@ var _ = common.SIGDescribe("CVE-2021-29923", func() {
 			}
 			return false, nil
 		})
+
 		// Service is working on the expected IP.
 		if err == nil {
 			return
@@ -136,7 +137,7 @@ var _ = common.SIGDescribe("CVE-2021-29923", func() {
 		// It may happen that the component implementing Services discard the IP.
 		// We have to check that the Service is not reachable in the address interpreted as decimal.
 		cmd = fmt.Sprintf("echo hostName | nc -v -t -w 2 %s %v", clusterIPOctal, servicePort)
-		err = wait.PollImmediate(1*time.Second, e2eservice.ServiceReachabilityShortPollTimeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, e2eservice.ServiceReachabilityShortPollTimeout, true, func(ctx context.Context) (bool, error) {
 			stdout, err := e2eoutput.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
 			if err != nil {
 				framework.Logf("Service reachability failing with error: %v\nRetrying...", err)
@@ -148,6 +149,7 @@ var _ = common.SIGDescribe("CVE-2021-29923", func() {
 			}
 			return false, nil
 		})
+
 		// Ouch, Service has worked on IP interpreted as octal.
 		if err == nil {
 			framework.Failf("WARNING: Your Cluster interprets Service ClusterIP %s as %s, please see https://nvd.nist.gov/vuln/detail/CVE-2021-29923", clusterIPZero, clusterIPOctal)

--- a/test/e2e/network/ingressclass.go
+++ b/test/e2e/network/ingressclass.go
@@ -134,7 +134,7 @@ var _ = common.SIGDescribe("IngressClass [Feature:Ingress]", func() {
 		defer cancel()
 
 		// the admission controller may take a few seconds to observe both ingress classes
-		if err := wait.Poll(time.Second, time.Minute, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
 			classes, err := cs.NetworkingV1().IngressClasses().List(ctx, metav1.ListOptions{})
 			if err != nil {
 				return false, nil

--- a/test/e2e/network/ingressclass.go
+++ b/test/e2e/network/ingressclass.go
@@ -92,7 +92,7 @@ var _ = common.SIGDescribe("IngressClass [Feature:Ingress]", func() {
 		lastFailure := ""
 
 		// the admission controller may take a few seconds to observe the ingress classes
-		if err := wait.PollWithContext(ctx, time.Second, time.Minute, func(ctx context.Context) (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
 			lastFailure = ""
 
 			ingress, err := createBasicIngress(ctx, cs, f.Namespace.Name)
@@ -134,7 +134,7 @@ var _ = common.SIGDescribe("IngressClass [Feature:Ingress]", func() {
 		defer cancel()
 
 		// the admission controller may take a few seconds to observe both ingress classes
-		if err := wait.PollUntilContextTimeout(context.Background(), time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
 			classes, err := cs.NetworkingV1().IngressClasses().List(ctx, metav1.ListOptions{})
 			if err != nil {
 				return false, nil

--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -218,7 +218,7 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 		cmd := fmt.Sprintf("conntrack -L -f %s -d %v "+
 			"| grep -m 1 'CLOSE_WAIT.*dport=%v' ",
 			ipFamily, ip, testDaemonTCPPort)
-		if err := wait.PollImmediate(2*time.Second, epsilonSeconds*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, epsilonSeconds*time.Second, true, func(ctx context.Context) (bool, error) {
 			result, err := e2eoutput.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", cmd)
 			// retry if we can't obtain the conntrack entry
 			if err != nil {

--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -665,7 +665,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 
 		framework.Logf("Waiting up to %v for service %q's internal LB to respond to requests", createTimeout, serviceName)
 		tcpIngressIP := e2eservice.GetIngressPoint(lbIngress)
-		if pollErr := wait.PollImmediate(pollInterval, createTimeout, func() (bool, error) {
+		if pollErr := wait.PollUntilContextTimeout(context.Background(), pollInterval, createTimeout, true, func(ctx context.Context) (bool, error) {
 			cmd := fmt.Sprintf(`curl -m 5 'http://%v:%v/echo?msg=hello'`, tcpIngressIP, svcPort)
 			stdout, err := e2eoutput.RunHostCmd(hostExec.Namespace, hostExec.Name, cmd)
 			if err != nil {
@@ -690,7 +690,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 		})
 		framework.ExpectNoError(err)
 		framework.Logf("Waiting up to %v for service %q to have an external LoadBalancer", createTimeout, serviceName)
-		if pollErr := wait.PollImmediate(pollInterval, createTimeout, func() (bool, error) {
+		if pollErr := wait.PollUntilContextTimeout(context.Background(), pollInterval, createTimeout, true, func(ctx context.Context) (bool, error) {
 			svc, err := cs.CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
@@ -724,7 +724,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 			})
 			framework.ExpectNoError(err)
 			framework.Logf("Waiting up to %v for service %q to have an internal LoadBalancer", createTimeout, serviceName)
-			if pollErr := wait.PollImmediate(pollInterval, createTimeout, func() (bool, error) {
+			if pollErr := wait.PollUntilContextTimeout(context.Background(), pollInterval, createTimeout, true, func(ctx context.Context) (bool, error) {
 				svc, err := cs.CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{})
 				if err != nil {
 					return false, err
@@ -801,7 +801,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 		ginkgo.By("health check should be reconciled")
 		pollInterval := framework.Poll * 10
 		loadBalancerPropagationTimeout := e2eservice.GetServiceLoadBalancerPropagationTimeout(ctx, cs)
-		if pollErr := wait.PollImmediate(pollInterval, loadBalancerPropagationTimeout, func() (bool, error) {
+		if pollErr := wait.PollUntilContextTimeout(context.Background(), pollInterval, loadBalancerPropagationTimeout, true, func(ctx context.Context) (bool, error) {
 			hc, err := gceCloud.GetHTTPHealthCheck(hcName)
 			if err != nil {
 				framework.Logf("ginkgo.Failed to get HttpHealthCheck(%q): %v", hcName, err)
@@ -1113,7 +1113,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 		// 30 seconds by default.
 		// Based on the above check if the pod receives the traffic.
 		ginkgo.By("checking client pod connected to the backend 1 on Node " + nodes.Items[0].Name)
-		if err := wait.PollImmediate(1*time.Second, loadBalancerLagTimeout, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, loadBalancerLagTimeout, true, func(ctx context.Context) (bool, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			return hostnames.Has(serverPod1.Spec.Hostname), nil
@@ -1139,7 +1139,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 		// Check that the second pod keeps receiving traffic
 		// UDP conntrack entries timeout is 30 sec by default
 		ginkgo.By("checking client pod connected to the backend 2 on Node " + nodes.Items[1].Name)
-		if err := wait.PollImmediate(1*time.Second, loadBalancerLagTimeout, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, loadBalancerLagTimeout, true, func(ctx context.Context) (bool, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			return hostnames.Has(serverPod2.Spec.Hostname), nil
@@ -1245,7 +1245,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 		// 30 seconds by default.
 		// Based on the above check if the pod receives the traffic.
 		ginkgo.By("checking client pod connected to the backend 1 on Node " + nodes.Items[0].Name)
-		if err := wait.PollImmediate(1*time.Second, loadBalancerLagTimeout, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, loadBalancerLagTimeout, true, func(ctx context.Context) (bool, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			return hostnames.Has(serverPod1.Spec.Hostname), nil
@@ -1271,7 +1271,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 		// Check that the second pod keeps receiving traffic
 		// UDP conntrack entries timeout is 30 sec by default
 		ginkgo.By("checking client pod connected to the backend 2 on Node " + nodes.Items[0].Name)
-		if err := wait.PollImmediate(1*time.Second, loadBalancerLagTimeout, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, loadBalancerLagTimeout, true, func(ctx context.Context) (bool, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			return hostnames.Has(serverPod2.Spec.Hostname), nil
@@ -1534,7 +1534,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 		var srcIP string
 		loadBalancerPropagationTimeout := e2eservice.GetServiceLoadBalancerPropagationTimeout(ctx, cs)
 		ginkgo.By(fmt.Sprintf("Hitting external lb %v from pod %v on node %v", ingressIP, pausePod.Name, pausePod.Spec.NodeName))
-		if pollErr := wait.PollImmediate(framework.Poll, loadBalancerPropagationTimeout, func() (bool, error) {
+		if pollErr := wait.PollUntilContextTimeout(context.Background(), framework.Poll, loadBalancerPropagationTimeout, true, func(ctx context.Context) (bool, error) {
 			stdout, err := e2eoutput.RunHostCmd(pausePod.Namespace, pausePod.Name, cmd)
 			if err != nil {
 				framework.Logf("got err: %v, retry until timeout", err)
@@ -1641,7 +1641,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 				}
 				return false, nil
 			}
-			if pollErr := wait.PollImmediate(framework.Poll, e2eservice.TestTimeout, pollFn); pollErr != nil {
+			if pollErr := wait.PollUntilContextTimeout(context.Background(), framework.Poll, e2eservice.TestTimeout, true, pollFn); pollErr != nil {
 				framework.Failf("Kube-proxy still exposing health check on node %v:%v, after ESIPP was turned off. body %s",
 					nodeName, healthCheckNodePort, body)
 			}
@@ -1650,7 +1650,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 		// Poll till kube-proxy re-adds the MASQUERADE rule on the node.
 		ginkgo.By(fmt.Sprintf("checking source ip is NOT preserved through loadbalancer %v", ingressIP))
 		var clientIP string
-		pollErr := wait.PollImmediate(framework.Poll, 3*e2eservice.KubeProxyLagTimeout, func() (bool, error) {
+		pollErr := wait.PollUntilContextTimeout(context.Background(), framework.Poll, 3*e2eservice.KubeProxyLagTimeout, true, func(ctx context.Context) (bool, error) {
 			clientIPPort, err := GetHTTPContent(ingressIP, svcTCPPort, e2eservice.KubeProxyLagTimeout, path)
 			if err != nil {
 				return false, nil
@@ -1671,6 +1671,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 			}
 			return false, nil
 		})
+
 		if pollErr != nil {
 			framework.Failf("Source IP WAS preserved even after ESIPP turned off. Got %v, expected a ten-dot cluster ip.", clientIP)
 		}
@@ -1689,7 +1690,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 		})
 		framework.ExpectNoError(err)
 		loadBalancerPropagationTimeout := e2eservice.GetServiceLoadBalancerPropagationTimeout(ctx, cs)
-		pollErr = wait.PollImmediate(framework.PollShortTimeout, loadBalancerPropagationTimeout, func() (bool, error) {
+		pollErr = wait.PollUntilContextTimeout(context.Background(), framework.PollShortTimeout, loadBalancerPropagationTimeout, true, func(ctx context.Context) (bool, error) {
 			clientIPPort, err := GetHTTPContent(ingressIP, svcTCPPort, e2eservice.KubeProxyLagTimeout, path)
 			if err != nil {
 				return false, nil
@@ -1711,6 +1712,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 			}
 			return false, nil
 		})
+
 		if pollErr != nil {
 			framework.Failf("Source IP (%v) is not the client IP even after ESIPP turned on, expected a public IP.", clientIP)
 		}
@@ -1751,7 +1753,7 @@ func testRollingUpdateLBConnectivityDisruption(ctx context.Context, f *framework
 
 	ginkgo.By("Checking that daemon pods launch on every schedulable node of the cluster")
 	creationTimeout := e2eservice.GetServiceLoadBalancerCreationTimeout(ctx, cs)
-	err = wait.PollImmediateWithContext(ctx, framework.Poll, creationTimeout, e2edaemonset.CheckDaemonPodOnNodes(f, ds, nodeNames))
+	err = wait.PollUntilContextTimeout(ctx, framework.Poll, creationTimeout, true, e2edaemonset.CheckDaemonPodOnNodes(f, ds, nodeNames))
 	framework.ExpectNoError(err, "error waiting for daemon pods to start")
 	err = e2edaemonset.CheckDaemonStatus(ctx, f, name)
 	framework.ExpectNoError(err)
@@ -1831,7 +1833,7 @@ func testRollingUpdateLBConnectivityDisruption(ctx context.Context, f *framework
 		framework.ExpectNoError(err)
 
 		framework.Logf("Check that daemon pods are available on every node of the cluster with the updated environment.")
-		err = wait.PollImmediate(framework.Poll, creationTimeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), framework.Poll, creationTimeout, true, func(ctx context.Context) (bool, error) {
 			podList, err := cs.CoreV1().Pods(ds.Namespace).List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				return false, err
@@ -1865,6 +1867,7 @@ func testRollingUpdateLBConnectivityDisruption(ctx context.Context, f *framework
 			framework.Logf("Number of running nodes: %d, number of updated ready pods: %d in daemonset %s", len(nodeNames), readyPods, ds.Name)
 			return readyPods == len(nodeNames), nil
 		})
+
 		framework.ExpectNoError(err, "error waiting for daemon pods to be ready")
 
 		// assert that the HTTP requests success rate is above the acceptable threshold after this rolling update

--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -1623,7 +1623,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 		for nodeName, nodeIP := range endpointNodeMap {
 			ginkgo.By(fmt.Sprintf("checking kube-proxy health check fails on node with endpoint (%s), public IP %s", nodeName, nodeIP))
 			var body string
-			pollFn := func() (bool, error) {
+			pollFn := func(ctx context.Context) (bool, error) {
 				// we expect connection failure here, but not other errors
 				resp, err := config.GetResponseFromTestContainer(ctx,
 					"http",
@@ -1641,7 +1641,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 				}
 				return false, nil
 			}
-			if pollErr := wait.PollUntilContextTimeout(context.Background(), framework.Poll, e2eservice.TestTimeout, true, pollFn); pollErr != nil {
+			if pollErr := wait.PollUntilContextTimeout(ctx, framework.Poll, e2eservice.TestTimeout, true, pollFn); pollErr != nil {
 				framework.Failf("Kube-proxy still exposing health check on node %v:%v, after ESIPP was turned off. body %s",
 					nodeName, healthCheckNodePort, body)
 			}

--- a/test/e2e/network/netpol/kubemanager.go
+++ b/test/e2e/network/netpol/kubemanager.go
@@ -190,7 +190,7 @@ func (k *kubeManager) probeConnectivity(args *probeConnectivityArgs) (bool, stri
 	// Instead of re-running the job on connectivity failure, the following conditionFunc when passed to PollImmediate, reruns
 	// the job when the observed value don't match the expected value, so we don't rely on return value of PollImmediate, we
 	// simply discard it and use probeError, defined outside scope of conditionFunc, for returning the result of probeConnectivity.
-	conditionFunc := func() (bool, error) {
+	conditionFunc := func(_ context.Context) (bool, error) {
 		_, stderr, probeError = k.executeRemoteCommand(args.nsFrom, args.podFrom, args.containerFrom, cmd)
 		// retry should only occur if expected and observed value don't match.
 		if args.expectConnectivity {

--- a/test/e2e/network/netpol/kubemanager.go
+++ b/test/e2e/network/netpol/kubemanager.go
@@ -19,6 +19,11 @@ package netpol
 import (
 	"context"
 	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,10 +32,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	netutils "k8s.io/utils/net"
-	"net"
-	"strconv"
-	"strings"
-	"time"
 )
 
 // defaultPollIntervalSeconds [seconds] is the default value for which the Prober will wait before attempting next attempt.
@@ -224,11 +225,7 @@ func (k *kubeManager) probeConnectivity(args *probeConnectivityArgs) (bool, stri
 	}
 
 	// ignore the result of PollImmediate, we are only concerned with probeError.
-	_ = wait.PollImmediate(
-		time.Duration(args.pollIntervalSeconds)*time.Second,
-		time.Duration(args.pollTimeoutSeconds)*time.Second,
-		conditionFunc,
-	)
+	_ = wait.PollUntilContextTimeout(context.Background(), time.Duration(args.pollIntervalSeconds)*time.Second, time.Duration(args.pollTimeoutSeconds)*time.Second, true, conditionFunc)
 
 	if probeError != nil {
 		return false, commandDebugString, nil

--- a/test/e2e/network/netpol/test_helper.go
+++ b/test/e2e/network/netpol/test_helper.go
@@ -169,7 +169,7 @@ func AddPodLabels(ctx context.Context, k8s *kubeManager, namespace string, name 
 	_, err = k8s.clientSet.CoreV1().Pods(namespace).Update(ctx, kubePod, metav1.UpdateOptions{})
 	framework.ExpectNoError(err, "Unable to add pod %s/%s labels", namespace, name)
 
-	err = wait.PollImmediate(waitInterval, waitTimeout, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), waitInterval, waitTimeout, true, func(ctx context.Context) (done bool, err error) {
 		waitForPod, err := k8s.getPod(ctx, namespace, name)
 		if err != nil {
 			return false, err
@@ -181,6 +181,7 @@ func AddPodLabels(ctx context.Context, k8s *kubeManager, namespace string, name 
 		}
 		return true, nil
 	})
+
 	framework.ExpectNoError(err, "Unable to wait for pod %s/%s to update labels", namespace, name)
 }
 
@@ -195,7 +196,7 @@ func ResetPodLabels(ctx context.Context, k8s *kubeManager, namespace string, nam
 	_, err = k8s.clientSet.CoreV1().Pods(namespace).Update(ctx, kubePod, metav1.UpdateOptions{})
 	framework.ExpectNoError(err, "Unable to add pod %s/%s labels", namespace, name)
 
-	err = wait.PollImmediate(waitInterval, waitTimeout, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), waitInterval, waitTimeout, true, func(ctx context.Context) (done bool, err error) {
 		waitForPod, err := k8s.getPod(ctx, namespace, name)
 		if err != nil {
 			return false, nil
@@ -207,5 +208,6 @@ func ResetPodLabels(ctx context.Context, k8s *kubeManager, namespace string, nam
 		}
 		return true, nil
 	})
+
 	framework.ExpectNoError(err, "Unable to wait for pod %s/%s to update labels", namespace, name)
 }

--- a/test/e2e/network/network_tiers.go
+++ b/test/e2e/network/network_tiers.go
@@ -176,7 +176,7 @@ func waitAndVerifyLBWithTier(ctx context.Context, jig *e2eservice.TestJig, exist
 func getLBNetworkTierByIP(ip string) (cloud.NetworkTier, error) {
 	var rule *compute.ForwardingRule
 	// Retry a few times to tolerate flakes.
-	err := wait.PollImmediate(5*time.Second, 15*time.Second, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 		obj, err := getGCEForwardingRuleByIP(ip)
 		if err != nil {
 			return false, err
@@ -184,6 +184,7 @@ func getLBNetworkTierByIP(ip string) (cloud.NetworkTier, error) {
 		rule = obj
 		return true, nil
 	})
+
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -25,7 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/cluster/ports"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enetwork "k8s.io/kubernetes/test/e2e/framework/network"
@@ -614,7 +614,7 @@ var _ = common.SIGDescribe("Networking", func() {
 		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, f.ClientSet, ns, podNames, svcIP, servicePort))
 
 		ginkgo.By("verifying that kubelet rules are eventually recreated")
-		err = utilwait.PollImmediate(framework.Poll, framework.RestartNodeReadyAgainTimeout, func() (bool, error) {
+		err = wait.PollImmediate(framework.Poll, framework.RestartNodeReadyAgainTimeout, func() (bool, error) {
 			result, err = e2essh.SSH(ctx, "sudo iptables-save -t mangle", host, framework.TestContext.Provider)
 			if err != nil || result.Code != 0 {
 				e2essh.LogResult(result)

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -614,7 +614,7 @@ var _ = common.SIGDescribe("Networking", func() {
 		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, f.ClientSet, ns, podNames, svcIP, servicePort))
 
 		ginkgo.By("verifying that kubelet rules are eventually recreated")
-		err = wait.PollImmediate(framework.Poll, framework.RestartNodeReadyAgainTimeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), framework.Poll, framework.RestartNodeReadyAgainTimeout, true, func(ctx context.Context) (bool, error) {
 			result, err = e2essh.SSH(ctx, "sudo iptables-save -t mangle", host, framework.TestContext.Provider)
 			if err != nil || result.Code != 0 {
 				e2essh.LogResult(result)
@@ -626,6 +626,7 @@ var _ = common.SIGDescribe("Networking", func() {
 			}
 			return false, nil
 		})
+
 		if err != nil {
 			e2essh.LogResult(result)
 		}

--- a/test/e2e/network/networking_perf.go
+++ b/test/e2e/network/networking_perf.go
@@ -169,7 +169,7 @@ var _ = common.SIGDescribe("Networking IPerf2 [Feature:Networking-Performance]",
 
 		// Make sure the server is ready to go
 		framework.Logf("waiting for iperf2 server endpoints")
-		err = wait.Poll(2*time.Second, largeClusterTimeout, func() (done bool, err error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 2*time.Second, largeClusterTimeout, false, func(ctx context.Context) (done bool, err error) {
 			listOptions := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", discoveryv1.LabelServiceName, serverServiceName)}
 			esList, err := f.ClientSet.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(ctx, listOptions)
 			framework.ExpectNoError(err, "Error fetching EndpointSlice for Service %s/%s", f.Namespace.Name, serverServiceName)
@@ -180,6 +180,7 @@ var _ = common.SIGDescribe("Networking IPerf2 [Feature:Networking-Performance]",
 			}
 			return true, nil
 		})
+
 		framework.ExpectNoError(err, "unable to wait for endpoints for the iperf service")
 		framework.Logf("found iperf2 server endpoints")
 
@@ -189,7 +190,7 @@ var _ = common.SIGDescribe("Networking IPerf2 [Feature:Networking-Performance]",
 
 		framework.Logf("waiting for client pods to be running")
 		var clientPodList *v1.PodList
-		err = wait.Poll(2*time.Second, largeClusterTimeout, func() (done bool, err error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 2*time.Second, largeClusterTimeout, false, func(ctx context.Context) (done bool, err error) {
 			clientPodList, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(ctx, clientPodsListOptions)
 			if err != nil {
 				return false, err
@@ -204,6 +205,7 @@ var _ = common.SIGDescribe("Networking IPerf2 [Feature:Networking-Performance]",
 			}
 			return true, nil
 		})
+
 		framework.ExpectNoError(err, "unable to wait for client pods to come up")
 		framework.Logf("all client pods are ready: %d pods", len(clientPodList.Items))
 

--- a/test/e2e/network/no_snat.go
+++ b/test/e2e/network/no_snat.go
@@ -83,7 +83,7 @@ var _ = common.SIGDescribe("NoSNAT [Feature:NoSNAT] [Slow]", func() {
 		}
 
 		ginkgo.By("waiting for all of the no-snat-test pods to be scheduled and running")
-		err = wait.PollImmediate(10*time.Second, 1*time.Minute, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 			pods, err := pc.List(ctx, metav1.ListOptions{LabelSelector: noSNATTestName})
 			if err != nil {
 				return false, err
@@ -98,8 +98,11 @@ var _ = common.SIGDescribe("NoSNAT [Feature:NoSNAT] [Slow]", func() {
 					return false, nil // pod is still pending
 				}
 			}
-			return true, nil // all pods are running
+			return true, nil
 		})
+
+		// all pods are running
+
 		framework.ExpectNoError(err)
 
 		ginkgo.By("sending traffic from each pod to the others and checking that SNAT does not occur")

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -491,8 +491,8 @@ func validateRedirectRequest(client *http.Client, redirectVerb string, urlString
 // validateProxyVerbRequest checks that a http request to a pod
 // or service was valid for any http verb. Requires agnhost image
 // with porter --json-response
-func validateProxyVerbRequest(client *http.Client, urlString string, httpVerb string, msg string) func() (bool, error) {
-	return func() (bool, error) {
+func validateProxyVerbRequest(client *http.Client, urlString string, httpVerb string, msg string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
 		var err error
 
 		request, err := http.NewRequest(httpVerb, urlString, nil)

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -353,7 +353,7 @@ var _ = common.SIGDescribe("Proxy", func() {
 				urlString := strings.TrimRight(f.ClientConfig().Host, "/") + "/api/v1/namespaces/" + ns + "/pods/agnhost/proxy/some/path/with/" + httpVerb
 				framework.Logf("Starting http.Client for %s", urlString)
 
-				pollErr := wait.PollImmediate(requestRetryPeriod, requestRetryTimeout, validateProxyVerbRequest(client, urlString, httpVerb, msg))
+				pollErr := wait.PollUntilContextTimeout(context.Background(), requestRetryPeriod, requestRetryTimeout, true, validateProxyVerbRequest(client, urlString, httpVerb, msg))
 				framework.ExpectNoError(err, "Service didn't start within time out period. %v", pollErr)
 			}
 
@@ -364,7 +364,7 @@ var _ = common.SIGDescribe("Proxy", func() {
 				urlString := strings.TrimRight(f.ClientConfig().Host, "/") + "/api/v1/namespaces/" + ns + "/services/test-service/proxy/some/path/with/" + httpVerb
 				framework.Logf("Starting http.Client for %s", urlString)
 
-				pollErr := wait.PollImmediate(requestRetryPeriod, requestRetryTimeout, validateProxyVerbRequest(client, urlString, httpVerb, msg))
+				pollErr := wait.PollUntilContextTimeout(context.Background(), requestRetryPeriod, requestRetryTimeout, true, validateProxyVerbRequest(client, urlString, httpVerb, msg))
 				framework.ExpectNoError(err, "Service didn't start within time out period. %v", pollErr)
 			}
 		})
@@ -447,7 +447,7 @@ var _ = common.SIGDescribe("Proxy", func() {
 				urlString := strings.TrimRight(f.ClientConfig().Host, "/") + "/api/v1/namespaces/" + ns + "/pods/agnhost/proxy?method=" + httpVerb
 				framework.Logf("Starting http.Client for %s", urlString)
 
-				pollErr := wait.PollImmediate(requestRetryPeriod, requestRetryTimeout, validateProxyVerbRequest(client, urlString, httpVerb, msg))
+				pollErr := wait.PollUntilContextTimeout(context.Background(), requestRetryPeriod, requestRetryTimeout, true, validateProxyVerbRequest(client, urlString, httpVerb, msg))
 				framework.ExpectNoError(pollErr, "Pod didn't start within time out period. %v", pollErr)
 			}
 
@@ -458,7 +458,7 @@ var _ = common.SIGDescribe("Proxy", func() {
 				urlString := strings.TrimRight(f.ClientConfig().Host, "/") + "/api/v1/namespaces/" + ns + "/services/" + testSvcName + "/proxy?method=" + httpVerb
 				framework.Logf("Starting http.Client for %s", urlString)
 
-				pollErr := wait.PollImmediate(requestRetryPeriod, requestRetryTimeout, validateProxyVerbRequest(client, urlString, httpVerb, msg))
+				pollErr := wait.PollUntilContextTimeout(context.Background(), requestRetryPeriod, requestRetryTimeout, true, validateProxyVerbRequest(client, urlString, httpVerb, msg))
 				framework.ExpectNoError(pollErr, "Service didn't start within time out period. %v", pollErr)
 			}
 

--- a/test/e2e/network/util.go
+++ b/test/e2e/network/util.go
@@ -62,7 +62,7 @@ func GetHTTPContent(host string, port int, timeout time.Duration, url string) (s
 // GetHTTPContentFromTestContainer returns the content of the given url by HTTP via a test container.
 func GetHTTPContentFromTestContainer(ctx context.Context, config *e2enetwork.NetworkingTestConfig, host string, port int, timeout time.Duration, dialCmd string) (string, error) {
 	var body string
-	pollFn := func() (bool, error) {
+	pollFn := func(ctx context.Context) (bool, error) {
 		resp, err := config.GetResponseFromTestContainer(ctx, "http", dialCmd, host, port)
 		if err != nil || len(resp.Errors) > 0 || len(resp.Responses) == 0 {
 			return false, nil
@@ -70,7 +70,7 @@ func GetHTTPContentFromTestContainer(ctx context.Context, config *e2enetwork.Net
 		body = resp.Responses[0]
 		return true, nil
 	}
-	if pollErr := wait.PollUntilContextTimeout(context.Background(), framework.Poll, timeout, true, pollFn); pollErr != nil {
+	if pollErr := wait.PollUntilContextTimeout(ctx, framework.Poll, timeout, true, pollFn); pollErr != nil {
 		return "", pollErr
 	}
 	return body, nil

--- a/test/e2e/node/events.go
+++ b/test/e2e/node/events.go
@@ -92,7 +92,7 @@ var _ = SIGDescribe("Events", func() {
 		var events *v1.EventList
 		// Check for scheduler event about the pod.
 		ginkgo.By("checking for scheduler event about the pod")
-		framework.ExpectNoError(wait.Poll(framework.Poll, 5*time.Minute, func() (bool, error) {
+		framework.ExpectNoError(wait.PollUntilContextTimeout(context.Background(), framework.Poll, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 			selector := fields.Set{
 				"involvedObject.kind":      "Pod",
 				"involvedObject.uid":       string(podWithUID.UID),
@@ -112,7 +112,7 @@ var _ = SIGDescribe("Events", func() {
 		}))
 		// Check for kubelet event about the pod.
 		ginkgo.By("checking for kubelet event about the pod")
-		framework.ExpectNoError(wait.Poll(framework.Poll, 5*time.Minute, func() (bool, error) {
+		framework.ExpectNoError(wait.PollUntilContextTimeout(context.Background(), framework.Poll, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 			selector := fields.Set{
 				"involvedObject.uid":       string(podWithUID.UID),
 				"involvedObject.kind":      "Pod",

--- a/test/e2e/node/pod_gc.go
+++ b/test/e2e/node/pod_gc.go
@@ -68,7 +68,7 @@ var _ = SIGDescribe("Pod garbage collector [Feature:PodGarbageCollector] [Slow]"
 		gcThreshold := 100
 
 		ginkgo.By(fmt.Sprintf("Waiting for gc controller to gc all but %d pods", gcThreshold))
-		pollErr := wait.Poll(1*time.Minute, timeout, func() (bool, error) {
+		pollErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Minute, timeout, false, func(ctx context.Context) (bool, error) {
 			pods, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).List(ctx, metav1.ListOptions{})
 			if err != nil {
 				framework.Logf("Failed to list pod %v", err)
@@ -80,6 +80,7 @@ var _ = SIGDescribe("Pod garbage collector [Feature:PodGarbageCollector] [Slow]"
 			}
 			return true, nil
 		})
+
 		if pollErr != nil {
 			framework.Failf("Failed to GC pods within %v, %v pods remaining, error: %v", timeout, len(pods.Items), err)
 		}

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -114,7 +114,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 			// for the kubelet to remove from api.  need to follow-up on if this
 			// latency between termination and reportal can be isolated further.
 			start := time.Now()
-			err = wait.Poll(time.Second*5, time.Second*30*3, func() (bool, error) {
+			err = wait.PollUntilContextTimeout(context.Background(), time.Second*5, time.Second*30*3, false, func(ctx context.Context) (bool, error) {
 				podList, err := e2ekubelet.GetKubeletPods(ctx, f.ClientSet, pod.Spec.NodeName)
 				if err != nil {
 					framework.Logf("Unable to retrieve kubelet pods for node %v: %v", pod.Spec.NodeName, err)
@@ -135,6 +135,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 				framework.Logf("no pod exists with the name we were looking for, assuming the termination request was observed and completed")
 				return true, nil
 			})
+
 			framework.ExpectNoError(err, "kubelet never observed the termination notice")
 
 			framework.ExpectNotEqual(lastPod.DeletionTimestamp, nil)
@@ -275,7 +276,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 			var eventList *v1.EventList
 			var err error
 			ginkgo.By("Getting events about the pod")
-			framework.ExpectNoError(wait.Poll(time.Second*2, time.Second*60, func() (bool, error) {
+			framework.ExpectNoError(wait.PollUntilContextTimeout(context.Background(), time.Second*2, time.Second*60, false, func(ctx context.Context) (bool, error) {
 				selector := fields.Set{
 					"involvedObject.kind":      "Pod",
 					"involvedObject.uid":       string(createdPod.UID),

--- a/test/e2e/node/pre_stop.go
+++ b/test/e2e/node/pre_stop.go
@@ -116,7 +116,7 @@ func testPreStop(ctx context.Context, c clientset.Interface, ns string) {
 	framework.ExpectNoError(err, fmt.Sprintf("deleting pod: %s", preStopDescr.Name))
 
 	// Validate that the server received the web poke.
-	err = wait.Poll(time.Second*5, time.Second*60, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second*5, time.Second*60, false, func(ctx context.Context) (bool, error) {
 
 		ctx, cancel := context.WithTimeout(ctx, framework.SingleCallTimeout)
 		defer cancel()
@@ -150,6 +150,7 @@ func testPreStop(ctx context.Context, c clientset.Interface, ns string) {
 		}
 		return false, nil
 	})
+
 	framework.ExpectNoError(err, "validating pre-stop.")
 }
 
@@ -196,7 +197,7 @@ var _ = SIGDescribe("PreStop", func() {
 
 		ginkgo.By("verifying the pod is running while in the graceful period termination")
 		result := &v1.PodList{}
-		err = wait.Poll(time.Second*5, time.Second*60, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), time.Second*5, time.Second*60, false, func(ctx context.Context) (bool, error) {
 			client, err := e2ekubelet.ProxyRequest(ctx, f.ClientSet, pod.Spec.NodeName, "pods", ports.KubeletPort)
 			framework.ExpectNoError(err, "failed to get the pods of the node")
 			err = client.Into(result)

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -176,11 +176,12 @@ var _ = SIGDescribe("LimitRange", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Verifying LimitRange updating is effective")
-		err = wait.Poll(time.Second*2, time.Second*20, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), time.Second*2, time.Second*20, false, func(ctx context.Context) (bool, error) {
 			limitRange, err = f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Get(ctx, limitRange.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 			return reflect.DeepEqual(limitRange.Spec.Limits[0].Min, newMin), nil
 		})
+
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Creating a Pod with less than former min resources")
@@ -198,7 +199,7 @@ var _ = SIGDescribe("LimitRange", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Verifying the LimitRange was deleted")
-		err = wait.Poll(time.Second*5, e2eservice.RespondingTimeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), time.Second*5, e2eservice.RespondingTimeout, false, func(ctx context.Context) (bool, error) {
 			limitRanges, err := f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).List(ctx, metav1.ListOptions{})
 
 			if err != nil {
@@ -218,6 +219,7 @@ var _ = SIGDescribe("LimitRange", func() {
 
 			return false, nil
 		})
+
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Creating a Pod with more than former max resources")
@@ -325,7 +327,7 @@ var _ = SIGDescribe("LimitRange", func() {
 		framework.ExpectNoError(err, "failed to delete the LimitRange by Collection")
 
 		ginkgo.By(fmt.Sprintf("Confirm that the limitRange %q has been deleted", lrName))
-		err = wait.PollImmediateWithContext(ctx, 1*time.Second, 10*time.Second, checkLimitRangeListQuantity(f, patchedLabelSelector, 0))
+		err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 10*time.Second, true, checkLimitRangeListQuantity(f, patchedLabelSelector, 0))
 		framework.ExpectNoError(err, "failed to count the required limitRanges")
 		framework.Logf("LimitRange %q has been deleted.", lrName)
 

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -728,7 +728,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			// - if it's less than expected replicas, it denotes its pods are under-preempted
 			// "*2" means pods of ReplicaSet{1,2} are expected to be only preempted once.
 			expectedRSPods := []int32{1 * 2, 1 * 2, 1}
-			err := wait.Poll(framework.Poll, framework.PollShortTimeout, func() (bool, error) {
+			err := wait.PollUntilContextTimeout(context.Background(), framework.Poll, framework.PollShortTimeout, false, func(ctx context.Context) (bool, error) {
 				for i := 0; i < len(podNamesSeen); i++ {
 					got := atomic.LoadInt32(&podNamesSeen[i])
 					if got < expectedRSPods[i] {
@@ -740,6 +740,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 				}
 				return true, nil
 			})
+
 			if err != nil {
 				framework.Logf("pods created so far: %v", podNamesSeen)
 				framework.Failf("failed pod observation expectations: %v", err)
@@ -905,7 +906,7 @@ func createPod(ctx context.Context, f *framework.Framework, conf pausePodConfig)
 // waitForPreemptingWithTimeout verifies if 'pod' is preempting within 'timeout', specifically it checks
 // if the 'spec.NodeName' field of preemptor 'pod' has been set.
 func waitForPreemptingWithTimeout(ctx context.Context, f *framework.Framework, pod *v1.Pod, timeout time.Duration) {
-	err := wait.Poll(2*time.Second, timeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
 		pod, err := f.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -915,6 +916,7 @@ func waitForPreemptingWithTimeout(ctx context.Context, f *framework.Framework, p
 		}
 		return false, err
 	})
+
 	framework.ExpectNoError(err, "pod %v/%v failed to preempt other pods", pod.Namespace, pod.Name)
 }
 

--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -363,10 +363,8 @@ func createBalancedPodForNodes(ctx context.Context, f *framework.Framework, cs c
 		if err != nil {
 			framework.Logf("Failed to delete memory balanced pods: %v.", err)
 		} else {
-			err := wait.PollImmediateWithContext(ctx, 2*time.Second, time.Minute, func(ctx context.Context) (bool, error) {
-				podList, err := cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
-					LabelSelector: labels.SelectorFromSet(labels.Set(balancePodLabel)).String(),
-				})
+			err := wait.PollUntilContextTimeout(ctx, 2*time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
+				podList, err := cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: labels.SelectorFromSet(labels.Set(balancePodLabel)).String()})
 				if err != nil {
 					framework.Logf("Failed to list memory balanced pods: %v.", err)
 					return false, nil
@@ -376,6 +374,7 @@ func createBalancedPodForNodes(ctx context.Context, f *framework.Framework, cs c
 				}
 				return true, nil
 			})
+
 			if err != nil {
 				framework.Logf("Failed to wait until all memory balanced pods are deleted: %v.", err)
 			}

--- a/test/e2e/storage/csi_mock/base.go
+++ b/test/e2e/storage/csi_mock/base.go
@@ -941,7 +941,7 @@ func anyOf(conditions ...wait.ConditionFunc) wait.ConditionFunc {
 }
 
 func waitForMaxVolumeCondition(pod *v1.Pod, cs clientset.Interface) error {
-	waitErr := wait.PollImmediate(10*time.Second, csiPodUnschedulableTimeout, func() (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, csiPodUnschedulableTimeout, true, func(ctx context.Context) (bool, error) {
 		pod, err := cs.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -955,6 +955,7 @@ func waitForMaxVolumeCondition(pod *v1.Pod, cs clientset.Interface) error {
 		}
 		return false, nil
 	})
+
 	if waitErr != nil {
 		return fmt.Errorf("error waiting for pod %s/%s to have max volume condition: %v", pod.Namespace, pod.Name, waitErr)
 	}

--- a/test/e2e/storage/csi_mock/csi_node_stage_error_cases.go
+++ b/test/e2e/storage/csi_mock/csi_node_stage_error_cases.go
@@ -185,7 +185,7 @@ var _ = utils.SIGDescribe("CSI Mock volume node stage", func() {
 				framework.ExpectNoError(err, "while deleting")
 
 				ginkgo.By("Waiting for all remaining expected CSI calls")
-				err = wait.Poll(time.Second, csiUnstageWaitTimeout, func() (done bool, err error) {
+				err = wait.PollUntilContextTimeout(context.Background(), time.Second, csiUnstageWaitTimeout, false, func(ctx context.Context) (done bool, err error) {
 					_, index, err := compareCSICalls(ctx, trackedCalls, test.expectedCalls, m.driver.GetCalls)
 					if err != nil {
 						return true, err
@@ -200,6 +200,7 @@ var _ = utils.SIGDescribe("CSI Mock volume node stage", func() {
 					}
 					return false, nil
 				})
+
 				framework.ExpectNoError(err, "while waiting for all CSI calls")
 			})
 		}
@@ -307,7 +308,7 @@ var _ = utils.SIGDescribe("CSI Mock volume node stage", func() {
 				framework.ExpectNoError(err, "while deleting the second pod")
 
 				ginkgo.By("Waiting for all remaining expected CSI calls")
-				err = wait.Poll(time.Second, csiUnstageWaitTimeout, func() (done bool, err error) {
+				err = wait.PollUntilContextTimeout(context.Background(), time.Second, csiUnstageWaitTimeout, false, func(ctx context.Context) (done bool, err error) {
 					_, index, err := compareCSICalls(ctx, trackedCalls, test.expectedCalls, m.driver.GetCalls)
 					if err != nil {
 						return true, err
@@ -322,6 +323,7 @@ var _ = utils.SIGDescribe("CSI Mock volume node stage", func() {
 					}
 					return false, nil
 				})
+
 				framework.ExpectNoError(err, "while waiting for all CSI calls")
 			})
 		}

--- a/test/e2e/storage/csi_mock/csi_storage_capacity.go
+++ b/test/e2e/storage/csi_mock/csi_storage_capacity.go
@@ -177,22 +177,25 @@ var _ = utils.SIGDescribe("CSI Mock volume storage capacity", func() {
 				}
 
 				var calls []drivers.MockCSICall
-				err = wait.PollImmediateUntilWithContext(ctx, time.Second, func(ctx context.Context) (done bool, err error) {
+				err = wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (done bool, err error) {
 					c, index, err := compareCSICalls(ctx, deterministicCalls, expected, m.driver.GetCalls)
 					if err != nil {
 						return true, fmt.Errorf("error waiting for expected CSI calls: %w", err)
 					}
 					calls = c
 					if index == 0 {
-						// No CSI call received yet
 						return false, nil
 					}
 					if len(expected) == index {
-						// all calls received
 						return true, nil
 					}
 					return false, nil
 				})
+
+				// No CSI call received yet
+
+				// all calls received
+
 				framework.ExpectNoError(err, "while waiting for all CSI calls")
 
 				// The capacity error is dealt with in two different ways.
@@ -363,11 +366,11 @@ var _ = utils.SIGDescribe("CSI Mock volume storage capacity", func() {
 					// safety margin.
 					podHasStorage(ctx, f.ClientSet, pod.Name, pod.Namespace, time.Now().Add(syncDelay)),
 				)
-				err = wait.PollImmediateUntil(poll, condition, ctx.Done())
+				err = wait.PollUntilContextCancel(ctx, poll, true, condition)
 				if test.expectFailure {
 					switch {
 					case errors.Is(err, context.DeadlineExceeded),
-						errors.Is(err, wait.ErrWaitTimeout),
+						errors.Is(err, wait.ErrorInterrupted(errors.New("TODO"))),
 						errors.Is(err, errNotEnoughSpace):
 						// Okay, we expected that.
 					case err == nil:

--- a/test/e2e/storage/csi_mock/csi_storage_capacity.go
+++ b/test/e2e/storage/csi_mock/csi_storage_capacity.go
@@ -360,17 +360,16 @@ var _ = utils.SIGDescribe("CSI Mock volume storage capacity", func() {
 				framework.ExpectEqual(sc.Name, scName, "pre-selected storage class name not used")
 
 				condition := anyOf(
-					podRunning(ctx, f.ClientSet, pod.Name, pod.Namespace),
+					podRunning(f.ClientSet, pod.Name, pod.Namespace),
 					// We only just created the CSIStorageCapacity objects, therefore
 					// we have to ignore all older events, plus the syncDelay as our
 					// safety margin.
-					podHasStorage(ctx, f.ClientSet, pod.Name, pod.Namespace, time.Now().Add(syncDelay)),
+					podHasStorage(f.ClientSet, pod.Name, pod.Namespace, time.Now().Add(syncDelay)),
 				)
 				err = wait.PollUntilContextCancel(ctx, poll, true, condition)
 				if test.expectFailure {
 					switch {
-					case errors.Is(err, context.DeadlineExceeded),
-						errors.Is(err, wait.ErrorInterrupted(errors.New("TODO"))),
+					case wait.Interrupted(err),
 						errors.Is(err, errNotEnoughSpace):
 						// Okay, we expected that.
 					case err == nil:

--- a/test/e2e/storage/csi_mock/csi_volume_limit.go
+++ b/test/e2e/storage/csi_mock/csi_volume_limit.go
@@ -129,7 +129,7 @@ var _ = utils.SIGDescribe("CSI Mock volume limit", func() {
 func checkCSINodeForLimits(nodeName string, driverName string, cs clientset.Interface) (int32, error) {
 	var attachLimit int32
 
-	waitErr := wait.PollImmediate(10*time.Second, csiNodeLimitUpdateTimeout, func() (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, csiNodeLimitUpdateTimeout, true, func(ctx context.Context) (bool, error) {
 		csiNode, err := cs.StorageV1().CSINodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
@@ -140,6 +140,7 @@ func checkCSINodeForLimits(nodeName string, driverName string, cs clientset.Inte
 		}
 		return false, nil
 	})
+
 	if waitErr != nil {
 		return 0, fmt.Errorf("error waiting for non-zero volume limit of driver %s on node %s: %v", driverName, nodeName, waitErr)
 	}

--- a/test/e2e/storage/detach_mounted.go
+++ b/test/e2e/storage/detach_mounted.go
@@ -134,7 +134,7 @@ func getUniqueVolumeName(pod *v1.Pod, driverName string) string {
 }
 
 func waitForVolumesNotInUse(ctx context.Context, client clientset.Interface, nodeName, volumeName string) error {
-	waitErr := wait.PollImmediateWithContext(ctx, 10*time.Second, 60*time.Second, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, 10*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("error fetching node %s with %v", nodeName, err)
@@ -147,6 +147,7 @@ func waitForVolumesNotInUse(ctx context.Context, client clientset.Interface, nod
 		}
 		return true, nil
 	})
+
 	if waitErr != nil {
 		return fmt.Errorf("error waiting for volumes to not be in use: %v", waitErr)
 	}
@@ -154,7 +155,7 @@ func waitForVolumesNotInUse(ctx context.Context, client clientset.Interface, nod
 }
 
 func waitForVolumesAttached(ctx context.Context, client clientset.Interface, nodeName, volumeName string) error {
-	waitErr := wait.PollImmediateWithContext(ctx, 2*time.Second, 2*time.Minute, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("error fetching node %s with %v", nodeName, err)
@@ -167,6 +168,7 @@ func waitForVolumesAttached(ctx context.Context, client clientset.Interface, nod
 		}
 		return false, nil
 	})
+
 	if waitErr != nil {
 		return fmt.Errorf("error waiting for volume %v to attach to node %v: %v", volumeName, nodeName, waitErr)
 	}
@@ -174,7 +176,7 @@ func waitForVolumesAttached(ctx context.Context, client clientset.Interface, nod
 }
 
 func waitForVolumesInUse(ctx context.Context, client clientset.Interface, nodeName, volumeName string) error {
-	waitErr := wait.PollImmediateWithContext(ctx, 10*time.Second, 60*time.Second, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, 10*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("error fetching node %s with %v", nodeName, err)
@@ -187,6 +189,7 @@ func waitForVolumesInUse(ctx context.Context, client clientset.Interface, nodeNa
 		}
 		return false, nil
 	})
+
 	if waitErr != nil {
 		return fmt.Errorf("error waiting for volume %v to be in use on node %v: %v", volumeName, nodeName, waitErr)
 	}

--- a/test/e2e/storage/local_volume_resize.go
+++ b/test/e2e/storage/local_volume_resize.go
@@ -139,7 +139,7 @@ func UpdatePVSize(ctx context.Context, pv *v1.PersistentVolume, size resource.Qu
 	pvToUpdate := pv.DeepCopy()
 
 	var lastError error
-	waitErr := wait.PollImmediateWithContext(ctx, 5*time.Second, csiResizeWaitPeriod, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, csiResizeWaitPeriod, true, func(ctx context.Context) (bool, error) {
 		var err error
 		pvToUpdate, err = c.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
 		if err != nil {
@@ -154,7 +154,8 @@ func UpdatePVSize(ctx context.Context, pv *v1.PersistentVolume, size resource.Qu
 		}
 		return true, nil
 	})
-	if waitErr == wait.ErrWaitTimeout {
+
+	if wait.Interrupted(waitErr) {
 		return nil, fmt.Errorf("timed out attempting to update PV size. last update error: %v", lastError)
 	}
 	if waitErr != nil {

--- a/test/e2e/storage/mounted_volume_resize.go
+++ b/test/e2e/storage/mounted_volume_resize.go
@@ -170,7 +170,7 @@ var _ = utils.SIGDescribe("Mounted volume expand [Feature:StorageProvider]", fun
 
 func waitForDeploymentToRecreatePod(ctx context.Context, client clientset.Interface, deployment *appsv1.Deployment) (v1.Pod, error) {
 	var runningPod v1.Pod
-	waitErr := wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		podList, err := e2edeployment.GetPodsForDeployment(ctx, client, deployment)
 		if err != nil {
 			return false, fmt.Errorf("failed to get pods for deployment: %w", err)
@@ -186,6 +186,7 @@ func waitForDeploymentToRecreatePod(ctx context.Context, client clientset.Interf
 		}
 		return false, nil
 	})
+
 	if waitErr != nil {
 		return runningPod, fmt.Errorf("error waiting for recreated pod: %v", waitErr)
 	}

--- a/test/e2e/storage/pd.go
+++ b/test/e2e/storage/pd.go
@@ -429,13 +429,14 @@ var _ = utils.SIGDescribe("Pod Disks [Feature:StorageProvider]", func() {
 						},
 					}
 					ginkgo.By("evicting host0Pod")
-					err = wait.PollImmediate(framework.Poll, podEvictTimeout, func() (bool, error) {
+					err = wait.PollUntilContextTimeout(context.Background(), framework.Poll, podEvictTimeout, true, func(ctx context.Context) (bool, error) {
 						if err := cs.CoreV1().Pods(ns).EvictV1(ctx, evictTarget); err != nil {
 							framework.Logf("Failed to evict host0Pod, ignoring error: %v", err)
 							return false, nil
 						}
 						return true, nil
 					})
+
 					framework.ExpectNoError(err, "failed to evict host0Pod after %v", podEvictTimeout)
 				}
 

--- a/test/e2e/storage/regional_pd.go
+++ b/test/e2e/storage/regional_pd.go
@@ -260,7 +260,7 @@ func testZonalFailover(ctx context.Context, c clientset.Interface, ns string) {
 	} else {
 		otherZone = cloudZones[0]
 	}
-	waitErr := wait.PollImmediateWithContext(ctx, framework.Poll, statefulSetReadyTimeout, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, framework.Poll, statefulSetReadyTimeout, true, func(ctx context.Context) (bool, error) {
 		framework.Logf("Checking whether new pod is scheduled in zone %q", otherZone)
 		pod := getPod(ctx, c, ns, regionalPDLabels)
 		node, err := c.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
@@ -270,6 +270,7 @@ func testZonalFailover(ctx context.Context, c clientset.Interface, ns string) {
 		newPodZone := node.Labels[v1.LabelTopologyZone]
 		return newPodZone == otherZone, nil
 	})
+
 	framework.ExpectNoError(waitErr, "Error waiting for pod to be scheduled in a different zone (%q): %v", otherZone, err)
 
 	err = waitForStatefulSetReplicasReady(ctx, statefulSet.Name, ns, c, 3*time.Second, framework.RestartPodReadyAgainTimeout)

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -731,7 +731,7 @@ func waitForPodSubpathError(ctx context.Context, f *framework.Framework, pod *v1
 		return fmt.Errorf("failed to find container that uses subpath")
 	}
 
-	waitErr := wait.PollImmediate(framework.Poll, f.Timeouts.PodStart, func() (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), framework.Poll, f.Timeouts.PodStart, true, func(ctx context.Context) (bool, error) {
 		pod, err := f.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -758,6 +758,7 @@ func waitForPodSubpathError(ctx context.Context, f *framework.Framework, pod *v1
 		}
 		return false, nil
 	})
+
 	if waitErr != nil {
 		return fmt.Errorf("error waiting for pod subpath error to occur: %v", waitErr)
 	}
@@ -818,7 +819,7 @@ func testPodContainerRestartWithHooks(ctx context.Context, f *framework.Framewor
 	// and "start pod".
 	ginkgo.By("Waiting for container to restart")
 	restarts := int32(0)
-	err = wait.PollImmediate(10*time.Second, f.Timeouts.PodDelete+f.Timeouts.PodStart, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, f.Timeouts.PodDelete+f.Timeouts.PodStart, true, func(ctx context.Context) (bool, error) {
 		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -835,6 +836,7 @@ func testPodContainerRestartWithHooks(ctx context.Context, f *framework.Framewor
 		}
 		return false, nil
 	})
+
 	framework.ExpectNoError(err, "while waiting for container to restart")
 
 	// Fix liveness probe
@@ -849,7 +851,7 @@ func testPodContainerRestartWithHooks(ctx context.Context, f *framework.Framewor
 	ginkgo.By("Waiting for container to stop restarting")
 	stableCount := int(0)
 	stableThreshold := int(time.Minute / framework.Poll)
-	err = wait.PollImmediate(framework.Poll, f.Timeouts.PodStartSlow, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), framework.Poll, f.Timeouts.PodStartSlow, true, func(ctx context.Context) (bool, error) {
 		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -872,6 +874,7 @@ func testPodContainerRestartWithHooks(ctx context.Context, f *framework.Framewor
 		}
 		return false, nil
 	})
+
 	framework.ExpectNoError(err, "while waiting for container to stabilize")
 }
 

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -311,7 +311,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		// Poll kubelet metrics waiting for the volume to be picked up
 		// by the volume stats collector
 		var kubeMetrics e2emetrics.KubeletMetrics
-		waitErr := wait.Poll(30*time.Second, 5*time.Minute, func() (bool, error) {
+		waitErr := wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 			framework.Logf("Grabbing Kubelet metrics")
 			// Grab kubelet metrics from the node the pod was scheduled on
 			var err error
@@ -325,6 +325,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 			}
 			return true, nil
 		})
+
 		framework.ExpectNoError(waitErr, "Unable to find metric %s for PVC %s/%s", kubeletKeyName, pvcNamespace, pvcName)
 
 		for _, key := range volumeStatKeys {

--- a/test/e2e/storage/vsphere/vsphere_utils.go
+++ b/test/e2e/storage/vsphere/vsphere_utils.go
@@ -91,7 +91,7 @@ func waitForVSphereDisksToDetach(ctx context.Context, nodeVolumes map[string][]s
 		return true, nil
 	})
 	if waitErr != nil {
-		if waitErr == wait.ErrWaitTimeout {
+		if wait.Interrupted(waitErr) {
 			return fmt.Errorf("volumes have not detached after %v: %v", detachTimeout, waitErr)
 		}
 		return fmt.Errorf("error waiting for volumes to detach: %v", waitErr)
@@ -132,7 +132,7 @@ func waitForVSphereDiskStatus(ctx context.Context, volumePath string, nodeName s
 		return false, nil
 	})
 	if waitErr != nil {
-		if waitErr == wait.ErrWaitTimeout {
+		if wait.Interrupted(waitErr) {
 			return fmt.Errorf("volume %q is not %s %q after %v: %v", volumePath, attachedStateMsg[expectedState], nodeName, timeout, waitErr)
 		}
 		return fmt.Errorf("error waiting for volume %q to be %s %q: %v", volumePath, attachedStateMsg[expectedState], nodeName, waitErr)

--- a/test/e2e/storage/vsphere/vsphere_volume_node_poweroff.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_node_poweroff.go
@@ -172,7 +172,7 @@ func waitForPodToFailover(ctx context.Context, client clientset.Interface, deplo
 	})
 
 	if waitErr != nil {
-		if waitErr == wait.ErrWaitTimeout {
+		if wait.Interrupted(waitErr) {
 			return "", fmt.Errorf("pod has not failed over after %v: %v", timeout, waitErr)
 		}
 		return "", fmt.Errorf("pod did not fail over from %q: %v", oldNode, waitErr)

--- a/test/e2e/upgrades/apps/cassandra.go
+++ b/test/e2e/upgrades/apps/cassandra.go
@@ -93,7 +93,7 @@ func (t *CassandraUpgradeTest) Setup(ctx context.Context, f *framework.Framework
 	cassandraKubectlCreate(ns, "tester.yaml")
 
 	ginkgo.By("Getting the ingress IPs from the services")
-	err := wait.PollImmediateWithContext(ctx, statefulsetPoll, statefulsetTimeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, statefulsetPoll, statefulsetTimeout, true, func(ctx context.Context) (bool, error) {
 		if t.ip = t.getServiceIP(ctx, f, ns, "test-server"); t.ip == "" {
 			return false, nil
 		}
@@ -103,6 +103,7 @@ func (t *CassandraUpgradeTest) Setup(ctx context.Context, f *framework.Framework
 		}
 		return true, nil
 	})
+
 	framework.ExpectNoError(err)
 	framework.Logf("Service endpoint is up")
 

--- a/test/e2e/upgrades/apps/deployments.go
+++ b/test/e2e/upgrades/apps/deployments.go
@@ -175,7 +175,7 @@ func (t *DeploymentUpgradeTest) Teardown(ctx context.Context, f *framework.Frame
 
 // waitForDeploymentRevision waits for becoming the target revision of a delopyment.
 func waitForDeploymentRevision(ctx context.Context, c clientset.Interface, d *appsv1.Deployment, targetRevision string) error {
-	err := wait.PollImmediate(poll, pollLongTimeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), poll, pollLongTimeout, true, func(ctx context.Context) (bool, error) {
 		deployment, err := c.AppsV1().Deployments(d.Namespace).Get(ctx, d.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -183,6 +183,7 @@ func waitForDeploymentRevision(ctx context.Context, c clientset.Interface, d *ap
 		revision := deployment.Annotations[deploymentutil.RevisionAnnotation]
 		return revision == targetRevision, nil
 	})
+
 	if err != nil {
 		return fmt.Errorf("error waiting for revision to become %q for deployment %q: %w", targetRevision, d.Name, err)
 	}

--- a/test/e2e/upgrades/apps/etcd.go
+++ b/test/e2e/upgrades/apps/etcd.go
@@ -88,7 +88,7 @@ func (t *EtcdUpgradeTest) Setup(ctx context.Context, f *framework.Framework) {
 	kubectlCreate(ns, "tester.yaml")
 
 	ginkgo.By("Getting the ingress IPs from the services")
-	err := wait.PollImmediateWithContext(ctx, statefulsetPoll, statefulsetTimeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, statefulsetPoll, statefulsetTimeout, true, func(ctx context.Context) (bool, error) {
 		if t.ip = t.getServiceIP(ctx, f, ns, "test-server"); t.ip == "" {
 			return false, nil
 		}
@@ -98,6 +98,7 @@ func (t *EtcdUpgradeTest) Setup(ctx context.Context, f *framework.Framework) {
 		}
 		return true, nil
 	})
+
 	framework.ExpectNoError(err)
 	framework.Logf("Service endpoint is up")
 

--- a/test/e2e/upgrades/apps/mysql.go
+++ b/test/e2e/upgrades/apps/mysql.go
@@ -103,7 +103,7 @@ func (t *MySQLUpgradeTest) Setup(ctx context.Context, f *framework.Framework) {
 	mysqlKubectlCreate(ns, "tester.yaml")
 
 	ginkgo.By("Getting the ingress IPs from the test-service")
-	err := wait.PollImmediateWithContext(ctx, statefulsetPoll, statefulsetTimeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, statefulsetPoll, statefulsetTimeout, true, func(ctx context.Context) (bool, error) {
 		if t.ip = t.getServiceIP(ctx, f, ns, "test-server"); t.ip == "" {
 			return false, nil
 		}
@@ -113,6 +113,7 @@ func (t *MySQLUpgradeTest) Setup(ctx context.Context, f *framework.Framework) {
 		}
 		return true, nil
 	})
+
 	framework.ExpectNoError(err)
 	framework.Logf("Service endpoint is up")
 

--- a/test/e2e/upgrades/auth/serviceaccount_admission_controller_migration.go
+++ b/test/e2e/upgrades/auth/serviceaccount_admission_controller_migration.go
@@ -90,7 +90,7 @@ func (t *ServiceAccountAdmissionControllerMigrationTest) Teardown(ctx context.Co
 func inClusterClientMustWork(ctx context.Context, f *framework.Framework, pod *v1.Pod) {
 	var logs string
 	since := time.Now()
-	if err := wait.PollImmediate(15*time.Second, 5*time.Minute, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 15*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		framework.Logf("Polling logs")
 		logs, err = e2epod.GetPodLogsSince(ctx, f.ClientSet, pod.Namespace, pod.Name, "inclusterclient", since)
 		if err != nil {

--- a/test/e2e/upgrades/network/kube_proxy_migration.go
+++ b/test/e2e/upgrades/network/kube_proxy_migration.go
@@ -142,7 +142,7 @@ func waitForKubeProxyStaticPodsRunning(ctx context.Context, c clientset.Interfac
 		return true, nil
 	}
 
-	if err := wait.PollImmediate(5*time.Second, defaultTestTimeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy static pods running: %w", err)
 	}
 	return nil
@@ -165,7 +165,7 @@ func waitForKubeProxyStaticPodsDisappear(ctx context.Context, c clientset.Interf
 		return true, nil
 	}
 
-	if err := wait.PollImmediate(5*time.Second, defaultTestTimeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy static pods disappear: %w", err)
 	}
 	return nil
@@ -189,7 +189,7 @@ func waitForKubeProxyDaemonSetRunning(ctx context.Context, f *framework.Framewor
 		return e2edaemonset.CheckRunningOnAllNodes(ctx, f, &daemonSets.Items[0])
 	}
 
-	if err := wait.PollImmediate(5*time.Second, defaultTestTimeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy DaemonSet running: %w", err)
 	}
 	return nil
@@ -212,7 +212,7 @@ func waitForKubeProxyDaemonSetDisappear(ctx context.Context, c clientset.Interfa
 		return true, nil
 	}
 
-	if err := wait.PollImmediate(5*time.Second, defaultTestTimeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy DaemonSet disappear: %w", err)
 	}
 	return nil

--- a/test/e2e/upgrades/network/kube_proxy_migration.go
+++ b/test/e2e/upgrades/network/kube_proxy_migration.go
@@ -115,7 +115,7 @@ func (t *KubeProxyDowngradeTest) Teardown(ctx context.Context, f *framework.Fram
 func waitForKubeProxyStaticPodsRunning(ctx context.Context, c clientset.Interface) error {
 	framework.Logf("Waiting up to %v for kube-proxy static pods running", defaultTestTimeout)
 
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		pods, err := getKubeProxyStaticPods(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to get kube-proxy static pods: %v", err)
@@ -142,7 +142,7 @@ func waitForKubeProxyStaticPodsRunning(ctx context.Context, c clientset.Interfac
 		return true, nil
 	}
 
-	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, defaultTestTimeout, true, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy static pods running: %w", err)
 	}
 	return nil
@@ -151,7 +151,7 @@ func waitForKubeProxyStaticPodsRunning(ctx context.Context, c clientset.Interfac
 func waitForKubeProxyStaticPodsDisappear(ctx context.Context, c clientset.Interface) error {
 	framework.Logf("Waiting up to %v for kube-proxy static pods disappear", defaultTestTimeout)
 
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		pods, err := getKubeProxyStaticPods(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to get kube-proxy static pods: %v", err)
@@ -165,7 +165,7 @@ func waitForKubeProxyStaticPodsDisappear(ctx context.Context, c clientset.Interf
 		return true, nil
 	}
 
-	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, defaultTestTimeout, true, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy static pods disappear: %w", err)
 	}
 	return nil
@@ -174,7 +174,7 @@ func waitForKubeProxyStaticPodsDisappear(ctx context.Context, c clientset.Interf
 func waitForKubeProxyDaemonSetRunning(ctx context.Context, f *framework.Framework, c clientset.Interface) error {
 	framework.Logf("Waiting up to %v for kube-proxy DaemonSet running", defaultTestTimeout)
 
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		daemonSets, err := getKubeProxyDaemonSet(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to get kube-proxy DaemonSet: %v", err)
@@ -189,7 +189,7 @@ func waitForKubeProxyDaemonSetRunning(ctx context.Context, f *framework.Framewor
 		return e2edaemonset.CheckRunningOnAllNodes(ctx, f, &daemonSets.Items[0])
 	}
 
-	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, defaultTestTimeout, true, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy DaemonSet running: %w", err)
 	}
 	return nil
@@ -198,7 +198,7 @@ func waitForKubeProxyDaemonSetRunning(ctx context.Context, f *framework.Framewor
 func waitForKubeProxyDaemonSetDisappear(ctx context.Context, c clientset.Interface) error {
 	framework.Logf("Waiting up to %v for kube-proxy DaemonSet disappear", defaultTestTimeout)
 
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		daemonSets, err := getKubeProxyDaemonSet(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to get kube-proxy DaemonSet: %v", err)
@@ -212,7 +212,7 @@ func waitForKubeProxyDaemonSetDisappear(ctx context.Context, c clientset.Interfa
 		return true, nil
 	}
 
-	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, defaultTestTimeout, true, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy DaemonSet disappear: %w", err)
 	}
 	return nil

--- a/test/e2e/windows/host_process.go
+++ b/test/e2e/windows/host_process.go
@@ -662,7 +662,7 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 		ginkgo.By("Getting container stats for pod")
 		statsChecked := false
 
-		wait.Poll(2*time.Second, timeout, func() (bool, error) {
+		wait.PollUntilContextTimeout(context.Background(), 2*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
 			return ensurePodsStatsOnNode(ctx, f.ClientSet, f.Namespace.Name, targetNode.Name, &statsChecked)
 		})
 

--- a/test/e2e/windows/utils.go
+++ b/test/e2e/windows/utils.go
@@ -38,7 +38,7 @@ import (
 // waits for a deployment to be created and the desired replicas
 // are updated and available, and no old pods are running.
 func waitForDeployment(getDeploymentFunc func() (*appsv1.Deployment, error), interval, timeout time.Duration) error {
-	return wait.PollImmediate(interval, timeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(ctx context.Context) (bool, error) {
 		deployment, err := getDeploymentFunc()
 		if err != nil {
 			if apierrors.IsNotFound(err) {
@@ -52,6 +52,7 @@ func waitForDeployment(getDeploymentFunc func() (*appsv1.Deployment, error), int
 		framework.Logf("deployment status %s", &deployment.Status)
 		return util.DeploymentComplete(deployment, &deployment.Status), nil
 	})
+
 }
 
 // gets the container runtime and version for a node

--- a/test/e2e_node/density_test.go
+++ b/test/e2e_node/density_test.go
@@ -548,7 +548,7 @@ func createBatchPodSequential(ctx context.Context, f *framework.Framework, pods 
 		create := metav1.Now()
 		createTimes[pod.Name] = create
 		p := e2epod.NewPodClient(f).Create(ctx, pod)
-		framework.ExpectNoError(wait.PollImmediateWithContext(ctx, 2*time.Second, framework.PodStartTimeout, podWatchedRunning(watchTimes, p.Name)))
+		framework.ExpectNoError(wait.PollUntilContextTimeout(ctx, 2*time.Second, framework.PodStartTimeout, true, podWatchedRunning(watchTimes, p.Name)))
 		e2eLags = append(e2eLags,
 			e2emetrics.PodLatencyData{Name: pod.Name, Latency: watchTimes[pod.Name].Time.Sub(create.Time)})
 	}

--- a/test/e2e_node/node_shutdown_linux_test.go
+++ b/test/e2e_node/node_shutdown_linux_test.go
@@ -235,7 +235,7 @@ var _ = SIGDescribe("GracefulNodeShutdown [Serial] [NodeFeature:GracefulNodeShut
 				})
 
 				// Ignore timeout error since the context will be explicitly cancelled and the watch will never return true
-				if err != nil && err != wait.ErrWaitTimeout {
+				if err != nil && !wait.Interrupted(err) {
 					framework.Failf("watch for invalid pod status failed: %v", err.Error())
 				}
 			}()

--- a/test/e2e_node/node_shutdown_linux_test.go
+++ b/test/e2e_node/node_shutdown_linux_test.go
@@ -234,7 +234,7 @@ var _ = SIGDescribe("GracefulNodeShutdown [Serial] [NodeFeature:GracefulNodeShut
 					return false, nil
 				})
 
-				// Ignore timeout error since the context will be explicitly cancelled and the watch will never return true
+				// Ignore error since the context will be explicitly cancelled and the watch will never return true
 				if err != nil && !wait.Interrupted(err) {
 					framework.Failf("watch for invalid pod status failed: %v", err.Error())
 				}

--- a/test/e2e_node/resource_collector.go
+++ b/test/e2e_node/resource_collector.go
@@ -103,7 +103,7 @@ func (r *ResourceCollector) Start() {
 		framework.Failf("Failed to get runtime container name in test-e2e-node resource collector.")
 	}
 
-	wait.Poll(1*time.Second, 1*time.Minute, func() (bool, error) {
+	wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
 		var err error
 		r.client, err = cadvisorclient.NewClient(fmt.Sprintf("http://localhost:%d/", cadvisorPort))
 		if err == nil {

--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -782,7 +782,7 @@ func updateKernelArguments(instance *compute.Instance, image string, kernelArgs 
 func rebootInstance(instance *compute.Instance) error {
 	// wait until the instance will not response to SSH
 	klog.Info("Reboot the node and wait for instance not to be available via SSH")
-	if waitErr := wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		if _, err := remote.SSH(instance.Name, "reboot"); err != nil {
 			return true, nil
 		}
@@ -794,7 +794,7 @@ func rebootInstance(instance *compute.Instance) error {
 
 	// wait until the instance will response again to SSH
 	klog.Info("Wait for instance to be available via SSH")
-	if waitErr := wait.PollImmediate(30*time.Second, 5*time.Minute, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		if _, err := remote.SSH(instance.Name, "sh", "-c", "date"); err != nil {
 			return false, nil
 		}

--- a/test/images/agnhost/openidmetadata/openidmetadata.go
+++ b/test/images/agnhost/openidmetadata/openidmetadata.go
@@ -210,7 +210,7 @@ func ensureWindowsDNSAvailability(issuer string) error {
 		return err
 	}
 
-	return wait.PollImmediate(5*time.Second, 20*time.Second, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 20*time.Second, true, func(ctx context.Context) (bool, error) {
 		ips, err := net.LookupHost(u.Host)
 		if err != nil {
 			log.Println(err)
@@ -219,4 +219,5 @@ func ensureWindowsDNSAvailability(issuer string) error {
 		log.Printf("OK: Resolved host %s: %v", u.Host, ips)
 		return true, nil
 	})
+
 }

--- a/test/integration/apimachinery/watch_restart_test.go
+++ b/test/integration/apimachinery/watch_restart_test.go
@@ -259,7 +259,7 @@ func TestWatchRestartsIfTimeoutNotReached(t *testing.T) {
 					t.Fatalf("Watch should have timed out but it exited without an error!")
 				}
 
-				if err != wait.ErrWaitTimeout && tc.succeed {
+				if !wait.Interrupted(err) && tc.succeed {
 					t.Fatalf("Watch exited with error: %v!", err)
 				}
 

--- a/test/integration/apiserver/admissionwebhook/admission_test.go
+++ b/test/integration/apiserver/admissionwebhook/admission_test.go
@@ -739,7 +739,7 @@ func testResourceDelete(c *testContext) {
 	c.admissionHolder.verify(c.t)
 
 	// wait for the item to be gone
-	err = wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		obj, err := c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil
@@ -750,6 +750,7 @@ func testResourceDelete(c *testContext) {
 		}
 		return false, err
 	})
+
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -784,7 +785,7 @@ func testResourceDelete(c *testContext) {
 	c.admissionHolder.verify(c.t)
 
 	// wait other finalizers (e.g., crd's customresourcecleanup finalizer) to be removed.
-	err = wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		obj, err := c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -799,6 +800,7 @@ func testResourceDelete(c *testContext) {
 		}
 		return true, nil
 	})
+
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -816,7 +818,7 @@ func testResourceDelete(c *testContext) {
 		return
 	}
 	// wait for the item to be gone
-	err = wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		obj, err := c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil
@@ -827,6 +829,7 @@ func testResourceDelete(c *testContext) {
 		}
 		return false, err
 	})
+
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -865,7 +868,7 @@ func testResourceDeletecollection(c *testContext) {
 	}
 
 	// wait for the item to be gone
-	err = wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		obj, err := c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil
@@ -876,6 +879,7 @@ func testResourceDeletecollection(c *testContext) {
 		}
 		return false, err
 	})
+
 	if err != nil {
 		c.t.Error(err)
 		return

--- a/test/integration/apiserver/admissionwebhook/client_auth_test.go
+++ b/test/integration/apiserver/admissionwebhook/client_auth_test.go
@@ -193,7 +193,7 @@ plugins:
 	}()
 
 	// wait until new webhook is called
-	if err := wait.PollImmediate(time.Millisecond*5, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*5, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		_, err = client.CoreV1().Pods("default").Patch(context.TODO(), clientAuthMarkerFixture.Name, types.JSONPatchType, []byte("[]"), metav1.PatchOptions{})
 		if t.Failed() {
 			return true, nil

--- a/test/integration/apiserver/admissionwebhook/duplicate_owner_ref_test.go
+++ b/test/integration/apiserver/admissionwebhook/duplicate_owner_ref_test.go
@@ -115,7 +115,7 @@ func TestMutatingWebhookDuplicateOwnerReferences(t *testing.T) {
 	// wait until new webhook is called
 	expectedWarning := fmt.Sprintf(handlers.DuplicateOwnerReferencesAfterMutatingAdmissionWarningFormat,
 		duplicateOwnerReferencesMarkerFixture.OwnerReferences[0].UID)
-	if err := wait.PollImmediate(time.Millisecond*5, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*5, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		pod, err = client.CoreV1().Pods("default").Patch(context.TODO(), duplicateOwnerReferencesMarkerFixture.Name, types.JSONPatchType, []byte("[]"), metav1.PatchOptions{})
 		if err != nil {
 			return false, err

--- a/test/integration/apiserver/admissionwebhook/invalid_managedFields_test.go
+++ b/test/integration/apiserver/admissionwebhook/invalid_managedFields_test.go
@@ -124,7 +124,7 @@ func TestMutatingWebhookResetsInvalidManagedFields(t *testing.T) {
 
 	// Make sure reset happens on patch requests
 	// wait until new webhook is called
-	if err := wait.PollImmediate(time.Millisecond*5, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*5, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		defer recordedWarnings.Reset()
 		pod, err = client.CoreV1().Pods("default").Patch(context.TODO(), invalidManagedFieldsMarkerFixture.Name, types.JSONPatchType, []byte("[]"), metav1.PatchOptions{})
 		if err != nil {

--- a/test/integration/apiserver/admissionwebhook/load_balance_test.go
+++ b/test/integration/apiserver/admissionwebhook/load_balance_test.go
@@ -142,7 +142,7 @@ func TestWebhookLoadBalance(t *testing.T) {
 	}()
 
 	// wait until new webhook is called the first time
-	if err := wait.PollImmediate(time.Millisecond*5, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*5, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		_, err = client.CoreV1().Pods("default").Patch(context.TODO(), loadBalanceMarkerFixture.Name, types.JSONPatchType, []byte("[]"), metav1.PatchOptions{})
 		select {
 		case <-upCh:

--- a/test/integration/apiserver/admissionwebhook/reinvocation_test.go
+++ b/test/integration/apiserver/admissionwebhook/reinvocation_test.go
@@ -393,7 +393,7 @@ func testWebhookReinvocationPolicy(t *testing.T, watchCache bool) {
 			}()
 
 			// wait until new webhook is called the first time
-			if err := wait.PollImmediate(time.Millisecond*5, wait.ForeverTestTimeout, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*5, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 				_, err = client.CoreV1().Pods(markerNs).Patch(context.TODO(), marker.Name, types.JSONPatchType, []byte("[]"), metav1.PatchOptions{})
 				select {
 				case <-upCh:

--- a/test/integration/apiserver/admissionwebhook/timeout_test.go
+++ b/test/integration/apiserver/admissionwebhook/timeout_test.go
@@ -265,7 +265,7 @@ func testWebhookTimeout(t *testing.T, watchCache bool) {
 			}()
 
 			// wait until new webhook is called the first time
-			if err := wait.PollImmediate(time.Millisecond*5, wait.ForeverTestTimeout, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*5, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 				_, err = client.CoreV1().Pods("default").Patch(context.TODO(), timeoutMarkerFixture.Name, types.JSONPatchType, []byte("[]"), metav1.PatchOptions{})
 				received := recorder.MarkerReceived()
 				if len(tt.mutatingWebhooks) > 0 && !received.Has("mutating") {

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -630,13 +630,14 @@ func TestListResourceVersion0(t *testing.T) {
 
 			if tc.watchCacheEnabled {
 				// poll until the watch cache has the full list in memory
-				err := wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+				err := wait.PollUntilContextTimeout(context.Background(), time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 					list, err := clientSet.AppsV1().ReplicaSets(ns.Name).List(context.Background(), metav1.ListOptions{ResourceVersion: "0"})
 					if err != nil {
 						return false, err
 					}
 					return len(list.Items) == 10, nil
 				})
+
 				if err != nil {
 					t.Fatalf("error waiting for watch cache to observe the full list: %v", err)
 				}

--- a/test/integration/apiserver/apply/apply_crd_test.go
+++ b/test/integration/apiserver/apply/apply_crd_test.go
@@ -509,7 +509,7 @@ func TestApplyCRDUnhandledSchema(t *testing.T) {
 		t.Fatal(err)
 	}
 	// wait until the CRD is established
-	err = wait.Poll(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 		localCrd, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), noxuBetaDefinition.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -523,6 +523,7 @@ func TestApplyCRDUnhandledSchema(t *testing.T) {
 		}
 		return false, nil
 	})
+
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -662,7 +662,7 @@ func TestUpdateVeryLargeObject(t *testing.T) {
 
 	// Should be able to update a small object to be near the object size limit.
 	var updateErr error
-	pollErr := wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		updateCfg, err := client.CoreV1().ConfigMaps(cfg.Namespace).Get(context.TODO(), cfg.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -680,7 +680,8 @@ func TestUpdateVeryLargeObject(t *testing.T) {
 		updateErr = err
 		return false, nil
 	})
-	if pollErr == wait.ErrWaitTimeout {
+
+	if wait.Interrupted(pollErr) {
 		t.Errorf("unable to update configMap: %v", updateErr)
 	}
 

--- a/test/integration/apiserver/cel/typeresolution_test.go
+++ b/test/integration/apiserver/cel/typeresolution_test.go
@@ -79,7 +79,7 @@ func TestTypeResolver(t *testing.T) {
 	discoveryResolver := &resolver.ClientDiscoveryResolver{Discovery: client.Discovery()}
 	definitionsResolver := resolver.NewDefinitionsSchemaResolver(k8sscheme.Scheme, openapi.GetOpenAPIDefinitions)
 	// wait until the CRD schema is published at the OpenAPI v3 endpoint
-	err = wait.PollImmediate(time.Second, time.Minute, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		p, err := client.OpenAPIV3().Paths()
 		if err != nil {
 			return
@@ -89,6 +89,7 @@ func TestTypeResolver(t *testing.T) {
 		}
 		return false, nil
 	})
+
 	if err != nil {
 		t.Fatalf("timeout wait for CRD schema publication: %v", err)
 	}

--- a/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
+++ b/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
@@ -877,7 +877,7 @@ func Test_ValidatingAdmissionPolicy_UpdateParamKind(t *testing.T) {
 	// and namespaces starting with "configmap-" are disallowed
 	// wait loop is required here since ConfigMaps were previousy allowed and we need to wait for the new policy
 	// to be enforced
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		disallowedNamespace = &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "configmap-",
@@ -972,7 +972,7 @@ func Test_ValidatingAdmissionPolicy_UpdateParamRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		disallowedNamespace := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-2-",
@@ -1025,7 +1025,7 @@ func Test_ValidatingAdmissionPolicy_UpdateParamRef(t *testing.T) {
 
 	// validate that namespaces starting with "test-2" are allowed
 	// and namespaces starting with "test-1" are disallowed
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		disallowedNamespace := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-1-",
@@ -1112,7 +1112,7 @@ func Test_ValidatingAdmissionPolicy_UpdateParamResource(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		disallowedNamespace := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-2-",
@@ -1159,7 +1159,7 @@ func Test_ValidatingAdmissionPolicy_UpdateParamResource(t *testing.T) {
 
 	// validate that namespaces starting with "test-2" are allowed
 	// and namespaces starting with "test-1" are disallowed
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		disallowedNamespace := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-1-",
@@ -1319,7 +1319,7 @@ func Test_ValidatingAdmissionPolicy_MatchByNamespaceSelector(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		matchedConfigMap := &v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "denied-",
@@ -1338,7 +1338,6 @@ func Test_ValidatingAdmissionPolicy_MatchByNamespaceSelector(t *testing.T) {
 		}
 
 		return true, nil
-
 	}); waitErr != nil {
 		t.Errorf("timed out waiting: %v", waitErr)
 	}
@@ -1450,7 +1449,7 @@ func Test_ValidatingAdmissionPolicy_MatchWithExcludeResources(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "not-matched-by-exclude-resources",
@@ -1469,7 +1468,6 @@ func Test_ValidatingAdmissionPolicy_MatchWithExcludeResources(t *testing.T) {
 		}
 
 		return true, nil
-
 	}); waitErr != nil {
 		t.Errorf("timed out waiting: %v", waitErr)
 	}
@@ -1710,7 +1708,7 @@ func Test_ValidatingAdmissionPolicy_PolicyDeletedThenRecreated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		disallowedNamespace := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "not-test-",
@@ -1740,7 +1738,7 @@ func Test_ValidatingAdmissionPolicy_PolicyDeletedThenRecreated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		allowedNamespace := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "not-test-",
@@ -1765,7 +1763,7 @@ func Test_ValidatingAdmissionPolicy_PolicyDeletedThenRecreated(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		disallowedNamespace := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "not-test-",
@@ -1828,7 +1826,7 @@ func Test_ValidatingAdmissionPolicy_BindingDeletedThenRecreated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		disallowedNamespace := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "not-test-",
@@ -1858,7 +1856,7 @@ func Test_ValidatingAdmissionPolicy_BindingDeletedThenRecreated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		allowedNamespace := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "not-test-",
@@ -1884,7 +1882,7 @@ func Test_ValidatingAdmissionPolicy_BindingDeletedThenRecreated(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		disallowedNamespace := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "not-test-",
@@ -1957,7 +1955,7 @@ func Test_ValidatingAdmissionPolicy_ParamResourceDeletedThenRecreated(t *testing
 		t.Fatal(err)
 	}
 
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		disallowedNamespace := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "not-test-",
@@ -1987,7 +1985,7 @@ func Test_ValidatingAdmissionPolicy_ParamResourceDeletedThenRecreated(t *testing
 		t.Fatal(err)
 	}
 
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		allowedNamespace := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "not-test-",
@@ -2014,7 +2012,7 @@ func Test_ValidatingAdmissionPolicy_ParamResourceDeletedThenRecreated(t *testing
 		t.Fatal(err)
 	}
 
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		disallowedNamespace := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "not-test-",
@@ -2187,7 +2185,7 @@ func TestBindingRemoval(t *testing.T) {
 		t.Fatal(err)
 	}
 	// check that the policy is active
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		namespace := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "check-namespace",
@@ -2211,7 +2209,7 @@ func TestBindingRemoval(t *testing.T) {
 	}
 
 	// wait for binding to be deleted
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 
 		_, err := client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicyBindings().Get(context.TODO(), "test-binding", metav1.GetOptions{})
 		if err != nil {
@@ -2228,7 +2226,7 @@ func TestBindingRemoval(t *testing.T) {
 	}
 
 	// policy should be considered in an invalid state and namespace creation should be allowed
-	if waitErr := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		namespace := &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-namespace",
@@ -2471,7 +2469,7 @@ func createAndWaitReadyNamespacedWithWarnHandler(t *testing.T, client *clientset
 		return err
 	}
 
-	if waitErr := wait.PollImmediate(time.Millisecond*5, wait.ForeverTestTimeout, func() (bool, error) {
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*5, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		handler.reset()
 		_, err := client.CoreV1().Endpoints(ns).Patch(context.TODO(), marker.Name, types.JSONPatchType, []byte("[]"), metav1.PatchOptions{})
 		if handler.hasObservedMarker() {

--- a/test/integration/apiserver/certreload/certreload_test.go
+++ b/test/integration/apiserver/certreload/certreload_test.go
@@ -181,12 +181,12 @@ func testClientCA(t *testing.T, recreate bool) {
 	defer tearDownFn()
 
 	// wait for request header info
-	err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, waitForConfigMapCAContent(t, kubeClient, "requestheader-client-ca-file", "-----BEGIN CERTIFICATE-----", 1))
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, waitForConfigMapCAContent(t, kubeClient, "requestheader-client-ca-file", "-----BEGIN CERTIFICATE-----", 1))
 	if err != nil {
 		t.Fatal(err)
 	}
 	// wait for client cert info
-	err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, waitForConfigMapCAContent(t, kubeClient, "client-ca-file", "-----BEGIN CERTIFICATE-----", 1))
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, waitForConfigMapCAContent(t, kubeClient, "client-ca-file", "-----BEGIN CERTIFICATE-----", 1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,20 +226,20 @@ func testClientCA(t *testing.T, recreate bool) {
 	}
 
 	// wait for updated request header info that contains both
-	err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, waitForConfigMapCAContent(t, kubeClient, "requestheader-client-ca-file", "-----BEGIN CERTIFICATE-----", 2))
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, waitForConfigMapCAContent(t, kubeClient, "requestheader-client-ca-file", "-----BEGIN CERTIFICATE-----", 2))
 	if err != nil {
 		t.Error(err)
 	}
-	err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, waitForConfigMapCAContent(t, kubeClient, "requestheader-client-ca-file", string(frontProxyCA.CACert), 1))
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, waitForConfigMapCAContent(t, kubeClient, "requestheader-client-ca-file", string(frontProxyCA.CACert), 1))
 	if err != nil {
 		t.Error(err)
 	}
 	// wait for updated client cert info that contains both
-	err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, waitForConfigMapCAContent(t, kubeClient, "client-ca-file", "-----BEGIN CERTIFICATE-----", 2))
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, waitForConfigMapCAContent(t, kubeClient, "client-ca-file", "-----BEGIN CERTIFICATE-----", 2))
 	if err != nil {
 		t.Error(err)
 	}
-	err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, waitForConfigMapCAContent(t, kubeClient, "client-ca-file", string(clientCA.CACert), 1))
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, waitForConfigMapCAContent(t, kubeClient, "client-ca-file", string(clientCA.CACert), 1))
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/integration/apiserver/certreload/certreload_test.go
+++ b/test/integration/apiserver/certreload/certreload_test.go
@@ -306,9 +306,9 @@ func testClientCA(t *testing.T, recreate bool) {
 	}
 }
 
-func waitForConfigMapCAContent(t *testing.T, kubeClient kubernetes.Interface, key, content string, count int) func() (bool, error) {
-	return func() (bool, error) {
-		clusterAuthInfo, err := kubeClient.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "extension-apiserver-authentication", metav1.GetOptions{})
+func waitForConfigMapCAContent(t *testing.T, kubeClient kubernetes.Interface, key, content string, count int) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		clusterAuthInfo, err := kubeClient.CoreV1().ConfigMaps("kube-system").Get(ctx, "extension-apiserver-authentication", metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}

--- a/test/integration/apiserver/crd_regression_test.go
+++ b/test/integration/apiserver/crd_regression_test.go
@@ -88,7 +88,7 @@ func TestCRDExponentialRecursionBug(t *testing.T) {
 	}
 
 	// Wait until the CRD exist in discovery
-	err = wait.PollImmediate(100*time.Millisecond, 15*time.Second, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 		groupResource, err := apiExtensionClient.Discovery().ServerResourcesForGroupVersion(crd.Spec.Group + "/" + crd.Spec.Versions[0].Name)
 		if err != nil {
 			return false, nil
@@ -100,6 +100,7 @@ func TestCRDExponentialRecursionBug(t *testing.T) {
 		}
 		return false, nil
 	})
+
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/flowcontrol/concurrency_test.go
+++ b/test/integration/apiserver/flowcontrol/concurrency_test.go
@@ -293,7 +293,7 @@ func createPriorityLevelAndBindingFlowSchemaForUser(c clientset.Interface, usern
 		return nil, nil, err
 	}
 
-	return pl, fs, wait.Poll(time.Second, timeout, func() (bool, error) {
+	return pl, fs, wait.PollUntilContextTimeout(context.Background(), time.Second, timeout, false, func(ctx context.Context) (bool, error) {
 		fs, err := c.FlowcontrolV1beta3().FlowSchemas().Get(context.TODO(), username, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -307,6 +307,7 @@ func createPriorityLevelAndBindingFlowSchemaForUser(c clientset.Interface, usern
 		}
 		return false, nil
 	})
+
 }
 
 func streamRequests(parallel int, request func(), wg *sync.WaitGroup, stopCh <-chan struct{}) {

--- a/test/integration/apiserver/flowcontrol/fs_condition_test.go
+++ b/test/integration/apiserver/flowcontrol/fs_condition_test.go
@@ -52,7 +52,7 @@ func TestConditionIsolation(t *testing.T) {
 	fsClient := loopbackClient.FlowcontrolV1beta3().FlowSchemas()
 	var dangleOrig *flowcontrol.FlowSchemaCondition
 
-	wait.PollUntil(time.Second, func() (bool, error) {
+	wait.PollUntilContextCancel(context.Background(), time.Second, false, func(ctx context.Context) (bool, error) {
 		fsGot, err := fsClient.Get(ctx, fsOrig.Name, metav1.GetOptions{})
 		if err != nil {
 			klog.Errorf("Failed to fetch FlowSchema %q: %v", fsOrig.Name, err)
@@ -60,7 +60,7 @@ func TestConditionIsolation(t *testing.T) {
 		}
 		dangleOrig = getCondition(fsGot.Status.Conditions, flowcontrol.FlowSchemaConditionDangling)
 		return dangleOrig != nil, nil
-	}, stopCh)
+	})
 
 	ssaType := flowcontrol.FlowSchemaConditionType("test-ssa")
 	patchSSA := flowcontrolapply.FlowSchema(fsOrig.Name).

--- a/test/integration/apiserver/openapi/openapi_v2_merge_test.go
+++ b/test/integration/apiserver/openapi/openapi_v2_merge_test.go
@@ -170,7 +170,7 @@ func TestOpenAPIV2CRDMergeNoDuplicateTypes(t *testing.T) {
 
 	var openAPISpec spec.Swagger
 	// Poll for the OpenAPI to be updated with the new CRD
-	wait.Poll(time.Second*1, wait.ForeverTestTimeout, func() (bool, error) {
+	wait.PollUntilContextTimeout(context.Background(), time.Second*1, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 		jsonData, err := clientset.RESTClient().Get().AbsPath("/openapi/v2").Do(context.TODO()).Raw()
 		if err != nil {
 			t.Fatal(err)

--- a/test/integration/apiserver/podlogs/podlogs_test.go
+++ b/test/integration/apiserver/podlogs/podlogs_test.go
@@ -277,7 +277,7 @@ func TestPodLogsKubeletClientCertReload(t *testing.T) {
 	}
 
 	// wait until the kubelet observes the new CA
-	if err := wait.PollImmediateUntilWithContext(ctx, time.Second, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
 		_, errLog := clientSet.CoreV1().Pods("ns").GetLogs(pod.Name, &corev1.PodLogOptions{}).DoRaw(ctx)
 		if errors.IsUnauthorized(errLog) {
 			return true, nil
@@ -296,7 +296,7 @@ func TestPodLogsKubeletClientCertReload(t *testing.T) {
 	}
 
 	// confirm that the API server observes the new client cert and closes existing connections to use it
-	if err := wait.PollImmediateUntilWithContext(ctx, time.Second, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
 		fixedPodLogs, errLog := clientSet.CoreV1().Pods("ns").GetLogs(pod.Name, &corev1.PodLogOptions{}).DoRaw(ctx)
 		if errors.IsUnauthorized(errLog) {
 			t.Log("api server has not observed new client cert")

--- a/test/integration/apiserver/watchcache_test.go
+++ b/test/integration/apiserver/watchcache_test.go
@@ -75,7 +75,7 @@ func multiEtcdSetup(t *testing.T) (clientset.Interface, framework.TearDownFunc) 
 	// waiting for post start hooks, so we just wait for default service to exist.
 	// TODO(wojtek-t): Figure out less fragile way.
 	ctx := context.Background()
-	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 		_, err := clientSet.CoreV1().Services("default").Get(ctx, "kubernetes", metav1.GetOptions{})
 		return err == nil, nil
 	}); err != nil {

--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -571,7 +571,7 @@ func TestNodeAuthorizer(t *testing.T) {
 // out and the last error returned by the method.
 func expect(t *testing.T, f func() error, wantErr func(error) bool) (timeout bool, lastErr error) {
 	t.Helper()
-	err := wait.PollImmediate(time.Second, 30*time.Second, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		t.Helper()
 		lastErr = f()
 		if wantErr(lastErr) {
@@ -580,6 +580,7 @@ func expect(t *testing.T, f func() error, wantErr func(error) bool) (timeout boo
 		t.Logf("unexpected response, will retry: %v", lastErr)
 		return false, nil
 	})
+
 	return err == nil, lastErr
 }
 

--- a/test/integration/auth/podsecurity_test.go
+++ b/test/integration/auth/podsecurity_test.go
@@ -196,7 +196,7 @@ func startPodSecurityWebhook(t *testing.T, testServer *kubeapiservertesting.Test
 		Host:   c.InsecureServing.Listener.Addr().String(),
 		Path:   "/readyz",
 	}).String()
-	if err := wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		resp, err := http.Get(readyz)
 		if err != nil {
 			return false, err
@@ -281,7 +281,7 @@ func installWebhook(t *testing.T, clientConfig *rest.Config, addr string) error 
 		},
 	}
 	// Wait for the invalid namespace to be rejected.
-	if err := wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Namespaces().Create(context.TODO(), invalidNamespace, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
 		if err != nil && apierrors.IsInvalid(err) {
 			return true, nil // An Invalid error indicates the webhook rejected the invalid level.

--- a/test/integration/authutil/authutil.go
+++ b/test/integration/authutil/authutil.go
@@ -49,7 +49,7 @@ func WaitForNamedAuthorizationUpdate(t *testing.T, ctx context.Context, c author
 		},
 	}
 
-	if err := wait.Poll(200*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 200*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 		response, err := c.SubjectAccessReviews().Create(ctx, review, metav1.CreateOptions{})
 		if err != nil {
 			return false, err

--- a/test/integration/certificates/controller_approval_test.go
+++ b/test/integration/certificates/controller_approval_test.go
@@ -152,7 +152,7 @@ const (
 )
 
 func waitForCertificateRequestApproved(client clientset.Interface, name string) error {
-	if err := wait.Poll(interval, timeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, false, func(ctx context.Context) (bool, error) {
 		csr, err := client.CertificatesV1().CertificateSigningRequests().Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -172,7 +172,7 @@ func ensureCertificateRequestNotApproved(client clientset.Interface, name string
 	// There is currently no way to explicitly check if the CSR has been rejected for auto-approval.
 	err := waitForCertificateRequestApproved(client, name)
 	switch {
-	case err == wait.ErrWaitTimeout:
+	case wait.Interrupted(err):
 		return nil
 	case err == nil:
 		return fmt.Errorf("CertificateSigningRequest was auto-approved")

--- a/test/integration/client/exec_test.go
+++ b/test/integration/client/exec_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -609,7 +608,7 @@ func (is *informerSpy) waitForEvents(t *testing.T, wantEvents bool) {
 			t.Fatalf("wanted events, but got error: %v", err)
 		}
 	} else {
-		if !errors.Is(err, wait.ErrorInterrupted(errors.New("TODO"))) {
+		if !wait.Interrupted(err) {
 			if err != nil {
 				t.Fatalf("wanted no events, but got error: %v", err)
 			} else {

--- a/test/integration/clustercidr/ipam_test.go
+++ b/test/integration/clustercidr/ipam_test.go
@@ -279,7 +279,7 @@ func TestIPAMMultiCIDRRangeAllocatorClusterCIDRDelete(t *testing.T) {
 		}
 
 		// Poll to make sure that the Node is deleted.
-		if err := wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			_, err := clientSet.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				return false, err
@@ -290,7 +290,7 @@ func TestIPAMMultiCIDRRangeAllocatorClusterCIDRDelete(t *testing.T) {
 		}
 
 		// Poll to make sure that the ClusterCIDR is now deleted, as there is no node associated with it.
-		if err := wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			_, err := clientSet.NetworkingV1alpha1().ClusterCIDRs().Get(context.TODO(), clusterCIDR.Name, metav1.GetOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				return false, err
@@ -502,7 +502,7 @@ func TestIPAMMultiCIDRRangeAllocatorClusterCIDRTieBreak(t *testing.T) {
 			}
 
 			// Wait till the Node is deleted.
-			if err := wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(context.Background(), time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 				_, err := clientSet.CoreV1().Nodes().Get(context.TODO(), test.node.Name, metav1.GetOptions{})
 				if err != nil && !apierrors.IsNotFound(err) {
 					return false, err
@@ -520,7 +520,7 @@ func TestIPAMMultiCIDRRangeAllocatorClusterCIDRTieBreak(t *testing.T) {
 				}
 
 				// Wait till the ClusterCIDR is deleted.
-				if err := wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+				if err := wait.PollUntilContextTimeout(context.Background(), time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 					_, err := clientSet.NetworkingV1alpha1().ClusterCIDRs().Get(context.TODO(), clusterCIDR.Name, metav1.GetOptions{})
 					if err != nil && !apierrors.IsNotFound(err) {
 						return false, err
@@ -633,7 +633,7 @@ func nodeSelector(labels map[string][]string) *v1.NodeSelector {
 
 func nodePodCIDRs(c clientset.Interface, name string) ([]string, error) {
 	var node *v1.Node
-	nodePollErr := wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+	nodePollErr := wait.PollUntilContextTimeout(context.Background(), time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		var err error
 		node, err = c.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {

--- a/test/integration/controlplane/apiserver_identity_test.go
+++ b/test/integration/controlplane/apiserver_identity_test.go
@@ -80,7 +80,7 @@ func TestCreateLeaseOnStart(t *testing.T) {
 	}
 
 	t.Logf(`Waiting the kube-apiserver Lease to be created`)
-	if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		leases, err := kubeclient.
 			CoordinationV1().
 			Leases(metav1.NamespaceSystem).
@@ -202,7 +202,7 @@ func testLeaseGarbageCollected(t *testing.T, client kubernetes.Interface, lease 
 		if _, err := client.CoordinationV1().Leases(ns).Create(context.TODO(), lease, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Unexpected error creating lease: %v", err)
 		}
-		if err := wait.PollImmediate(500*time.Millisecond, 5*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 			_, err := client.CoordinationV1().Leases(ns).Get(context.TODO(), lease.Name, metav1.GetOptions{})
 			if err == nil {
 				return false, nil
@@ -224,7 +224,7 @@ func testLeaseNotGarbageCollected(t *testing.T, client kubernetes.Interface, lea
 		if _, err := client.CoordinationV1().Leases(ns).Create(context.TODO(), lease, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Unexpected error creating lease: %v", err)
 		}
-		if err := wait.PollImmediate(500*time.Millisecond, 5*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 			_, err := client.CoordinationV1().Leases(ns).Get(context.TODO(), lease.Name, metav1.GetOptions{})
 			if err != nil && apierrors.IsNotFound(err) {
 				return true, nil

--- a/test/integration/controlplane/audit/audit_test.go
+++ b/test/integration/controlplane/audit/audit_test.go
@@ -394,7 +394,7 @@ func testAudit(t *testing.T, version string, level auditinternal.Level, enableMu
 	var lastMissingReport string
 	createNamespace(t, kubeclient, namespace)
 
-	if err := wait.Poll(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 		// perform configmap operations
 		configMapOperations(t, kubeclient, namespace)
 
@@ -435,7 +435,7 @@ func testAuditCrossGroupSubResource(t *testing.T, version string, expEvents []ut
 		t.Fatalf("%v resource has no cross-group sub-resources", expEvents[0].Resource)
 	}
 
-	if err := wait.Poll(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 		// perform cross-group subresources operations
 		if sa != nil {
 			tokenRequestOperations(t, kubeclient, sa.Namespace, sa.Name)

--- a/test/integration/controlplane/crd_test.go
+++ b/test/integration/controlplane/crd_test.go
@@ -262,7 +262,7 @@ func TestCRDOpenAPI(t *testing.T) {
 	waitForSpec := func(crd *apiextensionsv1.CustomResourceDefinition, expectedType string) {
 		t.Logf(`Waiting for {properties: {"foo": {"type":"%s"}}} to show up in schema`, expectedType)
 		lastMsg := ""
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 			lastMsg = ""
 			defName := crdDefinitionName(crd)
 			schema, err := getPublishedSchema(defName)

--- a/test/integration/controlplane/graceful_shutdown_test.go
+++ b/test/integration/controlplane/graceful_shutdown_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controlplane
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"sync"
@@ -80,7 +81,7 @@ func TestGracefulShutdown(t *testing.T) {
 	}()
 
 	t.Logf("server should fail new requests")
-	if err := wait.Poll(time.Millisecond*100, wait.ForeverTestTimeout, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, false, func(ctx context.Context) (done bool, err error) {
 		resp, err := client.Get(server.ClientConfig.Host + "/")
 		if err != nil {
 			return true, nil

--- a/test/integration/controlplane/kube_apiserver_test.go
+++ b/test/integration/controlplane/kube_apiserver_test.go
@@ -358,7 +358,7 @@ func triggerSpecUpdateWithProbeCRD(t *testing.T, apiextensionsclient *apiextensi
 
 	// Expect the probe CRD path to show up in the OpenAPI spec
 	// TODO(roycaihw): expose response header in rest client and utilize etag here
-	if err := wait.Poll(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 		_, exist, err := getOpenAPIPath(apiextensionsclient, fmt.Sprintf(`/apis/%s/v1/%ss/{name}`, group, name))
 		if err != nil {
 			return false, err
@@ -458,7 +458,7 @@ func testReconcilersAPIServerLease(t *testing.T, leaseCount int, apiServerCount 
 	wg.Wait()
 
 	// 2. verify API Server count servers have registered
-	if err := wait.PollImmediate(3*time.Second, 2*time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		client, err := kubernetes.NewForConfig(apiServerCountServers[0].ClientConfig)
 		if err != nil {
 			t.Logf("error creating client: %v", err)
@@ -502,7 +502,7 @@ func testReconcilersAPIServerLease(t *testing.T, leaseCount int, apiServerCount 
 	}
 
 	// 5. verify only leaseEndpoint servers left
-	if err := wait.PollImmediate(3*time.Second, 2*time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		client, err := kubernetes.NewForConfig(leaseServers[0].ClientConfig)
 		if err != nil {
 			t.Logf("create client error: %v", err)
@@ -548,7 +548,7 @@ func TestMultiAPIServerNodePortAllocation(t *testing.T) {
 		kubeAPIServers = append(kubeAPIServers, server)
 
 		// verify kube API servers have registered and create a client
-		if err := wait.PollImmediate(3*time.Second, 2*time.Minute, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 3*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 			client, err := kubernetes.NewForConfig(kubeAPIServers[i].ClientConfig)
 			if err != nil {
 				t.Logf("create client error: %v", err)

--- a/test/integration/controlplane/synthetic_controlplane_test.go
+++ b/test/integration/controlplane/synthetic_controlplane_test.go
@@ -94,7 +94,7 @@ func TestKubernetesService(t *testing.T) {
 	defer server.TearDownFn()
 
 	coreClient := clientset.NewForConfigOrDie(server.ClientConfig)
-	err := wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		if _, err := coreClient.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{}); err != nil && apierrors.IsNotFound(err) {
 			return false, nil
 		} else if err != nil {
@@ -102,6 +102,7 @@ func TestKubernetesService(t *testing.T) {
 		}
 		return true, nil
 	})
+
 	if err != nil {
 		t.Fatalf("Expected kubernetes service to exist, got: %v", err)
 	}
@@ -665,7 +666,7 @@ func TestAPIServerService(t *testing.T) {
 
 	client := clientset.NewForConfigOrDie(server.ClientConfig)
 
-	err := wait.Poll(time.Second, time.Minute, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
 		svcList, err := client.CoreV1().Services(metav1.NamespaceDefault).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
@@ -690,6 +691,7 @@ func TestAPIServerService(t *testing.T) {
 		}
 		return false, nil
 	})
+
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -721,7 +723,7 @@ func TestServiceAlloc(t *testing.T) {
 	}
 
 	// Wait until the default "kubernetes" service is created.
-	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err

--- a/test/integration/controlplane/transformation/kms_transformation_test.go
+++ b/test/integration/controlplane/transformation/kms_transformation_test.go
@@ -975,7 +975,7 @@ func verifyIfKMSTransformersSwapped(t *testing.T, wantPrefix string, test *trans
 	// generate a random int to be used in secret name
 	idx := rand.Intn(100000)
 
-	pollErr := wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.Background(), time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		// create secret
 		secretName := fmt.Sprintf("secret-%d", idx)
 		_, err := test.createSecret(secretName, "default")
@@ -1000,7 +1000,8 @@ func verifyIfKMSTransformersSwapped(t *testing.T, wantPrefix string, test *trans
 
 		return true, nil
 	})
-	if pollErr == wait.ErrWaitTimeout {
+
+	if wait.Interrupted(pollErr) {
 		t.Fatalf("failed to verify if kms transformers swapped, err: %v", swapErr)
 	}
 }

--- a/test/integration/controlplane/transformation/kmsv2_transformation_test.go
+++ b/test/integration/controlplane/transformation/kmsv2_transformation_test.go
@@ -270,18 +270,19 @@ resources:
 	// Wait 1 sec (poll interval to check resource version) until a resource version change is detected or timeout at 1 minute.
 
 	version3 := ""
-	err = wait.Poll(time.Second, time.Minute,
-		func() (bool, error) {
-			updatedPod, err = test.inplaceUpdatePod(testNamespace, updatedPod, dynamic.NewForConfigOrDie(test.kubeAPIServer.ClientConfig))
-			if err != nil {
-				return false, err
-			}
-			version3 = updatedPod.GetResourceVersion()
-			if version1 != version3 {
-				return true, nil
-			}
-			return false, nil
-		})
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
+
+		updatedPod, err = test.inplaceUpdatePod(testNamespace, updatedPod, dynamic.NewForConfigOrDie(test.kubeAPIServer.ClientConfig))
+		if err != nil {
+			return false, err
+		}
+		version3 = updatedPod.GetResourceVersion()
+		if version1 != version3 {
+			return true, nil
+		}
+		return false, nil
+	})
+
 	if err != nil {
 		t.Fatalf("Failed to detect one resource version update within the allotted time after keyID is updated and pod has been inplace updated, err: %v, ns: %s", err, testNamespace)
 	}

--- a/test/integration/controlplane/transformation/transformation_test.go
+++ b/test/integration/controlplane/transformation/transformation_test.go
@@ -519,7 +519,7 @@ func (e *transformTest) printMetrics() error {
 func mustBeHealthy(t kubeapiservertesting.Logger, checkName, wantBodyContains string, clientConfig *rest.Config, excludes ...string) {
 	t.Helper()
 	var restErr error
-	pollErr := wait.PollImmediate(2*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		body, ok, err := getHealthz(checkName, clientConfig, excludes...)
 		restErr = err
 		if err != nil {
@@ -532,7 +532,7 @@ func mustBeHealthy(t kubeapiservertesting.Logger, checkName, wantBodyContains st
 		return done, nil
 	})
 
-	if pollErr == wait.ErrWaitTimeout {
+	if wait.Interrupted(pollErr) {
 		t.Fatalf("failed to get the expected healthz status of OK for check: %s, error: %v, debug inner error: %v", checkName, pollErr, restErr)
 	}
 }
@@ -540,7 +540,7 @@ func mustBeHealthy(t kubeapiservertesting.Logger, checkName, wantBodyContains st
 func mustBeUnHealthy(t kubeapiservertesting.Logger, checkName, wantBodyContains string, clientConfig *rest.Config, excludes ...string) {
 	t.Helper()
 	var restErr error
-	pollErr := wait.PollImmediate(2*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		body, ok, err := getHealthz(checkName, clientConfig, excludes...)
 		restErr = err
 		if err != nil {
@@ -553,7 +553,7 @@ func mustBeUnHealthy(t kubeapiservertesting.Logger, checkName, wantBodyContains 
 		return done, nil
 	})
 
-	if pollErr == wait.ErrWaitTimeout {
+	if wait.Interrupted(pollErr) {
 		t.Fatalf("failed to get the expected healthz status of !OK for check: %s, error: %v, debug inner error: %v", checkName, pollErr, restErr)
 	}
 }

--- a/test/integration/cronjob/cronjob_test.go
+++ b/test/integration/cronjob/cronjob_test.go
@@ -96,7 +96,7 @@ func cleanupCronJobs(t *testing.T, cjClient clientbatchv1.CronJobInterface, name
 }
 
 func validateJobAndPod(t *testing.T, clientSet clientset.Interface, namespace string) {
-	if err := wait.PollImmediate(1*time.Second, 120*time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 120*time.Second, true, func(ctx context.Context) (bool, error) {
 		jobs, err := clientSet.BatchV1().Jobs(namespace).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			t.Fatalf("Failed to list jobs: %v", err)

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -312,9 +312,9 @@ func validateDaemonSetPodsAndMarkReady(
 
 // podUnschedulable returns a condition function that returns true if the given pod
 // gets unschedulable status.
-func podUnschedulable(c clientset.Interface, podNamespace, podName string) wait.ConditionFunc {
-	return func() (bool, error) {
-		pod, err := c.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+func podUnschedulable(c clientset.Interface, podNamespace, podName string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		pod, err := c.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}

--- a/test/integration/deployment/deployment_test.go
+++ b/test/integration/deployment/deployment_test.go
@@ -464,7 +464,7 @@ func TestDeploymentHashCollision(t *testing.T) {
 	}
 
 	// Expect deployment collision counter to increment
-	if err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
 		d, err := c.AppsV1().Deployments(ns.Name).Get(context.TODO(), tester.deployment.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, nil
@@ -985,7 +985,7 @@ func testRSControllerRefPatch(t *testing.T, tester *deploymentTester, rs *apps.R
 		t.Fatalf("failed to update replicaset %q: %v", rs.Name, err)
 	}
 
-	if err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
 		newRS, err := rsClient.Get(context.TODO(), rs.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -1203,7 +1203,7 @@ func TestReplicaSetOrphaningAndAdoptionWhenLabelsChange(t *testing.T) {
 
 	// Wait for the controllerRef of the replicaset to become nil
 	rsClient := tester.c.AppsV1().ReplicaSets(ns.Name)
-	if err = wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+	if err = wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
 		rs, err = rsClient.Get(context.TODO(), rs.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -1217,7 +1217,7 @@ func TestReplicaSetOrphaningAndAdoptionWhenLabelsChange(t *testing.T) {
 	// This will trigger collision avoidance due to deterministic nature of replicaset name
 	// i.e., the new replicaset will have a name with different hash to preserve name uniqueness
 	var newRS *apps.ReplicaSet
-	if err = wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+	if err = wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
 		newRS, err = testutil.GetNewReplicaSet(tester.deployment, c)
 		if err != nil {
 			return false, fmt.Errorf("failed to get new replicaset of deployment %q after orphaning: %v", deploymentName, err)
@@ -1241,7 +1241,7 @@ func TestReplicaSetOrphaningAndAdoptionWhenLabelsChange(t *testing.T) {
 	}
 
 	// Wait for the deployment to adopt the old replicaset
-	if err = wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+	if err = wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
 		rs, err := rsClient.Get(context.TODO(), rs.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/integration/deployment/util.go
+++ b/test/integration/deployment/util.go
@@ -196,7 +196,7 @@ func (d *deploymentTester) markUpdatedPodsReady(wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	ns := d.deployment.Namespace
-	err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
 		// We're done when the deployment is complete
 		if completed, err := d.deploymentComplete(); err != nil {
 			return false, err
@@ -221,6 +221,7 @@ func (d *deploymentTester) markUpdatedPodsReady(wg *sync.WaitGroup) {
 		}
 		return false, nil
 	})
+
 	if err != nil {
 		d.t.Errorf("failed to mark updated Deployment pods to ready: %v", err)
 	}
@@ -402,7 +403,7 @@ func (d *deploymentTester) scaleDeployment(newReplicas int32) error {
 
 // waitForReadyReplicas waits for number of ready replicas to equal number of replicas.
 func (d *deploymentTester) waitForReadyReplicas() error {
-	if err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
 		deployment, err := d.c.AppsV1().Deployments(d.deployment.Namespace).Get(context.TODO(), d.deployment.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("failed to get deployment %q: %v", d.deployment.Name, err)
@@ -416,7 +417,7 @@ func (d *deploymentTester) waitForReadyReplicas() error {
 
 // markUpdatedPodsReadyWithoutComplete marks updated Deployment pods as ready without waiting for deployment to complete.
 func (d *deploymentTester) markUpdatedPodsReadyWithoutComplete() error {
-	if err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
 		pods, err := d.listUpdatedPods()
 		if err != nil {
 			return false, err

--- a/test/integration/disruption/disruption_test.go
+++ b/test/integration/disruption/disruption_test.go
@@ -475,7 +475,7 @@ func newCustomResourceDefinition() *apiextensionsv1.CustomResourceDefinition {
 }
 
 func waitPDBStable(ctx context.Context, t *testing.T, clientSet clientset.Interface, podNum int32, ns, pdbName string) {
-	if err := wait.PollImmediate(2*time.Second, 60*time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		pdb, err := clientSet.PolicyV1().PodDisruptionBudgets(ns).Get(ctx, pdbName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -490,7 +490,7 @@ func waitPDBStable(ctx context.Context, t *testing.T, clientSet clientset.Interf
 }
 
 func waitToObservePods(t *testing.T, podInformer cache.SharedIndexInformer, podNum int, phase v1.PodPhase) {
-	if err := wait.PollImmediate(2*time.Second, 60*time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		objects := podInformer.GetIndexer().List()
 		if len(objects) != podNum {
 			return false, nil
@@ -745,7 +745,7 @@ func TestStalePodDisruption(t *testing.T) {
 			}
 			time.Sleep(stalePodDisruptionTimeout)
 			diff := ""
-			if err := wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (done bool, err error) {
+			if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (done bool, err error) {
 				pod, err = clientSet.CoreV1().Pods(nsName).Get(ctx, name, metav1.GetOptions{})
 				if err != nil {
 					return false, err

--- a/test/integration/dualstack/dualstack_endpoints_test.go
+++ b/test/integration/dualstack/dualstack_endpoints_test.go
@@ -53,7 +53,7 @@ func TestDualStackEndpoints(t *testing.T) {
 	defer tearDownFn()
 
 	// Wait until the default "kubernetes" service is created.
-	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
@@ -213,7 +213,7 @@ func TestDualStackEndpoints(t *testing.T) {
 			// wait until endpoints are created
 			// legacy endpoints are not dual stack
 			// and use the address of the first IP family
-			if err := wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 				e, err := client.CoreV1().Endpoints(ns.Name).Get(context.TODO(), svc.Name, metav1.GetOptions{})
 				if err != nil {
 					t.Logf("Error fetching endpoints: %v", err)
@@ -234,7 +234,7 @@ func TestDualStackEndpoints(t *testing.T) {
 			}
 
 			// wait until the endpoint slices are created
-			err = wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+			err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 				lSelector := discovery.LabelServiceName + "=" + svc.Name
 				esList, err := client.DiscoveryV1().EndpointSlices(ns.Name).List(context.TODO(), metav1.ListOptions{LabelSelector: lSelector})
 				if err != nil {
@@ -267,6 +267,7 @@ func TestDualStackEndpoints(t *testing.T) {
 				}
 				return true, nil
 			})
+
 			if err != nil {
 				t.Fatalf("Error waiting for endpoint slices: %v", err)
 			}

--- a/test/integration/dualstack/dualstack_test.go
+++ b/test/integration/dualstack/dualstack_test.go
@@ -53,7 +53,7 @@ func TestCreateServiceSingleStackIPv4(t *testing.T) {
 	defer tearDownFn()
 
 	// Wait until the default "kubernetes" service is created.
-	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
@@ -281,7 +281,7 @@ func TestCreateServiceDualStackIPv6(t *testing.T) {
 	defer tearDownFn()
 
 	// Wait until the default "kubernetes" service is created.
-	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
@@ -496,7 +496,7 @@ func TestCreateServiceDualStackIPv4IPv6(t *testing.T) {
 	defer tearDownFn()
 
 	// Wait until the default "kubernetes" service is created.
-	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
@@ -760,7 +760,7 @@ func TestCreateServiceDualStackIPv6IPv4(t *testing.T) {
 	defer tearDownFn()
 
 	// Wait until the default "kubernetes" service is created.
-	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
@@ -771,7 +771,7 @@ func TestCreateServiceDualStackIPv6IPv4(t *testing.T) {
 	}
 
 	// verify client is working
-	if err := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Endpoints("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil {
 			t.Logf("error fetching endpoints: %v", err)
@@ -978,7 +978,7 @@ func TestUpgradeDowngrade(t *testing.T) {
 	defer tearDownFn()
 
 	// Wait until the default "kubernetes" service is created.
-	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
@@ -1081,7 +1081,7 @@ func TestConvertToFromExternalName(t *testing.T) {
 	defer tearDownFn()
 
 	// Wait until the default "kubernetes" service is created.
-	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
@@ -1162,7 +1162,7 @@ func TestPreferDualStack(t *testing.T) {
 	defer tearDownFn()
 
 	// Wait until the default "kubernetes" service is created.
-	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
@@ -1235,7 +1235,7 @@ func TestServiceUpdate(t *testing.T) {
 	defer tearDownFn()
 
 	// Wait until the default "kubernetes" service is created.
-	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
@@ -1397,7 +1397,7 @@ func TestUpgradeServicePreferToDualStack(t *testing.T) {
 	})
 
 	// Wait until the default "kubernetes" service is created.
-	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
@@ -1456,7 +1456,7 @@ func TestUpgradeServicePreferToDualStack(t *testing.T) {
 	defer tearDownFn()
 
 	// Wait until the default "kubernetes" service is created.
-	if err = wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err = wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
@@ -1491,7 +1491,7 @@ func TestDowngradeServicePreferToDualStack(t *testing.T) {
 	})
 
 	// Wait until the default "kubernetes" service is created.
-	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err
@@ -1546,7 +1546,7 @@ func TestDowngradeServicePreferToDualStack(t *testing.T) {
 	defer tearDownFn()
 
 	// Wait until the default "kubernetes" service is created.
-	if err = wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err = wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, err

--- a/test/integration/endpoints/endpoints_test.go
+++ b/test/integration/endpoints/endpoints_test.go
@@ -106,7 +106,7 @@ func TestEndpointUpdates(t *testing.T) {
 
 	// Obtain ResourceVersion of the new endpoint created
 	var resVersion string
-	if err := wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		endpoints, err := client.CoreV1().Endpoints(ns.Name).Get(ctx, svc.Name, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("error fetching endpoints: %v", err)
@@ -135,7 +135,7 @@ func TestEndpointUpdates(t *testing.T) {
 		t.Fatalf("Failed to create service %s: %v", svc.Name, err)
 	}
 
-	if err := wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Endpoints(ns.Name).Get(ctx, svc2.Name, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("error fetching endpoints: %v", err)
@@ -230,7 +230,7 @@ func TestExternalNameToClusterIPTransition(t *testing.T) {
 		t.Fatalf("Failed to create service %s: %v", svc.Name, err)
 	}
 
-	err = wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		endpoints, err := client.CoreV1().Endpoints(ns.Name).Get(ctx, svc.Name, metav1.GetOptions{})
 		if err == nil {
 			t.Errorf("expected no endpoints for externalName service, got: %v", endpoints)
@@ -238,6 +238,7 @@ func TestExternalNameToClusterIPTransition(t *testing.T) {
 		}
 		return false, nil
 	})
+
 	if err == nil {
 		t.Errorf("expected error waiting for endpoints")
 	}
@@ -249,7 +250,7 @@ func TestExternalNameToClusterIPTransition(t *testing.T) {
 		t.Fatalf("Failed to update service %s: %v", svc1.Name, err)
 	}
 
-	if err := wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		ep, err := client.CoreV1().Endpoints(ns.Name).Get(ctx, svc1.Name, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("no endpoints found, error: %v", err)
@@ -372,7 +373,7 @@ func TestEndpointWithTerminatingPod(t *testing.T) {
 	}
 
 	// poll until associated Endpoints to the previously created Service exists
-	if err := wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		endpoints, err := client.CoreV1().Endpoints(ns.Name).Get(ctx, svc.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, nil
@@ -398,7 +399,7 @@ func TestEndpointWithTerminatingPod(t *testing.T) {
 	}
 
 	// poll until endpoint for deleted Pod is no longer in Endpoints.
-	if err := wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		// Ensure that the recently deleted Pod exists but with a deletion timestamp. If the Pod does not exist,
 		// we should fail the test since it is no longer validating against a terminating pod.
 		pod, err := client.CoreV1().Pods(ns.Name).Get(ctx, pod.Name, metav1.GetOptions{})

--- a/test/integration/endpointslice/endpointslicemirroring_test.go
+++ b/test/integration/endpointslice/endpointslicemirroring_test.go
@@ -271,7 +271,7 @@ func TestEndpointSliceMirroring(t *testing.T) {
 				}
 			}
 
-			err = wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+			err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 				lSelector := discovery.LabelServiceName + "=" + resourceName
 				esList, err := client.DiscoveryV1().EndpointSlices(ns.Name).List(ctx, metav1.ListOptions{LabelSelector: lSelector})
 				if err != nil {
@@ -300,6 +300,7 @@ func TestEndpointSliceMirroring(t *testing.T) {
 
 				return true, nil
 			})
+
 			if err != nil {
 				t.Fatalf("Timed out waiting for conditions: %v", err)
 			}
@@ -418,7 +419,7 @@ func TestEndpointSliceMirroringUpdates(t *testing.T) {
 			}
 
 			// verify the endpoint updates were mirrored
-			err = wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+			err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 				lSelector := discovery.LabelServiceName + "=" + service.Name
 				esList, err := client.DiscoveryV1().EndpointSlices(ns.Name).List(ctx, metav1.ListOptions{LabelSelector: lSelector})
 				if err != nil {
@@ -476,6 +477,7 @@ func TestEndpointSliceMirroringUpdates(t *testing.T) {
 				}
 				return true, nil
 			})
+
 			if err != nil {
 				t.Fatalf("Timed out waiting for conditions: %v", err)
 			}
@@ -608,7 +610,7 @@ func TestEndpointSliceMirroringSelectorTransition(t *testing.T) {
 
 func waitForMirroredSlices(t *testing.T, client *clientset.Clientset, nsName, svcName string, num int) error {
 	t.Helper()
-	return wait.PollImmediate(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), 1*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		lSelector := discovery.LabelServiceName + "=" + svcName
 		lSelector += "," + discovery.LabelManagedBy + "=endpointslicemirroring-controller.k8s.io"
 		esList, err := client.DiscoveryV1().EndpointSlices(nsName).List(context.TODO(), metav1.ListOptions{LabelSelector: lSelector})
@@ -624,6 +626,7 @@ func waitForMirroredSlices(t *testing.T, client *clientset.Clientset, nsName, sv
 
 		return true, nil
 	})
+
 }
 
 // isSubset check if all the elements in a exist in b

--- a/test/integration/endpointslice/endpointsliceterminating_test.go
+++ b/test/integration/endpointslice/endpointsliceterminating_test.go
@@ -204,7 +204,7 @@ func TestEndpointSliceTerminating(t *testing.T) {
 			}
 
 			// first check that endpoints are included, test should always have 1 initial endpoint
-			err = wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
+			err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 				esList, err := client.DiscoveryV1().EndpointSlices(ns.Name).List(context.TODO(), metav1.ListOptions{
 					LabelSelector: discovery.LabelServiceName + "=" + svc.Name,
 				})
@@ -228,6 +228,7 @@ func TestEndpointSliceTerminating(t *testing.T) {
 
 				return false, nil
 			})
+
 			if err != nil {
 				t.Errorf("Error waiting for endpoint slices: %v", err)
 			}
@@ -241,7 +242,7 @@ func TestEndpointSliceTerminating(t *testing.T) {
 			// Validate that terminating the endpoint will result in the expected endpoints in EndpointSlice.
 			// Use a stricter timeout value here since we should try to catch regressions in the time it takes to remove terminated endpoints.
 			var endpoints []discovery.Endpoint
-			err = wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
+			err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 				esList, err := client.DiscoveryV1().EndpointSlices(ns.Name).List(context.TODO(), metav1.ListOptions{
 					LabelSelector: discovery.LabelServiceName + "=" + svc.Name,
 				})
@@ -273,6 +274,7 @@ func TestEndpointSliceTerminating(t *testing.T) {
 
 				return true, nil
 			})
+
 			if err != nil {
 				t.Logf("actual endpoints: %v", endpoints)
 				t.Logf("expected endpoints: %v", testcase.expectedEndpoints)

--- a/test/integration/etcd/crd_overlap_storage_test.go
+++ b/test/integration/etcd/crd_overlap_storage_test.go
@@ -132,7 +132,7 @@ func TestOverlappingCustomResourceAPIService(t *testing.T) {
 	}
 
 	// Wait until it is established
-	if err := wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		crd, err := crdClient.CustomResourceDefinitions().Get(context.TODO(), crdCRD.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -203,7 +203,7 @@ func TestOverlappingCustomResourceAPIService(t *testing.T) {
 	}
 
 	// Make sure the CRD deletion succeeds
-	if err := wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		crd, err := crdClient.CustomResourceDefinitions().Get(context.TODO(), crdCRD.Name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil
@@ -295,7 +295,7 @@ func TestOverlappingCustomResourceCustomResourceDefinition(t *testing.T) {
 	}
 
 	// Wait until it is established
-	if err := wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		crd, err := crdClient.CustomResourceDefinitions().Get(context.TODO(), crdCRD.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -354,7 +354,7 @@ func TestOverlappingCustomResourceCustomResourceDefinition(t *testing.T) {
 	}
 
 	// Make sure the CRD deletion succeeds
-	if err := wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		crd, err := crdClient.CustomResourceDefinitions().Get(context.TODO(), crdCRD.Name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil

--- a/test/integration/events/events_test.go
+++ b/test/integration/events/events_test.go
@@ -72,7 +72,7 @@ func TestEventCompatibility(t *testing.T) {
 	newRecorder := newBroadcaster.NewRecorder(scheme.Scheme, "k8s.io/kube-scheduler")
 	newBroadcaster.StartRecordingToSink(stopCh)
 	newRecorder.Eventf(regarding, related, v1.EventTypeNormal, "memoryPressure", "killed", "memory pressure")
-	err = wait.PollImmediate(100*time.Millisecond, 20*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 20*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		v1Events, err := client.EventsV1().Events("").List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
@@ -92,6 +92,7 @@ func TestEventCompatibility(t *testing.T) {
 		}
 		return true, nil
 	})
+
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -165,7 +165,7 @@ func TestAggregatedAPIServer(t *testing.T) {
 	}
 
 	// wait for the API service to be available
-	err = wait.Poll(time.Second, wait.ForeverTestTimeout, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, wait.ForeverTestTimeout, false, func(ctx context.Context) (done bool, err error) {
 		apiService, err := aggregatorClient.ApiregistrationV1().APIServices().Get(ctx, "v1alpha1.wardle.example.com", metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -211,6 +211,7 @@ func TestAggregatedAPIServer(t *testing.T) {
 
 		return true, nil
 	})
+
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,25 +259,27 @@ func TestAggregatedAPIServer(t *testing.T) {
 
 	// Now we want to verify that the client CA bundles properly reflect the values for the cluster-authentication
 	var firstKubeCANames []string
-	err = wait.Poll(1*time.Second, wait.ForeverTestTimeout, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, wait.ForeverTestTimeout, false, func(ctx context.Context) (done bool, err error) {
 		firstKubeCANames, err = cert.GetClientCANamesForURL(kubeClientConfig.Host)
 		if err != nil {
 			return false, err
 		}
 		return len(firstKubeCANames) != 0, nil
 	})
+
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log(firstKubeCANames)
 	var firstWardleCANames []string
-	err = wait.Poll(1*time.Second, wait.ForeverTestTimeout, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, wait.ForeverTestTimeout, false, func(ctx context.Context) (done bool, err error) {
 		firstWardleCANames, err = cert.GetClientCANamesForURL(directWardleClientConfig.Host)
 		if err != nil {
 			return false, err
 		}
 		return len(firstWardleCANames) != 0, nil
 	})
+
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -346,7 +349,7 @@ func waitForWardleRunning(ctx context.Context, t *testing.T, wardleToKASKubeConf
 	var wardleClient client.Interface
 	lastHealthContent := []byte{}
 	var lastHealthErr error
-	err := wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		if _, err := os.Stat(directWardleClientConfig.CAFile); os.IsNotExist(err) { // wait until the file trust is created
 			lastHealthErr = err
 			return false, nil
@@ -366,6 +369,7 @@ func waitForWardleRunning(ctx context.Context, t *testing.T, wardleToKASKubeConf
 		}
 		return true, nil
 	})
+
 	if err != nil {
 		t.Log(string(lastHealthContent))
 		t.Log(lastHealthErr)
@@ -453,7 +457,7 @@ func TestAggregatedAPIServerRejectRedirectResponse(t *testing.T) {
 	}
 
 	// wait for the API service to be available
-	err = wait.Poll(time.Second, wait.ForeverTestTimeout, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, wait.ForeverTestTimeout, false, func(ctx context.Context) (done bool, err error) {
 		apiService, err := aggregatorClient.ApiregistrationV1().APIServices().Get(ctx, "v1alpha1.reject.redirect.example.com", metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -471,6 +475,7 @@ func TestAggregatedAPIServerRejectRedirectResponse(t *testing.T) {
 		}
 		return available, nil
 	})
+
 	if err != nil {
 		t.Errorf("%v", err)
 	}

--- a/test/integration/examples/webhook_test.go
+++ b/test/integration/examples/webhook_test.go
@@ -87,7 +87,7 @@ func TestWebhookLoopback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		_, err = client.CoreV1().ConfigMaps("default").Create(context.TODO(), &v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: "webhook-test"},
 			Data:       map[string]string{"invalid key": "value"},
@@ -102,6 +102,7 @@ func TestWebhookLoopback(t *testing.T) {
 		t.Logf("webhook not called yet, continuing...")
 		return false, nil
 	})
+
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -185,7 +185,7 @@ func StartTestServer(t testing.TB, setup TestServerSetup) (client.Interface, *re
 	kubeAPIServerClientConfig.ServerName = ""
 
 	// wait for health
-	err = wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		select {
 		case err := <-errCh:
 			return false, err
@@ -217,6 +217,7 @@ func StartTestServer(t testing.TB, setup TestServerSetup) (client.Interface, *re
 
 		return true, nil
 	})
+
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/framework/util.go
+++ b/test/integration/framework/util.go
@@ -63,13 +63,14 @@ func DeleteNamespaceOrDie(c clientset.Interface, ns *v1.Namespace, t testing.TB)
 func waitListAllNodes(c clientset.Interface) (*v1.NodeList, error) {
 	var nodes *v1.NodeList
 	var err error
-	if wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
+	if wait.PollUntilContextTimeout(context.Background(), poll, singleCallTimeout, true, func(ctx context.Context) (bool, error) {
 		nodes, err = c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
 		return true, nil
-	}) != nil {
+	}) !=
+		nil {
 		return nodes, err
 	}
 	return nodes, nil

--- a/test/integration/garbagecollector/cluster_scoped_owner_test.go
+++ b/test/integration/garbagecollector/cluster_scoped_owner_test.go
@@ -117,7 +117,7 @@ func TestClusterScopedOwners(t *testing.T) {
 	}
 
 	// wait for deletable children to go away
-	if err := wait.Poll(5*time.Second, 300*time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 300*time.Second, false, func(ctx context.Context) (bool, error) {
 		_, err := clientSet.CoreV1().ConfigMaps(ns.Name).Get(context.TODO(), "cm-missing", metav1.GetOptions{})
 		switch {
 		case apierrors.IsNotFound(err):

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -403,7 +403,7 @@ func testCrossNamespaceReferences(t *testing.T, watchCache bool) {
 			return false, nil
 		}
 		return true, nil
-	}); err != nil && !wait.Interrupted(err) {
+	}); err != nil && err != context.DeadlineExceeded {
 		t.Error(err)
 	}
 
@@ -417,7 +417,7 @@ func testCrossNamespaceReferences(t *testing.T, watchCache bool) {
 			return false, fmt.Errorf("expected %d valid children, got %d", validChildrenCount, len(children.Items))
 		}
 		return false, nil
-	}); err != nil && !wait.Interrupted(err) {
+	}); err != nil && err != context.DeadlineExceeded {
 		t.Error(err)
 	}
 

--- a/test/integration/kubelet/watch_manager_test.go
+++ b/test/integration/kubelet/watch_manager_test.go
@@ -108,7 +108,7 @@ func TestWatchBasedManager(t *testing.T) {
 				name := fmt.Sprintf("s%d", i*100+j)
 				start := time.Now()
 				store.AddReference(testNamespace, name)
-				err := wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (bool, error) {
+				err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 					obj, err := store.Get(testNamespace, name)
 					if err != nil {
 						t.Logf("failed on %s, retrying: %v", name, err)
@@ -119,6 +119,7 @@ func TestWatchBasedManager(t *testing.T) {
 					}
 					return true, nil
 				})
+
 				if err != nil {
 					select {
 					case errCh <- fmt.Errorf("failed on :%s: %v", name, err):

--- a/test/integration/namespace/ns_conditions_test.go
+++ b/test/integration/namespace/ns_conditions_test.go
@@ -84,7 +84,7 @@ func TestNamespaceCondition(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = wait.PollImmediate(1*time.Second, 60*time.Second, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		curr, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -112,6 +112,7 @@ func TestNamespaceCondition(t *testing.T) {
 		t.Log(spew.Sdump(curr))
 		return conditionsFound == 5, nil
 	})
+
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/network/services_test.go
+++ b/test/integration/network/services_test.go
@@ -52,7 +52,7 @@ func TestServicesFinalizersRepairLoop(t *testing.T) {
 	defer tearDownFn()
 
 	// verify client is working
-	if err := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Endpoints(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil {
 			t.Logf("error fetching endpoints: %v", err)
@@ -141,7 +141,7 @@ func TestServiceCIDR28bits(t *testing.T) {
 	defer tearDownFn()
 
 	// Wait until the default "kubernetes" service is created.
-	if err := wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Services(metav1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/integration/node/lifecycle_test.go
+++ b/test/integration/node/lifecycle_test.go
@@ -160,7 +160,7 @@ func TestEvictionForNoExecuteTaintAddedByUser(t *testing.T) {
 				t.Errorf("Failed to taint node in test %s <%s>, err: %v", name, nodes[nodeIndex].Name, err)
 			}
 
-			err = wait.PollImmediate(time.Second, time.Second*20, testutils.PodIsGettingEvicted(cs, testPod.Namespace, testPod.Name))
+			err = wait.PollUntilContextTimeout(context.Background(), time.Second, time.Second*20, true, testutils.PodIsGettingEvicted(cs, testPod.Namespace, testPod.Name))
 			if err != nil {
 				t.Fatalf("Error %q in test %q when waiting for terminating pod: %q", err, name, klog.KObj(testPod))
 			}
@@ -352,7 +352,7 @@ func TestTaintBasedEvictions(t *testing.T) {
 			}
 
 			if test.pod != nil {
-				err = wait.PollImmediate(time.Second, time.Second*15, func() (bool, error) {
+				err = wait.PollUntilContextTimeout(context.Background(), time.Second, time.Second*15, true, func(ctx context.Context) (bool, error) {
 					pod, err := cs.CoreV1().Pods(test.pod.Namespace).Get(context.TODO(), test.pod.Name, metav1.GetOptions{})
 					if err != nil {
 						return false, err
@@ -367,6 +367,7 @@ func TestTaintBasedEvictions(t *testing.T) {
 					}
 					return false, nil
 				})
+
 				if err != nil {
 					pod, _ := cs.CoreV1().Pods(testCtx.NS.Name).Get(context.TODO(), test.pod.Name, metav1.GetOptions{})
 					t.Fatalf("Error: %v, Expected test pod to be %s but it's %v", err, test.expectedWaitForPodCondition, pod)

--- a/test/integration/scheduler/extender/extender_test.go
+++ b/test/integration/scheduler/extender/extender_test.go
@@ -411,7 +411,7 @@ func DoTestPodScheduling(ns *v1.Namespace, t *testing.T, cs clientset.Interface)
 		t.Fatalf("Failed to create pod: %v", err)
 	}
 
-	err = wait.Poll(time.Second, wait.ForeverTestTimeout, testutils.PodScheduled(cs, myPod.Namespace, myPod.Name))
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, wait.ForeverTestTimeout, false, testutils.PodScheduled(cs, myPod.Namespace, myPod.Name))
 	if err != nil {
 		t.Fatalf("Failed to schedule pod: %v", err)
 	}

--- a/test/integration/scheduler/filters/filters_test.go
+++ b/test/integration/scheduler/filters/filters_test.go
@@ -830,7 +830,7 @@ func TestInterPodAffinity(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Error while creating pod: %v", err)
 				}
-				err = wait.Poll(pollInterval, wait.ForeverTestTimeout, testutils.PodScheduled(cs, createdPod.Namespace, createdPod.Name))
+				err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, testutils.PodScheduled(cs, createdPod.Namespace, createdPod.Name))
 				if err != nil {
 					t.Errorf("Error while creating pod: %v", err)
 				}
@@ -847,9 +847,9 @@ func TestInterPodAffinity(t *testing.T) {
 			}
 
 			if test.fits {
-				err = wait.Poll(pollInterval, wait.ForeverTestTimeout, testutils.PodScheduled(cs, testPod.Namespace, testPod.Name))
+				err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, testutils.PodScheduled(cs, testPod.Namespace, testPod.Name))
 			} else {
-				err = wait.Poll(pollInterval, wait.ForeverTestTimeout, podUnschedulable(cs, testPod.Namespace, testPod.Name))
+				err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, podUnschedulable(cs, testPod.Namespace, testPod.Name))
 			}
 			if err != nil {
 				t.Errorf("Error while trying to fit a pod: %v", err)
@@ -859,7 +859,7 @@ func TestInterPodAffinity(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error while deleting pod: %v", err)
 			}
-			err = wait.Poll(pollInterval, wait.ForeverTestTimeout, testutils.PodDeleted(cs, testCtx.NS.Name, test.pod.Name))
+			err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, testutils.PodDeleted(cs, testCtx.NS.Name, test.pod.Name))
 			if err != nil {
 				t.Errorf("Error while waiting for pod to get deleted: %v", err)
 			}
@@ -868,7 +868,7 @@ func TestInterPodAffinity(t *testing.T) {
 				if err != nil {
 					t.Errorf("Error while deleting pod: %v", err)
 				}
-				err = wait.Poll(pollInterval, wait.ForeverTestTimeout, testutils.PodDeleted(cs, pod.Namespace, pod.Name))
+				err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, testutils.PodDeleted(cs, pod.Namespace, pod.Name))
 				if err != nil {
 					t.Errorf("Error while waiting for pod to get deleted: %v", err)
 				}
@@ -1013,7 +1013,7 @@ func TestInterPodAffinityWithNamespaceSelector(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error while creating pod: %v", err)
 			}
-			err = wait.Poll(pollInterval, wait.ForeverTestTimeout, testutils.PodScheduled(cs, createdPod.Namespace, createdPod.Name))
+			err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, testutils.PodScheduled(cs, createdPod.Namespace, createdPod.Name))
 			if err != nil {
 				t.Errorf("Error while creating pod: %v", err)
 			}
@@ -1030,9 +1030,9 @@ func TestInterPodAffinityWithNamespaceSelector(t *testing.T) {
 			}
 
 			if test.fits {
-				err = wait.Poll(pollInterval, wait.ForeverTestTimeout, testutils.PodScheduled(cs, testPod.Namespace, testPod.Name))
+				err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, testutils.PodScheduled(cs, testPod.Namespace, testPod.Name))
 			} else {
-				err = wait.Poll(pollInterval, wait.ForeverTestTimeout, podUnschedulable(cs, testPod.Namespace, testPod.Name))
+				err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, podUnschedulable(cs, testPod.Namespace, testPod.Name))
 			}
 			if err != nil {
 				t.Errorf("Error while trying to fit a pod: %v", err)
@@ -1042,7 +1042,7 @@ func TestInterPodAffinityWithNamespaceSelector(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error while deleting pod: %v", err)
 			}
-			err = wait.Poll(pollInterval, wait.ForeverTestTimeout, testutils.PodDeleted(cs, testCtx.NS.Name, test.pod.Name))
+			err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, testutils.PodDeleted(cs, testCtx.NS.Name, test.pod.Name))
 			if err != nil {
 				t.Errorf("Error while waiting for pod to get deleted: %v", err)
 			}
@@ -1050,7 +1050,7 @@ func TestInterPodAffinityWithNamespaceSelector(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error while deleting pod: %v", err)
 			}
-			err = wait.Poll(pollInterval, wait.ForeverTestTimeout, testutils.PodDeleted(cs, test.existingPod.Namespace, test.existingPod.Name))
+			err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, testutils.PodDeleted(cs, test.existingPod.Namespace, test.existingPod.Name))
 			if err != nil {
 				t.Errorf("Error while waiting for pod to get deleted: %v", err)
 			}
@@ -1514,7 +1514,7 @@ func TestPodTopologySpreadFilter(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Error while creating pod during test: %v", err)
 				}
-				err = wait.Poll(pollInterval, wait.ForeverTestTimeout, testutils.PodScheduled(cs, createdPod.Namespace, createdPod.Name))
+				err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, testutils.PodScheduled(cs, createdPod.Namespace, createdPod.Name))
 				if err != nil {
 					t.Errorf("Error while waiting for pod during test: %v", err)
 				}
@@ -1525,9 +1525,9 @@ func TestPodTopologySpreadFilter(t *testing.T) {
 			}
 
 			if tt.fits {
-				err = wait.Poll(pollInterval, wait.ForeverTestTimeout, podScheduledIn(cs, testPod.Namespace, testPod.Name, tt.candidateNodes))
+				err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, podScheduledIn(cs, testPod.Namespace, testPod.Name, tt.candidateNodes))
 			} else {
-				err = wait.Poll(pollInterval, wait.ForeverTestTimeout, podUnschedulable(cs, testPod.Namespace, testPod.Name))
+				err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, podUnschedulable(cs, testPod.Namespace, testPod.Name))
 			}
 			if err != nil {
 				t.Errorf("Test Failed: %v", err)

--- a/test/integration/scheduler/plugins/plugins_test.go
+++ b/test/integration/scheduler/plugins/plugins_test.go
@@ -615,7 +615,7 @@ func TestPreFilterPlugin(t *testing.T) {
 					t.Errorf("Didn't expect the pod to be scheduled. error: %v", err)
 				}
 			} else if test.fail {
-				if err = wait.Poll(10*time.Millisecond, 30*time.Second, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
+				if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
 					t.Errorf("Expected a scheduling error, but got: %v", err)
 				}
 			} else {
@@ -788,7 +788,7 @@ func TestPostFilterPlugin(t *testing.T) {
 			}
 
 			if tt.rejectFilter {
-				if err = wait.Poll(10*time.Millisecond, 10*time.Second, podUnschedulable(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
+				if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 10*time.Second, false, podUnschedulable(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
 					t.Errorf("Didn't expect the pod to be scheduled.")
 				}
 
@@ -854,7 +854,7 @@ func TestScorePlugin(t *testing.T) {
 			}
 
 			if test.fail {
-				if err = wait.Poll(10*time.Millisecond, 30*time.Second, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
+				if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
 					t.Errorf("Expected a scheduling error, but got: %v", err)
 				}
 			} else {
@@ -950,8 +950,7 @@ func TestReservePluginReserve(t *testing.T) {
 			}
 
 			if test.fail {
-				if err = wait.Poll(10*time.Millisecond, 30*time.Second,
-					podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
+				if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
 					t.Errorf("Didn't expect the pod to be scheduled. error: %v", err)
 				}
 			} else {
@@ -1081,7 +1080,7 @@ func TestPrebindPlugin(t *testing.T) {
 					if err = testutils.WaitForPodToScheduleWithTimeout(testCtx.ClientSet, pod, 10*time.Second); err != nil {
 						t.Errorf("Expected the pod to be schedulable on retry, but got an error: %v", err)
 					}
-				} else if err = wait.Poll(10*time.Millisecond, 30*time.Second, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
+				} else if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
 					t.Errorf("Expected a scheduling error, but didn't get it. error: %v", err)
 				}
 			} else if test.reject {
@@ -1097,7 +1096,7 @@ func TestPrebindPlugin(t *testing.T) {
 			}
 
 			if test.unschedulablePod != nil {
-				if err := wait.Poll(10*time.Millisecond, 15*time.Second, func() (bool, error) {
+				if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 15*time.Second, false, func(ctx context.Context) (bool, error) {
 					// 2 means the unschedulable pod is expected to be retried at least twice.
 					// (one initial attempt plus the one moved by the preBind pod)
 					return int(filterPlugin.numFilterCalled) >= 2*nodesNum, nil
@@ -1227,7 +1226,7 @@ func TestUnReserveReservePlugins(t *testing.T) {
 			}
 
 			if test.fail {
-				if err = wait.Poll(10*time.Millisecond, 30*time.Second, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
+				if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
 					t.Errorf("Expected a reasons other than Unschedulable, but got: %v", err)
 				}
 
@@ -1475,7 +1474,7 @@ func TestUnReserveBindPlugins(t *testing.T) {
 			}
 
 			if test.fail {
-				if err = wait.Poll(10*time.Millisecond, 30*time.Second, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
+				if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
 					t.Errorf("Expected a reasons other than Unschedulable, but got: %v", err)
 				}
 
@@ -1647,9 +1646,7 @@ func TestBindPlugin(t *testing.T) {
 						t.Errorf("Expected %s not to be called, was called %d times.", bindPlugin2.Name(), bindPlugin1.numBindCalled)
 					}
 				}
-				if err = wait.Poll(10*time.Millisecond, 30*time.Second, func() (done bool, err error) {
-					return postBindPlugin.numPostBindCalled == 1, nil
-				}); err != nil {
+				if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (done bool, err error) { return postBindPlugin.numPostBindCalled == 1, nil }); err != nil {
 					t.Errorf("Expected the postbind plugin to be called once, was called %d times.", postBindPlugin.numPostBindCalled)
 				}
 				if reservePlugin.numUnreserveCalled != 0 {
@@ -1657,7 +1654,7 @@ func TestBindPlugin(t *testing.T) {
 				}
 			} else {
 				// bind plugin fails to bind the pod
-				if err = wait.Poll(10*time.Millisecond, 30*time.Second, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
+				if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
 					t.Errorf("Expected a scheduling error, but didn't get it. error: %v", err)
 				}
 				if postBindPlugin.numPostBindCalled > 0 {
@@ -1730,7 +1727,7 @@ func TestPostBindPlugin(t *testing.T) {
 			}
 
 			if test.preBindFail {
-				if err = wait.Poll(10*time.Millisecond, 30*time.Second, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
+				if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
 					t.Errorf("Expected a scheduling error, but didn't get it. error: %v", err)
 				}
 				if postBindPlugin.numPostBindCalled > 0 {
@@ -1826,7 +1823,7 @@ func TestPermitPlugin(t *testing.T) {
 				t.Errorf("Error while creating a test pod: %v", err)
 			}
 			if test.fail {
-				if err = wait.Poll(10*time.Millisecond, 30*time.Second, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
+				if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
 					t.Errorf("Expected a scheduling error, but didn't get it. error: %v", err)
 				}
 			} else {
@@ -1878,7 +1875,7 @@ func TestMultiplePermitPlugins(t *testing.T) {
 
 	var waitingPod framework.WaitingPod
 	// Wait until the test pod is actually waiting.
-	wait.Poll(10*time.Millisecond, 30*time.Second, func() (bool, error) {
+	wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 		waitingPod = perPlugin1.fh.GetWaitingPod(pod.UID)
 		return waitingPod != nil, nil
 	})
@@ -1933,16 +1930,15 @@ func TestPermitPluginsCancelled(t *testing.T) {
 
 	var waitingPod framework.WaitingPod
 	// Wait until the test pod is actually waiting.
-	wait.Poll(10*time.Millisecond, 30*time.Second, func() (bool, error) {
+	wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 		waitingPod = perPlugin1.fh.GetWaitingPod(pod.UID)
 		return waitingPod != nil, nil
 	})
 
 	perPlugin1.rejectAllPods()
 	// Wait some time for the permit plugins to be cancelled
-	err = wait.Poll(10*time.Millisecond, 30*time.Second, func() (bool, error) {
-		return perPlugin1.cancelled && perPlugin2.cancelled, nil
-	})
+	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (bool, error) { return perPlugin1.cancelled && perPlugin2.cancelled, nil })
+
 	if err != nil {
 		t.Errorf("Expected all permit plugins to be cancelled")
 	}
@@ -2072,7 +2068,7 @@ func TestFilterPlugin(t *testing.T) {
 			}
 
 			if test.fail {
-				if err = wait.Poll(10*time.Millisecond, 30*time.Second, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
+				if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
 					t.Errorf("Expected a scheduling error, but got: %v", err)
 				}
 				if filterPlugin.numFilterCalled < 1 {
@@ -2130,7 +2126,7 @@ func TestPreScorePlugin(t *testing.T) {
 			}
 
 			if test.fail {
-				if err = wait.Poll(10*time.Millisecond, 30*time.Second, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
+				if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, podSchedulingError(testCtx.ClientSet, pod.Namespace, pod.Name)); err != nil {
 					t.Errorf("Expected a scheduling error, but got: %v", err)
 				}
 			} else {
@@ -2350,7 +2346,7 @@ func TestPreemptWithPermitPlugin(t *testing.T) {
 					t.Fatalf("Error while creating the waiting pod: %v", err)
 				}
 				// Wait until the waiting-pod is actually waiting.
-				if err := wait.Poll(10*time.Millisecond, 30*time.Second, func() (bool, error) {
+				if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 					w := false
 					permitPlugin.fh.IterateOverWaitingPods(func(wp framework.WaitingPod) { w = true })
 					return w, nil
@@ -2375,7 +2371,7 @@ func TestPreemptWithPermitPlugin(t *testing.T) {
 			}
 
 			if w := tt.waitingPod; w != nil {
-				if err := wait.Poll(200*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+				if err := wait.PollUntilContextTimeout(context.Background(), 200*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 					w := false
 					permitPlugin.fh.IterateOverWaitingPods(func(wp framework.WaitingPod) { w = true })
 					return !w, nil

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -78,7 +78,7 @@ const filterPluginName = "filter-plugin"
 var lowPriority, mediumPriority, highPriority = int32(100), int32(200), int32(300)
 
 func waitForNominatedNodeNameWithTimeout(cs clientset.Interface, pod *v1.Pod, timeout time.Duration) error {
-	if err := wait.Poll(100*time.Millisecond, timeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, timeout, false, func(ctx context.Context) (bool, error) {
 		pod, err := cs.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -463,7 +463,7 @@ func TestPreemption(t *testing.T) {
 			// Wait for preemption of pods and make sure the other ones are not preempted.
 			for i, p := range pods {
 				if _, found := test.preemptedPodIndexes[i]; found {
-					if err = wait.Poll(time.Second, wait.ForeverTestTimeout, podIsGettingEvicted(cs, p.Namespace, p.Name)); err != nil {
+					if err = wait.PollUntilContextTimeout(context.Background(), time.Second, wait.ForeverTestTimeout, false, podIsGettingEvicted(cs, p.Namespace, p.Name)); err != nil {
 						t.Errorf("Pod %v/%v is not getting evicted.", p.Namespace, p.Name)
 					}
 					pod, err := cs.CoreV1().Pods(p.Namespace).Get(testCtx.Ctx, p.Name, metav1.GetOptions{})
@@ -846,8 +846,7 @@ func TestPreemptionStarvation(t *testing.T) {
 			}
 			// Make sure that all pending pods are being marked unschedulable.
 			for _, p := range pendingPods {
-				if err := wait.Poll(100*time.Millisecond, wait.ForeverTestTimeout,
-					podUnschedulable(cs, p.Namespace, p.Name)); err != nil {
+				if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, false, podUnschedulable(cs, p.Namespace, p.Name)); err != nil {
 					t.Errorf("Pod %v/%v didn't get marked unschedulable: %v", p.Namespace, p.Name, err)
 				}
 			}
@@ -1181,7 +1180,7 @@ func TestNominatedNodeCleanUp(t *testing.T) {
 			}
 
 			// Verify if .status.nominatedNodeName is cleared.
-			if err := wait.Poll(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 				pod, err := cs.CoreV1().Pods(ns).Get(context.TODO(), "medium", metav1.GetOptions{})
 				if err != nil {
 					t.Errorf("Error getting the medium pod: %v", err)
@@ -1453,7 +1452,7 @@ func TestPDBInPreemption(t *testing.T) {
 			// Wait for preemption of pods and make sure the other ones are not preempted.
 			for i, p := range pods {
 				if _, found := test.preemptedPodIndexes[i]; found {
-					if err = wait.Poll(time.Second, wait.ForeverTestTimeout, podIsGettingEvicted(cs, p.Namespace, p.Name)); err != nil {
+					if err = wait.PollUntilContextTimeout(context.Background(), time.Second, wait.ForeverTestTimeout, false, podIsGettingEvicted(cs, p.Namespace, p.Name)); err != nil {
 						t.Errorf("Test [%v]: Pod %v/%v is not getting evicted.", test.name, p.Namespace, p.Name)
 					}
 				} else {
@@ -1589,7 +1588,7 @@ func TestPreferNominatedNode(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error while creating high priority pod: %v", err)
 			}
-			err = wait.Poll(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+			err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 				preemptor, err = cs.CoreV1().Pods(test.pod.Namespace).Get(context.TODO(), test.pod.Name, metav1.GetOptions{})
 				if err != nil {
 					t.Errorf("Error getting the preemptor pod info: %v", err)
@@ -1599,6 +1598,7 @@ func TestPreferNominatedNode(t *testing.T) {
 				}
 				return true, nil
 			})
+
 			if err != nil {
 				t.Errorf("Cannot schedule Pod %v/%v, error: %v", test.pod.Namespace, test.pod.Name, err)
 			}
@@ -1943,7 +1943,7 @@ func TestReadWriteOncePodPreemption(t *testing.T) {
 			// Wait for preemption of pods and make sure the other ones are not preempted.
 			for i, p := range pods {
 				if _, found := test.preemptedPodIndexes[i]; found {
-					if err = wait.Poll(time.Second, wait.ForeverTestTimeout, podIsGettingEvicted(cs, p.Namespace, p.Name)); err != nil {
+					if err = wait.PollUntilContextTimeout(context.Background(), time.Second, wait.ForeverTestTimeout, false, podIsGettingEvicted(cs, p.Namespace, p.Name)); err != nil {
 						t.Errorf("Pod %v/%v is not getting evicted.", p.Namespace, p.Name)
 					}
 				} else {

--- a/test/integration/scheduler/queue_test.go
+++ b/test/integration/scheduler/queue_test.go
@@ -136,7 +136,7 @@ func TestSchedulingGates(t *testing.T) {
 			}
 
 			// Wait for the pods to be present in the scheduling queue.
-			if err := wait.Poll(time.Millisecond*200, wait.ForeverTestTimeout, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 				pendingPods, _ := testCtx.Scheduler.SchedulingQueue.PendingPods()
 				return len(pendingPods) == len(tt.pods), nil
 			}); err != nil {
@@ -214,7 +214,7 @@ func TestCoreResourceEnqueue(t *testing.T) {
 	}
 
 	// Wait for the three pods to be present in the scheduling queue.
-	if err := wait.Poll(time.Millisecond*200, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 		pendingPods, _ := testCtx.Scheduler.SchedulingQueue.PendingPods()
 		return len(pendingPods) == 3, nil
 	}); err != nil {
@@ -390,7 +390,7 @@ func TestCustomResourceEnqueue(t *testing.T) {
 	}
 
 	// Wait for the testing Pod to be present in the scheduling queue.
-	if err := wait.Poll(time.Millisecond*200, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 		pendingPods, _ := testCtx.Scheduler.SchedulingQueue.PendingPods()
 		return len(pendingPods) == 1, nil
 	}); err != nil {

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -145,7 +145,7 @@ func TestUnschedulableNodes(t *testing.T) {
 		if err == nil {
 			t.Errorf("Test %d: Pod scheduled successfully on unschedulable nodes", i)
 		}
-		if err != wait.ErrWaitTimeout {
+		if !wait.Interrupted(err) {
 			t.Errorf("Test %d: failed while trying to confirm the pod does not get scheduled on the node: %v", i, err)
 		} else {
 			t.Logf("Test %d: Pod did not get scheduled on an unschedulable node", i)
@@ -324,7 +324,7 @@ func TestMultipleSchedulingProfiles(t *testing.T) {
 	}
 
 	gotProfiles := make(map[string]string)
-	if err := wait.Poll(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 		var ev watch.Event
 		select {
 		case ev = <-evs.ResultChan():

--- a/test/integration/scheduler/scoring/priorities_test.go
+++ b/test/integration/scheduler/scoring/priorities_test.go
@@ -625,7 +625,7 @@ func TestPodTopologySpreadScoring(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Test Failed: error while creating pod during test: %v", err)
 				}
-				err = wait.Poll(pollInterval, wait.ForeverTestTimeout, testutils.PodScheduled(cs, createdPod.Namespace, createdPod.Name))
+				err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, testutils.PodScheduled(cs, createdPod.Namespace, createdPod.Name))
 				if err != nil {
 					t.Errorf("Test Failed: error while waiting for pod during test: %v", err)
 				}
@@ -637,9 +637,9 @@ func TestPodTopologySpreadScoring(t *testing.T) {
 			}
 
 			if tt.fits {
-				err = wait.Poll(pollInterval, wait.ForeverTestTimeout, podScheduledIn(cs, testPod.Namespace, testPod.Name, tt.want))
+				err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, podScheduledIn(cs, testPod.Namespace, testPod.Name, tt.want))
 			} else {
-				err = wait.Poll(pollInterval, wait.ForeverTestTimeout, podUnschedulable(cs, testPod.Namespace, testPod.Name))
+				err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, podUnschedulable(cs, testPod.Namespace, testPod.Name))
 			}
 			if err != nil {
 				t.Errorf("Test Failed: %v", err)
@@ -706,7 +706,7 @@ func TestDefaultPodTopologySpreadScoring(t *testing.T) {
 			}
 			var pods []v1.Pod
 			// Wait for all Pods scheduled.
-			err = wait.Poll(pollInterval, wait.ForeverTestTimeout, func() (bool, error) {
+			err = wait.PollUntilContextTimeout(context.Background(), pollInterval, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 				podList, err := cs.CoreV1().Pods(ns).List(testCtx.Ctx, metav1.ListOptions{})
 				if err != nil {
 					t.Fatalf("Cannot list pods to verify scheduling: %v", err)
@@ -719,6 +719,7 @@ func TestDefaultPodTopologySpreadScoring(t *testing.T) {
 				pods = podList.Items
 				return true, nil
 			})
+
 			// Verify zone spreading.
 			zoneCnts := make(map[string]int)
 			for _, p := range pods {

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -1072,7 +1072,7 @@ func createPods(ctx context.Context, b *testing.B, namespace string, cpo *create
 // namespace are scheduled. Times out after 10 minutes because even at the
 // lowest observed QPS of ~10 pods/sec, a 5000-node test should complete.
 func waitUntilPodsScheduledInNamespace(ctx context.Context, b *testing.B, podInformer coreinformers.PodInformer, namespace string, wantCount int) error {
-	return wait.PollImmediate(1*time.Second, 10*time.Minute, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
 		select {
 		case <-ctx.Done():
 			return true, ctx.Err()
@@ -1089,6 +1089,7 @@ func waitUntilPodsScheduledInNamespace(ctx context.Context, b *testing.B, podInf
 		b.Logf("namespace: %s, pods: want %d, got %d", namespace, wantCount, len(scheduled))
 		return false, nil
 	})
+
 }
 
 // waitUntilPodsScheduled blocks until the all pods in the given namespaces are

--- a/test/integration/statefulset/util.go
+++ b/test/integration/statefulset/util.go
@@ -233,7 +233,7 @@ func createSTSsPods(t *testing.T, clientSet clientset.Interface, stss []*appsv1.
 func waitSTSStable(t *testing.T, clientSet clientset.Interface, sts *appsv1.StatefulSet) {
 	stsClient := clientSet.AppsV1().StatefulSets(sts.Namespace)
 	desiredGeneration := sts.Generation
-	if err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
 		newSTS, err := stsClient.Get(context.TODO(), sts.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/integration/storageversion/gc_test.go
+++ b/test/integration/storageversion/gc_test.go
@@ -153,7 +153,7 @@ func createTestStorageVersion(t *testing.T, client kubernetes.Interface, ids ...
 }
 
 func assertStorageVersionDeleted(t *testing.T, client kubernetes.Interface) {
-	if err := wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		_, err := client.InternalV1alpha1().StorageVersions().Get(
 			context.TODO(), svName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
@@ -201,7 +201,7 @@ func deleteTestAPIServerIdentityLease(t *testing.T, client kubernetes.Interface,
 func assertStorageVersionEntries(t *testing.T, client kubernetes.Interface,
 	numEntries int, firstID string) {
 	var lastErr error
-	if err := wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		sv, err := client.InternalV1alpha1().StorageVersions().Get(
 			context.TODO(), svName, metav1.GetOptions{})
 		if err != nil {

--- a/test/integration/storageversion/storage_version_filter_test.go
+++ b/test/integration/storageversion/storage_version_filter_test.go
@@ -239,7 +239,7 @@ func TestStorageVersionBootstrap(t *testing.T) {
 	t.Run("after storage version manager complete", func(t *testing.T) {
 		// wait until healthz endpoint returns ok
 		client := clientset.NewForConfigOrDie(cfg)
-		err := wait.Poll(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+		err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 			result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do(context.TODO())
 			status := 0
 			result.StatusCode(&status)
@@ -248,6 +248,7 @@ func TestStorageVersionBootstrap(t *testing.T) {
 			}
 			return false, nil
 		})
+
 		if err != nil {
 			t.Errorf("failed to wait for /healthz to return ok: %v", err)
 		}

--- a/test/integration/ttlcontroller/ttlcontroller_test.go
+++ b/test/integration/ttlcontroller/ttlcontroller_test.go
@@ -107,7 +107,7 @@ func deleteNodes(t *testing.T, client *clientset.Clientset, startIndex, endIndex
 }
 
 func waitForNodesWithTTLAnnotation(t *testing.T, nodeLister listers.NodeLister, numNodes, ttlSeconds int) {
-	if err := wait.Poll(time.Second, 30*time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 		nodes, err := nodeLister.List(labels.Everything())
 		if err != nil || len(nodes) != numNodes {
 			return false, nil

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -164,9 +164,9 @@ func CleanupNodes(cs clientset.Interface, t *testing.T) {
 }
 
 // PodDeleted returns true if a pod is not found in the given namespace.
-func PodDeleted(c clientset.Interface, podNamespace, podName string) wait.ConditionFunc {
-	return func() (bool, error) {
-		pod, err := c.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+func PodDeleted(c clientset.Interface, podNamespace, podName string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		pod, err := c.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
@@ -266,9 +266,9 @@ func WaitForNodeTaints(cs clientset.Interface, node *v1.Node, taints []v1.Taint)
 
 // NodeTainted return a condition function that returns true if the given node contains
 // the taints.
-func NodeTainted(cs clientset.Interface, nodeName string, taints []v1.Taint) wait.ConditionFunc {
-	return func() (bool, error) {
-		node, err := cs.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+func NodeTainted(cs clientset.Interface, nodeName string, taints []v1.Taint) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		node, err := cs.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -359,7 +359,7 @@ func InitTestAPIServer(t *testing.T, nsPrefix string, admission admission.Interf
 
 // WaitForSchedulerCacheCleanup waits for cleanup of scheduler's cache to complete
 func WaitForSchedulerCacheCleanup(sched *scheduler.Scheduler, t *testing.T) {
-	schedulerCacheIsEmpty := func() (bool, error) {
+	schedulerCacheIsEmpty := func(ctx context.Context) (bool, error) {
 		dump := sched.Cache.Dump()
 
 		return len(dump.Nodes) == 0 && len(dump.AssumedPods) == 0, nil
@@ -437,9 +437,9 @@ func WaitForPodToSchedule(cs clientset.Interface, pod *v1.Pod) error {
 }
 
 // PodScheduled checks if the pod has been scheduled
-func PodScheduled(c clientset.Interface, podNamespace, podName string) wait.ConditionFunc {
-	return func() (bool, error) {
-		pod, err := c.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+func PodScheduled(c clientset.Interface, podNamespace, podName string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		pod, err := c.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
 			// This could be a connection error so we want to retry.
 			return false, nil
@@ -745,9 +745,9 @@ func RunPodWithContainers(cs clientset.Interface, pod *v1.Pod) (*v1.Pod, error) 
 }
 
 // PodIsGettingEvicted returns true if the pod's deletion timestamp is set.
-func PodIsGettingEvicted(c clientset.Interface, podNamespace, podName string) wait.ConditionFunc {
-	return func() (bool, error) {
-		pod, err := c.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+func PodIsGettingEvicted(c clientset.Interface, podNamespace, podName string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		pod, err := c.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -759,9 +759,9 @@ func PodIsGettingEvicted(c clientset.Interface, podNamespace, podName string) wa
 }
 
 // PodScheduledIn returns true if a given pod is placed onto one of the expected nodes.
-func PodScheduledIn(c clientset.Interface, podNamespace, podName string, nodeNames []string) wait.ConditionFunc {
-	return func() (bool, error) {
-		pod, err := c.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+func PodScheduledIn(c clientset.Interface, podNamespace, podName string, nodeNames []string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		pod, err := c.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
 			// This could be a connection error so we want to retry.
 			return false, nil
@@ -780,9 +780,9 @@ func PodScheduledIn(c clientset.Interface, podNamespace, podName string, nodeNam
 
 // PodUnschedulable returns a condition function that returns true if the given pod
 // gets unschedulable status of reason 'Unschedulable'.
-func PodUnschedulable(c clientset.Interface, podNamespace, podName string) wait.ConditionFunc {
-	return func() (bool, error) {
-		pod, err := c.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+func PodUnschedulable(c clientset.Interface, podNamespace, podName string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		pod, err := c.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
 			// This could be a connection error so we want to retry.
 			return false, nil
@@ -796,9 +796,9 @@ func PodUnschedulable(c clientset.Interface, podNamespace, podName string) wait.
 // PodSchedulingError returns a condition function that returns true if the given pod
 // gets unschedulable status for reasons other than "Unschedulable". The scheduler
 // records such reasons in case of error.
-func PodSchedulingError(c clientset.Interface, podNamespace, podName string) wait.ConditionFunc {
-	return func() (bool, error) {
-		pod, err := c.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+func PodSchedulingError(c clientset.Interface, podNamespace, podName string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		pod, err := c.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
 			// This could be a connection error so we want to retry.
 			return false, nil
@@ -811,9 +811,9 @@ func PodSchedulingError(c clientset.Interface, podNamespace, podName string) wai
 
 // PodSchedulingGated returns a condition function that returns true if the given pod
 // gets unschedulable status of reason 'SchedulingGated'.
-func PodSchedulingGated(c clientset.Interface, podNamespace, podName string) wait.ConditionFunc {
-	return func() (bool, error) {
-		pod, err := c.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+func PodSchedulingGated(c clientset.Interface, podNamespace, podName string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		pod, err := c.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
 			// This could be a connection error so we want to retry.
 			return false, nil

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -55,7 +55,7 @@ var (
 
 // WaitForPodToDisappear polls the API server if the pod has been deleted.
 func WaitForPodToDisappear(podClient coreclient.PodInterface, podName string, interval, timeout time.Duration) error {
-	return wait.PollImmediate(interval, timeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(ctx context.Context) (bool, error) {
 		_, err := podClient.Get(context.TODO(), podName, metav1.GetOptions{})
 		if err == nil {
 			return false, nil
@@ -65,6 +65,7 @@ func WaitForPodToDisappear(podClient coreclient.PodInterface, podName string, in
 		}
 		return false, err
 	})
+
 }
 
 // GetEtcdClients returns an initialized  clientv3.Client and clientv3.KV.

--- a/test/integration/volume/attach_detach_test.go
+++ b/test/integration/volume/attach_detach_test.go
@@ -366,7 +366,7 @@ func TestPodUpdateWithKeepTerminatedPodVolumes(t *testing.T) {
 // running the RC manager to prevent the rc manager from creating new pods
 // rather than adopting the existing ones.
 func waitToObservePods(t *testing.T, podInformer cache.SharedIndexInformer, podNum int) {
-	if err := wait.Poll(100*time.Millisecond, 60*time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 60*time.Second, false, func(ctx context.Context) (bool, error) {
 		objects := podInformer.GetIndexer().List()
 		if len(objects) == podNum {
 			return true, nil
@@ -379,7 +379,7 @@ func waitToObservePods(t *testing.T, podInformer cache.SharedIndexInformer, podN
 
 // wait for pods to be observed in desired state of world
 func waitForPodsInDSWP(t *testing.T, dswp volumecache.DesiredStateOfWorld) {
-	if err := wait.Poll(time.Millisecond*500, wait.ForeverTestTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*500, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 		pods := dswp.GetPodToAdd()
 		if len(pods) > 0 {
 			return true, nil
@@ -392,7 +392,7 @@ func waitForPodsInDSWP(t *testing.T, dswp volumecache.DesiredStateOfWorld) {
 
 // wait for pods to be observed in desired state of world
 func waitForPodFuncInDSWP(t *testing.T, dswp volumecache.DesiredStateOfWorld, checkTimeout time.Duration, failMessage string, podCount int) {
-	if err := wait.Poll(time.Millisecond*500, checkTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*500, checkTimeout, false, func(ctx context.Context) (bool, error) {
 		pods := dswp.GetPodToAdd()
 		if len(pods) == podCount {
 			return true, nil

--- a/test/integration/volumescheduling/util.go
+++ b/test/integration/volumescheduling/util.go
@@ -52,9 +52,9 @@ func waitForPodUnschedulable(cs clientset.Interface, pod *v1.Pod) error {
 }
 
 // podScheduled returns true if a node is assigned to the given pod.
-func podScheduled(c clientset.Interface, podNamespace, podName string) wait.ConditionFunc {
-	return func() (bool, error) {
-		pod, err := c.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+func podScheduled(c clientset.Interface, podNamespace, podName string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		pod, err := c.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
 			// This could be a connection error so we want to retry.
 			return false, nil
@@ -68,9 +68,9 @@ func podScheduled(c clientset.Interface, podNamespace, podName string) wait.Cond
 
 // podUnschedulable returns a condition function that returns true if the given pod
 // gets unschedulable status.
-func podUnschedulable(c clientset.Interface, podNamespace, podName string) wait.ConditionFunc {
-	return func() (bool, error) {
-		pod, err := c.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+func podUnschedulable(c clientset.Interface, podNamespace, podName string) wait.ConditionWithContextFunc {
+	return func(ctx context.Context) (bool, error) {
+		pod, err := c.CoreV1().Pods(podNamespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
 			// This could be a connection error so we want to retry.
 			return false, nil

--- a/test/integration/volumescheduling/util.go
+++ b/test/integration/volumescheduling/util.go
@@ -30,7 +30,7 @@ import (
 // waitForPodToScheduleWithTimeout waits for a pod to get scheduled and returns
 // an error if it does not scheduled within the given timeout.
 func waitForPodToScheduleWithTimeout(cs clientset.Interface, pod *v1.Pod, timeout time.Duration) error {
-	return wait.Poll(100*time.Millisecond, timeout, podScheduled(cs, pod.Namespace, pod.Name))
+	return wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, timeout, false, podScheduled(cs, pod.Namespace, pod.Name))
 }
 
 // waitForPodToSchedule waits for a pod to get scheduled and returns an error if
@@ -42,7 +42,7 @@ func waitForPodToSchedule(cs clientset.Interface, pod *v1.Pod) error {
 // waitForPodUnscheduleWithTimeout waits for a pod to fail scheduling and returns
 // an error if it does not become unschedulable within the given timeout.
 func waitForPodUnschedulableWithTimeout(cs clientset.Interface, pod *v1.Pod, timeout time.Duration) error {
-	return wait.Poll(100*time.Millisecond, timeout, podUnschedulable(cs, pod.Namespace, pod.Name))
+	return wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, timeout, false, podUnschedulable(cs, pod.Namespace, pod.Name))
 }
 
 // waitForPodUnschedule waits for a pod to fail scheduling and returns

--- a/test/integration/volumescheduling/volume_binding_test.go
+++ b/test/integration/volumescheduling/volume_binding_test.go
@@ -1332,7 +1332,7 @@ func validateProvisionAnn(claim *v1.PersistentVolumeClaim, volIsProvisioned bool
 }
 
 func waitForProvisionAnn(client clientset.Interface, pvc *v1.PersistentVolumeClaim, annShouldExist bool) error {
-	return wait.Poll(time.Second, 30*time.Second, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 		claim, err := client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -1342,6 +1342,7 @@ func waitForProvisionAnn(client clientset.Interface, pvc *v1.PersistentVolumeCla
 		}
 		return false, nil
 	})
+
 }
 
 func validatePVPhase(t *testing.T, client clientset.Interface, pvName string, phase v1.PersistentVolumePhase) {
@@ -1356,7 +1357,7 @@ func validatePVPhase(t *testing.T, client clientset.Interface, pvName string, ph
 }
 
 func waitForPVPhase(client clientset.Interface, pvName string, phase v1.PersistentVolumePhase) error {
-	return wait.PollImmediate(time.Second, 30*time.Second, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		pv, err := client.CoreV1().PersistentVolumes().Get(context.TODO(), pvName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -1367,10 +1368,11 @@ func waitForPVPhase(client clientset.Interface, pvName string, phase v1.Persiste
 		}
 		return false, nil
 	})
+
 }
 
 func waitForPVCBound(client clientset.Interface, pvc *v1.PersistentVolumeClaim) error {
-	return wait.Poll(time.Second, 30*time.Second, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 		claim, err := client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -1380,6 +1382,7 @@ func waitForPVCBound(client clientset.Interface, pvc *v1.PersistentVolumeClaim) 
 		}
 		return false, nil
 	})
+
 }
 
 func markNodeAffinity(pod *v1.Pod, node string) {

--- a/test/utils/pod_store.go
+++ b/test/utils/pod_store.go
@@ -56,7 +56,7 @@ func NewPodStore(c clientset.Interface, namespace string, label labels.Selector,
 	stopCh := make(chan struct{})
 	reflector := cache.NewReflector(lw, &v1.Pod{}, store, 0)
 	go reflector.Run(stopCh)
-	if err := wait.PollImmediate(50*time.Millisecond, 2*time.Minute, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		if len(reflector.LastSyncResourceVersion()) != 0 {
 			return true, nil
 		}

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -1798,7 +1798,7 @@ func (config *DaemonConfig) Run(ctx context.Context) error {
 	}
 	defer ps.Stop()
 
-	err = wait.Poll(time.Second, timeout, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, timeout, false, func(ctx context.Context) (bool, error) {
 		pods := ps.List()
 
 		nodeHasDaemon := sets.NewString()
@@ -1813,6 +1813,7 @@ func (config *DaemonConfig) Run(ctx context.Context) error {
 		config.LogFunc("Found %v/%v Daemons %v running", running, config.Name, len(nodes.Items))
 		return running == len(nodes.Items), nil
 	})
+
 	if err != nil {
 		config.LogFunc("Timed out while waiting for DaemonSet %v/%v to be running.", config.Namespace, config.Name)
 	} else {

--- a/test/utils/update_resources.go
+++ b/test/utils/update_resources.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -50,7 +51,7 @@ func ScaleResourceWithRetries(scalesGetter scaleclient.ScalesGetter, namespace, 
 	}
 	waitForReplicas := scale.NewRetryParams(waitRetryInterval, waitRetryTimeout)
 	cond := RetryErrorCondition(scale.ScaleCondition(scaler, preconditions, namespace, name, size, nil, gvr, false))
-	err := wait.PollImmediate(updateRetryInterval, updateRetryTimeout, cond)
+	err := wait.PollUntilContextTimeout(context.Background(), updateRetryInterval, updateRetryTimeout, true, cond)
 	if err == nil {
 		err = scale.WaitForScaleHasDesiredReplicas(scalesGetter, gvr.GroupResource(), name, namespace, size, waitForReplicas)
 	}


### PR DESCRIPTION
#107826 introduces two new Poll variants that handle context.Context cancellation consistently with idiomatic go and allow callers to detect cancellation. This PR is a WIP that transforms legacy calls to `Poll*` into the new methods, updates error handling, and generally makes our use of context consistent across the wait package.

It leverages a mechanical [gopatch](https://github.com/uber-go/gopatch) script in `hack/refactors/poll_with_context.patch` that performs the bulk of the transformation, with small prefactor changes and then manual fixups after.

The intent of this PR is to demonstrate the correctness of the new Poll methods in bulk and refine their execution to ensure there are no incorrect behaviors detected. The actual refactor may be performed in smaller chunks as necessary.

/kind cleanup

```release-note
```

```docs
```