### PR TITLE
Fix panic on ClusterIP allocation for /28 subnets

### DIFF
--- a/pkg/registry/core/service/allocator/bitmap.go
+++ b/pkg/registry/core/service/allocator/bitmap.go
@@ -68,6 +68,7 @@ func NewAllocationMap(max int, rangeSpec string) *AllocationBitmap {
 // allows to pass an offset that divides the allocation bitmap in two blocks.
 // The first block of values will not be used for random value assigned by the AllocateNext()
 // method until the second block of values has been exhausted.
+// The offset value must be always smaller than the bitmap size.
 func NewAllocationMapWithOffset(max int, rangeSpec string, offset int) *AllocationBitmap {
 	a := AllocationBitmap{
 		strategy: randomScanStrategyWithOffset{

--- a/pkg/registry/core/service/ipallocator/bitmap.go
+++ b/pkg/registry/core/service/ipallocator/bitmap.go
@@ -83,6 +83,11 @@ func New(cidr *net.IPNet, allocatorFactory allocator.AllocatorWithOffsetFactory)
 	base.Add(base, big.NewInt(1))
 	max--
 
+	// cidr with whole mask can be negative
+	if max < 0 {
+		max = 0
+	}
+
 	r := Range{
 		net:     cidr,
 		base:    base,
@@ -357,7 +362,10 @@ func calculateRangeOffset(cidr *net.IPNet) int {
 	)
 
 	cidrSize := netutils.RangeSize(cidr)
-	if cidrSize < min {
+	// available addresses are always less than the cidr size
+	// A /28 CIDR returns 16 addresses, but 2 of them, the network
+	// and broadcast addresses are not available.
+	if cidrSize <= min {
 		return 0
 	}
 

--- a/pkg/registry/core/service/ipallocator/bitmap_test.go
+++ b/pkg/registry/core/service/ipallocator/bitmap_test.go
@@ -798,7 +798,17 @@ func Test_calculateRangeOffset(t *testing.T) {
 		{
 			name: "small mask IPv4",
 			cidr: "192.168.1.1/28",
+			want: 0,
+		},
+		{
+			name: "small mask IPv4",
+			cidr: "192.168.1.1/27",
 			want: 16,
+		},
+		{
+			name: "small mask IPv6",
+			cidr: "fd00::1/124",
+			want: 0,
 		},
 		{
 			name: "small mask IPv6",


### PR DESCRIPTION
The ClusterIP allocator tries to reserve on part of the ServiceCIDR to allocate static IPs to the Services.

The heuristic of the allocator to obtain the offset was taking into account the whole range size, not the IPs available in the range, the subnet address and the broadcast address for IPv4 are not available.

This caused that for CIDRs with 16 hosts, /28 for IPv4 and /124 for IPv6, the offset calculated was higher than the max number of available addresses on the allocator, causing this to panic.

/kind bug
/kind regression
Fixes #115316

```release-note
Fix a regression in 1.25+ default configurations related to the ServiceIPStaticSubrange feature that caused the API server to panic when trying to allocate a Service with a dynamic ClusterIP and it has been configured with Service CIDRs with a /28 mask for IPv4 and a /124 mask for IPv6
```
