### PR TITLE
Automated cherry pick of #112990: test: demote service ClientIP affinity timeout tests from

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1540,38 +1540,6 @@
     named Kubernetes with the Namespace of default.
   release: v1.18
   file: test/e2e/network/service.go
-- testname: Service, NodePort type, session affinity to ClientIP with timeout
-  codename: '[sig-network] Services should have session affinity timeout work for
-    NodePort service [LinuxOnly] [Conformance]'
-  description: 'Create a service of type "NodePort" and provide service port and protocol.
-    Service''s sessionAffinity is set to "ClientIP" and session affinity timeout is
-    set. Service creation MUST be successful by assigning a "ClusterIP" to service
-    and allocating NodePort on all nodes. Create a Replication Controller to ensure
-    that 3 pods are running and are targeted by the service to serve hostname of the
-    pod when requests are sent to the service. Create another pod to make requests
-    to the service on node''s IP and NodePort. Service MUST serve the hostname from
-    the same pod of the replica for all consecutive requests until timeout. After
-    timeout, requests MUST be served from different pods of the replica. Service MUST
-    be reachable over serviceName and the ClusterIP on servicePort. Service MUST also
-    be reachable over node''s IP on NodePort. [LinuxOnly]: Windows does not support
-    session affinity.'
-  release: v1.19
-  file: test/e2e/network/service.go
-- testname: Service, ClusterIP type, session affinity to ClientIP with timeout
-  codename: '[sig-network] Services should have session affinity timeout work for
-    service with type clusterIP [LinuxOnly] [Conformance]'
-  description: 'Create a service of type "ClusterIP". Service''s sessionAffinity is
-    set to "ClientIP" and session affinity timeout is set. Service creation MUST be
-    successful by assigning "ClusterIP" to the service. Create a Replication Controller
-    to ensure that 3 pods are running and are targeted by the service to serve hostname
-    of the pod when requests are sent to the service. Create another pod to make requests
-    to the service. Service MUST serve the hostname from the same pod of the replica
-    for all consecutive requests until timeout expires. After timeout, requests MUST
-    be served from different pods of the replica. Service MUST be reachable over serviceName
-    and the ClusterIP on servicePort. [LinuxOnly]: Windows does not support session
-    affinity.'
-  release: v1.19
-  file: test/e2e/network/service.go
 - testname: Service, NodePort type, session affinity to ClientIP
   codename: '[sig-network] Services should have session affinity work for NodePort
     service [LinuxOnly] [Conformance]'

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2073,17 +2073,7 @@ var _ = common.SIGDescribe("Services", func() {
 		execAffinityTestForNonLBService(f, cs, svc)
 	})
 
-	/*
-		Release: v1.19
-		Testname: Service, ClusterIP type, session affinity to ClientIP with timeout
-		Description: Create a service of type "ClusterIP". Service's sessionAffinity is set to "ClientIP" and session affinity timeout is set. Service creation MUST be successful by assigning "ClusterIP" to the service.
-		Create a Replication Controller to ensure that 3 pods are running and are targeted by the service to serve hostname of the pod when requests are sent to the service.
-		Create another pod to make requests to the service. Service MUST serve the hostname from the same pod of the replica for all consecutive requests until timeout expires.
-		After timeout, requests MUST be served from different pods of the replica.
-		Service MUST be reachable over serviceName and the ClusterIP on servicePort.
-		[LinuxOnly]: Windows does not support session affinity.
-	*/
-	framework.ConformanceIt("should have session affinity timeout work for service with type clusterIP [LinuxOnly]", func() {
+	ginkgo.It("should have session affinity timeout work for service with type clusterIP [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-clusterip-timeout")
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		execAffinityTestForSessionAffinityTimeout(f, cs, svc)
@@ -2120,18 +2110,7 @@ var _ = common.SIGDescribe("Services", func() {
 		execAffinityTestForNonLBService(f, cs, svc)
 	})
 
-	/*
-		Release: v1.19
-		Testname: Service, NodePort type, session affinity to ClientIP with timeout
-		Description: Create a service of type "NodePort" and provide service port and protocol. Service's sessionAffinity is set to "ClientIP" and session affinity timeout is set.
-		Service creation MUST be successful by assigning a "ClusterIP" to service and allocating NodePort on all nodes.
-		Create a Replication Controller to ensure that 3 pods are running and are targeted by the service to serve hostname of the pod when requests are sent to the service.
-		Create another pod to make requests to the service on node's IP and NodePort. Service MUST serve the hostname from the same pod of the replica for all consecutive requests until timeout.
-		After timeout, requests MUST be served from different pods of the replica.
-		Service MUST be reachable over serviceName and the ClusterIP on servicePort. Service MUST also be reachable over node's IP on NodePort.
-		[LinuxOnly]: Windows does not support session affinity.
-	*/
-	framework.ConformanceIt("should have session affinity timeout work for NodePort service [LinuxOnly]", func() {
+	ginkgo.It("should have session affinity timeout work for NodePort service [LinuxOnly]", func() {
 		svc := getServeHostnameService("affinity-nodeport-timeout")
 		svc.Spec.Type = v1.ServiceTypeNodePort
 		execAffinityTestForSessionAffinityTimeout(f, cs, svc)


### PR DESCRIPTION
Cherry pick of #112990 on release-1.24.

#112990: test: demote service ClientIP affinity timeout tests from

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```