### PR TITLE
Improve performance on the cloud provider node-controller

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
@@ -19,6 +19,7 @@ package cloud
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -29,8 +30,10 @@ import (
 	"k8s.io/klog/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
+	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 	cloudprovider "k8s.io/cloud-provider"
 	cloudproviderapi "k8s.io/cloud-provider/api"
@@ -2431,6 +2434,111 @@ func TestGetProviderID(t *testing.T) {
 			if !cmp.Equal(providerID, test.expectedProviderID) {
 				t.Errorf("unexpected providerID %s", cmp.Diff(providerID, test.expectedProviderID))
 			}
+		})
+	}
+}
+
+func TestUpdateNodeStatus(t *testing.T) {
+	// emaulate the latency of the cloud API calls
+	const cloudLatency = 10 * time.Millisecond
+
+	generateNodes := func(n int) []runtime.Object {
+		result := []runtime.Object{}
+		for i := 0; i < n; i++ {
+			result = append(result, &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("node0%d", i),
+				},
+			})
+		}
+		return result
+	}
+
+	tests := []struct {
+		name    string
+		workers int32
+		nodes   int
+	}{
+		{
+			name:    "single thread",
+			workers: 1,
+			nodes:   100,
+		},
+		{
+			name:    "5 workers",
+			workers: 5,
+			nodes:   100,
+		},
+		{
+			name:    "10 workers",
+			workers: 10,
+			nodes:   100,
+		},
+		{
+			name:    "30 workers",
+			workers: 30,
+			nodes:   100,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeCloud := &fakecloud.Cloud{
+				EnableInstancesV2: false,
+				Addresses: []v1.NodeAddress{
+					{
+						Type:    v1.NodeHostName,
+						Address: "node0.cloud.internal",
+					},
+					{
+						Type:    v1.NodeInternalIP,
+						Address: "10.0.0.1",
+					},
+					{
+						Type:    v1.NodeExternalIP,
+						Address: "132.143.154.163",
+					},
+				},
+				RequestDelay: cloudLatency,
+				Err:          nil,
+			}
+
+			clientset := fake.NewSimpleClientset()
+			clientset.PrependReactor("patch", "nodes", func(action clienttesting.Action) (bool, runtime.Object, error) {
+				return true, &v1.Node{}, nil
+			})
+
+			factory := informers.NewSharedInformerFactory(clientset, 0)
+			eventBroadcaster := record.NewBroadcaster()
+			nodeInformer := factory.Core().V1().Nodes()
+			nodeIndexer := nodeInformer.Informer().GetIndexer()
+			cloudNodeController := &CloudNodeController{
+				kubeClient:                clientset,
+				nodeInformer:              nodeInformer,
+				nodesLister:               nodeInformer.Lister(),
+				nodesSynced:               func() bool { return true },
+				cloud:                     fakeCloud,
+				recorder:                  eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cloud-node-controller"}),
+				nodeStatusUpdateFrequency: 1 * time.Second,
+				workerCount:               test.workers,
+			}
+
+			for _, n := range generateNodes(test.nodes) {
+				err := nodeIndexer.Add(n)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			w := eventBroadcaster.StartLogging(klog.Infof)
+			defer w.Stop()
+
+			start := time.Now()
+			cloudNodeController.UpdateNodeStatus(context.TODO())
+			t.Logf("%d workers: processed %d nodes int %v ", test.workers, test.nodes, time.Since(start))
+			if len(fakeCloud.Calls) != test.nodes {
+				t.Errorf("expected %d cloud-provider calls, got %d", test.nodes, len(fakeCloud.Calls))
+			}
+
 		})
 	}
 }

--- a/staging/src/k8s.io/cloud-provider/fake/fake.go
+++ b/staging/src/k8s.io/cloud-provider/fake/fake.go
@@ -106,11 +106,10 @@ type Route struct {
 }
 
 func (f *Cloud) addCall(desc string) {
-	f.addCallLock.Lock()
-	defer f.addCallLock.Unlock()
-
 	time.Sleep(f.RequestDelay)
 
+	f.addCallLock.Lock()
+	defer f.addCallLock.Unlock()
 	f.Calls = append(f.Calls, desc)
 }
 


### PR DESCRIPTION
Following up on https://github.com/kubernetes/kubernetes/pull/113104 , use the new option to parallelize the reconcile loop that updates the nodes addresses and labels.

This is a problem in large clusters, since this loop is the one that reconciles the nodes addresses, it may cause that some instance get assigned a public ip but it takes a long time to represent it in the Node.Status
/kind cleanup

```release-note
NONE
```

```
go test -timeout 30s -run ^TestUpdateNodeStatus$ k8s.io/cloud-provider/controllers/node -v -race
=== RUN   TestUpdateNodeStatus
=== RUN   TestUpdateNodeStatus/single_thread
    node_controller_test.go:2537: 1 workers: processed 100 nodes int 1.055595262s 
=== RUN   TestUpdateNodeStatus/5_workers
    node_controller_test.go:2537: 5 workers: processed 100 nodes int 216.990972ms 
=== RUN   TestUpdateNodeStatus/10_workers
    node_controller_test.go:2537: 10 workers: processed 100 nodes int 112.422435ms 
=== RUN   TestUpdateNodeStatus/30_workers
    node_controller_test.go:2537: 30 workers: processed 100 nodes int 46.243204ms 
--- PASS: TestUpdateNodeStatus (1.44s)
    --- PASS: TestUpdateNodeStatus/single_thread (1.06s)
    --- PASS: TestUpdateNodeStatus/5_workers (0.22s)
    --- PASS: TestUpdateNodeStatus/10_workers (0.11s)
    --- PASS: TestUpdateNodeStatus/30_workers (0.05s)
```