### PR TITLE
Update NodePorts PreFilter to improve the scheduling efficiency of pod

### DIFF
--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -29,9 +29,11 @@ import (
 // NodePorts is a plugin that checks if a node has free ports for the requested pod ports.
 type NodePorts struct{}
 
-var _ framework.PreFilterPlugin = &NodePorts{}
-var _ framework.FilterPlugin = &NodePorts{}
-var _ framework.EnqueueExtensions = &NodePorts{}
+var (
+	_ framework.PreFilterPlugin   = &NodePorts{}
+	_ framework.FilterPlugin      = &NodePorts{}
+	_ framework.EnqueueExtensions = &NodePorts{}
+)
 
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
@@ -76,6 +78,9 @@ func getContainerPorts(pods ...*v1.Pod) []*v1.ContainerPort {
 // PreFilter invoked at the prefilter extension point.
 func (pl *NodePorts) PreFilter(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod) (*framework.PreFilterResult, *framework.Status) {
 	s := getContainerPorts(pod)
+	if len(s) != 0 {
+		return nil, framework.NewStatus(framework.Skip)
+	}
 	cycleState.Write(preFilterStateKey, preFilterState(s))
 	return nil, nil
 }

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -78,7 +78,8 @@ func getContainerPorts(pods ...*v1.Pod) []*v1.ContainerPort {
 // PreFilter invoked at the prefilter extension point.
 func (pl *NodePorts) PreFilter(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod) (*framework.PreFilterResult, *framework.Status) {
 	s := getContainerPorts(pod)
-	if len(s) != 0 {
+	// Skip if a pod has no ports.
+	if len(s) == 0 {
 		return nil, framework.NewStatus(framework.Skip)
 	}
 	cycleState.Write(preFilterStateKey, preFilterState(s))

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
@@ -18,6 +18,7 @@ package nodeports
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -174,9 +175,13 @@ func TestPreFilterDisabled(t *testing.T) {
 	p, _ := New(nil, nil)
 	cycleState := framework.NewCycleState()
 	gotStatus := p.(framework.FilterPlugin).Filter(context.Background(), cycleState, pod, nodeInfo)
-	wantStatus := framework.AsStatus(fmt.Errorf(`reading "PreFilterNodePorts" from cycleState: %w`, fmt.Errorf("not found")))
-	if diff := cmp.Diff(gotStatus, wantStatus); diff != "" {
-		t.Errorf("status does not match (-want,+got):\n%s", diff)
+	wantStatus := framework.AsStatus(fmt.Errorf(`reading "PreFilterNodePorts" from cycleState: %w`, errors.New("not found")))
+	if gotStatus.AsError().Error() != wantStatus.AsError().Error() {
+		t.Error("err does not match")
+		return
+	}
+	if gotStatus.Message() != wantStatus.Message() {
+		t.Error("message does not match")
 		return
 	}
 }

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
@@ -18,7 +18,6 @@ package nodeports
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -175,12 +174,9 @@ func TestPreFilterDisabled(t *testing.T) {
 	p, _ := New(nil, nil)
 	cycleState := framework.NewCycleState()
 	gotStatus := p.(framework.FilterPlugin).Filter(context.Background(), cycleState, pod, nodeInfo)
-	wantStatus := framework.AsStatus(fmt.Errorf(`reading "PreFilterNodePorts" from cycleState: %w`, errors.New("not found")))
-	cmpopt := cmp.Comparer(func(s1, s2 *framework.Status) bool {
-		return reflect.DeepEqual(s1, s2)
-	})
-	if diff := cmp.Diff(wantStatus, gotStatus, cmpopt); diff != "" {
-		t.Errorf("diff = %s\n", diff)
+	wantStatus := framework.AsStatus(fmt.Errorf(`reading "PreFilterNodePorts" from cycleState: %w`, framework.ErrNotFound))
+	if !reflect.DeepEqual(*wantStatus, *gotStatus) {
+		t.Errorf("status does not match: %v, want: %v", gotStatus, wantStatus)
 		return
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Update NodePorts PreFilter. Kubernetes scheduler skips if pod has no container ports on the NodePorts PreFilter.
This PR will improve the scheduling efficiency of pod.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref https://github.com/kubernetes/kubernetes/issues/114399

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
