### PR TITLE
`pod.spec.terminationGracePeriodSeconds` is a negative then convert to 1

### DIFF
--- a/pkg/api/pod/warnings.go
+++ b/pkg/api/pod/warnings.go
@@ -250,5 +250,9 @@ func warningsForPodSpecAndMeta(fieldPath *field.Path, podSpec *api.PodSpec, meta
 		return true
 	})
 
+	// warn if the terminationGracePeriodSeconds is negative.
+	if podSpec.TerminationGracePeriodSeconds != nil && *podSpec.TerminationGracePeriodSeconds < 0 {
+		warnings = append(warnings, fmt.Sprintf("%s: must be >= 0; negative values are invalid and will be treated as 1", fieldPath.Child("spec", "terminationGracePeriodSeconds")))
+	}
 	return warnings
 }

--- a/pkg/api/pod/warnings_test.go
+++ b/pkg/api/pod/warnings_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 func BenchmarkNoWarnings(b *testing.B) {
@@ -487,6 +488,18 @@ func TestWarnings(t *testing.T) {
 			},
 			expected: []string{
 				`spec.volumes[0].ephemeral.volumeClaimTemplate.spec.resources.requests[storage]: fractional byte value "200m" is invalid, must be an integer`,
+			},
+		},
+		{
+			name: "terminationGracePeriodSeconds is negative",
+			template: &api.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: api.PodSpec{
+					TerminationGracePeriodSeconds: utilpointer.Int64Ptr(-1),
+				},
+			},
+			expected: []string{
+				`spec.terminationGracePeriodSeconds: must be >= 0; negative values are invalid and will be treated as 1`,
 			},
 		},
 	}

--- a/pkg/apis/core/v1/conversion.go
+++ b/pkg/apis/core/v1/conversion.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/core"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
@@ -372,6 +373,11 @@ func Convert_v1_Pod_To_core_Pod(in *v1.Pod, out *core.Pod, s conversion.Scope) e
 	// drop init container annotations so they don't show up as differences when receiving requests from old clients
 	out.Annotations = dropInitContainerAnnotations(out.Annotations)
 
+	// Forcing the value of TerminationGracePeriodSeconds to 1 if it is negative.
+	// Just for Pod, not for PodSpec, because we don't want to change the behavior of the PodTemplate.
+	if in.Spec.TerminationGracePeriodSeconds != nil && *in.Spec.TerminationGracePeriodSeconds < 0 {
+		out.Spec.TerminationGracePeriodSeconds = utilpointer.Int64(1)
+	}
 	return nil
 }
 
@@ -384,6 +390,11 @@ func Convert_core_Pod_To_v1_Pod(in *core.Pod, out *v1.Pod, s conversion.Scope) e
 	// remove this once the oldest supported kubelet no longer honors the annotations over the field.
 	out.Annotations = dropInitContainerAnnotations(out.Annotations)
 
+	// Forcing the value of TerminationGracePeriodSeconds to 1 if it is negative.
+	// Just for Pod, not for PodSpec, because we don't want to change the behavior of the PodTemplate.
+	if in.Spec.TerminationGracePeriodSeconds != nil && *in.Spec.TerminationGracePeriodSeconds < 0 {
+		out.Spec.TerminationGracePeriodSeconds = utilpointer.Int64(1)
+	}
 	return nil
 }
 

--- a/pkg/apis/core/v1/conversion_test.go
+++ b/pkg/apis/core/v1/conversion_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
@@ -702,5 +703,84 @@ func Test_v1_NodeSpec_to_core_NodeSpec(t *testing.T) {
 				t.Errorf("%v:Convert v1.NodeSpec to core.NodeSpec failed core.PodCIDRs[%v]=%v expected %v", i, idx, coreNodeSpec.PodCIDRs[idx], testInput.PodCIDRs[idx])
 			}
 		}
+	}
+}
+
+func TestConvert_v1_Pod_To_core_Pod(t *testing.T) {
+	type args struct {
+		in  *v1.Pod
+		out *core.Pod
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		wantOut *core.Pod
+	}{
+		{
+			args: args{
+				in: &v1.Pod{
+					Spec: v1.PodSpec{
+						TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+					},
+				},
+				out: &core.Pod{},
+			},
+			wantOut: &core.Pod{
+				Spec: core.PodSpec{
+					TerminationGracePeriodSeconds: utilpointer.Int64(1),
+					SecurityContext:               &core.PodSecurityContext{},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := corev1.Convert_v1_Pod_To_core_Pod(tt.args.in, tt.args.out, nil); (err != nil) != tt.wantErr {
+				t.Errorf("Convert_v1_Pod_To_core_Pod() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if diff := cmp.Diff(tt.args.out, tt.wantOut); diff != "" {
+				t.Errorf("Convert_v1_Pod_To_core_Pod() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConvert_core_Pod_To_v1_Pod(t *testing.T) {
+	type args struct {
+		in  *core.Pod
+		out *v1.Pod
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		wantOut *v1.Pod
+	}{
+		{
+			args: args{
+				in: &core.Pod{
+					Spec: core.PodSpec{
+						TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+					},
+				},
+				out: &v1.Pod{},
+			},
+			wantOut: &v1.Pod{
+				Spec: v1.PodSpec{
+					TerminationGracePeriodSeconds: utilpointer.Int64(1),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := corev1.Convert_core_Pod_To_v1_Pod(tt.args.in, tt.args.out, nil); (err != nil) != tt.wantErr {
+				t.Errorf("Convert_core_Pod_To_v1_Pod() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if diff := cmp.Diff(tt.args.out, tt.wantOut); diff != "" {
+				t.Errorf("Convert_core_Pod_To_v1_Pod() mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

It's been 4 releases since it was allowed to change from negative to 1, so I think it's time to just set it to the default conversion

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Continue #98866
xref #103476

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Pods which have an invalid negative `spec.terminationGracePeriodSeconds` value will be treated as having terminationGracePeriodSeconds of 1
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
