### PR TITLE
e2e framework: revise import restrictions

### DIFF
--- a/test/e2e/framework/.import-restrictions
+++ b/test/e2e/framework/.import-restrictions
@@ -1,269 +1,34 @@
 rules:
-  - selectorRegexp: k8s[.]io/kubernetes/pkg/
+  # The core E2E framework is meant to be a normal Kubernetes client,
+  # which means that it shouldn't depend on internal
+  # code. But we are not there yet, so some exceptions
+  # have to be allowed. Over time the list of allowed
+  # packages should get shorter, not longer.
+  - selectorRegexp: ^k8s[.]io/kubernetes/pkg/
     allowedPrefixes:
-      - k8s.io/kubernetes/pkg/api/legacyscheme
-      - k8s.io/kubernetes/pkg/api/service
-      - k8s.io/kubernetes/pkg/api/v1/pod
-      - k8s.io/kubernetes/pkg/api/v1/resource
-      - k8s.io/kubernetes/pkg/api/v1/service
-      - k8s.io/kubernetes/pkg/api/pod
-      - k8s.io/kubernetes/pkg/api/node
-      - k8s.io/kubernetes/pkg/api/persistentvolumeclaim
-      - k8s.io/kubernetes/pkg/apis/apps
-      - k8s.io/kubernetes/pkg/apis/apps/validation
-      - k8s.io/kubernetes/pkg/apis/autoscaling
-      - k8s.io/kubernetes/pkg/apis/batch
-      - k8s.io/kubernetes/pkg/apis/certificates
-      - k8s.io/kubernetes/pkg/apis/certificates/v1
-      - k8s.io/kubernetes/pkg/apis/core
-      - k8s.io/kubernetes/pkg/apis/core/helper
-      - k8s.io/kubernetes/pkg/apis/core/install
-      - k8s.io/kubernetes/pkg/apis/core/pods
-      - k8s.io/kubernetes/pkg/apis/core/v1
-      - k8s.io/kubernetes/pkg/apis/core/v1/helper
-      - k8s.io/kubernetes/pkg/apis/core/v1/helper/qos
-      - k8s.io/kubernetes/pkg/apis/core/validation
-      - k8s.io/kubernetes/pkg/apis/extensions
-      - k8s.io/kubernetes/pkg/apis/networking
-      - k8s.io/kubernetes/pkg/apis/node
-      - k8s.io/kubernetes/pkg/apis/policy
-      - k8s.io/kubernetes/pkg/apis/policy/validation
-      - k8s.io/kubernetes/pkg/apis/scheduling
-      - k8s.io/kubernetes/pkg/apis/storage/v1/util
-      - k8s.io/kubernetes/pkg/capabilities
-      - k8s.io/kubernetes/pkg/client/conditions
-      - k8s.io/kubernetes/pkg/cloudprovider/providers
-      - k8s.io/kubernetes/pkg/controller
-      - k8s.io/kubernetes/pkg/controller/deployment/util
-      - k8s.io/kubernetes/pkg/controller/nodelifecycle
-      - k8s.io/kubernetes/pkg/controller/nodelifecycle/scheduler
-      - k8s.io/kubernetes/pkg/controller/service
-      - k8s.io/kubernetes/pkg/controller/util/node
-      - k8s.io/kubernetes/pkg/controller/volume/persistentvolume/util
-      - k8s.io/kubernetes/pkg/credentialprovider
-      - k8s.io/kubernetes/pkg/credentialprovider/aws
-      - k8s.io/kubernetes/pkg/credentialprovider/azure
-      - k8s.io/kubernetes/pkg/credentialprovider/gcp
-      - k8s.io/kubernetes/pkg/credentialprovider/secrets
-      - k8s.io/kubernetes/pkg/features
-      - k8s.io/kubernetes/pkg/fieldpath
-      - k8s.io/kubernetes/pkg/kubectl
-      - k8s.io/kubernetes/pkg/kubectl/apps
-      - k8s.io/kubernetes/pkg/kubectl/describe
-      - k8s.io/kubernetes/pkg/kubectl/describe/versioned
-      - k8s.io/kubernetes/pkg/kubectl/scheme
-      - k8s.io/kubernetes/pkg/kubectl/util
-      - k8s.io/kubernetes/pkg/kubectl/util/certificate
-      - k8s.io/kubernetes/pkg/kubectl/util/deployment
-      - k8s.io/kubernetes/pkg/kubectl/util/event
-      - k8s.io/kubernetes/pkg/kubectl/util/fieldpath
-      - k8s.io/kubernetes/pkg/kubectl/util/podutils
-      - k8s.io/kubernetes/pkg/kubectl/util/qos
-      - k8s.io/kubernetes/pkg/kubectl/util/rbac
-      - k8s.io/kubernetes/pkg/kubectl/util/resource
-      - k8s.io/kubernetes/pkg/kubectl/util/slice
-      - k8s.io/kubernetes/pkg/kubectl/util/storage
-      - k8s.io/kubernetes/pkg/kubelet
-      - k8s.io/kubernetes/pkg/kubelet/apis
-      - k8s.io/kubernetes/pkg/kubelet/apis/config
-      - k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1
-      - k8s.io/kubernetes/pkg/kubelet/cadvisor
-      - k8s.io/kubernetes/pkg/kubelet/certificate
-      - k8s.io/kubernetes/pkg/kubelet/certificate/bootstrap
-      - k8s.io/kubernetes/pkg/kubelet/checkpoint
-      - k8s.io/kubernetes/pkg/kubelet/checkpointmanager
-      - k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum
-      - k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors
-      - k8s.io/kubernetes/pkg/kubelet/cloudresource
-      - k8s.io/kubernetes/pkg/kubelet/cm
-      - k8s.io/kubernetes/pkg/kubelet/cm/cpumanager
-      - k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/containermap
-      - k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state
-      - k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology
-      - k8s.io/kubernetes/pkg/kubelet/cm/cpuset
-      - k8s.io/kubernetes/pkg/kubelet/cm/devicemanager
-      - k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/checkpoint
-      - k8s.io/kubernetes/pkg/kubelet/cm/topologymanager
-      - k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask
-      - k8s.io/kubernetes/pkg/kubelet/cm/util
-      - k8s.io/kubernetes/pkg/kubelet/config
-      - k8s.io/kubernetes/pkg/kubelet/configmap
-      - k8s.io/kubernetes/pkg/kubelet/container
-      - k8s.io/kubernetes/pkg/kubelet/envvars
-      - k8s.io/kubernetes/pkg/kubelet/eviction
-      - k8s.io/kubernetes/pkg/kubelet/eviction/api
-      - k8s.io/kubernetes/pkg/kubelet/events
-      - k8s.io/kubernetes/pkg/kubelet/images
-      - k8s.io/kubernetes/pkg/kubelet/kubeletconfig
-      - k8s.io/kubernetes/pkg/kubelet/kubeletconfig/checkpoint
-      - k8s.io/kubernetes/pkg/kubelet/kubeletconfig/checkpoint/store
-      - k8s.io/kubernetes/pkg/kubelet/kubeletconfig/configfiles
-      - k8s.io/kubernetes/pkg/kubelet/kubeletconfig/status
-      - k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/codec
-      - k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/files
-      - k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/log
-      - k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/panic
-      - k8s.io/kubernetes/pkg/kubelet/kuberuntime
-      - k8s.io/kubernetes/pkg/kubelet/kuberuntime/logs
-      - k8s.io/kubernetes/pkg/kubelet/leaky
-      - k8s.io/kubernetes/pkg/kubelet/lifecycle
-      - k8s.io/kubernetes/pkg/kubelet/logs
-      - k8s.io/kubernetes/pkg/kubelet/metrics
-      - k8s.io/kubernetes/pkg/kubelet/network/dns
-      - k8s.io/kubernetes/pkg/kubelet/nodelease
-      - k8s.io/kubernetes/pkg/kubelet/nodestatus
-      - k8s.io/kubernetes/pkg/kubelet/oom
-      - k8s.io/kubernetes/pkg/kubelet/pleg
-      - k8s.io/kubernetes/pkg/kubelet/pluginmanager
-      - k8s.io/kubernetes/pkg/kubelet/pluginmanager/cache
-      - k8s.io/kubernetes/pkg/kubelet/pluginmanager/metrics
-      - k8s.io/kubernetes/pkg/kubelet/pluginmanager/operationexecutor
-      - k8s.io/kubernetes/pkg/kubelet/pluginmanager/pluginwatcher
-      - k8s.io/kubernetes/pkg/kubelet/pluginmanager/pluginwatcher/example_plugin_apis/v1beta1
-      - k8s.io/kubernetes/pkg/kubelet/pluginmanager/pluginwatcher/example_plugin_apis/v1beta2
-      - k8s.io/kubernetes/pkg/kubelet/pluginmanager/reconciler
-      - k8s.io/kubernetes/pkg/kubelet/pod
-      - k8s.io/kubernetes/pkg/kubelet/preemption
-      - k8s.io/kubernetes/pkg/kubelet/prober
-      - k8s.io/kubernetes/pkg/kubelet/prober/results
-      - k8s.io/kubernetes/pkg/kubelet/qos
-      - k8s.io/kubernetes/pkg/kubelet/remote
-      - k8s.io/kubernetes/pkg/kubelet/runtimeclass
-      - k8s.io/kubernetes/pkg/kubelet/server
-      - k8s.io/kubernetes/pkg/kubelet/server/metrics
-      - k8s.io/kubernetes/pkg/kubelet/server/portforward
-      - k8s.io/kubernetes/pkg/kubelet/server/remotecommand
-      - k8s.io/kubernetes/pkg/kubelet/server/stats
-      - k8s.io/kubernetes/pkg/kubelet/server/streaming
-      - k8s.io/kubernetes/pkg/kubelet/stats
-      - k8s.io/kubernetes/pkg/kubelet/stats/pidlimit
-      - k8s.io/kubernetes/pkg/kubelet/status
-      - k8s.io/kubernetes/pkg/kubelet/secret
-      - k8s.io/kubernetes/pkg/kubelet/sysctl
-      - k8s.io/kubernetes/pkg/kubelet/types
-      - k8s.io/kubernetes/pkg/kubelet/token
-      - k8s.io/kubernetes/pkg/kubelet/util
-      - k8s.io/kubernetes/pkg/kubelet/util/format
-      - k8s.io/kubernetes/pkg/kubelet/util/manager
-      - k8s.io/kubernetes/pkg/kubelet/util/store
-      - k8s.io/kubernetes/pkg/kubelet/volumemanager
-      - k8s.io/kubernetes/pkg/kubelet/volumemanager/cache
-      - k8s.io/kubernetes/pkg/kubelet/volumemanager/metrics
-      - k8s.io/kubernetes/pkg/kubelet/volumemanager/populator
-      - k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler
-      - k8s.io/kubernetes/pkg/kubemark
-      - k8s.io/kubernetes/pkg/cluster/ports
-      - k8s.io/kubernetes/pkg/probe
-      - k8s.io/kubernetes/pkg/probe/exec
-      - k8s.io/kubernetes/pkg/probe/http
-      - k8s.io/kubernetes/pkg/probe/tcp
-      - k8s.io/kubernetes/pkg/proxy
-      - k8s.io/kubernetes/pkg/proxy/apis
-      - k8s.io/kubernetes/pkg/proxy/apis/config
-      - k8s.io/kubernetes/pkg/proxy/apis/config/scheme
-      - k8s.io/kubernetes/pkg/proxy/apis/config/v1alpha1
-      - k8s.io/kubernetes/pkg/proxy/apis/config/validation
-      - k8s.io/kubernetes/pkg/proxy/config
-      - k8s.io/kubernetes/pkg/proxy/healthcheck
-      - k8s.io/kubernetes/pkg/proxy/iptables
-      - k8s.io/kubernetes/pkg/proxy/ipvs
-      - k8s.io/kubernetes/pkg/proxy/metaproxier
-      - k8s.io/kubernetes/pkg/proxy/metrics
-      - k8s.io/kubernetes/pkg/proxy/util
-      - k8s.io/kubernetes/pkg/registry/core/service/allocator
-      - k8s.io/kubernetes/pkg/registry/core/service/portallocator
-      - k8s.io/kubernetes/pkg/scheduler/api
-      - k8s.io/kubernetes/pkg/scheduler/framework
-      - k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper
-      - k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeaffinity
-      - k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodename
-      - k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeports
-      - k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources
-      - k8s.io/kubernetes/pkg/scheduler/framework/runtime
-      - k8s.io/kubernetes/pkg/scheduler/internal/heap
-      - k8s.io/kubernetes/pkg/scheduler/internal/parallelize
-      - k8s.io/kubernetes/pkg/scheduler/internal/queue
-      - k8s.io/kubernetes/pkg/scheduler/listers
-      - k8s.io/kubernetes/pkg/scheduler/testing
-      - k8s.io/kubernetes/pkg/scheduler/metrics
-      - k8s.io/kubernetes/pkg/scheduler/nodeinfo
-      - k8s.io/kubernetes/pkg/scheduler/util
-      - k8s.io/kubernetes/pkg/scheduler/volumebinder
-      - k8s.io/kubernetes/pkg/scheduler
-      - k8s.io/kubernetes/pkg/scheduler/profile
-      - k8s.io/kubernetes/pkg/scheduler/testing
-      - k8s.io/kubernetes/pkg/security/apparmor
-      - k8s.io/kubernetes/pkg/securitycontext
-      - k8s.io/kubernetes/pkg/serviceaccount
-      - k8s.io/kubernetes/pkg/util/async
-      - k8s.io/kubernetes/pkg/util/bandwidth
-      - k8s.io/kubernetes/pkg/util/config
-      - k8s.io/kubernetes/pkg/util/configz
-      - k8s.io/kubernetes/pkg/util/conntrack
-      - k8s.io/kubernetes/pkg/util/env
-      - k8s.io/kubernetes/pkg/util/filesystem
-      - k8s.io/kubernetes/pkg/util/flag
-      - k8s.io/kubernetes/pkg/util/flock
-      - k8s.io/kubernetes/pkg/util/goroutinemap
-      - k8s.io/kubernetes/pkg/util/goroutinemap/exponentialbackoff
-      - k8s.io/kubernetes/pkg/util/hash
-      - k8s.io/kubernetes/pkg/util/ipset
-      - k8s.io/kubernetes/pkg/util/iptables
-      - k8s.io/kubernetes/pkg/util/ipvs
-      - k8s.io/kubernetes/pkg/util/labels
-      - k8s.io/kubernetes/pkg/util/node
-      - k8s.io/kubernetes/pkg/util/oom
-      - k8s.io/kubernetes/pkg/util/parsers
-      - k8s.io/kubernetes/pkg/util/pod
-      - k8s.io/kubernetes/pkg/util/procfs
-      - k8s.io/kubernetes/pkg/util/removeall
-      - k8s.io/kubernetes/pkg/util/resizefs
-      - k8s.io/kubernetes/pkg/util/rlimit
-      - k8s.io/kubernetes/pkg/util/selinux
-      - k8s.io/kubernetes/pkg/util/slice
-      - k8s.io/kubernetes/pkg/util/sysctl
-      - k8s.io/kubernetes/pkg/util/system
-      - k8s.io/kubernetes/pkg/util/tail
-      - k8s.io/kubernetes/pkg/util/taints
-      - k8s.io/kubernetes/pkg/volume
-      - k8s.io/kubernetes/pkg/volume/util
-      - k8s.io/kubernetes/pkg/volume/util/fs
-      - k8s.io/kubernetes/pkg/volume/util/fsquota
-      - k8s.io/kubernetes/pkg/volume/util/recyclerclient
-      - k8s.io/kubernetes/pkg/volume/util/subpath
-      - k8s.io/kubernetes/pkg/volume/util/types
-      - k8s.io/kubernetes/pkg/volume/util/volumepathhandler
-      # TODO: I have no idea why import-boss --include-test-files is yelling about these for k8s.io/kubernetes/test/e2e/framework/providers/kubemark
-      - k8s.io/kubernetes/pkg/apis/authentication
-      - k8s.io/kubernetes/pkg/apis/authentication/v1
-      - k8s.io/kubernetes/pkg/apis/certificates/v1beta1
-      - k8s.io/kubernetes/pkg/apis/storage/v1
-      - k8s.io/kubernetes/pkg/scheduler/internal/cache
-  - selectorRegexp: k8s[.]io/kubernetes/test/
-    allowedPrefixes:
-      - k8s.io/kubernetes/test/e2e/common
-      - k8s.io/kubernetes/test/e2e/framework
-      - k8s.io/kubernetes/test/e2e/framework/auth
-      - k8s.io/kubernetes/test/e2e/framework/ginkgowrapper
-      - k8s.io/kubernetes/test/e2e/framework/kubectl
-      - k8s.io/kubernetes/test/e2e/framework/log
-      - k8s.io/kubernetes/test/e2e/framework/metrics
-      - k8s.io/kubernetes/test/e2e/framework/network
-      - k8s.io/kubernetes/test/e2e/framework/node
-      - k8s.io/kubernetes/test/e2e/framework/pod
-      - k8s.io/kubernetes/test/e2e/framework/rc
-      - k8s.io/kubernetes/test/e2e/framework/resource
-      - k8s.io/kubernetes/test/e2e/framework/service
-      - k8s.io/kubernetes/test/e2e/framework/ssh
-      - k8s.io/kubernetes/test/e2e/framework/testfiles
-      - k8s.io/kubernetes/test/e2e/framework/websocket
-      - k8s.io/kubernetes/test/e2e/manifest
-      - k8s.io/kubernetes/test/e2e/perftype
-      - k8s.io/kubernetes/test/e2e/storage/utils
-      - k8s.io/kubernetes/test/e2e/system
-      - k8s.io/kubernetes/test/utils
-      - k8s.io/kubernetes/test/utils/image
-  # TODO: why is this here?
-  - selectorRegexp: k8s[.]io/kubernetes/third_party/
-    allowedPrefixes:
-    - k8s.io/kubernetes/third_party/forked/golang/expansion
+    - k8s.io/kubernetes/pkg/kubelet/apis/
+
+  # The following packages are okay to use:
+  #
+  # public API
+  - selectorRegexp: ^k8s[.]io/(api|apimachinery|client-go|component-base|klog|pod-security-admission|utils)/|^[a-z]+(/|$)|github.com/onsi/(ginkgo|gomega)|^k8s[.]io/kubernetes/test/(e2e/framework/internal/|utils)
+    allowedPrefixes: [ "" ]
+
+  # stdlib
+  - selectorRegexp: ^[a-z]+(/|$)
+    allowedPrefixes: [ "" ]
+
+  # Ginkgo + Gomega.
+  - selectorRegexp: github.com/onsi/(ginkgo|gomega)|^k8s[.]io/kubernetes/test/(e2e/framework/internal/|utils)
+    allowedPrefixes: [ "" ]
+
+  # some of the shared test helpers (but not E2E sub-packages!)
+  - selectorRegexp: ^k8s[.]io/kubernetes/test/(e2e/framework/internal/|utils)
+    allowedPrefixes: [ "" ]
+
+  # Everything else isn't.
+  #
+  # In particular importing any test/e2e/framework/* package would be a
+  # violation (sub-packages get to use the framework, not the other way
+  # around).
+  - selectorRegexp: .

