### PR TITLE
test: Update runtime class detection logic

### DIFF
--- a/test/e2e/framework/node/runtimeclass/runtimeclass.go
+++ b/test/e2e/framework/node/runtimeclass/runtimeclass.go
@@ -69,13 +69,15 @@ func NodeSupportsPreconfiguredRuntimeClassHandler(ctx context.Context, f *framew
 	// If the `runtimes.test-handler` substring is found in the runtime config, it is assumed that the handler is configured.
 	cmd := fmt.Sprintf(`if [ -e '/etc/containerd/config.toml' ]; then
 grep -q 'runtimes.%s' /etc/containerd/config.toml
-  return
+  exit
 fi
 
 if [ -e '/etc/crio/crio.conf' ]; then
   grep -q 'runtimes.%s' /etc/crio/crio.conf
-  return
+  exit
 fi
+
+exit 1
 `, PreconfiguredRuntimeClassHandler, PreconfiguredRuntimeClassHandler)
 
 	_, err = hostExec.IssueCommandWithResult(ctx, cmd, node)


### PR DESCRIPTION
#### What this PR does / why we need it:

In the `NodeSupportsPreconfiguredRuntimeClassHandler`, update the check for the runtime handler to return a failure if the `/etc/containerd/config.toml` or `/etc/crio/crio.conf` config files do not exist. If an error is returned, then the underlying test will be skipped.

Test manually with starting a kind cluster and moving the containerd config file and verifying that the test is skipped:

```
$ docker exec -it kind-worker /bin/bash
root@kind-worker:/# mv /etc/containerd/config.toml /etc/containerd/config.toml.bak
```

```
$ make WHAT="test/e2e/e2e.test"
$ ./_output/bin/e2e.test -kubeconfig /tmp/kubeconfig_kind -ginkgo.focus=".*should run a Pod requesting a RuntimeClass with a configured handler.*" --num-nodes=1 2>&1 -ginkgo.v=1 | tee -i "/tmp/build-log.txt"

...

[sig-node] RuntimeClass [It] should run a Pod requesting a RuntimeClass with a configured handler [NodeFeature:RuntimeHandler]
test/e2e/common/node/runtimeclass.go:85

  [SKIPPED] Skipping test as node does not have E2E runtime class handler preconfigured in container runtime config: command terminated with exit code 1
```

This is needed as some distros have non default config locations and should result in test being skipped, e.g. see https://github.com/kubernetes/kubernetes/pull/115219#issuecomment-1409987348

Signed-off-by: David Porter <david@porter.me>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
