### PR TITLE
removed function getAppArmorFS

### DIFF
--- a/pkg/security/apparmor/validate.go
+++ b/pkg/security/apparmor/validate.go
@@ -42,7 +42,7 @@ type Validator interface {
 // NewValidator is in order to find AppArmor FS
 func NewValidator() Validator {
 	if err := validateHost(); err != nil {
-		return nil
+		return &validator{validateHostErr: err}
 	}
 	return &validator{}
 }

--- a/pkg/security/apparmor/validate.go
+++ b/pkg/security/apparmor/validate.go
@@ -36,6 +36,7 @@ var isDisabledBuild bool
 // Validator is a interface for validating that a pod with an AppArmor profile can be run by a Node.
 type Validator interface {
 	Validate(pod *v1.Pod) error
+	ValidateHost() error
 }
 
 // NewValidator is in order to find AppArmor FS

--- a/pkg/security/apparmor/validate.go
+++ b/pkg/security/apparmor/validate.go
@@ -42,7 +42,7 @@ type Validator interface {
 // NewValidator is in order to find AppArmor FS
 func NewValidator() Validator {
 	if err := validateHost(); err != nil {
-		return &validator{validateHostErr: err}
+		return nil
 	}
 	return nil
 }

--- a/pkg/security/apparmor/validate.go
+++ b/pkg/security/apparmor/validate.go
@@ -17,11 +17,8 @@ limitations under the License.
 package apparmor
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
-	"os"
-	"path"
 	"strings"
 
 	"github.com/opencontainers/runc/libcontainer/apparmor"
@@ -30,7 +27,6 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
-	utilpath "k8s.io/utils/path"
 )
 
 // Whether AppArmor should be disabled by default.
@@ -48,20 +44,11 @@ func NewValidator() Validator {
 	if err := validateHost(); err != nil {
 		return &validator{validateHostErr: err}
 	}
-	appArmorFS, err := getAppArmorFS()
-	if err != nil {
-		return &validator{
-			validateHostErr: fmt.Errorf("error finding AppArmor FS: %v", err),
-		}
-	}
-	return &validator{
-		appArmorFS: appArmorFS,
-	}
+	return nil
 }
 
 type validator struct {
 	validateHostErr error
-	appArmorFS      string
 }
 
 func (v *validator) Validate(pod *v1.Pod) error {
@@ -116,37 +103,4 @@ func validateHost() error {
 	}
 
 	return nil
-}
-
-func getAppArmorFS() (string, error) {
-	mountsFile, err := os.Open("/proc/mounts")
-	if err != nil {
-		return "", fmt.Errorf("could not open /proc/mounts: %v", err)
-	}
-	defer mountsFile.Close()
-
-	scanner := bufio.NewScanner(mountsFile)
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
-		if len(fields) < 3 {
-			// Unknown line format; skip it.
-			continue
-		}
-		if fields[2] == "securityfs" {
-			appArmorFS := path.Join(fields[1], "apparmor")
-			if ok, err := utilpath.Exists(utilpath.CheckFollowSymlink, appArmorFS); !ok {
-				msg := fmt.Sprintf("path %s does not exist", appArmorFS)
-				if err != nil {
-					return "", fmt.Errorf("%s: %v", msg, err)
-				}
-				return "", errors.New(msg)
-			}
-			return appArmorFS, nil
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("error scanning mounts: %v", err)
-	}
-
-	return "", errors.New("securityfs not found")
 }

--- a/pkg/security/apparmor/validate.go
+++ b/pkg/security/apparmor/validate.go
@@ -36,7 +36,6 @@ var isDisabledBuild bool
 // Validator is a interface for validating that a pod with an AppArmor profile can be run by a Node.
 type Validator interface {
 	Validate(pod *v1.Pod) error
-	ValidateHost() error
 }
 
 // NewValidator is in order to find AppArmor FS

--- a/pkg/security/apparmor/validate.go
+++ b/pkg/security/apparmor/validate.go
@@ -44,7 +44,7 @@ func NewValidator() Validator {
 	if err := validateHost(); err != nil {
 		return nil
 	}
-	return nil
+	return &validator{}
 }
 
 type validator struct {

--- a/pkg/security/apparmor/validate_test.go
+++ b/pkg/security/apparmor/validate_test.go
@@ -27,25 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetAppArmorFS(t *testing.T) {
-	// This test only passes on systems running AppArmor with the default configuration.
-	// The test should be manually run if modifying the getAppArmorFS function.
-	t.Skip()
-
-	const expectedPath = "/sys/kernel/security/apparmor"
-	actualPath, err := getAppArmorFS()
-	assert.NoError(t, err)
-	assert.Equal(t, expectedPath, actualPath)
-}
-
-func TestValidateHost(t *testing.T) {
-	// This test only passes on systems running AppArmor with the default configuration.
-	// The test should be manually run if modifying the getAppArmorFS function.
-	t.Skip()
-
-	assert.NoError(t, validateHost())
-}
-
 func TestValidateBadHost(t *testing.T) {
 	hostErr := errors.New("expected host error")
 	v := &validator{
@@ -72,9 +53,7 @@ func TestValidateBadHost(t *testing.T) {
 }
 
 func TestValidateValidHost(t *testing.T) {
-	v := &validator{
-		appArmorFS: "./testdata/",
-	}
+	v := &validator{}
 
 	tests := []struct {
 		profile     string


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Remove the getAppArmorFS function
The return value of getAppArmorFS is not being used any longer and the entire method can be removed.

#### Which issue(s) this PR fixes:
Fixes /issues/115741

#### Does this PR introduce a user-facing change?
```release-note
None
```

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
https://github.com/kubernetes/enhancements/issues/24
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/24
```