### PR TITLE
Revert #114605: its unit test requires root permission

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -363,7 +363,19 @@ func (mounter *Mounter) Unmount(target string) error {
 	command := exec.Command("umount", target)
 	output, err := command.CombinedOutput()
 	if err != nil {
-		return checkUmountError(target, command, output, err, mounter.withSafeNotMountedBehavior)
+		if err.Error() == errNoChildProcesses {
+			if command.ProcessState.Success() {
+				// We don't consider errNoChildProcesses an error if the process itself succeeded (see - k/k issue #103753).
+				return nil
+			}
+			// Rewrite err with the actual exit error of the process.
+			err = &exec.ExitError{ProcessState: command.ProcessState}
+		}
+		if mounter.withSafeNotMountedBehavior && strings.Contains(string(output), errNotMounted) {
+			klog.V(4).Infof("ignoring 'not mounted' error for %s", target)
+			return nil
+		}
+		return fmt.Errorf("unmount failed: %v\nUnmounting arguments: %s\nOutput: %s", err, target, string(output))
 	}
 	return nil
 }
@@ -371,11 +383,11 @@ func (mounter *Mounter) Unmount(target string) error {
 // UnmountWithForce unmounts given target but will retry unmounting with force option
 // after given timeout.
 func (mounter *Mounter) UnmountWithForce(target string, umountTimeout time.Duration) error {
-	err := tryUnmount(target, mounter.withSafeNotMountedBehavior, umountTimeout)
+	err := tryUnmount(mounter, target, umountTimeout)
 	if err != nil {
 		if err == context.DeadlineExceeded {
 			klog.V(2).Infof("Timed out waiting for unmount of %s, trying with -f", target)
-			err = forceUmount(target, mounter.withSafeNotMountedBehavior)
+			err = forceUmount(target)
 		}
 		return err
 	}
@@ -787,13 +799,13 @@ func (mounter *Mounter) IsMountPoint(file string) (bool, error) {
 }
 
 // tryUnmount calls plain "umount" and waits for unmountTimeout for it to finish.
-func tryUnmount(target string, withSafeNotMountedBehavior bool, unmountTimeout time.Duration) error {
-	klog.V(4).Infof("Unmounting %s", target)
+func tryUnmount(mounter *Mounter, path string, unmountTimeout time.Duration) error {
+	klog.V(4).Infof("Unmounting %s", path)
 	ctx, cancel := context.WithTimeout(context.Background(), unmountTimeout)
 	defer cancel()
 
-	command := exec.CommandContext(ctx, "umount", target)
-	output, err := command.CombinedOutput()
+	cmd := exec.CommandContext(ctx, "umount", path)
+	out, cmderr := cmd.CombinedOutput()
 
 	// CombinedOutput() does not return DeadlineExceeded, make sure it's
 	// propagated on timeout.
@@ -801,35 +813,22 @@ func tryUnmount(target string, withSafeNotMountedBehavior bool, unmountTimeout t
 		return ctx.Err()
 	}
 
-	if err != nil {
-		return checkUmountError(target, command, output, err, withSafeNotMountedBehavior)
-	}
-	return nil
-}
-
-func forceUmount(target string, withSafeNotMountedBehavior bool) error {
-	command := exec.Command("umount", "-f", target)
-	output, err := command.CombinedOutput()
-
-	if err != nil {
-		return checkUmountError(target, command, output, err, withSafeNotMountedBehavior)
-	}
-	return nil
-}
-
-// checkUmountError checks a result of umount command and determine a return value.
-func checkUmountError(target string, command *exec.Cmd, output []byte, err error, withSafeNotMountedBehavior bool) error {
-	if err.Error() == errNoChildProcesses {
-		if command.ProcessState.Success() {
-			// We don't consider errNoChildProcesses an error if the process itself succeeded (see - k/k issue #103753).
+	if cmderr != nil {
+		if mounter.withSafeNotMountedBehavior && strings.Contains(string(out), errNotMounted) {
+			klog.V(4).Infof("ignoring 'not mounted' error for %s", path)
 			return nil
 		}
-		// Rewrite err with the actual exit error of the process.
-		err = &exec.ExitError{ProcessState: command.ProcessState}
+		return fmt.Errorf("unmount failed: %v\nUnmounting arguments: %s\nOutput: %s", cmderr, path, string(out))
 	}
-	if withSafeNotMountedBehavior && strings.Contains(string(output), errNotMounted) {
-		klog.V(4).Infof("ignoring 'not mounted' error for %s", target)
-		return nil
+	return nil
+}
+
+func forceUmount(path string) error {
+	cmd := exec.Command("umount", "-f", path)
+	out, cmderr := cmd.CombinedOutput()
+
+	if cmderr != nil {
+		return fmt.Errorf("unmount failed: %v\nUnmounting arguments: %s\nOutput: %s", cmderr, path, string(out))
 	}
-	return fmt.Errorf("unmount failed: %v\nUnmounting arguments: %s\nOutput: %s", err, target, string(output))
+	return nil
 }

--- a/staging/src/k8s.io/mount-utils/mount_linux_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux_test.go
@@ -705,28 +705,3 @@ func makeFakeCommandAction(stdout string, err error, cmdFn func()) testexec.Fake
 		return testexec.InitFakeCmd(&c, cmd, args...)
 	}
 }
-
-func TestNotMountedBehaviorOfUnmount(t *testing.T) {
-	target, err := ioutil.TempDir("", "kubelet-umount")
-	if err != nil {
-		t.Errorf("Cannot create temp dir: %v", err)
-	}
-
-	defer os.RemoveAll(target)
-
-	m := Mounter{withSafeNotMountedBehavior: true}
-	if err = m.Unmount(target); err != nil {
-		t.Errorf(`Expect complete Unmount(), but it dose not: %v`, err)
-	}
-
-	if err = tryUnmount(target, m.withSafeNotMountedBehavior, time.Minute); err != nil {
-		t.Errorf(`Expect complete tryUnmount(), but it does not: %v`, err)
-	}
-
-	// forceUmount exec "umount -f", so skip this case if user is not root.
-	if os.Getuid() == 0 {
-		if err = forceUmount(target, m.withSafeNotMountedBehavior); err != nil {
-			t.Errorf(`Expect complete forceUnmount(), but it does not: %v`, err)
-		}
-	}
-}


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
Revert PR #114605, because it requires root permissions to run unit tests.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
