### PR TITLE
change the comment in CRI API to point to the correct logs directory

### DIFF
--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
@@ -1315,7 +1315,7 @@ type PodSandboxConfig struct {
 	// structured logs, systemd-journald journal files, gRPC trace files, etc.
 	// E.g.,
 	//
-	//	PodSandboxConfig.LogDirectory = `/var/log/pods/<podUID>/`
+	//	PodSandboxConfig.LogDirectory = `/var/log/pods/<NAMESPACE>_<NAME>_<UID>/`
 	//	ContainerConfig.LogPath = `containerName/Instance#.log`
 	LogDirectory string `protobuf:"bytes,3,opt,name=log_directory,json=logDirectory,proto3" json:"log_directory,omitempty"`
 	// DNS config for the sandbox.
@@ -4716,13 +4716,8 @@ type ContainerConfig struct {
 	// the log (STDOUT and STDERR) on the host.
 	// E.g.,
 	//
-	//	PodSandboxConfig.LogDirectory = `/var/log/pods/<podUID>/`
+	//	PodSandboxConfig.LogDirectory = `/var/log/pods/<NAMESPACE>_<NAME>_<UID>/`
 	//	ContainerConfig.LogPath = `containerName/Instance#.log`
-	//
-	// WARNING: Log management and how kubelet should interface with the
-	// container logs are under active discussion in
-	// https://issues.k8s.io/24677. There *may* be future change of direction
-	// for logging as the discussion carries on.
 	LogPath string `protobuf:"bytes,11,opt,name=log_path,json=logPath,proto3" json:"log_path,omitempty"`
 	// Variables for interactive containers, these have very specialized
 	// use-cases (e.g. debugging).

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
@@ -324,10 +324,10 @@ message LinuxSandboxSecurityContext {
     // If set, the root filesystem of the sandbox is read-only.
     bool readonly_rootfs = 4;
     // List of groups applied to the first process run in the sandbox, in
-    // addition to the sandbox's primary GID, and group memberships defined 
+    // addition to the sandbox's primary GID, and group memberships defined
     // in the container image for the sandbox's primary UID of the container process.
     // If the list is empty, no additional groups are added to any container.
-    // Note that group memberships defined in the container image for the sandbox's primary UID 
+    // Note that group memberships defined in the container image for the sandbox's primary UID
     // of the container process are still effective, even if they are not included in this list.
     repeated int64 supplemental_groups = 5;
     // Indicates whether the sandbox will be asked to run a privileged
@@ -420,7 +420,7 @@ message PodSandboxConfig {
     // containers. For example, the files might be newline separated JSON
     // structured logs, systemd-journald journal files, gRPC trace files, etc.
     // E.g.,
-    //     PodSandboxConfig.LogDirectory = `/var/log/pods/<podUID>/`
+    //     PodSandboxConfig.LogDirectory = `/var/log/pods/<NAMESPACE>_<NAME>_<UID>/`
     //     ContainerConfig.LogPath = `containerName/Instance#.log`
     string log_directory = 3;
     // DNS config for the sandbox.
@@ -877,10 +877,10 @@ message LinuxContainerSecurityContext {
     // If set, the root filesystem of the container is read-only.
     bool readonly_rootfs = 7;
     // List of groups applied to the first process run in the container, in
-    // addition to the container's primary GID, and group memberships defined 
+    // addition to the container's primary GID, and group memberships defined
     // in the container image for the container's primary UID of the container process.
     // If the list is empty, no additional groups are added to any container.
-    // Note that group memberships defined in the container image for the container's primary UID 
+    // Note that group memberships defined in the container image for the container's primary UID
     // of the container process are still effective, even if they are not included in this list.
     repeated int64 supplemental_groups = 8;
     // no_new_privs defines if the flag for no_new_privs should be set on the
@@ -1060,13 +1060,8 @@ message ContainerConfig {
     // Path relative to PodSandboxConfig.LogDirectory for container to store
     // the log (STDOUT and STDERR) on the host.
     // E.g.,
-    //     PodSandboxConfig.LogDirectory = `/var/log/pods/<podUID>/`
+    //     PodSandboxConfig.LogDirectory = `/var/log/pods/<NAMESPACE>_<NAME>_<UID>/`
     //     ContainerConfig.LogPath = `containerName/Instance#.log`
-    //
-    // WARNING: Log management and how kubelet should interface with the
-    // container logs are under active discussion in
-    // https://issues.k8s.io/24677. There *may* be future change of direction
-    // for logging as the discussion carries on.
     string log_path = 11;
 
     // Variables for interactive containers, these have very specialized
@@ -1609,7 +1604,7 @@ message ContainerStats {
     FilesystemUsage writable_layer = 4;
 }
 
-// WindowsContainerStats provides the resource usage statistics for a container specific for Windows 
+// WindowsContainerStats provides the resource usage statistics for a container specific for Windows
 message WindowsContainerStats {
     // Information of the container.
     ContainerAttributes attributes = 1;
@@ -1745,7 +1740,7 @@ message MetricDescriptor {
     repeated string label_keys = 3;
 }
 
-message ListPodSandboxMetricsRequest {} 
+message ListPodSandboxMetricsRequest {}
 
 message ListPodSandboxMetricsResponse {
     repeated PodSandboxMetrics pod_metrics = 1;


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Just a clarification in the CRI API on the logs directory. Plus removing the old warning that is not applicable at this point.

/sig node
/assign @mrunalp 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```