### PR TITLE
apiextensions: Benchmark escaping in SchemaHas and pool Schemas

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -1381,6 +1381,11 @@ func schemaHasRecurse(s *apiextensions.JSONSchemaProps, pred func(s *apiextensio
 	return SchemaHas(schema, pred)
 }
 
+// SchemaHas recursively traverses the Schema and calls the `pred`
+// predicate to see if the schema contains specific values.
+//
+// The predicate MUST NOT keep a copy of the json schema NOR modify the
+// schema.
 func SchemaHas(s *apiextensions.JSONSchemaProps, pred func(s *apiextensions.JSONSchemaProps) bool) bool {
 	if s == nil {
 		return false


### PR DESCRIPTION
SchemaHas needs to escape the apiextensions.JSONSchemaProps pointer
since it's calling an arbitrary predicate function that can keep a copy
of the pointer (even though it shouldn't, but the compiler can't know
that). The leak is resulting in a fair amount of memory allocation when
installing many CRDs in a row (about 3% of the memory allocated happens
in this method).

Using a `sync.Pool` to re-use the buffers that have to escape in the
predicate significantly reduces the number of allocations needed to run
the SchemaHas method, as shown in the following example:
    
```
> benchstat old.bench new.bench
name         old time/op    new time/op    delta
SchemaHas-8    11.0ms ± 0%     2.1ms ± 1%   -80.60%  (p=0.008 n=5+5)
    
name         old alloc/op   new alloc/op   delta
SchemaHas-8    37.5MB ± 0%     0.0MB ± 0%  -100.00%  (p=0.008 n=5+5)
    
name         old allocs/op  new allocs/op  delta
SchemaHas-8     73.1k ± 0%      0.0k       -100.00%  (p=0.008 n=5+5)
```

That's not the most critical thing we have in the apiserver installing CRDs, but that's the best ROI since it's very easy to fix :-)

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes stuff

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

