### PR TITLE
Check for all errors in CRI connection validation

### DIFF
--- a/pkg/kubelet/cri/remote/remote_image.go
+++ b/pkg/kubelet/cri/remote/remote_image.go
@@ -25,9 +25,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/status"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	tracing "k8s.io/component-base/tracing"
 	"k8s.io/klog/v2"
@@ -93,13 +91,11 @@ func (r *remoteImageService) validateServiceConnection(ctx context.Context, conn
 	klog.V(4).InfoS("Validating the CRI v1 API image version")
 	r.imageClient = runtimeapi.NewImageServiceClient(conn)
 
-	if _, err := r.imageClient.ImageFsInfo(ctx, &runtimeapi.ImageFsInfoRequest{}); err == nil {
-		klog.V(2).InfoS("Validated CRI v1 image API")
-
-	} else if status.Code(err) == codes.Unimplemented {
-		return fmt.Errorf("CRI v1 image API is not implemented for endpoint %q: %w", endpoint, err)
+	if _, err := r.imageClient.ImageFsInfo(ctx, &runtimeapi.ImageFsInfoRequest{}); err != nil {
+		return fmt.Errorf("validate CRI v1 image API for endpoint %q: %w", endpoint, err)
 	}
 
+	klog.V(2).InfoS("Validated CRI v1 image API")
 	return nil
 }
 

--- a/pkg/kubelet/cri/remote/remote_runtime.go
+++ b/pkg/kubelet/cri/remote/remote_runtime.go
@@ -117,13 +117,11 @@ func (r *remoteRuntimeService) validateServiceConnection(ctx context.Context, co
 	klog.V(4).InfoS("Validating the CRI v1 API runtime version")
 	r.runtimeClient = runtimeapi.NewRuntimeServiceClient(conn)
 
-	if _, err := r.runtimeClient.Version(ctx, &runtimeapi.VersionRequest{}); err == nil {
-		klog.V(2).InfoS("Validated CRI v1 runtime API")
-
-	} else if status.Code(err) == codes.Unimplemented {
-		return fmt.Errorf("CRI v1 runtime API is not implemented for endpoint %q: %w", endpoint, err)
+	if _, err := r.runtimeClient.Version(ctx, &runtimeapi.VersionRequest{}); err != nil {
+		return fmt.Errorf("validate CRI v1 runtime API for endpoint %q: %w", endpoint, err)
 	}
 
+	klog.V(2).InfoS("Validated CRI v1 runtime API")
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

 We only have one CRI API (v1) to validate during the initial connection of the kubelet with the container runtime. Therefore we can now verify all kind of GRPC related issues.

#### Which issue(s) this PR fixes:

Fixes #114956, https://github.com/kubernetes-sigs/cri-tools/issues/1041

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fail CRI connection if service or image endpoint is throwing any error on kubelet startup.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
