### PR TITLE
k8s.io/component-base/logs: match full help text in unit test

### DIFF
--- a/staging/src/k8s.io/component-base/logs/api/v1/options_test.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/options_test.go
@@ -114,11 +114,11 @@ func TestFlagSet(t *testing.T) {
 		//     --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
 		// -v, --v Level                        number for the log level verbosity
 		//     --vmodule pattern=N,...          comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
-		assert.Regexp(t, `.*--logging-format.*default.*text.*
+		assert.Regexp(t, `^.*--logging-format.*default.*text.*
 .*--log-flush-frequency.*default 5s.*
 .*-v.*--v.*
 .*--vmodule.*pattern=N.*
-`, buffer.String())
+$`, buffer.String())
 	})
 
 	t.Run("flag", func(t *testing.T) {
@@ -141,7 +141,7 @@ func TestFlagSet(t *testing.T) {
 		//   	number for the log level verbosity
 		// -vmodule value
 		//   	comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
-		assert.Regexp(t, `.*-log-flush-frequency.*
+		assert.Regexp(t, `^.*-log-flush-frequency.*
 .*default 5s.*
 .*-logging-format.*
 .*default.*text.*
@@ -149,7 +149,7 @@ func TestFlagSet(t *testing.T) {
 .*
 .*-vmodule.*
 .*
-`, buffer.String())
+$`, buffer.String())
 	})
 
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The test was meant to fail when there are unexpected additional lines like the "panic calling String method" messages. But `assert.Regexp` does a search for the regexp, not a full string match, and thus succeeded even if those lines are present. A full match needs to be requested explicitly with ^ and $.

#### Special notes for your reviewer:

A follow-up to https://github.com/kubernetes/kubernetes/pull/114680

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @liggitt 