### PR TITLE
worker nodes are not necessarily not control-plane nodes

### DIFF
--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -110,9 +110,8 @@ func getReadySchedulableWorkerNode(ctx context.Context, c clientset.Interface) (
 	}
 	for i := range nodes.Items {
 		node := nodes.Items[i]
-		_, isMaster := node.Labels["node-role.kubernetes.io/master"]
-		_, isControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]
-		if !isMaster && !isControlPlane {
+		_, isWorker := node.Labels["node-role.kubernetes.io/worker"]
+		if isWorker {
 			return &node, nil
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Identify worker node on cluster where nodes can have multiple roles (e.g. single node cluster).

When running on single node clusters, tests such as:
```
[sig-network] LoadBalancers should be able to preserve UDP traffic when server pod cycles for a LoadBalancer service on the same node
```
fail with:
```
error getting a ready schedulable worker Node, err: there are currently no ready, schedulable worker nodes in the cluster
```

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A