### PR TITLE
Move the DeletePod call to the plugin interface for preemption.

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -339,6 +339,6 @@ func getPDBLister(informerFactory informers.SharedInformerFactory) policylisters
 	return informerFactory.Policy().V1().PodDisruptionBudgets().Lister()
 }
 
-func (pl *DefaultPreemption) DeletePod(ctx context.Context, cs kubernetes.Interface, victim, preemptor *v1.Pod) error {
+func (pl *DefaultPreemption) DeleteVictim(ctx context.Context, cs kubernetes.Interface, victim, preemptor *v1.Pod) error {
 	return util.DeletePod(ctx, cs, victim)
 }

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	policylisters "k8s.io/client-go/listers/policy/v1"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
@@ -336,4 +337,8 @@ func filterPodsWithPDBViolation(podInfos []*framework.PodInfo, pdbs []*policy.Po
 
 func getPDBLister(informerFactory informers.SharedInformerFactory) policylisters.PodDisruptionBudgetLister {
 	return informerFactory.Policy().V1().PodDisruptionBudgets().Lister()
+}
+
+func (pl *DefaultPreemption) DeletePod(ctx context.Context, cs kubernetes.Interface, victim, preemptor *v1.Pod) error {
+	return util.DeletePod(ctx, cs, victim)
 }

--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -124,6 +124,7 @@ type Interface interface {
 	SelectVictimsOnNode(ctx context.Context, state *framework.CycleState,
 		pod *v1.Pod, nodeInfo *framework.NodeInfo, pdbs []*policy.PodDisruptionBudget) ([]*v1.Pod, int, *framework.Status)
 	// DeleteVictim deletes the given victim pod from API server for preemption.
+	// Evaluator uses this function to delete the victim pod instead of calling the Pod delete API directly so that the preemption plugin can implement a hook on victim deletion.
 	DeleteVictim(ctx context.Context, cs kubernetes.Interface, victim, preemptor *v1.Pod) error
 }
 

--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -123,8 +123,8 @@ type Interface interface {
 	// Note that both `state` and `nodeInfo` are deep copied.
 	SelectVictimsOnNode(ctx context.Context, state *framework.CycleState,
 		pod *v1.Pod, nodeInfo *framework.NodeInfo, pdbs []*policy.PodDisruptionBudget) ([]*v1.Pod, int, *framework.Status)
-	// DeletePod deletes the given victim pod from API server for preemption.
-	DeletePod(ctx context.Context, cs kubernetes.Interface, victim, preemptor *v1.Pod) error
+	// DeleteVictim deletes the given victim pod from API server for preemption.
+	DeleteVictim(ctx context.Context, cs kubernetes.Interface, victim, preemptor *v1.Pod) error
 }
 
 type Evaluator struct {
@@ -375,7 +375,7 @@ func (ev *Evaluator) prepareCandidate(ctx context.Context, c Candidate, pod *v1.
 					return
 				}
 			}
-			if err := ev.DeletePod(ctx, cs, victim, pod); err != nil {
+			if err := ev.DeleteVictim(ctx, cs, victim, pod); err != nil {
 				klog.ErrorS(err, "Preempting pod", "pod", klog.KObj(victim), "preemptor", klog.KObj(pod))
 				errCh.SendErrorWithCancel(err, cancel)
 				return

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -47,6 +48,7 @@ import (
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/internal/queue"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	"k8s.io/kubernetes/pkg/scheduler/util"
 )
 
 var (
@@ -78,6 +80,10 @@ func (pl *FakePostFilterPlugin) CandidatesToVictimsMap(candidates []Candidate) m
 
 func (pl *FakePostFilterPlugin) PodEligibleToPreemptOthers(pod *v1.Pod, nominatedNodeStatus *framework.Status) (bool, string) {
 	return true, ""
+}
+
+func (pl *FakePostFilterPlugin) DeletePod(ctx context.Context, cs kubernetes.Interface, victim, preemptor *v1.Pod) error {
+	return util.DeletePod(ctx, cs, victim)
 }
 
 func TestNodesWherePreemptionMightHelp(t *testing.T) {

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -82,7 +82,7 @@ func (pl *FakePostFilterPlugin) PodEligibleToPreemptOthers(pod *v1.Pod, nominate
 	return true, ""
 }
 
-func (pl *FakePostFilterPlugin) DeletePod(ctx context.Context, cs kubernetes.Interface, victim, preemptor *v1.Pod) error {
+func (pl *FakePostFilterPlugin) DeleteVictim(ctx context.Context, cs kubernetes.Interface, victim, preemptor *v1.Pod) error {
 	return util.DeletePod(ctx, cs, victim)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:

/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change

-->
/kind feature
/kind api-change
#### What this PR does / why we need it:
Currently the scheduler's preemption library performs the call to delete a pod when it gets preempted. It doesnt use any deletion option or provide a hook for a plugin implementation to do things like annotate the node or log a message. This PR moves the DeletePod call up to the plugin interface and includes the existing behavior in the default plugin.

There is no functional change for the default preemption plugin. 3rd party preemption plugins will need to add a DeletePod method. They can use the existing util.DeletePod as the default plugin does unless they want to add special behavior.
 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
