### PR TITLE
Update ineligible endpoints yaml to include debug endpoints

### DIFF
--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -439,3 +439,13 @@
 - endpoint: createAuthorizationV1SelfSubjectRulesReview
   reason: Endpoint likely to be deprecated
   link: https://github.com/kubernetes/kubernetes/issues/112657#issuecomment-1265441626  
+- endpoint: connectCoreV1GetNamespacedPodPortforward
+  reason: Explicitly designed to be a debug feature
+  link: https://github.com/kubernetes/kubernetes/issues/112778#issuecomment-1427995711
+- endpoint: connectCoreV1GetNamespacedPodAttach
+  reason: Explicitly designed to be a debug feature
+  reason: Endpoint likely to be deprecated
+  link: https://github.com/kubernetes/kubernetes/issues/112778#issuecomment-1427995711
+- endpoint: connectCoreV1PostNamespacedPodAttach
+  reason: Explicitly designed to be a debug feature
+  link: https://github.com/kubernetes/kubernetes/issues/112778#issuecomment-1427995711


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
The general view is that the following endpoints are for debug purposes only and shouldn't be part of conformance.
This PR would prevent these endpoints been show as conformance technical debt.

- connectCoreV1GetNamespacedPodAttach
- connectCoreV1GetNamespacedPodPortforward
- connectCoreV1PostNamespacedPodAttach

**Special notes for your reviewer:**

**Does this PR introduce a user-facing change?:**

```
NONE
```

**Release note:**

```
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**

```
NONE
```

/sig architecture
/area conformance
/sig node