### PR TITLE
kubeadm: skip ipv4 check if the cluster is using IPv6 address

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -883,15 +883,11 @@ func (MemCheck) Name() string {
 	return "Mem"
 }
 
-// RunInitNodeChecks executes all individual, applicable to control-plane node checks.
-// The boolean flag 'isSecondaryControlPlane' controls whether we are running checks in a --join-control-plane scenario.
-// The boolean flag 'downloadCerts' controls whether we should skip checks on certificates because we are downloading them.
-// If the flag is set to true we should skip checks already executed by RunJoinNodeChecks.
-func RunInitNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfiguration, ignorePreflightErrors sets.Set[string], isSecondaryControlPlane bool, downloadCerts bool) error {
+func InitNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfiguration, ignorePreflightErrors sets.Set[string], isSecondaryControlPlane bool, downloadCerts bool) ([]Checker, error) {
 	if !isSecondaryControlPlane {
 		// First, check if we're root separately from the other preflight checks and fail fast
 		if err := RunRootCheckOnly(ignorePreflightErrors); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -912,13 +908,36 @@ func RunInitNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfigura
 		FileAvailableCheck{Path: kubeadmconstants.GetStaticPodFilepath(kubeadmconstants.Etcd, manifestsDir)},
 		HTTPProxyCheck{Proto: "https", Host: cfg.LocalAPIEndpoint.AdvertiseAddress},
 	}
+
+	// File content check for IPV4 and IPV6 are needed if it is:
+	// (dual stack)  `--service-cidr` or `--pod-network-cidr` is set with an IPV4 and IPV6 CIDR, `--apiserver-advertise-address` is optional as it can be auto detected.
+	// (single stack) which is decided by the `--apiserver-advertise-address`.
+	// Note that for the case of dual stack, user might only give IPV6 CIDR for `--service-cidr` and leave the `--apiserver-advertise-address` a default value which will be
+	// auto detected and properly bound to an IPV4 address, this will make the cluster non-functional eventually. The case like this should be avoided by the validation instead,
+	// i.e. We don't care whether the input values for those parameters are set correctly here but if it's an IPV4 scoped CIDR or address we will add the file content check for IPV4,
+	// as does the IPV6.
+	IPV4Check := false
+	IPV6Check := false
 	cidrs := strings.Split(cfg.Networking.ServiceSubnet, ",")
 	for _, cidr := range cidrs {
 		checks = append(checks, HTTPProxyCIDRCheck{Proto: "https", CIDR: cidr})
+		if !IPV4Check && netutils.IsIPv4CIDRString(cidr) {
+			IPV4Check = true
+		}
+		if !IPV6Check && netutils.IsIPv6CIDRString(cidr) {
+			IPV6Check = true
+		}
+
 	}
 	cidrs = strings.Split(cfg.Networking.PodSubnet, ",")
 	for _, cidr := range cidrs {
 		checks = append(checks, HTTPProxyCIDRCheck{Proto: "https", CIDR: cidr})
+		if !IPV4Check && netutils.IsIPv4CIDRString(cidr) {
+			IPV4Check = true
+		}
+		if !IPV6Check && netutils.IsIPv6CIDRString(cidr) {
+			IPV6Check = true
+		}
 	}
 
 	if !isSecondaryControlPlane {
@@ -926,9 +945,19 @@ func RunInitNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfigura
 
 		// Check if Bridge-netfilter and IPv6 relevant flags are set
 		if ip := netutils.ParseIPSloppy(cfg.LocalAPIEndpoint.AdvertiseAddress); ip != nil {
-			if netutils.IsIPv6(ip) {
-				checks = addIPv6Checks(checks)
+			if !IPV4Check && netutils.IsIPv4(ip) {
+				IPV4Check = true
 			}
+			if !IPV6Check && netutils.IsIPv6(ip) {
+				IPV6Check = true
+			}
+		}
+
+		if IPV4Check {
+			checks = addIPv4Checks(checks)
+		}
+		if IPV6Check {
+			checks = addIPv6Checks(checks)
 		}
 
 		// if using an external etcd
@@ -959,15 +988,25 @@ func RunInitNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfigura
 			checks = append(checks, FileExistingCheck{Path: cfg.Etcd.External.KeyFile, Label: "ExternalEtcdClientCertificates"})
 		}
 	}
+	return checks, nil
+}
 
