### PR TITLE
Disable SPDY pings for kubectl cp and add --ping flag for kubectl exec

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -121,6 +121,11 @@ func (s *SpdyRoundTripper) TLSClientConfig() *tls.Config {
 	return s.tlsConfig
 }
 
+// PingPeriod returns the period for sending Ping frames over established connections.
+func (s *SpdyRoundTripper) PingPeriod() time.Duration {
+	return s.pingPeriod
+}
+
 // Dial implements k8s.io/apimachinery/pkg/util/net.Dialer.
 func (s *SpdyRoundTripper) Dial(req *http.Request) (net.Conn, error) {
 	conn, err := s.dial(req)

--- a/staging/src/k8s.io/client-go/transport/spdy/spdy_test.go
+++ b/staging/src/k8s.io/client-go/transport/spdy/spdy_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"k8s.io/apimachinery/pkg/util/httpstream/spdy"
+	restclient "k8s.io/client-go/rest"
+	"testing"
+	"time"
+)
+
+func TestRoundTripperForShouldCreateUpgraderThatUsesDefaultPingPeriod(t *testing.T) {
+	_, upgrader, err := RoundTripperFor(&restclient.Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	spdyRoundTripper := upgrader.(*spdy.SpdyRoundTripper)
+	if spdyRoundTripper.PingPeriod() != DefaultPingPeriod {
+		t.Errorf("wrong ping period. expected: %v, got %v", DefaultPingPeriod, spdyRoundTripper.PingPeriod())
+	}
+}
+
+func TestRoundTripperWithPingForShouldCreateUpgraderThatUsesSpecifiedPingPeriod(t *testing.T) {
+	testCases := []struct {
+		Name       string
+		PingPeriod time.Duration
+	}{
+		{
+			Name:       "10s ping period",
+			PingPeriod: 10 * time.Second,
+		},
+		{
+			Name:       "No pings",
+			PingPeriod: 0,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, upgrader, err := RoundTripperWithPingFor(&restclient.Config{}, tc.PingPeriod)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			spdyRoundTripper := upgrader.(*spdy.SpdyRoundTripper)
+			if spdyRoundTripper.PingPeriod() != tc.PingPeriod {
+				t.Errorf("wrong ping period. expected: %v, got %v", tc.PingPeriod, spdyRoundTripper.PingPeriod())
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
SPDY pings seem to cause sporadic incomplete file transfer for `kubectl cp` and `kubectl exec`.

This PR disables pings for `kubectl cp` and makes them configurable via a `--ping` flag for `kubectl exec`.

#### Which issue(s) this PR fixes:
Fixes #60140 

#### Special notes for your reviewer:
Further context: https://github.com/kubernetes/kubernetes/issues/60140#issuecomment-1411477275

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where using kubectl cp to copy a large file from a remote pod would sometimes result in an incomplete file.
Added --ping flag to allow ping frequency to be configured or disabled for kubectl exec.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
