### PR TITLE
Cleanup deprecated metrics

### DIFF
--- a/pkg/controller/nodelifecycle/metrics.go
+++ b/pkg/controller/nodelifecycle/metrics.go
@@ -28,7 +28,6 @@ const (
 	zoneHealthStatisticKey  = "zone_health"
 	zoneSizeKey             = "zone_size"
 	zoneNoUnhealthyNodesKey = "unhealthy_nodes_in_zone"
-	evictionsNumberKey      = "evictions_number"
 	evictionsTotalKey       = "evictions_total"
 
 	updateNodeHealthKey     = "update_node_health_duration_seconds"
@@ -60,16 +59,6 @@ var (
 			Name:           zoneNoUnhealthyNodesKey,
 			Help:           "Gauge measuring number of not Ready Nodes per zones.",
 			StabilityLevel: metrics.ALPHA,
-		},
-		[]string{"zone"},
-	)
-	evictionsNumber = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Subsystem:         nodeControllerSubsystem,
-			Name:              evictionsNumberKey,
-			Help:              "Number of Node evictions that happened since current instance of NodeController started, This metric is replaced by node_collector_evictions_total.",
-			DeprecatedVersion: "1.24.0",
-			StabilityLevel:    metrics.ALPHA,
 		},
 		[]string{"zone"},
 	)
@@ -111,7 +100,6 @@ func Register() {
 		legacyregistry.MustRegister(zoneHealth)
 		legacyregistry.MustRegister(zoneSize)
 		legacyregistry.MustRegister(unhealthyNodes)
-		legacyregistry.MustRegister(evictionsNumber)
 		legacyregistry.MustRegister(evictionsTotal)
 		legacyregistry.MustRegister(updateNodeHealthDuration)
 		legacyregistry.MustRegister(updateAllNodesHealthDuration)

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -643,9 +643,8 @@ func (nc *Controller) doNoExecuteTaintingPass(ctx context.Context) {
 			}
 			result := controllerutil.SwapNodeControllerTaint(ctx, nc.kubeClient, []*v1.Taint{&taintToAdd}, []*v1.Taint{&oppositeTaint}, node)
 			if result {
-				//count the evictionsNumber
+				// Count the number of evictions.
 				zone := nodetopology.GetZoneKey(node)
-				evictionsNumber.WithLabelValues(zone).Inc()
 				evictionsTotal.WithLabelValues(zone).Inc()
 			}
 
@@ -1222,7 +1221,6 @@ func (nc *Controller) addPodEvictorForNewZone(logger klog.Logger, node *v1.Node)
 				flowcontrol.NewTokenBucketRateLimiter(nc.evictionLimiterQPS, scheduler.EvictionRateLimiterBurst))
 		// Init the metric for the new zone.
 		logger.Info("Initializing eviction metric for zone", "zone", zone)
-		evictionsNumber.WithLabelValues(zone).Add(0)
 		evictionsTotal.WithLabelValues(zone).Add(0)
 	}
 }

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -66,15 +66,6 @@ var (
 			StabilityLevel: metrics.STABLE,
 		}, []string{"result", "profile"})
 
-	e2eSchedulingLatency = metrics.NewHistogramVec(
-		&metrics.HistogramOpts{
-			Subsystem:         SchedulerSubsystem,
-			Name:              "e2e_scheduling_duration_seconds",
-			DeprecatedVersion: "1.23.0",
-			Help:              "E2e scheduling latency in seconds (scheduling algorithm + binding). This metric is replaced by scheduling_attempt_duration_seconds.",
-			Buckets:           metrics.ExponentialBuckets(0.001, 2, 15),
-			StabilityLevel:    metrics.ALPHA,
-		}, []string{"result", "profile"})
 	schedulingLatency = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem:      SchedulerSubsystem,
@@ -219,7 +210,6 @@ var (
 
 	metricsList = []metrics.Registerable{
 		scheduleAttempts,
-		e2eSchedulingLatency,
 		schedulingLatency,
 		SchedulingAlgorithmLatency,
 		PreemptionVictims,

--- a/pkg/scheduler/metrics/profile_metrics.go
+++ b/pkg/scheduler/metrics/profile_metrics.go
@@ -43,7 +43,6 @@ func PodScheduleError(profile string, duration float64) {
 }
 
 func observeScheduleAttemptAndLatency(result, profile string, duration float64) {
-	e2eSchedulingLatency.WithLabelValues(result, profile).Observe(duration)
 	schedulingLatency.WithLabelValues(result, profile).Observe(duration)
 	scheduleAttempts.WithLabelValues(result, profile).Inc()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Remove the following deprecated metrics:
- node_collector_evictions_number
- scheduler_e2e_scheduling_duration_seconds

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Remove the following deprecated metrics:
- node_collector_evictions_number replaced by node_collector_evictions_total
- scheduler_e2e_scheduling_duration_seconds replaced by scheduler_scheduling_attempt_duration_seconds
```

/cc @logicalhan 