### PR TITLE
wait: ExponentialBackoffWithContext should take context-aware fn

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
@@ -729,7 +729,7 @@ func poller(interval, timeout time.Duration) WaitWithContextFunc {
 
 // ExponentialBackoffWithContext works with a request context and a Backoff. It ensures that the retry wait never
 // exceeds the deadline specified by the request context.
-func ExponentialBackoffWithContext(ctx context.Context, backoff Backoff, condition ConditionFunc) error {
+func ExponentialBackoffWithContext(ctx context.Context, backoff Backoff, condition ConditionWithContextFunc) error {
 	for backoff.Steps > 0 {
 		select {
 		case <-ctx.Done():
@@ -737,7 +737,7 @@ func ExponentialBackoffWithContext(ctx context.Context, backoff Backoff, conditi
 		default:
 		}
 
-		if ok, err := runConditionWithCrashProtection(condition); err != nil || ok {
+		if ok, err := runConditionWithCrashProtectionWithContext(ctx, condition); err != nil || ok {
 			return err
 		}
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
@@ -875,7 +875,7 @@ func TestExponentialBackoffWithContext(t *testing.T) {
 			}
 
 			attempts := 0
-			err := ExponentialBackoffWithContext(test.ctxGetter(), backoff, func() (bool, error) {
+			err := ExponentialBackoffWithContext(test.ctxGetter(), backoff, func(_ context.Context) (bool, error) {
 				attempts++
 				return test.callback(attempts)
 			})

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook.go
@@ -121,7 +121,7 @@ func WithExponentialBackoff(ctx context.Context, retryBackoff wait.Backoff, webh
 	// having a webhook error allows us to track the last actual webhook error for requests that
 	// are later cancelled or time out.
 	var webhookErr error
-	err := wait.ExponentialBackoffWithContext(ctx, retryBackoff, func() (bool, error) {
+	err := wait.ExponentialBackoffWithContext(ctx, retryBackoff, func(_ context.Context) (bool, error) {
 		webhookErr = webhookFn()
 		if shouldRetry(webhookErr) {
 			return false, nil

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -673,7 +673,7 @@ func waitForDetachAndGrabMetrics(ctx context.Context, oldMetrics *storageControl
 		oldDetachCount = 0
 	}
 
-	verifyMetricFunc := func() (bool, error) {
+	verifyMetricFunc := func(ctx context.Context) (bool, error) {
 		updatedMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 
 		if err != nil {
@@ -821,7 +821,7 @@ func waitForPVControllerSync(ctx context.Context, metricsGrabber *e2emetrics.Gra
 		Factor:   1.2,
 		Steps:    21,
 	}
-	verifyMetricFunc := func() (bool, error) {
+	verifyMetricFunc := func(ctx context.Context) (bool, error) {
 		updatedMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 		if err != nil {
 			framework.Logf("Error fetching controller-manager metrics")
@@ -866,7 +866,7 @@ func waitForADControllerStatesMetrics(ctx context.Context, metricsGrabber *e2eme
 		Factor:   1.2,
 		Steps:    21,
 	}
-	verifyMetricFunc := func() (bool, error) {
+	verifyMetricFunc := func(ctx context.Context) (bool, error) {
 		updatedMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
 		if err != nil {
 			e2eskipper.Skipf("Could not get controller-manager metrics - skipping")


### PR DESCRIPTION
**NOTE**: This pull is part of a series of changes that introduce new context-cancellation-aware Poll methods, reduce the surface area of the wait package to a smaller set of functions (if unused, marked private, if consolidating, marked deprecated), unify the underlying loop implementation with better testing, consolidate the backoff manager code into a smaller chunk, and in general address a number of outstanding issues.  See #115077, #115116, #115113, #115140, #115064, and #107826.

The condition methods will eventually all take a context. Since we have been provided one, alter the accepted condition type and change the four references in tree.

Callers of ExponentialBackoffWithContext should use a condition aware function (ConditionWithContextFunc). If the context can be ignored the helper ConditionFunc.WithContext can be used to convert an existing function to the new type.

This is part of the general cleanup of the wait package to ensure the Kubelet can cancel propagation of sync methods in #107826 and simplifies future PRs to unify how the various backoff methods behave.

/kind cleanup

```release-note
Callers of wait.ExponentialBackoffWithContext must pass a ConditionWithContextFunc to be consistent with the signature and avoid creating a duplicate context. If your condition does not need a context you can use the `ConditionFunc.WithContext()` helper to ignore the context, or use ExponentialBackoff directly.
```

```docs
```