### PR TITLE
[WIP] apiserver: annotate requests that arrive early (server not ready) or late (during shutdown)

### DIFF
--- a/pkg/controlplane/instance_test.go
+++ b/pkg/controlplane/instance_test.go
@@ -42,6 +42,8 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/options"
@@ -99,6 +101,10 @@ func setUp(t *testing.T) (*etcd3testing.EtcdTestServer, Config, *assert.Assertio
 
 	kubeVersion := kubeversion.Get()
 	config.GenericConfig.Authorization.Authorizer = authorizerfactory.NewAlwaysAllowAuthorizer()
+	// setup a fake authenticator
+	config.GenericConfig.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		return &authenticator.Response{User: &user.DefaultInfo{Name: "user"}}, true, nil
+	})
 	config.GenericConfig.Version = &kubeVersion
 	config.ExtraConfig.StorageFactory = storageFactory
 	config.GenericConfig.LoopbackClientConfig = &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: legacyscheme.Codecs}}

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -915,6 +915,9 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	handler = genericapifilters.WithAudit(handler, c.AuditBackend, c.AuditPolicyRuleEvaluator, c.LongRunningFunc)
 	handler = filterlatency.TrackStarted(handler, c.TracerProvider, "audit")
 
+	handler = genericfilters.WithShutdownLateAnnotation(handler, c.lifecycleSignals.ShutdownInitiated, c.ShutdownDelayDuration)
+	handler = genericfilters.WithStartupEarlyAnnotation(handler, c.lifecycleSignals.HasBeenReady)
+
 	failedHandler := genericapifilters.Unauthorized(c.Serializer)
 	failedHandler = genericapifilters.WithFailedAuthenticationAudit(failedHandler, c.AuditBackend, c.AuditPolicyRuleEvaluator)
 

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -115,6 +115,10 @@ func TestNewWithDelegate(t *testing.T) {
 	wrappingConfig.PublicAddress = netutils.ParseIPSloppy("192.168.10.4")
 	wrappingConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	wrappingConfig.LoopbackClientConfig = &rest.Config{}
+	// setup a fake authenticator
+	wrappingConfig.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		return &authenticator.Response{User: &user.DefaultInfo{Name: "user"}}, true, nil
+	})
 
 	wrappingConfig.HealthzChecks = append(wrappingConfig.HealthzChecks, healthz.NamedCheck("wrapping-health", func(r *http.Request) error {
 		return fmt.Errorf("wrapping failed healthcheck")

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/with_early_late_annotations.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/with_early_late_annotations.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/klog/v2"
+	clockutils "k8s.io/utils/clock"
+	netutils "k8s.io/utils/net"
+)
+
+type lifecycleEvent interface {
+	// Name returns the name of the signal, useful for logging.
+	Name() string
+
+	// Signaled returns a channel that is closed when the underlying event
+	// has been signaled. Successive calls to Signaled return the same value.
+	Signaled() <-chan struct{}
+
+	// SignaledAt returns the time the event was signaled. If SignaledAt is
+	// invoked before the event is signaled (zero, false) will be returned.
+	SignaledAt() (time.Time, bool)
+}
+
+type shouldExemptFunc func(*http.Request) bool
+
+var (
+	// the health probes are not annotated by default
+	healthProbes = []string{
+		"/readyz",
+		"/healthz",
+		"/livez",
+	}
+)
+
+func exemptIfHealthProbe(r *http.Request) bool {
+	path := "/" + strings.TrimLeft(r.URL.Path, "/")
+	for _, probe := range healthProbes {
+		if strings.HasPrefix(path, probe) {
+			return true
+		}
+	}
+	return false
+}
+
+// WithShutdownLateAnnotation, if added to the handler chain, tracks the
+// incoming request(s) after the apiserver has initiated the graceful
+// shutdown, and annoates the audit event for these request(s) with
+// diagnostic information.
+// This enables us to identify the actor(s)/load balancer(s) that are sending
+// requests to the apiserver late during the server termination.
+func WithShutdownLateAnnotation(handler http.Handler, shutdownInitiated lifecycleEvent, delayDuration time.Duration) http.Handler {
+	return withShutdownLateAnnotation(handler, shutdownInitiated, delayDuration, exemptIfHealthProbe, clockutils.RealClock{})
+}
+
+func withShutdownLateAnnotation(handler http.Handler, shutdownInitiated lifecycleEvent, delayDuration time.Duration, shouldExemptFn shouldExemptFunc, clock clockutils.PassiveClock) http.Handler {
+	if shutdownInitiated == nil || clock == nil || delayDuration == time.Duration(0) || shouldExemptFn == nil {
+		klog.Warning("WithShutdownLateAnnotation filter is not being added to the handler chain")
+		return handler
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		select {
+		case <-shutdownInitiated.Signaled():
+		default:
+			handler.ServeHTTP(w, req)
+			return
+		}
+
+		requestor, exists := request.UserFrom(req.Context())
+		if !exists {
+			responsewriters.InternalError(w, req, errors.New("no user found for request"))
+			return
+		}
+
+		defer handler.ServeHTTP(w, req)
+
+		if shouldExemptFn(req) {
+			return
+		}
+		shutdownInitiatedAt, ok := shutdownInitiated.SignaledAt()
+		if !ok {
+			return
+		}
+		var isSelf bool
+		if requestor.GetName() == user.APIServerUser {
+			isSelf = true
+		}
+		loopback := isLoopback(req.RemoteAddr)
+
+		elapsedSince := clock.Since(shutdownInitiatedAt)
+		threshold := int(math.Round((float64(elapsedSince) / float64(delayDuration)) * 100))
+		// TODO: 80% is the threshold, if requests arrive after 80% of
+		//  shutdown-delay-duration elapses we annotate the request as late=true.
+		var isLate bool
+		if threshold > 80 {
+			isLate = true
+		}
+
+		audit.AddAuditAnnotation(req.Context(), "apiserver.k8s.io/shutdown",
+			fmt.Sprintf("elapsed=%s threshold=%d%% late=%t self=%t loopback=%t", elapsedSince.Round(time.Second).String(), threshold, isLate, isSelf, loopback))
+	})
+}
+
+func WithStartupEarlyAnnotation(handler http.Handler, hasBeenReady lifecycleEvent) http.Handler {
+	return withStartupEarlyAnnotation(handler, hasBeenReady, exemptIfHealthProbe)
+}
+
+func withStartupEarlyAnnotation(handler http.Handler, hasBeenReady lifecycleEvent, shouldExemptFn shouldExemptFunc) http.Handler {
+	if hasBeenReady == nil || shouldExemptFn == nil {
+		klog.Warning("WithStartupEarlyAnnotation filter is not being added to the handler chain")
+		return handler
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		select {
+		case <-hasBeenReady.Signaled():
+			handler.ServeHTTP(w, req)
+			return
+		default:
+		}
+
+		requestor, exists := request.UserFrom(req.Context())
+		if !exists {
+			responsewriters.InternalError(w, req, errors.New("no user found for request"))
+			return
+		}
+
+		defer handler.ServeHTTP(w, req)
+
+		if requestor.GetName() == user.APIServerUser {
+			return
+		}
+
+		audit.AddAuditAnnotation(req.Context(), "apiserver.k8s.io/startup", fmt.Sprintf("early=true self=false loopback=%t", isLoopback(req.RemoteAddr)))
+	})
+}
+
+func isLoopback(address string) bool {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		// if the address is missing a port, SplitHostPort will return an error
+		// with an empty host, and port value. For such an error, we should
+		// continue and try to parse the original address.
+		host = address
+	}
+	if ip := netutils.ParseIPSloppy(host); ip != nil {
+		return ip.IsLoopback()
+	}
+
+	return false
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/with_early_late_annotations_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/with_early_late_annotations_test.go
@@ -1,0 +1,437 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/audit"
+	authenticationuser "k8s.io/apiserver/pkg/authentication/user"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	utilsclock "k8s.io/utils/clock"
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+func TestWithShutdownLateAnnotation(t *testing.T) {
+	var (
+		shutdownDelayDuration     = 100 * time.Second
+		signaledAt                = time.Now()
+		elapsedAtWithingThreshold = signaledAt.Add(shutdownDelayDuration - 21*time.Second)
+		elapsedAtBeyondThreshold  = signaledAt.Add(shutdownDelayDuration - 19*time.Second)
+	)
+
+	tests := []struct {
+		name                    string
+		shutdownInitiated       func() lifecycleEvent
+		user                    authenticationuser.Info
+		clock                   func() utilsclock.PassiveClock
+		url                     string
+		remoteAddr              string
+		handlerInvoked          int
+		statusCodeExpected      int
+		annotationShouldContain string
+	}{
+		{
+			name: "shutdown is not initiated",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: make(chan struct{})}
+			},
+			handlerInvoked:     1,
+			statusCodeExpected: http.StatusOK,
+		},
+		{
+			name: "shutdown initiated, no user in request context",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel()}
+			},
+			handlerInvoked:     0,
+			statusCodeExpected: http.StatusInternalServerError,
+		},
+		{
+			name: "shutdown initiated, health probes are not annotated",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel()}
+			},
+			url:                "/readyz?verbos=1",
+			user:               &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			handlerInvoked:     1,
+			statusCodeExpected: http.StatusOK,
+		},
+		// use cases where the request will be annotated
+		{
+			name: "shutdown initiated, self=true",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel()}
+			},
+			user:                    &authenticationuser.DefaultInfo{Name: authenticationuser.APIServerUser},
+			handlerInvoked:          1,
+			statusCodeExpected:      http.StatusOK,
+			annotationShouldContain: "self=true",
+		},
+		{
+			name: "shutdown initiated, self=false",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel()}
+			},
+			user:                    &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			handlerInvoked:          1,
+			statusCodeExpected:      http.StatusOK,
+			annotationShouldContain: "self=false",
+		},
+		{
+			name: "shutdown initiated, loopback=true",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel()}
+			},
+			user:                    &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			remoteAddr:              "127.0.0.1:80",
+			handlerInvoked:          1,
+			statusCodeExpected:      http.StatusOK,
+			annotationShouldContain: "loopback=true",
+		},
+		{
+			name: "shutdown initiated, loopback=false",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel()}
+			},
+			user:                    &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			remoteAddr:              "www.foo.bar:80",
+			handlerInvoked:          1,
+			statusCodeExpected:      http.StatusOK,
+			annotationShouldContain: "loopback=false",
+		},
+		{
+			name: "shutdown initiated, within 80%",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{
+					ch: newClosedChannel(),
+					at: signaledAt,
+				}
+			},
+			clock: func() utilsclock.PassiveClock {
+				return clocktesting.NewFakeClock(elapsedAtWithingThreshold)
+			},
+			user:                    &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			handlerInvoked:          1,
+			statusCodeExpected:      http.StatusOK,
+			annotationShouldContain: "elapsed=1m19s threshold=79% late=false self=false loopback=false",
+		},
+		{
+			name: "shutdown initiated, outside 80%",
+			shutdownInitiated: func() lifecycleEvent {
+				return fakeLifecycleSignal{
+					ch: newClosedChannel(),
+					at: signaledAt,
+				}
+			},
+			clock: func() utilsclock.PassiveClock {
+				return clocktesting.NewFakeClock(elapsedAtBeyondThreshold)
+			},
+			user:                    &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			handlerInvoked:          1,
+			statusCodeExpected:      http.StatusOK,
+			annotationShouldContain: "elapsed=1m21s threshold=81% late=true self=false loopback=false",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var handlerInvoked int
+			handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				handlerInvoked++
+				w.WriteHeader(http.StatusOK)
+			})
+
+			event := test.shutdownInitiated()
+			var clock utilsclock.PassiveClock = utilsclock.RealClock{}
+			if test.clock != nil {
+				clock = test.clock()
+			}
+			target := withShutdownLateAnnotation(handler, event, shutdownDelayDuration, exemptIfHealthProbe, clock)
+
+			url := "/api/v1/namespaces"
+			if test.url != "" {
+				url = test.url
+			}
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				t.Fatalf("failed to create new http request - %v", err)
+			}
+			if test.remoteAddr != "" {
+				req.RemoteAddr = test.remoteAddr
+			}
+
+			ctx := req.Context()
+			if test.user != nil {
+				ctx = apirequest.WithUser(ctx, test.user)
+			}
+			ctx = audit.WithAuditContext(ctx)
+			req = req.WithContext(ctx)
+
+			ac := audit.AuditContextFrom(req.Context())
+			if ac == nil {
+				t.Fatalf("expected audit context inside the request context")
+			}
+			ac.Event = &auditinternal.Event{
+				Level: auditinternal.LevelMetadata,
+			}
+
+			w := httptest.NewRecorder()
+			w.Code = 0
+			target.ServeHTTP(w, req)
+
+			if test.handlerInvoked != handlerInvoked {
+				t.Errorf("expected the handler to be invoked: %d timed, but got: %d", test.handlerInvoked, handlerInvoked)
+			}
+			if test.statusCodeExpected != w.Result().StatusCode {
+				t.Errorf("expected status code: %d, but got: %d", test.statusCodeExpected, w.Result().StatusCode)
+			}
+
+			key := "apiserver.k8s.io/shutdown"
+			switch {
+			case len(test.annotationShouldContain) == 0:
+				if valueGot, ok := ac.Event.Annotations[key]; ok {
+					t.Errorf("did not expect annotation to be added, but got: %s", valueGot)
+				}
+			default:
+				if valueGot, ok := ac.Event.Annotations[key]; !ok || !strings.Contains(valueGot, test.annotationShouldContain) {
+					t.Errorf("expected annotation to match, diff: %s", cmp.Diff(test.annotationShouldContain, valueGot))
+				}
+			}
+		})
+	}
+}
+
+func TestWithStartupEarlyAnnotation(t *testing.T) {
+	tests := []struct {
+		name               string
+		readySignalFn      func() lifecycleEvent
+		user               authenticationuser.Info
+		remoteAddr         string
+		handlerInvoked     int
+		statusCodeExpected int
+		annotationExpected string
+	}{
+		{
+			name: "server is ready",
+			readySignalFn: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: newClosedChannel()}
+			},
+			handlerInvoked:     1,
+			statusCodeExpected: http.StatusOK,
+		},
+		{
+			name: "server not ready, no user in request context",
+			readySignalFn: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: make(chan struct{})}
+			},
+			handlerInvoked:     0,
+			statusCodeExpected: http.StatusInternalServerError,
+		},
+		{
+			name: "server not ready, self is true, not annotated",
+			readySignalFn: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: make(chan struct{})}
+			},
+			user:               &authenticationuser.DefaultInfo{Name: authenticationuser.APIServerUser},
+			handlerInvoked:     1,
+			statusCodeExpected: http.StatusOK,
+		},
+		{
+			name: "server not ready, self is false, request is annotated",
+			readySignalFn: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: make(chan struct{})}
+			},
+			user:               &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			handlerInvoked:     1,
+			statusCodeExpected: http.StatusOK,
+			annotationExpected: "early=true self=false loopback=false",
+		},
+		{
+			name: "server not ready, self is false, looback is true, request is annotated",
+			readySignalFn: func() lifecycleEvent {
+				return fakeLifecycleSignal{ch: make(chan struct{})}
+			},
+			user:               &authenticationuser.DefaultInfo{Name: authenticationuser.Anonymous},
+			remoteAddr:         "127.0.0.1:8080",
+			handlerInvoked:     1,
+			statusCodeExpected: http.StatusOK,
+			annotationExpected: "early=true self=false loopback=true",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var handlerInvoked int
+			handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				handlerInvoked++
+				w.WriteHeader(http.StatusOK)
+			})
+
+			event := test.readySignalFn()
+			target := WithStartupEarlyAnnotation(handler, event)
+
+			req, err := http.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+			if err != nil {
+				t.Fatalf("failed to create new http request - %v", err)
+			}
+			if test.remoteAddr != "" {
+				req.RemoteAddr = test.remoteAddr
+			}
+
+			ctx := req.Context()
+			if test.user != nil {
+				ctx = apirequest.WithUser(ctx, test.user)
+			}
+			ctx = audit.WithAuditContext(ctx)
+			req = req.WithContext(ctx)
+
+			ac := audit.AuditContextFrom(req.Context())
+			if ac == nil {
+				t.Fatalf("expected audit context inside the request context")
+			}
+			ac.Event = &auditinternal.Event{
+				Level: auditinternal.LevelMetadata,
+			}
+
+			w := httptest.NewRecorder()
+			w.Code = 0
+			target.ServeHTTP(w, req)
+
+			if test.handlerInvoked != handlerInvoked {
+				t.Errorf("expected the handler to be invoked: %d timed, but got: %d", test.handlerInvoked, handlerInvoked)
+			}
+			if test.statusCodeExpected != w.Result().StatusCode {
+				t.Errorf("expected status code: %d, but got: %d", test.statusCodeExpected, w.Result().StatusCode)
+			}
+
+			key := "apiserver.k8s.io/startup"
+			switch {
+			case len(test.annotationExpected) == 0:
+				if valueGot, ok := ac.Event.Annotations[key]; ok {
+					t.Errorf("did not expect annotation to be added, but got: %s", valueGot)
+				}
+			default:
+				if valueGot, ok := ac.Event.Annotations[key]; !ok || test.annotationExpected != valueGot {
+					t.Errorf("expected annotation: %s, but got: %s", test.annotationExpected, valueGot)
+				}
+			}
+		})
+	}
+}
+
+func TestIsLoopback(t *testing.T) {
+	tests := []struct {
+		address string
+		want    bool
+	}{
+		{
+			address: "www.foo.bar:80",
+			want:    false,
+		},
+		{
+			address: "www.foo.bar",
+			want:    false,
+		},
+		{
+			address: "127.0.0.1:8080",
+			want:    true,
+		},
+		{
+			address: "127.0.0.1",
+			want:    true,
+		},
+		{
+			address: "192.168.0.1",
+			want:    false,
+		},
+		// localhost does not work
+		{
+			address: "localhost:8080",
+			want:    false,
+		},
+		{
+			address: "localhost",
+			want:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.address, func(t *testing.T) {
+			if got := isLoopback(test.address); test.want != got {
+				t.Errorf("expected isLoopback to return: %t, but got: %t", test.want, got)
+			}
+		})
+	}
+}
+
+func TestExemptIfHealthProbe(t *testing.T) {
+	tests := []struct {
+		path   string
+		exempt bool
+	}{
+		{
+			path:   "/apis/v1/foo/bar",
+			exempt: false,
+		},
+		{
+			path:   "/readyz",
+			exempt: true,
+		},
+		{
+			path:   "/healthz?verbose=1",
+			exempt: true,
+		},
+		{
+			path:   "/livez",
+			exempt: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, test.path, nil)
+			if err != nil {
+				t.Fatalf("failed to create new http request - %v", err)
+			}
+			if got := exemptIfHealthProbe(req); test.exempt != got {
+				t.Errorf("expected exemptIfHealthProbe to return: %t, but got: %t", test.exempt, got)
+			}
+		})
+	}
+}
+
+type fakeLifecycleSignal struct {
+	ch <-chan struct{}
+	at time.Time
+}
+
+func (s fakeLifecycleSignal) Name() string                  { return "initiated" }
+func (s fakeLifecycleSignal) Signaled() <-chan struct{}     { return s.ch }
+func (s fakeLifecycleSignal) SignaledAt() (time.Time, bool) { return s.at, true }
+
+func newClosedChannel() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_graceful_termination_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_graceful_termination_test.go
@@ -37,6 +37,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
 	"k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
