### PR TITLE
Wait for logs pod to complete before counting lines

### DIFF
--- a/test/e2e/kubectl/logs.go
+++ b/test/e2e/kubectl/logs.go
@@ -183,8 +183,9 @@ var _ = SIGDescribe("Kubectl logs", func() {
 
 			ginkgo.It("should log default container if not specified", func(ctx context.Context) {
 				ginkgo.By("Waiting for log generator to start.")
-				if !e2epod.CheckPodsRunningReadyOrSucceeded(ctx, c, ns, []string{podName}, framework.PodStartTimeout) {
-					framework.Failf("Pod %s was not ready", podName)
+				// we need to wait for pod completion, to check the generated number of lines
+				if err := e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, c, podName, ns, framework.PodStartTimeout); err != nil {
+					framework.Failf("Pod %s did not finish: %v", podName, err)
 				}
 
 				ginkgo.By("specified container log lines")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:
Currently the new logs tests waits for the pod running and then checks for specified number of lines to be generated by the `logs-generator` command. To make it work properly, we need to wait for the pod to complete, to ensure we always get what we want. 

#### Which issue(s) this PR fixes:
Fixes #115126

#### Special notes for your reviewer:
/assign @aojea @pacoxu 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
