### PR TITLE
Ignore error when we can't find plugin capable of expanding the volum…

### DIFF
--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -280,9 +280,13 @@ func (expc *expandController) syncHandler(ctx context.Context, key string) error
 
 	volumePlugin, err := expc.volumePluginMgr.FindExpandablePluginBySpec(volumeSpec)
 	if err != nil || volumePlugin == nil {
-		msg := fmt.Errorf("didn't find a plugin capable of expanding the volume; " +
-			"waiting for an external controller to process this PVC")
-		klog.Infof("Ignoring the PVC %q (uid: %q) : %v.", key, pvc.UID, msg)
+		msg := "waiting for an external controller to expand this PVC"
+		eventType := v1.EventTypeNormal
+		if err != nil {
+			eventType = v1.EventTypeWarning
+		}
+		expc.recorder.Event(pvc, eventType, events.ExternalExpanding, msg)
+		klog.Infof("waiting for an external controller to expand the PVC %q (uid: %q)", key, pvc.UID)
 		// If we are expecting that an external plugin will handle resizing this volume then
 		// is no point in requeuing this PVC.
 		return nil

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -282,11 +282,6 @@ func (expc *expandController) syncHandler(ctx context.Context, key string) error
 	if err != nil || volumePlugin == nil {
 		msg := fmt.Errorf("didn't find a plugin capable of expanding the volume; " +
 			"waiting for an external controller to process this PVC")
-		eventType := v1.EventTypeNormal
-		if err != nil {
-			eventType = v1.EventTypeWarning
-		}
-		expc.recorder.Event(pvc, eventType, events.ExternalExpanding, fmt.Sprintf("Ignoring the PVC: %v.", msg))
 		klog.Infof("Ignoring the PVC %q (uid: %q) : %v.", key, pvc.UID, msg)
 		// If we are expecting that an external plugin will handle resizing this volume then
 		// is no point in requeuing this PVC.


### PR DESCRIPTION
The error message here is confusing and hence we should just not log any events and let external-resizer handle the expansion.

