### PR TITLE
More code-review changes from k/utlils cpuset review

### DIFF
--- a/pkg/kubelet/cm/cpuset/cpuset.go
+++ b/pkg/kubelet/cm/cpuset/cpuset.go
@@ -230,7 +230,7 @@ func Parse(s string) (CPUSet, error) {
 				return New(), err
 			}
 			if start > end {
-				return New(), fmt.Errorf("invalid range %q (%d >= %d)", r, start, end)
+				return New(), fmt.Errorf("invalid range %q (%d > %d)", r, start, end)
 			}
 			// start == end is acceptable (1-1 -> 1)
 

--- a/pkg/kubelet/cm/cpuset/cpuset_test.go
+++ b/pkg/kubelet/cm/cpuset/cpuset_test.go
@@ -35,7 +35,7 @@ func TestCPUSetSize(t *testing.T) {
 	for _, c := range testCases {
 		actual := c.cpuset.Size()
 		if actual != c.expected {
-			t.Fatalf("expected: %d, actual: %d, cpuset: [%v]", c.expected, actual, c.cpuset)
+			t.Errorf("expected: %d, actual: %d, cpuset: [%v]", c.expected, actual, c.cpuset)
 		}
 	}
 }
@@ -53,7 +53,7 @@ func TestCPUSetIsEmpty(t *testing.T) {
 	for _, c := range testCases {
 		actual := c.cpuset.IsEmpty()
 		if actual != c.expected {
-			t.Fatalf("expected: %t, IsEmpty() returned: %t, cpuset: [%v]", c.expected, actual, c.cpuset)
+			t.Errorf("expected: %t, IsEmpty() returned: %t, cpuset: [%v]", c.expected, actual, c.cpuset)
 		}
 	}
 }
