### PR TITLE
Allow headless services with type LoadBalancer for specialized proxiers

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/kubernetes/pkg/cluster/ports"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/fieldpath"
+	proxyapis "k8s.io/kubernetes/pkg/proxy/apis"
 	netutils "k8s.io/utils/net"
 )
 
@@ -4760,7 +4761,7 @@ func ValidateService(service *core.Service) field.ErrorList {
 				allErrs = append(allErrs, field.Invalid(portPath, port.Port, fmt.Sprintf("may not expose port %v externally since it is used by kubelet", ports.KubeletPort)))
 			}
 		}
-		if _, ok := service.ObjectMeta.Labels["service.kubernetes.io/service-proxy-name"]; !ok {
+		if _, ok := service.ObjectMeta.Labels[proxyapis.LabelServiceProxyName]; !ok {
 			if isHeadlessService(service) {
 				allErrs = append(allErrs, field.Invalid(specPath.Child("clusterIPs").Index(0), service.Spec.ClusterIPs[0], "may not be set to 'None' for LoadBalancer services"))
 			}

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -4760,8 +4760,10 @@ func ValidateService(service *core.Service) field.ErrorList {
 				allErrs = append(allErrs, field.Invalid(portPath, port.Port, fmt.Sprintf("may not expose port %v externally since it is used by kubelet", ports.KubeletPort)))
 			}
 		}
-		if isHeadlessService(service) {
-			allErrs = append(allErrs, field.Invalid(specPath.Child("clusterIPs").Index(0), service.Spec.ClusterIPs[0], "may not be set to 'None' for LoadBalancer services"))
+		if _, ok := service.ObjectMeta.Labels["service.kubernetes.io/service-proxy-name"]; !ok {
+			if isHeadlessService(service) {
+				allErrs = append(allErrs, field.Invalid(specPath.Child("clusterIPs").Index(0), service.Spec.ClusterIPs[0], "may not be set to 'None' for LoadBalancer services"))
+			}
 		}
 	case core.ServiceTypeNodePort:
 		if isHeadlessService(service) {

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -52,7 +52,6 @@ import (
 	"k8s.io/kubernetes/pkg/cluster/ports"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/fieldpath"
-	proxyapis "k8s.io/kubernetes/pkg/proxy/apis"
 	netutils "k8s.io/utils/net"
 )
 
@@ -4761,7 +4760,7 @@ func ValidateService(service *core.Service) field.ErrorList {
 				allErrs = append(allErrs, field.Invalid(portPath, port.Port, fmt.Sprintf("may not expose port %v externally since it is used by kubelet", ports.KubeletPort)))
 			}
 		}
-		if _, ok := service.ObjectMeta.Labels[proxyapis.LabelServiceProxyName]; !ok {
+		if _, ok := service.ObjectMeta.Labels["service.kubernetes.io/service-proxy-name"]; !ok {
 			if isHeadlessService(service) {
 				allErrs = append(allErrs, field.Invalid(specPath.Child("clusterIPs").Index(0), service.Spec.ClusterIPs[0], "may not be set to 'None' for LoadBalancer services"))
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Allow the combination `type: LoadBalancer` + `clusterIP: None` for services if a specialized proxy is used.

This combination is useful for specialized proxiers that only handles external traffic. I believe this to be the most common use-case for specialized proxiers.

#### Which issue(s) this PR fixes:

Fixes #115429

#### Special notes for your reviewer:

The restriction is lifted for _specialized proxiers only_, i.e. for services with the [service.kubernetes.io/service-proxy-name](https://kubernetes.io/docs/reference/labels-annotations-taints/#servicekubernetesioservice-proxy-name) label defined.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
