### PR TITLE
[ingress] Create with ingressClass annotation and IngressClassName both set

### DIFF
--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -276,9 +276,9 @@ func ValidateIngressCreate(ingress *networking.Ingress) field.ErrorList {
 	}
 	allErrs = append(allErrs, validateIngress(ingress, opts)...)
 	annotationVal, annotationIsSet := ingress.Annotations[annotationIngressClass]
-	if annotationIsSet && ingress.Spec.IngressClassName != nil {
+	if annotationIsSet && ingress.Spec.IngressClassName != nil && annotationVal != *ingress.Spec.IngressClassName {
 		annotationPath := field.NewPath("annotations").Child(annotationIngressClass)
-		allErrs = append(allErrs, field.Invalid(annotationPath, annotationVal, "can not be set when the class field is also set"))
+		allErrs = append(allErrs, field.Invalid(annotationPath, annotationVal, "ingressClass annotation and IngressClassName should have the same value"))
 	}
 	return allErrs
 }

--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -278,7 +278,7 @@ func ValidateIngressCreate(ingress *networking.Ingress) field.ErrorList {
 	annotationVal, annotationIsSet := ingress.Annotations[annotationIngressClass]
 	if annotationIsSet && ingress.Spec.IngressClassName != nil && annotationVal != *ingress.Spec.IngressClassName {
 		annotationPath := field.NewPath("annotations").Child(annotationIngressClass)
-		allErrs = append(allErrs, field.Invalid(annotationPath, annotationVal, "ingressClass annotation and IngressClassName should have the same value"))
+		allErrs = append(allErrs, field.Invalid(annotationPath, annotationVal, "must match `ingressClassName` when both are specified"))
 	}
 	return allErrs
 }

