### PR TITLE
InvalidImageName error could be moved to API Validation.

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -9906,6 +9906,40 @@ func TestValidatePod(t *testing.T) {
 				},
 			},
 		},
+		"all capitals for image": {
+			expectedError: "spec.containers[0].image",
+			spec: core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: "ns"},
+				Spec: core.PodSpec{
+					RestartPolicy: core.RestartPolicyAlways,
+					DNSPolicy:     core.DNSClusterFirst,
+					Containers:    []core.Container{{Name: "ctr", Image: "ALLCAPITALS", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
+				},
+			},
+		},
+		"http present in image": {
+			expectedError: "spec.containers[0].image",
+			spec: core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: "ns"},
+				Spec: core.PodSpec{
+					RestartPolicy: core.RestartPolicyAlways,
+					DNSPolicy:     core.DNSClusterFirst,
+					Containers:    []core.Container{{Name: "ctr", Image: "https://busybox", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
+				},
+			},
+		},
+		"hexadecimal name in image": {
+			expectedError: "spec.containers[0].image",
+			spec: core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: "ns"},
+				Spec: core.PodSpec{
+					RestartPolicy: core.RestartPolicyAlways,
+					DNSPolicy:     core.DNSClusterFirst,
+					Containers:    []core.Container{{Name: "ctr", Image: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
+				},
+			},
+		},
+
 		"bad namespace": {
 			expectedError: "metadata.namespace",
 			spec: core.Pod{

--- a/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
@@ -62,6 +62,21 @@ func TestPullImageWithError(t *testing.T) {
 	assert.Equal(t, 0, len(images))
 }
 
+func TestPullImageWithInvalidImageName(t *testing.T) {
+	_, fakeImageService, fakeManager, err := createTestRuntimeManager()
+	assert.NoError(t, err)
+
+	imageList := []string{"FAIL", "http://fail", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"}
+	fakeImageService.SetFakeImages(imageList)
+	for _, val := range imageList {
+		ctx := context.Background()
+		imageRef, err := fakeManager.PullImage(ctx, kubecontainer.ImageSpec{Image: val}, nil, nil)
+		assert.Error(t, err)
+		assert.Equal(t, "", imageRef)
+
+	}
+}
+
 func TestListImages(t *testing.T) {
 	ctx := context.Background()
 	_, fakeImageService, fakeManager, err := createTestRuntimeManager()

--- a/pkg/util/parsers/parsers_test.go
+++ b/pkg/util/parsers/parsers_test.go
@@ -24,10 +24,11 @@ import (
 // https://github.com/docker/docker/commit/4352da7803d182a6013a5238ce20a7c749db979a
 func TestParseImageName(t *testing.T) {
 	testCases := []struct {
-		Input  string
-		Repo   string
-		Tag    string
-		Digest string
+		Input       string
+		Repo        string
+		Tag         string
+		Digest      string
+		expectError bool
 	}{
 		{Input: "root", Repo: "docker.io/library/root", Tag: "latest"},
 		{Input: "root:tag", Repo: "docker.io/library/root", Tag: "tag"},
@@ -38,10 +39,13 @@ func TestParseImageName(t *testing.T) {
 		{Input: "url:5000/repo", Repo: "url:5000/repo", Tag: "latest"},
 		{Input: "url:5000/repo:tag", Repo: "url:5000/repo", Tag: "tag"},
 		{Input: "url:5000/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Repo: "url:5000/repo", Digest: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		{Input: "ROOT", expectError: true},
 	}
 	for _, testCase := range testCases {
 		repo, tag, digest, err := ParseImageName(testCase.Input)
-		if err != nil {
+		if testCase.expectError && err != nil {
+
+		} else if err != nil {
 			t.Errorf("ParseImageName(%s) failed: %v", testCase.Input, err)
 		} else if repo != testCase.Repo || tag != testCase.Tag || digest != testCase.Digest {
 			t.Errorf("Expected repo: %q, tag: %q and digest: %q, got %q, %q and %q", testCase.Repo, testCase.Tag, testCase.Digest,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Previously InvalidImageName is possible if your image has all capitals, fails docker regular expression checks.  This moves these checks to the API when creating the pod.  Avoids creating this resource.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add API Validation for container image names.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
https://github.com/kubernetes/enhancements/pull/3816 


<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
