### PR TITLE
Automated cherry pick of #113141: test: remove flaky pod update test in CSIInlineVolumes e2e

### DIFF
--- a/test/e2e/storage/csi_inline.go
+++ b/test/e2e/storage/csi_inline.go
@@ -200,13 +200,6 @@ var _ = utils.SIGDescribe("CSIInlineVolumes", func() {
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(patchedPod.Annotations["patched"], "true", "patched object should have the applied annotation")
 
-		ginkgo.By("updating")
-		podToUpdate := patchedPod.DeepCopy()
-		podToUpdate.Annotations["updated"] = "true"
-		updatedPod, err := client.Update(context.TODO(), podToUpdate, metav1.UpdateOptions{})
-		framework.ExpectNoError(err)
-		framework.ExpectEqual(updatedPod.Annotations["updated"], "true", "updated object should have the applied annotation")
-
 		ginkgo.By("deleting")
 		err = client.Delete(context.TODO(), createdPod.Name, metav1.DeleteOptions{})
 		framework.ExpectNoError(err)


### PR DESCRIPTION
Cherry pick of #113141 on release-1.25.

#113141: test: remove flaky pod update test in CSIInlineVolumes e2e

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```