### PR TITLE
DO NOT MERGE: wait: Unify the backoff methods with a single common implementation

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
@@ -729,7 +729,7 @@ func poller(interval, timeout time.Duration) WaitWithContextFunc {
 
 // ExponentialBackoffWithContext works with a request context and a Backoff. It ensures that the retry wait never
 // exceeds the deadline specified by the request context.
-func ExponentialBackoffWithContext(ctx context.Context, backoff Backoff, condition ConditionFunc) error {
+func ExponentialBackoffWithContext(ctx context.Context, backoff Backoff, condition ConditionWithContextFunc) error {
 	for backoff.Steps > 0 {
 		select {
 		case <-ctx.Done():
@@ -737,7 +737,7 @@ func ExponentialBackoffWithContext(ctx context.Context, backoff Backoff, conditi
 		default:
 		}
 
-		if ok, err := runConditionWithCrashProtection(condition); err != nil || ok {
+		if ok, err := runConditionWithCrashProtectionWithContext(ctx, condition); err != nil || ok {
 			return err
 		}
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
@@ -571,7 +571,7 @@ func PollImmediateInfiniteWithContext(ctx context.Context, interval time.Duratio
 // wait: user specified WaitFunc function that controls at what interval the condition
 // function should be invoked periodically and whether it is bound by a timeout.
 // condition: user specified ConditionWithContextFunc function.
-func poll(ctx context.Context, immediate bool, wait WaitWithContextFunc, condition ConditionWithContextFunc) error {
+func poll(ctx context.Context, immediate bool, wait waitWithContextFunc, condition ConditionWithContextFunc) error {
 	if immediate {
 		done, err := runConditionWithCrashProtectionWithContext(ctx, condition)
 		if err != nil {
@@ -587,55 +587,36 @@ func poll(ctx context.Context, immediate bool, wait WaitWithContextFunc, conditi
 		// returning ctx.Err() will break backward compatibility
 		return ErrWaitTimeout
 	default:
-		return WaitForWithContext(ctx, wait, condition)
+		return waitForWithContext(ctx, wait, condition)
 	}
 }
 
-// WaitFunc creates a channel that receives an item every time a test
+// waitFunc creates a channel that receives an item every time a test
 // should be executed and is closed when the last test should be invoked.
-type WaitFunc func(done <-chan struct{}) <-chan struct{}
+type waitFunc func(done <-chan struct{}) <-chan struct{}
 
 // WithContext converts the WaitFunc to an equivalent WaitWithContextFunc
-func (w WaitFunc) WithContext() WaitWithContextFunc {
+func (w waitFunc) WithContext() waitWithContextFunc {
 	return func(ctx context.Context) <-chan struct{} {
 		return w(ctx.Done())
 	}
 }
 
-// WaitWithContextFunc creates a channel that receives an item every time a test
+// waitWithContextFunc creates a channel that receives an item every time a test
 // should be executed and is closed when the last test should be invoked.
 //
 // When the specified context gets cancelled or expires the function
 // stops sending item and returns immediately.
-type WaitWithContextFunc func(ctx context.Context) <-chan struct{}
+//
+// Deprecated: Will be removed when the legacy Poll methods are removed.
+type waitWithContextFunc func(ctx context.Context) <-chan struct{}
 
-// WaitFor continually checks 'fn' as driven by 'wait'.
+// waitForWithContext continually checks 'fn' as driven by 'wait'.
 //
-// WaitFor gets a channel from 'wait()”, and then invokes 'fn' once for every value
-// placed on the channel and once more when the channel is closed. If the channel is closed
-// and 'fn' returns false without error, WaitFor returns ErrWaitTimeout.
-//
-// If 'fn' returns an error the loop ends and that error is returned. If
-// 'fn' returns true the loop ends and nil is returned.
-//
-// ErrWaitTimeout will be returned if the 'done' channel is closed without fn ever
-// returning true.
-//
-// When the done channel is closed, because the golang `select` statement is
-// "uniform pseudo-random", the `fn` might still run one or multiple time,
-// though eventually `WaitFor` will return.
-func WaitFor(wait WaitFunc, fn ConditionFunc, done <-chan struct{}) error {
-	ctx, cancel := ContextForChannel(done)
-	defer cancel()
-	return WaitForWithContext(ctx, wait.WithContext(), fn.WithContext())
-}
-
-// WaitForWithContext continually checks 'fn' as driven by 'wait'.
-//
-// WaitForWithContext gets a channel from 'wait()”, and then invokes 'fn'
+// waitForWithContext gets a channel from 'wait()”, and then invokes 'fn'
 // once for every value placed on the channel and once more when the
 // channel is closed. If the channel is closed and 'fn'
-// returns false without error, WaitForWithContext returns ErrWaitTimeout.
+// returns false without error, waitForWithContext returns ErrWaitTimeout.
 //
 // If 'fn' returns an error the loop ends and that error is returned. If
 // 'fn' returns true the loop ends and nil is returned.
@@ -645,8 +626,10 @@ func WaitFor(wait WaitFunc, fn ConditionFunc, done <-chan struct{}) error {
 //
 // When the ctx.Done() channel is closed, because the golang `select` statement is
 // "uniform pseudo-random", the `fn` might still run one or multiple times,
-// though eventually `WaitForWithContext` will return.
-func WaitForWithContext(ctx context.Context, wait WaitWithContextFunc, fn ConditionWithContextFunc) error {
+// though eventually `waitForWithContext` will return.
+//
+// Deprecated: Will be removed when the legacy Poll methods are removed.
+func waitForWithContext(ctx context.Context, wait waitWithContextFunc, fn ConditionWithContextFunc) error {
 	waitCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	c := wait(waitCtx)
@@ -680,8 +663,8 @@ func WaitForWithContext(ctx context.Context, wait WaitWithContextFunc, fn Condit
 //
 // Output ticks are not buffered. If the channel is not ready to receive an
 // item, the tick is skipped.
-func poller(interval, timeout time.Duration) WaitWithContextFunc {
-	return WaitWithContextFunc(func(ctx context.Context) <-chan struct{} {
+func poller(interval, timeout time.Duration) waitWithContextFunc {
+	return waitWithContextFunc(func(ctx context.Context) <-chan struct{} {
 		ch := make(chan struct{})
 
 		go func() {

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
@@ -196,8 +196,75 @@ func Jitter(duration time.Duration, maxFactor float64) time.Duration {
 	return wait
 }
 
-// ErrWaitTimeout is returned when the condition exited without success.
-var ErrWaitTimeout = errors.New("timed out waiting for the condition")
+// ErrWaitTimeout is returned when the condition was not satisfied in time.
+//
+// Deprecated: This type will be made private in 1.28 in favor of WaitEndedEarly
+// for checking errors or WrapEndedEarly(err) for returning a typed error.
+var ErrWaitTimeout = ErrorEndedEarly(errors.New("timed out waiting for the condition"))
+
+// EndedEarly returns true if the error returned by Poll or ExponentialBackoff
+// methods indicates the condition was not successful within the method execution.
+// Callers should use this method instead of comparing the error value directly to
+// ErrWaitTimeout, as methods that cancel a context may not return that error.
+//
+// Instead of:
+//
+//	err := wait.Poll(...)
+//	if err == wait.ErrWaitTimeout {
+//	    log.Infof("Wait for operation exceeded")
+//	} else ...
+//
+// Use:
+//
+//	err := wait.Poll(...)
+//	if wait.EndedEarly(err) {
+//	    log.Infof("Wait for operation exceeded")
+//	} else ...
+func EndedEarly(err error) bool {
+	switch {
+	case errors.Is(err, errErrWaitTimeout),
+		errors.Is(err, context.Canceled),
+		errors.Is(err, context.DeadlineExceeded):
+		return true
+	default:
+		return false
+	}
+}
+
+// errEndedEarly
+type errEndedEarly struct {
+	cause error
+}
+
+// ErrorEndedEarly returns an error that indicates the wait was ended
+// early for a given reason. If no cause is provided a generic error
+// will be used but callers are encouraged to provide a real cause for
+// clarity in debugging.
+func ErrorEndedEarly(cause error) error {
+	switch cause.(type) {
+	case errEndedEarly:
+		// no need to wrap twice since errEndedEarly is only needed
+		// once in a chain
+		return cause
+	default:
+		return errEndedEarly{cause}
+	}
+}
+
+// errErrWaitTimeout is the private version of the previous ErrWaitTimeout
+// and is private to prevent direct comparison. Use ErrorEndedEarly(...)
+// instead.
+var errErrWaitTimeout = errEndedEarly{}
+
+func (e errEndedEarly) Unwrap() error        { return e.cause }
+func (e errEndedEarly) Is(target error) bool { return target == errErrWaitTimeout }
+func (e errEndedEarly) Error() string {
+	if e.cause == nil {
+		// returns the same error message as before
+		return "timed out waiting for the condition"
+	}
+	return e.cause.Error()
+}
 
 // ConditionFunc returns true if the condition is satisfied, or an error
 // if the loop should be aborted.
@@ -408,12 +475,18 @@ func (b *backoffManager) Step() time.Duration {
 // 3. a sleep truncated by the cap on duration has been completed.
 // In case (1) the returned error is what the condition function returned.
 // In all other cases, ErrWaitTimeout is returned.
+//
+// Since backoffs are often subject to cancellation, we recommend using
+// ExponentialBackoffWithContext and passing a context to the method.
 func ExponentialBackoff(backoff Backoff, condition ConditionFunc) error {
 	return ExponentialBackoffWithContext(context.Background(), backoff, condition.WithContext())
 }
 
-// ExponentialBackoffWithContext works with a request context and a Backoff. It ensures that the retry wait never
-// exceeds the deadline specified by the request context.
+// ExponentialBackoffWithContext repeats a condition check with exponential backoff.
+// It immediately returns an error if the condition returns an error, the context is cancelled
+// or hits the deadline, or if the maximum attempts defined in backoff is exceeded (ErrWaitTimeout).
+// If an error is returned by the condition the backoff stops immediately. The condition will
+// never be invoked more than backoff.Steps times.
 func ExponentialBackoffWithContext(ctx context.Context, backoff Backoff, condition ConditionWithContextFunc) error {
 	steps := backoff.Steps
 	return loopConditionUntilContext(ctx, internalClock.NewTimer, backoff.DelayFunc(), true, true, func(ctx context.Context) (bool, error) {
@@ -432,6 +505,33 @@ func ExponentialBackoffWithContext(ctx context.Context, backoff Backoff, conditi
 	})
 }
 
+// PollUntilContextCancel tries a condition func until it returns true, an error, or the context
+// is cancelled or hits a deadline. condition will be invoked after the first interval if the
+// context is not cancelled first. The returned error will be from ctx.Err(), the condition's
+// err return value, or nil. If invoking condition takes longer than interval the next condition
+// will be invoked immediately. When using very short intervals, condition may be invoked multiple
+// times before a context cancellation is detected. If immediate is true, condition will be
+// invoked before waiting and guarantees that condition is invoked at least once, regardless of
+// whether the context has been cancelled.
+func PollUntilContextCancel(ctx context.Context, interval time.Duration, immediate bool, condition ConditionWithContextFunc) error {
+	return loopConditionUntilContext(ctx, internalClock.NewTimer, Backoff{Duration: interval}.DelayFunc(), immediate, false, condition)
+}
+
+// PollUntilContextTimeout will terminate polling after timeout duration by setting a context
+// timeout. This is provided as a convenience function for callers not currently executing under
+// a deadline and is equivalent to:
+//
+//	deadlineCtx, deadlineCancel := context.WithTimeout(ctx, timeout)
+//	err := PollUntilContextCancel(ctx, interval, immediate, condition)
+//
+// The deadline context will be cancelled if the Poll succeeds before the timeout, simplifying
+// inline usage. All other behavior is identical to PollWithContextTimeout.
+func PollUntilContextTimeout(ctx context.Context, interval, timeout time.Duration, immediate bool, condition ConditionWithContextFunc) error {
+	deadlineCtx, deadlineCancel := context.WithTimeout(ctx, timeout)
+	defer deadlineCancel()
+	return loopConditionUntilContext(deadlineCtx, internalClock.NewTimer, Backoff{Duration: interval}.DelayFunc(), immediate, false, condition)
+}
+
 // Poll tries a condition func until it returns true, an error, or the timeout
 // is reached.
 //
@@ -442,6 +542,10 @@ func ExponentialBackoffWithContext(ctx context.Context, backoff Backoff, conditi
 // window is too short.
 //
 // If you want to Poll something forever, see PollInfinite.
+//
+// Deprecated: Use PollWithContextCancel with a deadline context. Note that
+// the new method will no longer return ErrWaitTimeout and instead return errors
+// defined by the context package. Will be removed in 1.28.
 func Poll(interval, timeout time.Duration, condition ConditionFunc) error {
 	return PollWithContext(context.Background(), interval, timeout, condition.WithContext())
 }
@@ -457,6 +561,11 @@ func Poll(interval, timeout time.Duration, condition ConditionFunc) error {
 // window is too short.
 //
 // If you want to Poll something forever, see PollInfinite.
+//
+// Deprecated: This method does not return errors from context, use
+// PollWithContextCancel with a deadline context. Note that the new method
+// will no longer return ErrWaitTimeout and instead return errors defined by the
+// context package. Will be removed in 1.28.
 func PollWithContext(ctx context.Context, interval, timeout time.Duration, condition ConditionWithContextFunc) error {
 	return poll(ctx, false, poller(interval, timeout), condition)
 }
@@ -466,6 +575,10 @@ func PollWithContext(ctx context.Context, interval, timeout time.Duration, condi
 //
 // PollUntil always waits interval before the first run of 'condition'.
 // 'condition' will always be invoked at least once.
+//
+// Deprecated: Use PollWithContextCancel instead. Note that
+// the new method will no longer return ErrWaitTimeout and instead return errors
+// defined by the context package. Will be removed in 1.28.
 func PollUntil(interval time.Duration, condition ConditionFunc, stopCh <-chan struct{}) error {
 	ctx, cancel := ContextForChannel(stopCh)
 	defer cancel()
@@ -477,6 +590,10 @@ func PollUntil(interval time.Duration, condition ConditionFunc, stopCh <-chan st
 //
 // PollUntilWithContext always waits interval before the first run of 'condition'.
 // 'condition' will always be invoked at least once.
+//
+// Deprecated: This method does not return errors from context, use
+// PollWithContextCancel. Note that the new method will no longer return ErrWaitTimeout
+// and instead return errors defined by the context package. Will be removed in 1.28.
 func PollUntilWithContext(ctx context.Context, interval time.Duration, condition ConditionWithContextFunc) error {
 	return poll(ctx, false, poller(interval, 0), condition)
 }
@@ -487,6 +604,10 @@ func PollUntilWithContext(ctx context.Context, interval time.Duration, condition
 //
 // Some intervals may be missed if the condition takes too long or the time
 // window is too short.
+//
+// Deprecated: Use PollWithContextCancel without a deadline. Note that
+// the new method will no longer return ErrWaitTimeout and instead return errors
+// defined by the context package. Will be removed in 1.28.
 func PollInfinite(interval time.Duration, condition ConditionFunc) error {
 	return PollInfiniteWithContext(context.Background(), interval, condition.WithContext())
 }
@@ -497,6 +618,11 @@ func PollInfinite(interval time.Duration, condition ConditionFunc) error {
 //
 // Some intervals may be missed if the condition takes too long or the time
 // window is too short.
+//
+// Deprecated: This method does not return errors from context, use
+// PollWithContextCancel without a deadline. Note that the new method will no longer return
+// ErrWaitTimeout and instead return errors defined by the context package. Will be
+// removed in 1.28.
 func PollInfiniteWithContext(ctx context.Context, interval time.Duration, condition ConditionWithContextFunc) error {
 	return poll(ctx, false, poller(interval, 0), condition)
 }
@@ -511,6 +637,11 @@ func PollInfiniteWithContext(ctx context.Context, interval time.Duration, condit
 // window is too short.
 //
 // If you want to immediately Poll something forever, see PollImmediateInfinite.
+//
+// Deprecated: This method does not return errors from context, use
+// PollImmediateWithContextCancel without a deadline. Note that the new method will no longer
+// return ErrWaitTimeout and instead return errors defined by the context package. Will
+// be removed in 1.28.
 func PollImmediate(interval, timeout time.Duration, condition ConditionFunc) error {
 	return PollImmediateWithContext(context.Background(), interval, timeout, condition.WithContext())
 }
@@ -525,6 +656,11 @@ func PollImmediate(interval, timeout time.Duration, condition ConditionFunc) err
 // window is too short.
 //
 // If you want to immediately Poll something forever, see PollImmediateInfinite.
+//
+// Deprecated: This method does not return errors from context, use
+// PollImmediateWithContextCancel without a deadline. Note that the new method will no longer
+// return ErrWaitTimeout and instead return errors defined by the context package. Will
+// be removed in 1.28.
 func PollImmediateWithContext(ctx context.Context, interval, timeout time.Duration, condition ConditionWithContextFunc) error {
 	return poll(ctx, true, poller(interval, timeout), condition)
 }
@@ -533,6 +669,11 @@ func PollImmediateWithContext(ctx context.Context, interval, timeout time.Durati
 //
 // PollImmediateUntil runs the 'condition' before waiting for the interval.
 // 'condition' will always be invoked at least once.
+//
+// Deprecated: This method does not return errors from context, use
+// PollImmediateWithContextCancel without a deadline. Note that the new method will no longer
+// return ErrWaitTimeout and instead return errors defined by the context package. Will
+// be removed in 1.28.
 func PollImmediateUntil(interval time.Duration, condition ConditionFunc, stopCh <-chan struct{}) error {
 	ctx, cancel := ContextForChannel(stopCh)
 	defer cancel()
@@ -544,6 +685,11 @@ func PollImmediateUntil(interval time.Duration, condition ConditionFunc, stopCh 
 //
 // PollImmediateUntilWithContext runs the 'condition' before waiting for the interval.
 // 'condition' will always be invoked at least once.
+//
+// Deprecated: This method does not return errors from context, use
+// PollImmediateWithContextCancel without a deadline. Note that the new method will no longer
+// return ErrWaitTimeout and instead return errors defined by the context package. Will
+// be removed in 1.28.
 func PollImmediateUntilWithContext(ctx context.Context, interval time.Duration, condition ConditionWithContextFunc) error {
 	return poll(ctx, true, poller(interval, 0), condition)
 }
@@ -554,6 +700,11 @@ func PollImmediateUntilWithContext(ctx context.Context, interval time.Duration, 
 //
 // Some intervals may be missed if the condition takes too long or the time
 // window is too short.
+//
+// Deprecated: This method does not return errors from context, use
+// PollImmediateWithContextCancel without a deadline. Note that the new method will no longer
+// return ErrWaitTimeout and instead return errors defined by the context package. Will
+// be removed in 1.28.
 func PollImmediateInfinite(interval time.Duration, condition ConditionFunc) error {
 	return PollImmediateInfiniteWithContext(context.Background(), interval, condition.WithContext())
 }
@@ -565,19 +716,23 @@ func PollImmediateInfinite(interval time.Duration, condition ConditionFunc) erro
 //
 // Some intervals may be missed if the condition takes too long or the time
 // window is too short.
+//
+// Deprecated: This method does not return errors from context, use
+// PollImmediateWithContextCancel without a deadline. Note that the new method will no longer
+// return ErrWaitTimeout and instead return errors defined by the context package. Will
+// be removed in 1.28.
 func PollImmediateInfiniteWithContext(ctx context.Context, interval time.Duration, condition ConditionWithContextFunc) error {
 	return poll(ctx, true, poller(interval, 0), condition)
 }
 
-// Internally used, each of the public 'Poll*' function defined in this
-// package should invoke this internal function with appropriate parameters.
-// ctx: the context specified by the caller, for infinite polling pass
-// a context that never gets cancelled or expired.
-// immediate: if true, the 'condition' will be invoked before waiting for the interval,
-// in this case 'condition' will always be invoked at least once.
-// wait: user specified WaitFunc function that controls at what interval the condition
-// function should be invoked periodically and whether it is bound by a timeout.
-// condition: user specified ConditionWithContextFunc function.
+// poll invokes condition until it is satisfied, the context is cancelled, or an
+// error occurs. It returns ErrWaitWithTimeout on ANY loop error (including context
+// cancellation) unless returnContextErr is true. If immediate is true, the condition
+// will be invoked before beginning the wait loop, otherwise there is no guarantee that
+// condition will be invoked before returning. The wait function will be invoked between
+// each execution of condition.
+//
+// Deprecated: Will be removed in 1.28.
 func poll(ctx context.Context, immediate bool, wait waitWithContextFunc, condition ConditionWithContextFunc) error {
 	if immediate {
 		done, err := runConditionWithCrashProtectionWithContext(ctx, condition)
@@ -591,7 +746,8 @@ func poll(ctx context.Context, immediate bool, wait waitWithContextFunc, conditi
 
 	select {
 	case <-ctx.Done():
-		// returning ctx.Err() will break backward compatibility
+		// returning ctx.Err() will break backward compatibility, use new Poll*ContextCancel
+		// methods instead
 		return ErrWaitTimeout
 	default:
 		return waitForWithContext(ctx, wait, condition)
@@ -600,6 +756,8 @@ func poll(ctx context.Context, immediate bool, wait waitWithContextFunc, conditi
 
 // waitFunc creates a channel that receives an item every time a test
 // should be executed and is closed when the last test should be invoked.
+//
+// Deprecated: Will be removed in 1.28.
 type waitFunc func(done <-chan struct{}) <-chan struct{}
 
 // WithContext converts the WaitFunc to an equivalent WaitWithContextFunc
@@ -615,7 +773,7 @@ func (w waitFunc) WithContext() waitWithContextFunc {
 // When the specified context gets cancelled or expires the function
 // stops sending item and returns immediately.
 //
-// Deprecated: Will be removed when the legacy Poll methods are removed.
+// Deprecated: Will be removed in 1.28.
 type waitWithContextFunc func(ctx context.Context) <-chan struct{}
 
 // waitForWithContext continually checks 'fn' as driven by 'wait'.
@@ -635,7 +793,7 @@ type waitWithContextFunc func(ctx context.Context) <-chan struct{}
 // "uniform pseudo-random", the `fn` might still run one or multiple times,
 // though eventually `waitForWithContext` will return.
 //
-// Deprecated: Will be removed when the legacy Poll methods are removed.
+// Deprecated: Will be removed in 1.28.
 func waitForWithContext(ctx context.Context, wait waitWithContextFunc, fn ConditionWithContextFunc) error {
 	waitCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -654,7 +812,8 @@ func waitForWithContext(ctx context.Context, wait waitWithContextFunc, fn Condit
 				return ErrWaitTimeout
 			}
 		case <-ctx.Done():
-			// returning ctx.Err() will break backward compatibility
+			// returning ctx.Err() will break backward compatibility, use new Poll*ContextCancel
+			// methods instead
 			return ErrWaitTimeout
 		}
 	}
@@ -670,6 +829,8 @@ func waitForWithContext(ctx context.Context, wait waitWithContextFunc, fn Condit
 //
 // Output ticks are not buffered. If the channel is not ready to receive an
 // item, the tick is skipped.
+//
+// Deprecated: Will be removed in 1.28.
 func poller(interval, timeout time.Duration) waitWithContextFunc {
 	return waitWithContextFunc(func(ctx context.Context) <-chan struct{} {
 		ch := make(chan struct{})

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
@@ -249,14 +249,19 @@ func (cf ConditionFunc) WithContext() ConditionWithContextFunc {
 // Note the caller must *always* call the CancelFunc, otherwise resources may be leaked.
 func ContextForChannel(parentCh <-chan struct{}) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
-
-	go func() {
-		select {
-		case <-parentCh:
-			cancel()
-		case <-ctx.Done():
-		}
-	}()
+	select {
+	case <-parentCh:
+		// already closed, cancel now and no goroutine necessary
+		cancel()
+	default:
+		go func() {
+			select {
+			case <-parentCh:
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+	}
 	return ctx, cancel
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
@@ -396,6 +396,35 @@ func ExponentialBackoff(backoff Backoff, condition ConditionFunc) error {
 	return ErrWaitTimeout
 }
 
+// ExponentialBackoffWithContext works with a request context and a Backoff. It ensures that the retry wait never
+// exceeds the deadline specified by the request context.
+func ExponentialBackoffWithContext(ctx context.Context, backoff Backoff, condition ConditionWithContextFunc) error {
+	for backoff.Steps > 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if ok, err := runConditionWithCrashProtectionWithContext(ctx, condition); err != nil || ok {
+			return err
+		}
+
+		if backoff.Steps == 1 {
+			break
+		}
+
+		waitBeforeRetry := backoff.Step()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(waitBeforeRetry):
+		}
+	}
+
+	return ErrWaitTimeout
+}
+
 // Poll tries a condition func until it returns true, an error, or the timeout
 // is reached.
 //
@@ -690,33 +719,4 @@ func poller(interval, timeout time.Duration) WaitWithContextFunc {
 
 		return ch
 	})
-}
-
-// ExponentialBackoffWithContext works with a request context and a Backoff. It ensures that the retry wait never
-// exceeds the deadline specified by the request context.
-func ExponentialBackoffWithContext(ctx context.Context, backoff Backoff, condition ConditionWithContextFunc) error {
-	for backoff.Steps > 0 {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		if ok, err := runConditionWithCrashProtectionWithContext(ctx, condition); err != nil || ok {
-			return err
-		}
-
-		if backoff.Steps == 1 {
-			break
-		}
-
-		waitBeforeRetry := backoff.Step()
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(waitBeforeRetry):
-		}
-	}
-
-	return ErrWaitTimeout
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
@@ -875,7 +875,7 @@ func TestExponentialBackoffWithContext(t *testing.T) {
 			}
 
 			attempts := 0
-			err := ExponentialBackoffWithContext(test.ctxGetter(), backoff, func() (bool, error) {
+			err := ExponentialBackoffWithContext(test.ctxGetter(), backoff, func(_ context.Context) (bool, error) {
 				attempts++
 				return test.callback(attempts)
 			})

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
@@ -350,7 +350,7 @@ func (fp *fakePoller) GetwaitFunc() waitFunc {
 
 func TestPoll(t *testing.T) {
 	invocations := 0
-	f := ConditionFunc(func() (bool, error) {
+	f := ConditionWithContextFunc(func(ctx context.Context) (bool, error) {
 		invocations++
 		return true, nil
 	})
@@ -358,7 +358,7 @@ func TestPoll(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	if err := poll(ctx, false, fp.GetwaitFunc().WithContext(), f.WithContext()); err != nil {
+	if err := poll(ctx, false, fp.GetwaitFunc().WithContext(), f); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 	fp.wg.Wait()
@@ -533,7 +533,7 @@ func TestPollForever(t *testing.T) {
 	}
 }
 
-func TestWaitFor(t *testing.T) {
+func Test_waitFor(t *testing.T) {
 	var invocations int
 	testCases := map[string]struct {
 		F       ConditionFunc
@@ -593,9 +593,9 @@ func TestWaitFor(t *testing.T) {
 	}
 }
 
-// TestWaitForWithEarlyClosingwaitFunc tests WaitFor when the waitFunc closes its channel. The WaitFor should
+// Test_waitForWithEarlyClosing_waitFunc tests WaitFor when the waitFunc closes its channel. The WaitFor should
 // always return ErrWaitTimeout.
-func TestWaitForWithEarlyClosingwaitFunc(t *testing.T) {
+func Test_waitForWithEarlyClosing_waitFunc(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
@@ -661,14 +661,14 @@ func TestPollUntil(t *testing.T) {
 	close(stopCh)
 
 	go func() {
-		// release the condition func  if needed
-		for {
-			<-called
+		// release the condition func if needed
+		for range called {
 		}
 	}()
 
 	// make sure we finished the poll
 	<-pollDone
+	close(called)
 }
 
 func TestBackoff_Step(t *testing.T) {
@@ -928,6 +928,20 @@ func TestExponentialBackoffWithContext(t *testing.T) {
 			errExpected:      context.DeadlineExceeded,
 		},
 		{
+			name:             "no attempts expected with zero backoff steps",
+			steps:            0,
+			callback:         defaultCallback,
+			attemptsExpected: 0,
+			errExpected:      ErrWaitTimeout,
+		},
+		{
+			name:             "condition returns false with single backoff step",
+			steps:            1,
+			callback:         defaultCallback,
+			attemptsExpected: 1,
+			errExpected:      ErrWaitTimeout,
+		},
+		{
 			name:  "condition returns true with single backoff step",
 			steps: 1,
 			callback: func(_ int) (bool, error) {
@@ -957,12 +971,37 @@ func TestExponentialBackoffWithContext(t *testing.T) {
 			attemptsExpected: 3,
 			errExpected:      nil,
 		},
+		{
+			name:  "condition returns error no further attempts expected",
+			steps: 5,
+			callback: func(_ int) (bool, error) {
+				return true, conditionErr
+			},
+			attemptsExpected: 1,
+			errExpected:      conditionErr,
+		},
+		{
+			name:             "context already canceled no attempts expected",
+			steps:            5,
+			context:          cancelledContext,
+			callback:         defaultCallback,
+			attemptsExpected: 0,
+			errExpected:      context.Canceled,
+		},
+		{
+			name:             "context at deadline no attempts expected",
+			steps:            5,
+			context:          deadlinedContext,
+			callback:         defaultCallback,
+			attemptsExpected: 0,
+			errExpected:      context.DeadlineExceeded,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			backoff := Backoff{
-				Duration: 1 * time.Millisecond,
+				Duration: 1 * time.Microsecond,
 				Factor:   1.0,
 				Steps:    test.steps,
 			}
@@ -982,7 +1021,6 @@ func TestExponentialBackoffWithContext(t *testing.T) {
 				attempts++
 				defer func() {
 					if test.cancelContextAfter > 0 && test.cancelContextAfter == attempts {
-						t.Logf("cancelling")
 						cancel()
 					}
 				}()
@@ -1313,7 +1351,6 @@ func TestPollImmediateUntilWithContext(t *testing.T) {
 					return false, fakeErr
 				}
 			},
-			context:          defaultContext,
 			errExpected:      fakeErr,
 			attemptsExpected: 1,
 		},
@@ -1324,7 +1361,6 @@ func TestPollImmediateUntilWithContext(t *testing.T) {
 					return true, nil
 				}
 			},
-			context:          defaultContext,
 			errExpected:      nil,
 			attemptsExpected: 1,
 		},
@@ -1336,7 +1372,7 @@ func TestPollImmediateUntilWithContext(t *testing.T) {
 				}
 			},
 			context:          cancelledContext,
-			errExpected:      ErrWaitTimeout, // this should be context.Canceled, but this method cannot change
+			errExpected:      ErrWaitTimeout, // this should be context.Canceled but that would break callers that assume all errors are ErrWaitTimeout
 			attemptsExpected: 1,
 		},
 		{
@@ -1350,7 +1386,6 @@ func TestPollImmediateUntilWithContext(t *testing.T) {
 					return true, nil
 				}
 			},
-			context:          defaultContext,
 			errExpected:      nil,
 			attemptsExpected: 4,
 		},
@@ -1361,9 +1396,8 @@ func TestPollImmediateUntilWithContext(t *testing.T) {
 					return false, nil
 				}
 			},
-			context:                      defaultContext,
 			cancelContextAfterNthAttempt: 4,
-			errExpected:                  ErrWaitTimeout,
+			errExpected:                  ErrWaitTimeout, // this should be context.Canceled, but this method cannot change
 			attemptsExpected:             4,
 		},
 	}
@@ -1490,7 +1524,7 @@ func TestWaitForWithContext(t *testing.T) {
 	}
 }
 
-func TestPollInternal(t *testing.T) {
+func Test_poll(t *testing.T) {
 	fakeErr := errors.New("fake error")
 	tests := []struct {
 		name               string
@@ -1644,6 +1678,27 @@ func TestPollInternal(t *testing.T) {
 			attemptsExpected:   2,
 			errExpected:        ErrWaitTimeout,
 		},
+		{
+			name:      "context is cancelled after N attempts, context error not expected (legacy behavior)",
+			immediate: false,
+			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
+				return false, nil
+			}),
+			waitFunc: func() waitFunc {
+				return func(done <-chan struct{}) <-chan struct{} {
+					ch := make(chan struct{})
+					// just tick twice
+					go func() {
+						ch <- struct{}{}
+						ch <- struct{}{}
+					}()
+					return ch
+				}
+			},
+			cancelContextAfter: 2,
+			attemptsExpected:   2,
+			errExpected:        ErrWaitTimeout,
+		},
 	}
 
 	for _, test := range tests {
@@ -1726,5 +1781,125 @@ func Benchmark_loopConditionUntilContext_ShortDuration(b *testing.B) {
 		}); err != nil {
 			b.Fatalf("unexpected err: %v", err)
 		}
+	}
+}
+
+type errWrapper struct {
+	wrapped error
+}
+
+func (w errWrapper) Unwrap() error {
+	return w.wrapped
+}
+func (w errWrapper) Error() string {
+	return fmt.Sprintf("wrapped: %v", w.wrapped)
+}
+
+type errNotWrapper struct {
+	wrapped error
+}
+
+func (w errNotWrapper) Error() string {
+	return fmt.Sprintf("wrapped: %v", w.wrapped)
+}
+
+func TestEndedEarly(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			err:  ErrWaitTimeout,
+			want: true,
+		},
+		{
+			err:  context.Canceled,
+			want: true,
+		}, {
+			err:  context.DeadlineExceeded,
+			want: true,
+		},
+		{
+			err:  errWrapper{ErrWaitTimeout},
+			want: true,
+		},
+		{
+			err:  errWrapper{context.Canceled},
+			want: true,
+		},
+		{
+			err:  errWrapper{context.DeadlineExceeded},
+			want: true,
+		},
+		{
+			err:  ErrorEndedEarly(nil),
+			want: true,
+		},
+		{
+			err:  ErrorEndedEarly(errors.New("unknown")),
+			want: true,
+		},
+		{
+			err:  ErrorEndedEarly(context.Canceled),
+			want: true,
+		},
+		{
+			err:  ErrorEndedEarly(ErrWaitTimeout),
+			want: true,
+		},
+
+		{
+			err: nil,
+		},
+		{
+			err: errors.New("not a cancellation"),
+		},
+		{
+			err: errNotWrapper{ErrWaitTimeout},
+		},
+		{
+			err: errNotWrapper{context.Canceled},
+		},
+		{
+			err: errNotWrapper{context.DeadlineExceeded},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EndedEarly(tt.err); got != tt.want {
+				t.Errorf("EndedEarly() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestErrorEndedEarly(t *testing.T) {
+	internalErr := errEndedEarly{}
+	if ErrorEndedEarly(internalErr) != internalErr {
+		t.Fatalf("error should not be wrapped twice")
+	}
+
+	internalErr = errEndedEarly{errEndedEarly{}}
+	if ErrorEndedEarly(internalErr) != internalErr {
+		t.Fatalf("object should be identical")
+	}
+
+	in := errors.New("test")
+	actual, expected := ErrorEndedEarly(in), (errEndedEarly{in})
+	if actual != expected {
+		t.Fatalf("did not wrap error")
+	}
+	if !errors.Is(actual, errErrWaitTimeout) {
+		t.Fatalf("does not obey errors.Is contract")
+	}
+	if actual.Error() != in.Error() {
+		t.Fatalf("unexpected error output")
+	}
+	if !EndedEarly(actual) {
+		t.Fatalf("is not EndedEarly")
+	}
+	if EndedEarly(in) {
+		t.Fatalf("should not be EndedEarly")
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
@@ -21,11 +21,13 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
@@ -233,15 +235,24 @@ func TestJitterUntilNegativeFactor(t *testing.T) {
 	if now.Add(3 * time.Second).Before(time.Now()) {
 		t.Errorf("JitterUntil did not returned after predefined period with negative jitter factor when the stop chan was closed inside the func")
 	}
-
 }
 
 func TestExponentialBackoff(t *testing.T) {
+	// exits immediately
+	i := 0
+	err := ExponentialBackoff(Backoff{Factor: 1.0}, func() (bool, error) {
+		i++
+		return false, nil
+	})
+	if err != ErrWaitTimeout || i != 0 {
+		t.Errorf("unexpected error: %v", err)
+	}
+
 	opts := Backoff{Factor: 1.0, Steps: 3}
 
 	// waits up to steps
-	i := 0
-	err := ExponentialBackoff(opts, func() (bool, error) {
+	i = 0
+	err = ExponentialBackoff(opts, func() (bool, error) {
 		i++
 		return false, nil
 	})
@@ -376,6 +387,47 @@ func TestPollError(t *testing.T) {
 	used := atomic.LoadInt32(&fp.used)
 	if used != 1 {
 		t.Errorf("Expected exactly one tick, got %d", used)
+	}
+}
+
+func Test_loopConditionWithContextImmediateDelay(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Time{})
+	backoff := Backoff{Duration: time.Second}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	expectedError := errors.New("Expected error")
+	var attempt int
+	f := ConditionFunc(func() (bool, error) {
+		attempt++
+		return false, expectedError
+	})
+
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		if err := loopConditionUntilContext(ctx, fakeClock.NewTimer, backoff.Step, false, true, f.WithContext()); err == nil || err != expectedError {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}()
+
+	for !fakeClock.HasWaiters() {
+		time.Sleep(time.Microsecond)
+	}
+
+	fakeClock.Step(time.Second - time.Millisecond)
+	if attempt != 0 {
+		t.Fatalf("should still be waiting for condition")
+	}
+	fakeClock.Step(2 * time.Millisecond)
+
+	select {
+	case <-doneCh:
+	case <-time.After(time.Second):
+		t.Fatalf("should have exited after a single loop")
+	}
+	if attempt != 1 {
+		t.Fatalf("expected attempt")
 	}
 }
 
@@ -573,12 +625,12 @@ func TestWaitForWithEarlyClosingwaitFunc(t *testing.T) {
 func TestWaitForWithContextCancelsContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	waitFunc := poller(time.Millisecond, ForeverTestTimeout)
+	waitFn := poller(time.Millisecond, ForeverTestTimeout)
 
 	var ctxPassedToWait context.Context
 	waitForWithContext(ctx, func(ctx context.Context) <-chan struct{} {
 		ctxPassedToWait = ctx
-		return waitFunc(ctx)
+		return waitFn(ctx)
 	}, func(ctx context.Context) (bool, error) {
 		time.Sleep(10 * time.Millisecond)
 		return true, nil
@@ -624,6 +676,7 @@ func TestBackoff_Step(t *testing.T) {
 		initial *Backoff
 		want    []time.Duration
 	}{
+		{initial: &Backoff{Duration: time.Second, Steps: -1}, want: []time.Duration{time.Second, time.Second, time.Second}},
 		{initial: &Backoff{Duration: time.Second, Steps: 0}, want: []time.Duration{time.Second, time.Second, time.Second}},
 		{initial: &Backoff{Duration: time.Second, Steps: 1}, want: []time.Duration{time.Second, time.Second, time.Second}},
 		{initial: &Backoff{Duration: time.Second, Factor: 1.0, Steps: 1}, want: []time.Duration{time.Second, time.Second, time.Second}},
@@ -774,11 +827,23 @@ func TestBackoffStepWithResetWithRealClockExponential(t *testing.T) {
 	}
 }
 
-func TestExponentialBackoffWithContext(t *testing.T) {
-	defaultCtx := func() context.Context {
-		return context.Background()
+func defaultContext() (context.Context, context.CancelFunc) {
+	return context.WithCancel(context.Background())
+}
+func cancelledContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx, cancel
+}
+func deadlinedContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	for ctx.Err() != context.DeadlineExceeded {
+		time.Sleep(501 * time.Microsecond)
 	}
+	return ctx, cancel
+}
 
+func TestExponentialBackoffWithContext(t *testing.T) {
 	defaultCallback := func(_ int) (bool, error) {
 		return false, nil
 	}
@@ -786,17 +851,18 @@ func TestExponentialBackoffWithContext(t *testing.T) {
 	conditionErr := errors.New("condition failed")
 
 	tests := []struct {
-		name             string
-		steps            int
-		ctxGetter        func() context.Context
-		callback         func(calls int) (bool, error)
-		attemptsExpected int
-		errExpected      error
+		name               string
+		steps              int
+		zeroDuration       bool
+		context            func() (context.Context, context.CancelFunc)
+		callback           func(calls int) (bool, error)
+		cancelContextAfter int
+		attemptsExpected   int
+		errExpected        error
 	}{
 		{
 			name:             "no attempts expected with zero backoff steps",
 			steps:            0,
-			ctxGetter:        defaultCtx,
 			callback:         defaultCallback,
 			attemptsExpected: 0,
 			errExpected:      ErrWaitTimeout,
@@ -804,15 +870,13 @@ func TestExponentialBackoffWithContext(t *testing.T) {
 		{
 			name:             "condition returns false with single backoff step",
 			steps:            1,
-			ctxGetter:        defaultCtx,
 			callback:         defaultCallback,
 			attemptsExpected: 1,
 			errExpected:      ErrWaitTimeout,
 		},
 		{
-			name:      "condition returns true with single backoff step",
-			steps:     1,
-			ctxGetter: defaultCtx,
+			name:  "condition returns true with single backoff step",
+			steps: 1,
 			callback: func(_ int) (bool, error) {
 				return true, nil
 			},
@@ -822,15 +886,13 @@ func TestExponentialBackoffWithContext(t *testing.T) {
 		{
 			name:             "condition always returns false with multiple backoff steps",
 			steps:            5,
-			ctxGetter:        defaultCtx,
 			callback:         defaultCallback,
 			attemptsExpected: 5,
 			errExpected:      ErrWaitTimeout,
 		},
 		{
-			name:      "condition returns true after certain attempts with multiple backoff steps",
-			steps:     5,
-			ctxGetter: defaultCtx,
+			name:  "condition returns true after certain attempts with multiple backoff steps",
+			steps: 5,
 			callback: func(attempts int) (bool, error) {
 				if attempts == 3 {
 					return true, nil
@@ -841,9 +903,8 @@ func TestExponentialBackoffWithContext(t *testing.T) {
 			errExpected:      nil,
 		},
 		{
-			name:      "condition returns error no further attempts expected",
-			steps:     5,
-			ctxGetter: defaultCtx,
+			name:  "condition returns error no further attempts expected",
+			steps: 5,
 			callback: func(_ int) (bool, error) {
 				return true, conditionErr
 			},
@@ -851,16 +912,50 @@ func TestExponentialBackoffWithContext(t *testing.T) {
 			errExpected:      conditionErr,
 		},
 		{
-			name:  "context already canceled no attempts expected",
-			steps: 5,
-			ctxGetter: func() context.Context {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				return ctx
-			},
+			name:             "context already canceled no attempts expected",
+			steps:            5,
+			context:          cancelledContext,
 			callback:         defaultCallback,
 			attemptsExpected: 0,
 			errExpected:      context.Canceled,
+		},
+		{
+			name:             "context at deadline no attempts expected",
+			steps:            5,
+			context:          deadlinedContext,
+			callback:         defaultCallback,
+			attemptsExpected: 0,
+			errExpected:      context.DeadlineExceeded,
+		},
+		{
+			name:  "condition returns true with single backoff step",
+			steps: 1,
+			callback: func(_ int) (bool, error) {
+				return true, nil
+			},
+			attemptsExpected: 1,
+			errExpected:      nil,
+		},
+		{
+			name:               "condition always returns false with multiple backoff steps but is cancelled at step 4",
+			steps:              5,
+			callback:           defaultCallback,
+			attemptsExpected:   4,
+			cancelContextAfter: 4,
+			errExpected:        context.Canceled,
+		},
+		{
+			name:         "condition returns true after certain attempts with multiple backoff steps and zero duration",
+			steps:        5,
+			zeroDuration: true,
+			callback: func(attempts int) (bool, error) {
+				if attempts == 3 {
+					return true, nil
+				}
+				return false, nil
+			},
+			attemptsExpected: 3,
+			errExpected:      nil,
 		},
 	}
 
@@ -871,10 +966,26 @@ func TestExponentialBackoffWithContext(t *testing.T) {
 				Factor:   1.0,
 				Steps:    test.steps,
 			}
+			if test.zeroDuration {
+				backoff.Duration = 0
+			}
+
+			contextFn := test.context
+			if contextFn == nil {
+				contextFn = defaultContext
+			}
+			ctx, cancel := contextFn()
+			defer cancel()
 
 			attempts := 0
-			err := ExponentialBackoffWithContext(test.ctxGetter(), backoff, func(_ context.Context) (bool, error) {
+			err := ExponentialBackoffWithContext(ctx, backoff, func(_ context.Context) (bool, error) {
 				attempts++
+				defer func() {
+					if test.cancelContextAfter > 0 && test.cancelContextAfter == attempts {
+						t.Logf("cancelling")
+						cancel()
+					}
+				}()
 				return test.callback(attempts)
 			})
 
@@ -886,6 +997,302 @@ func TestExponentialBackoffWithContext(t *testing.T) {
 				t.Errorf("expected attempts count: %d but got: %d", test.attemptsExpected, attempts)
 			}
 		})
+	}
+}
+
+func Test_loopConditionUntilContext_semantic(t *testing.T) {
+	defaultCallback := func(_ int) (bool, error) {
+		return false, nil
+	}
+
+	conditionErr := errors.New("condition failed")
+
+	tests := []struct {
+		name               string
+		timerFn            TimerFunc
+		delayFn            DelayFunc
+		immediate          bool
+		sliding            bool
+		context            func() (context.Context, context.CancelFunc)
+		callback           func(calls int) (bool, error)
+		cancelContextAfter int
+		attemptsExpected   int
+		errExpected        error
+	}{
+		{
+			name: "condition successful is only one attempt",
+			callback: func(attempts int) (bool, error) {
+				return true, nil
+			},
+			attemptsExpected: 1,
+		},
+		{
+			name: "delayed condition successful causes return and attempts",
+			callback: func(attempts int) (bool, error) {
+				return attempts > 1, nil
+			},
+			attemptsExpected: 2,
+		},
+		{
+			name: "delayed condition successful causes return and attempts many times",
+			callback: func(attempts int) (bool, error) {
+				return attempts >= 100, nil
+			},
+			attemptsExpected: 100,
+		},
+		{
+			name: "condition returns error even if ok is true",
+			callback: func(_ int) (bool, error) {
+				return true, conditionErr
+			},
+			attemptsExpected: 1,
+			errExpected:      conditionErr,
+		},
+		{
+			name: "condition exits after an error",
+			callback: func(_ int) (bool, error) {
+				return false, conditionErr
+			},
+			attemptsExpected: 1,
+			errExpected:      conditionErr,
+		},
+		{
+			name:             "context already canceled no attempts expected",
+			context:          cancelledContext,
+			callback:         defaultCallback,
+			attemptsExpected: 0,
+			errExpected:      context.Canceled,
+		},
+		{
+			name:               "context cancelled after 5 attempts",
+			context:            defaultContext,
+			callback:           defaultCallback,
+			cancelContextAfter: 5,
+			attemptsExpected:   5,
+			errExpected:        context.Canceled,
+		},
+		{
+			name:             "context at deadline no attempts expected",
+			context:          deadlinedContext,
+			callback:         defaultCallback,
+			attemptsExpected: 0,
+			errExpected:      context.DeadlineExceeded,
+		},
+	}
+
+	for _, test := range tests {
+		for _, immediate := range []bool{true, false} {
+			t.Run(fmt.Sprintf("immediate=%t", immediate), func(t *testing.T) {
+				for _, sliding := range []bool{true, false} {
+					t.Run(fmt.Sprintf("sliding=%t", sliding), func(t *testing.T) {
+						t.Run(test.name, func(t *testing.T) {
+							contextFn := test.context
+							if contextFn == nil {
+								contextFn = defaultContext
+							}
+							ctx, cancel := contextFn()
+							defer cancel()
+
+							//fakeClock := &testingclock.FakeClock{}
+							timerFn := test.timerFn
+							if timerFn == nil {
+								timerFn = (clock.RealClock{}).NewTimer
+							}
+							delayFn := test.delayFn
+							if delayFn == nil {
+								delayFn = Backoff{Duration: time.Microsecond}.DelayFunc()
+							}
+							attempts := 0
+							err := loopConditionUntilContext(ctx, timerFn, delayFn, test.immediate, test.sliding, func(_ context.Context) (bool, error) {
+								attempts++
+								defer func() {
+									if test.cancelContextAfter > 0 && test.cancelContextAfter == attempts {
+										cancel()
+									}
+								}()
+								return test.callback(attempts)
+							})
+
+							if test.errExpected != err {
+								t.Errorf("expected error: %v but got: %v", test.errExpected, err)
+							}
+
+							if test.attemptsExpected != attempts {
+								t.Errorf("expected attempts count: %d but got: %d", test.attemptsExpected, attempts)
+							}
+						})
+					})
+				}
+			})
+		}
+	}
+}
+
+type timerWrapper struct {
+	timer   clock.Timer
+	resets  []time.Duration
+	onReset func(d time.Duration)
+}
+
+func (w *timerWrapper) C() <-chan time.Time { return w.timer.C() }
+func (w *timerWrapper) Stop() bool          { return w.timer.Stop() }
+func (w *timerWrapper) Reset(d time.Duration) bool {
+	w.resets = append(w.resets, d)
+	b := w.timer.Reset(d)
+	if w.onReset != nil {
+		w.onReset(d)
+	}
+	return b
+}
+
+func Test_loopConditionUntilContext_timings(t *testing.T) {
+	// defaultCallback := func(_ int) (bool, error) {
+	// 	return false, nil
+	// }
+
+	// conditionErr := errors.New("condition failed")
+
+	tests := []struct {
+		name               string
+		delayFn            DelayFunc
+		immediate          bool
+		sliding            bool
+		context            func() (context.Context, context.CancelFunc)
+		callback           func(calls int, lastInterval time.Duration) (bool, error)
+		cancelContextAfter int
+		attemptsExpected   int
+		errExpected        error
+		expectedIntervals  func(t *testing.T, delays []time.Duration, delaysRequested []time.Duration)
+	}{
+		{
+			name:    "condition success",
+			delayFn: Backoff{Duration: time.Second, Steps: 2, Factor: 2.0, Jitter: 0}.DelayFunc(),
+			callback: func(attempts int, _ time.Duration) (bool, error) {
+				return true, nil
+			},
+			attemptsExpected: 1,
+			expectedIntervals: func(t *testing.T, delays []time.Duration, delaysRequested []time.Duration) {
+				if reflect.DeepEqual(delays, []time.Duration{time.Second, 2 * time.Second}) {
+					return
+				}
+				if reflect.DeepEqual(delaysRequested, []time.Duration{time.Second}) {
+					return
+				}
+			},
+		},
+		{
+			name:      "condition success",
+			immediate: true,
+			delayFn:   Backoff{Duration: time.Second, Steps: 2, Factor: 2.0, Jitter: 0}.DelayFunc(),
+			callback: func(attempts int, _ time.Duration) (bool, error) {
+				return true, nil
+			},
+			attemptsExpected: 1,
+			expectedIntervals: func(t *testing.T, delays []time.Duration, delaysRequested []time.Duration) {
+				if reflect.DeepEqual(delays, []time.Duration{time.Second}) {
+					return
+				}
+				if reflect.DeepEqual(delaysRequested, []time.Duration{}) {
+					return
+				}
+			},
+		},
+		{
+			name:    "condition success",
+			sliding: true,
+			delayFn: Backoff{Duration: time.Second, Steps: 2, Factor: 2.0, Jitter: 0}.DelayFunc(),
+			callback: func(attempts int, _ time.Duration) (bool, error) {
+				return true, nil
+			},
+			attemptsExpected: 1,
+			expectedIntervals: func(t *testing.T, delays []time.Duration, delaysRequested []time.Duration) {
+				if reflect.DeepEqual(delays, []time.Duration{time.Second}) {
+					return
+				}
+				if !reflect.DeepEqual(delays, delaysRequested) {
+					t.Fatalf("sliding non-immediate should have equal delays: %v", cmp.Diff(delays, delaysRequested))
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s/sliding=%t/immediate=%t", test.name, test.sliding, test.immediate), func(t *testing.T) {
+			contextFn := test.context
+			if contextFn == nil {
+				contextFn = defaultContext
+			}
+			ctx, cancel := contextFn()
+			defer cancel()
+
+			fakeClock := &testingclock.FakeClock{}
+			var fakeTimers []*timerWrapper
+			timerFn := func(d time.Duration) clock.Timer {
+				t := fakeClock.NewTimer(d)
+				fakeClock.Step(d + 1)
+				w := &timerWrapper{timer: t, resets: []time.Duration{d}, onReset: func(d time.Duration) {
+					fakeClock.Step(d + 1)
+				}}
+				fakeTimers = append(fakeTimers, w)
+				return w
+			}
+
+			delayFn := test.delayFn
+			if delayFn == nil {
+				delayFn = Backoff{Duration: time.Microsecond}.DelayFunc()
+			}
+			var delays []time.Duration
+			wrappedDelayFn := func() time.Duration {
+				d := delayFn()
+				delays = append(delays, d)
+				return d
+			}
+			attempts := 0
+			err := loopConditionUntilContext(ctx, timerFn, wrappedDelayFn, test.immediate, test.sliding, func(_ context.Context) (bool, error) {
+				attempts++
+				defer func() {
+					if test.cancelContextAfter > 0 && test.cancelContextAfter == attempts {
+						cancel()
+					}
+				}()
+				return test.callback(attempts, delays[len(delays)-1])
+			})
+
+			if test.errExpected != err {
+				t.Errorf("expected error: %v but got: %v", test.errExpected, err)
+			}
+
+			if test.attemptsExpected != attempts {
+				t.Errorf("expected attempts count: %d but got: %d", test.attemptsExpected, attempts)
+			}
+			switch len(fakeTimers) {
+			case 0:
+				test.expectedIntervals(t, delays, nil)
+			case 1:
+				test.expectedIntervals(t, delays, fakeTimers[0].resets)
+			default:
+				t.Fatalf("expected zero or one timers: %#v", fakeTimers)
+			}
+		})
+	}
+}
+
+func BenchmarkExponentialBackoffWithContext(b *testing.B) {
+	backoff := Backoff{
+		Duration: 0,
+		Factor:   0,
+		Steps:    101,
+	}
+	ctx := context.Background()
+
+	for i := 0; i < b.N; i++ {
+		attempts := 0
+		if err := ExponentialBackoffWithContext(ctx, backoff, func(_ context.Context) (bool, error) {
+			attempts++
+			return attempts >= 100, nil
+		}); err != nil {
+			b.Fatalf("unexpected err: %v", err)
+		}
 	}
 }
 
@@ -906,9 +1313,7 @@ func TestPollImmediateUntilWithContext(t *testing.T) {
 					return false, fakeErr
 				}
 			},
-			context: func() (context.Context, context.CancelFunc) {
-				return context.WithCancel(context.Background())
-			},
+			context:          defaultContext,
 			errExpected:      fakeErr,
 			attemptsExpected: 1,
 		},
@@ -919,9 +1324,7 @@ func TestPollImmediateUntilWithContext(t *testing.T) {
 					return true, nil
 				}
 			},
-			context: func() (context.Context, context.CancelFunc) {
-				return context.WithCancel(context.Background())
-			},
+			context:          defaultContext,
 			errExpected:      nil,
 			attemptsExpected: 1,
 		},
@@ -932,12 +1335,8 @@ func TestPollImmediateUntilWithContext(t *testing.T) {
 					return false, nil
 				}
 			},
-			context: func() (context.Context, context.CancelFunc) {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				return ctx, cancel
-			},
-			errExpected:      ErrWaitTimeout,
+			context:          cancelledContext,
+			errExpected:      ErrWaitTimeout, // this should be context.Canceled, but this method cannot change
 			attemptsExpected: 1,
 		},
 		{
@@ -951,9 +1350,7 @@ func TestPollImmediateUntilWithContext(t *testing.T) {
 					return true, nil
 				}
 			},
-			context: func() (context.Context, context.CancelFunc) {
-				return context.WithCancel(context.Background())
-			},
+			context:          defaultContext,
 			errExpected:      nil,
 			attemptsExpected: 4,
 		},
@@ -964,9 +1361,7 @@ func TestPollImmediateUntilWithContext(t *testing.T) {
 					return false, nil
 				}
 			},
-			context: func() (context.Context, context.CancelFunc) {
-				return context.WithCancel(context.Background())
-			},
+			context:                      defaultContext,
 			cancelContextAfterNthAttempt: 4,
 			errExpected:                  ErrWaitTimeout,
 			attemptsExpected:             4,
@@ -975,7 +1370,11 @@ func TestPollImmediateUntilWithContext(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx, cancel := test.context()
+			contextFn := test.context
+			if contextFn == nil {
+				contextFn = defaultContext
+			}
+			ctx, cancel := contextFn()
 			defer cancel()
 
 			var attempts int
@@ -1013,10 +1412,8 @@ func TestWaitForWithContext(t *testing.T) {
 		errExpected      error
 	}{
 		{
-			name: "condition returns done=true on first attempt, no retry is attempted",
-			context: func() (context.Context, context.CancelFunc) {
-				return context.WithCancel(context.Background())
-			},
+			name:    "condition returns done=true on first attempt, no retry is attempted",
+			context: defaultContext,
 			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
 				return true, nil
 			}),
@@ -1025,10 +1422,8 @@ func TestWaitForWithContext(t *testing.T) {
 			errExpected:      nil,
 		},
 		{
-			name: "condition always returns done=false, timeout error expected",
-			context: func() (context.Context, context.CancelFunc) {
-				return context.WithCancel(context.Background())
-			},
+			name:    "condition always returns done=false, timeout error expected",
+			context: defaultContext,
 			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
 				return false, nil
 			}),
@@ -1038,10 +1433,8 @@ func TestWaitForWithContext(t *testing.T) {
 			errExpected:      ErrWaitTimeout,
 		},
 		{
-			name: "condition returns an error on first attempt, the error is returned",
-			context: func() (context.Context, context.CancelFunc) {
-				return context.WithCancel(context.Background())
-			},
+			name:    "condition returns an error on first attempt, the error is returned",
+			context: defaultContext,
 			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
 				return false, fakeErr
 			}),
@@ -1050,12 +1443,8 @@ func TestWaitForWithContext(t *testing.T) {
 			errExpected:      fakeErr,
 		},
 		{
-			name: "context is cancelled, context cancelled error expected",
-			context: func() (context.Context, context.CancelFunc) {
-				ctx, cancel := context.WithCancel(context.Background())
-				cancel()
-				return ctx, cancel
-			},
+			name:    "context is cancelled, context cancelled error expected",
+			context: cancelledContext,
 			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
 				return false, nil
 			}),
@@ -1081,7 +1470,11 @@ func TestWaitForWithContext(t *testing.T) {
 
 			ticker := test.waitFunc()
 			err := func() error {
-				ctx, cancel := test.context()
+				contextFn := test.context
+				if contextFn == nil {
+					contextFn = defaultContext
+				}
+				ctx, cancel := contextFn()
 				defer cancel()
 
 				return waitForWithContext(ctx, ticker.WithContext(), conditionWrapper)
@@ -1112,13 +1505,6 @@ func TestPollInternal(t *testing.T) {
 		{
 			name:      "immediate is true, condition returns an error",
 			immediate: true,
-			context: func() (context.Context, context.CancelFunc) {
-				// use a cancelled context, we want to make sure the
-				// condition is expected to be invoked immediately.
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				return ctx, cancel
-			},
 			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
 				return false, fakeErr
 			}),
@@ -1129,13 +1515,6 @@ func TestPollInternal(t *testing.T) {
 		{
 			name:      "immediate is true, condition returns true",
 			immediate: true,
-			context: func() (context.Context, context.CancelFunc) {
-				// use a cancelled context, we want to make sure the
-				// condition is expected to be invoked immediately.
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				return ctx, cancel
-			},
 			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
 				return true, nil
 			}),
@@ -1146,13 +1525,7 @@ func TestPollInternal(t *testing.T) {
 		{
 			name:      "immediate is true, context is cancelled, condition return false",
 			immediate: true,
-			context: func() (context.Context, context.CancelFunc) {
-				// use a cancelled context, we want to make sure the
-				// condition is expected to be invoked immediately.
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				return ctx, cancel
-			},
+			context:   cancelledContext,
 			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
 				return false, nil
 			}),
@@ -1163,13 +1536,7 @@ func TestPollInternal(t *testing.T) {
 		{
 			name:      "immediate is false, context is cancelled",
 			immediate: false,
-			context: func() (context.Context, context.CancelFunc) {
-				// use a cancelled context, we want to make sure the
-				// condition is expected to be invoked immediately.
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				return ctx, cancel
-			},
+			context:   cancelledContext,
 			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
 				return false, nil
 			}),
@@ -1180,9 +1547,6 @@ func TestPollInternal(t *testing.T) {
 		{
 			name:      "immediate is false, condition returns an error",
 			immediate: false,
-			context: func() (context.Context, context.CancelFunc) {
-				return context.WithCancel(context.Background())
-			},
 			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
 				return false, fakeErr
 			}),
@@ -1193,9 +1557,6 @@ func TestPollInternal(t *testing.T) {
 		{
 			name:      "immediate is false, condition returns true",
 			immediate: false,
-			context: func() (context.Context, context.CancelFunc) {
-				return context.WithCancel(context.Background())
-			},
 			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
 				return true, nil
 			}),
@@ -1206,9 +1567,6 @@ func TestPollInternal(t *testing.T) {
 		{
 			name:      "immediate is false, ticker channel is closed, condition returns true",
 			immediate: false,
-			context: func() (context.Context, context.CancelFunc) {
-				return context.WithCancel(context.Background())
-			},
 			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
 				return true, nil
 			}),
@@ -1225,9 +1583,6 @@ func TestPollInternal(t *testing.T) {
 		{
 			name:      "immediate is false, ticker channel is closed, condition returns error",
 			immediate: false,
-			context: func() (context.Context, context.CancelFunc) {
-				return context.WithCancel(context.Background())
-			},
 			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
 				return false, fakeErr
 			}),
@@ -1244,9 +1599,6 @@ func TestPollInternal(t *testing.T) {
 		{
 			name:      "immediate is false, ticker channel is closed, condition returns false",
 			immediate: false,
-			context: func() (context.Context, context.CancelFunc) {
-				return context.WithCancel(context.Background())
-			},
 			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
 				return false, nil
 			}),
@@ -1263,9 +1615,6 @@ func TestPollInternal(t *testing.T) {
 		{
 			name:      "condition always returns false, timeout error expected",
 			immediate: false,
-			context: func() (context.Context, context.CancelFunc) {
-				return context.WithCancel(context.Background())
-			},
 			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
 				return false, nil
 			}),
@@ -1277,9 +1626,6 @@ func TestPollInternal(t *testing.T) {
 		{
 			name:      "context is cancelled after N attempts, timeout error expected",
 			immediate: false,
-			context: func() (context.Context, context.CancelFunc) {
-				return context.WithCancel(context.Background())
-			},
 			condition: ConditionWithContextFunc(func(context.Context) (bool, error) {
 				return false, nil
 			}),
@@ -1310,7 +1656,11 @@ func TestPollInternal(t *testing.T) {
 				ticker = test.waitFunc()
 			}
 			err := func() error {
-				ctx, cancel := test.context()
+				contextFn := test.context
+				if contextFn == nil {
+					contextFn = defaultContext
+				}
+				ctx, cancel := contextFn()
 				defer cancel()
 
 				conditionWrapper := func(ctx context.Context) (done bool, err error) {
@@ -1335,5 +1685,46 @@ func TestPollInternal(t *testing.T) {
 				t.Errorf("Expected %d invocations, got %d", test.attemptsExpected, attempts)
 			}
 		})
+	}
+}
+
+func Benchmark_poll(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		attempts := 0
+		if err := poll(ctx, true, poller(time.Microsecond, 0), func(_ context.Context) (bool, error) {
+			attempts++
+			return attempts >= 100, nil
+		}); err != nil {
+			b.Fatalf("unexpected err: %v", err)
+		}
+	}
+}
+
+func Benchmark_loopConditionUntilContext_ZeroDuration(b *testing.B) {
+	ctx := context.Background()
+	delayFn := (&Backoff{Duration: 0}).DelayFunc()
+	for i := 0; i < b.N; i++ {
+		attempts := 0
+		if err := loopConditionUntilContext(ctx, internalClock.NewTimer, delayFn, true, false, func(_ context.Context) (bool, error) {
+			attempts++
+			return attempts >= 100, nil
+		}); err != nil {
+			b.Fatalf("unexpected err: %v", err)
+		}
+	}
+}
+
+func Benchmark_loopConditionUntilContext_ShortDuration(b *testing.B) {
+	ctx := context.Background()
+	delayFn := (&Backoff{Duration: time.Microsecond}).DelayFunc()
+	for i := 0; i < b.N; i++ {
+		attempts := 0
+		if err := loopConditionUntilContext(ctx, internalClock.NewTimer, delayFn, true, false, func(_ context.Context) (bool, error) {
+			attempts++
+			return attempts >= 100, nil
+		}); err != nil {
+			b.Fatalf("unexpected err: %v", err)
+		}
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
@@ -713,47 +713,65 @@ func TestContextForChannel(t *testing.T) {
 	}
 }
 
-func TestExponentialBackoffManagerGetNextBackoff(t *testing.T) {
+func TestBackoffStepWithResetExponential(t *testing.T) {
 	fc := testingclock.NewFakeClock(time.Now())
-	backoff := NewExponentialBackoffManager(1, 10, 10, 2.0, 0.0, fc)
+	backoff := Backoff{Duration: 1, Cap: 10, Factor: 2.0, Jitter: 0.0, Steps: 10}.StepWithReset(fc, 10)
 	durations := []time.Duration{1, 2, 4, 8, 10, 10, 10}
 	for i := 0; i < len(durations); i++ {
-		generatedBackoff := backoff.(*exponentialBackoffManagerImpl).getNextBackoff()
+		generatedBackoff := backoff()
 		if generatedBackoff != durations[i] {
 			t.Errorf("unexpected %d-th backoff: %d, expecting %d", i, generatedBackoff, durations[i])
 		}
 	}
 
 	fc.Step(11)
-	resetDuration := backoff.(*exponentialBackoffManagerImpl).getNextBackoff()
+	resetDuration := backoff()
 	if resetDuration != 1 {
 		t.Errorf("after reset, backoff should be 1, but got %d", resetDuration)
 	}
 }
 
-func TestJitteredBackoffManagerGetNextBackoff(t *testing.T) {
+func TestBackoffStepWithResetEmpty(t *testing.T) {
+	fc := testingclock.NewFakeClock(time.Now())
+	backoff := Backoff{Duration: 1, Cap: 10, Factor: 2.0, Jitter: 0.0, Steps: 10}.StepWithReset(fc, 0)
+	durations := []time.Duration{1, 1, 1, 1, 1, 1, 1}
+	for i := 0; i < len(durations); i++ {
+		generatedBackoff := backoff()
+		if generatedBackoff != durations[i] {
+			t.Errorf("unexpected %d-th backoff: %d, expecting %d", i, generatedBackoff, durations[i])
+		}
+	}
+
+	fc.Step(11)
+	resetDuration := backoff()
+	if resetDuration != 1 {
+		t.Errorf("after reset, backoff should be 1, but got %d", resetDuration)
+	}
+}
+
+func TestBackoffStepWithResetJitter(t *testing.T) {
 	// positive jitter
-	backoffMgr := NewJitteredBackoffManager(1, 1, testingclock.NewFakeClock(time.Now()))
+	backoff := Backoff{Duration: 1, Jitter: 1}.StepWithReset(testingclock.NewFakeClock(time.Now()), 0)
 	for i := 0; i < 5; i++ {
-		backoff := backoffMgr.(*jitteredBackoffManagerImpl).getNextBackoff()
-		if backoff < 1 || backoff > 2 {
-			t.Errorf("backoff out of range: %d", backoff)
+		value := backoff()
+		if value < 1 || value > 2 {
+			t.Errorf("backoff out of range: %d", value)
 		}
 	}
 
 	// negative jitter, shall be a fixed backoff
-	backoffMgr = NewJitteredBackoffManager(1, -1, testingclock.NewFakeClock(time.Now()))
-	backoff := backoffMgr.(*jitteredBackoffManagerImpl).getNextBackoff()
-	if backoff != 1 {
-		t.Errorf("backoff should be 1, but got %d", backoff)
+	backoff = Backoff{Duration: 1, Jitter: -1}.StepWithReset(testingclock.NewFakeClock(time.Now()), 0)
+	value := backoff()
+	if value != 1 {
+		t.Errorf("backoff should be 1, but got %d", value)
 	}
 }
 
-func TestJitterBackoffManagerWithRealClock(t *testing.T) {
-	backoffMgr := NewJitteredBackoffManager(1*time.Millisecond, 0, &clock.RealClock{})
+func TestBackoffStepWithResetWithRealClockJitter(t *testing.T) {
+	backoff := Backoff{Duration: 1 * time.Millisecond, Jitter: 0}.StepWithReset(&clock.RealClock{}, 0)
 	for i := 0; i < 5; i++ {
 		start := time.Now()
-		<-backoffMgr.Backoff().C()
+		<-RealTimer(backoff()).C()
 		passed := time.Since(start)
 		if passed < 1*time.Millisecond {
 			t.Errorf("backoff should be at least 1ms, but got %s", passed.String())
@@ -761,14 +779,14 @@ func TestJitterBackoffManagerWithRealClock(t *testing.T) {
 	}
 }
 
-func TestExponentialBackoffManagerWithRealClock(t *testing.T) {
+func TestBackoffStepWithResetWithRealClockExponential(t *testing.T) {
 	// backoff at least 1ms, 2ms, 4ms, 8ms, 10ms, 10ms, 10ms
 	durationFactors := []time.Duration{1, 2, 4, 8, 10, 10, 10}
-	backoffMgr := NewExponentialBackoffManager(1*time.Millisecond, 10*time.Millisecond, 1*time.Hour, 2.0, 0.0, &clock.RealClock{})
+	backoff := Backoff{Duration: 1 * time.Millisecond, Cap: 10 * time.Millisecond, Factor: 2.0, Jitter: 0.0, Steps: 10}.StepWithReset(&clock.RealClock{}, 1*time.Hour)
 
 	for i := range durationFactors {
 		start := time.Now()
-		<-backoffMgr.Backoff().C()
+		<-RealTimer(backoff()).C()
 		passed := time.Since(start)
 		if passed < durationFactors[i]*time.Millisecond {
 			t.Errorf("backoff should be at least %d ms, but got %s", durationFactors[i], passed.String())

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook.go
@@ -121,7 +121,7 @@ func WithExponentialBackoff(ctx context.Context, retryBackoff wait.Backoff, webh
 	// having a webhook error allows us to track the last actual webhook error for requests that
 	// are later cancelled or time out.
 	var webhookErr error
-	err := wait.ExponentialBackoffWithContext(ctx, retryBackoff, func() (bool, error) {
+	err := wait.ExponentialBackoffWithContext(ctx, retryBackoff, func(_ context.Context) (bool, error) {
 		webhookErr = webhookFn()
 		if shouldRetry(webhookErr) {
 			return false, nil

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -68,9 +68,9 @@ type Reflector struct {
 	listerWatcher ListerWatcher
 
 	// backoff manages backoff of ListWatch
-	backoffManager wait.BackoffManager
+	backoffManager wait.DelayFunc
 	// initConnBackoffManager manages backoff the initial connection with the Watch call of ListAndWatch.
-	initConnBackoffManager wait.BackoffManager
+	initConnBackoffManager wait.DelayFunc
 	// MaxInternalErrorRetryDuration defines how long we should retry internal errors returned by watch.
 	MaxInternalErrorRetryDuration time.Duration
 
@@ -212,8 +212,8 @@ func NewReflectorWithOptions(lw ListerWatcher, expectedType interface{}, store S
 		// We used to make the call every 1sec (1 QPS), the goal here is to achieve ~98% traffic reduction when
 		// API server is not healthy. With these parameters, backoff will stop at [30,60) sec interval which is
 		// 0.22 QPS. If we don't backoff for 2min, assume API server is healthy and we reset the backoff.
-		backoffManager:         wait.NewExponentialBackoffManager(800*time.Millisecond, 30*time.Second, 2*time.Minute, 2.0, 1.0, reflectorClock),
-		initConnBackoffManager: wait.NewExponentialBackoffManager(800*time.Millisecond, 30*time.Second, 2*time.Minute, 2.0, 1.0, reflectorClock),
+		backoffManager:         wait.Backoff{Duration: 800 * time.Millisecond, Cap: 30 * time.Second, Factor: 2.0, Jitter: 1.0, Steps: 20}.StepWithReset(reflectorClock, 2*time.Minute),
+		initConnBackoffManager: wait.Backoff{Duration: 800 * time.Millisecond, Cap: 30 * time.Second, Factor: 2.0, Jitter: 1.0, Steps: 20}.StepWithReset(reflectorClock, 2*time.Minute),
 		clock:                  reflectorClock,
 		watchErrorHandler:      WatchErrorHandler(DefaultWatchErrorHandler),
 		expectedType:           reflect.TypeOf(expectedType),
@@ -281,7 +281,7 @@ func (r *Reflector) Run(stopCh <-chan struct{}) {
 		if err := r.ListAndWatch(stopCh); err != nil {
 			r.watchErrorHandler(r, err)
 		}
-	}, r.backoffManager, true, stopCh)
+	}, r.clock.NewTimer, r.backoffManager, true, stopCh)
 	klog.V(3).Infof("Stopping reflector %s (%s) from %s", r.typeDescription, r.resyncPeriod, r.name)
 }
 
@@ -378,7 +378,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 			// If that's the case begin exponentially backing off and resend watch request.
 			// Do the same for "429" errors.
 			if utilnet.IsConnectionRefused(err) || apierrors.IsTooManyRequests(err) {
-				<-r.initConnBackoffManager.Backoff().C()
+				<-r.clock.After(r.initConnBackoffManager())
 				continue
 			}
 			return err
@@ -396,7 +396,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 					klog.V(4).Infof("%s: watch of %v closed with: %v", r.name, r.typeDescription, err)
 				case apierrors.IsTooManyRequests(err):
 					klog.V(2).Infof("%s: watch of %v returned 429 - backing off", r.name, r.typeDescription)
-					<-r.initConnBackoffManager.Backoff().C()
+					<-r.clock.After(r.initConnBackoffManager())
 					continue
 				case apierrors.IsInternalError(err) && retry.ShouldRetry():
 					klog.V(2).Infof("%s: retrying watch of %v internal error: %v", r.name, r.typeDescription, err)

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"reflect"
 	"strconv"
@@ -375,7 +376,7 @@ func TestReflectorListAndWatchInitConnBackoff(t *testing.T) {
 				stopCh := make(chan struct{})
 				connFails := test.numConnFails
 				fakeClock := testingclock.NewFakeClock(time.Unix(0, 0))
-				bm := wait.NewExponentialBackoffManager(time.Millisecond, maxBackoff, 100*time.Millisecond, 2.0, 1.0, fakeClock)
+				bm := wait.Backoff{Duration: time.Millisecond, Cap: maxBackoff, Factor: 2.0, Jitter: 1.0, Steps: math.MaxInt}.StepWithReset(fakeClock, 100*time.Millisecond)
 				done := make(chan struct{})
 				defer close(done)
 				go func() {
@@ -439,9 +440,9 @@ type fakeBackoff struct {
 	calls int
 }
 
-func (f *fakeBackoff) Backoff() clock.Timer {
+func (f *fakeBackoff) Step() time.Duration {
 	f.calls++
-	return f.clock.NewTimer(time.Duration(0))
+	return 0
 }
 
 func TestBackoffOnTooManyRequests(t *testing.T) {
@@ -474,7 +475,7 @@ func TestBackoffOnTooManyRequests(t *testing.T) {
 		name:                   "test-reflector",
 		listerWatcher:          lw,
 		store:                  NewFIFO(MetaNamespaceKeyFunc),
-		initConnBackoffManager: bm,
+		initConnBackoffManager: bm.Step,
 		clock:                  clock,
 		watchErrorHandler:      WatchErrorHandler(DefaultWatchErrorHandler),
 	}
@@ -543,7 +544,7 @@ func TestRetryInternalError(t *testing.T) {
 			name:                   "test-reflector",
 			listerWatcher:          lw,
 			store:                  NewFIFO(MetaNamespaceKeyFunc),
-			initConnBackoffManager: bm,
+			initConnBackoffManager: bm.Step,
 			clock:                  fakeClock,
 			watchErrorHandler:      WatchErrorHandler(DefaultWatchErrorHandler),
 		}

--- a/staging/src/k8s.io/client-go/tools/watch/until_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until_test.go
@@ -209,7 +209,7 @@ func TestUntilWithSync(t *testing.T) {
 			conditionFunc: func(e watch.Event) (bool, error) {
 				return true, nil
 			},
-			expectedErr:   errors.New("timed out waiting for the condition"),
+			expectedErr:   wait.ErrWaitTimeout,
 			expectedEvent: nil,
 		},
 		{

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
@@ -34,6 +34,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
 	azcache "k8s.io/legacy-cloud-providers/azure/cache"
 	"k8s.io/legacy-cloud-providers/azure/clients/interfaceclient/mockinterfaceclient"
@@ -487,7 +488,7 @@ func TestNodeAddresses(t *testing.T) {
 			metadataName:        "vm1",
 			vmType:              vmTypeStandard,
 			useInstanceMetadata: true,
-			expectedErrMsg:      fmt.Errorf("timed out waiting for the condition"),
+			expectedErrMsg:      wait.ErrWaitTimeout,
 		},
 		{
 			name:                "NodeAddresses should get IP addresses from Azure API if node's name isn't equal to metadataName",

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_routes_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_routes_test.go
@@ -33,6 +33,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/legacy-cloud-providers/azure/clients/routetableclient/mockroutetableclient"
 	"k8s.io/legacy-cloud-providers/azure/mockvmsets"
@@ -226,7 +227,7 @@ func TestCreateRoute(t *testing.T) {
 			name:           "CreateRoute should report error if error occurs when invoke GetIPByNodeName",
 			routeTableName: "rt7",
 			getIPError:     fmt.Errorf("getIP error"),
-			expectedErrMsg: fmt.Errorf("timed out waiting for the condition"),
+			expectedErrMsg: wait.ErrWaitTimeout,
 		},
 		{
 			name:               "CreateRoute should add route to cloud.RouteCIDRs if node is unmanaged",

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -673,7 +673,7 @@ func waitForDetachAndGrabMetrics(ctx context.Context, oldMetrics *storageControl
 		oldDetachCount = 0
 	}
 
-	verifyMetricFunc := func() (bool, error) {
+	verifyMetricFunc := func(ctx context.Context) (bool, error) {
 		updatedMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 
 		if err != nil {
@@ -821,7 +821,7 @@ func waitForPVControllerSync(ctx context.Context, metricsGrabber *e2emetrics.Gra
 		Factor:   1.2,
 		Steps:    21,
 	}
-	verifyMetricFunc := func() (bool, error) {
+	verifyMetricFunc := func(ctx context.Context) (bool, error) {
 		updatedMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 		if err != nil {
 			framework.Logf("Error fetching controller-manager metrics")
@@ -866,7 +866,7 @@ func waitForADControllerStatesMetrics(ctx context.Context, metricsGrabber *e2eme
 		Factor:   1.2,
 		Steps:    21,
 	}
-	verifyMetricFunc := func() (bool, error) {
+	verifyMetricFunc := func(ctx context.Context) (bool, error) {
 		updatedMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 		if err != nil {
 			e2eskipper.Skipf("Could not get controller-manager metrics - skipping")


### PR DESCRIPTION
This builds on #115064 to unify the backoff methods in wait with a single implementation that handles context, test injection, immediate execution, sliding windows, and the ability to leverage backoff managers. It changes no public signature or behavior. It does not change `Poll*` - that will be handled in #107826 or after. Only the second commit is new here.

The PR is for testing only right now.

/kind cleanup
/kind documentation
/kind feature

```release-note
```

```docs
```