### PR TITLE
Allow indexed jobs to have completions=nil

### DIFF
--- a/pkg/controller/job/indexed_job_utils.go
+++ b/pkg/controller/job/indexed_job_utils.go
@@ -341,3 +341,13 @@ func completionModeStr(job *batch.Job) string {
 	}
 	return string(batch.NonIndexedCompletion)
 }
+
+// When spec.Completions is nil, spec.Parallelism is used
+// as a drop-in replacement for generating the range of
+// completion indices.
+func getCompletions(job *batch.Job) int {
+	if job.Spec.Completions == nil {
+		return int(*job.Spec.Parallelism)
+	}
+	return int(*job.Spec.Completions)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/priority backlog
/sig apps

#### What this PR does / why we need it:
See #114862 and [KEP](https://github.com/kubernetes/enhancements/pull/3724) for the full proposal.

In summary, currently we validate that `spec.Completions` is set when `completionMode=Indexed` for an job. This proposal is to relax that validation. 

The use case is jobs with workers that require a form of autoscaling, like Ray, Spark or Horovord. By modeling these as jobs with spec.completion=nil, spec.parallelism can be used to scale the job.

While such jobs could be modeled as a StatefulSet, the job API offers batch-specific features that makes it a better fit (like [retriable and non retriable failures](https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures))

*This PR includes the following changes:*

1. If `spec.Completions` is nil, the job controller looks at spec.parallelism instead of spec.completions when calculating the range of indexes.
2. If `spec.Completions` is nil, when reducing parallelism, we remove higher completion indices first (otherwise the controller will eventually do that anyways to ensure that the pods have a continuous range).

#### Which issue(s) this PR fixes:
Fixes #114862

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/3724
```
