### PR TITLE
Automated cherry pick of #114886: kubectl: use v2 for hpa

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -584,7 +584,7 @@ func (f *TestFactory) KubernetesClientSet() (*kubernetes.Clientset, error) {
 	clientset.AuthorizationV1().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
 	clientset.AuthorizationV1beta1().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
 	clientset.AutoscalingV1().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
-	clientset.AutoscalingV2beta1().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
+	clientset.AutoscalingV2().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
 	clientset.BatchV1().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
 	clientset.CertificatesV1().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
 	clientset.CertificatesV1beta1().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
@@ -745,15 +745,15 @@ func testDynamicResources() []*restmapper.APIGroupResources {
 				Name: "autoscaling",
 				Versions: []metav1.GroupVersionForDiscovery{
 					{Version: "v1"},
-					{Version: "v2beta1"},
+					{Version: "v2"},
 				},
-				PreferredVersion: metav1.GroupVersionForDiscovery{Version: "v2beta1"},
+				PreferredVersion: metav1.GroupVersionForDiscovery{Version: "v2"},
 			},
 			VersionedResources: map[string][]metav1.APIResource{
 				"v1": {
 					{Name: "horizontalpodautoscalers", Namespaced: true, Kind: "HorizontalPodAutoscaler"},
 				},
-				"v2beta1": {
+				"v2": {
 					{Name: "horizontalpodautoscalers", Namespaced: true, Kind: "HorizontalPodAutoscaler"},
 				},
 			},

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -35,7 +35,7 @@ import (
 	"github.com/fatih/camelcase"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
@@ -207,7 +207,7 @@ func describerMap(clientConfig *rest.Config) (map[schema.GroupKind]ResourceDescr
 		{Group: discoveryv1beta1.GroupName, Kind: "EndpointSlice"}:                &EndpointSliceDescriber{c},
 		{Group: discoveryv1.GroupName, Kind: "EndpointSlice"}:                     &EndpointSliceDescriber{c},
 		{Group: policyv1beta1.GroupName, Kind: "PodSecurityPolicy"}:               &PodSecurityPolicyDescriber{c},
-		{Group: autoscalingv2beta2.GroupName, Kind: "HorizontalPodAutoscaler"}:    &HorizontalPodAutoscalerDescriber{c},
+		{Group: autoscalingv2.GroupName, Kind: "HorizontalPodAutoscaler"}:         &HorizontalPodAutoscalerDescriber{c},
 		{Group: extensionsv1beta1.GroupName, Kind: "Ingress"}:                     &IngressDescriber{c},
 		{Group: networkingv1beta1.GroupName, Kind: "Ingress"}:                     &IngressDescriber{c},
 		{Group: networkingv1beta1.GroupName, Kind: "IngressClass"}:                &IngressClassDescriber{c},
@@ -3937,15 +3937,15 @@ type HorizontalPodAutoscalerDescriber struct {
 func (d *HorizontalPodAutoscalerDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
 	var events *corev1.EventList
 
-	// autoscaling/v2beta2 is introduced since v1.12 and autoscaling/v1 does not have full backward compatibility
-	// with autoscaling/v2beta2, so describer will try to get and describe hpa v2beta2 object firstly, if it fails,
+	// autoscaling/v2 is introduced since v1.23 and autoscaling/v1 does not have full backward compatibility
+	// with autoscaling/v2, so describer will try to get and describe hpa v2 object firstly, if it fails,
 	// describer will fall back to do with hpa v1 object
-	hpaV2beta2, err := d.client.AutoscalingV2beta2().HorizontalPodAutoscalers(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	hpaV2, err := d.client.AutoscalingV2().HorizontalPodAutoscalers(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err == nil {
 		if describerSettings.ShowEvents {
-			events, _ = searchEvents(d.client.CoreV1(), hpaV2beta2, describerSettings.ChunkSize)
+			events, _ = searchEvents(d.client.CoreV1(), hpaV2, describerSettings.ChunkSize)
 		}
-		return describeHorizontalPodAutoscalerV2beta2(hpaV2beta2, events, d)
+		return describeHorizontalPodAutoscalerV2(hpaV2, events, d)
 	}
 
 	hpaV1, err := d.client.AutoscalingV1().HorizontalPodAutoscalers(namespace).Get(context.TODO(), name, metav1.GetOptions{})
@@ -3959,7 +3959,7 @@ func (d *HorizontalPodAutoscalerDescriber) Describe(namespace, name string, desc
 	return "", err
 }
 
-func describeHorizontalPodAutoscalerV2beta2(hpa *autoscalingv2beta2.HorizontalPodAutoscaler, events *corev1.EventList, d *HorizontalPodAutoscalerDescriber) (string, error) {
+func describeHorizontalPodAutoscalerV2(hpa *autoscalingv2.HorizontalPodAutoscaler, events *corev1.EventList, d *HorizontalPodAutoscalerDescriber) (string, error) {
 	return tabbedString(func(out io.Writer) error {
 		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", hpa.Name)
@@ -3973,7 +3973,7 @@ func describeHorizontalPodAutoscalerV2beta2(hpa *autoscalingv2beta2.HorizontalPo
 		w.Write(LEVEL_0, "Metrics:\t( current / target )\n")
 		for i, metric := range hpa.Spec.Metrics {
 			switch metric.Type {
-			case autoscalingv2beta2.ExternalMetricSourceType:
+			case autoscalingv2.ExternalMetricSourceType:
 				if metric.External.Target.AverageValue != nil {
 					current := "<unknown>"
 					if len(hpa.Status.CurrentMetrics) > i && hpa.Status.CurrentMetrics[i].External != nil &&
@@ -3989,15 +3989,15 @@ func describeHorizontalPodAutoscalerV2beta2(hpa *autoscalingv2beta2.HorizontalPo
 					w.Write(LEVEL_1, "%q (target value):\t%s / %s\n", metric.External.Metric.Name, current, metric.External.Target.Value.String())
 
 				}
-			case autoscalingv2beta2.PodsMetricSourceType:
+			case autoscalingv2.PodsMetricSourceType:
 				current := "<unknown>"
 				if len(hpa.Status.CurrentMetrics) > i && hpa.Status.CurrentMetrics[i].Pods != nil {
 					current = hpa.Status.CurrentMetrics[i].Pods.Current.AverageValue.String()
 				}
 				w.Write(LEVEL_1, "%q on pods:\t%s / %s\n", metric.Pods.Metric.Name, current, metric.Pods.Target.AverageValue.String())
-			case autoscalingv2beta2.ObjectMetricSourceType:
+			case autoscalingv2.ObjectMetricSourceType:
 				w.Write(LEVEL_1, "\"%s\" on %s/%s ", metric.Object.Metric.Name, metric.Object.DescribedObject.Kind, metric.Object.DescribedObject.Name)
-				if metric.Object.Target.Type == autoscalingv2beta2.AverageValueMetricType {
+				if metric.Object.Target.Type == autoscalingv2.AverageValueMetricType {
 					current := "<unknown>"
 					if len(hpa.Status.CurrentMetrics) > i && hpa.Status.CurrentMetrics[i].Object != nil {
 						current = hpa.Status.CurrentMetrics[i].Object.Current.AverageValue.String()
@@ -4010,7 +4010,7 @@ func describeHorizontalPodAutoscalerV2beta2(hpa *autoscalingv2beta2.HorizontalPo
 					}
 					w.Write(LEVEL_0, "(target value):\t%s / %s\n", current, metric.Object.Target.Value.String())
 				}
-			case autoscalingv2beta2.ResourceMetricSourceType:
+			case autoscalingv2.ResourceMetricSourceType:
 				w.Write(LEVEL_1, "resource %s on pods", string(metric.Resource.Name))
 				if metric.Resource.Target.AverageValue != nil {
 					current := "<unknown>"
@@ -4030,7 +4030,7 @@ func describeHorizontalPodAutoscalerV2beta2(hpa *autoscalingv2beta2.HorizontalPo
 					}
 					w.Write(LEVEL_1, "(as a percentage of request):\t%s / %s\n", current, target)
 				}
-			case autoscalingv2beta2.ContainerResourceMetricSourceType:
+			case autoscalingv2.ContainerResourceMetricSourceType:
 				w.Write(LEVEL_1, "resource %s of container \"%s\" on pods", string(metric.ContainerResource.Name), metric.ContainerResource.Container)
 				if metric.ContainerResource.Target.AverageValue != nil {
 					current := "<unknown>"
@@ -4086,7 +4086,7 @@ func describeHorizontalPodAutoscalerV2beta2(hpa *autoscalingv2beta2.HorizontalPo
 	})
 }
 
-func printDirectionBehavior(w PrefixWriter, direction string, rules *autoscalingv2beta2.HPAScalingRules) {
+func printDirectionBehavior(w PrefixWriter, direction string, rules *autoscalingv2.HPAScalingRules) {
 	if rules != nil {
 		w.Write(LEVEL_1, "%s:\n", direction)
 		if rules.StabilizationWindowSeconds != nil {
@@ -4096,7 +4096,7 @@ func printDirectionBehavior(w PrefixWriter, direction string, rules *autoscaling
 			if rules.SelectPolicy != nil {
 				w.Write(LEVEL_2, "Select Policy: %s\n", *rules.SelectPolicy)
 			} else {
-				w.Write(LEVEL_2, "Select Policy: %s\n", autoscalingv2beta2.MaxPolicySelect)
+				w.Write(LEVEL_2, "Select Policy: %s\n", autoscalingv2.MaxChangePolicySelect)
 			}
 			w.Write(LEVEL_2, "Policies:\n")
 			for _, p := range rules.Policies {

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -3072,26 +3072,26 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 	minReplicasVal := int32(2)
 	targetUtilizationVal := int32(80)
 	currentUtilizationVal := int32(50)
-	maxSelectPolicy := autoscalingv2beta2.MaxPolicySelect
+	maxSelectPolicy := autoscalingv2.MaxChangePolicySelect
 	metricLabelSelector, err := metav1.ParseToLabelSelector("label=value")
 	if err != nil {
 		t.Errorf("unable to parse label selector: %v", err)
 	}
-	testsV2beta2 := []struct {
+	testsv2 := []struct {
 		name string
-		hpa  autoscalingv2beta2.HorizontalPodAutoscaler
+		hpa  autoscalingv2.HorizontalPodAutoscaler
 	}{
 		{
 			"minReplicas unset",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MaxReplicas: 10,
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
 				},
@@ -3099,31 +3099,31 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"external source type, target average value (no current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ExternalMetricSourceType,
-							External: &autoscalingv2beta2.ExternalMetricSource{
-								Metric: autoscalingv2beta2.MetricIdentifier{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name:     "some-external-metric",
 									Selector: metricLabelSelector,
 								},
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:         autoscalingv2beta2.AverageValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:         autoscalingv2.AverageValueMetricType,
 									AverageValue: resource.NewMilliQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
 				},
@@ -3131,42 +3131,42 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"external source type, target average value (with current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ExternalMetricSourceType,
-							External: &autoscalingv2beta2.ExternalMetricSource{
-								Metric: autoscalingv2beta2.MetricIdentifier{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name:     "some-external-metric",
 									Selector: metricLabelSelector,
 								},
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:         autoscalingv2beta2.AverageValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:         autoscalingv2.AverageValueMetricType,
 									AverageValue: resource.NewMilliQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
-					CurrentMetrics: []autoscalingv2beta2.MetricStatus{
+					CurrentMetrics: []autoscalingv2.MetricStatus{
 						{
-							Type: autoscalingv2beta2.ExternalMetricSourceType,
-							External: &autoscalingv2beta2.ExternalMetricStatus{
-								Metric: autoscalingv2beta2.MetricIdentifier{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricStatus{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name:     "some-external-metric",
 									Selector: metricLabelSelector,
 								},
-								Current: autoscalingv2beta2.MetricValueStatus{
+								Current: autoscalingv2.MetricValueStatus{
 									AverageValue: resource.NewMilliQuantity(50, resource.DecimalSI),
 								},
 							},
@@ -3177,31 +3177,31 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"external source type, target value (no current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ExternalMetricSourceType,
-							External: &autoscalingv2beta2.ExternalMetricSource{
-								Metric: autoscalingv2beta2.MetricIdentifier{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name:     "some-external-metric",
 									Selector: metricLabelSelector,
 								},
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:  autoscalingv2beta2.ValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:  autoscalingv2.ValueMetricType,
 									Value: resource.NewMilliQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
 				},
@@ -3209,42 +3209,42 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"external source type, target value (with current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ExternalMetricSourceType,
-							External: &autoscalingv2beta2.ExternalMetricSource{
-								Metric: autoscalingv2beta2.MetricIdentifier{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name:     "some-external-metric",
 									Selector: metricLabelSelector,
 								},
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:  autoscalingv2beta2.ValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:  autoscalingv2.ValueMetricType,
 									Value: resource.NewMilliQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
-					CurrentMetrics: []autoscalingv2beta2.MetricStatus{
+					CurrentMetrics: []autoscalingv2.MetricStatus{
 						{
-							Type: autoscalingv2beta2.ExternalMetricSourceType,
-							External: &autoscalingv2beta2.ExternalMetricStatus{
-								Metric: autoscalingv2beta2.MetricIdentifier{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricStatus{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name:     "some-external-metric",
 									Selector: metricLabelSelector,
 								},
-								Current: autoscalingv2beta2.MetricValueStatus{
+								Current: autoscalingv2.MetricValueStatus{
 									Value: resource.NewMilliQuantity(50, resource.DecimalSI),
 								},
 							},
@@ -3255,30 +3255,30 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"pods source type (no current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.PodsMetricSourceType,
-							Pods: &autoscalingv2beta2.PodsMetricSource{
-								Metric: autoscalingv2beta2.MetricIdentifier{
+							Type: autoscalingv2.PodsMetricSourceType,
+							Pods: &autoscalingv2.PodsMetricSource{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name: "some-pods-metric",
 								},
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:         autoscalingv2beta2.AverageValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:         autoscalingv2.AverageValueMetricType,
 									AverageValue: resource.NewMilliQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
 				},
@@ -3286,40 +3286,40 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"pods source type (with current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.PodsMetricSourceType,
-							Pods: &autoscalingv2beta2.PodsMetricSource{
-								Metric: autoscalingv2beta2.MetricIdentifier{
+							Type: autoscalingv2.PodsMetricSourceType,
+							Pods: &autoscalingv2.PodsMetricSource{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name: "some-pods-metric",
 								},
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:         autoscalingv2beta2.AverageValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:         autoscalingv2.AverageValueMetricType,
 									AverageValue: resource.NewMilliQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
-					CurrentMetrics: []autoscalingv2beta2.MetricStatus{
+					CurrentMetrics: []autoscalingv2.MetricStatus{
 						{
-							Type: autoscalingv2beta2.PodsMetricSourceType,
-							Pods: &autoscalingv2beta2.PodsMetricStatus{
-								Metric: autoscalingv2beta2.MetricIdentifier{
+							Type: autoscalingv2.PodsMetricSourceType,
+							Pods: &autoscalingv2.PodsMetricStatus{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name: "some-pods-metric",
 								},
-								Current: autoscalingv2beta2.MetricValueStatus{
+								Current: autoscalingv2.MetricValueStatus{
 									AverageValue: resource.NewMilliQuantity(50, resource.DecimalSI),
 								},
 							},
@@ -3330,34 +3330,34 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"object source type target average value (no current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ObjectMetricSourceType,
-							Object: &autoscalingv2beta2.ObjectMetricSource{
-								DescribedObject: autoscalingv2beta2.CrossVersionObjectReference{
+							Type: autoscalingv2.ObjectMetricSourceType,
+							Object: &autoscalingv2.ObjectMetricSource{
+								DescribedObject: autoscalingv2.CrossVersionObjectReference{
 									Name: "some-service",
 									Kind: "Service",
 								},
-								Metric: autoscalingv2beta2.MetricIdentifier{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name: "some-service-metric",
 								},
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:         autoscalingv2beta2.AverageValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:         autoscalingv2.AverageValueMetricType,
 									AverageValue: resource.NewMilliQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
 				},
@@ -3365,48 +3365,48 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"object source type target average value (with current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ObjectMetricSourceType,
-							Object: &autoscalingv2beta2.ObjectMetricSource{
-								DescribedObject: autoscalingv2beta2.CrossVersionObjectReference{
+							Type: autoscalingv2.ObjectMetricSourceType,
+							Object: &autoscalingv2.ObjectMetricSource{
+								DescribedObject: autoscalingv2.CrossVersionObjectReference{
 									Name: "some-service",
 									Kind: "Service",
 								},
-								Metric: autoscalingv2beta2.MetricIdentifier{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name: "some-service-metric",
 								},
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:         autoscalingv2beta2.AverageValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:         autoscalingv2.AverageValueMetricType,
 									AverageValue: resource.NewMilliQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
-					CurrentMetrics: []autoscalingv2beta2.MetricStatus{
+					CurrentMetrics: []autoscalingv2.MetricStatus{
 						{
-							Type: autoscalingv2beta2.ObjectMetricSourceType,
-							Object: &autoscalingv2beta2.ObjectMetricStatus{
-								DescribedObject: autoscalingv2beta2.CrossVersionObjectReference{
+							Type: autoscalingv2.ObjectMetricSourceType,
+							Object: &autoscalingv2.ObjectMetricStatus{
+								DescribedObject: autoscalingv2.CrossVersionObjectReference{
 									Name: "some-service",
 									Kind: "Service",
 								},
-								Metric: autoscalingv2beta2.MetricIdentifier{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name: "some-service-metric",
 								},
-								Current: autoscalingv2beta2.MetricValueStatus{
+								Current: autoscalingv2.MetricValueStatus{
 									AverageValue: resource.NewMilliQuantity(50, resource.DecimalSI),
 								},
 							},
@@ -3417,34 +3417,34 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"object source type target value (no current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ObjectMetricSourceType,
-							Object: &autoscalingv2beta2.ObjectMetricSource{
-								DescribedObject: autoscalingv2beta2.CrossVersionObjectReference{
+							Type: autoscalingv2.ObjectMetricSourceType,
+							Object: &autoscalingv2.ObjectMetricSource{
+								DescribedObject: autoscalingv2.CrossVersionObjectReference{
 									Name: "some-service",
 									Kind: "Service",
 								},
-								Metric: autoscalingv2beta2.MetricIdentifier{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name: "some-service-metric",
 								},
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:  autoscalingv2beta2.ValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:  autoscalingv2.ValueMetricType,
 									Value: resource.NewMilliQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
 				},
@@ -3452,48 +3452,48 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"object source type target value (with current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ObjectMetricSourceType,
-							Object: &autoscalingv2beta2.ObjectMetricSource{
-								DescribedObject: autoscalingv2beta2.CrossVersionObjectReference{
+							Type: autoscalingv2.ObjectMetricSourceType,
+							Object: &autoscalingv2.ObjectMetricSource{
+								DescribedObject: autoscalingv2.CrossVersionObjectReference{
 									Name: "some-service",
 									Kind: "Service",
 								},
-								Metric: autoscalingv2beta2.MetricIdentifier{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name: "some-service-metric",
 								},
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:  autoscalingv2beta2.ValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:  autoscalingv2.ValueMetricType,
 									Value: resource.NewMilliQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
-					CurrentMetrics: []autoscalingv2beta2.MetricStatus{
+					CurrentMetrics: []autoscalingv2.MetricStatus{
 						{
-							Type: autoscalingv2beta2.ObjectMetricSourceType,
-							Object: &autoscalingv2beta2.ObjectMetricStatus{
-								DescribedObject: autoscalingv2beta2.CrossVersionObjectReference{
+							Type: autoscalingv2.ObjectMetricSourceType,
+							Object: &autoscalingv2.ObjectMetricStatus{
+								DescribedObject: autoscalingv2.CrossVersionObjectReference{
 									Name: "some-service",
 									Kind: "Service",
 								},
-								Metric: autoscalingv2beta2.MetricIdentifier{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name: "some-service-metric",
 								},
-								Current: autoscalingv2beta2.MetricValueStatus{
+								Current: autoscalingv2.MetricValueStatus{
 									Value: resource.NewMilliQuantity(50, resource.DecimalSI),
 								},
 							},
@@ -3504,28 +3504,28 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"resource source type, target average value (no current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ResourceMetricSourceType,
-							Resource: &autoscalingv2beta2.ResourceMetricSource{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricSource{
 								Name: corev1.ResourceCPU,
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:         autoscalingv2beta2.AverageValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:         autoscalingv2.AverageValueMetricType,
 									AverageValue: resource.NewMilliQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
 				},
@@ -3533,36 +3533,36 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"resource source type, target average value (with current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ResourceMetricSourceType,
-							Resource: &autoscalingv2beta2.ResourceMetricSource{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricSource{
 								Name: corev1.ResourceCPU,
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:         autoscalingv2beta2.AverageValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:         autoscalingv2.AverageValueMetricType,
 									AverageValue: resource.NewMilliQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
-					CurrentMetrics: []autoscalingv2beta2.MetricStatus{
+					CurrentMetrics: []autoscalingv2.MetricStatus{
 						{
-							Type: autoscalingv2beta2.ResourceMetricSourceType,
-							Resource: &autoscalingv2beta2.ResourceMetricStatus{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricStatus{
 								Name: corev1.ResourceCPU,
-								Current: autoscalingv2beta2.MetricValueStatus{
+								Current: autoscalingv2.MetricValueStatus{
 									AverageValue: resource.NewMilliQuantity(50, resource.DecimalSI),
 								},
 							},
@@ -3573,28 +3573,28 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"resource source type, target utilization (no current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ResourceMetricSourceType,
-							Resource: &autoscalingv2beta2.ResourceMetricSource{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricSource{
 								Name: corev1.ResourceCPU,
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:               autoscalingv2beta2.UtilizationMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:               autoscalingv2.UtilizationMetricType,
 									AverageUtilization: &targetUtilizationVal,
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
 				},
@@ -3602,36 +3602,36 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"resource source type, target utilization (with current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ResourceMetricSourceType,
-							Resource: &autoscalingv2beta2.ResourceMetricSource{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricSource{
 								Name: corev1.ResourceCPU,
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:               autoscalingv2beta2.UtilizationMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:               autoscalingv2.UtilizationMetricType,
 									AverageUtilization: &targetUtilizationVal,
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
-					CurrentMetrics: []autoscalingv2beta2.MetricStatus{
+					CurrentMetrics: []autoscalingv2.MetricStatus{
 						{
-							Type: autoscalingv2beta2.ResourceMetricSourceType,
-							Resource: &autoscalingv2beta2.ResourceMetricStatus{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricStatus{
 								Name: corev1.ResourceCPU,
-								Current: autoscalingv2beta2.MetricValueStatus{
+								Current: autoscalingv2.MetricValueStatus{
 									AverageUtilization: &currentUtilizationVal,
 									AverageValue:       resource.NewMilliQuantity(40, resource.DecimalSI),
 								},
@@ -3643,29 +3643,29 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"container resource source type, target average value (no current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ContainerResourceMetricSourceType,
-							ContainerResource: &autoscalingv2beta2.ContainerResourceMetricSource{
+							Type: autoscalingv2.ContainerResourceMetricSourceType,
+							ContainerResource: &autoscalingv2.ContainerResourceMetricSource{
 								Name:      corev1.ResourceCPU,
 								Container: "application",
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:         autoscalingv2beta2.AverageValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:         autoscalingv2.AverageValueMetricType,
 									AverageValue: resource.NewMilliQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
 				},
@@ -3673,38 +3673,38 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"container resource source type, target average value (with current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ContainerResourceMetricSourceType,
-							ContainerResource: &autoscalingv2beta2.ContainerResourceMetricSource{
+							Type: autoscalingv2.ContainerResourceMetricSourceType,
+							ContainerResource: &autoscalingv2.ContainerResourceMetricSource{
 								Name:      corev1.ResourceCPU,
 								Container: "application",
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:         autoscalingv2beta2.AverageValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:         autoscalingv2.AverageValueMetricType,
 									AverageValue: resource.NewMilliQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
-					CurrentMetrics: []autoscalingv2beta2.MetricStatus{
+					CurrentMetrics: []autoscalingv2.MetricStatus{
 						{
-							Type: autoscalingv2beta2.ContainerResourceMetricSourceType,
-							ContainerResource: &autoscalingv2beta2.ContainerResourceMetricStatus{
+							Type: autoscalingv2.ContainerResourceMetricSourceType,
+							ContainerResource: &autoscalingv2.ContainerResourceMetricStatus{
 								Name:      corev1.ResourceCPU,
 								Container: "application",
-								Current: autoscalingv2beta2.MetricValueStatus{
+								Current: autoscalingv2.MetricValueStatus{
 									AverageValue: resource.NewMilliQuantity(50, resource.DecimalSI),
 								},
 							},
@@ -3715,29 +3715,29 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"container resource source type, target utilization (no current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ContainerResourceMetricSourceType,
-							ContainerResource: &autoscalingv2beta2.ContainerResourceMetricSource{
+							Type: autoscalingv2.ContainerResourceMetricSourceType,
+							ContainerResource: &autoscalingv2.ContainerResourceMetricSource{
 								Name:      corev1.ResourceCPU,
 								Container: "application",
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:               autoscalingv2beta2.UtilizationMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:               autoscalingv2.UtilizationMetricType,
 									AverageUtilization: &targetUtilizationVal,
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
 				},
@@ -3745,38 +3745,38 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"container resource source type, target utilization (with current)",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ContainerResourceMetricSourceType,
-							ContainerResource: &autoscalingv2beta2.ContainerResourceMetricSource{
+							Type: autoscalingv2.ContainerResourceMetricSourceType,
+							ContainerResource: &autoscalingv2.ContainerResourceMetricSource{
 								Name:      corev1.ResourceCPU,
 								Container: "application",
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:               autoscalingv2beta2.UtilizationMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:               autoscalingv2.UtilizationMetricType,
 									AverageUtilization: &targetUtilizationVal,
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
-					CurrentMetrics: []autoscalingv2beta2.MetricStatus{
+					CurrentMetrics: []autoscalingv2.MetricStatus{
 						{
-							Type: autoscalingv2beta2.ContainerResourceMetricSourceType,
-							ContainerResource: &autoscalingv2beta2.ContainerResourceMetricStatus{
+							Type: autoscalingv2.ContainerResourceMetricSourceType,
+							ContainerResource: &autoscalingv2.ContainerResourceMetricStatus{
 								Name:      corev1.ResourceCPU,
 								Container: "application",
-								Current: autoscalingv2beta2.MetricValueStatus{
+								Current: autoscalingv2.MetricValueStatus{
 									AverageUtilization: &currentUtilizationVal,
 									AverageValue:       resource.NewMilliQuantity(40, resource.DecimalSI),
 								},
@@ -3789,71 +3789,71 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 
 		{
 			"multiple metrics",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "some-rc",
 						Kind: "ReplicationController",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.PodsMetricSourceType,
-							Pods: &autoscalingv2beta2.PodsMetricSource{
-								Metric: autoscalingv2beta2.MetricIdentifier{
+							Type: autoscalingv2.PodsMetricSourceType,
+							Pods: &autoscalingv2.PodsMetricSource{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name: "some-pods-metric",
 								},
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:         autoscalingv2beta2.AverageValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:         autoscalingv2.AverageValueMetricType,
 									AverageValue: resource.NewMilliQuantity(100, resource.DecimalSI),
 								},
 							},
 						},
 						{
-							Type: autoscalingv2beta2.ResourceMetricSourceType,
-							Resource: &autoscalingv2beta2.ResourceMetricSource{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricSource{
 								Name: corev1.ResourceCPU,
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:               autoscalingv2beta2.UtilizationMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:               autoscalingv2.UtilizationMetricType,
 									AverageUtilization: &targetUtilizationVal,
 								},
 							},
 						},
 						{
-							Type: autoscalingv2beta2.PodsMetricSourceType,
-							Pods: &autoscalingv2beta2.PodsMetricSource{
-								Metric: autoscalingv2beta2.MetricIdentifier{
+							Type: autoscalingv2.PodsMetricSourceType,
+							Pods: &autoscalingv2.PodsMetricSource{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name: "other-pods-metric",
 								},
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:         autoscalingv2beta2.AverageValueMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:         autoscalingv2.AverageValueMetricType,
 									AverageValue: resource.NewMilliQuantity(400, resource.DecimalSI),
 								},
 							},
 						},
 					},
 				},
-				Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
 					CurrentReplicas: 4,
 					DesiredReplicas: 5,
-					CurrentMetrics: []autoscalingv2beta2.MetricStatus{
+					CurrentMetrics: []autoscalingv2.MetricStatus{
 						{
-							Type: autoscalingv2beta2.PodsMetricSourceType,
-							Pods: &autoscalingv2beta2.PodsMetricStatus{
-								Metric: autoscalingv2beta2.MetricIdentifier{
+							Type: autoscalingv2.PodsMetricSourceType,
+							Pods: &autoscalingv2.PodsMetricStatus{
+								Metric: autoscalingv2.MetricIdentifier{
 									Name: "some-pods-metric",
 								},
-								Current: autoscalingv2beta2.MetricValueStatus{
+								Current: autoscalingv2.MetricValueStatus{
 									AverageValue: resource.NewMilliQuantity(50, resource.DecimalSI),
 								},
 							},
 						},
 						{
-							Type: autoscalingv2beta2.ResourceMetricSourceType,
-							Resource: &autoscalingv2beta2.ResourceMetricStatus{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricStatus{
 								Name: corev1.ResourceCPU,
-								Current: autoscalingv2beta2.MetricValueStatus{
+								Current: autoscalingv2.MetricValueStatus{
 									AverageUtilization: &currentUtilizationVal,
 									AverageValue:       resource.NewMilliQuantity(40, resource.DecimalSI),
 								},
@@ -3865,33 +3865,33 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"scale up behavior specified",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "behavior-target",
 						Kind: "Deployment",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ResourceMetricSourceType,
-							Resource: &autoscalingv2beta2.ResourceMetricSource{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricSource{
 								Name: corev1.ResourceCPU,
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:               autoscalingv2beta2.UtilizationMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:               autoscalingv2.UtilizationMetricType,
 									AverageUtilization: &targetUtilizationVal,
 								},
 							},
 						},
 					},
-					Behavior: &autoscalingv2beta2.HorizontalPodAutoscalerBehavior{
-						ScaleUp: &autoscalingv2beta2.HPAScalingRules{
+					Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
+						ScaleUp: &autoscalingv2.HPAScalingRules{
 							StabilizationWindowSeconds: utilpointer.Int32Ptr(30),
 							SelectPolicy:               &maxSelectPolicy,
-							Policies: []autoscalingv2beta2.HPAScalingPolicy{
-								{Type: autoscalingv2beta2.PodsScalingPolicy, Value: 10, PeriodSeconds: 10},
-								{Type: autoscalingv2beta2.PercentScalingPolicy, Value: 10, PeriodSeconds: 10},
+							Policies: []autoscalingv2.HPAScalingPolicy{
+								{Type: autoscalingv2.PodsScalingPolicy, Value: 10, PeriodSeconds: 10},
+								{Type: autoscalingv2.PercentScalingPolicy, Value: 10, PeriodSeconds: 10},
 							},
 						},
 					},
@@ -3900,32 +3900,32 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 		{
 			"scale down behavior specified",
-			autoscalingv2beta2.HorizontalPodAutoscaler{
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Name: "behavior-target",
 						Kind: "Deployment",
 					},
 					MinReplicas: &minReplicasVal,
 					MaxReplicas: 10,
-					Metrics: []autoscalingv2beta2.MetricSpec{
+					Metrics: []autoscalingv2.MetricSpec{
 						{
-							Type: autoscalingv2beta2.ResourceMetricSourceType,
-							Resource: &autoscalingv2beta2.ResourceMetricSource{
+							Type: autoscalingv2.ResourceMetricSourceType,
+							Resource: &autoscalingv2.ResourceMetricSource{
 								Name: corev1.ResourceCPU,
-								Target: autoscalingv2beta2.MetricTarget{
-									Type:               autoscalingv2beta2.UtilizationMetricType,
+								Target: autoscalingv2.MetricTarget{
+									Type:               autoscalingv2.UtilizationMetricType,
 									AverageUtilization: &targetUtilizationVal,
 								},
 							},
 						},
 					},
-					Behavior: &autoscalingv2beta2.HorizontalPodAutoscalerBehavior{
-						ScaleDown: &autoscalingv2beta2.HPAScalingRules{
+					Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
+						ScaleDown: &autoscalingv2.HPAScalingRules{
 							StabilizationWindowSeconds: utilpointer.Int32Ptr(30),
-							Policies: []autoscalingv2beta2.HPAScalingPolicy{
-								{Type: autoscalingv2beta2.PodsScalingPolicy, Value: 10, PeriodSeconds: 10},
-								{Type: autoscalingv2beta2.PercentScalingPolicy, Value: 10, PeriodSeconds: 10},
+							Policies: []autoscalingv2.HPAScalingPolicy{
+								{Type: autoscalingv2.PodsScalingPolicy, Value: 10, PeriodSeconds: 10},
+								{Type: autoscalingv2.PercentScalingPolicy, Value: 10, PeriodSeconds: 10},
 							},
 						},
 					},
@@ -3934,7 +3934,7 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 		},
 	}
 
-	for _, test := range testsV2beta2 {
+	for _, test := range testsv2 {
 		t.Run(test.name, func(t *testing.T) {
 			test.hpa.ObjectMeta = metav1.ObjectMeta{
 				Name:      "bar",
@@ -4195,7 +4195,7 @@ func TestDescribeEvents(t *testing.T) {
 			}, events),
 		},
 		"HorizontalPodAutoscaler": &HorizontalPodAutoscalerDescriber{
-			fake.NewSimpleClientset(&autoscalingv2beta2.HorizontalPodAutoscaler{
+			fake.NewSimpleClientset(&autoscalingv2.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
 					Namespace: "foo",

--- a/staging/src/k8s.io/kubectl/pkg/scheme/install.go
+++ b/staging/src/k8s.io/kubectl/pkg/scheme/install.go
@@ -29,7 +29,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	authorizationv1beta1 "k8s.io/api/authorization/v1beta1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	certificatesv1 "k8s.io/api/certificates/v1"
@@ -69,7 +69,7 @@ func init() {
 	utilruntime.Must(Scheme.SetVersionPriority(appsv1beta1.SchemeGroupVersion, appsv1beta2.SchemeGroupVersion, appsv1.SchemeGroupVersion))
 	utilruntime.Must(Scheme.SetVersionPriority(authenticationv1.SchemeGroupVersion, authenticationv1beta1.SchemeGroupVersion))
 	utilruntime.Must(Scheme.SetVersionPriority(authorizationv1.SchemeGroupVersion, authorizationv1beta1.SchemeGroupVersion))
-	utilruntime.Must(Scheme.SetVersionPriority(autoscalingv1.SchemeGroupVersion, autoscalingv2beta1.SchemeGroupVersion))
+	utilruntime.Must(Scheme.SetVersionPriority(autoscalingv1.SchemeGroupVersion, autoscalingv2.SchemeGroupVersion))
 	utilruntime.Must(Scheme.SetVersionPriority(batchv1.SchemeGroupVersion, batchv1beta1.SchemeGroupVersion))
 	utilruntime.Must(Scheme.SetVersionPriority(certificatesv1.SchemeGroupVersion, certificatesv1beta1.SchemeGroupVersion))
 	utilruntime.Must(Scheme.SetVersionPriority(extensionsv1beta1.SchemeGroupVersion))


### PR DESCRIPTION
Cherry pick of #114886 on release-1.25.

#114886: kubectl: use v2 for hpa

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```