### PR TITLE
kube-proxy: support the logging feature gates

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -57,6 +57,7 @@ import (
 	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/component-base/configz"
 	"k8s.io/component-base/logs"
+	logsapi "k8s.io/component-base/logs/api/v1"
 	metricsfeatures "k8s.io/component-base/metrics/features"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/metrics/prometheus/slis"
@@ -89,6 +90,7 @@ import (
 
 func init() {
 	utilruntime.Must(metricsfeatures.AddFeatureGates(utilfeature.DefaultMutableFeatureGate))
+	logsapi.AddFeatureGates(utilfeature.DefaultMutableFeatureGate)
 }
 
 // proxyRun defines the interface to run a specified ProxyServer


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When trying to bring up a cluster via kubeadm with these feature gates enabled, kube-proxy fails because it didn't know about `ContextualLogging`:

    kind: Cluster
    apiVersion: kind.x-k8s.io/v1alpha4
    nodes:
    - role: control-plane
    - role: worker
    - role: worker
    featureGates: {"DynamicResourceAllocation":true,"ContextualLogging":true}
    runtimeConfig: {"resource.k8s.io/v1alpha1":"true"}

    =>

    2023-01-20T07:07:54.474966617Z stderr F E0120 07:07:54.474846       1 run.go:74] "command failed" err="failed complete: unrecognized feature gate: ContextualLogging"

The effect of the logging feature gates is minor for kube-proxy, supporting them is mostly useful for the sake of consistency and to support kubeadm.


#### Which issue(s) this PR fixes:
Fixes https://testgrid.k8s.io/sig-instrumentation-tests#kind-json-logging-master

#### Does this PR introduce a user-facing change?
```release-note
kube-proxy accepts the ContextualLogging, LoggingAlphaOptions, LoggingBetaOptions feature gates.
```
