### PR TITLE
Change most `go install` to call our build tools

### DIFF
--- a/hack/lib/protoc.sh
+++ b/hack/lib/protoc.sh
@@ -27,7 +27,8 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 # $1: Full path to the directory where the api.proto file is
 function kube::protoc::generate_proto() {
   kube::golang::setup_env
-  GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
+  KUBE_VERBOSE=-1 hack/make-rules/build.sh \
+      k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
 
   kube::protoc::check_protoc
 

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -243,9 +243,7 @@ produceJUnitXMLReport() {
 
   if ! command -v prune-junit-xml >/dev/null 2>&1; then
     kube::log::status "prune-junit-xml not found; installing from hack/tools"
-    pushd "${KUBE_ROOT}/cmd/prune-junit-xml" >/dev/null
-      GO111MODULE=on go install .
-    popd >/dev/null
+    hack/make-rules/build.sh ./cmd/prune-junit-xml
   fi
   prune-junit-xml "${junit_xml_filename}"
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -584,7 +584,7 @@ function codegen::openapi() {
 }
 
 function codegen::applyconfigs() {
-    GO111MODULE=on GOPROXY=off go install \
+    hack/make-rules/build.sh \
         k8s.io/kubernetes/pkg/generated/openapi/cmd/models-schema \
         k8s.io/code-generator/cmd/applyconfiguration-gen
 
@@ -625,7 +625,7 @@ function codegen::applyconfigs() {
 }
 
 function codegen::clients() {
-    GO111MODULE=on GOPROXY=off go install \
+    hack/make-rules/build.sh \
         k8s.io/code-generator/cmd/client-gen
 
     local clientgen
@@ -673,7 +673,8 @@ function codegen::clients() {
 }
 
 function codegen::listers() {
-    GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/lister-gen
+    hack/make-rules/build.sh \
+        k8s.io/code-generator/cmd/lister-gen
 
     local listergen
     listergen=$(kube::util::find-binary "lister-gen")
@@ -706,7 +707,7 @@ function codegen::listers() {
 }
 
 function codegen::informers() {
-    GO111MODULE=on GOPROXY=off go install \
+    hack/make-rules/build.sh \
         k8s.io/code-generator/cmd/informer-gen
 
     local informergen

--- a/hack/update-generated-protobuf-dockerized.sh
+++ b/hack/update-generated-protobuf-dockerized.sh
@@ -28,8 +28,9 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
-GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/go-to-protobuf
-GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
+KUBE_VERBOSE=0 hack/make-rules/build.sh \
+    k8s.io/code-generator/cmd/go-to-protobuf \
+    k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
 
 if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3."* ]]; then
   echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"

--- a/hack/update-generated-runtime-dockerized.sh
+++ b/hack/update-generated-runtime-dockerized.sh
@@ -29,7 +29,8 @@ runtime_versions=("v1")
 
 kube::golang::setup_env
 
-GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
+KUBE_VERBOSE=0 hack/make-rules/build.sh \
+    k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
 
 if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3."* ]]; then
   echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"

--- a/hack/verify-external-dependencies-version.sh
+++ b/hack/verify-external-dependencies-version.sh
@@ -31,9 +31,9 @@ export GOBIN="${KUBE_OUTPUT_BINPATH}"
 PATH="${GOBIN}:${PATH}"
 
 # Install zeitgeist
-cd "${KUBE_ROOT}/hack/tools"
-GO111MODULE=on go install sigs.k8s.io/zeitgeist
-cd -
+pushd "${KUBE_ROOT}/hack/tools" >/dev/null
+  GO111MODULE=on go install sigs.k8s.io/zeitgeist
+popd >/dev/null
 
 # Prefer full path for running zeitgeist
 ZEITGEIST_BIN="$(which zeitgeist)"

--- a/hack/verify-import-boss.sh
+++ b/hack/verify-import-boss.sh
@@ -28,7 +28,8 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
-GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/import-boss
+hack/make-rules/build.sh \
+    k8s.io/code-generator/cmd/import-boss
 
 packages=(
   "k8s.io/kubernetes/pkg/..."


### PR DESCRIPTION
This removes some boilerplate stuff (`GOPROXY`, `GO111MODULE`) and makes other PRs (dead code cleanup, go workspaces) simpler.

/kind cleanup
/sig architecture

```release-note
NONE
```
