### PR TITLE
kubelet should not renew the list if the object was deleted after registration

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -969,8 +969,6 @@ type Kubelet struct {
 	registerWithTaints []v1.Taint
 	// Set to true to have the node register itself as schedulable.
 	registerSchedulable bool
-	// for internal book keeping; access only from within registerWithApiserver
-	registrationCompleted bool
 
 	// dnsConfigurer is used for setting up DNS resolver configuration when launching pods.
 	dnsConfigurer *dns.Configurer

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -3464,15 +3464,12 @@ func TestGenerateAPIPodStatusHostNetworkPodIPs(t *testing.T) {
 			defer testKubelet.Cleanup()
 			kl := testKubelet.kubelet
 
-			kl.nodeLister = testNodeLister{nodes: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: string(kl.nodeName)},
-					Status: v1.NodeStatus{
-						Addresses: tc.nodeAddresses,
-					},
+			kl.nodeLister = testNodeLister(&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: string(kl.nodeName)},
+				Status: v1.NodeStatus{
+					Addresses: tc.nodeAddresses,
 				},
-			}}
-
+			})
 			pod := podWithUIDNameNs("12345", "test-pod", "test-namespace")
 			pod.Spec.HostNetwork = true
 
@@ -3570,14 +3567,13 @@ func TestNodeAddressUpdatesGenerateAPIPodStatusHostNetworkPodIPs(t *testing.T) {
 			for _, ip := range tc.nodeIPs {
 				kl.nodeIPs = append(kl.nodeIPs, netutils.ParseIPSloppy(ip))
 			}
-			kl.nodeLister = testNodeLister{nodes: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: string(kl.nodeName)},
-					Status: v1.NodeStatus{
-						Addresses: tc.nodeAddresses,
-					},
+
+			kl.nodeLister = testNodeLister(&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: string(kl.nodeName)},
+				Status: v1.NodeStatus{
+					Addresses: tc.nodeAddresses,
 				},
-			}}
+			})
 
 			pod := podWithUIDNameNs("12345", "test-pod", "test-namespace")
 			pod.Spec.HostNetwork = true

--- a/pkg/kubelet/kubelet_resources_test.go
+++ b/pkg/kubelet/kubelet_resources_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,21 +30,17 @@ import (
 func TestPodResourceLimitsDefaulting(t *testing.T) {
 	tk := newTestKubelet(t, true)
 	defer tk.Cleanup()
-	tk.kubelet.nodeLister = &testNodeLister{
-		nodes: []*v1.Node{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: string(tk.kubelet.nodeName),
-				},
-				Status: v1.NodeStatus{
-					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("6"),
-						v1.ResourceMemory: resource.MustParse("4Gi"),
-					},
-				},
+	tk.kubelet.nodeLister = testNodeLister(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: string(tk.kubelet.nodeName),
+		},
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("6"),
+				v1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 		},
-	}
+	})
 	cases := []struct {
 		pod      *v1.Pod
 		expected *v1.Pod

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -84,7 +84,7 @@ func TestRunOnce(t *testing.T) {
 		rootDirectory:    basePath,
 		recorder:         &record.FakeRecorder{},
 		cadvisor:         cadvisor,
-		nodeLister:       testNodeLister{},
+		nodeLister:       testNodeLister(),
 		statusManager:    status.NewManager(nil, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker),
 		podManager:       podManager,
 		podWorkers:       &fakePodWorkers{},


### PR DESCRIPTION
Kubelet registers itself by creating a Node objects, however, this object can be deleted by an external entity.

Current logic assumes that kubelet, once is registered, is registered forever, that may cause the kubelet to keep working forever if the Node object has been deleted, without being part of the cluster (it keeps renewing the lease per example)

If the Node object was deleted and kubelet was already registered, kubelet should not keep renewing the lease.

/kind bug

```release-note
kubelet, once registered, will not renew the lease if the Node object has been deleted
```

