### PR TITLE
solved: Kubectl get unexpected returns when sorting No resources foun…

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
@@ -138,7 +138,7 @@ func SortObjects(decoder runtime.Decoder, objs []runtime.Object, fieldInput stri
 		}
 	}
 	if !fieldFoundOnce {
-		return nil, fmt.Errorf("couldn't find any field with path %q in the list of objects", field)
+		fmt.Printf("[kubectl] couldn't find any field with path %q in the list of objects\n", field)
 	}
 
 	sorter := NewRuntimeSort(field, objs)
@@ -407,7 +407,7 @@ func NewTableSorter(table *metav1.Table, field string) (*TableSorter, error) {
 	}
 
 	if len(table.Rows) > 0 && !fieldFoundOnce {
-		return nil, fmt.Errorf("couldn't find any field with path %q in the list of objects", field)
+		fmt.Printf("[kubectl] couldn't find any field with path %q in the list of objects\n", field)
 	}
 
 	return &TableSorter{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR solves https://github.com/kubernetes/kubectl/issues/1343 .  
If we want to sort pods on the basis of the label, If the field sorting does not exist, the results should still be returned using the default, unsorted output with a warning.

#### Which issue(s) this PR fixes:

Fixes # https://github.com/kubernetes/kubectl/issues/1343

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Added a warning message, if there are no pods with the label used for sorting.
```

