### PR TITLE
Automated cherry pick of #115349: update prev succeeded indexes for indexed jobs

### DIFF
--- a/pkg/controller/job/indexed_job_utils.go
+++ b/pkg/controller/job/indexed_job_utils.go
@@ -55,7 +55,7 @@ func calculateSucceededIndexes(job *batch.Job, pods []*v1.Pod) (orderedIntervals
 	var prevIntervals orderedIntervals
 	withFinalizers := trackingUncountedPods(job)
 	if withFinalizers {
-		prevIntervals = succeededIndexesFromJob(job)
+		prevIntervals = succeededIndexesFromString(job.Status.CompletedIndexes, int(*job.Spec.Completions))
 	}
 	newSucceeded := sets.NewInt()
 	for _, p := range pods {
@@ -152,20 +152,19 @@ func (oi orderedIntervals) has(ix int) bool {
 	return oi[hi].First <= ix
 }
 
-func succeededIndexesFromJob(job *batch.Job) orderedIntervals {
-	if job.Status.CompletedIndexes == "" {
+func succeededIndexesFromString(completedIndexes string, completions int) orderedIntervals {
+	if completedIndexes == "" {
 		return nil
 	}
 	var result orderedIntervals
 	var lastInterval *interval
-	completions := int(*job.Spec.Completions)
-	for _, intervalStr := range strings.Split(job.Status.CompletedIndexes, ",") {
+	for _, intervalStr := range strings.Split(completedIndexes, ",") {
 		limitsStr := strings.Split(intervalStr, "-")
 		var inter interval
 		var err error
 		inter.First, err = strconv.Atoi(limitsStr[0])
 		if err != nil {
-			klog.InfoS("Corrupted completed indexes interval, ignoring", "job", klog.KObj(job), "interval", intervalStr, "err", err)
+			klog.InfoS("Corrupted completed indexes interval, ignoring", "interval", intervalStr, "err", err)
 			continue
 		}
 		if inter.First >= completions {
@@ -174,7 +173,7 @@ func succeededIndexesFromJob(job *batch.Job) orderedIntervals {
 		if len(limitsStr) > 1 {
 			inter.Last, err = strconv.Atoi(limitsStr[1])
 			if err != nil {
-				klog.InfoS("Corrupted completed indexes interval, ignoring", "job", klog.KObj(job), "interval", intervalStr, "err", err)
+				klog.InfoS("Corrupted completed indexes interval, ignoring", "interval", intervalStr, "err", err)
 				continue
 			}
 			if inter.Last >= completions {


### PR DESCRIPTION
Cherry pick of #115349 on release-1.24.

#115349: update prev succeeded indexes for indexed jobs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed bug which caused the status of Indexed Jobs to only be updated when there are newly completed indexes. The completed indexes are now updated if the .status.completedIndexes has values outside of the [0, .spec.completions> range
```