### PR TITLE
[WIP] InitContainer type alias and basic renaming

### DIFF
--- a/pkg/api/pod/util_test.go
+++ b/pkg/api/pod/util_test.go
@@ -56,7 +56,7 @@ func TestVisitContainers(t *testing.T) {
 					{Name: "c1"},
 					{Name: "c2"},
 				},
-				InitContainers: []api.Container{
+				InitContainers: []api.InitContainer{
 					{Name: "i1"},
 					{Name: "i2"},
 				},
@@ -75,7 +75,7 @@ func TestVisitContainers(t *testing.T) {
 					{Name: "c1"},
 					{Name: "c2"},
 				},
-				InitContainers: []api.Container{
+				InitContainers: []api.InitContainer{
 					{Name: "i1"},
 					{Name: "i2"},
 				},
@@ -94,7 +94,7 @@ func TestVisitContainers(t *testing.T) {
 					{Name: "c1"},
 					{Name: "c2"},
 				},
-				InitContainers: []api.Container{
+				InitContainers: []api.InitContainer{
 					{Name: "i1"},
 					{Name: "i2"},
 				},
@@ -113,7 +113,7 @@ func TestVisitContainers(t *testing.T) {
 					{Name: "c1"},
 					{Name: "c2"},
 				},
-				InitContainers: []api.Container{
+				InitContainers: []api.InitContainer{
 					{Name: "i1"},
 					{Name: "i2"},
 				},
@@ -132,7 +132,7 @@ func TestVisitContainers(t *testing.T) {
 					{Name: "c1"},
 					{Name: "c2", SecurityContext: &api.SecurityContext{}},
 				},
-				InitContainers: []api.Container{
+				InitContainers: []api.InitContainer{
 					{Name: "i1"},
 					{Name: "i2", SecurityContext: &api.SecurityContext{}},
 				},
@@ -151,7 +151,7 @@ func TestVisitContainers(t *testing.T) {
 					{Name: "c1"},
 					{Name: "c2", SecurityContext: &api.SecurityContext{}},
 				},
-				InitContainers: []api.Container{
+				InitContainers: []api.InitContainer{
 					{Name: "i1"},
 					{Name: "i2", SecurityContext: &api.SecurityContext{}},
 				},
@@ -218,7 +218,7 @@ func TestPodSecrets(t *testing.T) {
 								Name: "Spec.Containers[*].Env[*].ValueFrom.SecretKeyRef"}}}}}}},
 			ImagePullSecrets: []api.LocalObjectReference{{
 				Name: "Spec.ImagePullSecrets"}},
