### PR TITLE
cacher: Fix watch behaviour for unset RV

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -482,6 +482,13 @@ func (c *Cacher) Delete(
 // Watch implements storage.Interface.
 func (c *Cacher) Watch(ctx context.Context, key string, opts storage.ListOptions) (watch.Interface, error) {
 	pred := opts.Predicate
+	// If the resourceVersion is unset, ensure that the rv
+	// from which the watch is being served, is the latest
+	// one. "latest" is ensured by serving the watch from
+	// the underlying storage.
+	if opts.ResourceVersion == "" {
+		return c.storage.Watch(ctx, key, opts)
+	}
 	watchRV, err := c.versioner.ParseResourceVersion(opts.ResourceVersion)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -277,6 +277,7 @@ func newTestCacher(s storage.Interface) (*Cacher, storage.Versioner, error) {
 }
 
 type dummyStorage struct {
+	sync.RWMutex
 	err error
 }
 
@@ -306,12 +307,21 @@ func (d *dummyStorage) Delete(_ context.Context, _ string, _ runtime.Object, _ *
 	return fmt.Errorf("unimplemented")
 }
 func (d *dummyStorage) Watch(_ context.Context, _ string, _ storage.ListOptions) (watch.Interface, error) {
-	return newDummyWatch(), nil
+	d.RLock()
+	defer d.RUnlock()
+
+	return newDummyWatch(), d.err
 }
 func (d *dummyStorage) Get(_ context.Context, _ string, _ storage.GetOptions, _ runtime.Object) error {
+	d.RLock()
+	defer d.RUnlock()
+
 	return d.err
 }
 func (d *dummyStorage) GetList(_ context.Context, _ string, _ storage.ListOptions, listObj runtime.Object) error {
+	d.RLock()
+	defer d.RUnlock()
+
 	podList := listObj.(*example.PodList)
 	podList.ListMeta = metav1.ListMeta{ResourceVersion: "100"}
 	return d.err
@@ -321,6 +331,12 @@ func (d *dummyStorage) GuaranteedUpdate(_ context.Context, _ string, _ runtime.O
 }
 func (d *dummyStorage) Count(_ string) (int64, error) {
 	return 0, fmt.Errorf("unimplemented")
+}
+func (d *dummyStorage) injectError(err error) {
+	d.Lock()
+	defer d.Unlock()
+
+	d.err = err
 }
 
 func TestGetListCacheBypass(t *testing.T) {
@@ -342,7 +358,7 @@ func TestGetListCacheBypass(t *testing.T) {
 	}
 
 	// Inject error to underlying layer and check if cacher is not bypassed.
-	backingStorage.err = errDummy
+	backingStorage.injectError(errDummy)
 	err = cacher.GetList(context.TODO(), "pods/ns", storage.ListOptions{
 		ResourceVersion: "0",
 		Predicate:       pred,
@@ -381,7 +397,7 @@ func TestGetListNonRecursiveCacheBypass(t *testing.T) {
 	}
 
 	// Inject error to underlying layer and check if cacher is not bypassed.
-	backingStorage.err = errDummy
+	backingStorage.injectError(errDummy)
 	err = cacher.GetList(context.TODO(), "pods/ns", storage.ListOptions{
 		ResourceVersion: "0",
 		Predicate:       pred,
@@ -415,7 +431,7 @@ func TestGetCacheBypass(t *testing.T) {
 	}
 
 	// Inject error to underlying layer and check if cacher is not bypassed.
-	backingStorage.err = errDummy
+	backingStorage.injectError(errDummy)
 	err = cacher.Get(context.TODO(), "pods/ns/pod-0", storage.GetOptions{
 		IgnoreNotFound:  true,
 		ResourceVersion: "0",


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug cleanup
/priority important-soon
#### What this PR does / why we need it:

This PR consists of 2 commits:
- #### Commit 1 (prep for commit 2):
  - This commit allows injecting errors for the Watch() method of the dummy storage impl.
  - As a consequence of this, a [race](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/115096/pull-kubernetes-unit/1614863523177828352) is introduced between when the injected error is written and read whenever a Watch() is invoked using the dummy storage. This commit adds locking in order to mitigate this.

- #### Commit 2:
  - The original design was to honour strong consistency semantics for when the RV is unset, i.e. serve the watch by
doing a quorum read.
  - However, the implementation did not match the intent, in that, the Cacher did not distinguish between set and unset RV.
This commit rectifies that behaviour by serving the watch from the underlying storage if the RV is unset.
  - This commit subsequently also adds a test for the same.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #114845

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
cacher: If RV is unset, the watch is now served from the underlying storage as documented.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @wojtek-t 