### PR TITLE
Fix/explain jsonpath

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/explain/explain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/explain_test.go
@@ -90,3 +90,69 @@ func TestSplitAndParseResourceRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitAndParseResourceRequestWithMatchingPrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		inResource string
+
+		expectedGVR        schema.GroupVersionResource
+		expectedFieldsPath []string
+		expectedErr        bool
+	}{
+		{
+			name:       "no trailing period",
+			inResource: "pods.field2.field3",
+
+			expectedGVR:        schema.GroupVersionResource{Resource: "pods", Version: "v1"},
+			expectedFieldsPath: []string{"field2", "field3"},
+		},
+		{
+			name:       "trailing period with correct fieldsPath",
+			inResource: "service.field2.field3.",
+
+			expectedGVR:        schema.GroupVersionResource{Resource: "services", Version: "v1"},
+			expectedFieldsPath: []string{"field2", "field3"},
+		},
+		{
+			name:       "field with dots 1",
+			inResource: `service.field2['field\.with\.dots']`,
+
+			expectedGVR:        schema.GroupVersionResource{Resource: "services", Version: "v1"},
+			expectedFieldsPath: []string{"field2", "field.with.dots"},
+		},
+		{
+			name:       "field with dots 2",
+			inResource: `service.field2.field\.with\.dots`,
+
+			expectedGVR:        schema.GroupVersionResource{Resource: "services", Version: "v1"},
+			expectedFieldsPath: []string{"field2", "field.with.dots"},
+		},
+		{
+			name:       "trailing period with incorrect fieldsPath",
+			inResource: "node.field2.field3.",
+
+			expectedGVR:        schema.GroupVersionResource{Resource: "nodes", Version: "v1"},
+			expectedFieldsPath: []string{"field2", "field3", ""},
+			expectedErr:        true,
+		},
+	}
+
+	mapper := testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotGVR, gotFieldsPath, err := SplitAndParseResourceRequestWithMatchingPrefix(tt.inResource, mapper)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(tt.expectedGVR, gotGVR) && !tt.expectedErr {
+				t.Errorf("%s: expected inResource: %s, got: %s", tt.name, tt.expectedGVR, gotGVR)
+			}
+
+			if !reflect.DeepEqual(tt.expectedFieldsPath, gotFieldsPath) && !tt.expectedErr {
+				t.Errorf("%s: expected fieldsPath: %s, got: %s", tt.name, tt.expectedFieldsPath, gotFieldsPath)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/explain/explain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/explain_test.go
@@ -49,6 +49,20 @@ func TestSplitAndParseResourceRequest(t *testing.T) {
 			expectedFieldsPath: []string{"field2", "field3"},
 		},
 		{
+			name:       "field with dots 1",
+			inResource: `service.field2['field\.with\.dots']`,
+
+			expectedGVR:        schema.GroupVersionResource{Resource: "services", Version: "v1"},
+			expectedFieldsPath: []string{"field2", "field.with.dots"},
+		},
+		{
+			name:       "field with dots 2",
+			inResource: `service.field2.field\.with\.dots`,
+
+			expectedGVR:        schema.GroupVersionResource{Resource: "services", Version: "v1"},
+			expectedFieldsPath: []string{"field2", "field.with.dots"},
+		},
+		{
 			name:       "trailing period with incorrect fieldsPath",
 			inResource: "node.field2.field3.",
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Adds true(er) jsonpath support for kubectl explain by utilizing the kubernetes jsonpath library to parse user inputs. This fixes a bug where fields with dots (`.`) in their name would cause explain to fail to find the resource. Also adds tests for these scenarios.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1286

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixes bug where explain was not properly respecting jsonpaths
```