### PR TITLE
scheduler(NodeResourcesFit & NodeResourcesBalancedAllocation): calculatePodResourceRequest in PreScore phase

### DIFF
--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -402,6 +402,7 @@ leaderElection:
 						{Name: "NodePorts"},
 					}
 					plugins.PreScore.Enabled = []config.Plugin{
+						{Name: "NodeResourcesFit"},
 						{Name: "InterPodAffinity"},
 						{Name: "TaintToleration"},
 					}
@@ -431,6 +432,7 @@ leaderElection:
 						{Name: "NodePorts"},
 					}
 					plugins.PreScore.Enabled = []config.Plugin{
+						{Name: "NodeResourcesFit"},
 						{Name: "InterPodAffinity"},
 						{Name: "TaintToleration"},
 					}

--- a/pkg/scheduler/apis/config/testing/defaults/defaults.go
+++ b/pkg/scheduler/apis/config/testing/defaults/defaults.go
@@ -75,6 +75,7 @@ var PluginsV1beta2 = &config.Plugins{
 			{Name: names.PodTopologySpread},
 			{Name: names.TaintToleration},
 			{Name: names.NodeAffinity},
+			{Name: names.NodeResourcesFit},
 		},
 	},
 	Score: config.PluginSet{
@@ -238,6 +239,7 @@ var ExpandedPluginsV1beta3 = &config.Plugins{
 		Enabled: []config.Plugin{
 			{Name: names.TaintToleration},
 			{Name: names.NodeAffinity},
+			{Name: names.NodeResourcesFit},
 			{Name: names.PodTopologySpread},
 			{Name: names.InterPodAffinity},
 		},
@@ -415,6 +417,7 @@ var ExpandedPluginsV1 = &config.Plugins{
 		Enabled: []config.Plugin{
 			{Name: names.TaintToleration},
 			{Name: names.NodeAffinity},
+			{Name: names.NodeResourcesFit},
 			{Name: names.PodTopologySpread},
 			{Name: names.InterPodAffinity},
 		},

--- a/pkg/scheduler/apis/config/testing/defaults/defaults.go
+++ b/pkg/scheduler/apis/config/testing/defaults/defaults.go
@@ -76,6 +76,7 @@ var PluginsV1beta2 = &config.Plugins{
 			{Name: names.TaintToleration},
 			{Name: names.NodeAffinity},
 			{Name: names.NodeResourcesFit},
+			{Name: names.NodeResourcesBalancedAllocation},
 		},
 	},
 	Score: config.PluginSet{
@@ -242,6 +243,7 @@ var ExpandedPluginsV1beta3 = &config.Plugins{
 			{Name: names.NodeResourcesFit},
 			{Name: names.PodTopologySpread},
 			{Name: names.InterPodAffinity},
+			{Name: names.NodeResourcesBalancedAllocation},
 		},
 	},
 	Score: config.PluginSet{
@@ -420,6 +422,7 @@ var ExpandedPluginsV1 = &config.Plugins{
 			{Name: names.NodeResourcesFit},
 			{Name: names.PodTopologySpread},
 			{Name: names.InterPodAffinity},
+			{Name: names.NodeResourcesBalancedAllocation},
 		},
 	},
 	Score: config.PluginSet{

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins.go
@@ -76,6 +76,7 @@ func getDefaultPlugins() *v1beta2.Plugins {
 				{Name: names.PodTopologySpread},
 				{Name: names.TaintToleration},
 				{Name: names.NodeAffinity},
+				{Name: names.NodeResourcesFit},
 			},
 		},
 		Score: v1beta2.PluginSet{

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins.go
@@ -77,6 +77,7 @@ func getDefaultPlugins() *v1beta2.Plugins {
 				{Name: names.TaintToleration},
 				{Name: names.NodeAffinity},
 				{Name: names.NodeResourcesFit},
+				{Name: names.NodeResourcesBalancedAllocation},
 			},
 		},
 		Score: v1beta2.PluginSet{

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
@@ -89,6 +89,7 @@ func TestApplyFeatureGates(t *testing.T) {
 						{Name: names.TaintToleration},
 						{Name: names.NodeAffinity},
 						{Name: names.NodeResourcesFit},
+						{Name: names.NodeResourcesBalancedAllocation},
 					},
 				},
 				Score: v1beta2.PluginSet{
@@ -178,6 +179,7 @@ func TestApplyFeatureGates(t *testing.T) {
 						{Name: names.TaintToleration},
 						{Name: names.NodeAffinity},
 						{Name: names.NodeResourcesFit},
+						{Name: names.NodeResourcesBalancedAllocation},
 					},
 				},
 				Score: v1beta2.PluginSet{

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins_test.go
@@ -88,6 +88,7 @@ func TestApplyFeatureGates(t *testing.T) {
 						{Name: names.PodTopologySpread},
 						{Name: names.TaintToleration},
 						{Name: names.NodeAffinity},
+						{Name: names.NodeResourcesFit},
 					},
 				},
 				Score: v1beta2.PluginSet{
@@ -176,6 +177,7 @@ func TestApplyFeatureGates(t *testing.T) {
 						{Name: names.PodTopologySpread},
 						{Name: names.TaintToleration},
 						{Name: names.NodeAffinity},
+						{Name: names.NodeResourcesFit},
 					},
 				},
 				Score: v1beta2.PluginSet{

--- a/pkg/scheduler/apis/config/v1beta2/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1beta2/defaults_test.go
@@ -378,6 +378,7 @@ func TestSchedulerDefaults(t *testing.T) {
 									{Name: names.PodTopologySpread},
 									{Name: names.TaintToleration},
 									{Name: names.NodeAffinity},
+									{Name: names.NodeResourcesFit},
 								},
 							},
 							Score: v1beta2.PluginSet{

--- a/pkg/scheduler/apis/config/v1beta2/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1beta2/defaults_test.go
@@ -379,6 +379,7 @@ func TestSchedulerDefaults(t *testing.T) {
 									{Name: names.TaintToleration},
 									{Name: names.NodeAffinity},
 									{Name: names.NodeResourcesFit},
+									{Name: names.NodeResourcesBalancedAllocation},
 								},
 							},
 							Score: v1beta2.PluginSet{

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -37,10 +37,52 @@ type BalancedAllocation struct {
 	resourceAllocationScorer
 }
 
+var _ framework.PreScorePlugin = &BalancedAllocation{}
 var _ framework.ScorePlugin = &BalancedAllocation{}
 
 // BalancedAllocationName is the name of the plugin used in the plugin registry and configurations.
-const BalancedAllocationName = names.NodeResourcesBalancedAllocation
+const (
+	BalancedAllocationName = names.NodeResourcesBalancedAllocation
+
+	// balancedAllocationPreScoreStateKey is the key in CycleState to NodeResourcesBalancedAllocation pre-computed data for Scoring.
+	balancedAllocationPreScoreStateKey = "PreScore" + BalancedAllocationName
+)
+
+// balancedAllocationPreScoreState computed at PreScore and used at Score.
+type balancedAllocationPreScoreState struct {
+	podRequest map[v1.ResourceName]int64
+}
+
+// Clone implements the mandatory Clone interface. We don't really copy the data since
+// there is no need for that.
+func (s *balancedAllocationPreScoreState) Clone() framework.StateData {
+	return s
+}
+
+// PreScore calculate pod resource request and writes cycle state used by Score.
+func (ba *BalancedAllocation) PreScore(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod, nodes []*v1.Node) *framework.Status {
+	if len(nodes) == 0 {
+		return nil
+	}
+	state := &balancedAllocationPreScoreState{
+		podRequest: ba.calculatePodResourceRequestMap(pod, ba.resources),
+	}
+	cycleState.Write(balancedAllocationPreScoreStateKey, state)
+	return nil
+}
+
+func getBalancedAllocationPreScoreState(cycleState *framework.CycleState) (*balancedAllocationPreScoreState, error) {
+	c, err := cycleState.Read(balancedAllocationPreScoreStateKey)
+	if err != nil {
+		return nil, fmt.Errorf("reading %q from cycleState: %w", balancedAllocationPreScoreStateKey, err)
+	}
+
+	s, ok := c.(*balancedAllocationPreScoreState)
+	if !ok {
+		return nil, fmt.Errorf("invalid PreScore state, got type %T", c)
+	}
+	return s, nil
+}
 
 // Name returns name of the plugin. It is used in logs, etc.
 func (ba *BalancedAllocation) Name() string {
@@ -54,12 +96,17 @@ func (ba *BalancedAllocation) Score(ctx context.Context, state *framework.CycleS
 		return 0, framework.AsStatus(fmt.Errorf("getting node %q from Snapshot: %w", nodeName, err))
 	}
 
+	s, err := getBalancedAllocationPreScoreState(state)
+	if err != nil {
+		s = &balancedAllocationPreScoreState{podRequest: ba.calculatePodResourceRequestMap(pod, ba.resources)}
+	}
+
 	// ba.score favors nodes with balanced resource usage rate.
 	// It calculates the standard deviation for those resources and prioritizes the node based on how close the usage of those resources is to each other.
 	// Detail: score = (1 - std) * MaxNodeScore, where std is calculated by the root square of Σ((fraction(i)-mean)^2)/len(resources)
 	// The algorithm is partly inspired by:
 	// "Wei Huang et al. An Energy Efficient Virtual Machine Placement Algorithm with Balanced Resource Utilization"
-	return ba.score(pod, nodeInfo)
+	return ba.score(pod, nodeInfo, s.podRequest)
 }
 
 // ScoreExtensions of the Score plugin.

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -61,9 +61,6 @@ func (s *balancedAllocationPreScoreState) Clone() framework.StateData {
 
 // PreScore calculates incoming pod's resource requests and writes them to the cycle state used.
 func (ba *BalancedAllocation) PreScore(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod, nodes []*v1.Node) *framework.Status {
-	if len(nodes) == 0 {
-		return nil
-	}
 	state := &balancedAllocationPreScoreState{
 		podRequest: ba.calculatePodResourceRequestMap(pod, ba.resources),
 	}

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -50,6 +50,8 @@ const (
 
 // balancedAllocationPreScoreState computed at PreScore and used at Score.
 type balancedAllocationPreScoreState struct {
+	// podRequests have the same order of the resources defined in NodeResourcesFitArgs.Resources,
+	// same for other place we store a list like that.
 	podRequests []int64
 }
 

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -59,7 +59,7 @@ func (s *balancedAllocationPreScoreState) Clone() framework.StateData {
 	return s
 }
 
-// PreScore calculate pod resource request and writes cycle state used by Score.
+// PreScore calculates incoming pod's resource requests and writes them to the cycle state used.
 func (ba *BalancedAllocation) PreScore(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod, nodes []*v1.Node) *framework.Status {
 	if len(nodes) == 0 {
 		return nil

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
@@ -117,13 +117,13 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 	}
 
 	tests := []struct {
-		pod             *v1.Pod
-		pods            []*v1.Pod
-		nodes           []*v1.Node
-		expectedList    framework.NodeScoreList
-		name            string
-		args            config.NodeResourcesBalancedAllocationArgs
-		disablePreScore bool
+		pod          *v1.Pod
+		pods         []*v1.Pod
+		nodes        []*v1.Node
+		expectedList framework.NodeScoreList
+		name         string
+		args         config.NodeResourcesBalancedAllocationArgs
+		runPreScore  bool
 	}{
 		{
 			// Node1 scores (remaining resources) on 0-MaxNodeScore scale
@@ -139,6 +139,7 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 			expectedList: []framework.NodeScore{{Name: "node1", Score: framework.MaxNodeScore}, {Name: "node2", Score: framework.MaxNodeScore}},
 			name:         "nothing scheduled, nothing requested",
 			args:         config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			runPreScore:  true,
 		},
 		{
 			// Node1 scores on 0-MaxNodeScore scale
@@ -156,6 +157,7 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 			expectedList: []framework.NodeScore{{Name: "node1", Score: 87}, {Name: "node2", Score: framework.MaxNodeScore}},
 			name:         "nothing scheduled, resources requested, differently sized nodes",
 			args:         config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			runPreScore:  true,
 		},
 		{
 			// Node1 scores on 0-MaxNodeScore scale
@@ -178,7 +180,8 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 				st.MakePod().Node("node2").Labels(labels1).Obj(),
 				st.MakePod().Node("node2").Labels(labels1).Obj(),
 			},
-			args: config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			args:        config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			runPreScore: true,
 		},
 		{
 			// Node1 scores on 0-MaxNodeScore scale
@@ -199,7 +202,8 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 				st.MakePod().Node("node1").Obj(),
 				st.MakePod().Node("node1").Obj(),
 			},
-			args: config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			args:        config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			runPreScore: true,
 		},
 		{
 			// Node1 scores on 0-MaxNodeScore scale
@@ -222,7 +226,8 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 				{Spec: cpuOnly2, ObjectMeta: metav1.ObjectMeta{Labels: labels1}},
 				{Spec: cpuAndMemory, ObjectMeta: metav1.ObjectMeta{Labels: labels1}},
 			},
-			args: config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			args:        config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			runPreScore: true,
 		},
 		{
 			// Node1 scores on 0-MaxNodeScore scale
@@ -243,7 +248,8 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 				{Spec: cpuOnly},
 				{Spec: cpuAndMemory},
 			},
-			args: config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			args:        config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			runPreScore: true,
 		},
 		{
 			// Node1 scores on 0-MaxNodeScore scale
@@ -264,7 +270,8 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 				{Spec: cpuOnly},
 				{Spec: cpuAndMemory},
 			},
-			args: config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			args:        config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			runPreScore: true,
 		},
 		{
 			// Node1 scores on 0-MaxNodeScore scale
@@ -286,7 +293,8 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 				{Spec: cpuOnly},
 				{Spec: cpuAndMemory},
 			},
-			args: config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			args:        config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			runPreScore: true,
 		},
 		{
 			pod:          st.MakePod().Obj(),
@@ -297,7 +305,8 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 				{Spec: cpuOnly},
 				{Spec: cpuAndMemory},
 			},
-			args: config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			args:        config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			runPreScore: true,
 		},
 		// Node1 scores on 0-MaxNodeScore scale
 		// CPU Fraction: 3000 / 3500 = 85.71%
@@ -328,6 +337,7 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 				{Name: string(v1.ResourceMemory), Weight: 1},
 				{Name: "nvidia.com/gpu", Weight: 1},
 			}},
