### PR TITLE
Document risk of HTTP response body in probe failure msg

### DIFF
--- a/pkg/probe/http/http.go
+++ b/pkg/probe/http/http.go
@@ -117,7 +117,9 @@ func DoHTTPProbe(req *http.Request, client GetHTTPInterface) (probe.Result, stri
 		return probe.Success, body, nil
 	}
 	klog.V(4).Infof("Probe failed for %s with request headers %v, response body: %v", url.String(), headers, body)
-	return probe.Failure, fmt.Sprintf("HTTP probe failed with statuscode: %d", res.StatusCode), nil
+	// Note: Until https://issue.k8s.io/99425 is addressed, this user-facing failure message must not contain the response body.
+	failureMsg := fmt.Sprintf("HTTP probe failed with statuscode: %d", res.StatusCode)
+	return probe.Failure, failureMsg, nil
 }
 
 // RedirectChecker returns a function that can be used to check HTTP redirects.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

It would be useful to have access to the HTTP response body for debugging HTTP probe failures, but unfortunately this would be a security problem due to https://github.com/kubernetes/kubernetes/issues/99425.

We get PRs with some frequency trying to make this change (e.g. https://github.com/kubernetes/kubernetes/pull/113447, https://github.com/kubernetes/kubernetes/pull/108918), so we should document the risk inline.

#### Which issue(s) this PR fixes:
For https://github.com/kubernetes/kubernetes/issues/99425

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @aojea 