### PR TITLE
Avoid typechecking stdlib

### DIFF
--- a/test/typecheck/main.go
+++ b/test/typecheck/main.go
@@ -80,7 +80,7 @@ var (
 func newConfig(platform string) *packages.Config {
 	platSplit := strings.Split(platform, "/")
 	goos, goarch := platSplit[0], platSplit[1]
-	mode := packages.NeedName | packages.NeedFiles | packages.NeedTypes | packages.NeedSyntax | packages.NeedDeps | packages.NeedImports
+	mode := packages.NeedName | packages.NeedFiles | packages.NeedTypes | packages.NeedSyntax | packages.NeedDeps | packages.NeedImports | packages.NeedModule
 	if *defuses {
 		mode = mode | packages.NeedTypesInfo
 	}
@@ -204,7 +204,7 @@ func (c *collector) verify(plat string) ([]string, error) {
 
 	for _, pkg := range allList {
 		if len(pkg.GoFiles) > 0 {
-			if len(pkg.Errors) > 0 {
+			if len(pkg.Errors) > 0 && (pkg.PkgPath == "main" || strings.Contains(pkg.PkgPath, ".")) {
 				errors = append(errors, pkg.Errors...)
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

typecheck can't reliably parse CGO files (we already exclude some CGO errors), and go1.20 makes some CGO-related changes that can't be parsed. Found as part of https://github.com/kubernetes/kubernetes/pull/115377 in https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/115377/pull-kubernetes-typecheck/1619385956501032960 run

By only paying attention to errors in packages named `main` or which have package paths containing a `.`, this skips accumulating typecheck errors for stdlib packages, limiting type check error accumulation to our packages and vendored packages:

> If the module path appears in a require directive and is not replaced, or if the module paths appears on the right side of a replace directive, the go command may need to download modules with that path, and some additional requirements must be satisfied.
>
> The leading path element (up to the first slash, if any), by convention a domain name, must contain only lower-case ASCII letters, ASCII digits, dots (., U+002E), and dashes (-, U+002D); it must contain at least one dot and cannot start with a dash.

xref https://github.com/kubernetes/release/issues/2815

```release-note
NONE
```
