### PR TITLE
kubelet: Fix fs quota monitoring on volumes

### DIFF
--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -301,12 +301,6 @@ func (ed *emptyDir) assignQuota(dir string, mounterSize *resource.Quantity) erro
 		if err != nil {
 			klog.V(3).Infof("Unable to check for quota support on %s: %s", dir, err.Error())
 		} else if hasQuotas {
-			_, err := fsquota.GetQuotaOnDir(ed.mounter, dir)
-			if err != nil {
-				klog.V(4).Infof("Attempt to check quota on dir %s failed: %v", dir, err)
-				// this is not a fatal error so return nil
-				return nil
-			}
 			klog.V(4).Infof("emptydir trying to assign quota %v on %s", mounterSize, dir)
 			if err := fsquota.AssignQuota(ed.mounter, dir, ed.pod.UID, mounterSize); err != nil {
 				klog.V(3).Infof("Set quota on %s failed %s", dir, err.Error())

--- a/pkg/volume/util/fsquota/project.go
+++ b/pkg/volume/util/fsquota/project.go
@@ -190,13 +190,13 @@ func addDirToProject(path string, id common.QuotaID, list *projectsList) (common
 	idMap := make(map[common.QuotaID]bool)
 	for _, project := range list.projects {
 		if project.data == path {
-			if id != project.id {
+			if id != common.BadQuotaID && id != project.id {
 				return common.BadQuotaID, false, fmt.Errorf("attempt to reassign project ID for %s", path)
 			}
 			// Trying to reassign a directory to the project it's
 			// already in.  Maybe this should be an error, but for
 			// now treat it as an idempotent operation
-			return id, false, nil
+			return project.id, false, nil
 		}
 		idMap[project.id] = true
 	}


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:

File system quota monitoring setup fails on subsequent invocations, each time quota setup is invoked a new random UID is generated for each pod and compared with the previously stored UID. 
This PR fixes it by keeping track of mapping between internal uid generated for a pod and actual external pod uid.
If there is already a quota project id associated with the folder it uses that instead of returning an error.
If quota is already set on a folder and the quota is the same it does an early exit.

#### Which issue(s) this PR fixes:
Fixes #114506, #112081, #115309

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
