### PR TITLE
fix restricted debug profile

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -1601,6 +1601,12 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 							ImagePullPolicy:          corev1.PullIfNotPresent,
 							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 							VolumeMounts:             nil,
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot: pointer.Bool(true),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+							},
 						},
 					},
 					HostIPC:       false,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles_test.go
@@ -397,7 +397,15 @@ func TestRestrictedProfile(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
-						{Name: "dbg", Image: "dbgimage"},
+						{
+							Name:  "dbg",
+							Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{"ALL"},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -410,6 +418,12 @@ func TestRestrictedProfile(t *testing.T) {
 						{
 							Name:  "dbg",
 							Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot: pointer.Bool(true),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

    fix restricted debug profile
    
    Ensure that the restricted debug profile with the node debugging
    styles doesn't clear security context after we have already set
    runAsNonRoot and drop-all capabilities.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig cli
