### PR TITLE
Fix legacy fallback stale for aggregated discovery

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
@@ -292,9 +292,9 @@ func (dm *discoveryManager) fetchFreshDiscoveryForService(gv metav1.GroupVersion
 			lastUpdated: now,
 		}
 
-		// Save the resolve, because it is still useful in case other services
-		// are already marked dirty. THey can use it without making http request
-		dm.setCacheEntryForService(info.service, cached)
+		// Do not save the resolve as the legacy fallback only fetches
+		// one group version and an API Service may serve multiple
+		// group versions.
 		return &cached, nil
 
 	case http.StatusOK:


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Fixes legacy fallback returning no resources for API Services that share the same service object.

The test does exercise this specific case, but I don't know if it's the best we can do. The bug reproduces only in the scenario that the number of APIServices added exceeds the amount that the workers are able to process concurrently (current 2 workers https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go#L402, so the test has three APIServices).

In this specific case, lastMarkedDirty is set to a time before the first request to the legacy fallback and subsequent calls to fetchFreshDiscoveryForService will use the cached version rather than fetching from the legacy endpoint.

https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go#L182-L187

The cache is problematic because we cache the entire service as a whole. However in the case of the legacy fallback, only the resources for one group-version is fetched so we should not cache it as the return value for the entire service since it can also serve other group-versions.

@deads2k has an alternate fix that involves partitioning the cache by APIService rather than by service, it's about the same performance if every service has a legacy fallback, but is probably slightly inefficient once the service migrates to use aggregated discovery: https://github.com/kubernetes/kubernetes/pull/115728

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Fixes https://github.com/kubernetes/kubernetes/issues/115559

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Yes, discovery document will correctly return the resources for aggregated apiservers that do not implement aggregated disovery
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @deads2k @alexzielenski @apelisse @seans3 
