### PR TITLE
remove ExecProbeTimeout feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -277,14 +277,6 @@ const (
 	// which avoids frequent relisting of containers which helps optimize performance.
 	EventedPLEG featuregate.Feature = "EventedPLEG"
 
-	// owner: @andrewsykim @SergeyKanzhelev
-	// GA: v1.20
-	//
-	// Ensure kubelet respects exec probe timeouts. Feature gate exists in-case existing workloads
-	// may depend on old behavior where exec probe timeouts were ignored.
-	// Lock to default and remove after v1.22 based on user feedback that should be reflected in KEP #1972 update
-	ExecProbeTimeout featuregate.Feature = "ExecProbeTimeout"
-
 	// owner: @gjkim42
 	// kep: https://kep.k8s.io/2595
 	// alpha: v1.22
@@ -905,8 +897,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	DynamicResourceAllocation: {Default: false, PreRelease: featuregate.Alpha},
 
 	EventedPLEG: {Default: false, PreRelease: featuregate.Alpha},
-
-	ExecProbeTimeout: {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
 
 	ExpandedDNSConfig: {Default: true, PreRelease: featuregate.Beta},
 

--- a/pkg/probe/exec/exec.go
+++ b/pkg/probe/exec/exec.go
@@ -19,8 +19,6 @@ package exec
 import (
 	"bytes"
 
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/util/ioutils"
 	"k8s.io/kubernetes/pkg/probe"
 
@@ -71,12 +69,8 @@ func (pr execProber) Probe(e exec.Cmd) (probe.Result, string, error) {
 
 		timeoutErr, ok := err.(*TimeoutError)
 		if ok {
-			if utilfeature.DefaultFeatureGate.Enabled(features.ExecProbeTimeout) {
-				// When exec probe timeout, data is empty, so we should return timeoutErr.Error() as the stdout.
-				return probe.Failure, timeoutErr.Error(), nil
-			}
-
-			klog.Warningf("Exec probe timed out after %s but ExecProbeTimeout feature gate was disabled", timeoutErr.Timeout())
+			// When exec probe timeout, data is empty, so we should return timeoutErr.Error() as the stdout.
+			return probe.Failure, timeoutErr.Error(), nil
 		}
 
 		return probe.Unknown, "", err


### PR DESCRIPTION
Nothing reflected in the KEP https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1972-kubelet-exec-probe-timeouts

The comment says remove after 1.22, so 1.27 should be safe :)

/kind cleanup
```release-note
NONE
```
