### PR TITLE
Allow SSH e2e node base64 key injection

### DIFF
--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -935,12 +935,13 @@ func ignitionInjectGCEPublicKey(path string, content string) string {
 	}
 
 	const sshPublicKeyFileContentMarker = "GCE_SSH_PUBLIC_KEY_FILE_CONTENT"
-	return strings.Replace(
-		content,
-		sshPublicKeyFileContentMarker,
-		base64.StdEncoding.EncodeToString(sshPublicKey),
-		1,
+	key := base64.StdEncoding.EncodeToString(sshPublicKey)
+	base64Marker := base64.StdEncoding.EncodeToString([]byte(sshPublicKeyFileContentMarker))
+	replacer := strings.NewReplacer(
+		sshPublicKeyFileContentMarker, key,
+		base64Marker, key,
 	)
+	return replacer.Replace(content)
 }
 
 func imageToInstanceName(imageConfig *internalGCEImage) string {


### PR DESCRIPTION

#### What type of PR is this?

/kind failing-test


#### What this PR does / why we need it:
With the change of the CRI-O jobs to use butane, we now have a verification for base64 data urls in place. This means that the following URL is invalid:

```
data:text/plain;base64,GCE_SSH_PUBLIC_KEY_FILE_CONTENT
```

This means we have to pass valid base64 to the URL. To fix that, we now allow to inject SSH key values with both, the
`GCE_SSH_PUBLIC_KEY_FILE_CONTENT` field and its base64 encoded variant.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:
PTAL @haircommander @harche 

Refers to https://github.com/kubernetes/test-infra/pull/28706
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
