### PR TITLE
dra: avoid goroutine leaks from event broadcaster

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/controller/controller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/controller/controller.go
@@ -160,6 +160,10 @@ func New(
 	podSchedulingInformer := informerFactory.Resource().V1alpha1().PodSchedulings()
 
 	eventBroadcaster := record.NewBroadcaster()
+	go func() {
+		<-ctx.Done()
+		eventBroadcaster.Shutdown()
+	}()
 	// TODO: use contextual logging in eventBroadcaster once it
 	// supports it. There is a StartStructuredLogging API, but it
 	// uses the global klog, which is worse than redirecting an unstructured


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When using these controllers in test/integration/scheduler_perf, the goroutine leak check there pointed out that broadcaster.Shutdown function wasn't called and thus goroutines leaked during a test.

#### Special notes for your reviewer:

For the full integration test, see https://github.com/kubernetes/kubernetes/compare/master...pohly:dra-integration-tests?expand=1

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
