### PR TITLE
fix race in aggregated discovery controller

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
@@ -61,14 +61,10 @@ type DiscoveryAggregationController interface {
 	// Spwans a worker which waits for added/updated apiservices and updates
 	// the unified discovery document by contacting the aggregated api services
 	Run(stopCh <-chan struct{})
-
-	// Returns true if all non-local APIServices that have been added
-	// are synced at least once to the discovery document
-	ExternalServicesSynced() bool
 }
 
 type discoveryManager struct {
-	// Locks `services`
+	// Locks `apiServices`
 	servicesLock sync.RWMutex
 
 	// Map from APIService's name (or a unique string for local servers)
@@ -146,9 +142,6 @@ type groupVersionInfo struct {
 	// This ensures that if the apiservice was changed after the last cached entry
 	// was stored, the discovery document will always be re-fetched.
 	lastMarkedDirty time.Time
-
-	// Last time sync function was run for this GV.
-	lastReconciled time.Time
 
 	// ServiceReference of this GroupVersion. This identifies the Service which
 	// describes how to contact the server responsible for this GroupVersion.
@@ -350,11 +343,7 @@ func (dm *discoveryManager) syncAPIService(apiServiceName string) error {
 	}
 
 	// Lookup last cached result for this apiservice's service.
-	now := time.Now()
 	cached, err := dm.fetchFreshDiscoveryForService(mgv, info)
-
-	info.lastReconciled = now
-	dm.setInfoForAPIService(apiServiceName, &info)
 
 	var entry apidiscoveryv2beta1.APIVersionDiscovery
 
@@ -475,18 +464,6 @@ func (dm *discoveryManager) RemoveAPIService(apiServiceName string) {
 		// mark dirty if there was actually something deleted
 		dm.dirtyAPIServiceQueue.Add(apiServiceName)
 	}
-}
-
-func (dm *discoveryManager) ExternalServicesSynced() bool {
-	dm.servicesLock.RLock()
-	defer dm.servicesLock.RUnlock()
-	for _, info := range dm.apiServices {
-		if info.lastReconciled.IsZero() {
-			return false
-		}
-	}
-
-	return true
 }
 
 //


### PR DESCRIPTION
Discovered by flaking `TestRemoveAPIServer`.

Caused by following sequence:

1. Add APIService to map
2. Begin Async Fetch (takes long time in flaking case)
3. Remove APIService from map
4. Finish Async Fetch & stores apiservice back in map to update lastReconciled time

fixes by removing lastReconciled (only used for testing) so it would not need to be updated.
and switching tests to just waiting until dirty queue is empty

had to put sleeps in the `TestRemoveAPIService` to be able to trigger the bug as well as after `fetchFreshDiscoveryForService` to simulate long-running request, as `stress` could not repro on my system

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

flaky test initially discovered in https://github.com/kubernetes/kubernetes/pull/115230#issuecomment-1398586564

but its also a bug outside of tests

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
