### PR TITLE
Ipvs: Enable Source Port hash flag for "mh" method.

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1180,6 +1180,10 @@ func (proxier *Proxier) syncProxyRules() {
 			serv.Flags |= utilipvs.FlagPersistent
 			serv.Timeout = uint32(svcInfo.StickyMaxAgeSeconds())
 		}
+		// Set the source hash flag needed for the distribution method "mh"
+		if proxier.ipvsScheduler == "mh" {
+			serv.Flags |= utilipvs.FlagSourceHash
+		}
 		// We need to bind ClusterIP to dummy interface, so set `bindAddr` parameter to `true` in syncService()
 		if err := proxier.syncService(svcPortNameString, serv, true, bindedAddresses); err == nil {
 			activeIPVSServices[serv.String()] = true
@@ -1232,6 +1236,10 @@ func (proxier *Proxier) syncProxyRules() {
 			if svcInfo.SessionAffinityType() == v1.ServiceAffinityClientIP {
 				serv.Flags |= utilipvs.FlagPersistent
 				serv.Timeout = uint32(svcInfo.StickyMaxAgeSeconds())
+			}
+			// Set the source hash flag needed for the distribution method "mh"
+			if proxier.ipvsScheduler == "mh" {
+				serv.Flags |= utilipvs.FlagSourceHash
 			}
 			if err := proxier.syncService(svcPortNameString, serv, true, bindedAddresses); err == nil {
 				activeIPVSServices[serv.String()] = true
@@ -1332,6 +1340,10 @@ func (proxier *Proxier) syncProxyRules() {
 			if svcInfo.SessionAffinityType() == v1.ServiceAffinityClientIP {
 				serv.Flags |= utilipvs.FlagPersistent
 				serv.Timeout = uint32(svcInfo.StickyMaxAgeSeconds())
+			}
+			// Set the source hash flag needed for the distribution method "mh"
+			if proxier.ipvsScheduler == "mh" {
+				serv.Flags |= utilipvs.FlagSourceHash
 			}
 			if err := proxier.syncService(svcPortNameString, serv, true, bindedAddresses); err == nil {
 				activeIPVSServices[serv.String()] = true
@@ -1475,6 +1487,10 @@ func (proxier *Proxier) syncProxyRules() {
 				if svcInfo.SessionAffinityType() == v1.ServiceAffinityClientIP {
 					serv.Flags |= utilipvs.FlagPersistent
 					serv.Timeout = uint32(svcInfo.StickyMaxAgeSeconds())
+				}
+				// Set the source hash flag needed for the distribution method "mh"
+				if proxier.ipvsScheduler == "mh" {
+					serv.Flags |= utilipvs.FlagSourceHash
 				}
 				// There is no need to bind Node IP to dummy interface, so set parameter `bindAddr` to `false`.
 				if err := proxier.syncService(svcPortNameString, serv, false, bindedAddresses); err == nil {

--- a/pkg/util/ipvs/ipvs.go
+++ b/pkg/util/ipvs/ipvs.go
@@ -67,6 +67,8 @@ const (
 	FlagPersistent = 0x1
 	// FlagHashed specify IPVS service hash flag
 	FlagHashed = 0x2
+	// FlagSourceHash enables IPVS service hashing on source port and source IP
+	FlagSourceHash = 0x10
 )
 
 // Equal check the equality of virtual server.

--- a/pkg/util/ipvs/ipvs_linux.go
+++ b/pkg/util/ipvs/ipvs_linux.go
@@ -225,9 +225,9 @@ func toVirtualServer(svc *libipvs.Service) (*VirtualServer, error) {
 		Timeout:   svc.Timeout,
 	}
 
-	// Test Flags >= 0x2, valid Flags ranges [0x2, 0x3]
+	// Test FlagHashed (0x2). A valid flag must include FlagHashed
 	if svc.Flags&FlagHashed == 0 {
-		return nil, fmt.Errorf("Flags of successfully created IPVS service should be >= %d since every service is hashed into the service table", FlagHashed)
+		return nil, fmt.Errorf("Flags of successfully created IPVS service should enable the flag (%x) since every service is hashed into the service table", FlagHashed)
 	}
 	// Sub Flags to 0x2
 	// 011 -> 001, 010 -> 000

--- a/pkg/util/ipvs/ipvs_linux_test.go
+++ b/pkg/util/ipvs/ipvs_linux_test.go
@@ -44,7 +44,7 @@ func Test_toVirtualServer(t *testing.T) {
 			},
 			VirtualServer{},
 			true,
-			fmt.Sprintf("IPVS Service Flags should be >= %d, got 0x0", FlagHashed),
+			fmt.Sprintf("IPVS Service Flags should include %x, got 0x0", FlagHashed),
 		},
 		{
 			libipvs.Service{
@@ -52,7 +52,7 @@ func Test_toVirtualServer(t *testing.T) {
 			},
 			VirtualServer{},
 			true,
-			fmt.Sprintf("IPVS Service Flags should be >= %d, got 0x1", FlagHashed),
+			fmt.Sprintf("IPVS Service Flags should include %x, got 0x1", FlagHashed),
 		},
 		{
 			libipvs.Service{
@@ -145,6 +145,30 @@ func Test_toVirtualServer(t *testing.T) {
 				Port:      0,
 				Scheduler: "wrr",
 				Flags:     ServiceFlags(FlagPersistent),
+				Timeout:   0,
+			},
+			false,
+			"",
+		},
+		{
+			libipvs.Service{
+				Protocol:      0,
+				Port:          0,
+				FWMark:        0,
+				SchedName:     "mh",
+				Flags:         uint32(FlagPersistent + FlagHashed + FlagSourceHash),
+				Timeout:       0,
+				Netmask:       0xffffffff,
+				AddressFamily: unix.AF_INET,
+				Address:       netutils.ParseIPSloppy("1.2.3.4"),
+				PEName:        "",
+			},
+			VirtualServer{
+				Address:   netutils.ParseIPSloppy("1.2.3.4"),
+				Protocol:  "",
+				Port:      0,
+				Scheduler: "mh",
+				Flags:     ServiceFlags(FlagPersistent + FlagSourceHash),
 				Timeout:   0,
 			},
 			false,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area kube-proxy
/area ipvs

#### What this PR does / why we need it:

When using `mh` or `sh`, kube-proxy always forwards connections from a client to only one single endpoint, leading to imbalance of traffic distribution as this endpoint is always busy to handle new connections while the others located on other nodes are entirely idle. See example in #115526 for more details.

The connections should be evenly distributed to all running endpoints to avoid unbalanced traffic distribution in this particular use-case when one dominant client can generate a vast majority of connections/traffic to a k8s cluster. 

#### Which issue(s) this PR fixes:
Fixes #115526

#### Special notes for your reviewer:

The fix in this PR simply enables the source port hash flag that IPVS supports for the distribution methods which includes both source IP and source port in calculating hash and selecting the target endpoint. Connections from a client with different source ports will be thus forwarded to all endpoints.

After enabling the flag, ipvs evenly distributes connections from a client to all endpoints like the printout examples below
```console
TCP  192.168.1.1:32000 mh (mh-port)
  -> 11.0.1.2:5001                Masq    1      0          41
  -> 11.0.2.2:5001                Masq    1      0          54
  -> 11.0.3.2:5001                Masq    1      0          50
  -> 11.0.4.2:5001                Masq    1      0          55
```

```console
TCP  192.168.1.1:32000 sh (sh-port)
  -> 11.0.1.2:5001                Masq    1      0          48
  -> 11.0.2.2:5001                Masq    1      0          50
  -> 11.0.3.2:5001                Masq    1      0          51
  -> 11.0.4.2:5001                Masq    1      0          51
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

