### PR TITLE
kmsv2: add metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope_test.go
@@ -31,6 +31,9 @@ import (
 	"k8s.io/apiserver/pkg/storage/value"
 	aestransformer "k8s.io/apiserver/pkg/storage/value/encrypt/aes"
 	kmstypes "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/v2alpha1"
+	"k8s.io/apiserver/pkg/storage/value/encrypt/envelope/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
 	kmsservice "k8s.io/kms/service"
 	testingclock "k8s.io/utils/clock/testing"
 )
@@ -38,6 +41,7 @@ import (
 const (
 	testText        = "abcdefghijklmnopqrstuvwxyz"
 	testContextText = "0123456789"
+	testKeyHash     = "sha256:6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
 	testKeyVersion  = "1"
 	testCacheTTL    = 10 * time.Second
 )
@@ -132,13 +136,16 @@ func TestEnvelopeCaching(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			envelopeService := newTestEnvelopeService()
 			fakeClock := testingclock.NewFakeClock(time.Now())
-			envelopeTransformer := newEnvelopeTransformerWithClock(envelopeService,
+			envelopeTransformer := newEnvelopeTransformerWithClock(envelopeService, testProviderName,
 				func(ctx context.Context) (string, error) {
 					return "", nil
 				},
+				func(ctx context.Context) error {
+					return nil
+				},
 				aestransformer.NewGCMTransformer, tt.cacheTTL, fakeClock)
 
-			ctx := context.Background()
+			ctx := testContext(t)
 			dataCtx := value.DefaultContext([]byte(testContextText))
 			originalText := []byte(testText)
 
@@ -211,13 +218,16 @@ func TestEnvelopeTransformerKeyIDGetter(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
 			envelopeService := newTestEnvelopeService()
-			envelopeTransformer := NewEnvelopeTransformer(envelopeService,
+			envelopeTransformer := NewEnvelopeTransformer(envelopeService, testProviderName,
 				func(ctx context.Context) (string, error) {
 					return tt.testKeyID, tt.testErr
 				},
+				func(ctx context.Context) error {
+					return nil
+				},
 				aestransformer.NewGCMTransformer)
 
-			ctx := context.Background()
+			ctx := testContext(t)
 			dataCtx := value.DefaultContext([]byte(testContextText))
 			originalText := []byte(testText)
 
@@ -279,12 +289,15 @@ func TestTransformToStorageError(t *testing.T) {
 			t.Parallel()
 			envelopeService := newTestEnvelopeService()
 			envelopeService.SetAnnotations(tt.annotations)
-			envelopeTransformer := NewEnvelopeTransformer(envelopeService,
+			envelopeTransformer := NewEnvelopeTransformer(envelopeService, testProviderName,
 				func(ctx context.Context) (string, error) {
 					return "", nil
 				},
+				func(ctx context.Context) error {
+					return nil
+				},
 				aestransformer.NewGCMTransformer)
-			ctx := context.Background()
+			ctx := testContext(t)
 			dataCtx := value.DefaultContext([]byte(testContextText))
 
 			_, err := envelopeTransformer.TransformToStorage(ctx, []byte(testText), dataCtx)
@@ -552,6 +565,66 @@ func TestValidateEncryptedDEK(t *testing.T) {
 				if err != nil {
 					t.Fatalf("expected no error, got %q", err)
 				}
+			}
+		})
+	}
+}
+
+func TestEnvelopeMetrics(t *testing.T) {
+	envelopeService := newTestEnvelopeService()
+	envelopeTransformer := NewEnvelopeTransformer(envelopeService, testProviderName,
+		func(ctx context.Context) (string, error) {
+			return testKeyVersion, nil
+		},
+		func(ctx context.Context) error {
+			return fmt.Errorf("health check probe called when encryption keyID is different")
+		},
+		aestransformer.NewGCMTransformer)
+
+	dataCtx := value.DefaultContext([]byte(testContextText))
+
+	kmsv2Transformer := value.PrefixTransformer{Prefix: []byte("k8s:enc:kms:v2:"), Transformer: envelopeTransformer}
+
+	testCases := []struct {
+		desc                  string
+		keyVersionFromEncrypt string
+		prefix                value.Transformer
+		metrics               []string
+		want                  string
+	}{
+		{
+			desc:                  "keyIDHash total",
+			keyVersionFromEncrypt: testKeyVersion,
+			prefix:                value.NewPrefixTransformers(nil, kmsv2Transformer),
+			metrics: []string{
+				"apiserver_envelope_encryption_key_id_hash_total",
+			},
+			want: fmt.Sprintf(`
+				# HELP apiserver_envelope_encryption_key_id_hash_total [ALPHA] Number of times a keyID is used split by transformation type and provider.
+				# TYPE apiserver_envelope_encryption_key_id_hash_total counter
+				apiserver_envelope_encryption_key_id_hash_total{key_id_hash="%s",provider_name="%s",transformation_type="%s"} 1
+        		apiserver_envelope_encryption_key_id_hash_total{key_id_hash="%s",provider_name="%s",transformation_type="%s"} 1
+				`, testKeyHash, testProviderName, metrics.FromStorageLabel, testKeyHash, testProviderName, metrics.ToStorageLabel),
+		},
+	}
+
+	metrics.DekCacheInterArrivals.Reset()
+	metrics.KeyIDHashTotal.Reset()
+
+	for _, tt := range testCases {
+		t.Run(tt.desc, func(t *testing.T) {
+			defer metrics.DekCacheInterArrivals.Reset()
+			defer metrics.KeyIDHashTotal.Reset()
+			ctx := testContext(t)
+			envelopeService.keyVersion = tt.keyVersionFromEncrypt
+			transformedData, err := tt.prefix.TransformToStorage(ctx, []byte(testText), dataCtx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tt.prefix.TransformFromStorage(ctx, transformedData, dataCtx)
+
+			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tt.want), tt.metrics...); err != nil {
+				t.Fatal(err)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
@@ -51,7 +51,7 @@ var (
 			Buckets:        metrics.ExponentialBuckets(5e-6, 2, 25),
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"transformation_type"},
+		[]string{"transformation_type", "transformer_prefix"},
 	)
 
 	transformerOperationsTotal = metrics.NewCounterVec(
@@ -111,12 +111,12 @@ func RegisterMetrics() {
 
 // RecordTransformation records latencies and count of TransformFromStorage and TransformToStorage operations.
 // Note that transformation_failures_total metric is deprecated, use transformation_operations_total instead.
-func RecordTransformation(transformationType, transformerPrefix string, start time.Time, err error) {
+func RecordTransformation(transformationType, transformerPrefix string, elapsed time.Duration, err error) {
 	transformerOperationsTotal.WithLabelValues(transformationType, transformerPrefix, status.Code(err).String()).Inc()
 
 	switch {
 	case err == nil:
-		transformerLatencies.WithLabelValues(transformationType).Observe(sinceInSeconds(start))
+		transformerLatencies.WithLabelValues(transformationType, transformerPrefix).Observe(elapsed.Seconds())
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/transformer.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/transformer.go
@@ -100,9 +100,9 @@ func (t *prefixTransformers) TransformFromStorage(ctx context.Context, data []by
 				continue
 			}
 			if len(transformer.Prefix) == 0 {
-				RecordTransformation("from_storage", "identity", start, err)
+				RecordTransformation("from_storage", "identity", time.Since(start), err)
 			} else {
-				RecordTransformation("from_storage", string(transformer.Prefix), start, err)
+				RecordTransformation("from_storage", string(transformer.Prefix), time.Since(start), err)
 			}
 
 			// It is valid to have overlapping prefixes when the same encryption provider
@@ -146,7 +146,7 @@ func (t *prefixTransformers) TransformFromStorage(ctx context.Context, data []by
 	if err := errors.Reduce(errors.NewAggregate(errs)); err != nil {
 		return nil, false, err
 	}
-	RecordTransformation("from_storage", "unknown", start, t.err)
+	RecordTransformation("from_storage", "unknown", time.Since(start), t.err)
 	return nil, false, t.err
 }
 
@@ -155,7 +155,7 @@ func (t *prefixTransformers) TransformToStorage(ctx context.Context, data []byte
 	start := time.Now()
 	transformer := t.transformers[0]
 	result, err := transformer.Transformer.TransformToStorage(ctx, data, dataCtx)
-	RecordTransformation("to_storage", string(transformer.Prefix), start, err)
+	RecordTransformation("to_storage", string(transformer.Prefix), time.Since(start), err)
 	if err != nil {
 		return nil, err
 	}

--- a/test/instrumentation/documentation/documentation-list.yaml
+++ b/test/instrumentation/documentation/documentation-list.yaml
@@ -3251,7 +3251,9 @@
   type: Histogram
   stabilityLevel: ALPHA
   labels:
+  - status
   - transformation_type
+  - transformer_prefix
   buckets:
   - 5e-06
   - 1e-05

--- a/test/instrumentation/documentation/documentation.md
+++ b/test/instrumentation/documentation/documentation.md
@@ -822,7 +822,7 @@ components using an HTTP scrape, and fetch the current metrics data in Prometheu
 <td class="metric_stability_level" data-stability="alpha">ALPHA</td>
 <td class="metric_type" data-type="histogram">Histogram</td>
 <td class="metric_description">Latencies in seconds of value transformation operations.</td>
-<td class="metric_labels_varying"><div class="metric_label">transformation_type</div></td>
+<td class="metric_labels_varying"><<div class="metric_label">status</div><div class="metric_label">transformation_type</div><div class="metric_label">transformer_prefix</div></td>
 <td class="metric_labels_constant"></td>
 <td class="metric_deprecated_version"></td></tr>
 <tr class="metric"><td class="metric_name">apiserver_storage_transformation_operations_total</td>


### PR DESCRIPTION
Signed-off-by: Rita Zhang <rita.z.zhang@gmail.com>


#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add metrics for kms envelop encryption to enhance observability and debugability. This is especially important for kmsv2 to ensure its mature for graduating to beta.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115305

#### Special notes for your reviewer:
Will complete documentation later after getting initial review and consensus on naming and metrics to add.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
apiserver_storage_transformation_operations_total metric has been updated to include labels transformer_prefix and status.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP] https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3299-kms-v2-improvements
```

/sig auth
/milestone v1.27