### PR TITLE
add some ut for cronjob strategy and timezone in schedule

### DIFF
--- a/pkg/registry/batch/job/strategy_test.go
+++ b/pkg/registry/batch/job/strategy_test.go
@@ -1104,14 +1104,14 @@ func TestJobStrategy_Validate(t *testing.T) {
 func TestStrategy_ResetFields(t *testing.T) {
 	resetFields := Strategy.GetResetFields()
 	if len(resetFields) != 1 {
-		t.Error("ResetFields should have 1 element")
+		t.Errorf("ResetFields should have 1 element, but have %d", len(resetFields))
 	}
 }
 
 func TestJobStatusStrategy_ResetFields(t *testing.T) {
 	resetFields := StatusStrategy.GetResetFields()
 	if len(resetFields) != 1 {
-		t.Error("ResetFields should have 1 element")
+		t.Errorf("ResetFields should have 1 element, but have %d", len(resetFields))
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Before
```
ok  	k8s.io/kubernetes/pkg/registry/batch/cronjob	0.723s	coverage: 57.4% of statements
```
After
```
ok  	k8s.io/kubernetes/pkg/registry/batch/cronjob	1.067s	coverage: 92.6% of statements
```
#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/enhancements/issues/3140

#### Special notes for your reviewer:
CronJobTimeZone will GA in v1.27 and this helps to adding the code coverage of it

#### Does this PR introduce a user-facing change?

```release-note
None
```

/cc @soltysh 