### PR TITLE
Do not use a global variable for etcdURL

### DIFF
--- a/test/integration/framework/etcd.go
+++ b/test/integration/framework/etcd.go
@@ -36,8 +36,6 @@ import (
 	"k8s.io/kubernetes/pkg/util/env"
 )
 
-var etcdURL = ""
-
 const installEtcd = `
 Cannot find etcd, cannot run integration tests
 Please see https://git.k8s.io/community/contributors/devel/sig-testing/integration-tests.md#install-etcd-dependency for instructions.
@@ -70,7 +68,7 @@ func startEtcd() (func(), error) {
 		os.Setenv("ETCD_UNSUPPORTED_ARCH", "arm64")
 	}
 
-	etcdURL = env.GetEnvAsStringOrFallback("KUBE_INTEGRATION_ETCD_URL", "http://127.0.0.1:2379")
+	etcdURL := env.GetEnvAsStringOrFallback("KUBE_INTEGRATION_ETCD_URL", "http://127.0.0.1:2379")
 	conn, err := net.Dial("tcp", strings.TrimPrefix(etcdURL, "http://"))
 	if err == nil {
 		klog.Infof("etcd already running at %s", etcdURL)
@@ -84,8 +82,7 @@ func startEtcd() (func(), error) {
 		return nil, err
 	}
 
-	etcdURL = currentURL
-	os.Setenv("KUBE_INTEGRATION_ETCD_URL", etcdURL)
+	os.Setenv("KUBE_INTEGRATION_ETCD_URL", currentURL)
 
 	return stop, nil
 }
@@ -221,5 +218,5 @@ func EtcdMain(tests func() int) {
 
 // GetEtcdURL returns the URL of the etcd instance started by EtcdMain.
 func GetEtcdURL() string {
-	return etcdURL
+	return env.GetEnvAsStringOrFallback("KUBE_INTEGRATION_ETCD_URL", "http://127.0.0.1:2379")
 }


### PR DESCRIPTION
we are saving this information in an env variable `KUBE_INTEGRATION_ETCD_URL`. So just pick it up from there when needed. Currently when someone uses `framework.RunCustomEtcd ` directly, the global variable is *not* set and the code that uses `GetEtcdURL` returns empty string.

See hacks i had to do to work around this problem in:
https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/547/commits/35ca4644894d6ea10071d8c8aab5489d2c8b44b9#diff-c6d4a56808f14e8c4bfc535d0e7350c9588d18bb54f30cf103d56d02f7c0bcceR42-R49

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
