### PR TITLE
Fix:  kubelet will not output logs after log file is rotated

### DIFF
--- a/pkg/kubelet/kuberuntime/logs/logs_test.go
+++ b/pkg/kubelet/kuberuntime/logs/logs_test.go
@@ -24,11 +24,13 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	apitesting "k8s.io/cri-api/pkg/apis/testing"
+	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/utils/pointer"
 
 	"github.com/stretchr/testify/assert"
@@ -208,6 +210,88 @@ func TestReadLogs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReadRotatedLog(t *testing.T) {
+	tmpDir := t.TempDir()
+	file, err := os.CreateTemp(tmpDir, "logfile")
+	if err != nil {
+		assert.NoErrorf(t, err, "unable to create temp file")
+	}
+
+	stdoutBuf := &bytes.Buffer{}
+	stderrBuf := &bytes.Buffer{}
+	containerID := "fake-container-id"
+	fakeRuntimeService := &apitesting.FakeRuntimeService{
+		Containers: map[string]*apitesting.FakeContainer{
+			containerID: {
+				ContainerStatus: runtimeapi.ContainerStatus{
+					State: runtimeapi.ContainerState_CONTAINER_RUNNING,
+				},
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Start to follow the container's log.
+	go func(ctx context.Context) {
+		podLogOptions := v1.PodLogOptions{
+			Follow: true,
+		}
+		opts := NewLogOptions(&podLogOptions, time.Now())
+		ReadLogs(ctx, file.Name(), containerID, opts, fakeRuntimeService, stdoutBuf, stderrBuf)
+	}(ctx)
+
+	// log in stdout
+	expectedStdout := "line0\nline2\nline4\nline6\nline8\n"
+	// log in stderr
+	expectedStderr := "line1\nline3\nline5\nline7\nline9\n"
+
+	dir := filepath.Dir(file.Name())
+	baseName := filepath.Base(file.Name())
+
+	// Write 10 lines to log file.
+	// Let ReadLogs start.
+	time.Sleep(50 * time.Millisecond)
+	for line := 0; line < 10; line++ {
+		// Write the first three lines to log file
+		now := time.Now().Format(types.RFC3339NanoLenient)
+		if line%2 == 0 {
+			file.WriteString(fmt.Sprintf(
+				`{"log":"line%d\n","stream":"stdout","time":"%s"}`+"\n", line, now))
+		} else {
+			file.WriteString(fmt.Sprintf(
+				`{"log":"line%d\n","stream":"stderr","time":"%s"}`+"\n", line, now))
+		}
+		time.Sleep(1 * time.Millisecond)
+
+		if line == 5 {
+			file.Close()
+			// Pretend to rotate the log.
+			rotatedName := fmt.Sprintf("%s.%s", baseName, time.Now().Format("220060102-150405"))
+			rotatedName = filepath.Join(dir, rotatedName)
+			if err := os.Rename(filepath.Join(dir, baseName), rotatedName); err != nil {
+				assert.NoErrorf(t, err, "failed to rotate log %q to %q", file.Name(), rotatedName)
+				return
+			}
+
+			newF := filepath.Join(dir, baseName)
+			if file, err = os.Create(newF); err != nil {
+				assert.NoError(t, err, "unable to create new log file")
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	// Make the function ReadLogs end.
+	fakeRuntimeService.Lock()
+	fakeRuntimeService.Containers[containerID].State = runtimeapi.ContainerState_CONTAINER_EXITED
+	fakeRuntimeService.Unlock()
+
+	assert.Equal(t, expectedStdout, stdoutBuf.String())
+	assert.Equal(t, expectedStderr, stderrBuf.String())
 }
 
 func TestParseLog(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
kubectl logs POD_NAME -f  won't output logs after kubelet rotate log file of the container .


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115701

#### Special notes for your reviewer:
Comment from the method Wacher.Add
```
// # Watching directories
//
// All files in a directory are monitored, including new files that are created
// after the watcher is started. Subdirectories are not watched (i.e. it's
// non-recursive).
//
// # Watching files
//
// Watching individual files (rather than directories) is generally not
// recommended as many tools update files atomically. Instead of "just" writing
// to the file a temporary file will be written to first, and if successful the
// temporary file is moved to to destination removing the original, or some
// variant thereof. The watcher on the original file is now lost, as it no
// longer exists.
//
// Instead, watch the parent directory and use Event.Name to filter out files
// you're not interested in. There is an example of this in [cmd/fsnotify/file.go].
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed the bug that kubelet could't output logs after log file rotated when kubectl logs POD_NAME -f is running.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
