### PR TITLE
[KMSv2] store hash of encrypted DEK as key in cache

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/cache.go
@@ -18,8 +18,11 @@ limitations under the License.
 package kmsv2
 
 import (
-	"encoding/base64"
+	"crypto/sha256"
+	"hash"
+	"sync"
 	"time"
+	"unsafe"
 
 	utilcache "k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/apiserver/pkg/storage/value"
@@ -29,18 +32,26 @@ import (
 type simpleCache struct {
 	cache *utilcache.Expiring
 	ttl   time.Duration
+	// hashPool is a per cache pool of hash.Hash (to avoid allocations from building the Hash)
+	// SHA-256 is used to prevent collisions
+	hashPool *sync.Pool
 }
 
 func newSimpleCache(clock clock.Clock, ttl time.Duration) *simpleCache {
 	return &simpleCache{
 		cache: utilcache.NewExpiringWithClock(clock),
 		ttl:   ttl,
+		hashPool: &sync.Pool{
+			New: func() interface{} {
+				return sha256.New()
+			},
+		},
 	}
 }
 
 // given a key, return the transformer, or nil if it does not exist in the cache
 func (c *simpleCache) get(key []byte) value.Transformer {
-	record, ok := c.cache.Get(base64.StdEncoding.EncodeToString(key))
+	record, ok := c.cache.Get(c.keyFunc(key))
 	if !ok {
 		return nil
 	}
@@ -55,5 +66,25 @@ func (c *simpleCache) set(key []byte, transformer value.Transformer) {
 	if transformer == nil {
 		panic("transformer must not be nil")
 	}
-	c.cache.Set(base64.StdEncoding.EncodeToString(key), transformer, c.ttl)
+	c.cache.Set(c.keyFunc(key), transformer, c.ttl)
+}
+
+// keyFunc generates a string key by hashing the inputs.
+// This lowers the memory requirement of the cache.
+func (c *simpleCache) keyFunc(s []byte) string {
+	h := c.hashPool.Get().(hash.Hash)
+	h.Reset()
+
+	if _, err := h.Write(s); err != nil {
+		panic(err) // Write() on hash never fails
+	}
+	key := toString(h.Sum(nil)) // skip base64 encoding to save an allocation
+	c.hashPool.Put(h)
+
+	return key
+}
+
+// toString performs unholy acts to avoid allocations
+func toString(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
 }


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Store hash of encrypted DEK as key in cache. The implementation was done referencing `cache_token_authenticator` https://github.com/kubernetes/kubernetes/blob/97ab147537f6999249c241e0896245bd961c32ae/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator.go#L81-L84

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