+			runPreScore: true,
 		},
 		// Only one node (node1) has the scalar resource, pod doesn't request the scalar resource and the scalar resource should be skipped for consideration.
 		// Node1: std = 0, score = 100
@@ -345,6 +355,7 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 				{Name: string(v1.ResourceCPU), Weight: 1},
 				{Name: "nvidia.com/gpu", Weight: 1},
 			}},
+			runPreScore: true,
 		},
 		{
 			// Node1 scores on 0-MaxNodeScore scale
@@ -365,8 +376,8 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 				{Spec: cpuOnly},
 				{Spec: cpuAndMemory},
 			},
-			args:            config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
-			disablePreScore: true,
+			args:        config.NodeResourcesBalancedAllocationArgs{Resources: defaultResourceBalancedAllocationSet},
+			runPreScore: false,
 		},
 	}
 
@@ -379,7 +390,7 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 			p, _ := NewBalancedAllocation(&test.args, fh, feature.Features{})
 			state := framework.NewCycleState()
 			for i := range test.nodes {
-				if !test.disablePreScore {
+				if !test.runPreScore {
 					status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.pod, test.nodes)
 					if !status.IsSuccess() {
 						t.Errorf("PreScore is expected to return success, but didn't. Got status: %v", status)

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
@@ -382,12 +382,12 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 				if !test.disablePreScore {
 					status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.pod, test.nodes)
 					if !status.IsSuccess() {
-						t.Errorf("unexpected error: %v", status)
+						t.Errorf("PreScore is expected to return success, but didn't. Got status: %v", status)
 					}
 				}
-				hostResult, err := p.(framework.ScorePlugin).Score(ctx, state, test.pod, test.nodes[i].Name)
-				if err != nil {
-					t.Errorf("unexpected error: %v", err)
+				hostResult, status := p.(framework.ScorePlugin).Score(ctx, state, test.pod, test.nodes[i].Name)
+				if !status.IsSuccess() {
+					t.Errorf("Score is expected to return success, but didn't. Got status: %v", status)
 				}
 				if !reflect.DeepEqual(test.expectedList[i].Score, hostResult) {
 					t.Errorf("got score %v for host %v, expected %v", hostResult, test.nodes[i].Name, test.expectedList[i].Score)

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -114,9 +114,6 @@ func (s *preScoreState) Clone() framework.StateData {
 
 // PreScore calculates incoming pod's resource requests and writes them to the cycle state used.
 func (f *Fit) PreScore(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod, nodes []*v1.Node) *framework.Status {
-	if len(nodes) == 0 {
-		return nil
-	}
 	state := &preScoreState{
 		podRequest: f.calculatePodResourceRequestMap(pod, f.resources),
 	}

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -103,6 +103,8 @@ func (s *preFilterState) Clone() framework.StateData {
 
 // preScoreState computed at PreScore and used at Score.
 type preScoreState struct {
+	// podRequests have the same order as the resources defined in NodeResourcesBalancedAllocationArgs.Resources,
+	// same for other place we store a list like that.
 	podRequests []int64
 }
 

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -112,7 +112,7 @@ func (s *preScoreState) Clone() framework.StateData {
 	return s
 }
 
-// PreScore calculate pod resource request and writes cycle state used by Score.
+// PreScore calculates incoming pod's resource requests and writes them to the cycle state used.
 func (f *Fit) PreScore(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod, nodes []*v1.Node) *framework.Status {
 	if len(nodes) == 0 {
 		return nil

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -103,7 +103,7 @@ func (s *preFilterState) Clone() framework.StateData {
 
 // preScoreState computed at PreScore and used at Score.
 type preScoreState struct {
-	podRequest map[v1.ResourceName]int64
+	podRequests []int64
 }
 
 // Clone implements the mandatory Clone interface. We don't really copy the data since
@@ -115,7 +115,7 @@ func (s *preScoreState) Clone() framework.StateData {
 // PreScore calculates incoming pod's resource requests and writes them to the cycle state used.
 func (f *Fit) PreScore(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod, nodes []*v1.Node) *framework.Status {
 	state := &preScoreState{
-		podRequest: f.calculatePodResourceRequestMap(pod, f.resources),
+		podRequests: f.calculatePodResourceRequestList(pod, f.resources),
 	}
 	cycleState.Write(preScoreStateKey, state)
 	return nil
@@ -378,9 +378,9 @@ func (f *Fit) Score(ctx context.Context, state *framework.CycleState, pod *v1.Po
 	s, err := getPreScoreState(state)
 	if err != nil {
 		s = &preScoreState{
-			podRequest: f.calculatePodResourceRequestMap(pod, f.resources),
+			podRequests: f.calculatePodResourceRequestList(pod, f.resources),
 		}
 	}
 
-	return f.score(pod, nodeInfo, s.podRequest)
+	return f.score(pod, nodeInfo, s.podRequests)
 }

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -653,7 +653,7 @@ func TestFitScore(t *testing.T) {
 		existingPods         []*v1.Pod
 		expectedPriorities   framework.NodeScoreList
 		nodeResourcesFitArgs config.NodeResourcesFitArgs
-		disablePreScore      bool
+		runPreScore          bool
 	}{
 		{
 			name: "test case for ScoringStrategy RequestedToCapacityRatio case1",
@@ -681,6 +681,7 @@ func TestFitScore(t *testing.T) {
 					},
 				},
 			},
+			runPreScore: true,
 		},
 		{
 			name: "test case for ScoringStrategy RequestedToCapacityRatio case2",
@@ -708,6 +709,7 @@ func TestFitScore(t *testing.T) {
 					},
 				},
 			},
+			runPreScore: true,
 		},
 		{
 			name: "test case for ScoringStrategy MostAllocated",
@@ -729,6 +731,7 @@ func TestFitScore(t *testing.T) {
 					Resources: defaultResources,
 				},
 			},
+			runPreScore: true,
 		},
 		{
 			name: "test case for ScoringStrategy LeastAllocated",
@@ -750,6 +753,7 @@ func TestFitScore(t *testing.T) {
 					Resources: defaultResources,
 				},
 			},
+			runPreScore: true,
 		},
 		{
 			name: "test case for ScoringStrategy RequestedToCapacityRatio case1 if PreScore is not called",
@@ -777,7 +781,7 @@ func TestFitScore(t *testing.T) {
 					},
 				},
 			},
-			disablePreScore: true,
+			runPreScore: false,
 		},
 		{
 			name: "test case for ScoringStrategy MostAllocated if PreScore is not called",
@@ -799,7 +803,7 @@ func TestFitScore(t *testing.T) {
 					Resources: defaultResources,
 				},
 			},
-			disablePreScore: true,
+			runPreScore: false,
 		},
 		{
 			name: "test case for ScoringStrategy LeastAllocated if PreScore is not called",
@@ -821,7 +825,7 @@ func TestFitScore(t *testing.T) {
 					Resources: defaultResources,
 				},
 			},
-			disablePreScore: true,
+			runPreScore: false,
 		},
 	}
 
@@ -841,7 +845,7 @@ func TestFitScore(t *testing.T) {
 
 			var gotPriorities framework.NodeScoreList
 			for _, n := range test.nodes {
-				if !test.disablePreScore {
+				if !test.runPreScore {
 					status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.requestedPod, test.nodes)
 					if !status.IsSuccess() {
 						t.Errorf("PreScore is expected to return success, but didn't. Got status: %v", status)

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -844,12 +844,12 @@ func TestFitScore(t *testing.T) {
 				if !test.disablePreScore {
 					status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.requestedPod, test.nodes)
 					if !status.IsSuccess() {
-						t.Errorf("unexpected error: %v", status)
+						t.Errorf("PreScore is expected to return success, but didn't. Got status: %v", status)
 					}
 				}
 				score, status := p.(framework.ScorePlugin).Score(ctx, state, test.requestedPod, n.Name)
 				if !status.IsSuccess() {
-					t.Errorf("unexpected error: %v", status)
+					t.Errorf("Score is expected to return success, but didn't. Got status: %v", status)
 				}
 				gotPriorities = append(gotPriorities, framework.NodeScore{Name: n.Name, Score: score})
 			}

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -653,6 +653,7 @@ func TestFitScore(t *testing.T) {
 		existingPods         []*v1.Pod
 		expectedPriorities   framework.NodeScoreList
 		nodeResourcesFitArgs config.NodeResourcesFitArgs
+		disablePreScore      bool
 	}{
 		{
 			name: "test case for ScoringStrategy RequestedToCapacityRatio case1",
@@ -750,6 +751,78 @@ func TestFitScore(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "test case for ScoringStrategy RequestedToCapacityRatio case1 if PreScore is not called",
+			requestedPod: st.MakePod().
+				Req(map[v1.ResourceName]string{"cpu": "3000", "memory": "5000"}).
+				Obj(),
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{"cpu": "4000", "memory": "10000"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{"cpu": "6000", "memory": "10000"}).Obj(),
+			},
+			existingPods: []*v1.Pod{
+				st.MakePod().Node("node1").Req(map[v1.ResourceName]string{"cpu": "2000", "memory": "4000"}).Obj(),
+				st.MakePod().Node("node2").Req(map[v1.ResourceName]string{"cpu": "1000", "memory": "2000"}).Obj(),
+			},
+			expectedPriorities: []framework.NodeScore{{Name: "node1", Score: 10}, {Name: "node2", Score: 32}},
+			nodeResourcesFitArgs: config.NodeResourcesFitArgs{
+				ScoringStrategy: &config.ScoringStrategy{
+					Type:      config.RequestedToCapacityRatio,
+					Resources: defaultResources,
+					RequestedToCapacityRatio: &config.RequestedToCapacityRatioParam{
+						Shape: []config.UtilizationShapePoint{
+							{Utilization: 0, Score: 10},
+							{Utilization: 100, Score: 0},
+						},
+					},
+				},
+			},
+			disablePreScore: true,
+		},
+		{
+			name: "test case for ScoringStrategy MostAllocated if PreScore is not called",
+			requestedPod: st.MakePod().
+				Req(map[v1.ResourceName]string{"cpu": "1000", "memory": "2000"}).
+				Obj(),
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{"cpu": "4000", "memory": "10000"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{"cpu": "6000", "memory": "10000"}).Obj(),
+			},
+			existingPods: []*v1.Pod{
+				st.MakePod().Node("node1").Req(map[v1.ResourceName]string{"cpu": "2000", "memory": "4000"}).Obj(),
+				st.MakePod().Node("node2").Req(map[v1.ResourceName]string{"cpu": "1000", "memory": "2000"}).Obj(),
+			},
+			expectedPriorities: []framework.NodeScore{{Name: "node1", Score: 67}, {Name: "node2", Score: 36}},
+			nodeResourcesFitArgs: config.NodeResourcesFitArgs{
+				ScoringStrategy: &config.ScoringStrategy{
+					Type:      config.MostAllocated,
+					Resources: defaultResources,
+				},
+			},
+			disablePreScore: true,
+		},
+		{
+			name: "test case for ScoringStrategy LeastAllocated if PreScore is not called",
+			requestedPod: st.MakePod().
+				Req(map[v1.ResourceName]string{"cpu": "1000", "memory": "2000"}).
+				Obj(),
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{"cpu": "4000", "memory": "10000"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{"cpu": "6000", "memory": "10000"}).Obj(),
+			},
+			existingPods: []*v1.Pod{
+				st.MakePod().Node("node1").Req(map[v1.ResourceName]string{"cpu": "2000", "memory": "4000"}).Obj(),
+				st.MakePod().Node("node2").Req(map[v1.ResourceName]string{"cpu": "1000", "memory": "2000"}).Obj(),
+			},
+			expectedPriorities: []framework.NodeScore{{Name: "node1", Score: 32}, {Name: "node2", Score: 63}},
+			nodeResourcesFitArgs: config.NodeResourcesFitArgs{
+				ScoringStrategy: &config.ScoringStrategy{
+					Type:      config.LeastAllocated,
+					Resources: defaultResources,
+				},
+			},
+			disablePreScore: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -768,9 +841,11 @@ func TestFitScore(t *testing.T) {
 
 			var gotPriorities framework.NodeScoreList
 			for _, n := range test.nodes {
-				status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.requestedPod, test.nodes)
-				if !status.IsSuccess() {
-					t.Errorf("unexpected error: %v", status)
+				if !test.disablePreScore {
+					status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.requestedPod, test.nodes)
+					if !status.IsSuccess() {
+						t.Errorf("unexpected error: %v", status)
+					}
 				}
 				score, status := p.(framework.ScorePlugin).Score(ctx, state, test.requestedPod, n.Name)
 				if !status.IsSuccess() {

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -768,6 +768,10 @@ func TestFitScore(t *testing.T) {
 
 			var gotPriorities framework.NodeScoreList
 			for _, n := range test.nodes {
+				status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.requestedPod, test.nodes)
+				if !status.IsSuccess() {
+					t.Errorf("unexpected error: %v", status)
+				}
 				score, status := p.(framework.ScorePlugin).Score(ctx, state, test.requestedPod, n.Name)
 				if !status.IsSuccess() {
 					t.Errorf("unexpected error: %v", status)
@@ -885,6 +889,7 @@ func BenchmarkTestFitScore(b *testing.B) {
 
 			requestedPod := st.MakePod().Req(map[v1.ResourceName]string{"cpu": "1000", "memory": "2000"}).Obj()
 			for i := 0; i < b.N; i++ {
+
 				_, status := p.Score(context.Background(), state, requestedPod, nodes[0].Name)
 				if !status.IsSuccess() {
 					b.Errorf("unexpected status: %v", status)

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
@@ -409,6 +409,10 @@ func TestLeastAllocatedScoringStrategy(t *testing.T) {
 
 			var gotScores framework.NodeScoreList
 			for _, n := range test.nodes {
+				status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.requestedPod, test.nodes)
+				if !status.IsSuccess() {
+					t.Errorf("unexpected error: %v", status)
+				}
 				score, status := p.(framework.ScorePlugin).Score(ctx, state, test.requestedPod, n.Name)
 				if status.Code() != test.wantStatusCode {
 					t.Errorf("unexpected status code, want: %v, got: %v", test.wantStatusCode, status)

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
@@ -416,7 +416,7 @@ func TestLeastAllocatedScoringStrategy(t *testing.T) {
 			for _, n := range test.nodes {
 				score, status := p.(framework.ScorePlugin).Score(ctx, state, test.requestedPod, n.Name)
 				if status.Code() != test.wantStatusCode {
-					t.Errorf("Score is expected to return success, but didn't, want: %v, got: %v", test.wantStatusCode, status)
+					t.Errorf("unexpected status code, want: %v, got: %v", test.wantStatusCode, status.Code())
 				}
 				gotScores = append(gotScores, framework.NodeScore{Name: n.Name, Score: score})
 			}

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated_test.go
@@ -407,15 +407,16 @@ func TestLeastAllocatedScoringStrategy(t *testing.T) {
 				return
 			}
 
+			status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.requestedPod, test.nodes)
+			if !status.IsSuccess() {
+				t.Errorf("PreScore is expected to return success, but didn't. Got status: %v", status)
+			}
+
 			var gotScores framework.NodeScoreList
 			for _, n := range test.nodes {
-				status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.requestedPod, test.nodes)
-				if !status.IsSuccess() {
-					t.Errorf("unexpected error: %v", status)
-				}
 				score, status := p.(framework.ScorePlugin).Score(ctx, state, test.requestedPod, n.Name)
 				if status.Code() != test.wantStatusCode {
-					t.Errorf("unexpected status code, want: %v, got: %v", test.wantStatusCode, status)
+					t.Errorf("Score is expected to return success, but didn't, want: %v, got: %v", test.wantStatusCode, status)
 				}
 				gotScores = append(gotScores, framework.NodeScore{Name: n.Name, Score: score})
 			}

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
@@ -366,6 +366,10 @@ func TestMostAllocatedScoringStrategy(t *testing.T) {
 
 			var gotScores framework.NodeScoreList
 			for _, n := range test.nodes {
+				status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.requestedPod, test.nodes)
+				if !status.IsSuccess() {
+					t.Errorf("unexpected error: %v", status)
+				}
 				score, status := p.(framework.ScorePlugin).Score(ctx, state, test.requestedPod, n.Name)
 				if status.Code() != test.wantStatusCode {
 					t.Errorf("unexpected status code, want: %v, got: %v", test.wantStatusCode, status.Code())

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
@@ -373,7 +373,7 @@ func TestMostAllocatedScoringStrategy(t *testing.T) {
 			for _, n := range test.nodes {
 				score, status := p.(framework.ScorePlugin).Score(ctx, state, test.requestedPod, n.Name)
 				if status.Code() != test.wantStatusCode {
-					t.Errorf("Score is expected to return success, but didn't, want: %v, got: %v", test.wantStatusCode, status.Code())
+					t.Errorf("unexpected status code, want: %v, got: %v", test.wantStatusCode, status.Code())
 				}
 				gotScores = append(gotScores, framework.NodeScore{Name: n.Name, Score: score})
 			}

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated_test.go
@@ -364,15 +364,16 @@ func TestMostAllocatedScoringStrategy(t *testing.T) {
 				return
 			}
 
+			status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.requestedPod, test.nodes)
+			if !status.IsSuccess() {
+				t.Errorf("PreScore is expected to return success, but didn't. Got status: %v", status)
+			}
+
 			var gotScores framework.NodeScoreList
 			for _, n := range test.nodes {
-				status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.requestedPod, test.nodes)
-				if !status.IsSuccess() {
-					t.Errorf("unexpected error: %v", status)
-				}
 				score, status := p.(framework.ScorePlugin).Score(ctx, state, test.requestedPod, n.Name)
 				if status.Code() != test.wantStatusCode {
-					t.Errorf("unexpected status code, want: %v, got: %v", test.wantStatusCode, status.Code())
+					t.Errorf("Score is expected to return success, but didn't, want: %v, got: %v", test.wantStatusCode, status.Code())
 				}
 				gotScores = append(gotScores, framework.NodeScore{Name: n.Name, Score: score})
 			}

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
@@ -129,6 +129,10 @@ func TestRequestedToCapacityRatioScoringStrategy(t *testing.T) {
 
 			var gotScores framework.NodeScoreList
 			for _, n := range test.nodes {
+				status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.requestedPod, test.nodes)
+				if !status.IsSuccess() {
+					t.Errorf("unexpected error: %v", status)
+				}
 				score, status := p.(framework.ScorePlugin).Score(ctx, state, test.requestedPod, n.Name)
 				if !status.IsSuccess() {
 					t.Errorf("unexpected error: %v", status)
@@ -321,6 +325,10 @@ func TestResourceBinPackingSingleExtended(t *testing.T) {
 
 			var gotList framework.NodeScoreList
 			for _, n := range test.nodes {
+				status := p.(framework.PreScorePlugin).PreScore(context.Background(), state, test.pod, test.nodes)
+				if !status.IsSuccess() {
+					t.Errorf("unexpected error: %v", status)
+				}
 				score, status := p.(framework.ScorePlugin).Score(context.Background(), state, test.pod, n.Name)
 				if !status.IsSuccess() {
 					t.Errorf("unexpected error: %v", status)
@@ -544,6 +552,10 @@ func TestResourceBinPackingMultipleExtended(t *testing.T) {
 
 			var gotScores framework.NodeScoreList
 			for _, n := range test.nodes {
+				status := p.(framework.PreScorePlugin).PreScore(context.Background(), state, test.pod, test.nodes)
+				if !status.IsSuccess() {
+					t.Errorf("unexpected error: %v", status)
+				}
 				score, status := p.(framework.ScorePlugin).Score(context.Background(), state, test.pod, n.Name)
 				if !status.IsSuccess() {
 					t.Errorf("unexpected error: %v", status)

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
@@ -131,11 +131,11 @@ func TestRequestedToCapacityRatioScoringStrategy(t *testing.T) {
 			for _, n := range test.nodes {
 				status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.requestedPod, test.nodes)
 				if !status.IsSuccess() {
-					t.Errorf("unexpected error: %v", status)
+					t.Errorf("PreScore is expected to return success, but didn't. Got status: %v", status)
 				}
 				score, status := p.(framework.ScorePlugin).Score(ctx, state, test.requestedPod, n.Name)
 				if !status.IsSuccess() {
-					t.Errorf("unexpected error: %v", status)
+					t.Errorf("Score is expected to return success, but didn't. Got status: %v", status)
 				}
 				gotScores = append(gotScores, framework.NodeScore{Name: n.Name, Score: score})
 			}
@@ -327,11 +327,11 @@ func TestResourceBinPackingSingleExtended(t *testing.T) {
 			for _, n := range test.nodes {
 				status := p.(framework.PreScorePlugin).PreScore(context.Background(), state, test.pod, test.nodes)
 				if !status.IsSuccess() {
-					t.Errorf("unexpected error: %v", status)
+					t.Errorf("PreScore is expected to return success, but didn't. Got status: %v", status)
 				}
 				score, status := p.(framework.ScorePlugin).Score(context.Background(), state, test.pod, n.Name)
 				if !status.IsSuccess() {
-					t.Errorf("unexpected error: %v", status)
+					t.Errorf("Score is expected to return success, but didn't. Got status: %v", status)
 				}
 				gotList = append(gotList, framework.NodeScore{Name: n.Name, Score: score})
 			}
@@ -550,15 +550,16 @@ func TestResourceBinPackingMultipleExtended(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
+			status := p.(framework.PreScorePlugin).PreScore(context.Background(), state, test.pod, test.nodes)
+			if !status.IsSuccess() {
+				t.Errorf("PreScore is expected to return success, but didn't. Got status: %v", status)
+			}
+
 			var gotScores framework.NodeScoreList
 			for _, n := range test.nodes {
-				status := p.(framework.PreScorePlugin).PreScore(context.Background(), state, test.pod, test.nodes)
-				if !status.IsSuccess() {
-					t.Errorf("unexpected error: %v", status)
-				}
 				score, status := p.(framework.ScorePlugin).Score(context.Background(), state, test.pod, n.Name)
 				if !status.IsSuccess() {
-					t.Errorf("unexpected error: %v", status)
+					t.Errorf("Score is expected to return success, but didn't. Got status: %v", status)
 				}
 				gotScores = append(gotScores, framework.NodeScore{Name: n.Name, Score: score})
 			}

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
@@ -35,6 +35,7 @@ type resourceAllocationScorer struct {
 	useRequested bool
 	scorer       func(requested, allocable []int64) int64
 	resources    []config.ResourceSpec
+	podRequest   map[v1.ResourceName]int64
 }
 
 // score will use `scorer` function to calculate the score.
@@ -84,7 +85,11 @@ func (r *resourceAllocationScorer) calculateResourceAllocatableRequest(nodeInfo 
 		requested = nodeInfo.Requested
 	}
 
-	podRequest := r.calculatePodResourceRequest(pod, resource)
+	podRequest, ok := r.podRequest[resource]
+	if !ok {
+		podRequest = r.calculatePodResourceRequest(pod, resource)
+	}
+
 	// If it's an extended resource, and the pod doesn't request it. We return (0, 0)
 	// as an implication to bypass scoring on this resource.
 	if podRequest == 0 && schedutil.IsScalarResourceName(resource) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

For plugin NodeResourcesFit and NodeResourcesBalancedAllocation, run `calculatePodResourceRequest` in PreScore phase.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes(https://github.com/kubernetes/kubernetes/pull/114390)

#### Special notes for your reviewer:

@alculquicondor 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NodeResourceFit and NodeResourcesBalancedAllocation implement the PreScore extension point for a more performant calculation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
