### PR TITLE
Call extender only when quantity of requested extended resource is greater than zero

### DIFF
--- a/pkg/scheduler/extender.go
+++ b/pkg/scheduler/extender.go
@@ -431,12 +431,18 @@ func (h *HTTPExtender) hasManagedResources(containers []v1.Container) bool {
 		container := &containers[i]
 		for resourceName := range container.Resources.Requests {
 			if h.managedResources.Has(string(resourceName)) {
-				return true
+				q := container.Resources.Requests[resourceName]
+				if q.Value() > 0 {
+					return true
+				}
 			}
 		}
 		for resourceName := range container.Resources.Limits {
 			if h.managedResources.Has(string(resourceName)) {
-				return true
+				q := container.Resources.Limits[resourceName]
+				if q.Value() > 0 {
+					return true
+				}
 			}
 		}
 	}

--- a/pkg/scheduler/extender_test.go
+++ b/pkg/scheduler/extender_test.go
@@ -359,6 +359,14 @@ func TestIsInterested(t *testing.T) {
 			pod: st.MakePod().Req(map[v1.ResourceName]string{
 				"memory": "0",
 			}).Obj(),
+			want: false,
+		},
+		{
+			label:    "Managed memory, container memory with Requests",
+			extender: mem,
+			pod: st.MakePod().Req(map[v1.ResourceName]string{
+				"memory": "1",
+			}).Obj(),
 			want: true,
 		},
 		{
@@ -367,6 +375,14 @@ func TestIsInterested(t *testing.T) {
 			pod: st.MakePod().Lim(map[v1.ResourceName]string{
 				"memory": "0",
 			}).Obj(),
+			want: false,
+		},
+		{
+			label:    "Managed memory, container memory with Limits",
+			extender: mem,
+			pod: st.MakePod().Lim(map[v1.ResourceName]string{
+				"memory": "1",
+			}).Obj(),
 			want: true,
 		},
 		{
@@ -374,6 +390,14 @@ func TestIsInterested(t *testing.T) {
 			extender: mem,
 			pod: st.MakePod().Container("app").InitReq(map[v1.ResourceName]string{
 				"memory": "0",
+			}).Obj(),
+			want: false,
+		},
+		{
+			label:    "Managed memory, init container memory",
+			extender: mem,
+			pod: st.MakePod().Container("app").InitReq(map[v1.ResourceName]string{
+				"memory": "1",
 			}).Obj(),
 			want: true,
 		},


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/release-note-none
#### What this PR does / why we need it:

We should call extender scheduler only when requested extended resource is greater than zero. Otherwise, it's possible to make kind of DoS attack to the extender.

For a large cluster, if set quantity of requested extended resource to 0, the corresponding extender is called and it'll process large amout of nodes and take a long time. And usually the processing is sequential, and later requests will be blocked.

We actually ran into this problem. One solution is enhancing our extender to just return for this kind of pod, as we have done. But I think it may be more appropriate to fix this in kube-scheduler.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
