### PR TITLE
pause: remove obsolete Windows buildx workaround

### DIFF
--- a/build/pause/Dockerfile_windows
+++ b/build/pause/Dockerfile_windows
@@ -17,9 +17,4 @@ FROM ${BASE}
 ARG ARCH
 ADD bin/pause-windows-${ARCH}.exe /pause.exe
 ADD bin/wincat-windows-amd64 /Windows/System32/wincat.exe
-
-# NOTE(claudiub): docker buildx sets the PATH env variable to a Linux-like PATH,
-# which is not desirable. See: https://github.com/moby/buildkit/issues/1560
-# TODO(claudiub): remove this once the issue has been resolved.
-ENV PATH="C:\Windows\system32;C:\Windows;"
 ENTRYPOINT ["/pause.exe"]


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node

#### What this PR does / why we need it:

The issue this workaround set out to address has been resolved in buildx for some time (since v0.8.0); there is no longer a need to preserve it.


#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- [Upstream Issue](https://github.com/moby/buildkit/issues/1560)