### PR TITLE
flaky test wait.sh: Add deployment assertion before running wait

### DIFF
--- a/test/cmd/wait.sh
+++ b/test/cmd/wait.sh
@@ -78,6 +78,9 @@ spec:
         command: ["/bin/sh", "-c", "sleep infinity"]
 EOF
 
+    # Make sure deployment is successfully applied
+    kube::test::wait_object_assert deployments "{{range.items}}{{${id_field:?}}}{{end}}" 'dtest'
+
     set +o errexit
     # wait timeout error because condition is invalid
     start_sec=$(date +"%s")


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
/kind flake

#### What this PR does / why we need it:
There is a test in wait.sh integration suite which is checking the given timeout value(passed by user) is equal to actual happened timeout value.

However, this test rarely gets `no matching resources found` error and causes flakiness. The reason is we are running wait command, immediately after applying deployment. In reality, timeout test does not care about deployment, since it is testing the timeout by passing invalid configurations. But we need this deployment to not get `no matching resources found` error.

example failing test: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/115529/pull-kubernetes-integration/1622903241190674432

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```