### PR TITLE
skip scale test for probes

### DIFF
--- a/pkg/kubelet/prober/scale_test.go
+++ b/pkg/kubelet/prober/scale_test.go
@@ -60,14 +60,16 @@ import (
 // Ref: https://github.com/kubernetes/kubernetes/issues/89898#issuecomment-1383207322
 
 func TestTCPPortExhaustion(t *testing.T) {
+	// This test creates a considereable number of connections in a short time
+	// and flakes on constrained environments, thus it is skipped by default.
+	// The test is left for manual verification or experimentation with new
+	// changes on the probes.
+	t.Skip("skipping TCP port exhaustion tests")
+
 	const (
 		numTestPods   = 1
 		numContainers = 600
 	)
-
-	if testing.Short() {
-		t.Skip("skipping TCP port exhaustion in short mode")
-	}
 
 	tests := []struct {
 		name string


### PR DESCRIPTION

/kind flake
/kind regression
```release-note
NONE
```


Skip the test added to verify that the probes are closing fast the sockets so it doesn't run automatically,  the test create a considerable number of connections, and it flakes or fails continuously on constrained environments.

The alternatives of adding it as an e2e is not much better, since we'll need a lot more of resources to replicate it, and seems a bit overwhelming for an e2e test.

The risk is not high, since the feature is covered by unit and e2e tests, this just automates the regression on performance, but is not something we are already doing, see per example Benchmarks.

We leave the test so it can be used for experimentation or on-demand verification of the feature or future features
