### PR TITLE
Automated cherry pick of #114933: Disable multiple pv mount tests for vsphere intree driver

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1217,7 +1217,7 @@ func InitVSphereDriver() storageframework.TestDriver {
 				storageframework.CapMultiPODs:         true,
 				storageframework.CapTopology:          true,
 				storageframework.CapBlock:             true,
-				storageframework.CapMultiplePVsSameID: true,
+				storageframework.CapMultiplePVsSameID: false,
 			},
 		},
 	}


### PR DESCRIPTION
Cherry pick of #114933 on release-1.26.

#114933: Disable multiple pv mount tests for vsphere intree driver

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```