### PR TITLE
[WIP] Cache encoded watch events to allow reusing it for all watchers

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
@@ -328,6 +328,7 @@ type Object interface {
 // CacheableObject allows an object to cache its different serializations
 // to avoid performing the same serialization multiple times.
 type CacheableObject interface {
+	Object
 	// CacheEncode writes an object to a stream. The <encode> function will
 	// be used in case of cache miss. The <encode> function takes ownership
 	// of the object.
@@ -344,6 +345,10 @@ type CacheableObject interface {
 	// to be passed to <encode> function in CacheEncode method.
 	// If CacheableObject is a wrapper, the copy of wrapped object should be returned.
 	GetObject() Object
+	// GetCachedEvent returns a cached watch event containing the encoded object.
+	// If the cache doesn't contain a particular encoding of an event, it executes
+	// the <eventProducer> method and stores it afterwards.
+	GetCachedEvent(id Identifier, eventProducer func() (Object, error)) (CacheableObject, error)
 }
 
 // Unstructured objects store values as map[string]interface{}, with only values that can be serialized

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
@@ -348,7 +348,7 @@ type CacheableObject interface {
 	// GetCachedEvent returns a cached watch event containing the encoded object.
 	// If the cache doesn't contain a particular encoding of an event, it executes
 	// the <eventProducer> method and stores it afterwards.
-	GetCachedEvent(id Identifier, eventProducer func() (Object, error)) (CacheableObject, error)
+	GetCachedEvent(id Identifier, eventProducer func() (Object, error)) (Object, error)
 }
 
 // Unstructured objects store values as map[string]interface{}, with only values that can be serialized

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/cacheable_object.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/cacheable_object.go
@@ -127,7 +127,7 @@ func (m *MockCacheableObject) GetObject() runtime.Object {
 	return &noncacheableTestObject{gvk: gvk}
 }
 
-func (m *MockCacheableObject) GetCachedEvent(id runtime.Identifier, eventProducer func() (runtime.Object, error)) (runtime.CacheableObject, error) {
+func (m *MockCacheableObject) GetCachedEvent(id runtime.Identifier, eventProducer func() (runtime.Object, error)) (runtime.Object, error) {
 	return m, nil
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/cacheable_object.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/cacheable_object.go
@@ -127,6 +127,10 @@ func (m *MockCacheableObject) GetObject() runtime.Object {
 	return &noncacheableTestObject{gvk: gvk}
 }
 
+func (m *MockCacheableObject) GetCachedEvent(id runtime.Identifier, eventProducer func() (runtime.Object, error)) (runtime.CacheableObject, error) {
+	return m, nil
+}
+
 func (m *MockCacheableObject) interceptedCalls() []runtime.Identifier {
 	return m.intercepted
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response_test.go
@@ -72,7 +72,7 @@ func (m *mockCacheableObject) GetObject() runtime.Object {
 	return m.obj
 }
 
-func (m *mockCacheableObject) GetCachedEvent(id runtime.Identifier, eventProducer func() (runtime.Object, error)) (runtime.CacheableObject, error) {
+func (m *mockCacheableObject) GetCachedEvent(id runtime.Identifier, eventProducer func() (runtime.Object, error)) (runtime.Object, error) {
 	return m, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response_test.go
@@ -72,6 +72,10 @@ func (m *mockCacheableObject) GetObject() runtime.Object {
 	return m.obj
 }
 
+func (m *mockCacheableObject) GetCachedEvent(id runtime.Identifier, eventProducer func() (runtime.Object, error)) (runtime.CacheableObject, error) {
+	return m, nil
+}
+
 type mockNamer struct{}
 
 func (*mockNamer) Namespace(_ *http.Request) (string, error)           { return "", nil }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
@@ -1024,7 +1024,7 @@ func (f *fakeCachingObject) GetObject() runtime.Object {
 	return f.obj
 }
 
-func (f *fakeCachingObject) GetCachedEvent(id runtime.Identifier, eventProducer func() (runtime.Object, error)) (runtime.CacheableObject, error) {
+func (f *fakeCachingObject) GetCachedEvent(id runtime.Identifier, eventProducer func() (runtime.Object, error)) (runtime.Object, error) {
 	return f, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
@@ -1024,6 +1024,10 @@ func (f *fakeCachingObject) GetObject() runtime.Object {
 	return f.obj
 }
 
+func (f *fakeCachingObject) GetCachedEvent(id runtime.Identifier, eventProducer func() (runtime.Object, error)) (runtime.CacheableObject, error) {
+	return f, nil
+}
+
 func (f *fakeCachingObject) GetObjectKind() schema.ObjectKind {
 	return f.obj.GetObjectKind()
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object.go
@@ -85,7 +85,7 @@ type cachingObject struct {
 	cachedEventsLock sync.RWMutex
 
 	// cachedEvents is a cache containing object's encodings into watch events.
-	cachedEvents map[runtime.Identifier]*cachingObject
+	cachedEvents map[runtime.Identifier]runtime.Object
 }
 
 // newCachingObject performs a deep copy of the given object and wraps it
@@ -168,7 +168,7 @@ func (o *cachingObject) GetObject() runtime.Object {
 
 // GetCachedEvent implements runtime.CacheableObject interface.
 // It returns a watch event containing the already encoded object.
-func (o *cachingObject) GetCachedEvent(id runtime.Identifier, eventProducer func() (runtime.Object, error)) (runtime.CacheableObject, error) {
+func (o *cachingObject) GetCachedEvent(id runtime.Identifier, eventProducer func() (runtime.Object, error)) (runtime.Object, error) {
 	o.cachedEventsLock.Lock()
 	defer o.cachedEventsLock.Unlock()
 
@@ -181,12 +181,8 @@ func (o *cachingObject) GetCachedEvent(id runtime.Identifier, eventProducer func
 		return nil, err
 	}
 
-	obj, err := newCachingObject(event)
-	if err != nil {
-		return nil, err
-	}
-	o.cachedEvents[id] = obj
-	return obj, nil
+	o.cachedEvents[id] = event
+	return event, nil
 }
 
 // GetObjectKind implements runtime.Object interface.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Instead of encoding watch events for every watch client separately, cache the encodings to allow for their reuse.

As pointed out in https://github.com/kubernetes/kubernetes/issues/110146#issue-1242974327, repeated event encodings hog a considerable amount of CPU in case of serving a heavy watch traffic of CustomResource objects which are forced to be encoded to JSON (as CRDs lack support for Protobuf encoding) due to costly json.compact calls inside the Golang's JSON serializer.

#### Which issue(s) this PR fixes:

Fixes #110146.

#### Special notes for your reviewer:

This is a slightly polished version of the change proposed in https://github.com/kubernetes/kubernetes/issues/110146#issuecomment-1335452144.

Holding the PR until we get some feedback and observe the change's performance impact in some test.

/hold

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
