### PR TITLE
e2e: Improve the dump output of nodes for readability

### DIFF
--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -450,6 +450,8 @@ var _ = SIGDescribe("Deployment", func() {
 		})
 		framework.ExpectNoError(err, "failed to see replicas of %v in namespace %v scale to requested amount of %v", testDeployment.Name, testNamespaceName, testDeploymentDefaultReplicas)
 
+		framework.ExpectError(nil, "DO NOT MERGE - DEBUG ONLY")
+
 		ginkgo.By("deleting the Deployment")
 		err = f.ClientSet.AppsV1().Deployments(testNamespaceName).DeleteCollection(ctx, metav1.DeleteOptions{GracePeriodSeconds: &one}, metav1.ListOptions{LabelSelector: testDeploymentLabelsFlat})
 		framework.ExpectNoError(err, "failed to delete Deployment via collection")

--- a/test/e2e/framework/debug/dump_test.go
+++ b/test/e2e/framework/debug/dump_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_formatTabularPods(t *testing.T) {
+	tests := []struct {
+		name string
+		pods []v1.Pod
+		want []string
+	}{
+		{
+			want: []string{
+				"POD PHASE START",
+				"   NAME READY RESTARTS STATE TIME",
+			},
+		},
+		{
+			pods: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "blah"},
+				},
+			},
+			want: []string{
+				"POD  PHASE START",
+				"   NAME READY RESTARTS STATE TIME",
+				"test ",
+			},
+		},
+		{
+			pods: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "blah"},
+					Status: v1.PodStatus{
+						Phase: v1.PodFailed,
+						InitContainerStatuses: []v1.ContainerStatus{
+							{Name: "first", State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: "Test"}}},
+						},
+						ContainerStatuses: []v1.ContainerStatus{
+							{Name: "second", State: v1.ContainerState{Running: &v1.ContainerStateRunning{}}},
+						},
+						EphemeralContainerStatuses: []v1.ContainerStatus{
+							{Name: "third", State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{Reason: "Test"}}},
+						},
+					},
+				},
+			},
+			want: []string{
+				"POD  PHASE START",
+				"    NAME   READY RESTARTS STATE           TIME",
+				"test Failed",
+				"  I first  false 0        waiting:Test    ",
+				"  C second false 0        running         0001-01-01T00:00:00Z",
+				"  E third  false 0        terminated:Test 0001-01-01T00:00:00Z",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatTabularPods(tt.pods); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("unexpected lines: %s", cmp.Diff(tt.want, got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
The dump output when an e2e fails is hard to scan. Improve the output
to format the node in json and add better tabular output for pods on
the node and the event list.


/kind cleanup

```release-note
NONE
```

```docs
```