### PR TITLE
Cherry pick of Aggregated Discovery Patches: #115302 #115770 #115998 #115859

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
@@ -292,9 +292,9 @@ func (dm *discoveryManager) fetchFreshDiscoveryForService(gv metav1.GroupVersion
 			lastUpdated: now,
 		}
 
-		// Save the resolve, because it is still useful in case other services
-		// are already marked dirty. THey can use it without making http request
-		dm.setCacheEntryForService(info.service, cached)
+		// Do not save the resolve as the legacy fallback only fetches
+		// one group version and an API Service may serve multiple
+		// group versions.
 		return &cached, nil
 
 	case http.StatusOK:

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
@@ -61,14 +61,10 @@ type DiscoveryAggregationController interface {
 	// Spwans a worker which waits for added/updated apiservices and updates
 	// the unified discovery document by contacting the aggregated api services
 	Run(stopCh <-chan struct{})
-
-	// Returns true if all non-local APIServices that have been added
-	// are synced at least once to the discovery document
-	ExternalServicesSynced() bool
 }
 
 type discoveryManager struct {
-	// Locks `services`
+	// Locks `apiServices`
 	servicesLock sync.RWMutex
 
 	// Map from APIService's name (or a unique string for local servers)
@@ -146,9 +142,6 @@ type groupVersionInfo struct {
 	// This ensures that if the apiservice was changed after the last cached entry
 	// was stored, the discovery document will always be re-fetched.
 	lastMarkedDirty time.Time
-
-	// Last time sync function was run for this GV.
-	lastReconciled time.Time
 
 	// ServiceReference of this GroupVersion. This identifies the Service which
 	// describes how to contact the server responsible for this GroupVersion.
@@ -350,11 +343,7 @@ func (dm *discoveryManager) syncAPIService(apiServiceName string) error {
 	}
 
 	// Lookup last cached result for this apiservice's service.
-	now := time.Now()
 	cached, err := dm.fetchFreshDiscoveryForService(mgv, info)
-
-	info.lastReconciled = now
-	dm.setInfoForAPIService(apiServiceName, &info)
 
 	var entry apidiscoveryv2beta1.APIVersionDiscovery
 
@@ -475,18 +464,6 @@ func (dm *discoveryManager) RemoveAPIService(apiServiceName string) {
 		// mark dirty if there was actually something deleted
 		dm.dirtyAPIServiceQueue.Add(apiServiceName)
 	}
-}
-
-func (dm *discoveryManager) ExternalServicesSynced() bool {
-	dm.servicesLock.RLock()
-	defer dm.servicesLock.RUnlock()
-	for _, info := range dm.apiServices {
-		if info.lastReconciled.IsZero() {
-			return false
-		}
-	}
-
-	return true
 }
 
 //

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery_test.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -38,19 +39,22 @@ import (
 	discoveryendpoint "k8s.io/apiserver/pkg/endpoints/discovery/aggregated"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
 
 func newDiscoveryManager(rm discoveryendpoint.ResourceManager) *discoveryManager {
-	return NewDiscoveryManager(rm).(*discoveryManager)
+	dm := NewDiscoveryManager(rm).(*discoveryManager)
+	dm.dirtyAPIServiceQueue = newCompleterWorkqueue(dm.dirtyAPIServiceQueue)
+
+	return dm
 }
 
-// Returns true if the queue of services to sync empty this means everything has
-// been reconciled and placed into merged document
-func waitForEmptyQueue(stopCh <-chan struct{}, dm *discoveryManager) bool {
+// Returns true if the queue of services to sync is complete which means
+// everything has been reconciled and placed into merged document
+func waitForQueueComplete(stopCh <-chan struct{}, dm *discoveryManager) bool {
 	return cache.WaitForCacheSync(stopCh, func() bool {
-		// Once items have successfully synced they are removed from queue.
-		return dm.dirtyAPIServiceQueue.Len() == 0
+		return dm.dirtyAPIServiceQueue.(*completerWorkqueue).isComplete()
 	})
 }
 
@@ -104,7 +108,7 @@ func TestBasic(t *testing.T) {
 
 	go aggregatedManager.Run(testCtx.Done())
 
-	require.True(t, waitForEmptyQueue(testCtx.Done(), aggregatedManager))
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	response, _, parsed := fetchPath(aggregatedResourceManager, "")
 	if response.StatusCode != 200 {
@@ -160,7 +164,44 @@ func TestDirty(t *testing.T) {
 	defer cancel()
 
 	go aggregatedManager.Run(testCtx.Done())
-	require.True(t, waitForEmptyQueue(testCtx.Done(), aggregatedManager))
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
+
+	// immediately check for ping, since Run() should block for local services
+	if !pinged.Load() {
+		t.Errorf("service handler never pinged")
+	}
+}
+
+// Shows that waitForQueueComplete also waits for syncing to
+// complete by artificially making the sync handler take a long time
+func TestWaitForSync(t *testing.T) {
+	pinged := atomic.Bool{}
+	service := discoveryendpoint.NewResourceManager()
+	aggregatedResourceManager := discoveryendpoint.NewResourceManager()
+
+	aggregatedManager := newDiscoveryManager(aggregatedResourceManager)
+
+	aggregatedManager.AddAPIService(&apiregistrationv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "v1.stable.example.com",
+		},
+		Spec: apiregistrationv1.APIServiceSpec{
+			Group:   "stable.example.com",
+			Version: "v1",
+			Service: &apiregistrationv1.ServiceReference{
+				Name: "test-service",
+			},
+		},
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(3 * time.Second)
+		pinged.Store(true)
+		service.ServeHTTP(w, r)
+	}))
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go aggregatedManager.Run(testCtx.Done())
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// immediately check for ping, since Run() should block for local services
 	if !pinged.Load() {
@@ -212,7 +253,7 @@ func TestRemoveAPIService(t *testing.T) {
 		aggregatedManager.RemoveAPIService(s.Name)
 	}
 
-	require.True(t, waitForEmptyQueue(testCtx.Done(), aggregatedManager))
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	response, _, parsed := fetchPath(aggyService, "")
 	if response.StatusCode != 200 {
@@ -356,7 +397,7 @@ func TestLegacyFallbackNoCache(t *testing.T) {
 	defer cancel()
 
 	go aggregatedManager.Run(testCtx.Done())
-	require.True(t, waitForEmptyQueue(testCtx.Done(), aggregatedManager))
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// At this point external services have synced. Check if discovery document
 	// includes the legacy resources
@@ -465,7 +506,7 @@ func TestLegacyFallback(t *testing.T) {
 	defer cancel()
 
 	go aggregatedManager.Run(testCtx.Done())
-	require.True(t, waitForEmptyQueue(testCtx.Done(), aggregatedManager))
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// At this point external services have synced. Check if discovery document
 	// includes the legacy resources
@@ -534,10 +575,10 @@ func TestNotModified(t *testing.T) {
 
 	// Important to wait here to ensure we prime the cache with the initial list
 	// of documents in order to exercise 304 Not Modified
-	require.True(t, waitForEmptyQueue(testCtx.Done(), aggregatedManager))
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
-	// Now add all groups. We excluded one group before so that AllServicesSynced
-	// could include it in this round. Now, if AllServicesSynced ever returns
+	// Now add all groups. We excluded one group before so that waitForQueueIsComplete
+	// could include it in this round. Now, if waitForQueueIsComplete ever returns
 	// true, it must have synced all the pre-existing groups before, which would
 	// return 304 Not Modified
 	for _, s := range apiServices {
@@ -545,7 +586,7 @@ func TestNotModified(t *testing.T) {
 	}
 
 	// This would wait the full timeout on 1.26.0.
-	require.True(t, waitForEmptyQueue(testCtx.Done(), aggregatedManager))
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 }
 
 // copied from staging/src/k8s.io/apiserver/pkg/endpoints/discovery/v2/handler_test.go
@@ -609,4 +650,49 @@ func fetchPath(handler http.Handler, etag string) (*http.Response, []byte, *apid
 	}
 
 	return w.Result(), bytes, decoded
+}
+
+// completerWorkqueue is a workqueue.RateLimitingInterface that implements
+// isComplete
+type completerWorkqueue struct {
+	lock sync.Mutex
+	workqueue.RateLimitingInterface
+	processing map[interface{}]struct{}
+}
+
+var _ = workqueue.RateLimitingInterface(&completerWorkqueue{})
+
+func newCompleterWorkqueue(wq workqueue.RateLimitingInterface) *completerWorkqueue {
+	return &completerWorkqueue{
+		RateLimitingInterface: wq,
+		processing:            make(map[interface{}]struct{}),
+	}
+}
+
+func (q *completerWorkqueue) Add(item interface{}) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	q.processing[item] = struct{}{}
+	q.RateLimitingInterface.Add(item)
+}
+
+func (q *completerWorkqueue) AddAfter(item interface{}, duration time.Duration) {
+	q.Add(item)
+}
+
+func (q *completerWorkqueue) AddRateLimited(item interface{}) {
+	q.Add(item)
+}
+
+func (q *completerWorkqueue) Done(item interface{}) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	delete(q.processing, item)
+	q.RateLimitingInterface.Done(item)
+}
+
+func (q *completerWorkqueue) isComplete() bool {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	return q.Len() == 0 && len(q.processing) == 0
 }


### PR DESCRIPTION
Cherry pick of aggregated discovery patches on release-1.26.

Includes 2 bug fixes, and 2 unit test fixes for flakes introduced with the new tests.

#115302: fix race in aggregated discovery handler
#115770: Fix legacy fallback stale for aggregated discovery
#115998: ut: fix TestLegacyFallbackNoCache versions order
#115859: Deflake tests in aggregated discovery

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix race in alpha aggregated discovery handler
Yes, discovery document will correctly return the resources for aggregated apiservers that do not implement aggregated disovery
```