### PR TITLE
apiserver/storage/storagebackend/factory: deflake unit test 'TestCreateHealthcheck'

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
@@ -89,8 +89,9 @@ func TestCreateHealthcheck(t *testing.T) {
 		{
 			name: "timeouts if response time higher than default timeout",
 			cfg: storagebackend.Config{
-				Type:      storagebackend.StorageTypeETCD3,
-				Transport: storagebackend.TransportConfig{},
+				Type:               storagebackend.StorageTypeETCD3,
+				Transport:          storagebackend.TransportConfig{},
+				HealthcheckTimeout: 2 * time.Second,
 			},
 			responseTime: 3 * time.Second,
 			want:         context.DeadlineExceeded,


### PR DESCRIPTION
Signed-off-by: TommyStarK <thomasmilox@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

If applied this commit will "deflake" the unit test `TestCreateHealthcheck` from `k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go`

- When stress testing the unit test before change

<img width="889" alt="Screenshot 2023-02-09 at 19 55 02" src="https://user-images.githubusercontent.com/9576370/217912856-de515623-9b07-41b6-98e9-27135c174d32.png">

- After change

<img width="287" alt="Screenshot 2023-02-09 at 20 07 44" src="https://user-images.githubusercontent.com/9576370/217913299-27533346-aba7-44e1-8604-9314de2385e2.png">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