--- a/test/e2e/framework/auth/.import-restrictions
+++ b/test/e2e/framework/auth/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/autoscaling/.import-restrictions
+++ b/test/e2e/framework/autoscaling/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/config/.import-restrictions
+++ b/test/e2e/framework/config/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/daemonset/.import-restrictions
+++ b/test/e2e/framework/daemonset/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/debug/.import-restrictions
+++ b/test/e2e/framework/debug/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/deployment/.import-restrictions
+++ b/test/e2e/framework/deployment/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/endpoints/.import-restrictions
+++ b/test/e2e/framework/endpoints/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/endpointslice/.import-restrictions
+++ b/test/e2e/framework/endpointslice/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/events/.import-restrictions
+++ b/test/e2e/framework/events/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/gpu/.import-restrictions
+++ b/test/e2e/framework/gpu/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/ingress/.import-restrictions
+++ b/test/e2e/framework/ingress/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/internal/.import-restrictions
+++ b/test/e2e/framework/internal/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/job/.import-restrictions
+++ b/test/e2e/framework/job/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/kubectl/.import-restrictions
+++ b/test/e2e/framework/kubectl/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/kubelet/.import-restrictions
+++ b/test/e2e/framework/kubelet/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/kubesystem/.import-restrictions
+++ b/test/e2e/framework/kubesystem/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/manifest/.import-restrictions
+++ b/test/e2e/framework/manifest/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/metrics/.import-restrictions
+++ b/test/e2e/framework/metrics/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/network/.import-restrictions
+++ b/test/e2e/framework/network/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/node/.import-restrictions
+++ b/test/e2e/framework/node/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/perf/.import-restrictions
+++ b/test/e2e/framework/perf/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/pod/.import-restrictions
+++ b/test/e2e/framework/pod/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/providers/.import-restrictions
+++ b/test/e2e/framework/providers/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/pv/.import-restrictions
+++ b/test/e2e/framework/pv/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/rc/.import-restrictions
+++ b/test/e2e/framework/rc/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/replicaset/.import-restrictions
+++ b/test/e2e/framework/replicaset/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/resource/.import-restrictions
+++ b/test/e2e/framework/resource/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/security/.import-restrictions
+++ b/test/e2e/framework/security/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/service/.import-restrictions
+++ b/test/e2e/framework/service/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/skipper/.import-restrictions
+++ b/test/e2e/framework/skipper/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/ssh/.import-restrictions
+++ b/test/e2e/framework/ssh/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/statefulset/.import-restrictions
+++ b/test/e2e/framework/statefulset/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/testfiles/.import-restrictions
+++ b/test/e2e/framework/testfiles/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/timer/.import-restrictions
+++ b/test/e2e/framework/timer/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/volume/.import-restrictions
+++ b/test/e2e/framework/volume/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/framework/websocket/.import-restrictions
+++ b/test/e2e/framework/websocket/.import-restrictions
@@ -1,0 +1,9 @@
+# This E2E framework sub-package is currently allowed to use arbitrary
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
+#
+# At some point it may become useful to also check this package's
+# dependencies more careful.
+rules:
+  - selectorRegexp: ""
+    allowedPrefixes: [ "" ]

--- a/test/e2e/network/.import-restrictions
+++ b/test/e2e/network/.import-restrictions
@@ -1,0 +1,6 @@
+rules:
+  # prevent any k8s.io/kubernetes/third_party imports outside of this package
+  # External Packages are used in the network/dns_common.go path
+  - selectorRegexp: k8s[.]io/kubernetes/third_party/
+    allowedPrefixes:
+    - k8s.io/kubernetes/third_party/forked/golang/net


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- test/e2e/framework/*.go should have very minimal dependencies. We can enforce that via import-boss.

- What each test/e2e/framework/* sub-package uses is less relevant, although ideally it also should be as minimal as possible in each case.

Enforcing this via import-boss ensures that new dependencies get flagged as problem and thus will get additional scrutiny. It might be okay to add them, but it needs to be considered.

#### Which issue(s) this PR fixes:
Fixes #115234

#### Special notes for your reviewer:

See https://github.com/kubernetes/kubernetes/pull/115296 for some prior discussion.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
