### PR TITLE
apiserver: deflake unit test 'TestCreateHealthcheck'

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -213,10 +213,10 @@ func newETCD3Check(c storagebackend.Config, timeout time.Duration, stopCh <-chan
 			return lastError.Load()
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
 		// See https://github.com/etcd-io/etcd/blob/c57f8b3af865d1b531b979889c602ba14377420e/etcdctl/ctlv3/command/ep_command.go#L118
 		now := time.Now()
 		_, err := client.Get(ctx, path.Join("/", c.Prefix, "health"))
+		cancel()
 		if err != nil {
 			err = fmt.Errorf("error getting data from etcd: %w", err)
 		}


### PR DESCRIPTION
Signed-off-by: TommyStarK <thomasmilox@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

If applied this commit will "deflake" the unit test `TestCreateHealthcheck` from `k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go`

- Before change

<img width="889" alt="217912856-de515623-9b07-41b6-98e9-27135c174d32" src="https://user-images.githubusercontent.com/9576370/218104307-e18d750c-24ba-4dfb-b79a-79d662c7c59e.png">


- After change

<img width="570" alt="Screenshot 2023-02-10 at 14 26 37" src="https://user-images.githubusercontent.com/9576370/218103787-e8ae4a1c-561b-46ab-bd9a-20b373f213a0.png">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
