### PR TITLE
Revert "use kube-proxy defaults values for CI"

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1758,7 +1758,7 @@ function prepare-kube-proxy-manifest-variables {
       exit 1
     fi
   fi
-  params+=" --iptables-sync-period=1m --iptables-min-sync-period=1s --ipvs-sync-period=1m --ipvs-min-sync-period=1s"
+  params+=" --iptables-sync-period=1m --iptables-min-sync-period=10s --ipvs-sync-period=1m --ipvs-min-sync-period=10s"
   if [[ -n "${KUBEPROXY_TEST_ARGS:-}" ]]; then
     params+=" ${KUBEPROXY_TEST_ARGS}"
   fi


### PR DESCRIPTION
This reverts commit bafeacd14d4287b4d1ac68d2156f7a468fc0dc89.
/kind cleanup
```release-note
NONE
```

We need to figure out if the additional CPU usage impacts network latency on the cluster, observed in the scalability dashboards around the time this has merged

Related to: #115720


