### PR TITLE
kubectl debug: add netadmin profile

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -190,7 +190,7 @@ func (o *DebugOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.ShareProcesses, "share-processes", o.ShareProcesses, i18n.T("When used with '--copy-to', enable process namespace sharing in the copy."))
 	cmd.Flags().StringVar(&o.TargetContainer, "target", "", i18n.T("When using an ephemeral container, target processes in this container name."))
 	cmd.Flags().BoolVarP(&o.TTY, "tty", "t", o.TTY, i18n.T("Allocate a TTY for the debugging container."))
-	cmd.Flags().StringVar(&o.Profile, "profile", ProfileLegacy, i18n.T(`Debugging profile. Options are "legacy", "general", "baseline", or "restricted".`))
+	cmd.Flags().StringVar(&o.Profile, "profile", ProfileLegacy, i18n.T(`Debugging profile. Options are "legacy", "general", "baseline", "netadmin", or "restricted".`))
 }
 
 // Complete finishes run-time initialization of debug.DebugOptions.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -294,6 +294,27 @@ func TestGenerateDebugContainer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "netadmin profile",
+			opts: &DebugOptions{
+				Image:      "busybox",
+				PullPolicy: corev1.PullIfNotPresent,
+				Profile:    ProfileNetadmin,
+			},
+			expected: &corev1.EphemeralContainer{
+				EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+					Name:                     "debugger-1",
+					Image:                    "busybox",
+					ImagePullPolicy:          corev1.PullIfNotPresent,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					SecurityContext: &corev1.SecurityContext{
+						Capabilities: &corev1.Capabilities{
+							Add: []corev1.Capability{"NET_ADMIN"},
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.opts.IOStreams = genericclioptions.NewTestIOStreamsDiscard()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package debug
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -420,6 +421,143 @@ func TestRestrictedProfile(t *testing.T) {
 			err := (&restrictedProfile{}).Apply(test.pod, test.containerName, test.target)
 			if (err != nil) != test.expectErr {
 				t.Fatalf("expect error: %v, got error: %v", test.expectErr, (err != nil))
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(test.expectPod, test.pod); diff != "" {
+				t.Error("unexpected diff in generated object: (-want +got):\n", diff)
+			}
+		})
+	}
+}
+
+func TestNetAdminProfile(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+		Spec: corev1.PodSpec{EphemeralContainers: []corev1.EphemeralContainer{
+			{
+				EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+					Name: "dbg", Image: "dbgimage",
+				},
+			},
+		}},
+	}
+
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		containerName string
+		target        runtime.Object
+		expectPod     *corev1.Pod
+		expectErr     error
+	}{
+		{
+			name:          "nil target",
+			pod:           pod,
+			containerName: "dbg",
+			target:        nil,
+			expectErr:     fmt.Errorf("netadmin profile: objects of type <nil> are not supported"),
+		},
+		{
+			name:          "debug by ephemeral container",
+			pod:           pod,
+			containerName: "dbg",
+			target:        pod,
+			expectPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{EphemeralContainers: []corev1.EphemeralContainer{
+					{
+						EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+							Name: "dbg", Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{"NET_ADMIN"},
+								},
+							},
+						},
+					},
+				}},
+			},
+		},
+		{
+			name: "debug by pod copy",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{Name: "dbg", Image: "dbgimage"},
+					},
+				},
+			},
+			containerName: "dbg",
+			target: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+					},
+				},
+			},
+			expectPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{
+							Name:  "dbg",
+							Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{"NET_ADMIN"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "debug by node",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "dbg", Image: "dbgimage"},
+					},
+				},
+			},
+			containerName: "dbg",
+			target:        testNode,
+			expectPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{
+					HostNetwork: true,
+					HostPID:     true,
+					HostIPC:     true,
+					Containers: []corev1.Container{
+						{
+							Name:  "dbg",
+							Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: pointer.BoolPtr(true),
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{"NET_ADMIN"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := (&netadminProfile{}).Apply(test.pod, test.containerName, test.target)
+			if (err == nil) != (test.expectErr == nil) || (err != nil && test.expectErr != nil && err.Error() != test.expectErr.Error()) {
+				t.Fatalf("expect error: %v, got error: %v", test.expectErr, err)
 			}
 			if err != nil {
 				return


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add the netadmin profile from KEP 1441
https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug#debugging-profiles

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/kubectl/issues/1108

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added "netadmin" debugging profiles for kubectl debug.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

[KEP 1441](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug#debugging-profiles)
