### PR TITLE
kubeadm: fix a bug where the uploaded kubelet configuration in kube-system/kubelet-config ConfigMap does not respect user patch

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/uploadconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/init/uploadconfig.go
@@ -104,7 +104,7 @@ func getUploadConfigPhaseFlags() []string {
 
 // runUploadKubeadmConfig uploads the kubeadm configuration to a ConfigMap
 func runUploadKubeadmConfig(c workflow.RunData) error {
-	cfg, client, err := getUploadConfigData(c)
+	cfg, client, _, err := getUploadConfigData(c)
 	if err != nil {
 		return err
 	}
@@ -118,13 +118,13 @@ func runUploadKubeadmConfig(c workflow.RunData) error {
 
 // runUploadKubeletConfig uploads the kubelet configuration to a ConfigMap
 func runUploadKubeletConfig(c workflow.RunData) error {
-	cfg, client, err := getUploadConfigData(c)
+	cfg, client, patchesDir, err := getUploadConfigData(c)
 	if err != nil {
 		return err
 	}
 
 	klog.V(1).Infoln("[upload-config] Uploading the kubelet component config to a ConfigMap")
-	if err = kubeletphase.CreateConfigMap(&cfg.ClusterConfiguration, client); err != nil {
+	if err = kubeletphase.CreateConfigMap(&cfg.ClusterConfiguration, patchesDir, client); err != nil {
 		return errors.Wrap(err, "error creating kubelet configuration ConfigMap")
 	}
 
@@ -135,15 +135,15 @@ func runUploadKubeletConfig(c workflow.RunData) error {
 	return nil
 }
 
-func getUploadConfigData(c workflow.RunData) (*kubeadmapi.InitConfiguration, clientset.Interface, error) {
+func getUploadConfigData(c workflow.RunData) (*kubeadmapi.InitConfiguration, clientset.Interface, string, error) {
 	data, ok := c.(InitData)
 	if !ok {
-		return nil, nil, errors.New("upload-config phase invoked with an invalid data struct")
+		return nil, nil, "", errors.New("upload-config phase invoked with an invalid data struct")
 	}
 	cfg := data.Cfg()
 	client, err := data.Client()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
-	return cfg, client, err
+	return cfg, client, data.PatchesDir(), err
 }

--- a/cmd/kubeadm/app/phases/kubelet/config.go
+++ b/cmd/kubeadm/app/phases/kubelet/config.go
@@ -68,10 +68,7 @@ func WriteConfigToDisk(cfg *kubeadmapi.ClusterConfiguration, kubeletDir, patches
 
 // CreateConfigMap creates a ConfigMap with the generic kubelet configuration.
 // Used at "kubeadm init" and "kubeadm upgrade" time
-func CreateConfigMap(cfg *kubeadmapi.ClusterConfiguration, client clientset.Interface) error {
-	configMapName := kubeadmconstants.KubeletBaseConfigurationConfigMap
-	fmt.Printf("[kubelet] Creating a ConfigMap %q in namespace %s with the configuration for the kubelets in the cluster\n", configMapName, metav1.NamespaceSystem)
-
+func CreateConfigMap(cfg *kubeadmapi.ClusterConfiguration, patchesDir string, client clientset.Interface) error {
 	kubeletCfg, ok := cfg.ComponentConfigs[componentconfigs.KubeletGroup]
 	if !ok {
 		return errors.New("no kubelet component config found in the active component config set")
@@ -81,6 +78,17 @@ func CreateConfigMap(cfg *kubeadmapi.ClusterConfiguration, client clientset.Inte
 	if err != nil {
 		return err
 	}
+
+	// Apply patches to the KubeletConfiguration
+	if len(patchesDir) != 0 {
+		kubeletBytes, err = applyKubeletConfigPatches(kubeletBytes, patchesDir, os.Stdout)
+		if err != nil {
+			return errors.Wrap(err, "could not apply patches to the KubeletConfiguration")
+		}
+	}
+
+	configMapName := kubeadmconstants.KubeletBaseConfigurationConfigMap
+	fmt.Printf("[kubelet] Creating a ConfigMap %q in namespace %s with the configuration for the kubelets in the cluster\n", configMapName, metav1.NamespaceSystem)
 
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/kubeadm/app/phases/kubelet/config_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/config_test.go
@@ -58,7 +58,7 @@ func TestCreateConfigMap(t *testing.T) {
 		t.Fatalf("unexpected failure when defaulting InitConfiguration: %v", err)
 	}
 
-	if err := CreateConfigMap(&internalcfg.ClusterConfiguration, client); err != nil {
+	if err := CreateConfigMap(&internalcfg.ClusterConfiguration, "", client); err != nil {
 		t.Errorf("CreateConfigMap: unexpected error %v", err)
 	}
 }

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -54,7 +54,7 @@ func PerformPostUpgradeTasks(client clientset.Interface, cfg *kubeadmapi.InitCon
 	}
 
 	// Create the new, version-branched kubelet ComponentConfig ConfigMap
-	if err := kubeletphase.CreateConfigMap(&cfg.ClusterConfiguration, client); err != nil {
+	if err := kubeletphase.CreateConfigMap(&cfg.ClusterConfiguration, patchesDir, client); err != nil {
 		errs = append(errs, errors.Wrap(err, "error creating kubelet configuration ConfigMap"))
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubeadm: fix a bug where the uploaded kubelet configuration in `kube-system/kubelet-config` ConfigMap does not respect user patch

We apply patches when writing `/var/lib/kubelet/config.yaml`：
https://github.com/kubernetes/kubernetes/blob/e944fc28ca33eae09e3466e23f809721534a020f/cmd/kubeadm/app/phases/kubelet/config.go#L43-L64

But we seem to have forgotten to apply patches when uploading the kubelet configuration:
https://github.com/kubernetes/kubernetes/blob/e944fc28ca33eae09e3466e23f809721534a020f/cmd/kubeadm/app/phases/kubelet/config.go#L75-L93

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: fix a bug where the uploaded kubelet configuration in `kube-system/kubelet-config` ConfigMap does not respect user patch
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
