### PR TITLE
e2e/network_policy: using Poll Immediate for intra pod connectivity probes

### DIFF
--- a/test/e2e/network/netpol/probe.go
+++ b/test/e2e/network/netpol/probe.go
@@ -25,6 +25,19 @@ import (
 	netutils "k8s.io/utils/net"
 )
 
+// probeConnectivityArgs is set of arguments for a probeConnectivity
+type probeConnectivityArgs struct {
+	nsFrom              string
+	podFrom             string
+	containerFrom       string
+	addrTo              string
+	protocol            v1.Protocol
+	toPort              int
+	timeoutSeconds      int
+	pollIntervalSeconds int
+	pollTimeoutSeconds  int
+}
+
 // decouple us from k8smanager.go
 type Prober interface {
 	probeConnectivity(args *probeConnectivityArgs) (bool, string, error)
@@ -32,12 +45,13 @@ type Prober interface {
 
 // ProbeJob packages the data for the input of a pod->pod connectivity probe
 type ProbeJob struct {
-	PodFrom        TestPod
-	PodTo          TestPod
-	PodToServiceIP string
-	ToPort         int
-	ToPodDNSDomain string
-	Protocol       v1.Protocol
+	PodFrom           TestPod
+	PodTo             TestPod
+	PodToServiceIP    string
+	ToPort            int
+	ToPodDNSDomain    string
+	Protocol          v1.Protocol
+	UseMaxPollTimeout bool
 }
 
 // ProbeJobResults packages the data for the results of a pod->pod connectivity probe
@@ -54,16 +68,22 @@ func ProbePodToPodConnectivity(prober Prober, allPods []TestPod, dnsDomain strin
 	jobs := make(chan *ProbeJob, size)
 	results := make(chan *ProbeJobResults, size)
 	for i := 0; i < getWorkers(); i++ {
-		go probeWorker(prober, jobs, results, getProbeTimeoutSeconds())
+		go probeWorker(prober, jobs, results)
 	}
 	for _, podFrom := range allPods {
 		for _, podTo := range allPods {
+			useMaxPollTimeout := false
+			// we only want to use max poll timeout for the probes where we expect connectivity from "podFrom" to "podTo".
+			if testCase.Reachability.Expected.Get(podFrom.PodString().String(), podTo.PodString().String()) {
+				useMaxPollTimeout = true
+			}
 			jobs <- &ProbeJob{
-				PodFrom:        podFrom,
-				PodTo:          podTo,
-				ToPort:         testCase.ToPort,
-				ToPodDNSDomain: dnsDomain,
-				Protocol:       testCase.Protocol,
+				PodFrom:           podFrom,
+				PodTo:             podTo,
+				ToPort:            testCase.ToPort,
+				ToPodDNSDomain:    dnsDomain,
+				Protocol:          testCase.Protocol,
+				UseMaxPollTimeout: useMaxPollTimeout,
 			}
 		}
 	}
@@ -91,7 +111,7 @@ func ProbePodToPodConnectivity(prober Prober, allPods []TestPod, dnsDomain strin
 
 // probeWorker continues polling a pod connectivity status, until the incoming "jobs" channel is closed, and writes results back out to the "results" channel.
 // it only writes pass/fail status to a channel and has no failure side effects, this is by design since we do not want to fail inside a goroutine.
-func probeWorker(prober Prober, jobs <-chan *ProbeJob, results chan<- *ProbeJobResults, timeoutSeconds int) {
+func probeWorker(prober Prober, jobs <-chan *ProbeJob, results chan<- *ProbeJobResults) {
 	defer ginkgo.GinkgoRecover()
 	for job := range jobs {
 		podFrom := job.PodFrom
@@ -110,13 +130,15 @@ func probeWorker(prober Prober, jobs <-chan *ProbeJob, results chan<- *ProbeJobR
 
 		// TODO make this work on dual-stack clusters...
 		connected, command, err := prober.probeConnectivity(&probeConnectivityArgs{
-			nsFrom:         podFrom.Namespace,
-			podFrom:        podFrom.Name,
-			containerFrom:  podFrom.ContainerName,
-			addrTo:         job.PodTo.ServiceIP,
-			protocol:       job.Protocol,
-			toPort:         job.ToPort,
-			timeoutSeconds: timeoutSeconds,
+			nsFrom:              podFrom.Namespace,
+			podFrom:             podFrom.Name,
+			containerFrom:       podFrom.ContainerName,
+			addrTo:              job.PodTo.ServiceIP,
+			protocol:            job.Protocol,
+			toPort:              job.ToPort,
+			timeoutSeconds:      getProbeTimeoutSeconds(),
+			pollIntervalSeconds: getPollIntervalSeconds(),
+			pollTimeoutSeconds:  getPollTimeoutSeconds(job.UseMaxPollTimeout),
 		})
 		result := &ProbeJobResults{
 			Job:         job,

--- a/test/e2e/network/netpol/test_helper.go
+++ b/test/e2e/network/netpol/test_helper.go
@@ -111,10 +111,13 @@ func waitForHTTPServers(k *kubeManager, model *Model) error {
 func ValidateOrFail(k8s *kubeManager, testCase *TestCase) {
 	ginkgo.By("Validating reachability matrix...")
 
-	// 1st try
+	// 1st try, exponential backoff (starting at 1s) will happen for every probe to accommodate infra that might be
+	// network-congested, as is common in some GH actions or other heavily oversubscribed CI systems.
 	ginkgo.By("Validating reachability matrix... (FIRST TRY)")
 	ProbePodToPodConnectivity(k8s, k8s.AllPods(), k8s.DNSDomain(), testCase)
-	// 2nd try, in case first one failed
+
+	// the aforementioned individual probe's exponential retries (introduced in january 2023) might be able to obviate
+	//  this step, let's investigate removing this massive secondary polling of the matrix some day.
 	if _, wrong, _, _ := testCase.Reachability.Summary(ignoreLoopback); wrong != 0 {
 		framework.Logf("failed first probe %d wrong results ... retrying (SECOND TRY)", wrong)
 		ProbePodToPodConnectivity(k8s, k8s.AllPods(), k8s.DNSDomain(), testCase)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds retries to truth table validation probes, by adding retires we essentially de-flake the network policy tests.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
