### PR TITLE
Automated cherry pick of #114680: k8s.io/component-base/logs: fix usage through Go flag

### DIFF
--- a/staging/src/k8s.io/component-base/logs/api/v1/options_test.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/options_test.go
@@ -109,10 +109,15 @@ func TestFlagSet(t *testing.T) {
 		var buffer bytes.Buffer
 		fs.SetOutput(&buffer)
 		fs.PrintDefaults()
-		assert.Equal(t, `      --logging-format string          Sets the log format. Permitted formats: "text". (default "text")
-      --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
-  -v, --v Level                        number for the log level verbosity
-      --vmodule pattern=N,...          comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
+		// Expected (Go 1.19, pflag v1.0.5):
+		//     --logging-format string          Sets the log format. Permitted formats: "text". (default "text")
+		//     --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
+		// -v, --v Level                        number for the log level verbosity
+		//     --vmodule pattern=N,...          comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
+		assert.Regexp(t, `.*--logging-format.*default.*text.*
+.*--log-flush-frequency.*default 5s.*
+.*-v.*--v.*
+.*--vmodule.*pattern=N.*
 `, buffer.String())
 	})
 
@@ -127,14 +132,23 @@ func TestFlagSet(t *testing.T) {
 		var buffer bytes.Buffer
 		fs.SetOutput(&buffer)
 		fs.PrintDefaults()
-		assert.Equal(t, `  -log-flush-frequency value
-    	Maximum number of seconds between log flushes (default 5s)
-  -logging-format value
-    	Sets the log format. Permitted formats: "text". (default text)
-  -v value
-    	number for the log level verbosity
-  -vmodule value
-    	comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
+		// Expected (Go 1.19):
+		// -log-flush-frequency value
+		//   	Maximum number of seconds between log flushes (default 5s)
+		// -logging-format value
+		//   	Sets the log format. Permitted formats: "text". (default text)
+		// -v value
+		//   	number for the log level verbosity
+		// -vmodule value
+		//   	comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
+		assert.Regexp(t, `.*-log-flush-frequency.*
+.*default 5s.*
+.*-logging-format.*
+.*default.*text.*
+.*-v.*
+.*
+.*-vmodule.*
+.*
 `, buffer.String())
 	})
 

--- a/staging/src/k8s.io/component-base/logs/api/v1/options_test.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/options_test.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"bytes"
 	"context"
+	"flag"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -98,6 +99,45 @@ func TestOptions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFlagSet(t *testing.T) {
+	t.Run("pflag", func(t *testing.T) {
+		newOptions := NewLoggingConfiguration()
+		var fs pflag.FlagSet
+		AddFlags(newOptions, &fs)
+		var buffer bytes.Buffer
+		fs.SetOutput(&buffer)
+		fs.PrintDefaults()
+		assert.Equal(t, `      --logging-format string          Sets the log format. Permitted formats: "text". (default "text")
+      --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
+  -v, --v Level                        number for the log level verbosity
+      --vmodule pattern=N,...          comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
+`, buffer.String())
+	})
+
+	t.Run("flag", func(t *testing.T) {
+		newOptions := NewLoggingConfiguration()
+		var pfs pflag.FlagSet
+		AddFlags(newOptions, &pfs)
+		var fs flag.FlagSet
+		pfs.VisitAll(func(f *pflag.Flag) {
+			fs.Var(f.Value, f.Name, f.Usage)
+		})
+		var buffer bytes.Buffer
+		fs.SetOutput(&buffer)
+		fs.PrintDefaults()
+		assert.Equal(t, `  -log-flush-frequency value
+    	Maximum number of seconds between log flushes (default 5s)
+  -logging-format value
+    	Sets the log format. Permitted formats: "text". (default text)
+  -v value
+    	number for the log level verbosity
+  -vmodule value
+    	comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
+`, buffer.String())
+	})
+
 }
 
 func TestContextualLogging(t *testing.T) {

--- a/staging/src/k8s.io/component-base/logs/api/v1/options_test.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/options_test.go
@@ -114,11 +114,11 @@ func TestFlagSet(t *testing.T) {
 		//     --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
 		// -v, --v Level                        number for the log level verbosity
 		//     --vmodule pattern=N,...          comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
-		assert.Regexp(t, `.*--logging-format.*default.*text.*
+		assert.Regexp(t, `^.*--logging-format.*default.*text.*
 .*--log-flush-frequency.*default 5s.*
 .*-v.*--v.*
 .*--vmodule.*pattern=N.*
-`, buffer.String())
+$`, buffer.String())
 	})
 
 	t.Run("flag", func(t *testing.T) {
@@ -141,7 +141,7 @@ func TestFlagSet(t *testing.T) {
 		//   	number for the log level verbosity
 		// -vmodule value
 		//   	comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
-		assert.Regexp(t, `.*-log-flush-frequency.*
+		assert.Regexp(t, `^.*-log-flush-frequency.*
 .*default 5s.*
 .*-logging-format.*
 .*default.*text.*
@@ -149,7 +149,7 @@ func TestFlagSet(t *testing.T) {
 .*
 .*-vmodule.*
 .*
-`, buffer.String())
+$`, buffer.String())
 	})
 
 }

--- a/staging/src/k8s.io/component-base/logs/api/v1/pflags.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/pflags.go
@@ -36,6 +36,9 @@ type vmoduleConfigurationPFlag struct {
 
 // String returns the -vmodule parameter (comma-separated list of pattern=N).
 func (wrapper vmoduleConfigurationPFlag) String() string {
+	if wrapper.value == nil {
+		return ""
+	}
 	var patterns []string
 	for _, item := range *wrapper.value {
 		patterns = append(patterns, fmt.Sprintf("%s=%d", item.FilePattern, item.Verbosity))
@@ -82,10 +85,16 @@ type verbosityLevelPflag struct {
 }
 
 func (wrapper verbosityLevelPflag) String() string {
+	if wrapper.value == nil {
+		return "0"
+	}
 	return strconv.FormatInt(int64(*wrapper.value), 10)
 }
 
 func (wrapper verbosityLevelPflag) Get() interface{} {
+	if wrapper.value == nil {
+		return VerbosityLevel(0)
+	}
 	return *wrapper.value
 }
 


### PR DESCRIPTION
Cherry pick of #114680 on release-1.26.

#114680: k8s.io/component-base/logs: fix usage through Go flag

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```