### PR TITLE
Prevents automatic restart of static Pods

### DIFF
--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"unsafe"

--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -61,7 +61,7 @@ func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName types.Node
 		var errReadSource error
 
 		if isFile {
-			byte_source, errReadSource = ioutil.ReadFile(source)
+			byte_source, errReadSource = os.ReadFile(source)
 		} else {
 			var resp *http.Response
 			resp, errReadSource = http.Get(source)


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
When the Kubelet version is updated, the static POD is prevented from automatically restarting due to the POD structure update
Therefore, change the UID value method to MD5 based on the file content to avoid unexpected restart during the upgrade due to different structure