### PR TITLE
Don't explicitly set image version in tests

### DIFF
--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -83,7 +83,6 @@ var _ = SIGDescribe("Security Context", func() {
 			gidDefinedInImage := int64(50000)
 			supplementalGroup := int64(60000)
 			agnhost := imageutils.GetConfig(imageutils.Agnhost)
-			(&agnhost).SetVersion("2.43")
 			pod := scTestPod(false, false)
 			pod.Spec.Containers[0].Image = agnhost.GetE2EImage()
 			pod.Spec.Containers[0].Command = []string{"id", "-G"}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig testing
/sig node

#### What this PR does / why we need it:
Image versions are already explicitly set in our manifests configuration, so tests should not be setting these values to ensure we're using the same versions across the board.

This is causing problems when downstream is mirroring images and the test overwrites the version to use for tests. 

#### Special notes for your reviewer:
/assign @rphillips @sanchezl 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
