### PR TITLE
wait: Unify the implementation of the two backoff managers

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -495,10 +495,10 @@ func (c *csiAttacher) waitForVolumeAttachDetachStatusWithLister(spec *volume.Spe
 		resetDuration = time.Minute
 		backoffFactor = 1.05
 		jitter        = 0.1
+		steps         = 7
 		clock         = &clock.RealClock{}
 	)
-	backoffMgr := wait.NewExponentialBackoffManager(initBackoff, maxBackoff, resetDuration, backoffFactor, jitter, clock)
-
+	backoff := wait.Backoff{Duration: initBackoff, Cap: maxBackoff, Factor: backoffFactor, Jitter: jitter, Steps: steps}.DelayWithReset(clock, resetDuration)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -509,8 +509,11 @@ func (c *csiAttacher) waitForVolumeAttachDetachStatusWithLister(spec *volume.Spe
 		klog.V(4).Info(log("Could not find CSI driver name in spec for volume [%v]", volumeHandle))
 	}
 
+	// TODO: this should use a context-aware wait.Poll/Until/Jitter method once they are unified in
+	// https://github.com/kubernetes/kubernetes/issue/107826 or a successor
+	t := clock.NewTimer(backoff())
+	defer t.Stop()
 	for {
-		t := backoffMgr.Backoff()
 		select {
 		case <-t.C():
 			successful, err := verifyStatus()
@@ -520,8 +523,8 @@ func (c *csiAttacher) waitForVolumeAttachDetachStatusWithLister(spec *volume.Spe
 			if successful {
 				return nil
 			}
+			t.Reset(backoff())
 		case <-ctx.Done():
-			t.Stop()
 			klog.Error(log("%s timeout after %v [volume=%v; attachment.ID=%v]", operation, timeout, volumeHandle, attachID))
 			return fmt.Errorf("timed out waiting for external-attacher of %v CSI driver to %v volume %v", csiDriverName, strings.ToLower(operation), volumeHandle)
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
@@ -19,7 +19,6 @@ package wait
 import (
 	"context"
 	"errors"
-	"math"
 	"math/rand"
 	"sync"
 	"time"
@@ -132,15 +131,29 @@ func NonSlidingUntilWithContext(ctx context.Context, f func(context.Context), pe
 // Close stopCh to stop. f may not be invoked if stop channel is already
 // closed. Pass NeverStop to if you don't want it stop.
 func JitterUntil(f func(), period time.Duration, jitterFactor float64, sliding bool, stopCh <-chan struct{}) {
-	BackoffUntil(f, NewJitteredBackoffManager(period, jitterFactor, &clock.RealClock{}), sliding, stopCh)
+	b := Backoff{Duration: period, Jitter: jitterFactor}
+	BackoffUntil(f, RealTimer, b.Step, sliding, stopCh)
 }
+
+var (
+	// RealTimer can be passed to methods that need a TimerFunc.
+	RealTimer = clock.RealClock{}.NewTimer
+)
+
+// TimerFunc allows the caller to inject a timer for testing. Most callers should use RealTimer.
+type TimerFunc func(time.Duration) clock.Timer
 
 // BackoffUntil loops until stop channel is closed, run f every duration given by BackoffManager.
 //
 // If sliding is true, the period is computed after f runs. If it is false then
 // period includes the runtime for f.
-func BackoffUntil(f func(), backoff BackoffManager, sliding bool, stopCh <-chan struct{}) {
+func BackoffUntil(f func(), timerFn TimerFunc, delayFn DelayFunc, sliding bool, stopCh <-chan struct{}) {
 	var t clock.Timer
+	defer func() {
+		if t != nil {
+			t.Stop()
+		}
+	}()
 	for {
 		select {
 		case <-stopCh:
@@ -148,8 +161,9 @@ func BackoffUntil(f func(), backoff BackoffManager, sliding bool, stopCh <-chan 
 		default:
 		}
 
+		var interval time.Duration
 		if !sliding {
-			t = backoff.Backoff()
+			interval = delayFn()
 		}
 
 		func() {
@@ -158,7 +172,12 @@ func BackoffUntil(f func(), backoff BackoffManager, sliding bool, stopCh <-chan 
 		}()
 
 		if sliding {
-			t = backoff.Backoff()
+			interval = delayFn()
+		}
+		if t == nil {
+			t = timerFn(interval)
+		} else {
+			t.Reset(interval)
 		}
 
 		// NOTE: b/c there is no priority selection in golang
@@ -168,9 +187,6 @@ func BackoffUntil(f func(), backoff BackoffManager, sliding bool, stopCh <-chan 
 		// of every loop to prevent extra executions of f().
 		select {
 		case <-stopCh:
-			if !t.Stop() {
-				<-t.C()
-			}
 			return
 		case <-t.C():
 		}
@@ -259,6 +275,9 @@ func runConditionWithCrashProtectionWithContext(ctx context.Context, condition C
 	return condition(ctx)
 }
 
+// DelayFunc returns the next time interval to wait.
+type DelayFunc func() time.Duration
+
 // Backoff holds parameters applied to a Backoff function.
 type Backoff struct {
 	// The initial duration.
@@ -285,17 +304,18 @@ type Backoff struct {
 	Cap time.Duration
 }
 
-// Step (1) returns an amount of time to sleep determined by the
-// original Duration and Jitter and (2) mutates the provided Backoff
-// to update its Steps and Duration.
+// Step returns an amount of time to sleep determined by the
+// original Duration and Jitter. The backoff is mutated to update its
+// Steps and Duration.
 func (b *Backoff) Step() time.Duration {
 	if b.Steps < 1 {
 		if b.Jitter > 0 {
 			return Jitter(b.Duration, b.Jitter)
 		}
 		return b.Duration
+	} else {
+		b.Steps--
 	}
-	b.Steps--
 
 	duration := b.Duration
 
@@ -314,103 +334,46 @@ func (b *Backoff) Step() time.Duration {
 	return duration
 }
 
-// BackoffManager manages backoff with a particular scheme based on its underlying implementation. It provides
-// an interface to return a timer for backoff, and caller shall backoff until Timer.C() drains. If the second Backoff()
-// is called before the timer from the first Backoff() call finishes, the first timer will NOT be drained and result in
-// undetermined behavior.
-// The BackoffManager is supposed to be called in a single-threaded environment.
-type BackoffManager interface {
-	Backoff() clock.Timer
+// DelayWithReset returns a DelayFunc that will return the appropriate next interval to
+// wait. Every resetInterval the backoff parameters are reset to their initial state.
+// This method is safe to invoke from multiple goroutines.
+func (b Backoff) DelayWithReset(c clock.Clock, resetInterval time.Duration) DelayFunc {
+	return (&backoffManager{
+		backoff:        b,
+		initialBackoff: b,
+		resetInterval:  resetInterval,
+
+		clock:     c,
+		lastStart: c.Now(),
+		timer:     nil,
+	}).Step
 }
 
-type exponentialBackoffManagerImpl struct {
-	backoff              *Backoff
-	backoffTimer         clock.Timer
-	lastBackoffStart     time.Time
-	initialBackoff       time.Duration
-	backoffResetDuration time.Duration
-	clock                clock.Clock
+type backoffManager struct {
+	backoff        Backoff
+	initialBackoff Backoff
+	resetInterval  time.Duration
+
+	clock clock.Clock
+
+	lock      sync.Mutex
+	lastStart time.Time
+	timer     clock.Timer
 }
 
-// NewExponentialBackoffManager returns a manager for managing exponential backoff. Each backoff is jittered and
-// backoff will not exceed the given max. If the backoff is not called within resetDuration, the backoff is reset.
-// This backoff manager is used to reduce load during upstream unhealthiness.
-func NewExponentialBackoffManager(initBackoff, maxBackoff, resetDuration time.Duration, backoffFactor, jitter float64, c clock.Clock) BackoffManager {
-	return &exponentialBackoffManagerImpl{
-		backoff: &Backoff{
-			Duration: initBackoff,
-			Factor:   backoffFactor,
-			Jitter:   jitter,
+// Step returns the expected next duration to wait.
+func (b *backoffManager) Step() time.Duration {
+	b.lock.Lock()
+	defer b.lock.Unlock()
 
-			// the current impl of wait.Backoff returns Backoff.Duration once steps are used up, which is not
-			// what we ideally need here, we set it to max int and assume we will never use up the steps
-			Steps: math.MaxInt32,
-			Cap:   maxBackoff,
-		},
-		backoffTimer:         nil,
-		initialBackoff:       initBackoff,
-		lastBackoffStart:     c.Now(),
-		backoffResetDuration: resetDuration,
-		clock:                c,
+	switch {
+	case b.resetInterval == 0:
+		b.backoff = b.initialBackoff
+	case b.clock.Now().Sub(b.lastStart) > b.resetInterval:
+		b.backoff = b.initialBackoff
+		b.lastStart = b.clock.Now()
 	}
-}
-
-func (b *exponentialBackoffManagerImpl) getNextBackoff() time.Duration {
-	if b.clock.Now().Sub(b.lastBackoffStart) > b.backoffResetDuration {
-		b.backoff.Steps = math.MaxInt32
-		b.backoff.Duration = b.initialBackoff
-	}
-	b.lastBackoffStart = b.clock.Now()
 	return b.backoff.Step()
-}
-
-// Backoff implements BackoffManager.Backoff, it returns a timer so caller can block on the timer for exponential backoff.
-// The returned timer must be drained before calling Backoff() the second time
-func (b *exponentialBackoffManagerImpl) Backoff() clock.Timer {
-	if b.backoffTimer == nil {
-		b.backoffTimer = b.clock.NewTimer(b.getNextBackoff())
-	} else {
-		b.backoffTimer.Reset(b.getNextBackoff())
-	}
-	return b.backoffTimer
-}
-
-type jitteredBackoffManagerImpl struct {
-	clock        clock.Clock
-	duration     time.Duration
-	jitter       float64
-	backoffTimer clock.Timer
-}
-
-// NewJitteredBackoffManager returns a BackoffManager that backoffs with given duration plus given jitter. If the jitter
-// is negative, backoff will not be jittered.
-func NewJitteredBackoffManager(duration time.Duration, jitter float64, c clock.Clock) BackoffManager {
-	return &jitteredBackoffManagerImpl{
-		clock:        c,
-		duration:     duration,
-		jitter:       jitter,
-		backoffTimer: nil,
-	}
-}
-
-func (j *jitteredBackoffManagerImpl) getNextBackoff() time.Duration {
-	jitteredPeriod := j.duration
-	if j.jitter > 0.0 {
-		jitteredPeriod = Jitter(j.duration, j.jitter)
-	}
-	return jitteredPeriod
-}
-
-// Backoff implements BackoffManager.Backoff, it returns a timer so caller can block on the timer for jittered backoff.
-// The returned timer must be drained before calling Backoff() the second time
-func (j *jitteredBackoffManagerImpl) Backoff() clock.Timer {
-	backoff := j.getNextBackoff()
-	if j.backoffTimer == nil {
-		j.backoffTimer = j.clock.NewTimer(backoff)
-	} else {
-		j.backoffTimer.Reset(backoff)
-	}
-	return j.backoffTimer
 }
 
 // ExponentialBackoff repeats a condition check with exponential backoff.


### PR DESCRIPTION
**NOTE**: This pull is part of a series of changes that introduce new context-cancellation-aware Poll methods, reduce the surface area of the wait package to a smaller set of functions (if unused, marked private, if consolidating, marked deprecated), unify the underlying loop implementation with better testing, consolidate the backoff manager code into a smaller chunk, and in general address a number of outstanding issues.  See #115077, #115116, #115113, #115140, #115064, and #107826.

Both backoff managers moved to wait in the last few years, but have different implementation code. In general they are performing similar operations as the Poll and Until methods with subtly different code paths. As part of unifying the various poll loops in wait and ensuring they handle context cancellation consistently for use within the codebase (specifically Kubelet for the near term), converge the implementations into Backoff, and reduce some of the code complexity to make it easier to review, but do not change user visible behavior.

/kind cleanup
/priority important-soon

```release-note
The wait.NewExponentialBackoffManager and wait.NewJitteringBackoffManager methods have been replaced by a method on wait.Backoff. DelayWithReset accepts a clock (for testing) and an interval after which the current state of the backoff struct will be reset with its original value.  Please see the godoc of the new method and the change for examples of how to replace usage of this function.
```

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```