### PR TITLE
Add windows nodeSelector to e2e storage testing pods

### DIFF
--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -422,5 +422,12 @@ func (d *driverDefinition) PrepareTest(ctx context.Context, f *framework.Framewo
 		Framework:           f,
 		ClientNodeSelection: e2epod.NodeSelection{Name: d.ClientNodeName},
 	}
+
+	if framework.NodeOSDistroIs("windows") {
+		e2econfig.ClientNodeSelection.Selector = map[string]string{"kubernetes.io/os": "windows"}
+	} else {
+		e2econfig.ClientNodeSelection.Selector = map[string]string{"kubernetes.io/os": "linux"}
+	}
+
 	return e2econfig
 }

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -165,15 +165,16 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 		}, l.config.Framework.Namespace.Name)
 		framework.Logf("In creating storage class object and pvc objects for driver - sc: %v, pvc: %v, src-pvc: %v", l.sc, l.pvc, l.sourcePVC)
 		l.testCase = &StorageClassTest{
-			Client:       l.config.Framework.ClientSet,
-			Timeouts:     f.Timeouts,
-			Claim:        l.pvc,
-			SourceClaim:  l.sourcePVC,
-			Class:        l.sc,
-			Provisioner:  l.sc.Provisioner,
-			ClaimSize:    claimSize,
-			ExpectedSize: claimSize,
-			VolumeMode:   pattern.VolMode,
+			Client:        l.config.Framework.ClientSet,
+			Timeouts:      f.Timeouts,
+			Claim:         l.pvc,
+			SourceClaim:   l.sourcePVC,
+			Class:         l.sc,
+			Provisioner:   l.sc.Provisioner,
+			ClaimSize:     claimSize,
+			ExpectedSize:  claimSize,
+			VolumeMode:    pattern.VolMode,
+			NodeSelection: l.config.ClientNodeSelection,
 		}
 	}
 

--- a/test/e2e/storage/testsuites/topology.go
+++ b/test/e2e/storage/testsuites/topology.go
@@ -325,7 +325,7 @@ func (t *topologyTestSuite) createResources(ctx context.Context, cs clientset.In
 	podConfig := e2epod.Config{
 		NS:            l.config.Framework.Namespace.Name,
 		PVCs:          []*v1.PersistentVolumeClaim{l.resource.Pvc},
-		NodeSelection: e2epod.NodeSelection{Affinity: affinity},
+		NodeSelection: e2epod.NodeSelection{Affinity: affinity, Selector: l.config.ClientNodeSelection.Selector},
 		SeLinuxLabel:  e2epod.GetLinuxLabel(),
 		ImageID:       e2epod.GetDefaultTestImageID(),
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- Pods launched by the e2e tests get stuck in `ContainerCreating` on Windows in EKS. 

- Checked against https://testgrid.k8s.io/provider-gcp-compute-persistent-disk-csi-driver#ci-windows-2019-provider-gcp-compute-persistent-disk-csi-driver.

- The VPC resource controller is responsible for annotating new pods with `vpc.amazonaws.com/PrivateIPv4Address` , if the `nodeSelector` label `kubernetes.io/os=windows`is missing from the pod Spec, the webhook will not annotate the pod for resources: https://github.com/aws/amazon-vpc-resource-controller-k8s/blob/master/webhooks/core/pod_webhook.go#L216-L226. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

Signed-off-by: torredil <torredil@amazon.com>
