### PR TITLE
Revert "restclient: rename "method" label to "verb""

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
@@ -77,9 +77,9 @@ var (
 		&k8smetrics.CounterOpts{
 			Name:           "rest_client_requests_total",
 			StabilityLevel: k8smetrics.ALPHA,
-			Help:           "Number of HTTP requests, partitioned by status code, verb, and host.",
+			Help:           "Number of HTTP requests, partitioned by status code, method, and host.",
 		},
-		[]string{"code", "verb", "host"},
+		[]string{"code", "method", "host"},
 	)
 
 	requestRetry = k8smetrics.NewCounterVec(

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics_test.go
@@ -42,9 +42,9 @@ func TestClientGOMetrics(t *testing.T) {
 				metrics.RequestResult.Increment(context.TODO(), "200", "POST", "www.foo.com")
 			},
 			want: `
-			            # HELP rest_client_requests_total [ALPHA] Number of HTTP requests, partitioned by status code, verb, and host.
+			            # HELP rest_client_requests_total [ALPHA] Number of HTTP requests, partitioned by status code, method, and host.
 			            # TYPE rest_client_requests_total counter
-			            rest_client_requests_total{code="200",host="www.foo.com",verb="POST"} 1
+			            rest_client_requests_total{code="200",host="www.foo.com",method="POST"} 1
 				`,
 		},
 		{


### PR DESCRIPTION
This reverts commit c9944709bce8ee8254c34ef48959e81f50140dea.

The label renaming introduces a change that would break the version skew without any alternative for the users.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```