### PR TITLE
Graduate `SeccompDefault` feature to stable / GA

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1150,10 +1150,6 @@ func RunKubelet(kubeServer *options.KubeletServer, kubeDeps *kubelet.Dependencie
 		kubeDeps.OSInterface = kubecontainer.RealOS{}
 	}
 
-	if kubeServer.KubeletConfiguration.SeccompDefault && !utilfeature.DefaultFeatureGate.Enabled(features.SeccompDefault) {
-		return fmt.Errorf("the SeccompDefault feature gate must be enabled in order to use the SeccompDefault configuration")
-	}
-
 	k, err := createAndInitKubelet(kubeServer,
 		kubeDeps,
 		hostname,

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -684,6 +684,7 @@ const (
 	// kep: https://kep.k8s.io/2413
 	// alpha: v1.22
 	// beta: v1.25
+	// ga: v1.27
 	//
 	// Enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
 	SeccompDefault featuregate.Feature = "SeccompDefault"
@@ -1017,7 +1018,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	RotateKubeletServerCertificate: {Default: true, PreRelease: featuregate.Beta},
 
-	SeccompDefault: {Default: true, PreRelease: featuregate.Beta},
+	SeccompDefault: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
 
 	ServiceIPStaticSubrange: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.28
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -57985,7 +57985,7 @@ func schema_k8sio_kubelet_config_v1beta1_KubeletConfiguration(ref common.Referen
 					},
 					"seccompDefault": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SeccompDefault enables the use of `RuntimeDefault` as the default seccomp profile for all workloads. This requires the corresponding SeccompDefault feature gate to be enabled as well. Default: false",
+							Description: "SeccompDefault enables the use of `RuntimeDefault` as the default seccomp profile for all workloads. Default: false",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -764,7 +764,6 @@ type KubeletConfiguration struct {
 	// +optional
 	EnableDebugFlagsHandler *bool `json:"enableDebugFlagsHandler,omitempty"`
 	// SeccompDefault enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
-	// This requires the corresponding SeccompDefault feature gate to be enabled as well.
 	// Default: false
 	// +optional
 	SeccompDefault *bool `json:"seccompDefault,omitempty"`


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Updating the required code and docs for `SeccompDefault` to go GA, which now means that we enable the feature per default.

#### Which issue(s) this PR fixes:

Refers to https://github.com/kubernetes/enhancements/issues/2413

#### Special notes for your reviewer:

cc @kubernetes/sig-node-api-reviews

#### Does this PR introduce a user-facing change?

```release-note
Graduated seccomp profile defaulting to GA.

Set the kubelet `--seccomp-default` flag or `seccompDefault` kubelet configuration field to `true` to make pods on that node default to using the `RuntimeDefault` seccomp profile.

Enabling seccomp for your workload can have a negative performance impact depending on the kernel and container runtime version in use.

Guidance for identifying and mitigating those issues is outlined in the Kubernetes [seccomp tutorial](https://k8s.io/docs/tutorials/security/seccomp).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
KEP: https://github.com/kubernetes/enhancements/tree/05f81b8/keps/sig-node/2413-seccomp-by-default
```
