### PR TITLE
solve race on NewHTTPProxyHandler

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/testing/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/testing/http.go
@@ -131,13 +131,13 @@ func (h *HTTPProxyHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 	wg.Add(2)
 
 	go func() {
-		defer h.t.Logf("Server read close, host=%s", req.Host)
 		defer wg.Done()
+		defer h.t.Logf("Server read close, host=%s", req.Host)
 		io.Copy(conn, sconn)
 	}()
 	go func() {
-		defer h.t.Logf("Server write close, host=%s", req.Host)
 		defer wg.Done()
+		defer h.t.Logf("Server write close, host=%s", req.Host)
 		io.Copy(sconn, conn)
 	}()
 


### PR DESCRIPTION
/kind flake

```release-note
NONE
```
Fixes: https://github.com/kubernetes/kubernetes/issues/115232
Fixes the flake, since it seems it is calling t.Logf after the test ends 
https://github.com/kubernetes/kubernetes/pull/113637#issuecomment-1398262133

```sh

$ go test -timeout 30s -run ^TestRoundTripAndNewConnection$ k8s.io/apimachinery/pkg/util/httpstream/spdy -race -c
$ stress ./spdy.test -test.run TestRoundTripAndNewConnection
5s: 353 runs so far, 0 failures
10s: 712 runs so far, 0 failures
15s: 1074 runs so far, 0 failures
20s: 1425 runs so far, 0 failures
25s: 1772 runs so far, 0 failures
30s: 2108 runs so far, 0 failures
35s: 2426 runs so far, 0 failures
40s: 2736 runs so far, 0 failures
45s: 3034 runs so far, 0 failures
50s: 3321 runs so far, 0 failures
55s: 3595 runs so far, 0 failures
1m0s: 3869 runs so far, 0 failures
1m5s: 4208 runs so far, 0 failures
1m10s: 4592 runs so far, 0 failures
1m15s: 4961 runs so far, 0 failures
1m20s: 5319 runs so far, 0 failures
1m25s: 5667 runs so far, 0 failures
```