### PR TITLE
Automated cherry pick of #114814: Do not create endpoints if service of type ExternalName

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -388,6 +388,12 @@ func (e *Controller) syncService(ctx context.Context, key string) error {
 		return nil
 	}
 
+	if service.Spec.Type == v1.ServiceTypeExternalName {
+		// services with Type ExternalName receive no endpoints from this controller;
+		// Ref: https://issues.k8s.io/105986
+		return nil
+	}
+
 	if service.Spec.Selector == nil {
 		// services without a selector receive no endpoints from this controller;
 		// these services will receive the endpoints that are created out-of-band via the REST API.

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -332,6 +332,12 @@ func (c *Controller) syncService(key string) error {
 		return err
 	}
 
+	if service.Spec.Type == v1.ServiceTypeExternalName {
+		// services with Type ExternalName receive no endpoints from this controller;
+		// Ref: https://issues.k8s.io/105986
+		return nil
+	}
+
 	if service.Spec.Selector == nil {
 		// services without a selector receive no endpoint slices from this controller;
 		// these services will receive endpoint slices that are created out-of-band via the REST API.


### PR DESCRIPTION
Cherry pick of #114814 on release-1.26.

#114814: Do not create endpoints if service of type ExternalName

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Don't create endpoints for Service of type ExternalName.
```