### PR TITLE
Switch image in gRPC probe tests to agnhost 

### DIFF
--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -524,7 +524,7 @@ var _ = SIGDescribe("Probing container", func() {
 		livenessProbe := &v1.Probe{
 			ProbeHandler: v1.ProbeHandler{
 				GRPC: &v1.GRPCAction{
-					Port:    2379,
+					Port:    5000,
 					Service: nil,
 				},
 			},

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -525,7 +525,7 @@ var _ = SIGDescribe("Probing container", func() {
 		livenessProbe := &v1.Probe{
 			ProbeHandler: v1.ProbeHandler{
 				GRPC: &v1.GRPCAction{
-					Port:    2379,
+					Port:    6379,
 					Service: nil,
 				},
 			},
@@ -534,7 +534,7 @@ var _ = SIGDescribe("Probing container", func() {
 			FailureThreshold:    1,
 		}
 
-		pod := gRPCServerPodSpec(nil, livenessProbe, "etcd")
+		pod := gRPCServerPodSpec(nil, livenessProbe, "agnhost")
 		RunLivenessTest(ctx, f, pod, 0, defaultObservationTimeout)
 	})
 
@@ -548,14 +548,14 @@ var _ = SIGDescribe("Probing container", func() {
 		livenessProbe := &v1.Probe{
 			ProbeHandler: v1.ProbeHandler{
 				GRPC: &v1.GRPCAction{
-					Port: 2333, // this port is wrong
+					Port: 6333, // this port is wrong
 				},
 			},
 			InitialDelaySeconds: probeTestInitialDelaySeconds * 4,
 			TimeoutSeconds:      5, // default 1s can be pretty aggressive in CI environments with low resources
 			FailureThreshold:    1,
 		}
-		pod := gRPCServerPodSpec(nil, livenessProbe, "etcd")
+		pod := gRPCServerPodSpec(nil, livenessProbe, "agnhost")
 		RunLivenessTest(ctx, f, pod, 1, defaultObservationTimeout)
 	})
 
@@ -630,7 +630,7 @@ done
 		podClient := e2epod.NewPodClient(f)
 		terminationGracePeriod := int64(30)
 		script := `
-_term() { 
+_term() {
 	rm -f /tmp/ready
 	rm -f /tmp/liveness
 	sleep 20
@@ -641,7 +641,7 @@ trap _term SIGTERM
 touch /tmp/ready
 touch /tmp/liveness
 
-while true; do 
+while true; do
   echo \"hello\"
   sleep 10
 done
@@ -1036,27 +1036,26 @@ func runReadinessFailTest(ctx context.Context, f *framework.Framework, pod *v1.P
 }
 
 func gRPCServerPodSpec(readinessProbe, livenessProbe *v1.Probe, containerName string) *v1.Pod {
-	etcdLocalhostAddress := "127.0.0.1"
+	agnhostLocalhostAddress := "127.0.0.1"
 	if framework.TestContext.ClusterIsIPv6() {
-		etcdLocalhostAddress = "::1"
+		agnhostLocalhostAddress = "::1"
 	}
-	etcdURL := fmt.Sprintf("http://%s", net.JoinHostPort(etcdLocalhostAddress, "2379"))
+	agnhostURL := fmt.Sprintf("http://%s", net.JoinHostPort(agnhostLocalhostAddress, "6379"))
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-grpc-" + string(uuid.NewUUID())},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
 					Name:  containerName,
-					Image: imageutils.GetE2EImage(imageutils.Etcd),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
 					Command: []string{
-						"/usr/local/bin/etcd",
+						"/usr/local/bin/agnhost",
 						"--listen-client-urls",
-						"http://0.0.0.0:2379", //should listen on all addresses
+						"http://0.0.0.0:6379", //should listen on all addresses
 						"--advertise-client-urls",
-						etcdURL,
+						agnhostURL,
 					},
-					// 2380 is an automatic peer URL
-					Ports:          []v1.ContainerPort{{ContainerPort: int32(2379)}, {ContainerPort: int32(2380)}},
+					Ports:          []v1.ContainerPort{{ContainerPort: int32(6379)}},
 					LivenessProbe:  livenessProbe,
 					ReadinessProbe: readinessProbe,
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature 
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Changes etcd image to agnhost image 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115781 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
No
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
