### PR TITLE
Automated cherry pick of #115341: apiserver: remove 34s from DELETECOLLECTION rest handler

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
@@ -183,12 +183,10 @@ func DeleteCollection(r rest.CollectionDeleter, checkBody bool, scope *RequestSc
 			return
 		}
 
-		// enforce a timeout of at most requestTimeoutUpperBound (34s) or less if the user-provided
-		// timeout inside the parent context is lower than requestTimeoutUpperBound.
-		ctx, cancel := context.WithTimeout(req.Context(), requestTimeoutUpperBound)
-		defer cancel()
-
-		ctx = request.WithNamespace(ctx, namespace)
+		// DELETECOLLECTION can be a lengthy operation,
+		// we should not impose any 34s timeout here.
+		// NOTE: This is similar to LIST which does not enforce a 34s timeout.
+		ctx := request.WithNamespace(req.Context(), namespace)
 
 		outputMediaType, _, err := negotiation.NegotiateOutputMediaType(req, scope.Serializer, scope)
 		if err != nil {


### PR DESCRIPTION
Cherry pick of #115341 on release-1.24.

#### What this PR does / why we need it:
Remove `34s`  timeout (enforced at rest handler layer) from `DELETECOLLECTION` since it is naturally a lengthy operation. This will enforce the default `60s` timeout on a `DELETECOLLECTION` request if the user does not specify any timeout in the request URI

#### Which issue(s) this PR fixes:

Fixes #115090

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fix the 1.21 regression that introduced 34s timeout for DELETECOLLECTION calls
```