-			InitContainers: []api.Container{{
+			InitContainers: []api.InitContainer{{
 				EnvFrom: []api.EnvFromSource{{
 					SecretRef: &api.SecretEnvSource{
 						LocalObjectReference: api.LocalObjectReference{
@@ -424,7 +424,7 @@ func TestPodConfigmaps(t *testing.T) {
 							ConfigMapKeyRef: &api.ConfigMapKeySelector{
 								LocalObjectReference: api.LocalObjectReference{
 									Name: "Spec.EphemeralContainers[*].EphemeralContainerCommon.Env[*].ValueFrom.ConfigMapKeyRef"}}}}}}}},
-			InitContainers: []api.Container{{
+			InitContainers: []api.InitContainer{{
 				EnvFrom: []api.EnvFromSource{{
 					ConfigMapRef: &api.ConfigMapEnvSource{
 						LocalObjectReference: api.LocalObjectReference{
@@ -602,7 +602,7 @@ func TestDropProcMount(t *testing.T) {
 			Spec: api.PodSpec{
 				RestartPolicy:  api.RestartPolicyNever,
 				Containers:     []api.Container{{Name: "container1", Image: "testimage", SecurityContext: &api.SecurityContext{ProcMount: &procMount}}},
-				InitContainers: []api.Container{{Name: "container1", Image: "testimage", SecurityContext: &api.SecurityContext{ProcMount: &procMount}}},
+				InitContainers: []api.InitContainer{{Name: "container1", Image: "testimage", SecurityContext: &api.SecurityContext{ProcMount: &procMount}}},
 			},
 		}
 	}
@@ -611,7 +611,7 @@ func TestDropProcMount(t *testing.T) {
 			Spec: api.PodSpec{
 				RestartPolicy:  api.RestartPolicyNever,
 				Containers:     []api.Container{{Name: "container1", Image: "testimage", SecurityContext: &api.SecurityContext{ProcMount: &defaultProcMount}}},
-				InitContainers: []api.Container{{Name: "container1", Image: "testimage", SecurityContext: &api.SecurityContext{ProcMount: &defaultProcMount}}},
+				InitContainers: []api.InitContainer{{Name: "container1", Image: "testimage", SecurityContext: &api.SecurityContext{ProcMount: &defaultProcMount}}},
 			},
 		}
 	}
@@ -620,7 +620,7 @@ func TestDropProcMount(t *testing.T) {
 			Spec: api.PodSpec{
 				RestartPolicy:  api.RestartPolicyNever,
 				Containers:     []api.Container{{Name: "container1", Image: "testimage", SecurityContext: &api.SecurityContext{ProcMount: nil}}},
-				InitContainers: []api.Container{{Name: "container1", Image: "testimage", SecurityContext: &api.SecurityContext{ProcMount: nil}}},
+				InitContainers: []api.InitContainer{{Name: "container1", Image: "testimage", SecurityContext: &api.SecurityContext{ProcMount: nil}}},
 			},
 		}
 	}
@@ -796,7 +796,7 @@ func TestDropDynamicResourceAllocation(t *testing.T) {
 					},
 				},
 			},
-			InitContainers: []api.Container{
+			InitContainers: []api.InitContainer{
 				{
 					Resources: api.ResourceRequirements{
 						Claims: []api.ResourceClaim{{Name: "my-claim"}},
@@ -825,7 +825,7 @@ func TestDropDynamicResourceAllocation(t *testing.T) {
 	podWithoutClaims := &api.Pod{
 		Spec: api.PodSpec{
 			Containers:          []api.Container{{}},
-			InitContainers:      []api.Container{{}},
+			InitContainers:      []api.InitContainer{{}},
 			EphemeralContainers: []api.EphemeralContainer{{}},
 		},
 	}

--- a/pkg/api/pod/warnings_test.go
+++ b/pkg/api/pod/warnings_test.go
@@ -66,7 +66,7 @@ func BenchmarkNoWarnings(b *testing.B) {
 				{Name: "secret1"},
 				{Name: "secret2"},
 			},
-			InitContainers: []api.Container{
+			InitContainers: []api.InitContainer{
 				{Name: "init1", Env: env, Resources: api.ResourceRequirements{Requests: resources, Limits: resources}},
 				{Name: "init2", Env: env, Resources: api.ResourceRequirements{Requests: resources, Limits: resources}},
 			},
@@ -113,7 +113,7 @@ func BenchmarkWarnings(b *testing.B) {
 				{Name: "secret1"},
 				{Name: ""},
 			},
-			InitContainers: []api.Container{
+			InitContainers: []api.InitContainer{
 				{Name: "init1", Env: env, Resources: api.ResourceRequirements{Requests: resources, Limits: resources}},
 				{Name: "init2", Env: env, Resources: api.ResourceRequirements{Requests: resources, Limits: resources}},
 			},
@@ -270,7 +270,7 @@ func TestWarnings(t *testing.T) {
 		{
 			name: "duplicate env",
 			template: &api.PodTemplateSpec{Spec: api.PodSpec{
-				InitContainers: []api.Container{{Env: []api.EnvVar{
+				InitContainers: []api.InitContainer{{Env: []api.EnvVar{
 					{Name: "a"},
 					{Name: "a"},
 					{Name: "a"},
@@ -291,7 +291,7 @@ func TestWarnings(t *testing.T) {
 		{
 			name: "fractional resources",
 			template: &api.PodTemplateSpec{Spec: api.PodSpec{
-				InitContainers: []api.Container{{
+				InitContainers: []api.InitContainer{{
 					Resources: api.ResourceRequirements{Requests: resources, Limits: resources},
 				}},
 				Containers: []api.Container{{

--- a/pkg/api/v1/pod/util_test.go
+++ b/pkg/api/v1/pod/util_test.go
@@ -220,7 +220,7 @@ func TestVisitContainers(t *testing.T) {
 					{Name: "c1"},
 					{Name: "c2"},
 				},
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{Name: "i1"},
 					{Name: "i2"},
 				},
@@ -239,7 +239,7 @@ func TestVisitContainers(t *testing.T) {
 					{Name: "c1"},
 					{Name: "c2"},
 				},
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{Name: "i1"},
 					{Name: "i2"},
 				},
@@ -258,7 +258,7 @@ func TestVisitContainers(t *testing.T) {
 					{Name: "c1"},
 					{Name: "c2"},
 				},
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{Name: "i1"},
 					{Name: "i2"},
 				},
@@ -277,7 +277,7 @@ func TestVisitContainers(t *testing.T) {
 					{Name: "c1"},
 					{Name: "c2"},
 				},
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{Name: "i1"},
 					{Name: "i2"},
 				},
@@ -296,7 +296,7 @@ func TestVisitContainers(t *testing.T) {
 					{Name: "c1"},
 					{Name: "c2", SecurityContext: &v1.SecurityContext{}},
 				},
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{Name: "i1"},
 					{Name: "i2", SecurityContext: &v1.SecurityContext{}},
 				},
@@ -315,7 +315,7 @@ func TestVisitContainers(t *testing.T) {
 					{Name: "c1"},
 					{Name: "c2", SecurityContext: &v1.SecurityContext{}},
 				},
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{Name: "i1"},
 					{Name: "i2", SecurityContext: &v1.SecurityContext{}},
 				},
@@ -382,7 +382,7 @@ func TestPodSecrets(t *testing.T) {
 								Name: "Spec.Containers[*].Env[*].ValueFrom.SecretKeyRef"}}}}}}},
 			ImagePullSecrets: []v1.LocalObjectReference{{
 				Name: "Spec.ImagePullSecrets"}},
-			InitContainers: []v1.Container{{
+			InitContainers: []v1.InitContainer{{
 				EnvFrom: []v1.EnvFromSource{{
 					SecretRef: &v1.SecretEnvSource{
 						LocalObjectReference: v1.LocalObjectReference{
@@ -588,7 +588,7 @@ func TestPodConfigmaps(t *testing.T) {
 							ConfigMapKeyRef: &v1.ConfigMapKeySelector{
 								LocalObjectReference: v1.LocalObjectReference{
 									Name: "Spec.EphemeralContainers[*].EphemeralContainerCommon.Env[*].ValueFrom.ConfigMapKeyRef"}}}}}}}},
-			InitContainers: []v1.Container{{
+			InitContainers: []v1.InitContainer{{
 				EnvFrom: []v1.EnvFromSource{{
 					ConfigMapRef: &v1.ConfigMapEnvSource{
 						LocalObjectReference: v1.LocalObjectReference{

--- a/pkg/api/v1/resource/helpers_test.go
+++ b/pkg/api/v1/resource/helpers_test.go
@@ -470,7 +470,7 @@ func TestPodRequestsAndLimitsWithoutOverhead(t *testing.T) {
 							},
 						},
 					},
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Name: "small-init",
 							Resources: v1.ResourceRequirements{
@@ -562,7 +562,7 @@ func getPod(cname string, resources podResources) *v1.Pod {
 					Resources: r,
 				},
 			},
-			InitContainers: []v1.Container{
+			InitContainers: []v1.InitContainer{
 				{
 					Name:      "init-" + cname,
 					Resources: r,

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -84,7 +84,7 @@ func getValidPodTemplateSpecForGenerated(selector *metav1.LabelSelector) api.Pod
 			RestartPolicy:  api.RestartPolicyOnFailure,
 			DNSPolicy:      api.DNSClusterFirst,
 			Containers:     []api.Container{{Name: "abc", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: api.TerminationMessageReadFile}},
-			InitContainers: []api.Container{{Name: "def", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: api.TerminationMessageReadFile}},
+			InitContainers: []api.InitContainer{{Name: "def", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: api.TerminationMessageReadFile}},
 		},
 	}
 }

--- a/pkg/apis/core/pods/helpers_test.go
+++ b/pkg/apis/core/pods/helpers_test.go
@@ -52,7 +52,7 @@ func TestVisitContainersWithPath(t *testing.T) {
 			"init containers",
 			field.NewPath("spec"),
 			&api.PodSpec{
-				InitContainers: []api.Container{
+				InitContainers: []api.InitContainer{
 					{Name: "i1"},
 					{Name: "i2"},
 				},
@@ -67,7 +67,7 @@ func TestVisitContainersWithPath(t *testing.T) {
 					{Name: "c1"},
 					{Name: "c2"},
 				},
-				InitContainers: []api.Container{
+				InitContainers: []api.InitContainer{
 					{Name: "i1"},
 					{Name: "i2"},
 				},
@@ -96,7 +96,7 @@ func TestVisitContainersWithPath(t *testing.T) {
 					{Name: "c1"},
 					{Name: "c2"},
 				},
-				InitContainers: []api.Container{
+				InitContainers: []api.InitContainer{
 					{Name: "i1"},
 					{Name: "i2"},
 				},
@@ -115,7 +115,7 @@ func TestVisitContainersWithPath(t *testing.T) {
 					{Name: "c1"},
 					{Name: "c2"},
 				},
-				InitContainers: []api.Container{
+				InitContainers: []api.InitContainer{
 					{Name: "i1"},
 					{Name: "i2"},
 				},

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2205,7 +2205,10 @@ type ResourceClaim struct {
 	Name string
 }
 
-// Container represents a single container that is expected to be run on the host.
+// A single application container that you want to run within a pod.
+type InitContainer = Container
+
+// A single application container that you want to run within a pod.
 type Container struct {
 	// Required: This must be a DNS_LABEL.  Each container in a pod must
 	// have a unique name.
@@ -2871,7 +2874,7 @@ type PodReadinessGate struct {
 type PodSpec struct {
 	Volumes []Volume
 	// List of initialization containers belonging to the pod.
-	InitContainers []Container
+	InitContainers []InitContainer
 	// List of containers belonging to the pod.
 	Containers []Container
 	// List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing

--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -759,7 +759,7 @@ func TestSetDefaultReplicationControllerInitContainers(t *testing.T) {
 				Spec: v1.ReplicationControllerSpec{
 					Template: &v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
-							InitContainers: []v1.Container{
+							InitContainers: []v1.InitContainer{
 								{
 									Name:  "install",
 									Image: "busybox",
@@ -782,7 +782,7 @@ func TestSetDefaultReplicationControllerInitContainers(t *testing.T) {
 				Spec: v1.ReplicationControllerSpec{
 					Template: &v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
-							InitContainers: []v1.Container{
+							InitContainers: []v1.InitContainer{
 								{
 									Name:  "fun",
 									Image: "alpine",
@@ -826,7 +826,7 @@ func TestSetDefaultReplicationControllerInitContainers(t *testing.T) {
 				Spec: v1.ReplicationControllerSpec{
 					Template: &v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
-							InitContainers: []v1.Container{
+							InitContainers: []v1.InitContainer{
 								{
 									Name:  "fun",
 									Image: "alpine",
@@ -859,7 +859,7 @@ func TestSetDefaultReplicationControllerInitContainers(t *testing.T) {
 				Spec: v1.ReplicationControllerSpec{
 					Template: &v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
-							InitContainers: []v1.Container{
+							InitContainers: []v1.InitContainer{
 								{
 									Name:  "fun",
 									Image: "alpine",
@@ -901,7 +901,7 @@ func TestSetDefaultReplicationControllerInitContainers(t *testing.T) {
 				Spec: v1.ReplicationControllerSpec{
 					Template: &v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
-							InitContainers: []v1.Container{
+							InitContainers: []v1.InitContainer{
 								{
 									Name:  "fun",
 									Image: "alpine",
@@ -961,7 +961,7 @@ func TestSetDefaultReplicationControllerInitContainers(t *testing.T) {
 				Spec: v1.ReplicationControllerSpec{
 					Template: &v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
-							InitContainers: []v1.Container{
+							InitContainers: []v1.InitContainer{
 								{
 									Name:  "fun",
 									Image: "alpine",

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -8746,7 +8746,7 @@ func TestValidatePodSpec(t *testing.T) {
 				{Name: "vol", VolumeSource: core.VolumeSource{EmptyDir: &core.EmptyDirVolumeSource{}}},
 			},
 			Containers:     []core.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
-			InitContainers: []core.Container{{Name: "ictr", Image: "iimage", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
+			InitContainers: []core.InitContainer{{Name: "ictr", Image: "iimage", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
 			RestartPolicy:  core.RestartPolicyAlways,
 			NodeSelector: map[string]string{
 				"key": "value",
@@ -8761,7 +8761,7 @@ func TestValidatePodSpec(t *testing.T) {
 				{Name: "vol", VolumeSource: core.VolumeSource{EmptyDir: &core.EmptyDirVolumeSource{}}},
 			},
 			Containers:     []core.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
-			InitContainers: []core.Container{{Name: "ictr", Image: "iimage", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
+			InitContainers: []core.InitContainer{{Name: "ictr", Image: "iimage", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
 			RestartPolicy:  core.RestartPolicyAlways,
 			NodeSelector: map[string]string{
 				"key": "value",
@@ -8923,7 +8923,7 @@ func TestValidatePodSpec(t *testing.T) {
 		},
 		"bad init container": {
 			Containers:     []core.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
-			InitContainers: []core.Container{{}},
+			InitContainers: []core.InitContainer{{}},
 			RestartPolicy:  core.RestartPolicyAlways,
 			DNSPolicy:      core.DNSClusterFirst,
 		},
@@ -9609,7 +9609,7 @@ func TestValidatePod(t *testing.T) {
 				},
 			},
 			Spec: core.PodSpec{
-				InitContainers: []core.Container{{Name: "init-ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
+				InitContainers: []core.InitContainer{{Name: "init-ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
 				Containers:     []core.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
 				RestartPolicy:  core.RestartPolicyAlways,
 				DNSPolicy:      core.DNSClusterFirst,
@@ -9655,7 +9655,7 @@ func TestValidatePod(t *testing.T) {
 		"valid extended resources for init container": {
 			ObjectMeta: metav1.ObjectMeta{Name: "valid-extended", Namespace: "ns"},
 			Spec: core.PodSpec{
-				InitContainers: []core.Container{
+				InitContainers: []core.InitContainer{
 					{
 						Name:            "valid-extended",
 						Image:           "image",
@@ -9679,7 +9679,7 @@ func TestValidatePod(t *testing.T) {
 		"valid extended resources for regular container": {
 			ObjectMeta: metav1.ObjectMeta{Name: "valid-extended", Namespace: "ns"},
 			Spec: core.PodSpec{
-				InitContainers: []core.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
+				InitContainers: []core.InitContainer{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
 				Containers: []core.Container{
 					{
 						Name:            "valid-extended",
@@ -10460,7 +10460,7 @@ func TestValidatePod(t *testing.T) {
 					},
 				},
 				Spec: core.PodSpec{
-					InitContainers: []core.Container{{Name: "init-ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
+					InitContainers: []core.InitContainer{{Name: "init-ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
 					Containers:     []core.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
 					RestartPolicy:  core.RestartPolicyAlways,
 					DNSPolicy:      core.DNSClusterFirst,
@@ -10592,7 +10592,7 @@ func TestValidatePod(t *testing.T) {
 			spec: core.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: "ns"},
 				Spec: core.PodSpec{
-					InitContainers: []core.Container{
+					InitContainers: []core.InitContainer{
 						{
 							Name:            "invalid",
 							Image:           "image",
@@ -10640,7 +10640,7 @@ func TestValidatePod(t *testing.T) {
 			spec: core.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: "ns"},
 				Spec: core.PodSpec{
-					InitContainers: []core.Container{
+					InitContainers: []core.InitContainer{
 						{
 							Name:            "invalid",
 							Image:           "image",
@@ -11008,7 +11008,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					Name: "foo",
 				},
 				Spec: core.PodSpec{
-					InitContainers: []core.Container{
+					InitContainers: []core.InitContainer{
 						{
 							Image: "foo:V1",
 						},
@@ -11018,7 +11018,7 @@ func TestValidatePodUpdate(t *testing.T) {
 			old: core.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: core.PodSpec{
-					InitContainers: []core.Container{
+					InitContainers: []core.InitContainer{
 						{
 							Image: "foo:V2",
 						},
@@ -11101,7 +11101,7 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: core.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: core.PodSpec{
-					InitContainers: []core.Container{
+					InitContainers: []core.InitContainer{
 						{
 							Name:                     "container",
 							Image:                    "foo:V1",
@@ -11114,7 +11114,7 @@ func TestValidatePodUpdate(t *testing.T) {
 			old: core.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: core.PodSpec{
-					InitContainers: []core.Container{
+					InitContainers: []core.InitContainer{
 						{
 							Name:                     "container",
 							Image:                    "foo:V2",
@@ -11160,7 +11160,7 @@ func TestValidatePodUpdate(t *testing.T) {
 			new: core.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: core.PodSpec{
-					InitContainers: []core.Container{
+					InitContainers: []core.InitContainer{
 						{
 							Name:                     "container",
 							TerminationMessagePolicy: "File",
@@ -11172,7 +11172,7 @@ func TestValidatePodUpdate(t *testing.T) {
 			old: core.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: core.PodSpec{
-					InitContainers: []core.Container{
+					InitContainers: []core.InitContainer{
 						{
 							Name:                     "container",
 							Image:                    "foo:V2",
@@ -20909,7 +20909,7 @@ func TestValidatePodTemplateSpecSeccomp(t *testing.T) {
 							TerminationMessagePolicy: core.TerminationMessageFallbackToLogsOnError,
 						},
 					},
-					InitContainers: []core.Container{
+					InitContainers: []core.InitContainer{
 						{
 							Name: "init-test",
 							SecurityContext: &core.SecurityContext{
@@ -21286,7 +21286,7 @@ func TestValidateWindowsHostProcessPod(t *testing.T) {
 						},
 					},
 				}},
-				InitContainers: []core.Container{{
+				InitContainers: []core.InitContainer{{
 					Name: containerName,
 					SecurityContext: &core.SecurityContext{
 						WindowsOptions: &core.WindowsSecurityContextOptions{
@@ -21312,7 +21312,7 @@ func TestValidateWindowsHostProcessPod(t *testing.T) {
 						},
 					},
 				}},
-				InitContainers: []core.Container{{
+				InitContainers: []core.InitContainer{{
 					Name: containerName,
 					SecurityContext: &core.SecurityContext{
 						WindowsOptions: &core.WindowsSecurityContextOptions{
@@ -21338,7 +21338,7 @@ func TestValidateWindowsHostProcessPod(t *testing.T) {
 						},
 					},
 				}},
-				InitContainers: []core.Container{{
+				InitContainers: []core.InitContainer{{
 					Name: containerName,
 					SecurityContext: &core.SecurityContext{
 						WindowsOptions: &core.WindowsSecurityContextOptions{
@@ -21364,7 +21364,7 @@ func TestValidateWindowsHostProcessPod(t *testing.T) {
 						},
 					},
 				}},
-				InitContainers: []core.Container{{
+				InitContainers: []core.InitContainer{{
 					Name: containerName,
 				}},
 			},
@@ -21388,7 +21388,7 @@ func TestValidateWindowsHostProcessPod(t *testing.T) {
 						},
 					},
 				}},
-				InitContainers: []core.Container{{
+				InitContainers: []core.InitContainer{{
 					Name: containerName,
 					SecurityContext: &core.SecurityContext{
 						WindowsOptions: &core.WindowsSecurityContextOptions{
@@ -21447,7 +21447,7 @@ func TestValidateWindowsHostProcessPod(t *testing.T) {
 						},
 					},
 				}},
-				InitContainers: []core.Container{{
+				InitContainers: []core.InitContainer{{
 					Name: containerName,
 				}},
 			},
@@ -21471,7 +21471,7 @@ func TestValidateWindowsHostProcessPod(t *testing.T) {
 						},
 					},
 				}},
-				InitContainers: []core.Container{{
+				InitContainers: []core.InitContainer{{
 					Name: containerName,
 				}},
 			},
@@ -21803,7 +21803,7 @@ func TestValidateDynamicResourceAllocation(t *testing.T) {
 		},
 		"init container": {
 			Containers:     []core.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File", Resources: core.ResourceRequirements{Claims: []core.ResourceClaim{{Name: "my-claim"}}}}},
-			InitContainers: []core.Container{{Name: "ctr-init", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File", Resources: core.ResourceRequirements{Claims: []core.ResourceClaim{{Name: "my-claim"}}}}},
+			InitContainers: []core.InitContainer{{Name: "ctr-init", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File", Resources: core.ResourceRequirements{Claims: []core.ResourceClaim{{Name: "my-claim"}}}}},
 			RestartPolicy:  core.RestartPolicyAlways,
 			DNSPolicy:      core.DNSClusterFirst,
 			ResourceClaims: []core.PodResourceClaim{

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -174,7 +174,7 @@ func makeMultiContainerPod(initCPUs, appCPUs []struct{ request, limit string }) 
 			UID:  "podUID",
 		},
 		Spec: v1.PodSpec{
-			InitContainers: []v1.Container{},
+			InitContainers: []v1.InitContainer{},
 			Containers:     []v1.Container{},
 		},
 	}
@@ -800,7 +800,7 @@ func TestReconcileState(t *testing.T) {
 						UID:  "fakePodUID",
 					},
 					Spec: v1.PodSpec{
-						InitContainers: []v1.Container{
+						InitContainers: []v1.InitContainer{
 							{
 								Name: "fakeContainerName",
 							},

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -1082,7 +1082,7 @@ func TestInitContainerDeviceAllocation(t *testing.T) {
 			UID: uuid.NewUUID(),
 		},
 		Spec: v1.PodSpec{
-			InitContainers: []v1.Container{
+			InitContainers: []v1.InitContainer{
 				{
 					Name: string(uuid.NewUUID()),
 					Resources: v1.ResourceRequirements{

--- a/pkg/kubelet/cm/devicemanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints_test.go
@@ -676,7 +676,7 @@ func TestGetPodDeviceRequest(t *testing.T) {
 			description: "Init container requests device plugin resource",
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
@@ -696,7 +696,7 @@ func TestGetPodDeviceRequest(t *testing.T) {
 			description: "Init containers request device plugin resource",
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
@@ -745,7 +745,7 @@ func TestGetPodDeviceRequest(t *testing.T) {
 			description: "Init containers and user containers request the same amount of device plugin resources",
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
@@ -798,7 +798,7 @@ func TestGetPodDeviceRequest(t *testing.T) {
 			description: "Init containers request more device plugin resources than user containers",
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
@@ -850,7 +850,7 @@ func TestGetPodDeviceRequest(t *testing.T) {
 			description: "User containers request more device plugin resources than init containers",
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
@@ -1517,7 +1517,7 @@ func getPodScopeTestCases() []topologyHintTestCase {
 					UID: "fakePod",
 				},
 				Spec: v1.PodSpec{
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{

--- a/pkg/kubelet/cm/helpers_linux_test.go
+++ b/pkg/kubelet/cm/helpers_linux_test.go
@@ -260,7 +260,7 @@ func TestResourceConfigForPod(t *testing.T) {
 							Resources: getResourceRequirements(getResourceList("100m", "100m"), getResourceList("", "")),
 						},
 					},
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Resources: getResourceRequirements(getResourceList("100m", "100m"), getResourceList("100m", "100Mi")),
 						},

--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -336,7 +336,7 @@ func TestGetContainerSpec(t *testing.T) {
 					Containers: []v1.Container{
 						{Name: "plain-ole-container"},
 					},
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{Name: "init-container"},
 					},
 				},
@@ -351,7 +351,7 @@ func TestGetContainerSpec(t *testing.T) {
 					Containers: []v1.Container{
 						{Name: "plain-ole-container"},
 					},
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{Name: "init-container"},
 					},
 				},
@@ -366,7 +366,7 @@ func TestGetContainerSpec(t *testing.T) {
 					Containers: []v1.Container{
 						{Name: "plain-ole-container"},
 					},
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{Name: "init-container"},
 					},
 					EphemeralContainers: []v1.EphemeralContainer{
@@ -532,7 +532,7 @@ func TestHasPrivilegedContainer(t *testing.T) {
 	for k, v := range tests {
 		pod := &v1.Pod{
 			Spec: v1.PodSpec{
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{SecurityContext: v.securityContext},
 				},
 			},

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -1966,7 +1966,7 @@ func TestPodPhaseWithRestartAlways(t *testing.T) {
 func TestPodPhaseWithRestartAlwaysInitContainers(t *testing.T) {
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
-		InitContainers: []v1.Container{
+		InitContainers: []v1.InitContainer{
 			{Name: "containerX"},
 		},
 		Containers: []v1.Container{
@@ -2169,7 +2169,7 @@ func TestPodPhaseWithRestartNever(t *testing.T) {
 func TestPodPhaseWithRestartNeverInitContainers(t *testing.T) {
 	desiredState := v1.PodSpec{
 		NodeName: "machine",
-		InitContainers: []v1.Container{
+		InitContainers: []v1.InitContainer{
 			{Name: "containerX"},
 		},
 		Containers: []v1.Container{

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -718,7 +718,7 @@ func TestPruneInitContainers(t *testing.T) {
 			Namespace: "new",
 		},
 		Spec: v1.PodSpec{
-			InitContainers: []v1.Container{init1, init2},
+			InitContainers: []v1.InitContainer{init1, init2},
 		},
 	}
 

--- a/pkg/kubelet/status/generate_test.go
+++ b/pkg/kubelet/status/generate_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -321,12 +321,12 @@ func TestGeneratePodReadyCondition(t *testing.T) {
 func TestGeneratePodInitializedCondition(t *testing.T) {
 	noInitContainer := &v1.PodSpec{}
 	oneInitContainer := &v1.PodSpec{
-		InitContainers: []v1.Container{
+		InitContainers: []v1.InitContainer{
 			{Name: "1234"},
 		},
 	}
 	twoInitContainer := &v1.PodSpec{
-		InitContainers: []v1.Container{
+		InitContainers: []v1.InitContainer{
 			{Name: "1234"},
 			{Name: "5678"},
 		},

--- a/pkg/quota/v1/evaluator/core/pods_test.go
+++ b/pkg/quota/v1/evaluator/core/pods_test.go
@@ -42,7 +42,7 @@ func TestPodConstraintsFunc(t *testing.T) {
 		"init container resource missing": {
 			pod: &api.Pod{
 				Spec: api.PodSpec{
-					InitContainers: []api.Container{{
+					InitContainers: []api.InitContainer{{
 						Name: "dummy",
 						Resources: api.ResourceRequirements{
 							Requests: api.ResourceList{api.ResourceCPU: resource.MustParse("1m")},
@@ -57,7 +57,7 @@ func TestPodConstraintsFunc(t *testing.T) {
 		"multiple init container resource missing": {
 			pod: &api.Pod{
 				Spec: api.PodSpec{
-					InitContainers: []api.Container{{
+					InitContainers: []api.InitContainer{{
 						Name: "foo",
 						Resources: api.ResourceRequirements{
 							Requests: api.ResourceList{api.ResourceCPU: resource.MustParse("1m")},
@@ -157,7 +157,7 @@ func TestPodEvaluatorUsage(t *testing.T) {
 		"init container CPU": {
 			pod: &api.Pod{
 				Spec: api.PodSpec{
-					InitContainers: []api.Container{{
+					InitContainers: []api.InitContainer{{
 						Resources: api.ResourceRequirements{
 							Requests: api.ResourceList{api.ResourceCPU: resource.MustParse("1m")},
 							Limits:   api.ResourceList{api.ResourceCPU: resource.MustParse("2m")},
@@ -176,7 +176,7 @@ func TestPodEvaluatorUsage(t *testing.T) {
 		"init container MEM": {
 			pod: &api.Pod{
 				Spec: api.PodSpec{
-					InitContainers: []api.Container{{
+					InitContainers: []api.InitContainer{{
 						Resources: api.ResourceRequirements{
 							Requests: api.ResourceList{api.ResourceMemory: resource.MustParse("1m")},
 							Limits:   api.ResourceList{api.ResourceMemory: resource.MustParse("2m")},
@@ -195,7 +195,7 @@ func TestPodEvaluatorUsage(t *testing.T) {
 		"init container local ephemeral storage": {
 			pod: &api.Pod{
 				Spec: api.PodSpec{
-					InitContainers: []api.Container{{
+					InitContainers: []api.InitContainer{{
 						Resources: api.ResourceRequirements{
 							Requests: api.ResourceList{api.ResourceEphemeralStorage: resource.MustParse("32Mi")},
 							Limits:   api.ResourceList{api.ResourceEphemeralStorage: resource.MustParse("64Mi")},
@@ -214,7 +214,7 @@ func TestPodEvaluatorUsage(t *testing.T) {
 		"init container hugepages": {
 			pod: &api.Pod{
 				Spec: api.PodSpec{
-					InitContainers: []api.Container{{
+					InitContainers: []api.InitContainer{{
 						Resources: api.ResourceRequirements{
 							Requests: api.ResourceList{api.ResourceName(api.ResourceHugePagesPrefix + "2Mi"): resource.MustParse("100Mi")},
 						},
@@ -231,7 +231,7 @@ func TestPodEvaluatorUsage(t *testing.T) {
 		"init container extended resources": {
 			pod: &api.Pod{
 				Spec: api.PodSpec{
-					InitContainers: []api.Container{{
+					InitContainers: []api.InitContainer{{
 						Resources: api.ResourceRequirements{
 							Requests: api.ResourceList{api.ResourceName("example.com/dongle"): resource.MustParse("3")},
 							Limits:   api.ResourceList{api.ResourceName("example.com/dongle"): resource.MustParse("3")},
@@ -357,7 +357,7 @@ func TestPodEvaluatorUsage(t *testing.T) {
 		"init container maximums override sum of containers": {
 			pod: &api.Pod{
 				Spec: api.PodSpec{
-					InitContainers: []api.Container{
+					InitContainers: []api.InitContainer{
 						{
 							Resources: api.ResourceRequirements{
 								Requests: api.ResourceList{

--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -500,7 +500,7 @@ func TestCheckLogLocation(t *testing.T) {
 						{Name: "container1"},
 						{Name: "container2"},
 					},
-					InitContainers: []api.Container{
+					InitContainers: []api.InitContainer{
 						{Name: "initcontainer1"},
 					},
 				},
@@ -518,7 +518,7 @@ func TestCheckLogLocation(t *testing.T) {
 						{Name: "container1"},
 						{Name: "container2"},
 					},
-					InitContainers: []api.Container{
+					InitContainers: []api.InitContainer{
 						{Name: "initcontainer1"},
 					},
 					EphemeralContainers: []api.EphemeralContainer{
@@ -846,7 +846,7 @@ func TestPodStrategyValidate(t *testing.T) {
 				Spec: api.PodSpec{
 					RestartPolicy: api.RestartPolicyAlways,
 					DNSPolicy:     api.DNSDefault,
-					InitContainers: []api.Container{{
+					InitContainers: []api.InitContainer{{
 						Name:                     containerName,
 						Image:                    "image",
 						ImagePullPolicy:          "IfNotPresent",
@@ -874,7 +874,7 @@ func TestPodStrategyValidate(t *testing.T) {
 				Spec: api.PodSpec{
 					RestartPolicy: api.RestartPolicyAlways,
 					DNSPolicy:     api.DNSDefault,
-					InitContainers: []api.Container{{
+					InitContainers: []api.InitContainer{{
 						Name:                     containerName,
 						Image:                    "image",
 						ImagePullPolicy:          "IfNotPresent",

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -625,7 +625,7 @@ func TestNodeInfoAddPod(t *testing.T) {
 						},
 					},
 				},
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
@@ -789,7 +789,7 @@ func TestNodeInfoAddPod(t *testing.T) {
 								},
 							},
 						},
-						InitContainers: []v1.Container{
+						InitContainers: []v1.InitContainer{
 							{
 								Resources: v1.ResourceRequirements{
 									Requests: v1.ResourceList{

--- a/pkg/scheduler/metrics/resources/resources_test.go
+++ b/pkg/scheduler/metrics/resources/resources_test.go
@@ -52,7 +52,7 @@ func Test_podResourceCollector_Handler(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
 			Spec: v1.PodSpec{
 				NodeName: "node-one",
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{Resources: v1.ResourceRequirements{
 						Requests: v1.ResourceList{
 							"cpu":    resource.MustParse("2"),
@@ -133,7 +133,7 @@ func Test_podResourceCollector_CollectWithStability(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
 					Spec: v1.PodSpec{
-						InitContainers: []v1.Container{},
+						InitContainers: []v1.InitContainer{},
 						Containers:     []v1.Container{},
 					},
 				},
@@ -169,7 +169,7 @@ func Test_podResourceCollector_CollectWithStability(t *testing.T) {
 					},
 				},
 			},
-			expected: `      
+			expected: `
 				# HELP kube_pod_resource_limit [ALPHA] Resources limit for workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
 				# TYPE kube_pod_resource_limit gauge
 				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 1
@@ -222,7 +222,7 @@ func Test_podResourceCollector_CollectWithStability(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo-pending"},
 					Spec: v1.PodSpec{
 						NodeName: "node-one",
-						InitContainers: []v1.Container{
+						InitContainers: []v1.InitContainer{
 							{Resources: v1.ResourceRequirements{Requests: v1.ResourceList{"cpu": resource.MustParse("1")}}},
 						},
 						Containers: []v1.Container{
@@ -251,7 +251,7 @@ func Test_podResourceCollector_CollectWithStability(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
 					Spec: v1.PodSpec{
-						InitContainers: []v1.Container{
+						InitContainers: []v1.InitContainer{
 							{Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									"cpu":                    resource.MustParse("0"),
@@ -312,7 +312,7 @@ func Test_podResourceCollector_CollectWithStability(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
 					Spec: v1.PodSpec{
 						NodeName: "node-one",
-						InitContainers: []v1.Container{
+						InitContainers: []v1.InitContainer{
 							{Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									"cpu":    resource.MustParse("2"),
@@ -362,7 +362,7 @@ func Test_podResourceCollector_CollectWithStability(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "foo"},
 					Spec: v1.PodSpec{
 						NodeName: "node-one",
-						InitContainers: []v1.Container{
+						InitContainers: []v1.InitContainer{
 							{Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									"cpu":    resource.MustParse("2"),
@@ -432,7 +432,7 @@ func Test_podResourceCollector_CollectWithStability(t *testing.T) {
 					},
 				},
 			},
-			expected: `            
+			expected: `
 				# HELP kube_pod_resource_limit [ALPHA] Resources limit for workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
 				# TYPE kube_pod_resource_limit gauge
 				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 3.25
@@ -454,7 +454,7 @@ func Test_podResourceCollector_CollectWithStability(t *testing.T) {
 							"memory": resource.MustParse("0.75G"),
 							"custom": resource.MustParse("0.5"),
 						},
-						InitContainers: []v1.Container{
+						InitContainers: []v1.InitContainer{
 							{Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									"cpu":    resource.MustParse("2"),

--- a/pkg/security/apparmor/validate_test.go
+++ b/pkg/security/apparmor/validate_test.go
@@ -109,7 +109,7 @@ func TestValidateValidHost(t *testing.T) {
 			},
 		},
 		Spec: v1.PodSpec{
-			InitContainers: []v1.Container{
+			InitContainers: []v1.InitContainer{
 				{Name: "init"},
 			},
 			Containers: []v1.Container{

--- a/pkg/volume/emptydir/empty_dir_test.go
+++ b/pkg/volume/emptydir/empty_dir_test.go
@@ -426,7 +426,7 @@ func TestGetHugePagesMountOptions(t *testing.T) {
 		"InitContainerAndContainerHasProperValues": {
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
@@ -451,7 +451,7 @@ func TestGetHugePagesMountOptions(t *testing.T) {
 		"InitContainerAndContainerHasDifferentPageSizes": {
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
@@ -526,7 +526,7 @@ func TestGetHugePagesMountOptions(t *testing.T) {
 		"InitContainerAndContainerHasProperValuesMultipleSizes": {
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{

--- a/pkg/volume/util/nested_volumes_test.go
+++ b/pkg/volume/util/nested_volumes_test.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -165,7 +165,7 @@ func TestGetNestedMountpoints(t *testing.T) {
 							},
 						},
 					},
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							VolumeMounts: []v1.VolumeMount{
 								{MountPath: "/mnt/dir", Name: "vol1"},

--- a/pkg/volume/util/util_test.go
+++ b/pkg/volume/util/util_test.go
@@ -167,7 +167,7 @@ func TestFsUserFrom(t *testing.T) {
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
 					SecurityContext: &v1.PodSecurityContext{},
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							SecurityContext: &v1.SecurityContext{
 								RunAsUser: utilptr.Int64Ptr(1000),
@@ -193,7 +193,7 @@ func TestFsUserFrom(t *testing.T) {
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
 					SecurityContext: &v1.PodSecurityContext{},
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							SecurityContext: &v1.SecurityContext{
 								RunAsUser: utilptr.Int64Ptr(999),
@@ -221,7 +221,7 @@ func TestFsUserFrom(t *testing.T) {
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
 					SecurityContext: &v1.PodSecurityContext{},
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							SecurityContext: &v1.SecurityContext{
 								RunAsUser: utilptr.Int64Ptr(1000),
@@ -682,7 +682,7 @@ func TestGetPodVolumeNames(t *testing.T) {
 			name: "pod with init containers",
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Name: "initContainer",
 							VolumeMounts: []v1.VolumeMount{
@@ -726,7 +726,7 @@ func TestGetPodVolumeNames(t *testing.T) {
 			name: "pod with multiple containers",
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Name: "initContainer1",
 							VolumeMounts: []v1.VolumeMount{
@@ -833,7 +833,7 @@ func TestGetPodVolumeNames(t *testing.T) {
 							Level: "s0:c1,c2",
 						},
 					},
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Name: "initContainer1",
 							SecurityContext: &v1.SecurityContext{

--- a/plugin/pkg/admission/alwayspullimages/admission_test.go
+++ b/plugin/pkg/admission/alwayspullimages/admission_test.go
@@ -35,7 +35,7 @@ func TestAdmission(t *testing.T) {
 	pod := api.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: namespace},
 		Spec: api.PodSpec{
-			InitContainers: []api.Container{
+			InitContainers: []api.InitContainer{
 				{Name: "init1", Image: "image"},
 				{Name: "init2", Image: "image", ImagePullPolicy: api.PullNever},
 				{Name: "init3", Image: "image", ImagePullPolicy: api.PullIfNotPresent},
@@ -71,7 +71,7 @@ func TestValidate(t *testing.T) {
 	pod := api.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: namespace},
 		Spec: api.PodSpec{
-			InitContainers: []api.Container{
+			InitContainers: []api.InitContainer{
 				{Name: "init1", Image: "image"},
 				{Name: "init2", Image: "image", ImagePullPolicy: api.PullNever},
 				{Name: "init3", Image: "image", ImagePullPolicy: api.PullIfNotPresent},

--- a/plugin/pkg/admission/extendedresourcetoleration/admission_test.go
+++ b/plugin/pkg/admission/extendedresourcetoleration/admission_test.go
@@ -100,14 +100,14 @@ func TestAdmit(t *testing.T) {
 			description: "pod with init container without any extended resources, expect no change in tolerations",
 			requestedPod: core.Pod{
 				Spec: core.PodSpec{
-					InitContainers: []core.Container{
+					InitContainers: []core.InitContainer{
 						containerRequestingMemory,
 					},
 				},
 			},
 			expectedPod: core.Pod{
 				Spec: core.PodSpec{
-					InitContainers: []core.Container{
+					InitContainers: []core.InitContainer{
 						containerRequestingMemory,
 					},
 				},
@@ -141,14 +141,14 @@ func TestAdmit(t *testing.T) {
 			description: "pod with init container with extended resource, expect toleration to be added",
 			requestedPod: core.Pod{
 				Spec: core.PodSpec{
-					InitContainers: []core.Container{
+					InitContainers: []core.InitContainer{
 						containerRequestingExtendedResource2,
 					},
 				},
 			},
 			expectedPod: core.Pod{
 				Spec: core.PodSpec{
-					InitContainers: []core.Container{
+					InitContainers: []core.InitContainer{
 						containerRequestingExtendedResource2,
 					},
 					Tolerations: []core.Toleration{
@@ -209,7 +209,7 @@ func TestAdmit(t *testing.T) {
 						containerRequestingMemory,
 						containerRequestingExtendedResource1,
 					},
-					InitContainers: []core.Container{
+					InitContainers: []core.InitContainer{
 						containerRequestingCPU,
 						containerRequestingExtendedResource2,
 					},
@@ -221,7 +221,7 @@ func TestAdmit(t *testing.T) {
 						containerRequestingMemory,
 						containerRequestingExtendedResource1,
 					},
-					InitContainers: []core.Container{
+					InitContainers: []core.InitContainer{
 						containerRequestingCPU,
 						containerRequestingExtendedResource2,
 					},

--- a/plugin/pkg/admission/imagepolicy/admission_test.go
+++ b/plugin/pkg/admission/imagepolicy/admission_test.go
@@ -682,7 +682,7 @@ func TestContainerCombinations(t *testing.T) {
 							SecurityContext: &api.SecurityContext{},
 						},
 					},
-					InitContainers: []api.Container{
+					InitContainers: []api.InitContainer{
 						{
 							Image:           "bad",
 							SecurityContext: &api.SecurityContext{},
@@ -705,7 +705,7 @@ func TestContainerCombinations(t *testing.T) {
 							SecurityContext: &api.SecurityContext{},
 						},
 					},
-					InitContainers: []api.Container{
+					InitContainers: []api.InitContainer{
 						{
 							Image:           "good",
 							SecurityContext: &api.SecurityContext{},
@@ -728,7 +728,7 @@ func TestContainerCombinations(t *testing.T) {
 							SecurityContext: &api.SecurityContext{},
 						},
 					},
-					InitContainers: []api.Container{
+					InitContainers: []api.InitContainer{
 						{
 							Image:           "good",
 							SecurityContext: &api.SecurityContext{},

--- a/plugin/pkg/admission/serviceaccount/admission_test.go
+++ b/plugin/pkg/admission/serviceaccount/admission_test.go
@@ -353,7 +353,7 @@ func TestAutomountsAPIToken(t *testing.T) {
 	// testing InitContainers
 	pod = &api.Pod{
 		Spec: api.PodSpec{
-			InitContainers: []api.Container{
+			InitContainers: []api.InitContainer{
 				{},
 			},
 		},
@@ -439,7 +439,7 @@ func TestRespectsExistingMount(t *testing.T) {
 	// check init containers
 	pod = &api.Pod{
 		Spec: api.PodSpec{
-			InitContainers: []api.Container{
+			InitContainers: []api.InitContainer{
 				{
 					VolumeMounts: []api.VolumeMount{
 						expectedVolumeMount,
@@ -523,7 +523,7 @@ func TestAllowsReferencedSecret(t *testing.T) {
 
 	pod2 = &api.Pod{
 		Spec: api.PodSpec{
-			InitContainers: []api.Container{
+			InitContainers: []api.InitContainer{
 				{
 					Name: "container-1",
 					Env: []api.EnvVar{
@@ -600,7 +600,7 @@ func TestRejectsUnreferencedSecretVolumes(t *testing.T) {
 
 	pod2 = &api.Pod{
 		Spec: api.PodSpec{
-			InitContainers: []api.Container{
+			InitContainers: []api.InitContainer{
 				{
 					Name: "container-1",
 					Env: []api.EnvVar{

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2342,6 +2342,9 @@ const (
 )
 
 // A single application container that you want to run within a pod.
+type InitContainer = Container
+
+// A single application container that you want to run within a pod.
 type Container struct {
 	// Name of the container specified as a DNS_LABEL.
 	// Each container in a pod must have a unique name (DNS_LABEL).
@@ -3143,7 +3146,7 @@ type PodSpec struct {
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 	// +patchMergeKey=name
 	// +patchStrategy=merge
-	InitContainers []Container `json:"initContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,20,rep,name=initContainers"`
+	InitContainers []InitContainer `json:"initContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,20,rep,name=initContainers"`
 	// List of containers belonging to the pod.
 	// Containers cannot currently be added or removed.
 	// There must be at least one container in a Pod.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach_test.go
@@ -175,7 +175,7 @@ func TestPodAndContainerAttach(t *testing.T) {
 			pod, err := test.options.findAttachablePod(&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "test"},
 				Spec: corev1.PodSpec{
-					InitContainers: []corev1.Container{
+					InitContainers: []corev1.InitContainer{
 						{
 							Name: "initfoo",
 						},
@@ -458,7 +458,7 @@ func attachPod() *corev1.Pod {
 					Name: "bar",
 				},
 			},
-			InitContainers: []corev1.Container{
+			InitContainers: []corev1.InitContainer{
 				{
 					Name: "initfoo",
 				},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -167,7 +167,7 @@ func TestGenerateDebugContainer(t *testing.T) {
 			},
 			pod: &corev1.Pod{
 				Spec: corev1.PodSpec{
-					InitContainers: []corev1.Container{
+					InitContainers: []corev1.InitContainer{
 						{
 							Name: "init-container-1",
 						},
@@ -684,7 +684,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					Name: "target",
 				},
 				Spec: corev1.PodSpec{
-					InitContainers: []corev1.Container{
+					InitContainers: []corev1.InitContainer{
 						{
 							Name: "init-container-1",
 						},
@@ -704,7 +704,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 					Name: "debugger",
 				},
 				Spec: corev1.PodSpec{
-					InitContainers: []corev1.Container{
+					InitContainers: []corev1.InitContainer{
 						{
 							Name: "init-container-1",
 						},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env_test.go
@@ -766,7 +766,7 @@ func TestSetEnvRemoteWithSpecificContainers(t *testing.T) {
 			Spec: appsv1.DeploymentSpec{
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
-						InitContainers: []corev1.Container{
+						InitContainers: []corev1.InitContainer{
 							{
 								Name:  "init",
 								Image: "redis",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image_test.go
@@ -222,7 +222,7 @@ func TestSetImageRemote(t *testing.T) {
 									Image: "nginx",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "busybox",
 									Image: "busybox",
@@ -249,7 +249,7 @@ func TestSetImageRemote(t *testing.T) {
 									Image: "nginx",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "busybox",
 									Image: "busybox",
@@ -276,7 +276,7 @@ func TestSetImageRemote(t *testing.T) {
 									Image: "nginx",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "busybox",
 									Image: "busybox",
@@ -303,7 +303,7 @@ func TestSetImageRemote(t *testing.T) {
 									Image: "nginx",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "busybox",
 									Image: "busybox",
@@ -330,7 +330,7 @@ func TestSetImageRemote(t *testing.T) {
 									Image: "nginx",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "busybox",
 									Image: "busybox",
@@ -357,7 +357,7 @@ func TestSetImageRemote(t *testing.T) {
 									Image: "nginx",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "busybox",
 									Image: "busybox",
@@ -384,7 +384,7 @@ func TestSetImageRemote(t *testing.T) {
 									Image: "nginx",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "busybox",
 									Image: "busybox",
@@ -411,7 +411,7 @@ func TestSetImageRemote(t *testing.T) {
 									Image: "nginx",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "busybox",
 									Image: "busybox",
@@ -438,7 +438,7 @@ func TestSetImageRemote(t *testing.T) {
 									Image: "nginx",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "busybox",
 									Image: "busybox",
@@ -465,7 +465,7 @@ func TestSetImageRemote(t *testing.T) {
 									Image: "nginx",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "busybox",
 									Image: "busybox",
@@ -492,7 +492,7 @@ func TestSetImageRemote(t *testing.T) {
 									Image: "nginx",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "busybox",
 									Image: "busybox",
@@ -519,7 +519,7 @@ func TestSetImageRemote(t *testing.T) {
 									Image: "nginx",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "busybox",
 									Image: "busybox",
@@ -546,7 +546,7 @@ func TestSetImageRemote(t *testing.T) {
 									Image: "nginx",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "busybox",
 									Image: "busybox",
@@ -575,7 +575,7 @@ func TestSetImageRemote(t *testing.T) {
 											Image: "nginx",
 										},
 									},
-									InitContainers: []corev1.Container{
+									InitContainers: []corev1.InitContainer{
 										{
 											Name:  "busybox",
 											Image: "busybox",
@@ -604,7 +604,7 @@ func TestSetImageRemote(t *testing.T) {
 									Image: "nginx",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "busybox",
 									Image: "busybox",
@@ -689,7 +689,7 @@ func TestSetImageRemoteWithSpecificContainers(t *testing.T) {
 									Image: "nginx",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "busybox",
 									Image: "busybox",
@@ -716,7 +716,7 @@ func TestSetImageRemoteWithSpecificContainers(t *testing.T) {
 									Image: "busybox",
 								},
 							},
-							InitContainers: []corev1.Container{
+							InitContainers: []corev1.InitContainer{
 								{
 									Name:  "nginx",
 									Image: "nginx",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources_test.go
@@ -556,7 +556,7 @@ func TestSetResourcesRemoteWithSpecificContainers(t *testing.T) {
 			Spec: appsv1.DeploymentSpec{
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
-						InitContainers: []corev1.Container{
+						InitContainers: []corev1.InitContainer{
 							{
 								Name:  "init",
 								Image: "redis",

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history_test.go
@@ -415,7 +415,7 @@ func TestApplyDaemonSetHistory(t *testing.T) {
 							Annotations: map[string]string{"version": "v3"},
 						},
 						Spec: corev1.PodSpec{
-							InitContainers:   []corev1.Container{{Name: "i0"}},
+							InitContainers:   []corev1.InitContainer{{Name: "i0"}},
 							Containers:       []corev1.Container{{Name: "c0"}},
 							Volumes:          []corev1.Volume{{Name: "v0"}},
 							NodeSelector:     map[string]string{"1dsa": "n0"},
@@ -433,7 +433,7 @@ func TestApplyDaemonSetHistory(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{{Name: "c1"}},
 							// keep diversity field, eg: nil or empty slice
-							InitContainers: []corev1.Container{},
+							InitContainers: []corev1.InitContainer{},
 						},
 					},
 				},
@@ -445,7 +445,7 @@ func TestApplyDaemonSetHistory(t *testing.T) {
 				Spec: appsv1.DaemonSetSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
-							InitContainers: []corev1.Container{{Name: "i0"}},
+							InitContainers: []corev1.InitContainer{{Name: "i0"}},
 						},
 					},
 				},
@@ -457,7 +457,7 @@ func TestApplyDaemonSetHistory(t *testing.T) {
 							Annotations: map[string]string{"version": "v3"},
 						},
 						Spec: corev1.PodSpec{
-							InitContainers: []corev1.Container{{Name: "i1"}},
+							InitContainers: []corev1.InitContainer{{Name: "i1"}},
 							Containers:     []corev1.Container{{Name: "c1"}},
 							Volumes:        []corev1.Volume{{Name: "v1"}},
 						},
@@ -475,7 +475,7 @@ func TestApplyDaemonSetHistory(t *testing.T) {
 						},
 						Spec: corev1.PodSpec{
 							Containers:     []corev1.Container{{Name: "c1"}},
-							InitContainers: []corev1.Container{{Name: "i0"}},
+							InitContainers: []corev1.InitContainer{{Name: "i0"}},
 							Volumes:        []corev1.Volume{{Name: "v0"}},
 						},
 					},
@@ -488,7 +488,7 @@ func TestApplyDaemonSetHistory(t *testing.T) {
 							Annotations: map[string]string{"version": "v1"},
 						},
 						Spec: corev1.PodSpec{
-							InitContainers: []corev1.Container{{Name: "i1"}},
+							InitContainers: []corev1.InitContainer{{Name: "i1"}},
 							Containers:     []corev1.Container{{Name: "c1"}},
 							Volumes:        []corev1.Volume{{Name: "v1"}},
 						},

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
@@ -485,7 +485,7 @@ func testPodWithTwoContainersAndTwoInitContainers() *corev1.Pod {
 			Namespace: "test",
 		},
 		Spec: corev1.PodSpec{
-			InitContainers: []corev1.Container{
+			InitContainers: []corev1.InitContainer{
 				{Name: "foo-2-and-2-initc1"},
 				{Name: "foo-2-and-2-initc2"},
 			},
@@ -609,7 +609,7 @@ func testPodWithTwoContainersAndTwoInitAndOneEphemeralContainers() *corev1.Pod {
 			Namespace: "test",
 		},
 		Spec: corev1.PodSpec{
-			InitContainers: []corev1.Container{
+			InitContainers: []corev1.InitContainer{
 				{Name: "foo-2-and-2-and-1-initc1"},
 				{Name: "foo-2-and-2-and-1-initc2"},
 			},

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollback_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollback_test.go
@@ -85,7 +85,7 @@ func TestStatefulSetApplyRevision(t *testing.T) {
 							Annotations: map[string]string{"version": "v3"},
 						},
 						Spec: corev1.PodSpec{
-							InitContainers: []corev1.Container{{Name: "i0"}},
+							InitContainers: []corev1.InitContainer{{Name: "i0"}},
 							Containers:     []corev1.Container{{Name: "c0"}},
 							Volumes:        []corev1.Volume{{Name: "v0"}},
 							NodeSelector:   map[string]string{"1dsa": "n0"},
@@ -99,7 +99,7 @@ func TestStatefulSetApplyRevision(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{{Name: "c1"}},
 							// keep diversity field, eg: nil or empty slice
-							InitContainers: []corev1.Container{},
+							InitContainers: []corev1.InitContainer{},
 						},
 					},
 				},
@@ -111,7 +111,7 @@ func TestStatefulSetApplyRevision(t *testing.T) {
 				Spec: appsv1.StatefulSetSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
-							InitContainers: []corev1.Container{{Name: "i0"}},
+							InitContainers: []corev1.InitContainer{{Name: "i0"}},
 						},
 					},
 				},
@@ -123,7 +123,7 @@ func TestStatefulSetApplyRevision(t *testing.T) {
 							Annotations: map[string]string{"version": "v3"},
 						},
 						Spec: corev1.PodSpec{
-							InitContainers: []corev1.Container{{Name: "i1"}},
+							InitContainers: []corev1.InitContainer{{Name: "i1"}},
 							Containers:     []corev1.Container{{Name: "c1"}},
 							Volumes:        []corev1.Volume{{Name: "v1"}},
 						},
@@ -141,7 +141,7 @@ func TestStatefulSetApplyRevision(t *testing.T) {
 						},
 						Spec: corev1.PodSpec{
 							Containers:     []corev1.Container{{Name: "c1"}},
-							InitContainers: []corev1.Container{{Name: "i0"}},
+							InitContainers: []corev1.InitContainer{{Name: "i0"}},
 							Volumes:        []corev1.Volume{{Name: "v0"}},
 						},
 					},
@@ -154,7 +154,7 @@ func TestStatefulSetApplyRevision(t *testing.T) {
 							Annotations: map[string]string{"version": "v2"},
 						},
 						Spec: corev1.PodSpec{
-							InitContainers: []corev1.Container{{Name: "i1"}},
+							InitContainers: []corev1.InitContainer{{Name: "i1"}},
 							Containers:     []corev1.Container{{Name: "c1"}},
 							Volumes:        []corev1.Volume{{Name: "v1"}},
 						},

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures.go
@@ -60,7 +60,7 @@ func init() {
 	// Define minimal valid baseline pod.
 	// This must remain valid for all versions.
 	baseline_1_0 := &corev1.Pod{Spec: corev1.PodSpec{
-		InitContainers: []corev1.Container{{Name: "initcontainer1", Image: "k8s.gcr.io/pause"}},
+		InitContainers: []corev1.InitContainer{{Name: "initcontainer1", Image: "k8s.gcr.io/pause"}},
 		Containers:     []corev1.Container{{Name: "container1", Image: "k8s.gcr.io/pause"}}}}
 	minimalValidPods[api.LevelBaseline][api.MajorMinorVersion(1, 0)] = baseline_1_0
 

--- a/test/e2e/common/node/init_container.go
+++ b/test/e2e/common/node/init_container.go
@@ -188,7 +188,7 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 			},
 			Spec: v1.PodSpec{
 				RestartPolicy: v1.RestartPolicyNever,
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{
 						Name:    "init1",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
@@ -265,7 +265,7 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 				},
 			},
 			Spec: v1.PodSpec{
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{
 						Name:    "init1",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
@@ -345,7 +345,7 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 				},
 			},
 			Spec: v1.PodSpec{
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{
 						Name:    "init1",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
@@ -469,7 +469,7 @@ var _ = SIGDescribe("InitContainer [NodeConformance]", func() {
 			},
 			Spec: v1.PodSpec{
 				RestartPolicy: v1.RestartPolicyNever,
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{
 						Name:    "init1",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -240,7 +240,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 				},
 				Spec: v1.PodSpec{
 					RestartPolicy: v1.RestartPolicyOnFailure,
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Name:  "foo",
 							Image: image,
@@ -533,7 +533,7 @@ func (s podFastDeleteScenario) Pod(worker, attempt int) *v1.Pod {
 			Spec: v1.PodSpec{
 				RestartPolicy:                 v1.RestartPolicyNever,
 				TerminationGracePeriodSeconds: &one,
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{
 						Name:  "fail",
 						Image: imageutils.GetE2EImage(imageutils.BusyBox),

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -544,7 +544,7 @@ func SubpathTestPod(f *framework.Framework, subpath, volumeType string, source *
 			Namespace: f.Namespace.Name,
 		},
 		Spec: v1.PodSpec{
-			InitContainers: []v1.Container{
+			InitContainers: []v1.InitContainer{
 				{
 					Name:            fmt.Sprintf("init-volume-%s", suffix),
 					Image:           e2epod.GetDefaultTestImage(),

--- a/test/e2e/storage/testsuites/volume_io.go
+++ b/test/e2e/storage/testsuites/volume_io.go
@@ -192,7 +192,7 @@ func makePodSpec(config e2evolume.TestConfig, initCmd string, volsrc v1.VolumeSo
 			},
 		},
 		Spec: v1.PodSpec{
-			InitContainers: []v1.Container{
+			InitContainers: []v1.InitContainer{
 				{
 					Name:  config.Prefix + "-io-init",
 					Image: e2epod.GetDefaultTestImage(),

--- a/test/e2e/windows/host_process.go
+++ b/test/e2e/windows/host_process.go
@@ -51,10 +51,10 @@ const (
 		throw "Contents of /etc/configmap/text.txt are not as expected"
 	}
 	if (-not(Test-Path $env:CONTAINER_SANDBOX_MOUNT_POINT\etc\hostpath)) {
-		throw "Cannot find hostpath volume" 
+		throw "Cannot find hostpath volume"
 	}
 	if (-not(Test-Path $env:CONTAINER_SANDBOX_MOUNT_POINT\etc\downwardapi\podname)) {
-		throw "Cannot find podname file in downward-api volume" 
+		throw "Cannot find podname file in downward-api volume"
 	}
 	$c = Get-Content -Path $env:CONTAINER_SANDBOX_MOUNT_POINT\etc\downwardapi\podname
 	if ($c -ne "host-process-volume-mounts") {
@@ -159,7 +159,7 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 					},
 				},
 				HostNetwork: true,
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
 						Name:    "configure-node",
@@ -541,7 +541,7 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 					},
 				},
 				HostNetwork: true,
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{
 						SecurityContext: &v1.SecurityContext{
 							WindowsOptions: &v1.WindowsSecurityContextOptions{
@@ -809,7 +809,7 @@ var _ = SIGDescribe("[Feature:WindowsHostProcessContainers] [MinimumKubeletVersi
 					},
 				},
 				HostNetwork: true,
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
 						Name:    "setup",

--- a/test/e2e/windows/kubelet_stats.go
+++ b/test/e2e/windows/kubelet_stats.go
@@ -257,7 +257,7 @@ func newKubeletStatsTestPods(numPods int, image imageutils.Config, nodeName stri
 						},
 					},
 				},
-				InitContainers: []v1.Container{
+				InitContainers: []v1.InitContainer{
 					{
 						Image: image.GetE2EImage(),
 						Name:  "init-container",

--- a/test/e2e_node/node_problem_detector_linux.go
+++ b/test/e2e_node/node_problem_detector_linux.go
@@ -234,7 +234,7 @@ current-context: local-context
 							},
 						},
 					},
-					InitContainers: []v1.Container{
+					InitContainers: []v1.InitContainer{
 						{
 							Name:    "init-log-file",
 							Image:   "debian",

--- a/test/images/agnhost/webhook/patch_test.go
+++ b/test/images/agnhost/webhook/patch_test.go
@@ -68,12 +68,12 @@ func TestPatches(t *testing.T) {
 			patch: podsInitContainerPatch,
 			initial: corev1.Pod{
 				Spec: corev1.PodSpec{
-					InitContainers: []corev1.Container{},
+					InitContainers: []corev1.InitContainer{},
 				},
 			},
 			expected: &corev1.Pod{
 				Spec: corev1.PodSpec{
-					InitContainers: []corev1.Container{
+					InitContainers: []corev1.InitContainer{
 						{
 							Image:     "webhook-added-image",
 							Name:      "webhook-added-init-container",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Related to #115362 

Basic renaming of a `Container` to `InitContainer` type by aliasing it.

#### Special notes for your reviewer:

This is one of the steps toward de-sharing the type.

```release-note
NONE
```