### PR TITLE
Use host protoc if it is the correct version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ network_closure.sh
 /third_party/etcd*
 /default.etcd
 
+# Also ignore protoc installed by hack/install-protoc.sh
+/third_party/protoc*
+
 # User cluster configs
 .kubeconfig
 

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -53,6 +53,13 @@ dependencies:
     - path: cluster/gce/gci/configure.sh
       match: DEFAULT_CRICTL_VERSION=
 
+  # protoc
+  - name: "protoc"
+    version: 3.19.4
+    refPaths:
+    - path: hack/lib/protoc.sh
+      match: PROTOC_VERSION=
+
   # etcd
   - name: "etcd"
     version: 3.5.6

--- a/hack/install-protoc.sh
+++ b/hack/install-protoc.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is convenience to download and install protoc in third_party.
+# Usage: `hack/install-protoc.sh`.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/protoc.sh"
+
+kube::protoc::install

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -18,6 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Short-circuit if init.sh has already been sourced
+[[ $(type -t kube::init::loaded) == function ]] && return 0
+
 # Unset CDPATH so that path interpolation can work correctly
 # https://github.com/kubernetes/kubernetes/issues/52255
 unset CDPATH
@@ -210,4 +213,9 @@ kube::realpath() {
     return 1
   fi
   kube::readlinkdashf "${1}"
+}
+
+# Marker function to indicate init.sh has been fully sourced
+kube::init::loaded() {
+  return 0
 }

--- a/hack/lib/protoc.sh
+++ b/hack/lib/protoc.sh
@@ -18,6 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Short-circuit if protoc.sh has already been sourced
+[[ $(type -t kube::protoc::loaded) == function ]] && return 0
+
 # The root of the build/dist directory
 KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 source "${KUBE_ROOT}/hack/lib/init.sh"
@@ -133,4 +136,9 @@ function kube::protoc::install() {
     kube::log::info "protoc v${PROTOC_VERSION} installed. To use:"
     kube::log::info "export PATH=\"$(pwd)/protoc:\${PATH}\""
   )
+}
+
+# Marker function to indicate protoc.sh has been fully sourced
+kube::protoc::loaded() {
+  return 0
 }

--- a/hack/lib/protoc.sh
+++ b/hack/lib/protoc.sh
@@ -69,6 +69,7 @@ function kube::protoc::protoc() {
     PATH="${gogopath}:${PATH}" protoc \
       --proto_path="$(pwd -P)" \
       --proto_path="${KUBE_ROOT}/vendor" \
+      --proto_path="${KUBE_ROOT}/third_party/protobuf" \
       --gogo_out=paths=source_relative,plugins=grpc:. \
       api.proto
   )

--- a/hack/lib/protoc.sh
+++ b/hack/lib/protoc.sh
@@ -22,6 +22,8 @@ set -o pipefail
 KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
+PROTOC_VERSION=3.19.4
+
 # Generates $1/api.pb.go from the protobuf file $1/api.proto
 # and formats it correctly
 # $1: Full path to the directory where the api.proto file is
@@ -36,17 +38,15 @@ function kube::protoc::generate_proto() {
   kube::protoc::format "${package}"
 }
 
-# Checks that the current protoc version is at least version 3.0.0-beta1
+# Checks that the current protoc version matches the required version and
 # exit 1 if it's not the case
 function kube::protoc::check_protoc() {
-  if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3."* ]]; then
-    echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"
-    echo "install the platform appropriate Protobuf package for your OS: "
-    echo
-    echo "  https://github.com/protocolbuffers/protobuf/releases"
-    echo
-    echo "WARNING: Protobuf changes are not being validated"
-    exit 1
+  if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc ${PROTOC_VERSION}"* ]]; then
+    echo "Generating protobuf requires protoc ${PROTOC_VERSION}."
+    echo "Run hack/install-protoc.sh or download and install the"
+    echo "platform-appropriate Protobuf package for your OS from"
+    echo "https://github.com/protocolbuffers/protobuf/releases"
+    return 1
   fi
 }
 

--- a/hack/update-generated-proto-bindings-dockerized.sh
+++ b/hack/update-generated-proto-bindings-dockerized.sh
@@ -22,6 +22,7 @@ set -o pipefail
 
 KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd -P)"
 
+source "${KUBE_ROOT}/hack/lib/init.sh"
 source "${KUBE_ROOT}/hack/lib/protoc.sh"
 source "${KUBE_ROOT}/hack/lib/util.sh"
 
@@ -29,6 +30,8 @@ if [ "$#" == 0 ]; then
     echo "usage: $0 <api_dir>..."
     exit 1
 fi
+
+kube::protoc::check_protoc
 
 for api; do
     # This can't use `git ls-files` because it runs in a container without the

--- a/hack/update-generated-protobuf-dockerized.sh
+++ b/hack/update-generated-protobuf-dockerized.sh
@@ -25,21 +25,13 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
+source "${KUBE_ROOT}/hack/lib/protoc.sh"
 
+kube::protoc::check_protoc
 kube::golang::setup_env
 
 GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/go-to-protobuf
 GO111MODULE=on GOPROXY=off go install k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
-
-if [[ -z "$(which protoc)" || "$(protoc --version)" != "libprotoc 3."* ]]; then
-  echo "Generating protobuf requires protoc 3.0.0-beta1 or newer. Please download and"
-  echo "install the platform appropriate Protobuf package for your OS: "
-  echo
-  echo "  https://github.com/protocolbuffers/protobuf/releases"
-  echo
-  echo "WARNING: Protobuf changes are not being validated"
-  exit 1
-fi
 
 gotoprotobuf=$(kube::util::find-binary "go-to-protobuf")
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR is the follow-up promised in https://github.com/kubernetes/kubernetes/pull/115238#discussion_r1083312052

* Adds helper script to install the desired version of protoc (like etcd)
* Tightens checking of protoc version (since differences would impact generated code and fail validation)
* Uses protoc directly if it is the correct version (speeds up generation and allows generation to work on development machines without docker available)

With this change, `hack/update-codegen.sh` can run on a development machine which does not have docker available

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
