### PR TITLE
Revert "UpdateOrCreateToken get secrets err handling optimization"

### DIFF
--- a/cmd/kubeadm/app/phases/bootstraptoken/node/token.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/node/token.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
@@ -42,10 +41,7 @@ func UpdateOrCreateTokens(client clientset.Interface, failIfExists bool, tokens 
 
 		secretName := bootstraputil.BootstrapTokenSecretName(token.Token.ID)
 		secret, err := client.CoreV1().Secrets(metav1.NamespaceSystem).Get(context.TODO(), secretName, metav1.GetOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-		if secret != nil && failIfExists {
+		if secret != nil && err == nil && failIfExists {
 			return errors.Errorf("a token with id %q already exists", token.Token.ID)
 		}
 


### PR DESCRIPTION
Reverts kubernetes/kubernetes#115000

the PR caused ~a panic in~ kubeadm init to fail:

```
I0113 07:57:13.544782     300 round_trippers.go:553] GET https://172.17.0.7:6443/api/v1/namespaces/kube-system/secrets/bootstrap-token-82xr2k?timeout=10s 404 Not Found in 2 milliseconds
a token with id "82xr2k" already exists
k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node.UpdateOrCreateTokens
	cmd/kubeadm/app/phases/bootstraptoken/node/token.go:49
k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node.CreateNewTokens
	cmd/kubeadm/app/phases/bootstraptoken/node/token.go:35
k8s.io/kubernetes/cmd/kubeadm/app/phases/copycerts.createShortLivedBootstrapToken
	cmd/kubeadm/app/phases/copycerts/copycerts.go:73
k8s.io/kubernetes/cmd/kubeadm/app/phases/copycerts.UploadCerts
	cmd/kubeadm/app/phases/copycerts/copycerts.go:95
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/init.runUploadCerts
	cmd/kubeadm/app/cmd/phases/init/uploadcerts.go:71
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).Run.func1
	cmd/kubeadm/app/cmd/phases/workflow/runner.go:259
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).visitAll
	cmd/kubeadm/app/cmd/phases/workflow/runner.go:446
k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).Run
	cmd/kubeadm/app/cmd/phases/workflow/runner.go:232
k8s.io/kubernetes/cmd/kubeadm/app/cmd.newCmdInit.func1
```

https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-kubelet-1-25-on-latest/1613806184970588160/build-log.txt

https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-kubelet-1-25-on-latest
