### PR TITLE
test: Add e2e node test to check for unknown pods

### DIFF
--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -31,11 +31,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
-	"k8s.io/kubernetes/pkg/kubelet/types"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -370,28 +368,6 @@ func runTopologyManagerPolicySuiteTests(ctx context.Context, f *framework.Framew
 
 	ginkgo.By("running multiple Gu pods")
 	runMultipleGuPods(ctx, f)
-}
-
-// waitForAllContainerRemoval waits until all the containers on a given pod are really gone.
-// This is needed by the e2e tests which involve exclusive resource allocation (cpu, topology manager; podresources; etc.)
-// In these cases, we need to make sure the tests clean up after themselves to make sure each test runs in
-// a pristine environment. The only way known so far to do that is to introduce this wait.
-// Worth noting, however, that this makes the test runtime much bigger.
-func waitForAllContainerRemoval(ctx context.Context, podName, podNS string) {
-	rs, _, err := getCRIClient()
-	framework.ExpectNoError(err)
-	gomega.Eventually(ctx, func(ctx context.Context) bool {
-		containers, err := rs.ListContainers(ctx, &runtimeapi.ContainerFilter{
-			LabelSelector: map[string]string{
-				types.KubernetesPodNameLabel:      podName,
-				types.KubernetesPodNamespaceLabel: podNS,
-			},
-		})
-		if err != nil {
-			return false
-		}
-		return len(containers) == 0
-	}, 2*time.Minute, 1*time.Second).Should(gomega.BeTrue())
 }
 
 func runTopologyManagerPositiveTest(ctx context.Context, f *framework.Framework, numPods int, ctnAttrs, initCtnAttrs []tmCtnAttribute, envInfo *testEnvInfo) {

--- a/test/e2e_node/unknown_pods_test.go
+++ b/test/e2e_node/unknown_pods_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"os"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+/*
+* Unknown pods are pods which are unknown pods to the kubelet, but are still
+* running in the container runtime. If kubelet detects a pod which is not in
+* the config (i.e. not present in API-server or static pod), but running as
+* detected in container runtime, kubelet should aggressively terminate the pod.
+*
+* This situation can be encountered if a pod is running, then kubelet is
+* stopped, and while stopped, the manifest is deleted (by force deleting the
+* API pod or deleting the static pod manifest), and then restarting the
+* kubelet. Upon restart, kubelet will see the pod as running via the container
+* runtime, but it will not be present in the config, thus making the pod a
+* "unknown pod". Kubelet should then proceed to terminate these unknown pods.
+ */
+var _ = SIGDescribe("Unknown Pods [Serial] [Disruptive]", func() {
+	f := framework.NewDefaultFramework("unknown-pods")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
+
+	ginkgo.Context("when creating a mirror pod", func() {
+		var ns, podPath, staticPodName, mirrorPodName string
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			ns = f.Namespace.Name
+			staticPodName = "unknown-test-pod-" + string(uuid.NewUUID())
+			mirrorPodName = staticPodName + "-" + framework.TestContext.NodeName
+
+			podPath = framework.TestContext.KubeletConfig.StaticPodPath
+
+			framework.Logf("create the static pod %v", staticPodName)
+			err := createStaticPodWithGracePeriod(podPath, staticPodName, ns)
+			framework.ExpectNoError(err)
+
+			framework.Logf("wait for the mirror pod %v to be running", mirrorPodName)
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				return checkMirrorPodRunning(ctx, f.ClientSet, mirrorPodName, ns)
+			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeNil())
+		})
+
+		ginkgo.It("the static pod should be terminated and cleaned up due to becoming a unknown pod due to being force deleted while kubelet is not running", func(ctx context.Context) {
+			framework.Logf("Stopping the kubelet")
+			startKubelet := stopKubelet()
+
+			pod, err := f.ClientSet.CoreV1().Pods(ns).Get(ctx, mirrorPodName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+
+			// wait until the kubelet health check will fail
+			gomega.Eventually(ctx, func() bool {
+				return kubeletHealthCheck(kubeletHealthCheckURL)
+			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeFalse())
+
+			framework.Logf("Delete the static pod manifest while the kubelet is not running")
+			file := staticPodPath(podPath, staticPodName, ns)
+			framework.Logf("deleting static pod manifest %q", file)
+			err = os.Remove(file)
+			framework.ExpectNoError(err)
+
+			framework.Logf("Starting the kubelet")
+			startKubelet()
+
+			// wait until the kubelet health check will succeed
+			gomega.Eventually(ctx, func() bool {
+				return kubeletHealthCheck(kubeletHealthCheckURL)
+			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrue())
+
+			framework.Logf("wait for the mirror pod %v to disappear", mirrorPodName)
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				return checkMirrorPodDisappear(ctx, f.ClientSet, mirrorPodName, ns)
+			}, f.Timeouts.PodDelete, f.Timeouts.Poll).Should(gomega.BeNil())
+
+			waitForAllContainerRemoval(ctx, pod.Name, pod.Namespace)
+		})
+
+		ginkgo.AfterEach(func(ctx context.Context) {
+			framework.Logf("deleting the static pod %v", staticPodName)
+			err := deleteStaticPod(podPath, staticPodName, ns)
+			if !os.IsNotExist(err) {
+				framework.ExpectNoError(err)
+			}
+
+			framework.Logf("wait for the mirror pod to disappear")
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				return checkMirrorPodDisappear(ctx, f.ClientSet, mirrorPodName, ns)
+			}, f.Timeouts.PodDelete, f.Timeouts.Poll).Should(gomega.BeNil())
+		})
+	})
+
+	ginkgo.Context("when creating a API pod", func() {
+		var ns, podName string
+
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			ns = f.Namespace.Name
+			podName = "unknown-test-pause-pod-" + string(uuid.NewUUID())
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: podName,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "pause",
+							Image: imageutils.GetPauseImageName(),
+						},
+					},
+				},
+			}
+
+			e2epod.NewPodClient(f).CreateSync(ctx, pod)
+		})
+
+		ginkgo.It("the api pod should be terminated and cleaned up due to becoming a unknown pod due to being force deleted while kubelet is not running", func(ctx context.Context) {
+			framework.Logf("Stopping the kubelet")
+			startKubelet := stopKubelet()
+
+			pod, err := f.ClientSet.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+
+			// wait until the kubelet health check will fail
+			gomega.Eventually(ctx, func() bool {
+				return kubeletHealthCheck(kubeletHealthCheckURL)
+			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeFalse())
+
+			framework.Logf("Delete the pod while the kubelet is not running")
+			// Delete pod sync by name will force delete the pod, removing it from kubelet's config
+			deletePodSyncByName(ctx, f, podName)
+
+			framework.Logf("Starting the kubelet")
+			startKubelet()
+
+			// wait until the kubelet health check will succeed
+			gomega.Eventually(ctx, func() bool {
+				return kubeletHealthCheck(kubeletHealthCheckURL)
+			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrue())
+
+			framework.Logf("wait for the pod %v to disappear", podName)
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				return checkMirrorPodDisappear(ctx, f.ClientSet, podName, ns)
+			}, f.Timeouts.PodDelete, f.Timeouts.Poll).Should(gomega.BeNil())
+
+			waitForAllContainerRemoval(ctx, pod.Name, pod.Namespace)
+		})
+	})
+})


### PR DESCRIPTION
#### What this PR does / why we need it:

Unknown pods are pods which are unknown pods to the kubelet, but are still running in the container runtime. If kubelet detects a pod which is not in the config (i.e. not present in API-server or static pod), but running as detected in container runtime, kubelet should aggressively terminate the pod.

This situation can be encountered if a pod is running, then kubelet is stopped, and while stopped, the manifest is deleted (by force deleting the API pod or deleting the static pod manifest), and then restarting the kubelet. Upon restart, kubelet will see the pod as running via the container runtime, but it will not be present in the config, thus making the pod a "unknown pod". Kubelet should then proceed to terminate these unknown pods.

Add two tests that ensure that unknown pods will be terminated (1) static pods and (2) API pods. The test will start a pod, stop the kubelet, force delete the pod (by deleting the manifest or force deleting the pod), and then restarting the kubelet. The container runtime is then queried to ensure the containers are terminated by kubelet.

Signed-off-by: David Porter <david@porter.me>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
