### PR TITLE
e2e/network_policy: using expected!=observed as condition for polling probeConnectivity

### DIFF
--- a/test/e2e/network/netpol/kubemanager.go
+++ b/test/e2e/network/netpol/kubemanager.go
@@ -34,15 +34,10 @@ import (
 )
 
 // defaultPollIntervalSeconds [seconds] is the default value for which the Prober will wait before attempting next attempt.
-const defaultPollIntervalSeconds = 2
+const defaultPollIntervalSeconds = 1
 
 // defaultPollTimeoutSeconds [seconds] is the default timeout when polling on probes.
-// using this value leads to a minimum of 2 attempts for every probe
-const defaultPollTimeoutSeconds = 1
-
-// maxPollTimeoutSeconds [seconds] is the max timeout when polling on probes, this should only be used when expect a
-// successful probe; use defaultPollTimeout otherwise
-const maxPollTimeoutSeconds = 10
+const defaultPollTimeoutSeconds = 10
 
 // TestPod represents an actual running pod. For each Pod defined by the model,
 // there will be a corresponding TestPod. TestPod includes some runtime info
@@ -185,18 +180,57 @@ func (k *kubeManager) probeConnectivity(args *probeConnectivityArgs) (bool, stri
 
 	attempt := 0
 
-	err := wait.PollImmediate(time.Duration(args.pollIntervalSeconds)*time.Second, time.Duration(args.pollTimeoutSeconds)*time.Second,
-		func() (bool, error) {
-			stdout, stderr, err := k.executeRemoteCommand(args.nsFrom, args.podFrom, args.containerFrom, cmd)
-			if err != nil {
-				framework.Logf("retrying probe #%d :: %s/%s -> %s: error when running command: err - %v /// stdout - %s /// stderr - %s", attempt+1, args.nsFrom, args.podFrom, args.addrTo, err, stdout, stderr)
+	// NOTE: The return value of this function[probeConnectivity] should be true if the probe is successful and false otherwise.
+
+	// probeError will be the return value of this function[probeConnectivity] call.
+	var probeError error
+	var stderr string
+
+	// Instead of re-running the job on connectivity failure, the following conditionFunc when passed to PollImmediate, reruns
+	// the job when the observed value don't match the expected value, so we don't rely on return value of PollImmediate, we
+	// simply discard it and use probeError, defined outside scope of conditionFunc, for returning the result of probeConnectivity.
+	conditionFunc := func() (bool, error) {
+		_, stderr, probeError = k.executeRemoteCommand(args.nsFrom, args.podFrom, args.containerFrom, cmd)
+		// retry should only occur if expected and observed value don't match.
+		if args.expectConnectivity {
+			if probeError != nil {
+				// since we expect connectivity here, we fail the condition for PollImmediate to reattempt the probe.
+				// this happens in the cases where network is congested, we don't have any policy rejecting traffic
+				// from "podFrom" to "podTo" and probes from "podFrom" to "podTo" are failing.
+				framework.Logf("probe #%d :: connectivity expected :: %s/%s -> %s :: stderr - %s",
+					attempt+1, args.nsFrom, args.podFrom, args.addrTo, stderr,
+				)
+				attempt++
+				return false, nil
+			} else {
+				// we got the expected results, exit immediately.
+				return true, nil
+			}
+		} else {
+			if probeError != nil {
+				// we got the expected results, exit immediately.
+				return true, nil
+			} else {
+				// since we don't expect connectivity here, we fail the condition for PollImmediate to reattempt the probe.
+				// this happens in the cases where we have policy rejecting traffic from "podFrom" to "podTo", but CNI takes
+				// time to implement the policy and probe from "podFrom" to "podTo" was successful in that window.
+				framework.Logf(" probe #%d :: connectivity not expected :: %s/%s -> %s",
+					attempt+1, args.nsFrom, args.podFrom, args.addrTo,
+				)
 				attempt++
 				return false, nil
 			}
-			return true, nil
-		})
+		}
+	}
 
-	if err != nil {
+	// ignore the result of PollImmediate, we are only concerned with probeError.
+	_ = wait.PollImmediate(
+		time.Duration(args.pollIntervalSeconds)*time.Second,
+		time.Duration(args.pollTimeoutSeconds)*time.Second,
+		conditionFunc,
+	)
+
+	if probeError != nil {
 		return false, commandDebugString, nil
 	}
 	return true, commandDebugString, nil
@@ -309,10 +343,10 @@ func getPollIntervalSeconds() int {
 	return defaultPollIntervalSeconds
 }
 
-// getPollTimeout returns the timeout for polling on probes.
-func getPollTimeoutSeconds(useMaxPollTimout bool) int {
-	if useMaxPollTimout {
-		return maxPollTimeoutSeconds
+// getPollTimeout returns the timeout for polling on probes, and takes windows heuristics into account, where requests can take longer sometimes.
+func getPollTimeoutSeconds() int {
+	if framework.NodeOSDistroIs("windows") {
+		return defaultPollTimeoutSeconds * 2
 	}
 	return defaultPollTimeoutSeconds
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR presents a better version of the condition function which is used for polling in the probe connectivity function to test intra-pod connectivity and de-flake the tests to more extent. 

https://github.com/kubernetes/kubernetes/pull/115207 retries the probes on connection failure, in this version we retry only when the observed connectivity value doesn't match the expected value. 

Tested on 4 nodes kind cluster by running 25 e2e network policy tests concurrently (peaking 300 pods), after retries all tests eventually passed. 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
