### PR TITLE
client-go: add DNS resolver latency metrics

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -930,7 +930,7 @@ func (r *Request) newHTTPRequest(ctx context.Context) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	req = req.WithContext(httptrace.WithClientTrace(req.Context(), newDNSMetricsTrace(ctx)))
+	req = req.WithContext(httptrace.WithClientTrace(ctx, newDNSMetricsTrace(ctx)))
 	req.Header = r.headers
 	return req, nil
 }

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -947,10 +947,12 @@ func newDNSMetricsTrace(ctx context.Context) *httptrace.ClientTrace {
 	return &httptrace.ClientTrace{
 		DNSStart: func(info httptrace.DNSStartInfo) {
 			dns.Lock()
+			defer dns.Unlock()
 			dns.start = time.Now()
 			dns.host = info.Host
 		},
 		DNSDone: func(info httptrace.DNSDoneInfo) {
+			dns.Lock()
 			defer dns.Unlock()
 			metrics.ResolverLatency.Observe(ctx, dns.host, time.Since(dns.start))
 		},

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -926,16 +926,15 @@ func (r *Request) newHTTPRequest(ctx context.Context) (*http.Request, error) {
 	}
 
 	url := r.URL().String()
-	req, err := http.NewRequest(r.verb, url, body)
+	req, err := http.NewRequestWithContext(httptrace.WithClientTrace(ctx, newDNSMetricsTrace(ctx)), r.verb, url, body)
 	if err != nil {
 		return nil, err
 	}
-	req = req.WithContext(httptrace.WithClientTrace(ctx, newDNSMetricsTrace(ctx)))
 	req.Header = r.headers
 	return req, nil
 }
 
-// newDNSMetricsTrace returns an HTTP trace that tracks time spend on DNS lookups per network/host.
+// newDNSMetricsTrace returns an HTTP trace that tracks time spent on DNS lookups per host.
 // This metric is available in client as "rest_client_dns_resolution_duration_seconds".
 func newDNSMetricsTrace(ctx context.Context) *httptrace.ClientTrace {
 	type dnsMetric struct {

--- a/staging/src/k8s.io/client-go/tools/metrics/metrics.go
+++ b/staging/src/k8s.io/client-go/tools/metrics/metrics.go
@@ -42,6 +42,10 @@ type LatencyMetric interface {
 	Observe(ctx context.Context, verb string, u url.URL, latency time.Duration)
 }
 
+type ResolverLatencyMetric interface {
+	Observe(ctx context.Context, host string, latency time.Duration)
+}
+
 // SizeMetric observes client response size partitioned by verb and host.
 type SizeMetric interface {
 	Observe(ctx context.Context, verb string, host string, size float64)
@@ -82,6 +86,8 @@ var (
 	ClientCertRotationAge DurationMetric = noopDuration{}
 	// RequestLatency is the latency metric that rest clients will update.
 	RequestLatency LatencyMetric = noopLatency{}
+	// ResolverLatency is the latency metric that DNS resolver will update
+	ResolverLatency ResolverLatencyMetric = noopResolverLatency{}
 	// RequestSize is the request size metric that rest clients will update.
 	RequestSize SizeMetric = noopSize{}
 	// ResponseSize is the response size metric that rest clients will update.
@@ -109,6 +115,7 @@ type RegisterOpts struct {
 	ClientCertExpiry      ExpiryMetric
 	ClientCertRotationAge DurationMetric
 	RequestLatency        LatencyMetric
+	ResolverLatency       ResolverLatencyMetric
 	RequestSize           SizeMetric
 	ResponseSize          SizeMetric
 	RateLimiterLatency    LatencyMetric
@@ -131,6 +138,9 @@ func Register(opts RegisterOpts) {
 		}
 		if opts.RequestLatency != nil {
 			RequestLatency = opts.RequestLatency
+		}
+		if opts.ResolverLatency != nil {
+			ResolverLatency = opts.ResolverLatency
 		}
 		if opts.RequestSize != nil {
 			RequestSize = opts.RequestSize
@@ -170,6 +180,11 @@ func (noopExpiry) Set(*time.Time) {}
 type noopLatency struct{}
 
 func (noopLatency) Observe(context.Context, string, url.URL, time.Duration) {}
+
+type noopResolverLatency struct{}
+
+func (n noopResolverLatency) Observe(ctx context.Context, host string, latency time.Duration) {
+}
 
 type noopSize struct{}
 

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
@@ -42,11 +42,11 @@ var (
 	)
 
 	// resolverLatency is a Prometheus Histogram metric type partitioned by
-	// "network", and "address" labels. It is used for the rest client DNS resolver latency metrics.
+	// "host" labels. It is used for the rest client DNS resolver latency metrics.
 	resolverLatency = k8smetrics.NewHistogramVec(
 		&k8smetrics.HistogramOpts{
 			Name:           "rest_client_dns_resolution_duration_seconds",
-			Help:           "DNS resolver latency in seconds. Broken down by network, and address.",
+			Help:           "DNS resolver latency in seconds. Broken down by host.",
 			StabilityLevel: k8smetrics.ALPHA,
 			Buckets:        []float64{0.005, 0.025, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0},
 		},

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
@@ -41,6 +41,18 @@ var (
 		[]string{"verb", "host"},
 	)
 
+	// resolverLatency is a Prometheus Histogram metric type partitioned by
+	// "network", and "address" labels. It is used for the rest client DNS resolver latency metrics.
+	resolverLatency = k8smetrics.NewHistogramVec(
+		&k8smetrics.HistogramOpts{
+			Name:           "rest_client_dns_resolution_duration_seconds",
+			Help:           "DNS resolver latency in seconds. Broken down by network, and address.",
+			StabilityLevel: k8smetrics.ALPHA,
+			Buckets:        []float64{0.005, 0.025, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0},
+		},
+		[]string{"host"},
+	)
+
 	requestSize = k8smetrics.NewHistogramVec(
 		&k8smetrics.HistogramOpts{
 			Name:           "rest_client_request_size_bytes",
@@ -189,6 +201,7 @@ func init() {
 		ClientCertExpiry:      execPluginCertTTLAdapter,
 		ClientCertRotationAge: &rotationAdapter{m: execPluginCertRotation},
 		RequestLatency:        &latencyAdapter{m: requestLatency},
+		ResolverLatency:       &resolverLatencyAdapter{m: resolverLatency},
 		RequestSize:           &sizeAdapter{m: requestSize},
 		ResponseSize:          &sizeAdapter{m: responseSize},
 		RateLimiterLatency:    &latencyAdapter{m: rateLimiterLatency},
@@ -206,6 +219,14 @@ type latencyAdapter struct {
 
 func (l *latencyAdapter) Observe(ctx context.Context, verb string, u url.URL, latency time.Duration) {
 	l.m.WithContext(ctx).WithLabelValues(verb, u.Host).Observe(latency.Seconds())
+}
+
+type resolverLatencyAdapter struct {
+	m *k8smetrics.HistogramVec
+}
+
+func (l *resolverLatencyAdapter) Observe(ctx context.Context, host string, latency time.Duration) {
+	l.m.WithContext(ctx).WithLabelValues(host).Observe(latency.Seconds())
 }
 
 type sizeAdapter struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

DNS failures and resolving latencies today are impossible to track in client-go metrics. If the request timeout is, for example, set to 5s, and DNS resolving takes 4s, then the request might timeout, but the reason why it failed is hidden from admins.
This PR adds a new Prometheus metric `rest_client_dns_resolution_duration_seconds` that observes the DNS resolver latencies and existing request latency.

> It’s not DNS
> There’s no way it’s DNS
> It was DNS

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

```release-note
Allow to monitor client-go DNS resolver latencies via `rest_client_dns_resolution_duration_seconds` Prometheus metric
```