@@ -1015,6 +1017,10 @@ func newGenericAPIServer(t *testing.T, fAudit *fakeAudit, keepListening bool) *G
 	config.ShutdownWatchTerminationGracePeriod = 2 * time.Second
 	config.AuditPolicyRuleEvaluator = fAudit
 	config.AuditBackend = fAudit
+	// setup a fake authenticator
+	config.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		return &authenticator.Response{User: &user.DefaultInfo{Name: "user"}}, true, nil
+	})
 
 	s, err := config.Complete(nil).New("test", NewEmptyDelegate())
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_graceful_termination_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_graceful_termination_test.go
@@ -1021,6 +1021,7 @@ func newGenericAPIServer(t *testing.T, fAudit *fakeAudit, keepListening bool) *G
 	config.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
 		return &authenticator.Response{User: &user.DefaultInfo{Name: "user"}}, true, nil
 	})
+	config.AnnotateEarlyAndLateRequests = true
 
 	s, err := config.Complete(nil).New("test", NewEmptyDelegate())
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -43,6 +43,8 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apiserver/pkg/apis/example"
 	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/discovery"
 	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
@@ -171,6 +173,9 @@ func TestInstallAPIGroups(t *testing.T) {
 
 	config.LegacyAPIGroupPrefixes = sets.NewString("/apiPrefix")
 	config.DiscoveryAddresses = discovery.DefaultAddresses{DefaultAddress: "ExternalAddress"}
+	config.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		return &authenticator.Response{User: &user.DefaultInfo{Name: "user"}}, true, nil
+	})
 
 	s, err := config.Complete(nil).New("test", NewEmptyDelegate())
 	if err != nil {
@@ -450,6 +455,9 @@ func TestNotRestRoutesHaveAuth(t *testing.T) {
 	authz := mockAuthorizer{}
 
 	config.LegacyAPIGroupPrefixes = sets.NewString("/apiPrefix")
+	config.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		return &authenticator.Response{User: &user.DefaultInfo{Name: "user"}}, true, nil
+	})
 	config.Authorization.Authorizer = &authz
 
 	config.EnableIndex = true

