### PR TITLE
Rename "method" label to "verb" in rest_client_requests_total

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
@@ -77,9 +77,9 @@ var (
 		&k8smetrics.CounterOpts{
 			Name:           "rest_client_requests_total",
 			StabilityLevel: k8smetrics.ALPHA,
-			Help:           "Number of HTTP requests, partitioned by status code, method, and host.",
+			Help:           "Number of HTTP requests, partitioned by status code, verb, and host.",
 		},
-		[]string{"code", "method", "host"},
+		[]string{"code", "verb", "host"},
 	)
 
 	execPluginCertTTLAdapter = &expiryToTTLAdapter{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind api-change
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Verb is the commonly used label when referring to HTTP verbs.
rest_client_requests_total is the only metric in the rest package using
`method` instead of `verb` which makes it inconsistent and confusing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

reverted in https://github.com/kubernetes/kubernetes/pull/115808, original release note was:
```
The alpha `rest_client_requests_total` metric renamed the "method" label to "verb" to be consistent with other rest client metrics.
```

/cc @logicalhan 