### PR TITLE
Migrated `pkg/controller/endpointslice` and `pkg/controller/endpointslicemirroring` to contextual logging

### DIFF
--- a/cmd/kube-controller-manager/app/discovery.go
+++ b/cmd/kube-controller-manager/app/discovery.go
@@ -49,6 +49,6 @@ func startEndpointSliceMirroringController(ctx context.Context, controllerContex
 		controllerContext.ComponentConfig.EndpointSliceMirroringController.MirroringMaxEndpointsPerSubset,
 		controllerContext.ClientBuilder.ClientOrDie("endpointslicemirroring-controller"),
 		controllerContext.ComponentConfig.EndpointSliceMirroringController.MirroringEndpointUpdatesBatchPeriod.Duration,
-	).Run(int(controllerContext.ComponentConfig.EndpointSliceMirroringController.MirroringConcurrentServiceEndpointSyncs), ctx.Done())
+	).Run(ctx, int(controllerContext.ComponentConfig.EndpointSliceMirroringController.MirroringConcurrentServiceEndpointSyncs))
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/discovery.go
+++ b/cmd/kube-controller-manager/app/discovery.go
@@ -29,6 +29,7 @@ import (
 
 func startEndpointSliceController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
 	go endpointslicecontroller.NewController(
+		ctx,
 		controllerContext.InformerFactory.Core().V1().Pods(),
 		controllerContext.InformerFactory.Core().V1().Services(),
 		controllerContext.InformerFactory.Core().V1().Nodes(),
@@ -36,7 +37,7 @@ func startEndpointSliceController(ctx context.Context, controllerContext Control
 		controllerContext.ComponentConfig.EndpointSliceController.MaxEndpointsPerSlice,
 		controllerContext.ClientBuilder.ClientOrDie("endpointslice-controller"),
 		controllerContext.ComponentConfig.EndpointSliceController.EndpointUpdatesBatchPeriod.Duration,
-	).Run(int(controllerContext.ComponentConfig.EndpointSliceController.ConcurrentServiceEndpointSyncs), ctx.Done())
+	).Run(ctx, int(controllerContext.ComponentConfig.EndpointSliceController.ConcurrentServiceEndpointSyncs))
 	return nil, true, nil
 }
 

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -39,7 +39,7 @@ contextual k8s.io/kubernetes/test/e2e/dra/.*
 -contextual k8s.io/kubernetes/pkg/controller/controller_ref_manager.go
 -contextual k8s.io/kubernetes/pkg/controller/controller_utils.go
 -contextual k8s.io/kubernetes/pkg/controller/disruption/.*
--contextual k8s.io/kubernetes/pkg/controller/endpointslice/.*
+-contextual k8s.io/kubernetes/pkg/controller/endpoint/.*
 -contextual k8s.io/kubernetes/pkg/controller/endpointslicemirroring/.*
 -contextual k8s.io/kubernetes/pkg/controller/garbagecollector/.*
 -contextual k8s.io/kubernetes/pkg/controller/nodeipam/.*

--- a/pkg/controller/endpointslice/topologycache/topologycache_test.go
+++ b/pkg/controller/endpointslice/topologycache/topologycache_test.go
@@ -27,6 +27,7 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/pointer"
 )
 
@@ -382,7 +383,8 @@ func TestAddHints(t *testing.T) {
 			cache := NewTopologyCache()
 			cache.cpuRatiosByZone = tc.cpuRatiosByZone
 
-			slicesToCreate, slicesToUpdate, events := cache.AddHints(tc.sliceInfo)
+			logger, _ := ktesting.NewTestContext(t)
+			slicesToCreate, slicesToUpdate, events := cache.AddHints(logger, tc.sliceInfo)
 
 			expectEquivalentSlices(t, slicesToCreate, tc.expectedSlicesToCreate)
 			expectEquivalentSlices(t, slicesToUpdate, tc.expectedSlicesToUpdate)
@@ -580,7 +582,8 @@ func TestSetNodes(t *testing.T) {
 				})
 			}
 
