### PR TITLE
use --null instead of -Z in grep invocation

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -130,7 +130,7 @@ function codegen::prerelease() {
     fi
     local tag_dirs=()
     kube::util::read-array tag_dirs < <( \
-        grep -l -Z --color=never '+k8s:prerelease-lifecycle-gen=true' "${ALL_K8S_TAG_FILES[@]}" \
+        grep -l --null --color=never '+k8s:prerelease-lifecycle-gen=true' "${ALL_K8S_TAG_FILES[@]}" \
             | xargs -0 -n1 dirname \
             | LC_ALL=C sort -u)
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
@@ -189,7 +189,7 @@ function codegen::deepcopy() {
     fi
     local tag_dirs=()
     kube::util::read-array tag_dirs < <( \
-        grep -l -Z --color=never '+k8s:deepcopy-gen=' "${ALL_K8S_TAG_FILES[@]}" \
+        grep -l --null --color=never '+k8s:deepcopy-gen=' "${ALL_K8S_TAG_FILES[@]}" \
             | xargs -0 -n1 dirname \
             | LC_ALL=C sort -u)
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
@@ -255,7 +255,7 @@ function codegen::defaults() {
     fi
     local tag_dirs=()
     kube::util::read-array tag_dirs < <( \
-        grep -l -Z --color=never '+k8s:defaulter-gen=' "${ALL_K8S_TAG_FILES[@]}" \
+        grep -l --null --color=never '+k8s:defaulter-gen=' "${ALL_K8S_TAG_FILES[@]}" \
             | xargs -0 -n1 dirname \
             | LC_ALL=C sort -u)
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
@@ -326,7 +326,7 @@ function codegen::conversions() {
     fi
     local tag_dirs=()
     kube::util::read-array tag_dirs < <(\
-        grep -l -Z --color=never '^// *+k8s:conversion-gen=' "${ALL_K8S_TAG_FILES[@]}" \
+        grep -l --null --color=never '^// *+k8s:conversion-gen=' "${ALL_K8S_TAG_FILES[@]}" \
             | xargs -0 -n1 dirname \
             | LC_ALL=C sort -u)
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
@@ -536,7 +536,7 @@ function codegen::openapi() {
 
         local tag_dirs=()
         kube::util::read-array tag_dirs < <(
-            grep -l -Z --color=never '+k8s:openapi-gen=' $(indirect_array "${prefix}_tag_files") \
+            grep -l --null --color=never '+k8s:openapi-gen=' $(indirect_array "${prefix}_tag_files") \
                 | xargs -0 -n1 dirname \
                 | LC_ALL=C sort -u)
 


### PR DESCRIPTION
macOS ships with BSD grep and other tools by default. Usually I override this with GNU grep in my PATH, but tripped over this when that wasn't the case.

`hack/update_codegen.sh` has something like the following in a few places:

```sh
    local tag_dirs=()
    kube::util::read-array tag_dirs < <(\
        grep -l -Z --color=never '^// *+k8s:conversion-gen=' "${ALL_K8S_TAG_FILES[@]}" \
            | xargs -0 -n1 dirname \
            | LC_ALL=C sort -u)
```

On Linux `man grep` has this information:
```console
       -Z, --null
              Output a zero byte (the ASCII NUL character) instead of
              the character that normally follows a file name.  For
              example, grep -lZ outputs a zero byte after each file name
              instead of the usual newline.  This option makes the
              output unambiguous, even in the presence of file names
              containing unusual characters like newlines.  This option
              can be used with commands like find -print0, perl -0, sort
              -z, and xargs -0 to process arbitrary file names, even
              those that contain newline characters.
```
On my platform macOS 13.0 (and likely other BSD grep releases):
```console
     --null  Prints a zero-byte after the file name.
...
     -Z, --decompress
             Force grep to behave as zgrep.
```

The consequence is that on macOS, `xargs -0` is not able to split its input into a list of directories and instead leaves the filenames in the path. `defaulter-gen`, `conversion-gen` and other tools trip up as a result. 

Changing the flag to `--null` fixed the issue for me on macOS with BSD grep.

I have not tested this flag change on any Linux distro, but my research on Linux man pages for grep show it should work.

TLDR:

BSD grep has a different behavior from GNU grep with -Z.
--null has consistent behavior across both implementations.
Even if we don't explicitly support BSD grep, it is easy enough to use `--null`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

fixes some tooling when run against BSD grep

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

