### PR TITLE
e2e dra: fix resource limits in a mixed cluster

### DIFF
--- a/test/e2e/dra/test-driver/app/controller.go
+++ b/test/e2e/dra/test-driver/app/controller.go
@@ -198,8 +198,9 @@ func (c *ExampleController) allocate(ctx context.Context, claim *resourcev1alpha
 				// number of allocations (even spreading) or the most (packing).
 				node = viableNodes[rand.Intn(len(viableNodes))]
 				logger.Info("picked a node ourselves", "selectedNode", selectedNode)
-			} else if c.resources.MaxAllocations > 0 &&
-				c.countAllocations(node) >= c.resources.MaxAllocations {
+			} else if !contains(c.resources.Nodes, node) ||
+				c.resources.MaxAllocations > 0 &&
+					c.countAllocations(node) >= c.resources.MaxAllocations {
 				return nil, fmt.Errorf("resources exhausted on node %q", node)
 			}
 		} else {
@@ -292,7 +293,7 @@ func (c *ExampleController) UnsuitableNodes(ctx context.Context, pod *v1.Pod, cl
 				// can only work if a node has capacity left
 				// for all of them. Also, nodes that the driver
 				// doesn't run on cannot be used.
-				if contains(c.resources.Nodes, node) &&
+				if !contains(c.resources.Nodes, node) ||
 					allocationsPerNode[node]+len(claims) > c.resources.MaxAllocations {
 					claim.UnsuitableNodes = append(claim.UnsuitableNodes, node)
 				}
@@ -305,7 +306,7 @@ func (c *ExampleController) UnsuitableNodes(ctx context.Context, pod *v1.Pod, cl
 	for _, claim := range claims {
 		claim.UnsuitableNodes = nil
 		for _, node := range potentialNodes {
-			if contains(c.resources.Nodes, node) &&
+			if !contains(c.resources.Nodes, node) ||
 				allocations+len(claims) > c.resources.MaxAllocations {
 				claim.UnsuitableNodes = append(claim.UnsuitableNodes, node)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The check for "resources available on a node" must treat nodes that are not listed as "no resources available". The previous logic only worked because all nodes were listed during E2E testing. The upcoming integration testing is covering additional scenarios and triggered this broken case.

#### Special notes for your reviewer:

For the full integration test, see https://github.com/kubernetes/kubernetes/compare/master...pohly:dra-integration-tests?expand=1


#### Does this PR introduce a user-facing change?
```release-note
NONE
```
