### PR TITLE
getHost and getHostname have documentation swapped for IPv6

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/library/urls.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/urls.go
@@ -61,9 +61,9 @@ import (
 //
 //   - getScheme: If absent in the URL, returns an empty string.
 //
-//   - getHostname: IPv6 addresses are returned with braces, e.g. "[::1]". If absent in the URL, returns an empty string.
+//   - getHostname: IPv6 addresses are returned without braces, e.g. "::1". If absent in the URL, returns an empty string.
 //
-//   - getHost: IPv6 addresses are returned without braces, e.g. "::1". If absent in the URL, returns an empty string.
+//   - getHost: IPv6 addresses are returned with braces, e.g. "[::1]". If absent in the URL, returns an empty string.
 //
 //   - getEscapedPath: The string returned by getEscapedPath is URL escaped, e.g. "with space" becomes "with%20space".
 //     If absent in the URL, returns an empty string.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
The CEL functions `getHost` and `getHostname` have their documentation swapped for the part referring to IPv6. The examples provided in the same documentation show the suggested change, work correctly, nad match with the suggested change (I tested them).


#### Special notes for your reviewer:
This is a simple mistake when writing the two similar changes. No side effects.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
