### PR TITLE
fix WaitForPodNotFoundInNamespace for namespace and podname order

### DIFF
--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -228,7 +228,7 @@ var _ = SIGDescribe("Job", func() {
 			framework.ExpectNoError(err, "failed to evict the pod: %s/%s", pod.Name, pod.Namespace)
 
 			ginkgo.By(fmt.Sprintf("Awaiting for the pod: %s/%s to be deleted", pod.Name, pod.Namespace))
-			err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace, f.Timeouts.PodDelete)
+			err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, pod.Namespace, pod.Name, f.Timeouts.PodDelete)
 			framework.ExpectNoError(err, "failed to await for the pod to be deleted: %s/%s", pod.Name, pod.Namespace)
 
 			ginkgo.By("Ensuring job reaches completions")

--- a/test/e2e/framework/pod/delete.go
+++ b/test/e2e/framework/pod/delete.go
@@ -68,7 +68,7 @@ func DeletePodWithWaitByName(ctx context.Context, c clientset.Interface, podName
 		return fmt.Errorf("pod Delete API error: %w", err)
 	}
 	framework.Logf("Wait up to %v for pod %q to be fully deleted", PodDeleteTimeout, podName)
-	err = WaitForPodNotFoundInNamespace(ctx, c, podName, podNamespace, PodDeleteTimeout)
+	err = WaitForPodNotFoundInNamespace(ctx, c, podNamespace, podName, PodDeleteTimeout)
 	if err != nil {
 		return fmt.Errorf("pod %q was not deleted: %w", podName, err)
 	}

