### PR TITLE
apiserver cluster egress metrics: backport to release-1.26

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go
@@ -36,7 +36,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/apis/apiserver"
 	egressmetrics "k8s.io/apiserver/pkg/server/egressselector/metrics"
-	compbasemetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/tracing"
 	"k8s.io/klog/v2"
 	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
@@ -45,7 +45,7 @@ import (
 var directDialer utilnet.DialFunc = http.DefaultTransport.(*http.Transport).DialContext
 
 func init() {
-	client.Metrics.RegisterMetrics(compbasemetrics.NewKubeRegistry().Registerer())
+	client.Metrics.RegisterMetrics(legacyregistry.Registerer())
 }
 
 // EgressSelector is the map of network context type to context dialer, for network egress.

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector_test.go
@@ -18,6 +18,7 @@ package egressselector
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -31,6 +32,9 @@ import (
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/metrics/testutil"
 	testingclock "k8s.io/utils/clock/testing"
+	clientmetrics "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics"
+	ccmetrics "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/common/metrics"
+	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
 )
 
 type fakeEgressSelection struct {
@@ -272,5 +276,70 @@ func TestMetrics(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestKonnectivityClientMetrics(t *testing.T) {
+	testcases := []struct {
+		name    string
+		metrics []string
+		trigger func()
+		want    string
+	}{
+		{
+			name:    "stream packets",
+			metrics: []string{"konnectivity_network_proxy_client_stream_packets_total"},
+			trigger: func() {
+				clientmetrics.Metrics.ObservePacket(ccmetrics.SegmentFromClient, client.PacketType_DIAL_REQ)
+			},
+			want: `
+# HELP konnectivity_network_proxy_client_stream_packets_total Count of packets processed, by segment and packet type (example: from_client, DIAL_REQ)
+# TYPE konnectivity_network_proxy_client_stream_packets_total counter
+konnectivity_network_proxy_client_stream_packets_total{packet_type="DIAL_REQ",segment="from_client"} 1
+`,
+		},
+		{
+			name:    "stream errors",
+			metrics: []string{"konnectivity_network_proxy_client_stream_errors_total"},
+			trigger: func() {
+				clientmetrics.Metrics.ObserveStreamError(ccmetrics.SegmentToClient, errors.New("example"), client.PacketType_DIAL_RSP)
+			},
+			want: `
+# HELP konnectivity_network_proxy_client_stream_errors_total Count of gRPC stream errors, by segment, grpc Code, packet type. (example: from_agent, Code.Unavailable, DIAL_RSP)
+# TYPE konnectivity_network_proxy_client_stream_errors_total counter
+konnectivity_network_proxy_client_stream_errors_total{code="Unknown",packet_type="DIAL_RSP",segment="to_client"} 1
+`,
+		},
+		{
+			name:    "dial failure",
+			metrics: []string{"konnectivity_network_proxy_client_dial_failure_total"},
+			trigger: func() {
+				clientmetrics.Metrics.ObserveDialFailure(clientmetrics.DialFailureTimeout)
+			},
+			want: `
+# HELP konnectivity_network_proxy_client_dial_failure_total Number of dial failures observed, by reason (example: remote endpoint error)
+# TYPE konnectivity_network_proxy_client_dial_failure_total counter
+konnectivity_network_proxy_client_dial_failure_total{reason="timeout"} 1
+`,
+		},
+		{
+			name:    "client connections",
+			metrics: []string{"konnectivity_network_proxy_client_client_connections"},
+			trigger: func() {
+				clientmetrics.Metrics.GetClientConnectionsMetric().WithLabelValues("dialing").Inc()
+			},
+			want: `
+# HELP konnectivity_network_proxy_client_client_connections Number of open client connections, by status (Example: dialing)
+# TYPE konnectivity_network_proxy_client_client_connections gauge
+konnectivity_network_proxy_client_client_connections{status="dialing"} 1
+`,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.trigger()
+			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tc.want), tc.metrics...); err != nil {
+				t.Errorf("GatherAndCompare error: %v", err)
+			}
+		})
+	}
 }

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
@@ -42,6 +42,9 @@ var (
 
 	// Register registers a collectable metric but uses the global registry
 	Register = defaultRegistry.Register
+
+	// Registerer exposes the global registerer
+	Registerer = defaultRegistry.Registerer
 )
 
 func init() {


### PR DESCRIPTION

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

Backport the fix https://github.com/kubernetes/kubernetes/pull/115327 to release-1.26 branch.

#### Which issue(s) this PR fixes:

Fixes #115327

#### Special notes for your reviewer:

Clean cherry pick.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
