### PR TITLE
Automated cherry pick of #115503: Fix for issue with Loadbalancer policy

### DIFF
--- a/pkg/proxy/winkernel/hnsV2.go
+++ b/pkg/proxy/winkernel/hnsV2.go
@@ -99,8 +99,28 @@ func (hns hnsV2) getAllEndpointsByNetwork(networkName string) (map[string]*(endp
 			terminating: false,
 		}
 		endpointInfos[ep.IpConfigurations[0].IpAddress] = endpointInfos[ep.Id]
+
+		if len(ep.IpConfigurations) == 1 {
+			continue
+		}
+
+		// If ipFamilyPolicy is RequireDualStack or PreferDualStack, then there will be 2 IPS (iPV4 and IPV6)
+		// in the endpoint list
+		endpointDualstack := &endpointsInfo{
+			ip:         ep.IpConfigurations[1].IpAddress,
+			isLocal:    uint32(ep.Flags&hcn.EndpointFlagsRemoteEndpoint) == 0,
+			macAddress: ep.MacAddress,
+			hnsID:      ep.Id,
+			hns:        hns,
+			// only ready and not terminating endpoints were added to HNS
+			ready:       true,
+			serving:     true,
+			terminating: false,
+		}
+		endpointInfos[ep.IpConfigurations[1].IpAddress] = endpointDualstack
 	}
 	klog.V(3).InfoS("Queried endpoints from network", "network", networkName)
+	klog.V(5).InfoS("Queried endpoints details", "network", networkName, "endpointInfos", endpointInfos)
 	return endpointInfos, nil
 }
 

--- a/pkg/proxy/winkernel/hns_test.go
+++ b/pkg/proxy/winkernel/hns_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 
 	"github.com/Microsoft/hcsshim/hcn"
+	"github.com/stretchr/testify/assert"
 
 	"strings"
 	"testing"
@@ -37,6 +38,7 @@ const (
 	gatewayAddress    = "192.168.1.1"
 	epMacAddress      = "00-11-22-33-44-55"
 	epIpAddress       = "192.168.1.3"
+	epIpv6Address     = "192::3"
 	epIpAddressB      = "192.168.1.4"
 	epIpAddressRemote = "192.168.2.3"
 	epPaAddress       = "10.0.0.3"
@@ -115,6 +117,52 @@ func TestDeleteLoadBalancer(t *testing.T) {
 	testDeleteLoadBalancer(t, hnsV1)
 	testDeleteLoadBalancer(t, hnsV2)
 }
+
+func TestGetAllEndpointsByNetwork(t *testing.T) {
+	hns := hnsV2{}
+	Network := mustTestNetwork(t)
+
+	ipv4Config := &hcn.IpConfig{
+		IpAddress: epIpAddress,
+	}
+	ipv6Config := &hcn.IpConfig{
+		IpAddress: epIpv6Address,
+	}
+	Endpoint := &hcn.HostComputeEndpoint{
+		IpConfigurations: []hcn.IpConfig{*ipv4Config, *ipv6Config},
+		MacAddress:       epMacAddress,
+		SchemaVersion: hcn.SchemaVersion{
+			Major: 2,
+			Minor: 0,
+		},
+	}
+	Endpoint, err := Network.CreateEndpoint(Endpoint)
+	if err != nil {
+		t.Error(err)
+	}
+
+	mapEndpointsInfo, err := hns.getAllEndpointsByNetwork(Network.Name)
+	if err != nil {
+		t.Error(err)
+	}
+	endpointIpv4, ipv4EpPresent := mapEndpointsInfo[ipv4Config.IpAddress]
+	assert.True(t, ipv4EpPresent, "IPV4 endpoint is missing in Dualstack mode")
+	assert.Equal(t, endpointIpv4.ip, epIpAddress, "IPV4 IP is missing in Dualstack mode")
+
+	endpointIpv6, ipv6EpPresent := mapEndpointsInfo[ipv6Config.IpAddress]
+	assert.True(t, ipv6EpPresent, "IPV6 endpoint is missing in Dualstack mode")
+	assert.Equal(t, endpointIpv6.ip, epIpv6Address, "IPV6 IP is missing in Dualstack mode")
+
+	err = Endpoint.Delete()
+	if err != nil {
+		t.Error(err)
+	}
+	err = Network.Delete()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func testGetNetworkByName(t *testing.T, hns HostNetworkService) {
 	Network := mustTestNetwork(t)
 


### PR DESCRIPTION
Cherry pick of #115503 on release-1.24.

#115503: Fix for issue with Loadbalancer policy

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixing issue with Winkernel Proxier - IPV6 load balancer policies are missing when service is configured with ipFamilyPolicy: RequireDualStack
```