### PR TITLE
scheduler: protect concurrent access to PodInfo.Pod

### DIFF
--- a/pkg/scheduler/extender.go
+++ b/pkg/scheduler/extender.go
@@ -210,8 +210,9 @@ func (h *HTTPExtender) convertPodUIDToPod(
 	metaPod *extenderv1.MetaPod,
 	nodeInfo *framework.NodeInfo) (*v1.Pod, error) {
 	for _, p := range nodeInfo.Pods {
-		if string(p.Pod.UID) == metaPod.UID {
-			return p.Pod, nil
+		pod := p.Pod.Load()
+		if string(pod.UID) == metaPod.UID {
+			return pod, nil
 		}
 	}
 	return nil, fmt.Errorf("extender: %v claims to preempt pod (UID: %v) on node: %v, but the pod is not found on that node",

--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
@@ -76,11 +76,11 @@ func (s *preFilterState) updateWithPod(pInfo *framework.PodInfo, node *v1.Node, 
 		return
 	}
 
-	s.existingAntiAffinityCounts.updateWithAntiAffinityTerms(pInfo.RequiredAntiAffinityTerms, s.podInfo.Pod, s.namespaceLabels, node, multiplier)
-	s.affinityCounts.updateWithAffinityTerms(s.podInfo.RequiredAffinityTerms, pInfo.Pod, node, multiplier)
+	s.existingAntiAffinityCounts.updateWithAntiAffinityTerms(pInfo.RequiredAntiAffinityTerms, s.podInfo.Pod.Load(), s.namespaceLabels, node, multiplier)
+	s.affinityCounts.updateWithAffinityTerms(s.podInfo.RequiredAffinityTerms, pInfo.Pod.Load(), node, multiplier)
 	// The incoming pod's terms have the namespaceSelector merged into the namespaces, and so
 	// here we don't lookup the updated pod's namespace labels, hence passing nil for nsLabels.
-	s.antiAffinityCounts.updateWithAntiAffinityTerms(s.podInfo.RequiredAntiAffinityTerms, pInfo.Pod, nil, node, multiplier)
+	s.antiAffinityCounts.updateWithAntiAffinityTerms(s.podInfo.RequiredAntiAffinityTerms, pInfo.Pod.Load(), nil, node, multiplier)
 }
 
 type topologyPair struct {
@@ -204,10 +204,10 @@ func (pl *InterPodAffinity) getIncomingAffinityAntiAffinityCounts(ctx context.Co
 		affinity := make(topologyToMatchedTermCount)
 		antiAffinity := make(topologyToMatchedTermCount)
 		for _, existingPod := range nodeInfo.Pods {
-			affinity.updateWithAffinityTerms(podInfo.RequiredAffinityTerms, existingPod.Pod, node, 1)
+			affinity.updateWithAffinityTerms(podInfo.RequiredAffinityTerms, existingPod.Pod.Load(), node, 1)
 			// The incoming pod's terms have the namespaceSelector merged into the namespaces, and so
 			// here we don't lookup the existing pod's namespace labels, hence passing nil for nsLabels.
-			antiAffinity.updateWithAntiAffinityTerms(podInfo.RequiredAntiAffinityTerms, existingPod.Pod, nil, node, 1)
+			antiAffinity.updateWithAntiAffinityTerms(podInfo.RequiredAntiAffinityTerms, existingPod.Pod.Load(), nil, node, 1)
 		}
 
 		if len(affinity) > 0 || len(antiAffinity) > 0 {
@@ -358,7 +358,7 @@ func satisfyPodAffinity(state *preFilterState, nodeInfo *framework.NodeInfo) boo
 		// in the cluster matches the namespace and selector of this pod, the pod matches
 		// its own terms, and the node has all the requested topologies, then we allow the pod
 		// to pass the affinity check.
-		if len(state.affinityCounts) == 0 && podMatchesAllAffinityTerms(state.podInfo.RequiredAffinityTerms, state.podInfo.Pod) {
+		if len(state.affinityCounts) == 0 && podMatchesAllAffinityTerms(state.podInfo.RequiredAffinityTerms, state.podInfo.Pod.Load()) {
 			return true
 		}
 		return false

--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
@@ -93,14 +93,14 @@ func (pl *InterPodAffinity) processExistingPod(
 	// value as that of <existingPods>`s node by the term`s weight.
 	// Note that the incoming pod's terms have the namespaceSelector merged into the namespaces, and so
 	// here we don't lookup the existing pod's namespace labels, hence passing nil for nsLabels.
-	topoScore.processTerms(state.podInfo.PreferredAffinityTerms, existingPod.Pod, nil, existingPodNode, 1)
+	topoScore.processTerms(state.podInfo.PreferredAffinityTerms, existingPod.Pod.Load(), nil, existingPodNode, 1)
 
 	// For every soft pod anti-affinity term of <pod>, if <existingPod> matches the term,
 	// decrement <p.counts> for every node in the cluster with the same <term.TopologyKey>
 	// value as that of <existingPod>`s node by the term`s weight.
 	// Note that the incoming pod's terms have the namespaceSelector merged into the namespaces, and so
 	// here we don't lookup the existing pod's namespace labels, hence passing nil for nsLabels.
-	topoScore.processTerms(state.podInfo.PreferredAntiAffinityTerms, existingPod.Pod, nil, existingPodNode, -1)
+	topoScore.processTerms(state.podInfo.PreferredAntiAffinityTerms, existingPod.Pod.Load(), nil, existingPodNode, -1)
 
 	// For every hard pod affinity term of <existingPod>, if <pod> matches the term,
 	// increment <p.counts> for every node in the cluster with the same <term.TopologyKey>

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -117,7 +117,7 @@ func (pl *CSILimits) Filter(ctx context.Context, _ *framework.CycleState, pod *v
 
 	attachedVolumes := make(map[string]string)
 	for _, existingPod := range nodeInfo.Pods {
-		if err := pl.filterAttachableVolumes(existingPod.Pod, csiNode, false /* existing pod */, attachedVolumes); err != nil {
+		if err := pl.filterAttachableVolumes(existingPod.Pod.Load(), csiNode, false /* existing pod */, attachedVolumes); err != nil {
 			return framework.AsStatus(err)
 		}
 	}

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
@@ -250,7 +250,7 @@ func (pl *nonCSILimits) Filter(ctx context.Context, _ *framework.CycleState, pod
 	// count unique volumes
 	existingVolumes := make(sets.String)
 	for _, existingPod := range nodeInfo.Pods {
-		if err := pl.filterVolumes(existingPod.Pod, false /* existing pod */, existingVolumes); err != nil {
+		if err := pl.filterVolumes(existingPod.Pod.Load(), false /* existing pod */, existingVolumes); err != nil {
 			return framework.AsStatus(err)
 		}
 	}

--- a/pkg/scheduler/framework/plugins/podtopologyspread/common.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/common.go
@@ -148,10 +148,11 @@ func countPodsMatchSelector(podInfos []*framework.PodInfo, selector labels.Selec
 	count := 0
 	for _, p := range podInfos {
 		// Bypass terminating Pod (see #87621).
-		if p.Pod.DeletionTimestamp != nil || p.Pod.Namespace != ns {
+		pod := p.Pod.Load()
+		if pod.DeletionTimestamp != nil || pod.Namespace != ns {
 			continue
 		}
-		if selector.Matches(labels.Set(p.Pod.Labels)) {
+		if selector.Matches(labels.Set(pod.Labels)) {
 			count++
 		}
 	}

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -169,7 +169,7 @@ func (pl *PodTopologySpread) AddPod(ctx context.Context, cycleState *framework.C
 		return framework.AsStatus(err)
 	}
 
-	pl.updateWithPod(s, podInfoToAdd.Pod, podToSchedule, nodeInfo.Node(), 1)
+	pl.updateWithPod(s, podInfoToAdd.Pod.Load(), podToSchedule, nodeInfo.Node(), 1)
 	return nil
 }
 
@@ -180,7 +180,7 @@ func (pl *PodTopologySpread) RemovePod(ctx context.Context, cycleState *framewor
 		return framework.AsStatus(err)
 	}
 
-	pl.updateWithPod(s, podInfoToRemove.Pod, podToSchedule, nodeInfo.Node(), -1)
+	pl.updateWithPod(s, podInfoToRemove.Pod.Load(), podToSchedule, nodeInfo.Node(), -1)
 	return nil
 }
 

--- a/pkg/scheduler/framework/plugins/queuesort/priority_sort.go
+++ b/pkg/scheduler/framework/plugins/queuesort/priority_sort.go
@@ -40,8 +40,8 @@ func (pl *PrioritySort) Name() string {
 // It sorts pods based on their priority. When priorities are equal, it uses
 // PodQueueInfo.timestamp.
 func (pl *PrioritySort) Less(pInfo1, pInfo2 *framework.QueuedPodInfo) bool {
-	p1 := corev1helpers.PodPriority(pInfo1.Pod)
-	p2 := corev1helpers.PodPriority(pInfo2.Pod)
+	p1 := corev1helpers.PodPriority(pInfo1.Pod.Load())
+	p2 := corev1helpers.PodPriority(pInfo2.Pod.Load())
 	return (p1 > p2) || (p1 == p2 && pInfo1.Timestamp.Before(pInfo2.Timestamp))
 }
 

--- a/pkg/scheduler/framework/plugins/selectorspread/selector_spread.go
+++ b/pkg/scheduler/framework/plugins/selectorspread/selector_spread.go
@@ -224,8 +224,9 @@ func countMatchingPods(namespace string, selector labels.Selector, nodeInfo *fra
 	for _, p := range nodeInfo.Pods {
 		// Ignore pods being deleted for spreading purposes
 		// Similar to how it is done for SelectorSpreadPriority
-		if namespace == p.Pod.Namespace && p.Pod.DeletionTimestamp == nil {
-			if selector.Matches(labels.Set(p.Pod.Labels)) {
+		pod := p.Pod.Load()
+		if namespace == pod.Namespace && pod.DeletionTimestamp == nil {
+			if selector.Matches(labels.Set(pod.Labels)) {
 				count++
 			}
 		}

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
@@ -70,7 +70,7 @@ func (s *preFilterState) updateWithPod(podInfo *framework.PodInfo, multiplier in
 
 func (s *preFilterState) conflictingPVCRefCountForPod(podInfo *framework.PodInfo) int {
 	conflicts := 0
-	for _, volume := range podInfo.Pod.Spec.Volumes {
+	for _, volume := range podInfo.Pod.Load().Spec.Volumes {
 		if volume.PersistentVolumeClaim == nil {
 			continue
 		}
@@ -264,7 +264,7 @@ func satisfyVolumeConflicts(pod *v1.Pod, nodeInfo *framework.NodeInfo) bool {
 		}
 
 		for _, ev := range nodeInfo.Pods {
-			if isVolumeConflict(v, ev.Pod) {
+			if isVolumeConflict(v, ev.Pod.Load()) {
 				return false
 			}
 		}

--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -540,8 +540,9 @@ func getLowerPriorityNominatedPods(pn framework.PodNominator, pod *v1.Pod, nodeN
 	var lowerPriorityPods []*v1.Pod
 	podPriority := corev1helpers.PodPriority(pod)
 	for _, pi := range podInfos {
-		if corev1helpers.PodPriority(pi.Pod) < podPriority {
-			lowerPriorityPods = append(lowerPriorityPods, pi.Pod)
+		pod := pi.Pod.Load()
+		if corev1helpers.PodPriority(pod) < podPriority {
+			lowerPriorityPods = append(lowerPriorityPods, pod)
 		}
 	}
 	return lowerPriorityPods

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -65,7 +65,7 @@ type FakePostFilterPlugin struct {
 func (pl *FakePostFilterPlugin) SelectVictimsOnNode(
 	ctx context.Context, state *framework.CycleState, pod *v1.Pod,
 	nodeInfo *framework.NodeInfo, pdbs []*policy.PodDisruptionBudget) (victims []*v1.Pod, numViolatingVictim int, status *framework.Status) {
-	return append(victims, nodeInfo.Pods[0].Pod), pl.numViolatingVictim, nil
+	return append(victims, nodeInfo.Pods[0].Pod.Load()), pl.numViolatingVictim, nil
 }
 
 func (pl *FakePostFilterPlugin) GetOffsetAndNumCandidates(nodes int32) (int32, int32) {

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -876,7 +876,8 @@ func addNominatedPods(ctx context.Context, fh framework.Handle, pod *v1.Pod, sta
 	stateOut := state.Clone()
 	podsAdded := false
 	for _, pi := range nominatedPodInfos {
-		if corev1.PodPriority(pi.Pod) >= corev1.PodPriority(pod) && pi.Pod.UID != pod.UID {
+		piPod := pi.Pod.Load()
+		if corev1.PodPriority(piPod) >= corev1.PodPriority(pod) && piPod.UID != pod.UID {
 			nodeInfoOut.AddPodInfo(pi)
 			status := fh.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
 			if !status.IsSuccess() {

--- a/pkg/scheduler/internal/cache/debugger/comparer.go
+++ b/pkg/scheduler/internal/cache/debugger/comparer.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
@@ -92,7 +92,7 @@ func (c *CacheComparer) ComparePods(pods, waitingPods []*v1.Pod, nodeinfos map[s
 	cached := []string{}
 	for _, nodeinfo := range nodeinfos {
 		for _, p := range nodeinfo.Pods {
-			cached = append(cached, string(p.Pod.UID))
+			cached = append(cached, string(p.Pod.Load().UID))
 		}
 	}
 	for _, pod := range waitingPods {

--- a/pkg/scheduler/internal/cache/debugger/dumper.go
+++ b/pkg/scheduler/internal/cache/debugger/dumper.go
@@ -22,7 +22,7 @@ import (
 
 	"k8s.io/klog/v2"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
 	"k8s.io/kubernetes/pkg/scheduler/internal/queue"
@@ -69,14 +69,14 @@ func (d *CacheDumper) printNodeInfo(name string, n *framework.NodeInfo) string {
 		name, n.Node() == nil, n.Requested, n.Allocatable, len(n.Pods)))
 	// Dumping Pod Info
 	for _, p := range n.Pods {
-		nodeData.WriteString(printPod(p.Pod))
+		nodeData.WriteString(printPod(p.Pod.Load()))
 	}
 	// Dumping nominated pods info on the node
 	nominatedPodInfos := d.podQueue.NominatedPodsForNode(name)
 	if len(nominatedPodInfos) != 0 {
 		nodeData.WriteString(fmt.Sprintf("Nominated Pods(number: %v):\n", len(nominatedPodInfos)))
 		for _, pi := range nominatedPodInfos {
-			nodeData.WriteString(printPod(pi.Pod))
+			nodeData.WriteString(printPod(pi.Pod.Load()))
 		}
 	}
 	return nodeData.String()

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -602,11 +602,11 @@ func TestSchedulerScheduleOne(t *testing.T) {
 				return item.mockResult.result, item.mockResult.err
 			}
 			sched.FailureHandler = func(_ context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *framework.Status, _ *framework.NominatingInfo, _ time.Time) {
-				gotPod = p.Pod
+				gotPod = p.Pod.Load()
 				gotError = status.AsError()
 
 				msg := truncateMessage(gotError.Error())
-				fwk.EventRecorder().Eventf(p.Pod, nil, v1.EventTypeWarning, "FailedScheduling", "Scheduling", msg)
+				fwk.EventRecorder().Eventf(gotPod, nil, v1.EventTypeWarning, "FailedScheduling", "Scheduling", msg)
 			}
 			called := make(chan struct{})
 			stopFunc, err := eventBroadcaster.StartEventWatcher(func(obj runtime.Object) {
@@ -2982,7 +2982,7 @@ func setupTestScheduler(ctx context.Context, t *testing.T, queuedPodStore *clien
 		errChan <- err
 
 		msg := truncateMessage(err.Error())
-		fwk.EventRecorder().Eventf(p.Pod, nil, v1.EventTypeWarning, "FailedScheduling", "Scheduling", msg)
+		fwk.EventRecorder().Eventf(p.Pod.Load(), nil, v1.EventTypeWarning, "FailedScheduling", "Scheduling", msg)
 	}
 	return sched, bindingChan, errChan
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -298,7 +298,7 @@ func TestFailureHandler(t *testing.T) {
 				if e != nil {
 					t.Fatalf("Cannot pop pod from the activeQ: %v", e)
 				}
-				got = head.Pod
+				got = head.Pod.Load()
 			} else {
 				got = getPodFromPriorityQueue(queue, testPod)
 			}

--- a/pkg/scheduler/testing/fake_extender.go
+++ b/pkg/scheduler/testing/fake_extender.go
@@ -246,9 +246,10 @@ func (f *FakeExtender) selectVictimsOnNodeByExtender(pod *v1.Pod, node *v1.Node)
 	// check if the given pod can be scheduled.
 	podPriority := corev1helpers.PodPriority(pod)
 	for _, p := range nodeInfoCopy.Pods {
-		if corev1helpers.PodPriority(p.Pod) < podPriority {
-			potentialVictims = append(potentialVictims, p.Pod)
-			removePod(p.Pod)
+		pod := p.Pod.Load()
+		if corev1helpers.PodPriority(pod) < podPriority {
+			potentialVictims = append(potentialVictims, pod)
+			removePod(pod)
 		}
 	}
 	sort.Slice(potentialVictims, func(i, j int) bool { return util.MoreImportantPod(potentialVictims[i], potentialVictims[j]) })

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -1487,7 +1487,7 @@ func initTestPreferNominatedNode(t *testing.T, nsPrefix string, opts ...schedule
 		podInfo = f()
 		// Scheduler.Next() may return nil when scheduler is shutting down.
 		if podInfo != nil {
-			podInfo.Pod.Status.NominatedNodeName = "node-1"
+			podInfo.Pod.Load().Status.NominatedNodeName = "node-1"
 		}
 		return podInfo
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The pointer gets updated by informer callbacks in parallel to pod scheduling, without taking any locks. This showed up in a scheduler_perf test case involving dynamic resource allocation because there pod scheduling fails, which (for the first time in those benchmarks?) exercise additional code paths.

There's no obvious lock that could protect this field. Even if there was one, finding all code locations which currently don't hold it when accessing the field would be difficult. Therefore conversion to an atomic.Pointer is used to fix this problem: the type change causes compile errors in (most) users of the field which haven't been updated to call Load resp. Store.

The one exception is when the field is passed to functions taking an interface{}: such code compiles and then fails at runtime.

The race report was (line numbers to not exactly match current master):

    $ go test -v -timeout=0 -bench=.*/SchedulingWithInlineResourceClaims/ -race ./test/integration/scheduler_perf

    WARNING: DATA RACE
    Write at 0x00c000baafc0 by goroutine 25750:
      k8s.io/kubernetes/pkg/scheduler/framework.(*PodInfo).Update()
          /nvme/gopath/src/k8s.io/kubernetes/pkg/scheduler/framework/types.go:216 +0xd2e
      k8s.io/kubernetes/pkg/scheduler/internal/queue.updatePod()
          /nvme/gopath/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue.go:903 +0x5a4
      k8s.io/kubernetes/pkg/scheduler/internal/queue.(*PriorityQueue).Update()
          /nvme/gopath/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue.go:620 +0x582
      k8s.io/kubernetes/pkg/scheduler.(*Scheduler).updatePodInSchedulingQueue()
          /nvme/gopath/src/k8s.io/kubernetes/pkg/scheduler/eventhandlers.go:140 +0x359
      k8s.io/kubernetes/pkg/scheduler.(*Scheduler).updatePodInSchedulingQueue-fm()
          <autogenerated>:1 +0x6d
      k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache/controller.go:246 +0x8b
      k8s.io/client-go/tools/cache.(*ResourceEventHandlerFuncs).OnUpdate()
          <autogenerated>:1 +0x29
      k8s.io/client-go/tools/cache.FilteringResourceEventHandler.OnUpdate()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache/controller.go:311 +0xf7
      k8s.io/client-go/tools/cache.(*FilteringResourceEventHandler).OnUpdate()
          <autogenerated>:1 +0x8d
      k8s.io/client-go/tools/cache.(*processorListener).run.func1()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache/shared_informer.go:973 +0x21e
      k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:157 +0x48
      k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:158 +0xce
      k8s.io/apimachinery/pkg/util/wait.JitterUntil()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:135 +0x10d
      k8s.io/apimachinery/pkg/util/wait.Until()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:92 +0x78
      k8s.io/client-go/tools/cache.(*processorListener).run()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache/shared_informer.go:969 +0x18
      k8s.io/client-go/tools/cache.(*processorListener).run-fm()
          <autogenerated>:1 +0x39
      k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:75 +0x73

    Previous read at 0x00c000baafc0 by goroutine 25981:
      k8s.io/kubernetes/pkg/scheduler/internal/queue.(*nominator).add()
          /nvme/gopath/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue.go:1024 +0xda4
      k8s.io/kubernetes/pkg/scheduler/internal/queue.(*nominator).AddNominatedPod()
          /nvme/gopath/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue.go:841 +0x58
      k8s.io/kubernetes/pkg/scheduler/internal/queue.(*PriorityQueue).AddNominatedPod()
          <autogenerated>:1 +0x63
      k8s.io/kubernetes/pkg/scheduler.(*Scheduler).handleSchedulingFailure()
          /nvme/gopath/src/k8s.io/kubernetes/pkg/scheduler/schedule_one.go:916 +0x1a34
      k8s.io/kubernetes/pkg/scheduler.(*Scheduler).handleSchedulingFailure-fm()
          <autogenerated>:1 +0xcc
      k8s.io/kubernetes/pkg/scheduler.(*Scheduler).scheduleOne()
          /nvme/gopath/src/k8s.io/kubernetes/pkg/scheduler/schedule_one.go:97 +0x962
      k8s.io/kubernetes/pkg/scheduler.(*Scheduler).scheduleOne-fm()
          <autogenerated>:1 +0x4d
      k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:190 +0x4c
      k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:157 +0x48
      k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:158 +0xce
      k8s.io/apimachinery/pkg/util/wait.JitterUntil()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:135 +0x10d
      k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:190 +0xaa
      k8s.io/apimachinery/pkg/util/wait.UntilWithContext()
          /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:101 +0x52
      k8s.io/kubernetes/pkg/scheduler.(*Scheduler).Run.func1()
          /nvme/gopath/src/k8s.io/kubernetes/pkg/scheduler/scheduler.go:357 +0x5a


#### Which issue(s) this PR fixes:
Fixes #115762 

#### Special notes for your reviewer:

This contains one "govet" suppression because of https://github.com/google/go-cmp/issues/310#issuecomment-1430338479

#### Does this PR introduce a user-facing change?
```release-note
scheduler: fixed a data race
```
