### PR TITLE
Automated cherry pick of #115179: Fix nil pointer error in nodevolumelimits csi logging

### DIFF
--- a/pkg/scheduler/framework/fake/listers.go
+++ b/pkg/scheduler/framework/fake/listers.go
@@ -257,12 +257,16 @@ func (nodes NodeInfoLister) HavePodsWithRequiredAntiAffinityList() ([]*framework
 var _ storagelisters.CSINodeLister = CSINodeLister{}
 
 // CSINodeLister declares a storagev1.CSINode type for testing.
-type CSINodeLister storagev1.CSINode
+type CSINodeLister []storagev1.CSINode
 
 // Get returns a fake CSINode object.
 func (n CSINodeLister) Get(name string) (*storagev1.CSINode, error) {
-	csiNode := storagev1.CSINode(n)
-	return &csiNode, nil
+	for _, cn := range n {
+		if cn.Name == name {
+			return &cn, nil
+		}
+	}
+	return nil, fmt.Errorf("csiNode %q not found", name)
 }
 
 // List lists all CSINodes in the indexer.

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -231,8 +231,12 @@ func (pl *CSILimits) checkAttachableInlineVolume(vol v1.Volume, csiNode *storage
 		return fmt.Errorf("looking up provisioner name for volume %v: %w", vol, err)
 	}
 	if !isCSIMigrationOn(csiNode, inTreeProvisionerName) {
+		csiNodeName := ""
+		if csiNode != nil {
+			csiNodeName = csiNode.Name
+		}
 		klog.V(5).InfoS("CSI Migration is not enabled for provisioner", "provisioner", inTreeProvisionerName,
-			"pod", klog.KObj(pod), "csiNode", csiNode.Name)
+			"pod", klog.KObj(pod), "csiNode", csiNodeName)
 		return nil
 	}
 	// Do translation for the in-tree volume.


### PR DESCRIPTION
Cherry pick of #115179 on release-1.26.

#115179: Fix nil pointer error in nodevolumelimits csi logging

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix 1.25 regression causing a nil pointer error in nodevolumelimits csi logging
```
