### PR TITLE
webhook metrics top out at 2.5s but default timeout is 10s

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -178,7 +178,7 @@ func newAdmissionMetrics() *AdmissionMetrics {
 				Subsystem:      subsystem,
 				Name:           "webhook_admission_duration_seconds",
 				Help:           "Admission webhook latency histogram in seconds, identified by name and broken out for each operation and API resource and type (validate or admit).",
-				Buckets:        []float64{0.005, 0.025, 0.1, 0.5, 1.0, 2.5},
+				Buckets:        []float64{0.005, 0.025, 0.1, 0.5, 1.0, 2.5, 10},
 				StabilityLevel: metrics.STABLE,
 			},
 			[]string{"name", "type", "operation", "rejected"},

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -178,7 +178,7 @@ func newAdmissionMetrics() *AdmissionMetrics {
 				Subsystem:      subsystem,
 				Name:           "webhook_admission_duration_seconds",
 				Help:           "Admission webhook latency histogram in seconds, identified by name and broken out for each operation and API resource and type (validate or admit).",
-				Buckets:        []float64{0.005, 0.025, 0.1, 0.5, 1.0, 2.5, 10},
+				Buckets:        []float64{0.005, 0.025, 0.1, 0.5, 1.0, 2.5, 10, 25},
 				StabilityLevel: metrics.STABLE,
 			},
 			[]string{"name", "type", "operation", "rejected"},

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -291,6 +291,7 @@
   - 1
   - 2.5
   - 10
+  - 25
 - name: current_inflight_requests
   subsystem: apiserver
   help: Maximal number of currently used inflight request limit of this apiserver

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -290,6 +290,7 @@
   - 0.5
   - 1
   - 2.5
+  - 10
 - name: current_inflight_requests
   subsystem: apiserver
   help: Maximal number of currently used inflight request limit of this apiserver


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

Since our webhook metrics top out at 2.5s, charts will only display latencies as topping out at 2.5s but default webhook timeout is 10s. Therefore, increase the top bucket to 10s.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`apiserver_admission_webhook_admission_duration_seconds` buckets have been expanded, 25s is now the largest bucket size to match the webhook default timeout.
```