--- a/staging/src/k8s.io/apiserver/pkg/server/lifecycle_signals_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/lifecycle_signals_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+func TestLifecycleSignal(t *testing.T) {
+	signalName := "mysignal"
+	signaledAt := time.Now()
+	clock := clocktesting.NewFakeClock(signaledAt)
+	s := newNamedChannelWrapper(signalName, clock)
+
+	if s.Name() != signalName {
+		t.Errorf("expected signal name to match: %q, but got: %q", signalName, s.Name())
+	}
+	if at, ok := s.SignaledAt(); ok || !at.IsZero() {
+		t.Errorf("expected SignaledAt to return (zero, false) but got: (%s, %t)", at, ok)
+	}
+	select {
+	case <-s.Signaled():
+		t.Errorf("expected the lifecycle event to not be signaled initially")
+	default:
+	}
+
+	s.Signal()
+
+	if at, ok := s.SignaledAt(); !ok || !at.Equal(signaledAt) {
+		t.Errorf("expected SignaledAt to return (%s, true) but got: (%s, %t)", signaledAt, at, ok)
+	}
+	select {
+	case <-s.Signaled():
+	default:
+		t.Errorf("expected the lifecycle event to be signaled")
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -29,6 +29,7 @@ import (
 	"io/ioutil"
 	"math/big"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -40,6 +41,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/discovery"
 	restclient "k8s.io/client-go/rest"
@@ -298,6 +301,10 @@ func TestServerRunWithSNI(t *testing.T) {
 			// get port
 			secureOptions.BindPort = ln.Addr().(*net.TCPAddr).Port
 			config.LoopbackClientConfig = &restclient.Config{}
+			// setup a fake authenticator
+			config.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+				return &authenticator.Response{User: &user.DefaultInfo{Name: "user"}}, true, nil
+			})
 			if err := secureOptions.ApplyTo(&config.SecureServing, &config.LoopbackClientConfig); err != nil {
 				t.Fatalf("failed applying the SecureServingOptions: %v", err)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

add audit annotations to incoming requests that:
- arrive too early (server not fully initialized yet) 
- arrive during the graceful server shutdown window

Why do we need it:
Some HA clusters front their kube-apiserver instances with load balancers, both external and internal. We want to understand how long it takes the load balancers to respect the readiness (/readyz) probes and take an unhealthy apiserver instance out of its pool.
The client (a disruption test), upon receiving an error from its probe, can use the audit ID to fetch the corresponding audit entry, check if it has these annotations.

- I am hoping that this will help toward zero-disruption maintenance of a HA kube cluster.
- This feature is enabled with a new server option `annotate-early-and-late-requests`, by default it is not enabled, in keeping with the current behavior


Below is an example of a request that arrives late:
```
annotations {
  "apiserver.k8s.io/shutdown":"elapsed=1m5s threshold=93% late=true self=false loopback=false",
}
```
it gives us the following information:
- `shutdown-delay-duration` is `70s`. and the request arrived after `1m5s` since the apiserver received the TERM signal
- it's not a kube-apiserver self (loopback to itself) request
- the remote IP is not localhost

Similarly, the following is an annotation from an early request:
```
annotations {
  "apiserver.k8s.io/startup":"early=true self=false loopback=false"
}
```

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