--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -528,7 +528,7 @@ func WaitForPodSuccessInNamespaceSlow(ctx context.Context, c clientset.Interface
 // Unlike `waitForPodTerminatedInNamespace`, the pod's Phase and Reason are ignored. If the pod Get
 // api returns IsNotFound then the wait stops and nil is returned. If the Get api returns an error other
 // than "not found" and that error is final, that error is returned and the wait stops.
-func WaitForPodNotFoundInNamespace(ctx context.Context, c clientset.Interface, podName, ns string, timeout time.Duration) error {
+func WaitForPodNotFoundInNamespace(ctx context.Context, c clientset.Interface, ns, podName string, timeout time.Duration) error {
 	err := framework.Gomega().Eventually(ctx, framework.HandleRetry(func(ctx context.Context) (*v1.Pod, error) {
 		pod, err := c.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {

--- a/test/e2e/network/netpol/network_legacy.go
+++ b/test/e2e/network/netpol/network_legacy.go
@@ -777,15 +777,15 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 			framework.ExpectNoError(err, "Error creating Network Policy %v: %v", policy.ObjectMeta.Name, err)
 
 			testCanConnect(ctx, f, f.Namespace, "client-a", service, clientAAllowedPort)
-			err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, "client-a", f.Namespace.Name, f.Timeouts.PodDelete)
+			err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, f.Namespace.Name, "client-a", f.Timeouts.PodDelete)
 			framework.ExpectNoError(err, "Expected pod to be not found.")
 
 			testCannotConnect(ctx, f, f.Namespace, "client-b", service, clientAAllowedPort)
-			err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, "client-b", f.Namespace.Name, f.Timeouts.PodDelete)
+			err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, f.Namespace.Name, "client-b", f.Timeouts.PodDelete)
 			framework.ExpectNoError(err, "Expected pod to be not found.")
 
 			testCannotConnect(ctx, f, f.Namespace, "client-a", service, clientANotAllowedPort)
-			err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, "client-a", f.Namespace.Name, f.Timeouts.PodDelete)
+			err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, f.Namespace.Name, "client-a", f.Timeouts.PodDelete)
 			framework.ExpectNoError(err, "Expected pod to be not found.")
 
 			const (
@@ -824,7 +824,7 @@ var _ = common.SIGDescribe("NetworkPolicyLegacy [LinuxOnly]", func() {
 			ginkgo.DeferCleanup(cleanupNetworkPolicy, f, policy)
 
 			testCannotConnect(ctx, f, f.Namespace, "client-b", service, clientBNotAllowedPort)
-			err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, "client-b", f.Namespace.Name, f.Timeouts.PodDelete)
+			err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, f.Namespace.Name, "client-b", f.Timeouts.PodDelete)
 			framework.ExpectNoError(err, "Expected pod to be not found.")
 
 			testCannotConnect(ctx, f, f.Namespace, "client-a", service, clientBNotAllowedPort)

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -1007,7 +1007,7 @@ func StopPodAndDependents(ctx context.Context, c clientset.Interface, timeouts *
 		framework.Logf("pod Delete API error: %v", err)
 	}
 	framework.Logf("Wait up to %v for pod %q to be fully deleted", timeouts.PodDelete, pod.Name)
-	framework.ExpectNoError(e2epod.WaitForPodNotFoundInNamespace(ctx, c, pod.Name, pod.Namespace, timeouts.PodDelete))
+	framework.ExpectNoError(e2epod.WaitForPodNotFoundInNamespace(ctx, c, pod.Namespace, pod.Name, timeouts.PodDelete))
 	if len(podPVs) > 0 {
 		for _, pv := range podPVs {
 			// As with CSI inline volumes, we use the pod delete timeout here because conceptually

--- a/test/e2e/storage/utils/utils.go
+++ b/test/e2e/storage/utils/utils.go
@@ -177,7 +177,7 @@ func TestVolumeUnmountsFromDeletedPodWithForceOption(ctx context.Context, c clie
 
 	ginkgo.By("Starting the kubelet and waiting for pod to delete.")
 	KubeletCommand(ctx, KStart, c, clientPod)
-	err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, clientPod.Name, f.Namespace.Name, f.Timeouts.PodDelete)
+	err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, f.Namespace.Name, clientPod.Name, f.Timeouts.PodDelete)
 	if err != nil {
 		framework.ExpectNoError(err, "Expected pod to be not found.")
 	}
@@ -207,7 +207,7 @@ func TestVolumeUnmountsFromDeletedPodWithForceOption(ctx context.Context, c clie
 		CheckReadFromPath(f, secondPod, v1.PersistentVolumeFilesystem, false, volumePath, byteLen, seed)
 		err = c.CoreV1().Pods(secondPod.Namespace).Delete(context.TODO(), secondPod.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err, "when deleting the second pod")
-		err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, secondPod.Name, f.Namespace.Name, f.Timeouts.PodDelete)
+		err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, f.Namespace.Name, secondPod.Name, f.Timeouts.PodDelete)
 		framework.ExpectNoError(err, "when waiting for the second pod to disappear")
 	}
 
@@ -285,7 +285,7 @@ func TestVolumeUnmapsFromDeletedPodWithForceOption(ctx context.Context, c client
 
 	ginkgo.By("Starting the kubelet and waiting for pod to delete.")
 	KubeletCommand(ctx, KStart, c, clientPod)
-	err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, clientPod.Name, f.Namespace.Name, f.Timeouts.PodDelete)
+	err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, f.Namespace.Name, clientPod.Name, f.Timeouts.PodDelete)
 	framework.ExpectNoError(err, "Expected pod to be not found.")
 
 	if forceDelete {


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
After [#113298](https://github.com/kubernetes/kubernetes/pull/113298) was merged, some CI failed.

WaitForPodNotFoundInNamespace
https://github.com/kubernetes/kubernetes/blob/561a35f3582abb25da76d31c7c2abc4277054b04/test/e2e/framework/pod/wait.go#L531

https://github.com/kubernetes/kubernetes/blob/561a35f3582abb25da76d31c7c2abc4277054b04/test/e2e_node/node_problem_detector_linux.go#L436

https://github.com/kubernetes/kubernetes/blob/561a35f3582abb25da76d31c7c2abc4277054b04/test/e2e/storage/utils/utils.go#L210

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/115539

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```
