### PR TITLE
scheduler perf: contextual logging

### DIFF
--- a/test/integration/apiserver/watchcache_test.go
+++ b/test/integration/apiserver/watchcache_test.go
@@ -37,12 +37,12 @@ import (
 // with one of them containing events and the other all other objects.
 func multiEtcdSetup(t *testing.T) (clientset.Interface, framework.TearDownFunc) {
 	etcdArgs := []string{"--experimental-watch-progress-notify-interval", "1s"}
-	etcd0URL, stopEtcd0, err := framework.RunCustomEtcd("etcd_watchcache0", etcdArgs)
+	etcd0URL, stopEtcd0, err := framework.RunCustomEtcd("etcd_watchcache0", etcdArgs, nil)
 	if err != nil {
 		t.Fatalf("Couldn't start etcd: %v", err)
 	}
 
-	etcd1URL, stopEtcd1, err := framework.RunCustomEtcd("etcd_watchcache1", etcdArgs)
+	etcd1URL, stopEtcd1, err := framework.RunCustomEtcd("etcd_watchcache1", etcdArgs, nil)
 	if err != nil {
 		t.Fatalf("Couldn't start etcd: %v", err)
 	}

--- a/test/integration/framework/logger.go
+++ b/test/integration/framework/logger.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"flag"
+	"io"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// RedirectKlog modifies the global klog logger so that it writes via
+// tb.Log. This only works when different tests run sequentially and causes
+// this file to be logged by testing.TB, so this is inferior compared to
+// per-test output with klog/ktesting. Converting code to use ktesting
+// and contextual logging is preferred.
+//
+// The writer is returned. It can be used to redirect also other output, for
+// example of commands.
+func RedirectKlog(tb testing.TB) io.Writer {
+	expectNoError := func(err error) {
+		if err != nil {
+			tb.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	state := klog.CaptureState()
+	tb.Cleanup(state.Restore)
+	var fs flag.FlagSet
+	klog.InitFlags(&fs)
+	expectNoError(fs.Set("log_file", "/dev/null"))
+	expectNoError(fs.Set("logtostderr", "false"))
+	expectNoError(fs.Set("alsologtostderr", "false"))
+	expectNoError(fs.Set("stderrthreshold", "10"))
+	expectNoError(fs.Set("one_output", "true"))
+	output := testingWriter{TB: tb}
+	klog.SetOutput(output)
+	return output
+}
+
+type testingWriter struct {
+	testing.TB
+}
+
+func (tw testingWriter) Write(data []byte) (int, error) {
+	logLen := len(data)
+	if logLen == 0 {
+		return 0, nil
+	}
+	// Trim trailing line break? Log will add it.
+	if data[logLen-1] == '\n' {
+		logLen--
+	}
+	// We could call TB.Helper here, but that doesn't really help because
+	// then our caller (code in klog) will be reported instead, which isn't
+	// right either. klog itself would have to call TB.Helper, but doesn't
+	// know about the TB instance and thus cannot do it.
+	tw.Log(string(data[:logLen]))
+	return len(data), nil
+}
+
+var _ io.Writer = testingWriter{}

--- a/test/integration/scheduler_perf/main_test.go
+++ b/test/integration/scheduler_perf/main_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"k8s.io/klog/v2/ktesting"
-	"k8s.io/kubernetes/test/integration/framework"
 )
 
 func TestMain(m *testing.M) {
@@ -30,5 +29,5 @@ func TestMain(m *testing.M) {
 	ktesting.DefaultConfig.AddFlags(flag.CommandLine)
 	flag.Parse()
 
-	framework.EtcdMain(m.Run)
+	m.Run()
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This makes the output shorter (important when invoked manually) when using `go test` instead of `go test -v`. It becomes possible to feed the output into benchstat, something that failed earlier because the output was too noisy.

As a positive side effect, each test case now runs with its own etcd. This avoids any potential performance impact of the etcd database containing data from a previous test case.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @kerthcet 