### PR TITLE
Optimization on running prePreEnqueuePlugins before adding pods into activeQ

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -521,7 +521,9 @@ func (p *PriorityQueue) flushBackoffQCompleted() {
 			klog.ErrorS(err, "Unable to pop pod from backoff queue despite backoff completion", "pod", klog.KObj(pod))
 			break
 		}
-		if added, _ := p.addToActiveQ(pInfo); added {
+		if err := p.activeQ.Add(pInfo); err != nil {
+			klog.ErrorS(err, "Error adding pod to the active queue", "pod", klog.KObj(pInfo.Pod))
+		} else {
 			klog.V(5).InfoS("Pod moved to an internal scheduling queue", "pod", klog.KObj(pod), "event", BackoffComplete, "queue", activeQName)
 			metrics.SchedulerQueueIncomingPods.WithLabelValues("active", BackoffComplete).Inc()
 			activated = true

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -447,6 +447,8 @@ func TestPriorityQueue_Activate(t *testing.T) {
 }
 
 type preEnqueuePlugin struct {
+	// called counts the number of calling PreEnqueue()
+	called     int
 	allowlists []string
 }
 
@@ -455,6 +457,7 @@ func (pl *preEnqueuePlugin) Name() string {
 }
 
 func (pl *preEnqueuePlugin) PreEnqueue(ctx context.Context, p *v1.Pod) *framework.Status {
+	pl.called++
 	for _, allowed := range pl.allowlists {
 		for label := range p.Labels {
 			if label == allowed {
@@ -531,6 +534,47 @@ func TestPriorityQueue_addToActiveQ(t *testing.T) {
 			// Ensure the pod is still located in unschedulablePods.
 			if tt.wantUnschedulablePods != len(q.unschedulablePods.podInfoMap) {
 				t.Errorf("Unexpected unschedulablePods: want %v, but got %v", tt.wantUnschedulablePods, len(q.unschedulablePods.podInfoMap))
+			}
+		})
+	}
+}
+
+func TestPriorityQueue_flushBackoffQCompleted(t *testing.T) {
+	tests := []struct {
+		name                       string
+		plugin                     framework.PreEnqueuePlugin
+		pod                        *v1.Pod
+		operations                 []operation
+		wantPreEnqueuePluginCalled int
+	}{
+		{
+			name:   "preEnqueue plugin registered, not running preEnqueue plugin when backoff completed",
+			plugin: &preEnqueuePlugin{},
+			pod:    st.MakePod().Name("foo").Label("foo", "").Obj(),
+			operations: []operation{
+				addPodBackoffQ,
+				flushBackoffQ,
+			},
+			wantPreEnqueuePluginCalled: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			m := map[string][]framework.PreEnqueuePlugin{"": {tt.plugin}}
+			c := testingclock.NewFakeClock(time.Now())
+			q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), []runtime.Object{tt.pod}, WithPreEnqueuePluginMap(m),
+				WithPodInitialBackoffDuration(time.Second*1), WithPodMaxBackoffDuration(time.Second*60), WithClock(c))
+			pInfo := newQueuedPodInfoForLookup(tt.pod)
+			pInfo.Gated = true
+			for _, op := range tt.operations {
+				op(q, pInfo)
+			}
+			if tt.wantPreEnqueuePluginCalled != tt.plugin.(*preEnqueuePlugin).called {
+				t.Errorf("Unexpected number of calling preEnqueue: want %v, but got %v", tt.wantPreEnqueuePluginCalled, tt.plugin.(*preEnqueuePlugin).called)
 			}
 		})
 	}


### PR DESCRIPTION

#### What type of PR is this?
/kind feature
/sig scheduling

#### What this PR does / why we need it:
discussion: https://github.com/kubernetes/kubernetes/pull/113275#discussion_r1014545938

- pods called in flushBackoffQCompleted() should have already passed all PreEnqueue plugins, and given its state is one-way transitional, we don't need to go through PreEnqueue plugins again.

- add a flag to call/skip PreEnqueue plugins.

#### Which issue(s) this PR fixes:

Part of #113608 

#### Special notes for your reviewer:
cc @Huang-Wei 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