+// RunInitNodeChecks executes all individual, applicable to control-plane node checks.
+// The boolean flag 'isSecondaryControlPlane' controls whether we are running checks in a --join-control-plane scenario.
+// The boolean flag 'downloadCerts' controls whether we should skip checks on certificates because we are downloading them.
+// If the flag is set to true we should skip checks already executed by RunJoinNodeChecks.
+func RunInitNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.InitConfiguration, ignorePreflightErrors sets.Set[string], isSecondaryControlPlane bool, downloadCerts bool) error {
+	checks, err := InitNodeChecks(execer, cfg, ignorePreflightErrors, isSecondaryControlPlane, downloadCerts)
+	if err != nil {
+		return err
+	}
 	return RunChecks(checks, os.Stderr, ignorePreflightErrors)
 }
 
-// RunJoinNodeChecks executes all individual, applicable to node checks.
-func RunJoinNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.JoinConfiguration, ignorePreflightErrors sets.Set[string]) error {
+func JoinNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.JoinConfiguration, ignorePreflightErrors sets.Set[string]) ([]Checker, error) {
 	// First, check if we're root separately from the other preflight checks and fail fast
 	if err := RunRootCheckOnly(ignorePreflightErrors); err != nil {
-		return err
+		return nil, err
 	}
 
 	checks := []Checker{
@@ -986,13 +1025,24 @@ func RunJoinNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.JoinConfigura
 				HTTPProxyCheck{Proto: "https", Host: ipstr},
 			)
 			if ip := netutils.ParseIPSloppy(ipstr); ip != nil {
+				if netutils.IsIPv4(ip) {
+					checks = addIPv4Checks(checks)
+				}
 				if netutils.IsIPv6(ip) {
 					checks = addIPv6Checks(checks)
 				}
 			}
 		}
 	}
+	return checks, nil
+}
 
+// RunJoinNodeChecks executes all individual, applicable to node checks.
+func RunJoinNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.JoinConfiguration, ignorePreflightErrors sets.Set[string]) error {
+	checks, err := JoinNodeChecks(execer, cfg, ignorePreflightErrors)
+	if err != nil {
+		return err
+	}
 	return RunChecks(checks, os.Stderr, ignorePreflightErrors)
 }
 
@@ -1007,7 +1057,6 @@ func addCommonChecks(execer utilsexec.Interface, k8sVersion string, nodeReg *kub
 	}
 
 	// non-windows checks
