### PR TITLE
ValidatingAdmissionPolicy: use natively-typed informer for params

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/controller.go
@@ -26,8 +26,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
 	"k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/matching"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 
 	"k8s.io/api/admissionregistration/v1alpha1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -293,6 +293,31 @@ func (c *celAdmissionController) Validate(
 					continue
 				}
 			}
+
+			// Ensure param is populated with its GVK for consistency
+			// (CRD dynamic informer always returns objects with kind/apiversion,
+			// but native types do not include populated TypeMeta.
+			if param != nil {
+				if paramGVK := param.GetObjectKind(); paramGVK.GroupVersionKind().Empty() {
+					// https://github.com/kubernetes/client-go/issues/413#issue-324586398
+					gvks, _, err := k8sscheme.Scheme.ObjectKinds(param)
+					if err != nil {
+						return fmt.Errorf("missing apiVersion or kind and cannot assign it; %w", err)
+					}
+
+					for _, gvk := range gvks {
+						if len(gvk.Kind) == 0 {
+							continue
+						}
+						if len(gvk.Version) == 0 || gvk.Version == runtime.APIVersionInternal {
+							continue
+						}
+						paramGVK.SetGroupVersionKind(gvk)
+						break
+					}
+				}
+			}
+
 			decisions, err := bindingInfo.validator.Validate(a, o, param, matchKind)
 			if err != nil {
 				// runtime error. Apply failure policy

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/controller.go
@@ -25,13 +25,13 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/matching"
 
 	"k8s.io/api/admissionregistration/v1alpha1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -65,7 +65,7 @@ type celAdmissionController struct {
 // against all of its registered bindings.
 type policyData struct {
 	definitionInfo
-	paramController generic.Controller[*unstructured.Unstructured]
+	paramController generic.Controller[runtime.Object]
 	bindings        []bindingInfo
 }
 
@@ -96,7 +96,7 @@ type bindingInfo struct {
 
 type paramInfo struct {
 	// Controller which is watching this param CRD
-	controller generic.Controller[*unstructured.Unstructured]
+	controller generic.Controller[runtime.Object]
 
 	// Function to call to stop the informer and clean up the controller
 	stop func()
@@ -116,6 +116,7 @@ func NewAdmissionController(
 		definitions: atomic.Value{},
 		policyController: newPolicyController(
 			restMapper,
+			client,
 			dynamicClient,
 			&CELValidatorCompiler{
 				Matcher: matching.NewMatcher(informerFactory.Core().V1().Namespaces().Lister(), client),
@@ -241,7 +242,7 @@ func (c *celAdmissionController) Validate(
 				continue
 			}
 
-			var param *unstructured.Unstructured
+			var param runtime.Object
 
 			// If definition has paramKind, paramRef is required in binding.
 			// If definition has no paramKind, paramRef set in binding will be ignored.

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/controller_reconcile.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/controller_reconcile.go
@@ -25,13 +25,15 @@ import (
 	"k8s.io/api/admissionregistration/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	celmetrics "k8s.io/apiserver/pkg/admission/cel"
 	"k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/internal/generic"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -74,10 +76,13 @@ type policyController struct {
 	// All keys must have at least one dependent binding
 	// All binding names MUST exist as a key bindingInfos
 	definitionsToBindings map[namespacedName]sets.Set[namespacedName]
+
+	client kubernetes.Interface
 }
 
 func newPolicyController(
 	restMapper meta.RESTMapper,
+	client kubernetes.Interface,
 	dynamicClient dynamic.Interface,
 	validatorCompiler ValidatorCompiler,
 	policiesInformer generic.Informer[*v1alpha1.ValidatingAdmissionPolicy],
@@ -108,6 +113,7 @@ func newPolicyController(
 		),
 		restMapper:    restMapper,
 		dynamicClient: dynamicClient,
+		client:        client,
 	}
 	return res
 }
@@ -237,18 +243,50 @@ func (c *policyController) reconcilePolicyDefinition(namespace, name string, def
 	} else {
 		instanceContext, instanceCancel := context.WithCancel(c.context)
 
-		// Watch for new instances of this policy
-		informer := dynamicinformer.NewFilteredDynamicInformer(
-			c.dynamicClient,
-			paramsGVR.Resource,
-			corev1.NamespaceAll,
-			30*time.Second, // TODO: do we really need to ever resync these?
-			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-			nil,
-		)
+		var informer informers.GenericInformer
+
+		// Informer Factory is optional
+		if c.client != nil {
+			// Create temporary informer factory
+			// Cannot use the k8s shared informer factory for dynamic params informer.
+			// Would leak unnecessary informers when we are done since we would have to
+			// call informerFactory.Start() with a longer-lived stopCh than necessary.
+			// SharedInformerFactory does not support temporary usage.
+			dynamicFactory := informers.NewSharedInformerFactory(c.client, 10*time.Minute)
+
+			// Look for a typed informer. If it does not exist
+			informer, err = dynamicFactory.ForResource(paramsGVR.Resource)
+
+			// Ignore error. We fallback to dynamic informer if there is no
+			// typed informer
+			if err != nil {
+				informer = nil
+			} else {
+				dynamicFactory.Start(instanceContext.Done())
+			}
+		}
+
+		if informer == nil {
+			// Dynamic JSON informer fallback.
+			// Cannot use shared dynamic informer since it would be impossible
+			// to clean CRD informers properly with multiple dependents
+			// (cannot start ahead of time, and cannot track dependencies via stopCh)
+			informer = dynamicinformer.NewFilteredDynamicInformer(
+				c.dynamicClient,
+				paramsGVR.Resource,
+				corev1.NamespaceAll,
+				// Use same interval as is used for k8s typed sharedInformerFactory
+				// https://github.com/kubernetes/kubernetes/blob/7e0923899fed622efbc8679cca6b000d43633e38/cmd/kube-apiserver/app/server.go#L430
+				10*time.Minute,
+				cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+				nil,
+			)
+
+			go informer.Informer().Run(instanceContext.Done())
+		}
 
 		controller := generic.NewController(
-			generic.NewInformer[*unstructured.Unstructured](informer.Informer()),
+			generic.NewInformer[runtime.Object](informer.Informer()),
 			c.reconcileParams,
 			generic.ControllerOptions{
 				Workers: 1,
@@ -262,7 +300,6 @@ func (c *policyController) reconcilePolicyDefinition(namespace, name string, def
 			dependentDefinitions: sets.New(nn),
 		}
 
-		go informer.Informer().Run(instanceContext.Done())
 		go controller.Run(instanceContext)
 	}
 
@@ -329,7 +366,7 @@ func (c *policyController) reconcilePolicyBinding(namespace, name string, bindin
 	return nil
 }
 
-func (c *policyController) reconcileParams(namespace, name string, params *unstructured.Unstructured) error {
+func (c *policyController) reconcileParams(namespace, name string, params runtime.Object) error {
 	// Do nothing.
 	// When we add informational type checking we will need to compile in the
 	// reconcile loops instead of lazily so we can add compiler errors / type
@@ -365,7 +402,7 @@ func (c *policyController) latestPolicyData() []policyData {
 			bindingInfos = append(bindingInfos, *bindingInfo)
 		}
 
-		var paramController generic.Controller[*unstructured.Unstructured]
+		var paramController generic.Controller[runtime.Object]
 		if paramKind := definitionInfo.lastReconciledValue.Spec.ParamKind; paramKind != nil {
 			if info, ok := c.paramsCRDControllers[*paramKind]; ok {
 				paramController = info.controller


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This changes cel validating admission controller plugin to use a typed informer if it is available, rather than unconditionally creating a dynamic informer.

Original design of CEL only allowed CRD params, but was rescoped to include any type; so this change is necessary to prevent duplicate caches and inefficient ser/des.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @cici37 @jpbetz 