### PR TITLE
Use proper tmp directory for update-openapi-spec.sh

### DIFF
--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -47,12 +47,12 @@ trap cleanup EXIT SIGINT
 
 kube::golang::setup_env
 
-TMP_DIR=$(mktemp -d /tmp/update-openapi-spec.XXXX)
+TMP_DIR=${TMP_DIR:-$(mktemp -d 2>/dev/null || mktemp -d -t update-openapi-spec.XXXX)}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 API_PORT=${API_PORT:-8050}
 API_HOST=${API_HOST:-127.0.0.1}
-API_LOGFILE=${API_LOGFILE:-/tmp/openapi-api-server.log}
+API_LOGFILE=${API_LOGFILE:-${TMP_DIR}/openapi-api-server.log}
 
 kube::etcd::start
 
@@ -60,7 +60,7 @@ echo "dummy_token,admin,admin" > "${TMP_DIR}/tokenauth.csv"
 
 # setup envs for TokenRequest required flags
 SERVICE_ACCOUNT_LOOKUP=${SERVICE_ACCOUNT_LOOKUP:-true}
-SERVICE_ACCOUNT_KEY=${SERVICE_ACCOUNT_KEY:-/tmp/kube-serviceaccount.key}
+SERVICE_ACCOUNT_KEY=${SERVICE_ACCOUNT_KEY:-${TMP_DIR}/kube-serviceaccount.key}
 # Generate ServiceAccount key if needed
 if [[ ! -f "${SERVICE_ACCOUNT_KEY}" ]]; then
   mkdir -p "$(dirname "${SERVICE_ACCOUNT_KEY}")"

--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -47,7 +47,7 @@ trap cleanup EXIT SIGINT
 
 kube::golang::setup_env
 
-TMP_DIR=${TMP_DIR:-$(mktemp -d 2>/dev/null || mktemp -d -t update-openapi-spec.XXXX)}
+TMP_DIR=${TMP_DIR:-$(kube::realpath "$(mktemp -d -t "$(basename "$0").XXXXXX")")}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 API_PORT=${API_PORT:-8050}


### PR DESCRIPTION
This change introduces a separate temp folder for `update-openapi-spec.sh` to avoid permission issues with other scripts.

#### What type of PR is this?

/kind bug
/sig node

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/115105

