### PR TITLE
kubelet: detect readonly fs

### DIFF
--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -1437,8 +1437,9 @@ func TestReadyCondition(t *testing.T) {
 					event:     event,
 				})
 			}
+
 			// construct setter
-			setter := ReadyCondition(nowFunc, runtimeErrorsFunc, networkErrorsFunc, storageErrorsFunc, tc.appArmorValidateHostFunc, cmStatusFunc, nodeShutdownErrorsFunc, recordEventFunc, !tc.disableLocalStorageCapacityIsolation)
+			setter := ReadyCondition(nowFunc, []func() error{runtimeErrorsFunc, networkErrorsFunc, storageErrorsFunc, nodeShutdownErrorsFunc}, tc.appArmorValidateHostFunc, cmStatusFunc, recordEventFunc, !tc.disableLocalStorageCapacityIsolation)
 			// call setter on node
 			if err := setter(ctx, tc.node); err != nil {
 				t.Fatalf("unexpected error: %v", err)

--- a/pkg/volume/metrics_du.go
+++ b/pkg/volume/metrics_du.go
@@ -73,13 +73,13 @@ func (md *metricsDu) getDiskUsage(metrics *Metrics) error {
 // getFsInfo writes metrics.Capacity and metrics.Available from the filesystem
 // info
 func (md *metricsDu) getFsInfo(metrics *Metrics) error {
-	available, capacity, _, inodes, inodesFree, _, err := fs.Info(md.path)
+	info, err := fs.Info(md.path)
 	if err != nil {
 		return NewFsInfoFailedError(err)
 	}
-	metrics.Available = resource.NewQuantity(available, resource.BinarySI)
-	metrics.Capacity = resource.NewQuantity(capacity, resource.BinarySI)
-	metrics.Inodes = resource.NewQuantity(inodes, resource.BinarySI)
-	metrics.InodesFree = resource.NewQuantity(inodesFree, resource.BinarySI)
+	metrics.Available = resource.NewQuantity(info.Available, resource.BinarySI)
+	metrics.Capacity = resource.NewQuantity(info.Capacity, resource.BinarySI)
+	metrics.Inodes = resource.NewQuantity(info.Inodes, resource.BinarySI)
+	metrics.InodesFree = resource.NewQuantity(info.InodesFree, resource.BinarySI)
 	return nil
 }

--- a/pkg/volume/metrics_statfs.go
+++ b/pkg/volume/metrics_statfs.go
@@ -61,15 +61,15 @@ func (md *metricsStatFS) GetMetrics() (*Metrics, error) {
 
 // getFsInfo writes metrics.Capacity, metrics.Used and metrics.Available from the filesystem info
 func (md *metricsStatFS) getFsInfo(metrics *Metrics) error {
-	available, capacity, usage, inodes, inodesFree, inodesUsed, err := fs.Info(md.path)
+	info, err := fs.Info(md.path)
 	if err != nil {
 		return NewFsInfoFailedError(err)
 	}
-	metrics.Available = resource.NewQuantity(available, resource.BinarySI)
-	metrics.Capacity = resource.NewQuantity(capacity, resource.BinarySI)
-	metrics.Used = resource.NewQuantity(usage, resource.BinarySI)
-	metrics.Inodes = resource.NewQuantity(inodes, resource.BinarySI)
-	metrics.InodesFree = resource.NewQuantity(inodesFree, resource.BinarySI)
-	metrics.InodesUsed = resource.NewQuantity(inodesUsed, resource.BinarySI)
+	metrics.Available = resource.NewQuantity(info.Available, resource.BinarySI)
+	metrics.Capacity = resource.NewQuantity(info.Capacity, resource.BinarySI)
+	metrics.Used = resource.NewQuantity(info.Usage, resource.BinarySI)
+	metrics.Inodes = resource.NewQuantity(info.Inodes, resource.BinarySI)
+	metrics.InodesFree = resource.NewQuantity(info.InodesFree, resource.BinarySI)
+	metrics.InodesUsed = resource.NewQuantity(info.InodesUsed, resource.BinarySI)
 	return nil
 }

--- a/pkg/volume/util/fs/fs.go
+++ b/pkg/volume/util/fs/fs.go
@@ -19,130 +19,25 @@ limitations under the License.
 
 package fs
 
-import (
-	"fmt"
-	"os"
-	"path/filepath"
-	"syscall"
-	"time"
-
-	"golang.org/x/sys/unix"
-
-	servermetrics "k8s.io/kubernetes/pkg/kubelet/server/metrics"
-	"k8s.io/kubernetes/pkg/volume/util/fsquota"
-)
-
 type UsageInfo struct {
 	Bytes  int64
 	Inodes int64
 }
 
-// Info linux returns (available bytes, byte capacity, byte usage, total inodes, inodes free, inode usage, error)
-// for the filesystem that path resides upon.
-func Info(path string) (int64, int64, int64, int64, int64, int64, error) {
-	statfs := &unix.Statfs_t{}
-	err := unix.Statfs(path, statfs)
-	if err != nil {
-		return 0, 0, 0, 0, 0, 0, err
-	}
-
-	// Available is blocks available * fragment size
-	available := int64(statfs.Bavail) * int64(statfs.Bsize)
-
-	// Capacity is total block count * fragment size
-	capacity := int64(statfs.Blocks) * int64(statfs.Bsize)
-
-	// Usage is block being used * fragment size (aka block size).
-	usage := (int64(statfs.Blocks) - int64(statfs.Bfree)) * int64(statfs.Bsize)
-
-	inodes := int64(statfs.Files)
-	inodesFree := int64(statfs.Ffree)
-	inodesUsed := inodes - inodesFree
-
-	return available, capacity, usage, inodes, inodesFree, inodesUsed, nil
-}
-
-// DiskUsage calculates the number of inodes and disk usage for a given directory
-func DiskUsage(path string) (UsageInfo, error) {
-	var usage UsageInfo
-
-	if path == "" {
-		return usage, fmt.Errorf("invalid directory")
-	}
-
-	// First check whether the quota system knows about this directory
-	// A nil quantity or error means that the path does not support quotas
-	// or xfs_quota tool is missing and we should use other mechanisms.
-	startTime := time.Now()
-	consumption, _ := fsquota.GetConsumption(path)
-	if consumption != nil {
-		usage.Bytes = consumption.Value()
-		defer servermetrics.CollectVolumeStatCalDuration("fsquota", startTime)
-	} else {
-		defer servermetrics.CollectVolumeStatCalDuration("du", startTime)
-	}
-
-	inodes, _ := fsquota.GetInodes(path)
-	if inodes != nil {
-		usage.Inodes = inodes.Value()
-	}
-
-	if inodes != nil && consumption != nil {
-		return usage, nil
-	}
-
-	topLevelStat := &unix.Stat_t{}
-	err := unix.Stat(path, topLevelStat)
-	if err != nil {
-		return usage, err
-	}
-
-	// dedupedInode stores inodes that could be duplicates (nlink > 1)
-	dedupedInodes := make(map[uint64]struct{})
-
-	err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-		// ignore files that have been deleted after directory was read
-		if os.IsNotExist(err) {
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("unable to count inodes for %s: %s", path, err)
-		}
-
-		// according to the docs, Sys can be nil
-		if info.Sys() == nil {
-			return fmt.Errorf("fileinfo Sys is nil")
-		}
-
-		s, ok := info.Sys().(*syscall.Stat_t)
-		if !ok {
-			return fmt.Errorf("unsupported fileinfo; could not convert to stat_t")
-		}
-
-		if s.Dev != topLevelStat.Dev {
-			// don't descend into directories on other devices
-			return filepath.SkipDir
-		}
-
-		// Dedupe hardlinks
-		if s.Nlink > 1 {
-			if _, ok := dedupedInodes[s.Ino]; !ok {
-				dedupedInodes[s.Ino] = struct{}{}
-			} else {
-				return nil
-			}
-		}
-
-		if consumption == nil {
-			usage.Bytes += int64(s.Blocks) * int64(512) // blocksize in bytes
-		}
-
-		if inodes == nil {
-			usage.Inodes++
-		}
-
-		return nil
-	})
-
-	return usage, err
+// FSInfo is the filesystem information
+type FSInfo struct {
+	// Available is the amount of space available on the filesystem in bytes
+	Available int64
+	// Capacity is the total capacity of the filesystem in bytes
+	Capacity int64
+	// Usage is the amount of used space on the filesystem in bytes
+	Usage int64
+	// Inodes is the amount of inodes available on the filesystem
+	Inodes int64
+	// InodesFree is the amount of inodes free for use on the disk
+	InodesFree int64
+	// InodesFree is the amount of inodes in use on the disk
+	InodesUsed int64
+	// ReadOnly indicates that the filesystem is mounted as read-only
+	ReadOnly bool
 }

--- a/pkg/volume/util/fs/fs.go
+++ b/pkg/volume/util/fs/fs.go
@@ -1,6 +1,3 @@
-//go:build linux || darwin
-// +build linux darwin
-
 /*
 Copyright 2014 The Kubernetes Authors.
 

--- a/pkg/volume/util/fs/fs_darwin.go
+++ b/pkg/volume/util/fs/fs_darwin.go
@@ -1,8 +1,7 @@
-//go:build !linux && !darwin && !windows
-// +build !linux,!darwin,!windows
+//go:build darwin
 
 /*
-Copyright 2014 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,17 +18,8 @@ limitations under the License.
 
 package fs
 
-import (
-	"fmt"
-)
+import "golang.org/x/sys/unix"
 
-// Info unsupported returns 0 values for available and capacity and an error.
-func Info(path string) (FSInfo, error) {
-	return FSInfo{}, fmt.Errorf("fsinfo not supported for this build")
-}
-
-// DiskUsage gets disk usage of specified path.
-func DiskUsage(path string) (UsageInfo, error) {
-	var usage UsageInfo
-	return usage, fmt.Errorf("directory disk usage not supported for this build.")
+func isReadOnlyMount(statfs *unix.Statfs_t) bool {
+	return (statfs.Flags & unix.MNT_RDONLY) != 0
 }

--- a/pkg/volume/util/fs/fs_darwin_test.go
+++ b/pkg/volume/util/fs/fs_darwin_test.go
@@ -1,0 +1,43 @@
+//go:build darwin
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fs
+
+import "testing"
+
+func TestInfoReadonly(t *testing.T) {
+	const roPath = "/"
+	info, err := Info(roPath)
+	if err != nil {
+		t.Errorf("Info() should not error = %v", err)
+		return
+	}
+	if !info.ReadOnly {
+		t.Errorf("expected %s to be mounted read-only on darwin", roPath)
+	}
+
+	const rwPath = "/System/Volumes/Data"
+	info, err = Info(rwPath)
+	if err != nil {
+		t.Errorf("Info() should not error = %v", err)
+		return
+	}
+	if info.ReadOnly {
+		t.Errorf("expected %s to be mounted read/write on darwin", rwPath)
+	}
+}

--- a/pkg/volume/util/fs/fs_linux.go
+++ b/pkg/volume/util/fs/fs_linux.go
@@ -1,8 +1,7 @@
-//go:build !linux && !darwin && !windows
-// +build !linux,!darwin,!windows
+//go:build linux
 
 /*
-Copyright 2014 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,17 +18,8 @@ limitations under the License.
 
 package fs
 
-import (
-	"fmt"
-)
+import "golang.org/x/sys/unix"
 
-// Info unsupported returns 0 values for available and capacity and an error.
-func Info(path string) (FSInfo, error) {
-	return FSInfo{}, fmt.Errorf("fsinfo not supported for this build")
-}
-
-// DiskUsage gets disk usage of specified path.
-func DiskUsage(path string) (UsageInfo, error) {
-	var usage UsageInfo
-	return usage, fmt.Errorf("directory disk usage not supported for this build.")
+func isReadOnlyMount(statfs *unix.Statfs_t) bool {
+	return (statfs.Flags & unix.ST_RDONLY) != 0
 }

--- a/pkg/volume/util/fs/fs_unix.go
+++ b/pkg/volume/util/fs/fs_unix.go
@@ -1,0 +1,142 @@
+//go:build unix
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	servermetrics "k8s.io/kubernetes/pkg/kubelet/server/metrics"
+	"k8s.io/kubernetes/pkg/volume/util/fsquota"
+)
+
+// Info linux returns filesystem information for the filesystem that path resides upon.
+func Info(path string) (FSInfo, error) {
+	statfs := &unix.Statfs_t{}
+	err := unix.Statfs(path, statfs)
+	if err != nil {
+		return FSInfo{}, err
+	}
+
+	info := FSInfo{
+		// Available is blocks available * fragment size
+		Available: int64(statfs.Bavail) * int64(statfs.Bsize),
+		// Capacity is total block count * fragment size
+		Capacity: int64(statfs.Blocks) * int64(statfs.Bsize),
+		// Usage is block being used * fragment size (aka block size).
+		Usage: (int64(statfs.Blocks) - int64(statfs.Bfree)) * int64(statfs.Bsize),
+
+		Inodes:     int64(statfs.Files),
+		InodesFree: int64(statfs.Ffree),
+		InodesUsed: int64(statfs.Files) - int64(statfs.Ffree),
+		ReadOnly:   (statfs.Flags & unix.ST_RDONLY) != 0,
+	}
+
+	return info, nil
+}
+
+// DiskUsage calculates the number of inodes and disk usage for a given directory
+func DiskUsage(path string) (UsageInfo, error) {
+	var usage UsageInfo
+
+	if path == "" {
+		return usage, fmt.Errorf("invalid directory")
+	}
+
+	// First check whether the quota system knows about this directory
+	// A nil quantity or error means that the path does not support quotas
+	// or xfs_quota tool is missing and we should use other mechanisms.
+	startTime := time.Now()
+	consumption, _ := fsquota.GetConsumption(path)
+	if consumption != nil {
+		usage.Bytes = consumption.Value()
+		defer servermetrics.CollectVolumeStatCalDuration("fsquota", startTime)
+	} else {
+		defer servermetrics.CollectVolumeStatCalDuration("du", startTime)
+	}
+
+	inodes, _ := fsquota.GetInodes(path)
+	if inodes != nil {
+		usage.Inodes = inodes.Value()
+	}
+
+	if inodes != nil && consumption != nil {
+		return usage, nil
+	}
+
+	topLevelStat := &unix.Stat_t{}
+	err := unix.Stat(path, topLevelStat)
+	if err != nil {
+		return usage, err
+	}
+
+	// dedupedInode stores inodes that could be duplicates (nlink > 1)
+	dedupedInodes := make(map[uint64]struct{})
+
+	err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		// ignore files that have been deleted after directory was read
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("unable to count inodes for %s: %s", path, err)
+		}
+
+		// according to the docs, Sys can be nil
+		if info.Sys() == nil {
+			return fmt.Errorf("fileinfo Sys is nil")
+		}
+
+		s, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("unsupported fileinfo; could not convert to stat_t")
+		}
+
+		if s.Dev != topLevelStat.Dev {
+			// don't descend into directories on other devices
+			return filepath.SkipDir
+		}
+
+		// Dedupe hardlinks
+		if s.Nlink > 1 {
+			if _, ok := dedupedInodes[s.Ino]; !ok {
+				dedupedInodes[s.Ino] = struct{}{}
+			} else {
+				return nil
+			}
+		}
+
+		if consumption == nil {
+			usage.Bytes += int64(s.Blocks) * int64(512) // blocksize in bytes
+		}
+
+		if inodes == nil {
+			usage.Inodes++
+		}
+
+		return nil
+	})
+
+	return usage, err
+}

--- a/pkg/volume/util/fs/fs_unix.go
+++ b/pkg/volume/util/fs/fs_unix.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume/util/fsquota"
 )
 
-// Info linux returns filesystem information for the filesystem that path resides upon.
+// Info returns filesystem information for the filesystem that path resides upon.
 func Info(path string) (FSInfo, error) {
 	statfs := &unix.Statfs_t{}
 	err := unix.Statfs(path, statfs)
@@ -50,7 +50,8 @@ func Info(path string) (FSInfo, error) {
 		Inodes:     int64(statfs.Files),
 		InodesFree: int64(statfs.Ffree),
 		InodesUsed: int64(statfs.Files) - int64(statfs.Ffree),
-		ReadOnly:   (statfs.Flags & unix.ST_RDONLY) != 0,
+		// the constant name for read-only filesystems differs between linux and the BSDs
+		ReadOnly: isReadOnlyMount(statfs),
 	}
 
 	return info, nil

--- a/pkg/volume/util/fs/fs_unix_test.go
+++ b/pkg/volume/util/fs/fs_unix_test.go
@@ -102,6 +102,7 @@ func TestInfo(t *testing.T) {
 }
 
 func validateInfo(t *testing.T, info FSInfo) {
+	t.Helper()
 	// All of these should be greater than zero on a real system
 	if info.Available <= 0 {
 		t.Errorf("Info() availablebytes should be greater than 0, got %v", info.Available)

--- a/pkg/volume/util/fs/fs_unix_test.go
+++ b/pkg/volume/util/fs/fs_unix_test.go
@@ -1,0 +1,130 @@
+//go:build unix
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fs
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDiskUsage(t *testing.T) {
+	dir1, err := os.MkdirTemp("", "dir_1")
+	if err != nil {
+		t.Fatalf("creating temp directory, %s", err)
+	}
+	defer os.RemoveAll(dir1)
+
+	initialUsage, err := DiskUsage(dir1)
+	if err != nil {
+		t.Errorf("DiskUsage should not error, got %s", err)
+		return
+	}
+
+	tmpfile1, err := os.CreateTemp(dir1, "test")
+	if err != nil {
+		t.Fatalf("creating temp file, %s", err)
+	}
+	if _, err = tmpfile1.WriteString("just for testing"); err != nil {
+		t.Fatalf("writing to file, %s", err)
+	}
+
+	dir2, err := os.MkdirTemp(dir1, "dir_2")
+	if err != nil {
+		t.Fatalf("creating temp directory, %s", err)
+	}
+	tmpfile2, err := os.CreateTemp(dir2, "test")
+	if err != nil {
+		t.Fatalf("creating temp file, %s", err)
+	}
+	if _, err = tmpfile2.WriteString("just for testing"); err != nil {
+		t.Fatalf("writing to file, %s", err)
+	}
+
+	usage, err := DiskUsage(dir1)
+	if err != nil {
+		t.Errorf("DiskUsage should not error, got %s", err)
+	}
+
+	if initialUsage.Bytes >= usage.Bytes {
+		t.Fatalf("expected directory disk usage to increase after creating files, had initial of %d and post-create of %d",
+			initialUsage.Bytes, usage.Bytes)
+	}
+	if initialUsage.Inodes >= usage.Inodes {
+		t.Fatalf("expected directory inode usage to increase after creating files, had initial of %d and post-create of %d",
+			initialUsage.Bytes, usage.Bytes)
+	}
+}
+
+func TestInfo(t *testing.T) {
+	dir1, err := os.MkdirTemp("", "dir_1")
+	if err != nil {
+		t.Fatalf("creating temp directory, %s", err)
+	}
+	defer os.RemoveAll(dir1)
+
+	// should pass for folder path
+	info, err := Info(dir1)
+	if err != nil {
+		t.Errorf("Info() should not error, got %s", err)
+		return
+	}
+	validateInfo(t, info)
+
+	// should pass for file
+	tmpfile1, err := os.CreateTemp(dir1, "test")
+	if err != nil {
+		t.Fatalf("creating temp file, %s", err)
+	}
+	if _, err = tmpfile1.WriteString("just for testing"); err != nil {
+		t.Fatalf("writing to file, %s", err)
+	}
+	info, err = Info(tmpfile1.Name())
+	if err != nil {
+		t.Errorf("Info() should not error = %v", err)
+	}
+	validateInfo(t, info)
+}
+
+func validateInfo(t *testing.T, info FSInfo) {
+	// All of these should be greater than zero on a real system
+	if info.Available <= 0 {
+		t.Errorf("Info() availablebytes should be greater than 0, got %v", info.Available)
+	}
+	if info.Capacity <= 0 {
+		t.Errorf("Info() capacity should be greater than 0, got %v", info.Capacity)
+	}
+	if info.Usage <= 0 {
+		t.Errorf("Info() got usage should be greater than 0, got %v", info.Usage)
+	}
+
+	// inodes will always be non-zero for Linux
+	if info.Inodes <= 0 {
+		t.Errorf("Info().InodesTotal should be greater than 0, got %v", info.Inodes)
+	}
+	if info.InodesFree <= 0 {
+		t.Errorf("Info().InodesFree should be greater than 0, got %v", info.InodesFree)
+	}
+	if info.InodesUsed <= 0 {
+		t.Errorf("Info().InodesUsed should be greater than 0, got %v", info.InodesUsed)
+	}
+	// tmp shouldn't be on a read-only filesystem
+	if info.ReadOnly {
+		t.Errorf("Info().ReadOnly should be false")
+	}
+}

--- a/pkg/volume/util/fs/fs_windows.go
+++ b/pkg/volume/util/fs/fs_windows.go
@@ -33,11 +33,6 @@ var (
 	procGetDiskFreeSpaceEx = modkernel32.NewProc("GetDiskFreeSpaceExW")
 )
 
-type UsageInfo struct {
-	Bytes  int64
-	Inodes int64
-}
-
 // Info returns (available bytes, byte capacity, byte usage, total inodes, inodes free, inode usage, error)
 // for the filesystem that path resides upon.
 func Info(path string) (int64, int64, int64, int64, int64, int64, error) {

--- a/pkg/volume/util/fs/fs_windows.go
+++ b/pkg/volume/util/fs/fs_windows.go
@@ -35,7 +35,7 @@ var (
 
 // Info returns (available bytes, byte capacity, byte usage, total inodes, inodes free, inode usage, error)
 // for the filesystem that path resides upon.
-func Info(path string) (int64, int64, int64, int64, int64, int64, error) {
+func Info(path string) (FSInfo, error) {
 	var freeBytesAvailable, totalNumberOfBytes, totalNumberOfFreeBytes int64
 	var err error
 
@@ -55,10 +55,18 @@ func Info(path string) (int64, int64, int64, int64, int64, int64, error) {
 		0,
 	)
 	if ret == 0 {
-		return 0, 0, 0, 0, 0, 0, err
+		return FSInfo{}, err
 	}
 
-	return freeBytesAvailable, totalNumberOfBytes, totalNumberOfBytes - freeBytesAvailable, 0, 0, 0, nil
+	return FSInfo{
+		Available:  freeBytesAvailable,
+		Capacity:   totalNumberOfBytes,
+		Usage:      totalNumberOfBytes - freeBytesAvailable,
+		Inodes:     0,
+		InodesFree: 0,
+		InodesUsed: 0,
+		ReadOnly:   false,
+	}, nil
 }
 
 // DiskUsage gets disk usage of specified path.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Detects readonly filesystems for the root and pods directory and the inability to write files  to those locations, and reports that as the node being not ready.  This prevents pods from continuing to schedule to the node when they will never be able to successfully start until the disk issues are resolved.

#### Which issue(s) this PR fixes:
Fixes #99126

#### Special notes for your reviewer:

Sample describe node output that occurs after re-mounting the filesystem as readonly:

```
Conditions:
  Type             Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
  ----             ------  -----------------                 ------------------                ------                       -------
  MemoryPressure   False   Tue, 14 Feb 2023 04:19:17 +0000   Tue, 14 Feb 2023 04:18:16 +0000   KubeletHasSufficientMemory   kubelet has sufficient memory available
  DiskPressure     False   Tue, 14 Feb 2023 04:19:17 +0000   Tue, 14 Feb 2023 04:18:16 +0000   KubeletHasNoDiskPressure     kubelet has no disk pressure
  PIDPressure      False   Tue, 14 Feb 2023 04:19:17 +0000   Tue, 14 Feb 2023 04:18:16 +0000   KubeletHasSufficientPID      kubelet has sufficient PID available
  Ready            False   Tue, 14 Feb 2023 04:19:17 +0000   Tue, 14 Feb 2023 04:19:17 +0000   KubeletNotReady              [root directory /var/lib/kubelet is mounted read-only, pods directory /var/lib/kubelet/pods is mounted read-only]
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Nodes will report a condition of KubeletNotReady if the filesystem with the root or pods directory is re-mounted as read-only, or in some other way becomes unwritable.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
