### PR TITLE
Automated cherry pick of #115354: dynamic resource allocation: avoid apiserver complaint about

### DIFF
--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha1_openapi.json
@@ -466,7 +466,10 @@
               "default": {}
             },
             "type": "array",
-            "x-kubernetes-list-type": "set"
+            "x-kubernetes-list-map-keys": [
+              "uid"
+            ],
+            "x-kubernetes-list-type": "map"
           }
         },
         "type": "object"

--- a/pkg/apis/resource/validation/validation_resourceclaim_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaim_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/resource"
@@ -395,7 +396,7 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 						resource.ResourceClaimConsumerReference{
 							Resource: "pods",
 							Name:     fmt.Sprintf("foo-%d", i),
-							UID:      "1",
+							UID:      types.UID(fmt.Sprintf("%d", i)),
 						})
 				}
 				return claim
@@ -410,7 +411,7 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 						resource.ResourceClaimConsumerReference{
 							Resource: "pods",
 							Name:     fmt.Sprintf("foo-%d", i),
-							UID:      "1",
+							UID:      types.UID(fmt.Sprintf("%d", i)),
 						})
 				}
 				return claim
@@ -425,19 +426,15 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 						resource.ResourceClaimConsumerReference{
 							Resource: "pods",
 							Name:     fmt.Sprintf("foo-%d", i),
-							UID:      "1",
+							UID:      types.UID(fmt.Sprintf("%d", i)),
 						})
 				}
 				return claim
 			},
 		},
 		"invalid-reserved-for-duplicate": {
-			wantFailures: field.ErrorList{field.Duplicate(field.NewPath("status", "reservedFor").Index(1), resource.ResourceClaimConsumerReference{
-				Resource: "pods",
-				Name:     "foo",
-				UID:      "1",
-			})},
-			oldClaim: validAllocatedClaim,
+			wantFailures: field.ErrorList{field.Duplicate(field.NewPath("status", "reservedFor").Index(1).Child("uid"), types.UID("1"))},
+			oldClaim:     validAllocatedClaim,
 			update: func(claim *resource.ResourceClaim) *resource.ResourceClaim {
 				for i := 0; i < 2; i++ {
 					claim.Status.ReservedFor = append(claim.Status.ReservedFor,
@@ -463,7 +460,7 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 						resource.ResourceClaimConsumerReference{
 							Resource: "pods",
 							Name:     fmt.Sprintf("foo-%d", i),
-							UID:      "1",
+							UID:      types.UID(fmt.Sprintf("%d", i)),
 						})
 				}
 				return claim

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -41924,7 +41924,10 @@ func schema_k8sio_api_resource_v1alpha1_ResourceClaimStatus(ref common.Reference
 					"reservedFor": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"uid",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{

--- a/staging/src/k8s.io/api/resource/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1alpha1/generated.proto
@@ -248,7 +248,8 @@ message ResourceClaimStatus {
   // There can be at most 32 such reservations. This may get increased in
   // the future, but not reduced.
   //
-  // +listType=set
+  // +listType=map
+  // +listMapKey=uid
   // +optional
   repeated ResourceClaimConsumerReference reservedFor = 3;
 

--- a/staging/src/k8s.io/api/resource/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha1/types.go
@@ -112,7 +112,8 @@ type ResourceClaimStatus struct {
 	// There can be at most 32 such reservations. This may get increased in
 	// the future, but not reduced.
 	//
-	// +listType=set
+	// +listType=map
+	// +listMapKey=uid
 	// +optional
 	ReservedFor []ResourceClaimConsumerReference `json:"reservedFor,omitempty" protobuf:"bytes,3,opt,name=reservedFor"`
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -11661,6 +11661,8 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             namedType: io.k8s.api.resource.v1alpha1.ResourceClaimConsumerReference
           elementRelationship: associative
+          keys:
+          - uid
 - name: io.k8s.api.resource.v1alpha1.ResourceClaimTemplate
   map:
     fields:


### PR DESCRIPTION
Cherry pick of #115354 on release-1.26.

#115354: dynamic resource allocation: avoid apiserver complaint about

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```