### PR TITLE
Automated cherry pick of #115322: Fix panic on ClusterIP allocation for /28 subnets

### DIFF
--- a/pkg/registry/core/service/allocator/bitmap.go
+++ b/pkg/registry/core/service/allocator/bitmap.go
@@ -68,6 +68,7 @@ func NewAllocationMap(max int, rangeSpec string) *AllocationBitmap {
 // allows to pass an offset that divides the allocation bitmap in two blocks.
 // The first block of values will not be used for random value assigned by the AllocateNext()
 // method until the second block of values has been exhausted.
+// The offset value must be always smaller than the bitmap size.
 func NewAllocationMapWithOffset(max int, rangeSpec string, offset int) *AllocationBitmap {
 	a := AllocationBitmap{
 		strategy: randomScanStrategyWithOffset{

--- a/pkg/registry/core/service/ipallocator/allocator.go
+++ b/pkg/registry/core/service/ipallocator/allocator.go
@@ -116,6 +116,11 @@ func New(cidr *net.IPNet, allocatorFactory allocator.AllocatorWithOffsetFactory)
 	base.Add(base, big.NewInt(1))
 	max--
 
+	// cidr with whole mask can be negative
+	if max < 0 {
+		max = 0
+	}
+
 	r := Range{
 		net:     cidr,
 		base:    base,
@@ -393,7 +398,10 @@ func calculateRangeOffset(cidr *net.IPNet) int {
 	)
 
 	cidrSize := netutils.RangeSize(cidr)
-	if cidrSize < min {
+	// available addresses are always less than the cidr size
+	// A /28 CIDR returns 16 addresses, but 2 of them, the network
+	// and broadcast addresses are not available.
+	if cidrSize <= min {
 		return 0
 	}
 

--- a/pkg/registry/core/service/ipallocator/allocator_test.go
+++ b/pkg/registry/core/service/ipallocator/allocator_test.go
@@ -795,7 +795,17 @@ func Test_calculateRangeOffset(t *testing.T) {
 		{
 			name: "small mask IPv4",
 			cidr: "192.168.1.1/28",
+			want: 0,
+		},
+		{
+			name: "small mask IPv4",
+			cidr: "192.168.1.1/27",
 			want: 16,
+		},
+		{
+			name: "small mask IPv6",
+			cidr: "fd00::1/124",
+			want: 0,
 		},
 		{
 			name: "small mask IPv6",


### PR DESCRIPTION
Cherry pick of #115322 on release-1.25.

#115322: Fix panic on ClusterIP allocation for /28 subnets

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a regression in 1.25+ default configurations related to the ServiceIPStaticSubrange feature that caused the API server to panic when trying to allocate a Service with a dynamic ClusterIP and it has been configured with Service CIDRs with a /28 mask for IPv4 and a /124 mask for IPv6
```
