### PR TITLE
Refactor diff command to split flags from options

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -117,8 +117,22 @@ type DiffOptions struct {
 	pruner           *pruner
 }
 
-func NewDiffOptions(ioStreams genericclioptions.IOStreams) *DiffOptions {
-	return &DiffOptions{
+type DiffFlags struct {
+	FilenameOptions resource.FilenameOptions
+
+	ServerSideApply   bool
+	FieldManager      string
+	ForceConflicts    bool
+	ShowManagedFields bool	
+
+	Selector         string
+	Prune 					 bool
+	PruneAllowList   string
+	Diff             *DiffProgram
+}
+
+func NewDiffFlags(ioStreams genericclioptions.IOStreams) *DiffFlags {
+	return &DiffFlags{
 		Diff: &DiffProgram{
 			Exec:      exec.New(),
 			IOStreams: ioStreams,
@@ -126,8 +140,27 @@ func NewDiffOptions(ioStreams genericclioptions.IOStreams) *DiffOptions {
 	}
 }
 
+func (f *DiffFlags) AddFlags(cmd *cobra.Command) {
+	// Flag errors exit with code 1, however according to the diff
+	// command it means changes were found.
+	// Thus, it should return status code greater than 1.
+	cmd.SetFlagErrorFunc(func(command *cobra.Command, err error) error {
+		cmdutil.CheckDiffErr(cmdutil.UsageErrorf(cmd, err.Error()))
+		return nil
+	})
+
+	usage := "contains the configuration to diff"
+	cmd.Flags().StringArray("prune-allowlist", []string{}, "Overwrite the default whitelist with <group/version/kind> for --prune")
+	cmd.Flags().Bool("prune", false, "Include resources that would be deleted by pruning. Can be used with -l and default shows all resources would be pruned")
+	cmd.Flags().BoolVar(&f.ShowManagedFields, "show-managed-fields", f.ShowManagedFields, "If true, include managed fields in the diff.")
+	cmdutil.AddFilenameOptionFlags(cmd, &f.FilenameOptions, usage)
+	cmdutil.AddServerSideApplyFlags(cmd)
+	cmdutil.AddFieldManagerFlagVar(cmd, &f.FieldManager, apply.FieldManagerClientSideApply)
+	cmdutil.AddLabelSelectorFlagVar(cmd, &f.Selector)
+}
+
 func NewCmdDiff(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
-	options := NewDiffOptions(streams)
+	flags := NewDiffFlags(streams)
 	cmd := &cobra.Command{
 		Use:                   "diff -f FILENAME",
 		DisableFlagsInUseLine: true,
@@ -135,7 +168,8 @@ func NewCmdDiff(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		Long:                  diffLong,
 		Example:               diffExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckDiffErr(options.Complete(f, cmd, args))
+			options, err := flags.ToOptions(f, cmd, args)
+			cmdutil.CheckDiffErr(err)
 			cmdutil.CheckDiffErr(options.Validate())
 			// `kubectl diff` propagates the error code from
 			// diff or `KUBECTL_EXTERNAL_DIFF`. Also, we
@@ -152,23 +186,7 @@ func NewCmdDiff(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		},
 	}
 
-	// Flag errors exit with code 1, however according to the diff
-	// command it means changes were found.
-	// Thus, it should return status code greater than 1.
-	cmd.SetFlagErrorFunc(func(command *cobra.Command, err error) error {
-		cmdutil.CheckDiffErr(cmdutil.UsageErrorf(cmd, err.Error()))
-		return nil
-	})
-
-	usage := "contains the configuration to diff"
-	cmd.Flags().StringArray("prune-allowlist", []string{}, "Overwrite the default whitelist with <group/version/kind> for --prune")
-	cmd.Flags().Bool("prune", false, "Include resources that would be deleted by pruning. Can be used with -l and default shows all resources would be pruned")
-	cmd.Flags().BoolVar(&options.ShowManagedFields, "show-managed-fields", options.ShowManagedFields, "If true, include managed fields in the diff.")
-	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)
-	cmdutil.AddServerSideApplyFlags(cmd)
-	cmdutil.AddFieldManagerFlagVar(cmd, &options.FieldManager, apply.FieldManagerClientSideApply)
-	cmdutil.AddLabelSelectorFlagVar(cmd, &options.Selector)
-
+	flags.AddFlags(cmd)
 	return cmd
 }
 
@@ -613,57 +631,79 @@ func isConflict(err error) bool {
 	return err != nil && errors.IsConflict(err)
 }
 
-func (o *DiffOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+// ToOptions converts from CLI inputs to runtime inputs
+//func (o *DiffOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+func (flags *DiffFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, args []string) (*DiffOptions, error) {
 	if len(args) != 0 {
-		return cmdutil.UsageErrorf(cmd, "Unexpected args: %v", args)
+		return nil, cmdutil.UsageErrorf(cmd, "Unexpected args: %v", args)
 	}
 
 	var err error
 
-	err = o.FilenameOptions.RequireFilenameOrKustomize()
+	err = flags.FilenameOptions.RequireFilenameOrKustomize()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	o.ServerSideApply = cmdutil.GetServerSideApplyFlag(cmd)
-	o.FieldManager = apply.GetApplyFieldManagerFlag(cmd, o.ServerSideApply)
-	o.ForceConflicts = cmdutil.GetForceConflictsFlag(cmd)
-	if o.ForceConflicts && !o.ServerSideApply {
-		return fmt.Errorf("--force-conflicts only works with --server-side")
+	flags.ServerSideApply = cmdutil.GetServerSideApplyFlag(cmd)
+	flags.FieldManager = apply.GetApplyFieldManagerFlag(cmd, flags.ServerSideApply)
+	flags.ForceConflicts = cmdutil.GetForceConflictsFlag(cmd)
+	if flags.ForceConflicts && !flags.ServerSideApply {
+		return nil, fmt.Errorf("--force-conflicts only works with --server-side")
 	}
 
-	if !o.ServerSideApply {
-		o.OpenAPISchema, err = f.OpenAPISchema()
+	var openAPISchema openapi.Resources
+	if !flags.ServerSideApply {
+		openAPISchema, err = f.OpenAPISchema()
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	o.DynamicClient, err = f.DynamicClient()
+	dynamicClient, err := f.DynamicClient()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	o.CmdNamespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
+	cmdNamespace, enforceNamespace, err := f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
+	var p *pruner
 	if cmdutil.GetFlagBool(cmd, "prune") {
 		mapper, err := f.ToRESTMapper()
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		resources, err := prune.ParseResources(mapper, cmdutil.GetFlagStringArray(cmd, "prune-allowlist"))
 		if err != nil {
-			return err
+			return nil, err
 		}
-		o.pruner = newPruner(o.DynamicClient, mapper, resources, o.Selector)
+		p = newPruner(dynamicClient, mapper, resources, flags.Selector)
 	}
 
-	o.Builder = f.NewBuilder()
-	return nil
+	builder := f.NewBuilder()
+
+	return &DiffOptions{
+		FilenameOptions: flags.FilenameOptions,
+
+		ServerSideApply: flags.ServerSideApply,
+		FieldManager: flags.FieldManager,
+		ForceConflicts: flags.ForceConflicts,
+		ShowManagedFields: flags.ShowManagedFields,
+
+		Selector: flags.Selector,
+		OpenAPISchema: openAPISchema,
+		DynamicClient: dynamicClient,
+		CmdNamespace: cmdNamespace,
+		EnforceNamespace: enforceNamespace,
+		Builder: builder,
+		Diff: flags.Diff,
+		pruner: p,
+		
+	}, nil
 }
 
 // Run uses the factory to parse file arguments, find the version to

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -117,6 +117,9 @@ type DiffOptions struct {
 	pruner           *pruner
 }
 
+// DiffFlags directly reflect the information that CLI is gathering via flags.  They will be converted to Options, which
+// reflect the runtime requirements for the command.  This structure reduces the transformation to wiring and makes
+// the logic itself easy to unit test
 type DiffFlags struct {
 	FilenameOptions resource.FilenameOptions
 
@@ -131,6 +134,7 @@ type DiffFlags struct {
 	Diff             *DiffProgram
 }
 
+// NewDiffFlags returns a default DiffFlags
 func NewDiffFlags(ioStreams genericclioptions.IOStreams) *DiffFlags {
 	return &DiffFlags{
 		Diff: &DiffProgram{
@@ -140,6 +144,7 @@ func NewDiffFlags(ioStreams genericclioptions.IOStreams) *DiffFlags {
 	}
 }
 
+// AddFlags registers flags for a cli
 func (f *DiffFlags) AddFlags(cmd *cobra.Command) {
 	// Flag errors exit with code 1, however according to the diff
 	// command it means changes were found.
@@ -159,6 +164,7 @@ func (f *DiffFlags) AddFlags(cmd *cobra.Command) {
 	cmdutil.AddLabelSelectorFlagVar(cmd, &f.Selector)
 }
 
+// NewCmdDiff creates the `diff` command
 func NewCmdDiff(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	flags := NewDiffFlags(streams)
 	cmd := &cobra.Command{
@@ -632,7 +638,6 @@ func isConflict(err error) bool {
 }
 
 // ToOptions converts from CLI inputs to runtime inputs
-//func (o *DiffOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 func (flags *DiffFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, args []string) (*DiffOptions, error) {
 	if len(args) != 0 {
 		return nil, cmdutil.UsageErrorf(cmd, "Unexpected args: %v", args)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -126,12 +126,10 @@ type DiffFlags struct {
 	ServerSideApply   bool
 	FieldManager      string
 	ForceConflicts    bool
-	ShowManagedFields bool	
+	ShowManagedFields bool
 
-	Selector         string
-	Prune 					 bool
-	PruneAllowList   string
-	Diff             *DiffProgram
+	Selector string
+	Diff     *DiffProgram
 }
 
 // NewDiffFlags returns a default DiffFlags
@@ -694,20 +692,19 @@ func (flags *DiffFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, args []
 	return &DiffOptions{
 		FilenameOptions: flags.FilenameOptions,
 
-		ServerSideApply: flags.ServerSideApply,
-		FieldManager: flags.FieldManager,
-		ForceConflicts: flags.ForceConflicts,
+		ServerSideApply:   flags.ServerSideApply,
+		FieldManager:      flags.FieldManager,
+		ForceConflicts:    flags.ForceConflicts,
 		ShowManagedFields: flags.ShowManagedFields,
 
-		Selector: flags.Selector,
-		OpenAPISchema: openAPISchema,
-		DynamicClient: dynamicClient,
-		CmdNamespace: cmdNamespace,
+		Selector:         flags.Selector,
+		OpenAPISchema:    openAPISchema,
+		DynamicClient:    dynamicClient,
+		CmdNamespace:     cmdNamespace,
 		EnforceNamespace: enforceNamespace,
-		Builder: builder,
-		Diff: flags.Diff,
-		pruner: p,
-		
+		Builder:          builder,
+		Diff:             flags.Diff,
+		pruner:           p,
 	}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: brunopecampos <brunopecampos@protonmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Refactor Diff command to split flags from options

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref https://github.com/kubernetes/kubectl/issues/1046

#### Special notes for your reviewer:
Added DiffFlag struct and NewDiffFlags() function. Adapted NewCmdDiff() and replace Complete method to ToOptions for it to work correctly.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

