### PR TITLE
cri-api: fix comment lines about PROPAGATION_PRIVATE

### DIFF
--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
@@ -77,7 +77,7 @@ func (Protocol) EnumDescriptor() ([]byte, []int) {
 type MountPropagation int32
 
 const (
-	// No mount propagation ("private" in Linux terminology).
+	// No mount propagation ("rprivate" in Linux terminology).
 	MountPropagation_PROPAGATION_PRIVATE MountPropagation = 0
 	// Mounts get propagated from the host to the container ("rslave" in Linux).
 	MountPropagation_PROPAGATION_HOST_TO_CONTAINER MountPropagation = 1

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
@@ -199,7 +199,7 @@ message PortMapping {
 }
 
 enum MountPropagation {
-    // No mount propagation ("private" in Linux terminology).
+    // No mount propagation ("rprivate" in Linux terminology).
     PROPAGATION_PRIVATE = 0;
     // Mounts get propagated from the host to the container ("rslave" in Linux).
     PROPAGATION_HOST_TO_CONTAINER = 1;


### PR DESCRIPTION
The current CRI implementations treat `PROPAGATION_PRIVATE` as "rprivate", not "private":
- https://github.com/containerd/containerd/blob/v1.6.16/pkg/cri/opts/spec_linux.go#L181
- https://github.com/cri-o/cri-o/blob/v1.26.1/server/container_create_linux.go#L982

However, this is not always true for cri-dockerd, which treats `PROPAGATION_PRIVATE` as noop and lets dockerd use its default propagation mode:
- https://github.com/Mirantis/cri-dockerd/blob/v0.3.1/libdocker/helpers.go#L235-L236 (The "private is default" comment in L236 is inaccurate)

dockerd's default propagation mode is "rprivate" for most cases, but dockerd changes its default propagation mode to "rslave" when the mount source contains the daemon root (`/var/lib/docker`):
- https://github.com/moby/moby/blob/v20.10.23/volume/mounts/linux_parser.go#L145
- https://github.com/moby/moby/blob/v20.10.23/daemon/volumes.go#L137-L143
- https://github.com/moby/moby/blob/v20.10.23/daemon/volumes_linux.go#L11-L36

This behavior was introduced in Docker 18.03 (moby/moby#36055).

Related:
- kubernetes/website#39385
- Mirantis/cri-dockerd#159

- - -
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation

#### What this PR does / why we need it:

Fix a comment line about `PROPAGATION_PRIVATE` because it is inaccurate.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->


A manifest to verify the behavior:
```yaml
---
apiVersion: v1
kind: Pod
metadata:
  name: propagation-test1
spec:
  containers:
    - name: sleep
      image: busybox
      command: ['sleep', 'infinity']
      volumeMounts:
        - mountPath: /mnt
          name: mnt
          mountPropagation: None
          # The mount propagation `None` is translated to:
          # - cri-dockerd v0.3.0, with Docker v20.10.23: rprivate
          # - containerd v1.6.15: rprivate
          # - CRI-O v1.24.1: rprivate
  volumes:
    - name: mnt
      hostPath:
        path: /mnt
---
apiVersion: v1
kind: Pod
metadata:
  name: propagation-test2
spec:
  containers:
    - name: sleep
      image: busybox
      command: ['sleep', 'infinity']
      volumeMounts:
        - mountPath: /mnt
          name: mnt
          mountPropagation: None
          # The mount propagation `None` is translated to:
          # - cri-dockerd v0.3.0, with Docker v20.10.23: rslave
          # - containerd v1.6.15: rprivate
          # - CRI-O v1.24.1: rprivate
          #
          # Docker changes the default propagation to "rslave",
          # because the mount source (`/`) contains `/var/lib/docker`.
          # - https://github.com/moby/moby/blob/v20.10.23/daemon/volumes.go#L137-L143
          # - https://github.com/moby/moby/blob/v20.10.23/daemon/volumes_linux.go#L11-L36
          #
          # This behavior was introduced in Docker 18.03: https://github.com/moby/moby/pull/36055
          #
          # containerd and CRI-O do not automatically change the propagation:
          # - https://github.com/containerd/containerd/blob/v1.6.15/pkg/cri/opts/spec_linux.go#L181
          # - https://github.com/cri-o/cri-o/blob/v1.24.1/server/container_create_linux.go#L967
  volumes:
    - name: mnt
      hostPath:
        path: /
```