### PR TITLE
Add new ignoreFiles array to device plugin manager

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -271,7 +271,7 @@ func (m *ManagerImpl) GetWatcherHandler() cache.PluginHandler {
 
 // checkpointFile returns device plugin checkpoint file path.
 func (m *ManagerImpl) checkpointFile() string {
-	return filepath.Join(m.checkpointdir, kubeletDeviceManagerCheckpoint)
+	return filepath.Join(m.checkpointdir, KubeletDeviceManagerCheckpoint)
 }
 
 // Start starts the Device Plugin Manager and start initialization of
@@ -432,9 +432,9 @@ func (m *ManagerImpl) writeCheckpoint() error {
 	data := checkpoint.New(m.podDevices.toCheckpointData(),
 		registeredDevs)
 	m.mutex.Unlock()
-	err := m.checkpointManager.CreateCheckpoint(kubeletDeviceManagerCheckpoint, data)
+	err := m.checkpointManager.CreateCheckpoint(KubeletDeviceManagerCheckpoint, data)
 	if err != nil {
-		err2 := fmt.Errorf("failed to write checkpoint file %q: %v", kubeletDeviceManagerCheckpoint, err)
+		err2 := fmt.Errorf("failed to write checkpoint file %q: %v", KubeletDeviceManagerCheckpoint, err)
 		klog.InfoS("Failed to write checkpoint file", "err", err)
 		return err2
 	}
@@ -452,7 +452,7 @@ func (m *ManagerImpl) readCheckpoint() error {
 	if err != nil {
 		if err == errors.ErrCheckpointNotFound {
 			// no point in trying anything else
-			klog.InfoS("Failed to read data from checkpoint", "checkpoint", kubeletDeviceManagerCheckpoint, "err", err)
+			klog.InfoS("Failed to read data from checkpoint", "checkpoint", KubeletDeviceManagerCheckpoint, "err", err)
 			return nil
 		}
 
@@ -465,7 +465,7 @@ func (m *ManagerImpl) readCheckpoint() error {
 			// a tiny fraction of time, so what matters most is the current checkpoint read error.
 			return err
 		}
-		klog.InfoS("Read data from a V1 checkpoint", "checkpoint", kubeletDeviceManagerCheckpoint)
+		klog.InfoS("Read data from a V1 checkpoint", "checkpoint", KubeletDeviceManagerCheckpoint)
 	}
 
 	m.mutex.Lock()
@@ -487,7 +487,7 @@ func (m *ManagerImpl) getCheckpointV2() (checkpoint.DeviceManagerCheckpoint, err
 	registeredDevs := make(map[string][]string)
 	devEntries := make([]checkpoint.PodDevicesEntry, 0)
 	cp := checkpoint.New(devEntries, registeredDevs)
-	err := m.checkpointManager.GetCheckpoint(kubeletDeviceManagerCheckpoint, cp)
+	err := m.checkpointManager.GetCheckpoint(KubeletDeviceManagerCheckpoint, cp)
 	return cp, err
 }
 
@@ -495,7 +495,7 @@ func (m *ManagerImpl) getCheckpointV1() (checkpoint.DeviceManagerCheckpoint, err
 	registeredDevs := make(map[string][]string)
 	devEntries := make([]checkpoint.PodDevicesEntryV1, 0)
 	cp := checkpoint.NewV1(devEntries, registeredDevs)
-	err := m.checkpointManager.GetCheckpoint(kubeletDeviceManagerCheckpoint, cp)
+	err := m.checkpointManager.GetCheckpoint(KubeletDeviceManagerCheckpoint, cp)
 	return cp, err
 }
 

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -104,5 +104,5 @@ const (
 // take effect.
 const endpointStopGracePeriod = time.Duration(5) * time.Minute
 
-// kubeletDeviceManagerCheckpoint is the file name of device plugin checkpoint
-const kubeletDeviceManagerCheckpoint = "kubelet_internal_checkpoint"
+// KubeletDeviceManagerCheckpoint is the file name of device plugin checkpoint
+const KubeletDeviceManagerCheckpoint = "kubelet_internal_checkpoint"

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -64,6 +64,7 @@ import (
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 	pluginwatcherapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	"k8s.io/kubernetes/pkg/features"
@@ -73,6 +74,7 @@ import (
 	kubeletcertificate "k8s.io/kubernetes/pkg/kubelet/certificate"
 	"k8s.io/kubernetes/pkg/kubelet/cloudresource"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
+	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager"
 	draplugin "k8s.io/kubernetes/pkg/kubelet/cm/dra/plugin"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/configmap"
@@ -798,9 +800,13 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	if err != nil {
 		return nil, err
 	}
+
+	// NewPluginManager takes a string array of filenames to ignore when checking for new device plugin sockets
+	// Given that the Kubelet registry socket and the Kubelet internal checkpoint are in the same directory, we need to pass their filenames so that they are ignored
 	klet.pluginManager = pluginmanager.NewPluginManager(
 		klet.getPluginsRegistrationDir(), /* sockDir */
 		kubeDeps.Recorder,
+		[]string{v1beta1.KubeletSocketFilename, devicemanager.KubeletDeviceManagerCheckpoint},
 	)
 
 	// If the experimentalMounterPathFlag is set, we do not want to

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -393,6 +393,7 @@ func newTestKubeletWithImageList(
 	kubelet.pluginManager = pluginmanager.NewPluginManager(
 		kubelet.getPluginsRegistrationDir(), /* sockDir */
 		kubelet.recorder,
+		[]string{},
 	)
 	kubelet.setNodeStatusFuncs = kubelet.defaultNodeStatusFuncs()
 

--- a/pkg/kubelet/pluginmanager/plugin_manager.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager.go
@@ -53,7 +53,8 @@ const (
 // PluginManager interface.
 func NewPluginManager(
 	sockDir string,
-	recorder record.EventRecorder) PluginManager {
+	recorder record.EventRecorder,
+	watcherIgnoreFiles []string) PluginManager {
 	asw := cache.NewActualStateOfWorld()
 	dsw := cache.NewDesiredStateOfWorld()
 	reconciler := reconciler.NewReconciler(
@@ -68,9 +69,10 @@ func NewPluginManager(
 	)
 
 	pm := &pluginManager{
-		desiredStateOfWorldPopulator: pluginwatcher.NewWatcher(
+		desiredStateOfWorldPopulator: pluginwatcher.NewWatcherWithIgnoreFiles(
 			sockDir,
 			dsw,
+			watcherIgnoreFiles,
 		),
 		reconciler:          reconciler,
 		desiredStateOfWorld: dsw,

--- a/pkg/kubelet/pluginmanager/plugin_manager_test.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager_test.go
@@ -165,6 +165,7 @@ func newTestPluginManager(sockDir string) PluginManager {
 	pm := NewPluginManager(
 		sockDir,
 		&record.FakeRecorder{},
+		[]string{},
 	)
 	return pm
 }

--- a/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/constants.go
+++ b/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/constants.go
@@ -28,8 +28,10 @@ const (
 	// Only privileged pods have access to this path
 	// Note: Placeholder until we find a "standard path"
 	DevicePluginPath = "/var/lib/kubelet/device-plugins/"
+	// KubeletSocketFilename is the file name of the Kubelet registry socket
+	KubeletSocketFilename = "kubelet.sock"
 	// KubeletSocket is the path of the Kubelet registry socket
-	KubeletSocket = DevicePluginPath + "kubelet.sock"
+	KubeletSocket = DevicePluginPath + KubeletSocketFilename
 
 	// DevicePluginPathWindows Avoid failed to run Kubelet: bad socketPath,
 	// must be an absolute path: /var/lib/kubelet/device-plugins/kubelet.sock
@@ -37,7 +39,7 @@ const (
 	// https://github.com/kubernetes/kubernetes/pull/93285#discussion_r458140701
 	DevicePluginPathWindows = "\\var\\lib\\kubelet\\device-plugins\\"
 	// KubeletSocketWindows is the path of the Kubelet registry socket on windows
-	KubeletSocketWindows = DevicePluginPathWindows + "kubelet.sock"
+	KubeletSocketWindows = DevicePluginPathWindows + KubeletSocketFilename
 
 	// KubeletPreStartContainerRPCTimeoutInSecs is the timeout duration in secs for PreStartContainer RPC
 	// Timeout duration in secs for PreStartContainer RPC

--- a/test/e2e_node/device_manager_test.go
+++ b/test/e2e_node/device_manager_test.go
@@ -31,6 +31,7 @@ import (
 	kubeletpodresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 	"k8s.io/kubernetes/pkg/kubelet/apis/podresources"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/checkpoint"
 	"k8s.io/kubernetes/pkg/kubelet/util"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -46,12 +47,11 @@ import (
 
 const (
 	devicePluginDir = "/var/lib/kubelet/device-plugins"
-	checkpointName  = "kubelet_internal_checkpoint"
 )
 
 // Serial because the test updates kubelet configuration.
 var _ = SIGDescribe("Device Manager  [Serial] [Feature:DeviceManager][NodeFeature:DeviceManager]", func() {
-	checkpointFullPath := filepath.Join(devicePluginDir, checkpointName)
+	checkpointFullPath := filepath.Join(devicePluginDir, devicemanager.KubeletDeviceManagerCheckpoint)
 	f := framework.NewDefaultFramework("devicemanager-test")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
@@ -103,7 +103,7 @@ var _ = SIGDescribe("Device Manager  [Serial] [Feature:DeviceManager][NodeFeatur
 			killKubelet("SIGSTOP")
 
 			ginkgo.By("rewriting the kubelet checkpoint file as v1")
-			err := rewriteCheckpointAsV1(devicePluginDir, checkpointName)
+			err := rewriteCheckpointAsV1(devicePluginDir, devicemanager.KubeletDeviceManagerCheckpoint)
 			// make sure we remove any leftovers
 			defer os.Remove(checkpointFullPath)
 			framework.ExpectNoError(err)
@@ -223,7 +223,7 @@ var _ = SIGDescribe("Device Manager  [Serial] [Feature:DeviceManager][NodeFeatur
 			killKubelet("SIGSTOP")
 
 			ginkgo.By("rewriting the kubelet checkpoint file as v1")
-			err = rewriteCheckpointAsV1(devicePluginDir, checkpointName)
+			err = rewriteCheckpointAsV1(devicePluginDir, devicemanager.KubeletDeviceManagerCheckpoint)
 			// make sure we remove any leftovers
 			defer os.Remove(checkpointFullPath)
 			framework.ExpectNoError(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/sig testing
/sig windows

/priority important-soon

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
All manager tests now pass on Windows. The device plugin manager now has a new ignoreFiles string array field which is to be filled with the names of files it should ignore when registering new device plugins. Ignoring its own registry socket and the kubelet internal checkpoint makes it so the Windows tests do not time out anymore by trying to determine if these files are Unix sockets.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related #114508

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
