### PR TITLE
Remove 4 CSIDriver endpoints with conformance test from the Ineligible endpoint list

### DIFF
--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -52,9 +52,6 @@
 - endpoint: createCoreV1PersistentVolume
   reason: vendor specific feature
   link: https://github.com/kubernetes/community/blame/master/contributors/devel/sig-architecture/conformance-tests.md#L64
-- endpoint: createStorageV1CSIDriver
-  reason: vendor specific feature
-  link: https://github.com/kubernetes/community/blame/master/contributors/devel/sig-architecture/conformance-tests.md#L64
 - endpoint: createStorageV1CSINode
   reason: vendor specific feature
   link: https://github.com/kubernetes/community/blame/master/contributors/devel/sig-architecture/conformance-tests.md#L64
@@ -91,9 +88,6 @@
 - endpoint: deleteStorageV1CollectionVolumeAttachment
   reason: vendor specific feature
   link: https://github.com/kubernetes/community/blame/master/contributors/devel/sig-architecture/conformance-tests.md#L64
-- endpoint: deleteStorageV1CSIDriver
-  reason: vendor specific feature
-  link: https://github.com/kubernetes/community/blame/master/contributors/devel/sig-architecture/conformance-tests.md#L64
 - endpoint: deleteStorageV1CSINode
   reason: vendor specific feature
   link: https://github.com/kubernetes/community/blame/master/contributors/devel/sig-architecture/conformance-tests.md#L64
@@ -128,9 +122,6 @@
   reason: vendor specific feature
   link: https://github.com/kubernetes/community/blame/master/contributors/devel/sig-architecture/conformance-tests.md#L64
 - endpoint: listCoreV1PersistentVolumeClaimForAllNamespaces
-  reason: vendor specific feature
-  link: https://github.com/kubernetes/community/blame/master/contributors/devel/sig-architecture/conformance-tests.md#L64
-- endpoint: listStorageV1CSIDriver
   reason: vendor specific feature
   link: https://github.com/kubernetes/community/blame/master/contributors/devel/sig-architecture/conformance-tests.md#L64
 - endpoint: listStorageV1CSINode
@@ -188,9 +179,6 @@
   reason: vendor specific feature
   link: https://github.com/kubernetes/community/blame/master/contributors/devel/sig-architecture/conformance-tests.md#L64
 - endpoint: readCoreV1PersistentVolumeStatus
-  reason: vendor specific feature
-  link: https://github.com/kubernetes/community/blame/master/contributors/devel/sig-architecture/conformance-tests.md#L64
-- endpoint: readStorageV1CSIDriver
   reason: vendor specific feature
   link: https://github.com/kubernetes/community/blame/master/contributors/devel/sig-architecture/conformance-tests.md#L64
 - endpoint: readStorageV1CSINode


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
Remove endpoint with conformance test from the list
- createStorageV1CSIDriver TESTED
- deleteStorageV1CSIDriver TESTED
- listStorageV1CSIDriver TESTED
- readStorageV1CSIDriver TESTED


**Special notes for your reviewer:**
These endpoint are tested by [CSI Inline Volumes: promote API tests to conformance #111724](https://github.com/kubernetes/kubernetes/pull/111724)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig architecture
/area conformance