### PR TITLE
[GCE] [cluster] Split run controllers per controller-manager

### DIFF
--- a/cluster/addons/cloud-controller-manager/cloud-node-controller-role.yaml
+++ b/cluster/addons/cloud-controller-manager/cloud-node-controller-role.yaml
@@ -45,6 +45,7 @@ rules:
   verbs:
   - get
   - update
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -255,6 +255,9 @@ if [[ (( "${KUBE_FEATURE_GATES:-}" == *"AllAlpha=true"* ) || ( "${KUBE_FEATURE_G
   RUN_CONTROLLERS="${RUN_CONTROLLERS:-*,endpointslice}"
 fi
 
+# By default disable gkenetworkparamset controller in CCM
+RUN_CCM_CONTROLLERS="${RUN_CCM_CONTROLLERS:-*,-gkenetworkparamset}"
+
 # List of the set of feature gates recognized by the GCP CCM
 export CCM_FEATURE_GATES="APIListChunking,APIPriorityAndFairness,APIResponseCompression,APIServerIdentity,APIServerTracing,AllAlpha,AllBeta,CustomResourceValidationExpressions,KMSv2,OpenAPIEnums,OpenAPIV3,RemainingItemCount,ServerSideFieldValidation,StorageVersionAPI,StorageVersionHash"
 

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -156,6 +156,9 @@ if [[ (( "${KUBE_FEATURE_GATES:-}" = *"AllAlpha=true"* ) || ( "${KUBE_FEATURE_GA
   RUN_CONTROLLERS=${RUN_CONTROLLERS:-*,endpointslice}
 fi
 
+# By default disable gkenetworkparamset controller in CCM
+RUN_CCM_CONTROLLERS="${RUN_CCM_CONTROLLERS:-*,-gkenetworkparamset}"
+
 # Optional: set feature gates
 # shellcheck disable=SC2034 # Variables sourced in other scripts.
 FEATURE_GATES=${KUBE_FEATURE_GATES:-}

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2246,7 +2246,6 @@ function start-kube-controller-manager {
   cp "${src_file}" /etc/kubernetes/manifests
 }
 
-# (TODO/cloud-provider-gcp): Figure out how to inject
 # Starts cloud controller manager.
 # It prepares the log file, loads the docker image, calculates variables, sets them
 # in the manifest file, and then copies the manifest file to /etc/kubernetes/manifests.
@@ -2309,8 +2308,8 @@ function start-cloud-controller-manager {
       echo "None of the given feature gates (${FEATURE_GATES}) were found to be safe to pass to the CCM"
     fi
   fi
-  if [[ -n "${RUN_CONTROLLERS:-}" ]]; then
-    params+=("--controllers=${RUN_CONTROLLERS}")
+  if [[ -n "${RUN_CCM_CONTROLLERS:-}" ]]; then
+    params+=("--controllers=${RUN_CCM_CONTROLLERS}")
   fi
 
   echo "Converting manifest for cloud provider controller-manager"
@@ -3572,7 +3571,6 @@ function main() {
       log-wrap 'StartKonnectivityServer' start-konnectivity-server
     fi
     log-wrap 'StartKubeControllerManager' start-kube-controller-manager
-    # (TODO/cloud-provider-gcp): Figure out how to inject
     if [[ "${CLOUD_PROVIDER_FLAG:-gce}" == "external" ]]; then
       log-wrap 'StartCloudControllerManager' start-cloud-controller-manager
     fi

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1280,6 +1280,11 @@ EOF
 RUN_CONTROLLERS: $(yaml-quote "${RUN_CONTROLLERS}")
 EOF
   fi
+  if [ -n "${RUN_CCM_CONTROLLERS:-}" ]; then
+    cat >>"$file" <<EOF
+RUN_CCM_CONTROLLERS: $(yaml-quote "${RUN_CCM_CONTROLLERS}")
+EOF
+  fi
   if [ -n "${PROVIDER_VARS:-}" ]; then
     local var_name
     local var_value


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

/sig cloud-provider
/cc @cheftako
/cc @andrewsykim
/assign @aojea
#### What this PR does / why we need it:

Adds new env variable that allows setting controllers in CCM independent of KCM controllers. Setting the same controllers might create a split brain scenario.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

This will mostly affect https://k8s-testgrid.appspot.com/provider-gcp-periodics#disable-cloud-provider

After this PR will merge, we should add "RUN_CONTROLLERS" without CCM controllers to https://k8s-testgrid.appspot.com/provider-gcp-periodics#disable-cloud-provider