-			cache.SetNodes(nodes)
+			logger, _ := ktesting.NewTestContext(t)
+			cache.SetNodes(logger, nodes)
 
 			if cache.sufficientNodeInfo != tc.expectSufficientNodeInfo {
 				t.Errorf("Expected sufficientNodeInfo to be %t, got %t", tc.expectSufficientNodeInfo, cache.sufficientNodeInfo)
@@ -680,11 +683,12 @@ func TestTopologyCacheRace(t *testing.T) {
 		})
 	}
 
+	logger, _ := ktesting.NewTestContext(t)
 	go func() {
-		cache.SetNodes(nodes)
+		cache.SetNodes(logger, nodes)
 	}()
 	go func() {
-		cache.AddHints(sliceInfo)
+		cache.AddHints(logger, sliceInfo)
 	}()
 }
 

--- a/pkg/controller/endpointslice/topologycache/utils.go
+++ b/pkg/controller/endpointslice/topologycache/utils.go
@@ -77,7 +77,7 @@ func FormatWithAddressType(s string, addressType discovery.AddressType) string {
 // It allocates endpoints from the provided givingZones to the provided
 // receivingZones. This returns a map that represents the changes in allocated
 // endpoints by zone.
-func redistributeHints(slices []*discovery.EndpointSlice, givingZones, receivingZones map[string]int) map[string]int {
+func redistributeHints(logger klog.Logger, slices []*discovery.EndpointSlice, givingZones, receivingZones map[string]int) map[string]int {
 	redistributions := map[string]int{}
 
 	for _, slice := range slices {
@@ -91,7 +91,7 @@ func redistributeHints(slices []*discovery.EndpointSlice, givingZones, receiving
 			}
 			if endpoint.Zone == nil || *endpoint.Zone == "" {
 				// This should always be caught earlier in AddHints()
-				klog.Warningf("Endpoint found without zone specified")
+				logger.Info("Endpoint found without zone specified")
 				continue
 			}
 

--- a/pkg/controller/endpointslice/topologycache/utils_test.go
+++ b/pkg/controller/endpointslice/topologycache/utils_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	discovery "k8s.io/api/discovery/v1"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/pointer"
 )
 
@@ -73,7 +74,8 @@ func Test_redistributeHints(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualRedistributions := redistributeHints(tc.slices, tc.givingZones, tc.receivingZones)
+			logger, _ := ktesting.NewTestContext(t)
+			actualRedistributions := redistributeHints(logger, tc.slices, tc.givingZones, tc.receivingZones)
 
 			if len(actualRedistributions) != len(tc.expectedRedistributions) {
 				t.Fatalf("Expected redistributions for %d zones, got %d (%+v)", len(tc.expectedRedistributions), len(actualRedistributions), actualRedistributions)

--- a/pkg/controller/endpointslice/utils_test.go
+++ b/pkg/controller/endpointslice/utils_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/pointer"
 )
 
@@ -206,8 +207,9 @@ func TestNewEndpointSlice(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
 			svc := tc.updateSvc(service)
-			generatedSlice := newEndpointSlice(&svc, &endpointMeta)
+			generatedSlice := newEndpointSlice(logger, &svc, &endpointMeta)
 			assert.EqualValues(t, tc.expectedSlice, generatedSlice)
 		})
 	}
@@ -587,7 +589,8 @@ func TestGetEndpointPorts(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			actualPorts := getEndpointPorts(tc.service, tc.pod)
+			logger, _ := ktesting.NewTestContext(t)
+			actualPorts := getEndpointPorts(logger, tc.service, tc.pod)
 
 			if len(actualPorts) != len(tc.expectedPorts) {
 				t.Fatalf("Expected %d ports, got %d", len(tc.expectedPorts), len(actualPorts))
@@ -875,8 +878,9 @@ func TestSetEndpointSliceLabels(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
 			svc := tc.updateSvc(service)
-			labels, updated := setEndpointSliceLabels(tc.epSlice, &svc)
+			labels, updated := setEndpointSliceLabels(logger, tc.epSlice, &svc)
 			assert.EqualValues(t, updated, tc.expectedUpdate)
 			assert.EqualValues(t, tc.expectedLabels, labels)
 		})
@@ -1113,7 +1117,8 @@ func TestSupportedServiceAddressType(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			addressTypes := getAddressTypesForService(&testCase.service)
+			logger, _ := ktesting.NewTestContext(t)
+			addressTypes := getAddressTypesForService(logger, &testCase.service)
 			if len(addressTypes) != len(testCase.expectedAddressTypes) {
 				t.Fatalf("expected count address types %v got %v", len(testCase.expectedAddressTypes), len(addressTypes))
 			}

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/controller"
 )
 
@@ -242,7 +243,8 @@ func TestSyncEndpoints(t *testing.T) {
 				}
 			}
 
-			err := esController.syncEndpoints(fmt.Sprintf("%s/%s", namespace, endpointsName))
+			logger, _ := ktesting.NewTestContext(t)
+			err := esController.syncEndpoints(logger, fmt.Sprintf("%s/%s", namespace, endpointsName))
 			if err != nil {
 				t.Fatalf("Unexpected error from syncEndpoints: %v", err)
 			}

--- a/pkg/controller/endpointslicemirroring/reconciler.go
+++ b/pkg/controller/endpointslicemirroring/reconciler.go
@@ -62,7 +62,7 @@ type reconciler struct {
 // reconcile takes an Endpoints resource and ensures that corresponding
 // EndpointSlices exist. It creates, updates, or deletes EndpointSlices to
 // ensure the desired set of addresses are represented by EndpointSlices.
-func (r *reconciler) reconcile(endpoints *corev1.Endpoints, existingSlices []*discovery.EndpointSlice) error {
+func (r *reconciler) reconcile(logger klog.Logger, endpoints *corev1.Endpoints, existingSlices []*discovery.EndpointSlice) error {
 	// Calculate desired state.
 	d := newDesiredCalc()
 
@@ -88,7 +88,7 @@ func (r *reconciler) reconcile(endpoints *corev1.Endpoints, existingSlices []*di
 				totalAddressesAdded++
 			} else {
 				numInvalidAddresses++
-				klog.Warningf("Address in %s/%s Endpoints is not a valid IP, it will not be mirrored to an EndpointSlice: %s", endpoints.Namespace, endpoints.Name, address.IP)
+				logger.Info("Address in Endpoints is not a valid IP, it will not be mirrored to an EndpointSlice", "endpoints", klog.KObj(endpoints), "IP", address.IP)
 			}
 		}
 
@@ -103,7 +103,7 @@ func (r *reconciler) reconcile(endpoints *corev1.Endpoints, existingSlices []*di
 				totalAddressesAdded++
 			} else {
 				numInvalidAddresses++
-				klog.Warningf("Address in %s/%s Endpoints is not a valid IP, it will not be mirrored to an EndpointSlice: %s", endpoints.Namespace, endpoints.Name, address.IP)
+				logger.Info("Address in Endpoints is not a valid IP, it will not be mirrored to an EndpointSlice", "endpoints", klog.KObj(endpoints), "IP", address.IP)
 			}
 		}
 
@@ -124,7 +124,7 @@ func (r *reconciler) reconcile(endpoints *corev1.Endpoints, existingSlices []*di
 	// Record a separate event if we skipped mirroring due to the number of
 	// addresses exceeding MaxEndpointsPerSubset.
 	if addressesSkipped > numInvalidAddresses {
-		klog.Warningf("%d addresses in %s/%s Endpoints were skipped due to exceeding MaxEndpointsPerSubset", addressesSkipped, endpoints.Namespace, endpoints.Name)
+		logger.Info("Addresses in Endpoints were skipped due to exceeding MaxEndpointsPerSubset", "skippedAddresses", addressesSkipped, "endpoints", klog.KObj(endpoints))
 		r.eventRecorder.Eventf(endpoints, corev1.EventTypeWarning, TooManyAddressesToMirror,
 			"A max of %d addresses can be mirrored to EndpointSlices per Endpoints subset. %d addresses were skipped", r.maxEndpointsPerSubset, addressesSkipped)
 	}

--- a/pkg/controller/endpointslicemirroring/reconciler_test.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-base/metrics/testutil"
+	"k8s.io/klog/v2/ktesting"
 	endpointsv1 "k8s.io/kubernetes/pkg/api/v1/endpoints"
 	"k8s.io/kubernetes/pkg/controller/endpointslicemirroring/metrics"
 	endpointsliceutil "k8s.io/kubernetes/pkg/controller/util/endpointslice"
@@ -1261,7 +1262,8 @@ func fetchEndpointSlices(t *testing.T, client *fake.Clientset, namespace string)
 
 func reconcileHelper(t *testing.T, r *reconciler, endpoints *corev1.Endpoints, existingSlices []*discovery.EndpointSlice) {
 	t.Helper()
-	err := r.reconcile(endpoints, existingSlices)
+	logger, _ := ktesting.NewTestContext(t)
+	err := r.reconcile(logger, endpoints, existingSlices)
 	if err != nil {
 		t.Fatalf("Expected no error reconciling Endpoint Slices, got: %v", err)
 	}

--- a/test/integration/dualstack/dualstack_endpoints_test.go
+++ b/test/integration/dualstack/dualstack_endpoints_test.go
@@ -100,6 +100,7 @@ func TestDualStackEndpoints(t *testing.T) {
 		1*time.Second)
 
 	epsController := endpointslice.NewController(
+		ctx,
 		informers.Core().V1().Pods(),
 		informers.Core().V1().Services(),
 		informers.Core().V1().Nodes(),
@@ -112,7 +113,7 @@ func TestDualStackEndpoints(t *testing.T) {
 	informers.Start(ctx.Done())
 	// use only one worker to serialize the updates
 	go epController.Run(ctx, 1)
-	go epsController.Run(1, ctx.Done())
+	go epsController.Run(ctx, 1)
 
 	var testcases = []struct {
 		name           string

--- a/test/integration/endpointslice/endpointslicemirroring_test.go
+++ b/test/integration/endpointslice/endpointslicemirroring_test.go
@@ -47,6 +47,7 @@ func TestEndpointSliceMirroring(t *testing.T) {
 		t.Fatalf("Error creating clientset: %v", err)
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	resyncPeriod := 12 * time.Hour
 	informers := informers.NewSharedInformerFactory(client, resyncPeriod)
 
@@ -58,6 +59,7 @@ func TestEndpointSliceMirroring(t *testing.T) {
 		1*time.Second)
 
 	epsController := endpointslice.NewController(
+		ctx,
 		informers.Core().V1().Pods(),
 		informers.Core().V1().Services(),
 		informers.Core().V1().Nodes(),
@@ -75,11 +77,10 @@ func TestEndpointSliceMirroring(t *testing.T) {
 		1*time.Second)
 
 	// Start informer and controllers
-	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	informers.Start(ctx.Done())
 	go epController.Run(ctx, 5)
-	go epsController.Run(5, ctx.Done())
+	go epsController.Run(ctx, 5)
 	go epsmController.Run(5, ctx.Done())
 
 	testCases := []struct {


### PR DESCRIPTION
Signed-off-by: Naman <namanlakhwani@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Convert EndpointSlice functions to structured logging when context parameter is not available, otherwise, convert to contextual logging
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/enhancements/issues/3077

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Migrated the `EndpointSlice` and `EndpointSliceMirroring` controllers (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging
```

/wg structured-logging
/area logging
/assign @pohly