### PR TITLE
Migrate apiserver tracing_test.go to registry.k8s.io

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/tracing_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/tracing_test.go
@@ -144,7 +144,7 @@ spec:
         k8s-app: agent
     spec:
       containers:
-        - image: k8s.gcr.io/busybox
+        - image: registry.k8s.io/busybox
           name: agent
 `,
 			expectedResult: nil,


### PR DESCRIPTION
Part of kubernetes/k8s.io#4738