@@ -72,12 +72,12 @@ func TestCPUSetContains(t *testing.T) {
 	for _, c := range testCases {
 		for _, elem := range c.mustContain {
 			if !c.cpuset.Contains(elem) {
-				t.Fatalf("expected cpuset to contain element %d: [%v]", elem, c.cpuset)
+				t.Errorf("expected cpuset to contain element %d: [%v]", elem, c.cpuset)
 			}
 		}
 		for _, elem := range c.mustNotContain {
 			if c.cpuset.Contains(elem) {
-				t.Fatalf("expected cpuset not to contain element %d: [%v]", elem, c.cpuset)
+				t.Errorf("expected cpuset not to contain element %d: [%v]", elem, c.cpuset)
 			}
 		}
 	}
@@ -108,12 +108,12 @@ func TestCPUSetEqual(t *testing.T) {
 
 	for _, c := range shouldEqual {
 		if !c.s1.Equals(c.s2) {
-			t.Fatalf("expected cpusets to be equal: s1: [%v], s2: [%v]", c.s1, c.s2)
+			t.Errorf("expected cpusets to be equal: s1: [%v], s2: [%v]", c.s1, c.s2)
 		}
 	}
 	for _, c := range shouldNotEqual {
 		if c.s1.Equals(c.s2) {
-			t.Fatalf("expected cpusets to not be equal: s1: [%v], s2: [%v]", c.s1, c.s2)
+			t.Errorf("expected cpusets to not be equal: s1: [%v], s2: [%v]", c.s1, c.s2)
 		}
 	}
 }
@@ -151,12 +151,12 @@ func TestCPUSetIsSubsetOf(t *testing.T) {
 
 	for _, c := range shouldBeSubset {
 		if !c.s1.IsSubsetOf(c.s2) {
-			t.Fatalf("expected s1 to be a subset of s2: s1: [%v], s2: [%v]", c.s1, c.s2)
+			t.Errorf("expected s1 to be a subset of s2: s1: [%v], s2: [%v]", c.s1, c.s2)
 		}
 	}
 	for _, c := range shouldNotBeSubset {
 		if c.s1.IsSubsetOf(c.s2) {
-			t.Fatalf("expected s1 to not be a subset of s2: s1: [%v], s2: [%v]", c.s1, c.s2)
+			t.Errorf("expected s1 to not be a subset of s2: s1: [%v], s2: [%v]", c.s1, c.s2)
 		}
 	}
 }
@@ -193,7 +193,7 @@ func TestCPUSetUnion(t *testing.T) {
 	for _, c := range testCases {
 		result := c.s1.Union(c.others...)
 		if !result.Equals(c.expected) {
-			t.Fatalf("expected the union of s1 and s2 to be [%v] (got [%v]), others: [%v]", c.expected, result, c.others)
+			t.Errorf("expected the union of s1 and s2 to be [%v] (got [%v]), others: [%v]", c.expected, result, c.others)
 		}
 	}
 }
@@ -224,7 +224,7 @@ func TestCPUSetIntersection(t *testing.T) {
 	for _, c := range testCases {
 		result := c.s1.Intersection(c.s2)
 		if !result.Equals(c.expected) {
-			t.Fatalf("expected the intersection of s1 and s2 to be [%v] (got [%v]), s1: [%v], s2: [%v]", c.expected, result, c.s1, c.s2)
+			t.Errorf("expected the intersection of s1 and s2 to be [%v] (got [%v]), s1: [%v], s2: [%v]", c.expected, result, c.s1, c.s2)
 		}
 	}
 }
@@ -255,7 +255,7 @@ func TestCPUSetDifference(t *testing.T) {
 	for _, c := range testCases {
 		result := c.s1.Difference(c.s2)
 		if !result.Equals(c.expected) {
-			t.Fatalf("expected the difference of s1 and s2 to be [%v] (got [%v]), s1: [%v], s2: [%v]", c.expected, result, c.s1, c.s2)
+			t.Errorf("expected the difference of s1 and s2 to be [%v] (got [%v]), s1: [%v], s2: [%v]", c.expected, result, c.s1, c.s2)
 		}
 	}
 }
@@ -274,7 +274,7 @@ func TestCPUSetList(t *testing.T) {
 	for _, c := range testCases {
 		result := c.set.List()
 		if !reflect.DeepEqual(result, c.expected) {
-			t.Fatalf("unexpected List() contents. got [%v] want [%v] (set: [%v])", result, c.expected, c.set)
+			t.Errorf("unexpected List() contents. got [%v] want [%v] (set: [%v])", result, c.expected, c.set)
 		}
 
 		// We cannot rely on internal storage order details for a unit test.
@@ -282,7 +282,7 @@ func TestCPUSetList(t *testing.T) {
 		result = c.set.UnsortedList()
 		sort.Ints(result)
 		if !reflect.DeepEqual(result, c.expected) {
-			t.Fatalf("unexpected UnsortedList() contents. got [%v] want [%v] (set: [%v])", result, c.expected, c.set)
+			t.Errorf("unexpected UnsortedList() contents. got [%v] want [%v] (set: [%v])", result, c.expected, c.set)
 		}
 	}
 }
@@ -301,7 +301,7 @@ func TestCPUSetString(t *testing.T) {
 	for _, c := range testCases {
 		result := c.set.String()
 		if result != c.expected {
-			t.Fatalf("expected set as string to be %s (got \"%s\"), s: [%v]", c.expected, result, c.set)
+			t.Errorf("expected set as string to be %s (got \"%s\"), s: [%v]", c.expected, result, c.set)
 		}
 	}
 }
@@ -324,10 +324,10 @@ func TestParse(t *testing.T) {
 	for _, c := range positiveTestCases {
 		result, err := Parse(c.cpusetString)
 		if err != nil {
-			t.Fatalf("expected error not to have occurred: %v", err)
+			t.Errorf("expected error not to have occurred: %v", err)
 		}
 		if !result.Equals(c.expected) {
-			t.Fatalf("expected string \"%s\" to parse as [%v] (got [%v])", c.cpusetString, c.expected, result)
+			t.Errorf("expected string \"%s\" to parse as [%v] (got [%v])", c.cpusetString, c.expected, result)
 		}
 	}
 
@@ -343,7 +343,7 @@ func TestParse(t *testing.T) {
 	for _, c := range negativeTestCases {
 		result, err := Parse(c)
 		if err == nil {
-			t.Fatalf("expected parse failure of \"%s\", but it succeeded as \"%s\"", c, result.String())
+			t.Errorf("expected parse failure of \"%s\", but it succeeded as \"%s\"", c, result.String())
 		}
 	}
 }


### PR DESCRIPTION
More preparation for cpuset to be moved into k/utils

Small second round code review changes before import in https://github.com/kubernetes/utils/pull/267

https://github.com/kubernetes/kubernetes/issues/112899

/kind cleanup