### PR TITLE
Support for elastic Indexed Jobs

### DIFF
--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -25,17 +25,16 @@ import (
 	"github.com/robfig/cron/v3"
 
 	v1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unversionedvalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/utils/pointer"
 )
 
@@ -377,7 +376,7 @@ func ValidateJobUpdateStatus(job, oldJob *batch.Job) field.ErrorList {
 func ValidateJobSpecUpdate(spec, oldSpec batch.JobSpec, fldPath *field.Path, opts JobValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, ValidateJobSpec(&spec, fldPath, opts.PodValidationOptions)...)
-	allErrs = append(allErrs, validateCompletions(spec, oldSpec, fldPath.Child("completions"))...)
+	allErrs = append(allErrs, validateCompletions(spec, oldSpec, fldPath.Child("completions"), opts)...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.Selector, oldSpec.Selector, fldPath.Child("selector"))...)
 	allErrs = append(allErrs, validatePodTemplateUpdate(spec, oldSpec, fldPath, opts)...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.CompletionMode, oldSpec.CompletionMode, fldPath.Child("completionMode"))...)
@@ -567,31 +566,31 @@ func ValidateJobTemplateSpec(spec *batch.JobTemplateSpec, fldPath *field.Path, o
 	return allErrs
 }
 
-func validateCompletions(spec, oldSpec batch.JobSpec, fldPath *field.Path) field.ErrorList {
-	if !feature.DefaultFeatureGate.Enabled(features.ElasticIndexedJob) {
+func validateCompletions(spec, oldSpec batch.JobSpec, fldPath *field.Path, opts JobValidationOptions) field.ErrorList {
+	if !opts.AllowElasticIndexedJobs {
 		return apivalidation.ValidateImmutableField(spec.Completions, oldSpec.Completions, fldPath)
 	}
+
 	// Completions is immutable for non-indexed jobs.
 	// For Indexed Jobs, if ElasticIndexedJob feature gate is not enabled,
 	// fall back to validating that spec.Completions is always immutable.
-	var allErrs field.ErrorList
 	isIndexedJob := spec.CompletionMode != nil && *spec.CompletionMode == batch.IndexedCompletion
 	if !isIndexedJob {
 		return apivalidation.ValidateImmutableField(spec.Completions, oldSpec.Completions, fldPath)
 	}
 
+	var allErrs field.ErrorList
+	if apiequality.Semantic.DeepEqual(spec.Completions, oldSpec.Completions) {
+		return allErrs
+	}
 	// Indexed Jobs cannot set completions to nil. The nil check
 	// is already performed in validateJobSpec, no need to add another error.
-	if spec.Completions == nil || oldSpec.Completions == nil {
+	if spec.Completions == nil {
 		return allErrs
 	}
 
-	// For Indexed Jobs, spec.Completions can only be mutated in tandem
-	// with spec.Parallelism such that spec.Completions == spec.Parallelism
-	if *spec.Completions != *oldSpec.Completions {
-		if *spec.Completions != *spec.Parallelism || *oldSpec.Completions != *oldSpec.Parallelism {
-			allErrs = append(allErrs, field.Invalid(fldPath, spec.Completions, fmt.Sprintf("can only be modified in tandem with %s", fldPath.Root().Child("parallelism").String())))
-		}
+	if *spec.Completions != *spec.Parallelism {
+		allErrs = append(allErrs, field.Invalid(fldPath, spec.Completions, fmt.Sprintf("can only be modified in tandem with %s", fldPath.Root().Child("parallelism").String())))
 	}
 	return allErrs
 }
@@ -602,4 +601,6 @@ type JobValidationOptions struct {
 	AllowTrackingAnnotation bool
 	// Allow mutable node affinity, selector and tolerations of the template
 	AllowMutableSchedulingDirectives bool
+	// Allow elastic indexed jobs
+	AllowElasticIndexedJobs bool
 }

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -1298,6 +1298,9 @@ func TestValidateJobUpdate(t *testing.T) {
 				job.Spec.Completions = pointer.Int32Ptr(2)
 				job.Spec.Parallelism = pointer.Int32Ptr(2)
 			},
+			opts: JobValidationOptions{
+				AllowElasticIndexedJobs: true,
+			},
 		},
 		"previous parallelism != previous completions, new parallelism == new completions": {
 			old: batch.Job{
@@ -1314,9 +1317,8 @@ func TestValidateJobUpdate(t *testing.T) {
 				job.Spec.Completions = pointer.Int32Ptr(3)
 				job.Spec.Parallelism = pointer.Int32Ptr(3)
 			},
-			err: &field.Error{
-				Type:  field.ErrorTypeInvalid,
-				Field: "spec.completions",
+			opts: JobValidationOptions{
+				AllowElasticIndexedJobs: true,
 			},
 		},
 		"indexed job updating completions and parallelism to different values is invalid": {
@@ -1333,6 +1335,9 @@ func TestValidateJobUpdate(t *testing.T) {
 			update: func(job *batch.Job) {
 				job.Spec.Completions = pointer.Int32Ptr(2)
 				job.Spec.Parallelism = pointer.Int32Ptr(3)
+			},
+			opts: JobValidationOptions{
+				AllowElasticIndexedJobs: true,
 			},
 			err: &field.Error{
 				Type:  field.ErrorTypeInvalid,
@@ -1354,6 +1359,9 @@ func TestValidateJobUpdate(t *testing.T) {
 				job.Spec.Completions = nil
 				job.Spec.Parallelism = pointer.Int32Ptr(3)
 			},
+			opts: JobValidationOptions{
+				AllowElasticIndexedJobs: true,
+			},
 			err: &field.Error{
 				Type:  field.ErrorTypeRequired,
 				Field: "spec.completions",
@@ -1374,6 +1382,9 @@ func TestValidateJobUpdate(t *testing.T) {
 				job.Spec.Completions = pointer.Int32Ptr(2)
 				job.Spec.Parallelism = pointer.Int32Ptr(1)
 			},
+			opts: JobValidationOptions{
+				AllowElasticIndexedJobs: true,
+			},
 		},
 		"indexed job with completions unchanged, parallelism increased higher than completions": {
 			old: batch.Job{
@@ -1389,6 +1400,9 @@ func TestValidateJobUpdate(t *testing.T) {
 			update: func(job *batch.Job) {
 				job.Spec.Completions = pointer.Int32Ptr(2)
 				job.Spec.Parallelism = pointer.Int32Ptr(3)
+			},
+			opts: JobValidationOptions{
+				AllowElasticIndexedJobs: true,
 			},
 		},
 	}

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -919,7 +919,7 @@ func TestValidateJobUpdate(t *testing.T) {
 				job.Spec.ManualSelector = pointer.BoolPtr(true)
 			},
 		},
-		"immutable completion": {
+		"immutable completions for non-indexed jobs": {
 			old: batch.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 				Spec: batch.JobSpec{
@@ -1281,6 +1281,114 @@ func TestValidateJobUpdate(t *testing.T) {
 			},
 			opts: JobValidationOptions{
 				AllowMutableSchedulingDirectives: true,
+			},
+		},
+		"update completions and parallelism to same value is valid": {
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: batch.JobSpec{
+					Selector:       validGeneratedSelector,
+					Template:       validPodTemplateSpecForGenerated,
+					Completions:    pointer.Int32Ptr(1),
+					Parallelism:    pointer.Int32Ptr(1),
+					CompletionMode: completionModePtr(batch.IndexedCompletion),
+				},
+			},
+			update: func(job *batch.Job) {
+				job.Spec.Completions = pointer.Int32Ptr(2)
+				job.Spec.Parallelism = pointer.Int32Ptr(2)
+			},
+		},
+		"previous parallelism != previous completions, new parallelism == new completions": {
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: batch.JobSpec{
+					Selector:       validGeneratedSelector,
+					Template:       validPodTemplateSpecForGenerated,
+					Completions:    pointer.Int32Ptr(1),
+					Parallelism:    pointer.Int32Ptr(2),
+					CompletionMode: completionModePtr(batch.IndexedCompletion),
+				},
+			},
+			update: func(job *batch.Job) {
+				job.Spec.Completions = pointer.Int32Ptr(3)
+				job.Spec.Parallelism = pointer.Int32Ptr(3)
+			},
+			err: &field.Error{
+				Type:  field.ErrorTypeInvalid,
+				Field: "spec.completions",
+			},
+		},
+		"indexed job updating completions and parallelism to different values is invalid": {
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: batch.JobSpec{
+					Selector:       validGeneratedSelector,
+					Template:       validPodTemplateSpecForGenerated,
+					Completions:    pointer.Int32Ptr(1),
+					Parallelism:    pointer.Int32Ptr(1),
+					CompletionMode: completionModePtr(batch.IndexedCompletion),
+				},
+			},
+			update: func(job *batch.Job) {
+				job.Spec.Completions = pointer.Int32Ptr(2)
+				job.Spec.Parallelism = pointer.Int32Ptr(3)
+			},
+			err: &field.Error{
+				Type:  field.ErrorTypeInvalid,
+				Field: "spec.completions",
+			},
+		},
+		"indexed job with completions set updated to nil does not panic": {
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: batch.JobSpec{
+					Selector:       validGeneratedSelector,
+					Template:       validPodTemplateSpecForGenerated,
+					Completions:    pointer.Int32Ptr(1),
+					Parallelism:    pointer.Int32Ptr(1),
+					CompletionMode: completionModePtr(batch.IndexedCompletion),
+				},
+			},
+			update: func(job *batch.Job) {
+				job.Spec.Completions = nil
+				job.Spec.Parallelism = pointer.Int32Ptr(3)
+			},
+			err: &field.Error{
+				Type:  field.ErrorTypeRequired,
+				Field: "spec.completions",
+			},
+		},
+		"indexed job with completions unchanged, parallelism reduced to less than completions": {
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: batch.JobSpec{
+					Selector:       validGeneratedSelector,
+					Template:       validPodTemplateSpecForGenerated,
+					Completions:    pointer.Int32Ptr(2),
+					Parallelism:    pointer.Int32Ptr(2),
+					CompletionMode: completionModePtr(batch.IndexedCompletion),
+				},
+			},
+			update: func(job *batch.Job) {
+				job.Spec.Completions = pointer.Int32Ptr(2)
+				job.Spec.Parallelism = pointer.Int32Ptr(1)
+			},
+		},
+		"indexed job with completions unchanged, parallelism increased higher than completions": {
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: batch.JobSpec{
+					Selector:       validGeneratedSelector,
+					Template:       validPodTemplateSpecForGenerated,
+					Completions:    pointer.Int32Ptr(2),
+					Parallelism:    pointer.Int32Ptr(2),
+					CompletionMode: completionModePtr(batch.IndexedCompletion),
+				},
+			},
+			update: func(job *batch.Job) {
+				job.Spec.Completions = pointer.Int32Ptr(2)
+				job.Spec.Parallelism = pointer.Int32Ptr(3)
 			},
 		},
 	}

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -935,6 +935,22 @@ func TestValidateJobUpdate(t *testing.T) {
 				Field: "spec.completions",
 			},
 		},
+		"immutable completions for indexed job when AllowElasticIndexedJobs is false": {
+			old: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: batch.JobSpec{
+					Selector: validGeneratedSelector,
+					Template: validPodTemplateSpecForGenerated,
+				},
+			},
+			update: func(job *batch.Job) {
+				job.Spec.Completions = pointer.Int32Ptr(1)
+			},
+			err: &field.Error{
+				Type:  field.ErrorTypeInvalid,
+				Field: "spec.completions",
+			},
+		},
 		"immutable selector": {
 			old: batch.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -237,8 +237,7 @@ func TestControllerSyncJob(t *testing.T) {
 		expectedConditionStatus v1.ConditionStatus
 		expectedConditionReason string
 		expectedCreatedIndexes  sets.Int
-
-		expectedPodPatches int
+		expectedPodPatches      int
 
 		// features
 		jobReadyPodsEnabled bool

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -685,6 +685,15 @@ const (
 	// certificate as expiration approaches.
 	RotateKubeletServerCertificate featuregate.Feature = "RotateKubeletServerCertificate"
 
+	// owner: @danielvegamyhre
+	// kep: https://kep.k8s.io/2413
+	// beta: v1.27
+	//
+	// Allows mutating spec.completions for Indexed job when done in tandem with
+	// spec.parallelism. Specifically, spec.completions is mutable iff spec.completions
+	// equals to spec.parallelism before and after the update.
+	ElasticIndexedJob featuregate.Feature = "ElasticIndexedJob"
+
 	// owner: @saschagrunert
 	// kep: https://kep.k8s.io/2413
 	// alpha: v1.22
@@ -1022,6 +1031,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	RetroactiveDefaultStorageClass: {Default: true, PreRelease: featuregate.Beta},
 
 	RotateKubeletServerCertificate: {Default: true, PreRelease: featuregate.Beta},
+
+	ElasticIndexedJob: {Default: true, PreRelease: featuregate.Beta},
 
 	SeccompDefault: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
 

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -184,11 +184,10 @@ func validationOptionsForJob(newJob, oldJob *batch.Job) batchvalidation.JobValid
 		notStarted := oldJob.Status.StartTime == nil
 		opts.AllowMutableSchedulingDirectives = utilfeature.DefaultFeatureGate.Enabled(features.JobMutableNodeSchedulingDirectives) &&
 			suspended && notStarted
-
-		// Elastic indexed jobs (mutable completions iff updated parallelism == updated completions)
-		opts.AllowElasticIndexedJobs = utilfeature.DefaultFeatureGate.Enabled(features.ElasticIndexedJob)
 	}
 
+	// Elastic indexed jobs (mutable completions iff updated parallelism == updated completions)
+	opts.AllowElasticIndexedJobs = utilfeature.DefaultFeatureGate.Enabled(features.ElasticIndexedJob)
 	return opts
 }
 

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -185,6 +185,8 @@ func validationOptionsForJob(newJob, oldJob *batch.Job) batchvalidation.JobValid
 		opts.AllowMutableSchedulingDirectives = utilfeature.DefaultFeatureGate.Enabled(features.JobMutableNodeSchedulingDirectives) &&
 			suspended && notStarted
 
+		// Elastic indexed jobs (mutable completions iff updated parallelism == updated completions)
+		opts.AllowElasticIndexedJobs = utilfeature.DefaultFeatureGate.Enabled(features.ElasticIndexedJob)
 	}
 
 	return opts

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -1030,12 +1030,9 @@ func TestIndexedJob(t *testing.T) {
 }
 
 func TestElasticIndexedJob(t *testing.T) {
-	const (
-		noCompletionsUpdate = -1
-		initialCompletions  = 3
-	)
+	const initialCompletions int32 = 3
 	type jobUpdate struct {
-		completions          int
+		completions          *int32
 		succeedIndexes       []int
 		failIndexes          []int
 		wantSucceededIndexes string
@@ -1051,7 +1048,7 @@ func TestElasticIndexedJob(t *testing.T) {
 		"feature flag off, mutation not allowed": {
 			jobUpdates: []jobUpdate{
 				{
-					completions: 4,
+					completions: pointer.Int32Ptr(4),
 				},
 			},
 			wantErr: apierrors.NewInvalid(
@@ -1060,23 +1057,22 @@ func TestElasticIndexedJob(t *testing.T) {
 				field.ErrorList{field.Invalid(field.NewPath("spec", "completions"), 4, "field is immutable")},
 			),
 		},
-		"scale up, verify that the range expands, and the job finishes successfully when indexes including the ones in the new range exit successfully": {
+		"scale up": {
 			featureGate: true,
 			jobUpdates: []jobUpdate{
 				{
 					// Scale up completions 3->4 then succeed indexes 0-3
-					completions:          4,
+					completions:          pointer.Int32Ptr(4),
 					succeedIndexes:       []int{0, 1, 2, 3},
 					wantSucceededIndexes: "0-3",
 				},
 			},
 		},
-		"scale down, verify that the range shrinks, and the job finishes successfully when indexes only in the smaller range finishes successfully, and verify that failures that happened for indexes that are now outside the range still count": {
+		"scale down": {
 			featureGate: true,
 			jobUpdates: []jobUpdate{
 				// First succeed index 1 and fail index 2 while completions is still original value (3).
 				{
-					completions:          noCompletionsUpdate,
 					succeedIndexes:       []int{1},
 					failIndexes:          []int{2},
 					wantSucceededIndexes: "1",
@@ -1087,19 +1083,18 @@ func TestElasticIndexedJob(t *testing.T) {
 				// Scale down completions 3->1, verify prev failure out of range still counts
 				// but succeeded out of range does not.
 				{
-					completions:          1,
+					completions:          pointer.Int32Ptr(1),
 					succeedIndexes:       []int{0},
 					wantSucceededIndexes: "0",
 					wantFailed:           1,
 				},
 			},
 		},
-		"index finishes successfully, scale down to exclude the index, then scale up to include it back. verify that the index was restarted and job finishes successfully after all indexes complete": {
+		"index finishes successfully, scale down, scale up": {
 			featureGate: true,
 			jobUpdates: []jobUpdate{
 				// First succeed index 2 while completions is still original value (3).
 				{
-					completions:          noCompletionsUpdate,
 					succeedIndexes:       []int{2},
 					wantSucceededIndexes: "2",
 					wantRemainingIndexes: sets.NewInt(0, 1),
@@ -1107,13 +1102,13 @@ func TestElasticIndexedJob(t *testing.T) {
 				},
 				// Scale completions down 3->2 to exclude previously succeeded index.
 				{
-					completions:          2,
+					completions:          pointer.Int32Ptr(2),
 					wantRemainingIndexes: sets.NewInt(0, 1),
 					wantActivePods:       2,
 				},
 				// Scale completions back up to include previously succeeded index that was temporarily out of range.
 				{
-					completions:          3,
+					completions:          pointer.Int32Ptr(3),
 					succeedIndexes:       []int{0, 1, 2},
 					wantSucceededIndexes: "0-2",
 				},
@@ -1122,7 +1117,9 @@ func TestElasticIndexedJob(t *testing.T) {
 		"scale down to 0, verify that the job succeeds": {
 			featureGate: true,
 			jobUpdates: []jobUpdate{
-				{},
+				{
+					completions: pointer.Int32Ptr(0),
+				},
 			},
 		},
 	}
@@ -1141,8 +1138,8 @@ func TestElasticIndexedJob(t *testing.T) {
 			mode := batchv1.IndexedCompletion
 			jobObj, err := createJobWithDefaults(ctx, clientSet, ns.Name, &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Parallelism:    pointer.Int32Ptr(int32(initialCompletions)),
-					Completions:    pointer.Int32Ptr(int32(initialCompletions)),
+					Parallelism:    pointer.Int32Ptr(initialCompletions),
+					Completions:    pointer.Int32Ptr(initialCompletions),
 					CompletionMode: &mode,
 				},
 			})
@@ -1168,16 +1165,12 @@ func TestElasticIndexedJob(t *testing.T) {
 
 			for _, update := range tc.jobUpdates {
 				// Update Job spec if necessary.
-				if update.completions != noCompletionsUpdate {
+				if update.completions != nil {
 					if jobObj, err = updateJob(ctx, jobClient, jobObj.Name, func(j *batchv1.Job) {
-						j.Spec.Completions = pointer.Int32Ptr(int32(update.completions))
-						j.Spec.Parallelism = pointer.Int32Ptr(int32(update.completions))
+						j.Spec.Completions = update.completions
+						j.Spec.Parallelism = update.completions
 					}); err != nil {
-						if tc.wantErr == nil {
-							t.Fatalf("Failed to update Job: %v", err)
-						}
-						statusErr := err.(*apierrors.StatusError)
-						if diff := cmp.Diff(tc.wantErr, statusErr); diff != "" {
+						if diff := cmp.Diff(tc.wantErr, err); diff != "" {
 							t.Fatalf("Unexpected or missing errors (-want/+got): %s", diff)
 						}
 						return
@@ -1185,20 +1178,16 @@ func TestElasticIndexedJob(t *testing.T) {
 				}
 
 				// Succeed specified indexes.
-				if update.succeedIndexes != nil {
-					for _, idx := range update.succeedIndexes {
-						if err := setJobPhaseForIndex(ctx, clientSet, jobObj, v1.PodSucceeded, idx); err != nil {
-							t.Fatalf("Failed trying to succeed pod with index %d: %v", idx, err)
-						}
+				for _, idx := range update.succeedIndexes {
+					if err := setJobPhaseForIndex(ctx, clientSet, jobObj, v1.PodSucceeded, idx); err != nil {
+						t.Fatalf("Failed trying to succeed pod with index %d: %v", idx, err)
 					}
 				}
 
 				// Fail specified indexes.
-				if update.failIndexes != nil {
-					for _, idx := range update.failIndexes {
-						if err := setJobPhaseForIndex(ctx, clientSet, jobObj, v1.PodFailed, idx); err != nil {
-							t.Fatalf("Failed trying to fail pod with index %d: %v", idx, err)
-						}
+				for _, idx := range update.failIndexes {
+					if err := setJobPhaseForIndex(ctx, clientSet, jobObj, v1.PodFailed, idx); err != nil {
+						t.Fatalf("Failed trying to fail pod with index %d: %v", idx, err)
 					}
 				}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/priority backlog
/sig apps

#### What this PR does / why we need it:
See [KEP](https://github.com/kubernetes/enhancements/pull/3724) for the full proposal.

In summary, for an Job update event to Indexed Jobs, currently we validate that `spec.Completions` is immutable. This proposal is to modify the validation to allow `spec.Completions` to mutable iff `spec.Parallelism` is mutated in tandem such that `spec.Completions == spec.Parallelism`. This will allow for Indexed Jobs to be scaled by modifying completions and parallelism in tandem.

*From the KEP*:

There are cases where a batch workload requires an autoscaled indexed job with stable 
DNS pod names, for example MPI Horovord, Ray, PyTorch etc. This is currently not possible 
because `spec.completions`, which controls the range of indexes in `Indexed` job, is immutable. 
While such workloads could be modeled as a StatefulSet, the Job API is a better fit because it
offers batch-specific features such as allowing indexes to run to completion, and [pod and container failure handling](https://kubernetes.io/docs/concepts/workloads/controllers/job/#handling-pod-and-container-failures).

In the above mentioned cases, there is no distinction between the concept of "how many completed 
indexes do I need" (i.e., `spec.completions`) and the concept of "how many pods do I want running
at a time" (i.e., `spec.parallelism`). All indexes are expected to start at the same time, but they
can finish at different times.

The above behavior can be modeled using an Indexed job with
- `spec.completions` equal to `spec.parallelism`
- mutable `spec.completions` and `spec.parallelism` as long as they are mutated together such that completions == parallelism both before and after the update.

*This PR includes the following changes:*

1. On a Job update event for an Indexed Job, we no long validate that spec.Completions is immutable.
2. On a Job update event for an Indexed Job, we validate that if spec.Completions can only be mutated iff spec.Parallelism is mutated in tandem with it, such that spec.Completions == spec.Parallelism.
3. When spec.Parallelism is scaled down for an Indexed Job, the job controller removes higher indices first to ensure a continuous range of pod completion indices.

#### Which issue(s) this PR fixes:
#114862

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
API validation relaxed allowing Indexed Jobs to be scaled up/down by changing parallelism and completions in tandem, such that parallelism == completions.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/3724
```