--- a/pkg/apis/networking/validation/validation_test.go
+++ b/pkg/apis/networking/validation/validation_test.go
@@ -1005,7 +1005,7 @@ func TestValidateIngressCreate(t *testing.T) {
 				ingress.Spec.IngressClassName = utilpointer.String("bar")
 				ingress.Annotations = map[string]string{annotationIngressClass: "foo"}
 			},
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("annotations").Child(annotationIngressClass), "foo", "ingressClass annotation and IngressClassName should have the same value")},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("annotations").Child(annotationIngressClass), "foo", "must match `ingressClassName` when both are specified")},
 		},
 		"valid regex path": {
 			tweakIngress: func(ingress *networking.Ingress) {

--- a/pkg/apis/networking/validation/validation_test.go
+++ b/pkg/apis/networking/validation/validation_test.go
@@ -993,12 +993,19 @@ func TestValidateIngressCreate(t *testing.T) {
 			},
 			expectedErrs: field.ErrorList{},
 		},
-		"class field and annotation set": {
+		"class field and annotation set with same value": {
+			tweakIngress: func(ingress *networking.Ingress) {
+				ingress.Spec.IngressClassName = utilpointer.String("foo")
+				ingress.Annotations = map[string]string{annotationIngressClass: "foo"}
+			},
+			expectedErrs: field.ErrorList{},
+		},
+		"class field and annotation set with different value": {
 			tweakIngress: func(ingress *networking.Ingress) {
 				ingress.Spec.IngressClassName = utilpointer.String("bar")
 				ingress.Annotations = map[string]string{annotationIngressClass: "foo"}
 			},
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("annotations").Child(annotationIngressClass), "foo", "can not be set when the class field is also set")},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("annotations").Child(annotationIngressClass), "foo", "ingressClass annotation and IngressClassName should have the same value")},
 		},
 		"valid regex path": {
 			tweakIngress: func(ingress *networking.Ingress) {

--- a/pkg/registry/networking/ingress/strategy.go
+++ b/pkg/registry/networking/ingress/strategy.go
@@ -18,6 +18,7 @@ package ingress
 
 import (
 	"context"
+	"fmt"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -101,8 +102,8 @@ func (ingressStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object)
 	var warnings []string
 	ingress := obj.(*networking.Ingress)
 	_, annotationIsSet := ingress.Annotations[annotationIngressClass]
-	if annotationIsSet && ingress.Spec.IngressClassName != nil {
-		warnings = append(warnings, "ingressClass annotation and IngressClassName should not be set at the same time")
+	if annotationIsSet && ingress.Spec.IngressClassName == nil {
+		warnings = append(warnings, fmt.Sprintf("annotation %q is deprecated, please use 'spec.ingressClassName' instead", annotationIngressClass))
 	}
 	return warnings
 }

--- a/pkg/registry/networking/ingress/strategy_test.go
+++ b/pkg/registry/networking/ingress/strategy_test.go
@@ -19,9 +19,11 @@ package ingress
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/kubernetes/pkg/apis/networking"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 func newIngress() networking.Ingress {
@@ -136,5 +138,70 @@ func TestIngressStatusStrategy(t *testing.T) {
 	errs := StatusStrategy.ValidateUpdate(ctx, &newIngress, &oldIngress)
 	if len(errs) != 0 {
 		t.Errorf("Unexpected error %v", errs)
+	}
+}
+
+func TestWarningsOnCreate(t *testing.T) {
+	ctx := genericapirequest.NewDefaultContext()
+	if !StatusStrategy.NamespaceScoped() {
+		t.Errorf("Ingress must be namespace scoped")
+	}
+	if StatusStrategy.AllowCreateOnUpdate() {
+		t.Errorf("Ingress should not allow create on update")
+	}
+
+	serviceBackend := &networking.IngressServiceBackend{
+		Name: "defaultbackend",
+		Port: networking.ServiceBackendPort{
+			Number: 80,
+		},
+	}
+	defaultBackend := networking.IngressBackend{
+		Service: serviceBackend,
+	}
+	baseIngress := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test123",
+			Namespace:       "test123",
+			ResourceVersion: "1234",
+		},
+		Spec: networking.IngressSpec{
+			DefaultBackend: &defaultBackend,
+			Rules:          []networking.IngressRule{},
+		},
+	}
+
+	testCases := map[string]struct {
+		tweakIngress     func(ingress *networking.Ingress)
+		expectedWarnings []string
+	}{
+		"ingressClass annotation and IngressClassName set": {
+			tweakIngress: func(ingress *networking.Ingress) {
+				ingress.Spec.IngressClassName = utilpointer.String("foo")
+				ingress.Annotations = map[string]string{annotationIngressClass: "foo"}
+			},
+			expectedWarnings: []string{"ingressClass annotation and IngressClassName should not be set at the same time"},
+		},
+		"ingressClass annotation set": {
+			tweakIngress: func(ingress *networking.Ingress) {
+				ingress.Annotations = map[string]string{annotationIngressClass: "foo"}
+			},
+		},
+		"IngressClassName set": {
+			tweakIngress: func(ingress *networking.Ingress) {
+				ingress.Spec.IngressClassName = utilpointer.String("foo")
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			newIngress := baseIngress.DeepCopy()
+			testCase.tweakIngress(newIngress)
+			warnings := Strategy.WarningsOnCreate(ctx, newIngress)
+			if diff := cmp.Diff(warnings, testCase.expectedWarnings); diff != "" {
+				t.Errorf("warings does not match (-want,+got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/pkg/registry/networking/ingress/strategy_test.go
+++ b/pkg/registry/networking/ingress/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ingress
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -175,17 +176,11 @@ func TestWarningsOnCreate(t *testing.T) {
 		tweakIngress     func(ingress *networking.Ingress)
 		expectedWarnings []string
 	}{
-		"ingressClass annotation and IngressClassName set": {
-			tweakIngress: func(ingress *networking.Ingress) {
-				ingress.Spec.IngressClassName = utilpointer.String("foo")
-				ingress.Annotations = map[string]string{annotationIngressClass: "foo"}
-			},
-			expectedWarnings: []string{"ingressClass annotation and IngressClassName should not be set at the same time"},
-		},
-		"ingressClass annotation set": {
+		"ingressClass annotation set, IngressClassName not set": {
 			tweakIngress: func(ingress *networking.Ingress) {
 				ingress.Annotations = map[string]string{annotationIngressClass: "foo"}
 			},
+			expectedWarnings: []string{fmt.Sprintf("annotation %q is deprecated, please use 'spec.ingressClassName' instead", annotationIngressClass)},
 		},
 		"IngressClassName set": {
 			tweakIngress: func(ingress *networking.Ingress) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Loosening validation rules for ingress creation, let ingress with ingressClass annotation and IngressClassName both set pass. Instead, add an api warning for it.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115018

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Ingress with ingressClass annotation and IngressClassName both set can be created now.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
