### PR TITLE
dynamic resource allocation: avoid apiserver complaint about list content

### DIFF
--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha1_openapi.json
@@ -466,7 +466,10 @@
               "default": {}
             },
             "type": "array",
-            "x-kubernetes-list-type": "set"
+            "x-kubernetes-list-map-keys": [
+              "uid"
+            ],
+            "x-kubernetes-list-type": "map"
           }
         },
         "type": "object"

--- a/pkg/apis/resource/validation/validation_resourceclaim_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaim_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/resource"
@@ -395,7 +396,7 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 						resource.ResourceClaimConsumerReference{
 							Resource: "pods",
 							Name:     fmt.Sprintf("foo-%d", i),
-							UID:      "1",
+							UID:      types.UID(fmt.Sprintf("%d", i)),
 						})
 				}
 				return claim
@@ -410,7 +411,7 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 						resource.ResourceClaimConsumerReference{
 							Resource: "pods",
 							Name:     fmt.Sprintf("foo-%d", i),
-							UID:      "1",
+							UID:      types.UID(fmt.Sprintf("%d", i)),
 						})
 				}
 				return claim
@@ -425,19 +426,15 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 						resource.ResourceClaimConsumerReference{
 							Resource: "pods",
 							Name:     fmt.Sprintf("foo-%d", i),
-							UID:      "1",
+							UID:      types.UID(fmt.Sprintf("%d", i)),
 						})
 				}
 				return claim
 			},
 		},
 		"invalid-reserved-for-duplicate": {
-			wantFailures: field.ErrorList{field.Duplicate(field.NewPath("status", "reservedFor").Index(1), resource.ResourceClaimConsumerReference{
-				Resource: "pods",
-				Name:     "foo",
-				UID:      "1",
-			})},
-			oldClaim: validAllocatedClaim,
+			wantFailures: field.ErrorList{field.Duplicate(field.NewPath("status", "reservedFor").Index(1).Child("uid"), types.UID("1"))},
+			oldClaim:     validAllocatedClaim,
 			update: func(claim *resource.ResourceClaim) *resource.ResourceClaim {
 				for i := 0; i < 2; i++ {
 					claim.Status.ReservedFor = append(claim.Status.ReservedFor,
@@ -463,7 +460,7 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 						resource.ResourceClaimConsumerReference{
 							Resource: "pods",
 							Name:     fmt.Sprintf("foo-%d", i),
-							UID:      "1",
+							UID:      types.UID(fmt.Sprintf("%d", i)),
 						})
 				}
 				return claim

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -41280,7 +41280,10 @@ func schema_k8sio_api_resource_v1alpha1_ResourceClaimStatus(ref common.Reference
 					"reservedFor": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"uid",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{

--- a/staging/src/k8s.io/api/resource/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1alpha1/generated.proto
@@ -248,7 +248,8 @@ message ResourceClaimStatus {
   // There can be at most 32 such reservations. This may get increased in
   // the future, but not reduced.
   //
-  // +listType=set
+  // +listType=map
+  // +listMapKey=uid
   // +optional
   repeated ResourceClaimConsumerReference reservedFor = 3;
 

--- a/staging/src/k8s.io/api/resource/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha1/types.go
@@ -112,7 +112,8 @@ type ResourceClaimStatus struct {
 	// There can be at most 32 such reservations. This may get increased in
 	// the future, but not reduced.
 	//
-	// +listType=set
+	// +listType=map
+	// +listMapKey=uid
 	// +optional
 	ReservedFor []ResourceClaimConsumerReference `json:"reservedFor,omitempty" protobuf:"bytes,3,opt,name=reservedFor"`
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -11415,6 +11415,8 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             namedType: io.k8s.api.resource.v1alpha1.ResourceClaimConsumerReference
           elementRelationship: associative
+          keys:
+          - uid
 - name: io.k8s.api.resource.v1alpha1.ResourceClaimTemplate
   map:
     fields:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This fixes the following warning (error?) in the apiserver:

    E0126 18:10:38.665239   16370 fieldmanager.go:210] "[SHOULD NOT HAPPEN] failed to update managedFields" err="failed to convert new object (test/claim-84; resource.k8s.io/v1alpha1, Kind=ResourceClaim) to smd typed: .status.reservedFor: element 0: associative list without keys has an element that's a map type" VersionKind="/, Kind=" namespace="test" name="claim-84"

The root cause is the same as in e50e8a0c919c0e02dc9a0ffaebb685d5348027b4: nothing in Kubernetes outright complains about a list of items where the item type is comparable in Go, but not a simple type. This nonetheless isn't supposed to be done in the API and can causes problems elsewhere.

For the ReservedFor field, everything seems to work okay except for the warning. However, it's better to follow conventions and use a map. This is possible in this case because UID is guaranteed to be a unique key.

#### Which issue(s) this PR fixes:
Fixes #115330

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?
```release-note
A fix in the resource.k8s.io/v1alpha1/ResourceClaim API avoids harmless (?) ".status.reservedFor: element 0: associative list without keys has an element that's a map type" errors in the apiserver. Validation now rejects the incorrect reuse of the same UID in different entries.
```