### PR TITLE
e2e: revise complete report creation

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -162,18 +162,6 @@ if [[ "${GINKGO_NO_COLOR}" == "y" ]]; then
   ginkgo_args+=("--no-color")
 fi
 
-if [[ -n "${E2E_REPORT_DIR:-}" ]]; then
-    report_dir="${E2E_REPORT_DIR}"
-else
-    # Some jobs don't use E2E_REPORT_DIR and instead pass --report-dir=<dir>
-    # as parameter.
-    for arg in "${@}"; do
-        # shellcheck disable=SC2001
-        # (style): See if you can use ${variable//search/replace} instead.
-        case "$arg" in -report-dir=*|--report-dir=*) report_dir="$(echo "$arg" | sed -e 's/^[^=]*=//')";; esac
-    done
-fi
-
 # The --host setting is used only when providing --auth_config
 # If --kubeconfig is used, the host to use is retrieved from the .kubeconfig
 # file and the one provided with --host is ignored.
@@ -194,19 +182,6 @@ case "${E2E_TEST_DEBUG_TOOL:-ginkgo}" in
       program+=("--nodes=25")
     fi
     program+=("${ginkgo_args[@]:+${ginkgo_args[@]}}")
-
-    if [[ -n "${report_dir:-}" ]]; then
-        # The JUnit report written by the E2E suite gets truncated to avoid
-        # overwhelming the tools that need to process it. For manual analysis
-        # it is useful to have the full reports in both formats that Ginkgo
-        # supports:
-        # - JUnit for comparison with the truncated report.
-        # - JSON because it is a faithful representation of
-        #   all available information.
-        #
-        # This has to be passed to the CLI, the suite doesn't support --output-dir.
-        program+=("--output-dir=${report_dir}" "--junit-report=ginkgo_report.xml" "--json-report=ginkgo_report.json")
-    fi
     ;;
   delve) program=("dlv" "exec") ;;
   gdb) program=("gdb") ;;
@@ -221,6 +196,11 @@ if [ "${E2E_TEST_DEBUG_TOOL:-ginkgo}" != "ginkgo" ]; then
     suite_args+=("--ginkgo.${arg#--}")
   done
 fi
+
+# Generate full dumps of the test result and progress in <report-dir>/ginkgo/,
+# using the Ginkgo-specific JSON format and JUnit XML. Ignored if --report-dir
+# is not used.
+suite_args+=(--report-complete-ginkgo --report-complete-junit)
 
 # The following invocation is fairly complex. Let's dump it to simplify
 # determining what the final options are. Enabled by default in CI

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -113,15 +113,6 @@ func RunE2ETests(t *testing.T) {
 	gomega.RegisterFailHandler(framework.Fail)
 
 	// Run tests through the Ginkgo runner with output to console + JUnit for Jenkins
-	if framework.TestContext.ReportDir != "" {
-		// TODO: we should probably only be trying to create this directory once
-		// rather than once-per-Ginkgo-node.
-		// NOTE: junit report can be simply created by executing your tests with the new --junit-report flags instead.
-		if err := os.MkdirAll(framework.TestContext.ReportDir, 0755); err != nil {
-			klog.Errorf("Failed creating report directory: %v", err)
-		}
-	}
-
 	suiteConfig, reporterConfig := framework.CreateGinkgoConfig()
 	klog.Infof("Starting e2e run %q on Ginkgo node %d", framework.RunID, suiteConfig.ParallelProcess)
 	ginkgo.RunSpecs(t, "Kubernetes e2e suite", suiteConfig, reporterConfig)

--- a/test/e2e/framework/internal/junit/junit.go
+++ b/test/e2e/framework/internal/junit/junit.go
@@ -26,7 +26,7 @@ import (
 // normally written by `ginkgo --junit-report`. This is needed because the full
 // report can become too large for tools like Spyglass
 // (https://github.com/kubernetes/kubernetes/issues/111510).
-func WriteJUnitReport(report ginkgo.Report, filename string) {
+func WriteJUnitReport(report ginkgo.Report, filename string) error {
 	config := reporters.JunitReportConfig{
 		// Remove details for specs where we don't care.
 		OmitTimelinesForSpecState: types.SpecStatePassed | types.SpecStateSkipped,
@@ -38,5 +38,5 @@ func WriteJUnitReport(report ginkgo.Report, filename string) {
 		OmitFailureMessageAttr: true,
 	}
 
-	reporters.GenerateJUnitReportWithConfig(report, filename, config)
+	return reporters.GenerateJUnitReportWithConfig(report, filename, config)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The previous approach was based on the observation that some Prow jobs use the --report-dir parameter instead of the E2E_REPORT_DIR env variable. Parsing the command line was necessary to use the --json-report and --junit-report parameters.

But that is complex and can be avoided by triggering the creation of complete reports in the E2E test suite. The paths are hard-coded and relative to the report directory to keep the code simple.

There was a report that k8s-triage started processing more data after 6db4b741dd9e2588b4dcd47bb8c1ec4aca4842ce was merged. It's unclear whether that was because of the new <report-dir>/ginkgo_report.xml file. To avoid this potential problem, the reports are now in a "ginkgo" sub-directory.

While at it, error checking gets enhanced:
- Create directories at the start of the suite and bail out early if that fails.
- Added missing error checking of truncated JUnit report writing.

#### Does this PR introduce a user-facing change?
```release-note
e2e framework: added `--report-complete-ginkgo` and `--report-complete-junit` parameters. They work like `ginkgo --json-report <report dir>/ginkgo/report.json --junit-report <report dir>/ginkgo/report.xml`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
