### PR TITLE
test: Simplify NPD start timestamp calculation

### DIFF
--- a/test/e2e/node/node_problem_detector.go
+++ b/test/e2e/node/node_problem_detector.go
@@ -131,44 +131,20 @@ var _ = SIGDescribe("NodeProblemDetector", func() {
 				framework.ExpectEqual(result.Code, 0)
 				gomega.Expect(result.Stdout).NotTo(gomega.ContainSubstring("node-problem-detector.service: Failed"))
 
-				// Let's assume that node problem detector has started the same time as kubelet
-				// We only will check for the KubeletStart if parsing of date here succeed
-				// This is an optimization to not ssh one more time to get kubelet's start time.
-				// Also we assume specific datetime format to simplify the logic
-				output := result.Stdout
+				// We only will check for the KubeletStart even if parsing of date here succeeded.
+				ginkgo.By(fmt.Sprintf("Check when node-problem-detector started on node %q", host))
+				npdStartTimeCommand := "sudo systemctl show --timestamp=utc node-problem-detector -P ActiveEnterTimestamp"
+				result, err = e2essh.SSH(ctx, npdStartTimeCommand, host, framework.TestContext.Provider)
+				framework.ExpectNoError(err)
+				framework.ExpectEqual(result.Code, 0)
 
-				// searching for the line "Apr 14 04:47:42 gke-cluster-1-default-pool-b1565719-eqht systemd[1]: Started Kubernetes node problem detector." and fallback to
-				idx := strings.Index(output, "Started Kubernetes node problem detector")
-				if idx != -1 {
-					output = output[:idx]
-					idx = strings.LastIndex(output, "\n")
-
-					if idx != -1 {
-						output = output[0:15]
-					}
-
-					st, err := time.Parse("Jan 02 15:04:05", output)
-					st = st.AddDate(time.Now().Year(), 0, 0)
-
-					if err == nil {
-						checkForKubeletStart = time.Since(st) < time.Hour
-					}
+				// The time format matches the systemd format.
+				// 'utc': 'Day YYYY-MM-DD HH:MM:SS UTC (see https://www.freedesktop.org/software/systemd/man/systemd.time.html)
+				st, err := time.Parse("Mon 2006-01-02 15:04:05 MST", result.Stdout)
+				if err != nil {
+					framework.Logf("Failed to parse when NPD started. Got exit code: %v and stdout: %v, error: %v. Will skip check for kubelet start event.", result.Code, result.Stdout, err)
 				} else {
-					// fallback to searching the line:
-					// -- Logs begin at Thu 2022-04-28 17:32:39 UTC, end at Thu 2022-04-28 17:40:05 UTC. --
-					idx := strings.Index(output, ", end at ")
-
-					output = output[:idx]
-					idx = strings.LastIndex(output, "-- Logs begin at ")
-					if idx != -1 {
-						output = output[17:]
-					}
-
-					st, err := time.Parse("Mon 2006-01-02 15:04:05 MST", output)
-
-					if err == nil {
-						checkForKubeletStart = time.Since(st) < time.Hour
-					}
+					checkForKubeletStart = time.Since(st) < time.Hour
 				}
 
 				cpuUsage, uptime := getCPUStat(ctx, f, host)


### PR DESCRIPTION
The NPD test checks when NPD started to determine if it is needed to check the kubelet start event. The current logic requires parsing the journalctl logs which is quite fragile and is broken now because of systemd changing the expected log format.

Newer versions of systemd do not print "end at" or "logs begin at" and instead may print "No entries", which will result in the test panicking.

```
$ journalctl -u foo.service
-- No entries --
```

For units started, it will not print "end at" or "logs begin at":

```
root@ubuntu-jammy:~# journalctl -u foo.service
Feb 08 22:02:19 ubuntu-jammy systemd[1]: Started /usr/bin/sleep 1s.
Feb 08 22:02:20 ubuntu-jammy systemd[1]: foo.service: Deactivated successfully.
```

To avoid relying on log parsing which is fragile, let's instead directly ask systemd when the NPD service started and parse the resulting timestamp.

Signed-off-by: David Porter <david@porter.me>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
