### PR TITLE
wait: Use a context implementation for ContextForChannel

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -242,7 +242,7 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 
 	// No leader election, run directly
 	if !c.ComponentConfig.Generic.LeaderElection.LeaderElect {
-		ctx, _ := wait.ContextForChannel(stopCh)
+		ctx := wait.ContextForChannel(stopCh)
 		run(ctx, saTokenControllerInitFunc, NewControllerInitializers)
 		return nil
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
@@ -523,8 +523,7 @@ func Test_waitFor(t *testing.T) {
 		err := func() error {
 			done := make(chan struct{})
 			defer close(done)
-			ctx, cancel := ContextForChannel(done)
-			defer cancel()
+			ctx := ContextForChannel(done)
 			return waitForWithContext(ctx, ticker.WithContext(), c.F.WithContext())
 		}()
 		switch {
@@ -547,8 +546,7 @@ func Test_waitForWithEarlyClosing_waitFunc(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	ctx, cancel := ContextForChannel(stopCh)
-	defer cancel()
+	ctx := ContextForChannel(stopCh)
 	start := time.Now()
 	err := waitForWithContext(ctx, func(ctx context.Context) <-chan struct{} {
 		c := make(chan struct{})
@@ -575,8 +573,7 @@ func Test_waitForWithClosedChannel(t *testing.T) {
 	close(stopCh)
 	c := make(chan struct{})
 	defer close(c)
-	ctx, cancel := ContextForChannel(stopCh)
-	defer cancel()
+	ctx := ContextForChannel(stopCh)
 
 	start := time.Now()
 	err := waitForWithContext(ctx, func(_ context.Context) <-chan struct{} {
@@ -699,8 +696,7 @@ func TestContextForChannel(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ctx, cancel := ContextForChannel(parentCh)
-			defer cancel()
+			ctx := ContextForChannel(parentCh)
 			<-ctx.Done()
 		}()
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package options
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -228,8 +229,8 @@ func (s *EtcdOptions) Complete(
 	}
 
 	if len(s.EncryptionProviderConfigFilepath) != 0 {
-		ctxTransformers, closeTransformers := wait.ContextForChannel(stopCh)
-		ctxServer, _ := wait.ContextForChannel(stopCh) // explicitly ignore cancel here because we do not own the server's lifecycle
+		ctxServer := wait.ContextForChannel(stopCh)
+		ctxTransformers, closeTransformers := context.WithCancel(ctxServer)
 
 		encryptionConfiguration, err := encryptionconfig.LoadEncryptionConfig(ctxTransformers, s.EncryptionProviderConfigFilepath, s.EncryptionProviderConfigAutomaticReload)
 		if err != nil {

--- a/staging/src/k8s.io/cloud-provider/app/controllermanager.go
+++ b/staging/src/k8s.io/cloud-provider/app/controllermanager.go
@@ -199,7 +199,7 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface
 	}
 
 	if !c.ComponentConfig.Generic.LeaderElection.LeaderElect {
-		ctx, _ := wait.ContextForChannel(stopCh)
+		ctx := wait.ContextForChannel(stopCh)
 		run(ctx, controllerInitializers)
 		<-stopCh
 		return nil


### PR DESCRIPTION
**NOTE**: This pull is part of a series of changes that introduce new context-cancellation-aware Poll methods, reduce the surface area of the wait package to a smaller set of functions (if unused, marked private, if consolidating, marked deprecated), unify the underlying loop implementation with better testing, consolidate the backoff manager code into a smaller chunk, and in general address a number of outstanding issues.  See #115077, #115116, #115113, #115140, #115064, and #107826.

ContextForChannel uses a goroutine to transform a channel close to a context cancel. However, this exposes a synchronization issue if we want to unify the underlying implementation between contextless and with context - a ConditionFunc that closes the channel today expects the behavior that no subsequent conditions will be invoked (we have a test in wait_test.go TestUntilReturnsImmediately that verifies this expectation). We can't unify the implementation without ensuring this property holds.

To do that this commit changes from the goroutine propagation to implementing context.Context and using stopCh as the Done(). We then implement Err() by returning context.Canceled and stub the other methods. Since our context cannot be explicitly cancelled by users, we cease to return the cancelFn and callers that need that behavior must wrap the context as normal.

This should be invisible to clients - they would already observe the same behavior from the context, and the existing error behavior of Poll* is preserved (which ignores ctx.Err()).

As a side effect, one less goroutine is created making it more efficient.

/kind cleanup

```release-note
wait.ContextForChannel() now implements the context.Context interface and does not return a cancellation function.
```

```docs
```