-	checks = addIPv4Checks(checks)
 	checks = addSwapCheck(checks)
 	checks = addExecChecks(checks, execer)
 	checks = append(checks,

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/lithammer/dedent"
 	"github.com/pkg/errors"
 
@@ -36,7 +37,9 @@ import (
 	fakeexec "k8s.io/utils/exec/testing"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	utilruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
 )
 
@@ -1001,6 +1004,137 @@ func TestMemCheck(t *testing.T) {
 				t.Errorf("expected 0 warnings but got %d: %q", len(warnings), warnings)
 			} else if len(errors) != rt.expectedErrors {
 				t.Errorf("expected %d error(s) but got %d: %q", rt.expectedErrors, len(errors), errors)
+			}
+		})
+	}
+}
+
+func TestInitIPCheck(t *testing.T) {
+	// skip this test, if OS in not Linux, since it will ONLY pass on Linux.
+	if runtime.GOOS != "linux" {
+		t.Skip("unsupported OS")
+	}
+	// should be a privileged user for the `init` command, otherwise just skip it.
+	isPrivileged := IsPrivilegedUserCheck{}
+	if _, err := isPrivileged.Check(); err != nil {
+		t.Skip("not a privileged user")
+	}
+	internalcfg, err := configutil.DefaultedStaticInitConfiguration()
+	if err != nil {
+		t.Fatalf("unexpected failure when defaulting InitConfiguration: %v", err)
+	}
+	internalcfg.LocalAPIEndpoint.AdvertiseAddress = "" // AdvertiseAddress is optional, it could be auto-detected.
+	ipv4File := "FileContent--proc-sys-net-ipv4-ip_forward"
+	ipv6File := "FileContent--proc-sys-net-ipv6-conf-default-forwarding"
+	var tests = []struct {
+		testName    string
+		PodSubnet   string
+		serviceCidr string
+		expStr      []string
+	}{
+		{
+			testName:    "dual stack",
+			PodSubnet:   "fda9:d324:354d:0::/56",
+			serviceCidr: "10.96.0.0/16,fda9:d324:354d:1::/112",
+			expStr:      []string{"FileContent--proc-sys-net-ipv4-ip_forward", "FileContent--proc-sys-net-ipv6-conf-default-forwarding"},
+		},
+		{
+			testName:    "single stack ipv4",
+			PodSubnet:   "10.244.0.0/16",
+			serviceCidr: "10.96.0.0/16",
+			expStr:      []string{"FileContent--proc-sys-net-ipv4-ip_forward"},
+		},
+		{
+			testName:    "single stack ipv6",
+			PodSubnet:   "fda9:d324:354d:0::/56",
+			serviceCidr: "fda9:d324:354d:1::/112",
+			expStr:      []string{"FileContent--proc-sys-net-ipv6-conf-default-forwarding"},
+		},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.testName, func(t *testing.T) {
+			checkList := []string{}
+			internalcfg.Networking.ServiceSubnet = rt.serviceCidr
+			internalcfg.Networking.PodSubnet = rt.PodSubnet
+			checks, err := InitNodeChecks(exec.New(), internalcfg, nil, false, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, check := range checks {
+				if check.Name() == ipv4File {
+					checkList = append(checkList, ipv4File)
+				}
+				if check.Name() == ipv6File {
+					checkList = append(checkList, ipv6File)
+				}
+			}
+			if diff := cmp.Diff(checkList, rt.expStr); diff != "" {
+				t.Fatalf("unexpected file content check (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestJoinIPCheck(t *testing.T) {
+	// skip this test, if OS in not Linux, since it will ONLY pass on Linux.
+	if runtime.GOOS != "linux" {
+		t.Skip("unsupported OS")
+	}
+	// should be a privileged user for the `join` command, otherwise just skip it.
+	isPrivileged := IsPrivilegedUserCheck{}
+	if _, err := isPrivileged.Check(); err != nil {
+		t.Skip("not a privileged user")
+	}
+	internalcfg, err := configutil.DefaultedJoinConfiguration(&kubeadmapiv1.JoinConfiguration{
+		Discovery: kubeadmapiv1.Discovery{
+			BootstrapToken: &kubeadmapiv1.BootstrapTokenDiscovery{
+				Token:                    configutil.PlaceholderToken.Token.String(),
+				APIServerEndpoint:        "kube-apiserver:6443",
+				UnsafeSkipCAVerification: true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected failure when defaulting JoinConfiguration: %v", err)
+	}
+	ipv4File := "FileContent--proc-sys-net-ipv4-ip_forward"
+	ipv6File := "FileContent--proc-sys-net-ipv6-conf-default-forwarding"
+	var tests = []struct {
+		testName string
+		endpoint string
+		expStr   []string
+	}{
+		{
+			testName: "single stack ipv4",
+			endpoint: "10.244.0.0:1234",
+			expStr:   []string{"FileContent--proc-sys-net-ipv4-ip_forward"},
+		},
+		{
+			testName: "single stack ipv6",
+			endpoint: "[fda9:d324:354d:0::]:1234",
+			expStr:   []string{"FileContent--proc-sys-net-ipv6-conf-default-forwarding"},
+		},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.testName, func(t *testing.T) {
+			checkList := []string{}
+			internalcfg.Discovery.BootstrapToken.APIServerEndpoint = rt.endpoint
+			checks, err := JoinNodeChecks(exec.New(), internalcfg, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, check := range checks {
+				if check.Name() == ipv4File {
+					checkList = append(checkList, ipv4File)
+				}
+				if check.Name() == ipv6File {
+					checkList = append(checkList, ipv6File)
+				}
+			}
+			if diff := cmp.Diff(checkList, rt.expStr); diff != "" {
+				t.Fatalf("unexpected file content check (-want,+got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Dave Chen <dave.chen@arm.com>


/kind bug



This PR was tested,

```
# cat /proc/sys/net/ipv4/ip_forward
0

# cat /proc/sys/net/bridge/bridge-nf-call-iptables
0


kubeadm init --apiserver-advertise-address=2604:13a0:40221:5e00::3 --feature-gates PublicKeysECDSA=true --cri-socket unix:///var/run/containerd/containerd.sock --upload-certs --pod-network-cidr=fda9:d324:354d:0::/56 --service-cidr=fda9:d324:354d:1::/112


...
Then you can join any number of worker nodes by running the following on each as root:

kubeadm join [2604:13a0:40221:5e00::3]:6443 --token 3ttfg6.qfybe6wwjv2qzqah \
        --discovery-token-ca-cert-hash sha256:79aee86c5b5dd46ce6add46e4e9601706b41e666687feddf0fa50e75a79d042b

```


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fix: https://github.com/kubernetes/kubeadm/issues/2806

#### Special notes for your reviewer:
It's still possible to have the pod has the IPV4 address assigned if it's intending to bootstrap a cluster with IPv6 address, this should be fine as CNI should take care of that IIUC.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
File content check for IPV4 is not enabled by default, and the check of IPV4 or IPV6 is done for `kubeadm init` or `kubeadm join` only in case the user intends to create a cluster to support that kind of IP address family
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
