### PR TITLE
refactor validatingadmissionpolicy cel validator and compiler to be reusable

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - jpbetz
+  - cici37
+  - alexzielenski
+reviewers:
+  - jpbetz
+  - cici37
+  - alexzielenski

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/compile_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/compile_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package validatingadmissionpolicy
+package cel
 
 import (
 	"strings"
@@ -104,22 +104,34 @@ func TestCompileValidatingPolicyExpression(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, expr := range tc.expressions {
-				result := CompileValidatingPolicyExpression(expr, tc.hasParams)
+				result := CompileCELExpression(&fakeExpressionAccessor{
+					expr,
+				}, tc.hasParams)
 				if result.Error != nil {
 					t.Errorf("Unexpected error: %v", result.Error)
 				}
 			}
 			for expr, expectErr := range tc.errorExpressions {
-				result := CompileValidatingPolicyExpression(expr, tc.hasParams)
+				result := CompileCELExpression(&fakeExpressionAccessor{
+					expr,
+				}, tc.hasParams)
 				if result.Error == nil {
 					t.Errorf("Expected expression '%s' to contain '%v' but got no error", expr, expectErr)
 					continue
 				}
 				if !strings.Contains(result.Error.Error(), expectErr) {
-					t.Errorf("Expected validation '%s' error to contain '%v' but got: %v", expr, expectErr, result.Error)
+					t.Errorf("Expected compilation '%s' error to contain '%v' but got: %v", expr, expectErr, result.Error)
 				}
 				continue
 			}
 		})
 	}
+}
+
+type fakeExpressionAccessor struct {
+	expression string
+}
+
+func (f *fakeExpressionAccessor) GetExpression() string {
+	return f.expression
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/filter.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/filter.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cel
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/google/cel-go/interpreter"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
+)
+
+// filterCompiler implement the interface FilterCompiler.
+type filterCompiler struct {
+}
+
+func NewFilterCompiler() FilterCompiler {
+	return &filterCompiler{}
+}
+
+type evaluationActivation struct {
+	object, oldObject, params, request interface{}
+}
+
+// ResolveName returns a value from the activation by qualified name, or false if the name
+// could not be found.
+func (a *evaluationActivation) ResolveName(name string) (interface{}, bool) {
+	switch name {
+	case ObjectVarName:
+		return a.object, true
+	case OldObjectVarName:
+		return a.oldObject, true
+	case ParamsVarName:
+		return a.params, true
+	case RequestVarName:
+		return a.request, true
+	default:
+		return nil, false
+	}
+}
+
+// Parent returns the parent of the current activation, may be nil.
+// If non-nil, the parent will be searched during resolve calls.
+func (a *evaluationActivation) Parent() interpreter.Activation {
+	return nil
+}
+
+// Compile compiles the cel expressions defined in the ExpressionAccessors into a Filter
+func (c *filterCompiler) Compile(expressionAccessors []ExpressionAccessor, hasParam bool) Filter {
+	if len(expressionAccessors) == 0 {
+		return nil
+	}
+	compilationResults := make([]CompilationResult, len(expressionAccessors))
+	for i, expressionAccessor := range expressionAccessors {
+		compilationResults[i] = CompileCELExpression(expressionAccessor, hasParam)
+	}
+	return NewFilter(compilationResults)
+}
+
+// filter implements the Filter interface
+type filter struct {
+	compilationResults []CompilationResult
+}
+
+func NewFilter(compilationResults []CompilationResult) Filter {
+	return &filter{
+		compilationResults,
+	}
+}
+
+func convertObjectToUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
+	if obj == nil || reflect.ValueOf(obj).IsNil() {
+		return &unstructured.Unstructured{Object: nil}, nil
+	}
+	ret, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: ret}, nil
+}
+
+func objectToResolveVal(r runtime.Object) (interface{}, error) {
+	if r == nil || reflect.ValueOf(r).IsNil() {
+		return nil, nil
+	}
+	v, err := convertObjectToUnstructured(r)
+	if err != nil {
+		return nil, err
+	}
+	return v.Object, nil
+}
+
+// Evaluate evaluates the compiled CEL expressions converting them into CELEvaluations
+// errors per evaluation are returned on the Evaluation object
+func (f *filter) ForInput(versionedAttr *generic.VersionedAttributes, versionedParams runtime.Object, request *admissionv1.AdmissionRequest) ([]EvaluationResult, error) {
+	// TODO: replace unstructured with ref.Val for CEL variables when native type support is available
+	evaluations := make([]EvaluationResult, len(f.compilationResults))
+	var err error
+
+	oldObjectVal, err := objectToResolveVal(versionedAttr.VersionedOldObject)
+	if err != nil {
+		return nil, err
+	}
+	objectVal, err := objectToResolveVal(versionedAttr.VersionedObject)
+	if err != nil {
+		return nil, err
+	}
+	paramsVal, err := objectToResolveVal(versionedParams)
+	if err != nil {
+		return nil, err
+	}
+
+	requestVal, err := convertObjectToUnstructured(request)
+	if err != nil {
+		return nil, err
+	}
+	va := &evaluationActivation{
+		object:    objectVal,
+		oldObject: oldObjectVal,
+		params:    paramsVal,
+		request:   requestVal.Object,
+	}
+
+	for i, compilationResult := range f.compilationResults {
+		var evaluation = &evaluations[i]
+		evaluation.ExpressionAccessor = compilationResult.ExpressionAccessor
+		if compilationResult.Error != nil {
+			evaluation.Error = errors.New(fmt.Sprintf("compilation error: %v", compilationResult.Error))
+			continue
+		}
+		if compilationResult.Program == nil {
+			evaluation.Error = errors.New("unexpected internal error compiling expression")
+			continue
+		}
+		t1 := time.Now()
+		evalResult, _, err := compilationResult.Program.Eval(va)
+		elapsed := time.Since(t1)
+		evaluation.Elapsed = elapsed
+		if err != nil {
+			evaluation.Error = errors.New(fmt.Sprintf("expression '%v' resulted in error: %v", compilationResult.ExpressionAccessor.GetExpression(), err))
+		} else {
+			evaluation.EvalResult = evalResult
+		}
+	}
+
+	return evaluations, nil
+}
+
+// TODO: to reuse https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request/admissionreview.go#L154
+func CreateAdmissionRequest(attr admission.Attributes) *admissionv1.AdmissionRequest {
+	// FIXME: how to get resource GVK, GVR and subresource?
+	gvk := attr.GetKind()
+	gvr := attr.GetResource()
+	subresource := attr.GetSubresource()
+
+	requestGVK := attr.GetKind()
+	requestGVR := attr.GetResource()
+	requestSubResource := attr.GetSubresource()
+
+	aUserInfo := attr.GetUserInfo()
+	var userInfo authenticationv1.UserInfo
+	if aUserInfo != nil {
+		userInfo = authenticationv1.UserInfo{
+			Extra:    make(map[string]authenticationv1.ExtraValue),
+			Groups:   aUserInfo.GetGroups(),
+			UID:      aUserInfo.GetUID(),
+			Username: aUserInfo.GetName(),
+		}
+		// Convert the extra information in the user object
+		for key, val := range aUserInfo.GetExtra() {
+			userInfo.Extra[key] = authenticationv1.ExtraValue(val)
+		}
+	}
+
+	dryRun := attr.IsDryRun()
+
+	return &admissionv1.AdmissionRequest{
+		Kind: metav1.GroupVersionKind{
+			Group:   gvk.Group,
+			Kind:    gvk.Kind,
+			Version: gvk.Version,
+		},
+		Resource: metav1.GroupVersionResource{
+			Group:    gvr.Group,
+			Resource: gvr.Resource,
+			Version:  gvr.Version,
+		},
+		SubResource: subresource,
+		RequestKind: &metav1.GroupVersionKind{
+			Group:   requestGVK.Group,
+			Kind:    requestGVK.Kind,
+			Version: requestGVK.Version,
+		},
+		RequestResource: &metav1.GroupVersionResource{
+			Group:    requestGVR.Group,
+			Resource: requestGVR.Resource,
+			Version:  requestGVR.Version,
+		},
+		RequestSubResource: requestSubResource,
+		Name:               attr.GetName(),
+		Namespace:          attr.GetNamespace(),
+		Operation:          admissionv1.Operation(attr.GetOperation()),
+		UserInfo:           userInfo,
+		// Leave Object and OldObject unset since we don't provide access to them via request
+		DryRun: &dryRun,
+		Options: runtime.RawExtension{
+			Object: attr.GetOperationOptions(),
+		},
+	}
+}
+
+// CompilationErrors returns a list of all the errors from the compilation of the evaluator
+func (e *filter) CompilationErrors() []error {
+	compilationErrors := []error{}
+	for _, result := range e.compilationResults {
+		if result.Error != nil {
+			compilationErrors = append(compilationErrors, result.Error)
+		}
+	}
+	return compilationErrors
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/filter_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/filter_test.go
@@ -1,0 +1,584 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cel
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	celtypes "github.com/google/cel-go/common/types"
+	"github.com/stretchr/testify/require"
+	apiservercel "k8s.io/apiserver/pkg/cel"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
+)
+
+type condition struct {
+	Expression string
+}
+
+func (c *condition) GetExpression() string {
+	return c.Expression
+}
+
+func TestCompile(t *testing.T) {
+	cases := []struct {
+		name             string
+		validation       []ExpressionAccessor
+		errorExpressions map[string]string
+	}{
+		{
+			name: "invalid syntax",
+			validation: []ExpressionAccessor{
+				&condition{
+					Expression: "1 < 'asdf'",
+				},
+				&condition{
+					Expression: "1 < 2",
+				},
+			},
+			errorExpressions: map[string]string{
+				"1 < 'asdf'": "found no matching overload for '_<_' applied to '(int, string)",
+			},
+		},
+		{
+			name: "valid syntax",
+			validation: []ExpressionAccessor{
+				&condition{
+					Expression: "1 < 2",
+				},
+				&condition{
+					Expression: "object.spec.string.matches('[0-9]+')",
+				},
+				&condition{
+					Expression: "request.kind.group == 'example.com' && request.kind.version == 'v1' && request.kind.kind == 'Fake'",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var c filterCompiler
+			e := c.Compile(tc.validation, false)
+			if e == nil {
+				t.Fatalf("unexpected nil validator")
+			}
+			validations := tc.validation
+			CompilationResults := e.(*filter).compilationResults
+			require.Equal(t, len(validations), len(CompilationResults))
+
+			meets := make([]bool, len(validations))
+			for expr, expectErr := range tc.errorExpressions {
+				for i, result := range CompilationResults {
+					if validations[i].GetExpression() == expr {
+						if result.Error == nil {
+							t.Errorf("Expect expression '%s' to contain error '%v' but got no error", expr, expectErr)
+						} else if !strings.Contains(result.Error.Error(), expectErr) {
+							t.Errorf("Expected validations '%s' error to contain '%v' but got: %v", expr, expectErr, result.Error)
+						}
+						meets[i] = true
+					}
+				}
+			}
+			for i, meet := range meets {
+				if !meet && CompilationResults[i].Error != nil {
+					t.Errorf("Unexpected err '%v' for expression '%s'", CompilationResults[i].Error, validations[i].GetExpression())
+				}
+			}
+		})
+	}
+}
+
+func TestFilter(t *testing.T) {
+	configMapParams := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		Data: map[string]string{
+			"fakeString": "fake",
+		},
+	}
+	crdParams := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"testSize": 10,
+			},
+		},
+	}
+	podObject := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "testnode",
+		},
+	}
+
+	var nilUnstructured *unstructured.Unstructured
+	cases := []struct {
+		name         string
+		attributes   admission.Attributes
+		params       runtime.Object
+		validations  []ExpressionAccessor
+		results      []EvaluationResult
+		hasParamKind bool
+	}{
+		{
+			name: "valid syntax for object",
+			validations: []ExpressionAccessor{
+				&condition{
+					Expression: "has(object.subsets) && object.subsets.size() < 2",
+				},
+			},
+			attributes: newValidAttribute(nil, false),
+			results: []EvaluationResult{
+				{
+					EvalResult: celtypes.True,
+				},
+			},
+			hasParamKind: false,
+		},
+		{
+			name: "valid syntax for metadata",
+			validations: []ExpressionAccessor{
+				&condition{
+					Expression: "object.metadata.name == 'endpoints1'",
+				},
+			},
+			attributes: newValidAttribute(nil, false),
+			results: []EvaluationResult{
+				{
+					EvalResult: celtypes.True,
+				},
+			},
+			hasParamKind: false,
+		},
+		{
+			name: "valid syntax for oldObject",
+			validations: []ExpressionAccessor{
+				&condition{
+					Expression: "oldObject == null",
+				},
+				&condition{
+					Expression: "object != null",
+				},
+			},
+			attributes: newValidAttribute(nil, false),
+			results: []EvaluationResult{
+				{
+					EvalResult: celtypes.True,
+				},
+				{
+					EvalResult: celtypes.True,
+				},
+			},
+			hasParamKind: false,
+		},
+		{
+			name: "valid syntax for request",
+			validations: []ExpressionAccessor{
+				&condition{
+					Expression: "request.operation == 'CREATE'",
+				},
+			},
+			attributes: newValidAttribute(nil, false),
+			results: []EvaluationResult{
+				{
+					EvalResult: celtypes.True,
+				},
+			},
+			hasParamKind: false,
+		},
+		{
+			name: "valid syntax for configMap",
+			validations: []ExpressionAccessor{
+				&condition{
+					Expression: "request.namespace != params.data.fakeString",
+				},
+			},
+			attributes: newValidAttribute(nil, false),
+			results: []EvaluationResult{
+				{
+					EvalResult: celtypes.True,
+				},
+			},
+			hasParamKind: true,
+			params:       configMapParams,
+		},
+		{
+			name: "test failure",
+			validations: []ExpressionAccessor{
+				&condition{
+					Expression: "object.subsets.size() > 2",
+				},
+			},
+			attributes: newValidAttribute(nil, false),
+			results: []EvaluationResult{
+				{
+					EvalResult: celtypes.False,
+				},
+			},
+			hasParamKind: true,
+			params: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Data: map[string]string{
+					"fakeString": "fake",
+				},
+			},
+		},
+		{
+			name: "test failure with multiple validations",
+			validations: []ExpressionAccessor{
+				&condition{
+					Expression: "has(object.subsets)",
+				},
+				&condition{
+					Expression: "object.subsets.size() > 2",
+				},
+			},
+			attributes: newValidAttribute(nil, false),
+			results: []EvaluationResult{
+				{
+					EvalResult: celtypes.True,
+				},
+				{
+					EvalResult: celtypes.False,
+				},
+			},
+			hasParamKind: true,
+			params:       configMapParams,
+		},
+		{
+			name: "test failure policy with multiple failed validations",
+			validations: []ExpressionAccessor{
+				&condition{
+					Expression: "oldObject != null",
+				},
+				&condition{
+					Expression: "object.subsets.size() > 2",
+				},
+			},
+			attributes: newValidAttribute(nil, false),
+			results: []EvaluationResult{
+				{
+					EvalResult: celtypes.False,
+				},
+				{
+					EvalResult: celtypes.False,
+				},
+			},
+			hasParamKind: true,
+			params:       configMapParams,
+		},
+		{
+			name: "test Object null in delete",
+			validations: []ExpressionAccessor{
+				&condition{
+					Expression: "oldObject != null",
+				},
+				&condition{
+					Expression: "object == null",
+				},
+			},
+			attributes: newValidAttribute(nil, true),
+			results: []EvaluationResult{
+				{
+					EvalResult: celtypes.True,
+				},
+				{
+					EvalResult: celtypes.True,
+				},
+			},
+			hasParamKind: true,
+			params:       configMapParams,
+		},
+		{
+			name: "test runtime error",
+			validations: []ExpressionAccessor{
+				&condition{
+					Expression: "oldObject.x == 100",
+				},
+			},
+			attributes: newValidAttribute(nil, true),
+			results: []EvaluationResult{
+				{
+					Error: errors.New("expression 'oldObject.x == 100' resulted in error"),
+				},
+			},
+			hasParamKind: true,
+			params:       configMapParams,
+		},
+		{
+			name: "test against crd param",
+			validations: []ExpressionAccessor{
+				&condition{
+					Expression: "object.subsets.size() < params.spec.testSize",
+				},
+			},
+			attributes: newValidAttribute(nil, false),
+			results: []EvaluationResult{
+				{
+					EvalResult: celtypes.True,
+				},
+			},
+			hasParamKind: true,
+			params:       crdParams,
+		},
+		{
+			name: "test compile failure",
+			validations: []ExpressionAccessor{
+				&condition{
+					Expression: "fail to compile test",
+				},
+				&condition{
+					Expression: "object.subsets.size() > params.spec.testSize",
+				},
+			},
+			attributes: newValidAttribute(nil, false),
+			results: []EvaluationResult{
+				{
+					Error: errors.New("compilation error"),
+				},
+				{
+					EvalResult: celtypes.False,
+				},
+			},
+			hasParamKind: true,
+			params:       crdParams,
+		},
+		{
+			name: "test pod",
+			validations: []ExpressionAccessor{
+				&condition{
+					Expression: "object.spec.nodeName == 'testnode'",
+				},
+			},
+			attributes: newValidAttribute(&podObject, false),
+			results: []EvaluationResult{
+				{
+					EvalResult: celtypes.True,
+				},
+			},
+			hasParamKind: true,
+			params:       crdParams,
+		},
+		{
+			name: "test deny paramKind without paramRef",
+			validations: []ExpressionAccessor{
+				&condition{
+					Expression: "params != null",
+				},
+			},
+			attributes: newValidAttribute(&podObject, false),
+			results: []EvaluationResult{
+				{
+					EvalResult: celtypes.False,
+				},
+			},
+			hasParamKind: true,
+		},
+		{
+			name: "test allow paramKind without paramRef",
+			validations: []ExpressionAccessor{
+				&condition{
+					Expression: "params == null",
+				},
+			},
+			attributes: newValidAttribute(&podObject, false),
+			results: []EvaluationResult{
+				{
+					EvalResult: celtypes.True,
+				},
+			},
+			hasParamKind: true,
+			params:       runtime.Object(nilUnstructured),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := filterCompiler{}
+			f := c.Compile(tc.validations, tc.hasParamKind)
+			if f == nil {
+				t.Fatalf("unexpected nil validator")
+			}
+			validations := tc.validations
+			CompilationResults := f.(*filter).compilationResults
+			require.Equal(t, len(validations), len(CompilationResults))
+
+			versionedAttr, err := generic.NewVersionedAttributes(tc.attributes, tc.attributes.GetKind(), newObjectInterfacesForTest())
+			if err != nil {
+				t.Fatalf("unexpected error on conversion: %v", err)
+			}
+
+			evalResults, err := f.ForInput(versionedAttr, tc.params, CreateAdmissionRequest(versionedAttr.Attributes))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			require.Equal(t, len(evalResults), len(tc.results))
+			for i, result := range tc.results {
+				if result.EvalResult != evalResults[i].EvalResult {
+					t.Errorf("Expected result '%v' but got '%v'", result.EvalResult, evalResults[i].EvalResult)
+				}
+				if result.Error != nil && !strings.Contains(evalResults[i].Error.Error(), result.Error.Error()) {
+					t.Errorf("Expected result '%v' but got '%v'", result.Error, evalResults[i].Error)
+				}
+			}
+		})
+	}
+}
+
+// newObjectInterfacesForTest returns an ObjectInterfaces appropriate for test cases in this file.
+func newObjectInterfacesForTest() admission.ObjectInterfaces {
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	return admission.NewObjectInterfacesFromScheme(scheme)
+}
+
+func newValidAttribute(object runtime.Object, isDelete bool) admission.Attributes {
+	var oldObject runtime.Object
+	if !isDelete {
+		if object == nil {
+			object = &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "endpoints1",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{{IP: "127.0.0.0"}},
+					},
+				},
+			}
+		}
+	} else {
+		object = nil
+		oldObject = &corev1.Endpoints{
+			Subsets: []corev1.EndpointSubset{
+				{
+					Addresses: []corev1.EndpointAddress{{IP: "127.0.0.0"}},
+				},
+			},
+		}
+	}
+	return admission.NewAttributesRecord(object, oldObject, schema.GroupVersionKind{}, "default", "foo", schema.GroupVersionResource{}, "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+}
+
+func TestCompilationErrors(t *testing.T) {
+	cases := []struct {
+		name     string
+		results  []CompilationResult
+		expected []error
+	}{
+		{
+			name:     "no errors, empty list",
+			results:  []CompilationResult{},
+			expected: []error{},
+		},
+		{
+			name: "no errors, several results",
+			results: []CompilationResult{
+				{}, {}, {},
+			},
+			expected: []error{},
+		},
+		{
+			name: "all errors",
+			results: []CompilationResult{
+				{
+					Error: &apiservercel.Error{
+						Detail: "error1",
+					},
+				},
+				{
+					Error: &apiservercel.Error{
+						Detail: "error2",
+					},
+				},
+				{
+					Error: &apiservercel.Error{
+						Detail: "error3",
+					},
+				},
+			},
+			expected: []error{
+				errors.New("error1"),
+				errors.New("error2"),
+				errors.New("error3"),
+			},
+		},
+		{
+			name: "mixed errors and non errors",
+			results: []CompilationResult{
+				{},
+				{
+					Error: &apiservercel.Error{
+						Detail: "error1",
+					},
+				},
+				{},
+				{
+					Error: &apiservercel.Error{
+						Detail: "error2",
+					},
+				},
+				{},
+				{},
+				{
+					Error: &apiservercel.Error{
+						Detail: "error3",
+					},
+				},
+				{},
+			},
+			expected: []error{
+				errors.New("error1"),
+				errors.New("error2"),
+				errors.New("error3"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := filter{
+				compilationResults: tc.results,
+			}
+			compilationErrors := e.CompilationErrors()
+			if compilationErrors == nil {
+				t.Fatalf("unexpected nil value returned")
+			}
+			require.Equal(t, len(compilationErrors), len(tc.expected))
+
+			for i, expectedError := range tc.expected {
+				if expectedError.Error() != compilationErrors[i].Error() {
+					t.Errorf("Expected error '%v' but got '%v'", expectedError.Error(), compilationErrors[i].Error())
+				}
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/interface.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/interface.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cel
+
+import (
+	"time"
+
+	"github.com/google/cel-go/common/types/ref"
+
+	v1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
+)
+
+var _ ExpressionAccessor = &MatchCondition{}
+
+type ExpressionAccessor interface {
+	GetExpression() string
+}
+
+// EvaluationResult contains the minimal required fields and metadata of a cel evaluation
+type EvaluationResult struct {
+	EvalResult         ref.Val
+	ExpressionAccessor ExpressionAccessor
+	Elapsed            time.Duration
+	Error              error
+}
+
+// MatchCondition contains the inputs needed to compile, evaluate and match a cel expression
+type MatchCondition struct {
+	Expression string
+}
+
+func (v *MatchCondition) GetExpression() string {
+	return v.Expression
+}
+
+// FilterCompiler contains a function to assist with converting types and values to/from CEL-typed values.
+type FilterCompiler interface {
+	// Compile is used for the cel expression compilation
+	Compile(expressions []ExpressionAccessor, hasParam bool) Filter
+}
+
+// Filter contains a function to evaluate compiled CEL-typed values
+// It expects the inbound object to already have been converted to the version expected
+// by the underlying CEL code (which is indicated by the match criteria of a policy definition).
+// versionedParams may be nil.
+type Filter interface {
+	// ForInput converts compiled CEL-typed values into evaluated CEL-typed values
+	ForInput(versionedAttr *generic.VersionedAttributes, versionedParams runtime.Object, request *v1.AdmissionRequest) ([]EvaluationResult, error)
+
+	// CompilationErrors returns a list of errors from the compilation of the evaluator
+	CompilationErrors() []error
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/matcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/matcher.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validatingadmissionpolicy
+
+import (
+	"k8s.io/api/admissionregistration/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/matching"
+)
+
+var _ matching.MatchCriteria = &matchCriteria{}
+
+type matchCriteria struct {
+	constraints *v1alpha1.MatchResources
+}
+
+// GetParsedNamespaceSelector returns the converted LabelSelector which implements labels.Selector
+func (m *matchCriteria) GetParsedNamespaceSelector() (labels.Selector, error) {
+	return metav1.LabelSelectorAsSelector(m.constraints.NamespaceSelector)
+}
+
+// GetParsedObjectSelector returns the converted LabelSelector which implements labels.Selector
+func (m *matchCriteria) GetParsedObjectSelector() (labels.Selector, error) {
+	return metav1.LabelSelectorAsSelector(m.constraints.ObjectSelector)
+}
+
+// GetMatchResources returns the matchConstraints
+func (m *matchCriteria) GetMatchResources() v1alpha1.MatchResources {
+	return *m.constraints
+}
+
+type matcher struct {
+	Matcher *matching.Matcher
+}
+
+func NewMatcher(m *matching.Matcher) Matcher {
+	return &matcher{
+		Matcher: m,
+	}
+}
+
+// ValidateInitialization checks if Matcher is initialized.
+func (c *matcher) ValidateInitialization() error {
+	return c.Matcher.ValidateInitialization()
+}
+
+// DefinitionMatches returns whether this ValidatingAdmissionPolicy matches the provided admission resource request
+func (c *matcher) DefinitionMatches(a admission.Attributes, o admission.ObjectInterfaces, definition *v1alpha1.ValidatingAdmissionPolicy) (bool, schema.GroupVersionKind, error) {
+	criteria := matchCriteria{constraints: definition.Spec.MatchConstraints}
+	return c.Matcher.Matches(a, o, &criteria)
+}
+
+// BindingMatches returns whether this ValidatingAdmissionPolicyBinding matches the provided admission resource request
+func (c *matcher) BindingMatches(a admission.Attributes, o admission.ObjectInterfaces, binding *v1alpha1.ValidatingAdmissionPolicyBinding) (bool, error) {
+	if binding.Spec.MatchResources == nil {
+		return true, nil
+	}
+	criteria := matchCriteria{constraints: binding.Spec.MatchResources}
+	isMatch, _, err := c.Matcher.Matches(a, o, &criteria)
+	return isMatch, err
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/policy_decision.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/policy_decision.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"time"
 
-	"k8s.io/api/admissionregistration/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -39,6 +38,7 @@ const (
 	EvalDeny  PolicyDecisionEvaluation = "deny"
 )
 
+// PolicyDecision contains the action determined from a cel evaluation along with metadata such as message, reason and duration
 type PolicyDecision struct {
 	Action     PolicyDecisionAction
 	Evaluation PolicyDecisionEvaluation
@@ -47,13 +47,7 @@ type PolicyDecision struct {
 	Elapsed    time.Duration
 }
 
-type policyDecisionWithMetadata struct {
-	PolicyDecision
-	Definition *v1alpha1.ValidatingAdmissionPolicy
-	Binding    *v1alpha1.ValidatingAdmissionPolicyBinding
-}
-
-func ReasonToCode(r metav1.StatusReason) int32 {
+func reasonToCode(r metav1.StatusReason) int32 {
 	switch r {
 	case metav1.StatusReasonForbidden:
 		return http.StatusForbidden

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/validator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/validator_test.go
@@ -17,551 +17,459 @@ limitations under the License.
 package validatingadmissionpolicy
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"github.com/stretchr/testify/require"
 
+	celtypes "github.com/google/cel-go/common/types"
+
+	admissionv1 "k8s.io/api/admission/v1"
 	v1 "k8s.io/api/admissionregistration/v1"
-	"k8s.io/api/admissionregistration/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/cel"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
 )
 
-func TestCompile(t *testing.T) {
-	cases := []struct {
-		name             string
-		policy           *v1alpha1.ValidatingAdmissionPolicy
-		errorExpressions map[string]string
-	}{
-		{
-			name: "invalid syntax",
-			policy: &v1alpha1.ValidatingAdmissionPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Spec: v1alpha1.ValidatingAdmissionPolicySpec{
-					FailurePolicy: func() *v1alpha1.FailurePolicyType {
-						r := v1alpha1.FailurePolicyType("Fail")
-						return &r
-					}(),
-					ParamKind: &v1alpha1.ParamKind{
-						APIVersion: "rules.example.com/v1",
-						Kind:       "ReplicaLimit",
-					},
-					Validations: []v1alpha1.Validation{
-						{
-							Expression: "1 < 'asdf'",
-						},
-						{
-							Expression: "1 < 2",
-						},
-					},
-					MatchConstraints: &v1alpha1.MatchResources{
-						MatchPolicy: func() *v1alpha1.MatchPolicyType {
-							r := v1alpha1.MatchPolicyType("Exact")
-							return &r
-						}(),
-						ResourceRules: []v1alpha1.NamedRuleWithOperations{
-							{
-								RuleWithOperations: v1alpha1.RuleWithOperations{
-									Operations: []v1.OperationType{"CREATE"},
-									Rule: v1.Rule{
-										APIGroups:   []string{"a"},
-										APIVersions: []string{"a"},
-										Resources:   []string{"a"},
-									},
-								},
-							},
-						},
-						ObjectSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"a": "b"},
-						},
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"a": "b"},
-						},
-					},
-				},
-			},
-			errorExpressions: map[string]string{
-				"1 < 'asdf'": "found no matching overload for '_<_' applied to '(int, string)",
-			},
-		},
-		{
-			name: "valid syntax",
-			policy: &v1alpha1.ValidatingAdmissionPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Spec: v1alpha1.ValidatingAdmissionPolicySpec{
-					FailurePolicy: func() *v1alpha1.FailurePolicyType {
-						r := v1alpha1.FailurePolicyType("Fail")
-						return &r
-					}(),
-					Validations: []v1alpha1.Validation{
-						{
-							Expression: "1 < 2",
-						},
-						{
-							Expression: "object.spec.string.matches('[0-9]+')",
-						},
-						{
-							Expression: "request.kind.group == 'example.com' && request.kind.version == 'v1' && request.kind.kind == 'Fake'",
-						},
-					},
-					MatchConstraints: &v1alpha1.MatchResources{
-						MatchPolicy: func() *v1alpha1.MatchPolicyType {
-							r := v1alpha1.MatchPolicyType("Exact")
-							return &r
-						}(),
-						ResourceRules: []v1alpha1.NamedRuleWithOperations{
-							{
-								RuleWithOperations: v1alpha1.RuleWithOperations{
-									Operations: []v1.OperationType{"CREATE"},
-									Rule: v1.Rule{
-										APIGroups:   []string{"a"},
-										APIVersions: []string{"a"},
-										Resources:   []string{"a"},
-									},
-								},
-							},
-						},
-						ObjectSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"a": "b"},
-						},
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"a": "b"},
-						},
-					},
-				},
-			},
-		},
-	}
+var _ cel.Filter = &fakeCelFilter{}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			var c CELValidatorCompiler
-			validator := c.Compile(tc.policy)
-			if validator == nil {
-				t.Fatalf("unexpected nil validator")
-			}
-			validations := tc.policy.Spec.Validations
-			CompilationResults := validator.(*CELValidator).compilationResults
-			require.Equal(t, len(validations), len(CompilationResults))
-
-			meets := make([]bool, len(validations))
-			for expr, expectErr := range tc.errorExpressions {
-				for i, result := range CompilationResults {
-					if validations[i].Expression == expr {
-						if result.Error == nil {
-							t.Errorf("Expect expression '%s' to contain error '%v' but got no error", expr, expectErr)
-						} else if !strings.Contains(result.Error.Error(), expectErr) {
-							t.Errorf("Expected validation '%s' error to contain '%v' but got: %v", expr, expectErr, result.Error)
-						}
-						meets[i] = true
-					}
-				}
-			}
-			for i, meet := range meets {
-				if !meet && CompilationResults[i].Error != nil {
-					t.Errorf("Unexpected err '%v' for expression '%s'", CompilationResults[i].Error, validations[i].Expression)
-				}
-			}
-		})
-	}
+type fakeCelFilter struct {
+	evaluations []cel.EvaluationResult
+	throwError  bool
 }
 
-func getValidPolicy(validations []v1alpha1.Validation, params *v1alpha1.ParamKind, fp *v1alpha1.FailurePolicyType) *v1alpha1.ValidatingAdmissionPolicy {
-	if fp == nil {
-		fp = func() *v1alpha1.FailurePolicyType {
-			r := v1alpha1.FailurePolicyType("Fail")
-			return &r
-		}()
+func (f *fakeCelFilter) ForInput(versionedAttr *generic.VersionedAttributes, versionedParams runtime.Object, request *admissionv1.AdmissionRequest) ([]cel.EvaluationResult, error) {
+	if f.throwError {
+		return nil, errors.New("test error")
 	}
-	return &v1alpha1.ValidatingAdmissionPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "foo",
-		},
-		Spec: v1alpha1.ValidatingAdmissionPolicySpec{
-			FailurePolicy: fp,
-			Validations:   validations,
-			ParamKind:     params,
-			MatchConstraints: &v1alpha1.MatchResources{
-				MatchPolicy: func() *v1alpha1.MatchPolicyType {
-					r := v1alpha1.MatchPolicyType("Exact")
-					return &r
-				}(),
-				ResourceRules: []v1alpha1.NamedRuleWithOperations{
-					{
-						RuleWithOperations: v1alpha1.RuleWithOperations{
-							Operations: []v1.OperationType{"CREATE"},
-							Rule: v1.Rule{
-								APIGroups:   []string{"a"},
-								APIVersions: []string{"a"},
-								Resources:   []string{"a"},
-							},
-						},
-					},
-				},
-				ObjectSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"a": "b"},
-				},
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"a": "b"},
-				},
-			},
-		},
-	}
+	return f.evaluations, nil
 }
 
-func generatedDecision(k PolicyDecisionAction, m string, r metav1.StatusReason) PolicyDecision {
-	return PolicyDecision{Action: k, Message: m, Reason: r}
+func (f *fakeCelFilter) CompilationErrors() []error {
+	return []error{}
 }
 
 func TestValidate(t *testing.T) {
-	// we fake the paramKind in ValidatingAdmissionPolicy for testing since the params is directly passed from cel admission
-	// Inside validator.go, we only check if paramKind exists
-	hasParamKind := &v1alpha1.ParamKind{
-		APIVersion: "v1",
-		Kind:       "ConfigMap",
-	}
-	ignorePolicy := func() *v1alpha1.FailurePolicyType {
-		r := v1alpha1.FailurePolicyType("Ignore")
-		return &r
-	}()
-	forbiddenReason := func() *metav1.StatusReason {
-		r := metav1.StatusReasonForbidden
-		return &r
-	}()
+	ignore := v1.Ignore
+	fail := v1.Fail
 
-	configMapParams := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "foo",
-		},
-		Data: map[string]string{
-			"fakeString": "fake",
-		},
-	}
-	crdParams := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"spec": map[string]interface{}{
-				"testSize": 10,
-			},
-		},
-	}
-	podObject := corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "foo",
-		},
-		Spec: corev1.PodSpec{
-			NodeName: "testnode",
-		},
-	}
+	forbiddenReason := metav1.StatusReasonForbidden
+	unauthorizedReason := metav1.StatusReasonUnauthorized
 
-	var nilUnstructured *unstructured.Unstructured
+	fakeAttr := admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{}, "default", "foo", schema.GroupVersionResource{}, "", admission.Create, nil, false, nil)
+	fakeVersionedAttr, _ := generic.NewVersionedAttributes(fakeAttr, schema.GroupVersionKind{}, nil)
 
 	cases := []struct {
-		name            string
-		policy          *v1alpha1.ValidatingAdmissionPolicy
-		attributes      admission.Attributes
-		params          runtime.Object
-		policyDecisions []PolicyDecision
+		name           string
+		failPolicy     *v1.FailurePolicyType
+		evaluations    []cel.EvaluationResult
+		policyDecision []PolicyDecision
+		throwError     bool
 	}{
 		{
-			name: "valid syntax for object",
-			policy: getValidPolicy([]v1alpha1.Validation{
+			name: "test pass",
+			evaluations: []cel.EvaluationResult{
 				{
-					Expression: "has(object.subsets) && object.subsets.size() < 2",
+					EvalResult:         celtypes.True,
+					ExpressionAccessor: &ValidationCondition{},
 				},
-			}, nil, nil),
-			attributes: newValidAttribute(nil, false),
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionAdmit, "", ""),
+			},
+			policyDecision: []PolicyDecision{
+				{
+					Action: ActionAdmit,
+				},
 			},
 		},
 		{
-			name: "valid syntax for metadata",
-			policy: getValidPolicy([]v1alpha1.Validation{
+			name: "test multiple pass",
+			evaluations: []cel.EvaluationResult{
 				{
-					Expression: "object.metadata.name == 'endpoints1'",
+					EvalResult:         celtypes.True,
+					ExpressionAccessor: &ValidationCondition{},
 				},
-			}, nil, nil),
-			attributes: newValidAttribute(nil, false),
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionAdmit, "", ""),
+				{
+					EvalResult:         celtypes.True,
+					ExpressionAccessor: &ValidationCondition{},
+				},
+			},
+			policyDecision: []PolicyDecision{
+				{
+					Action: ActionAdmit,
+				},
+				{
+					Action: ActionAdmit,
+				},
 			},
 		},
 		{
-			name: "valid syntax for oldObject",
-			policy: getValidPolicy([]v1alpha1.Validation{
+			name: "test error with failurepolicy ignore",
+			evaluations: []cel.EvaluationResult{
 				{
-					Expression: "oldObject == null",
+					Error:              errors.New(""),
+					ExpressionAccessor: &ValidationCondition{},
 				},
+			},
+			policyDecision: []PolicyDecision{
 				{
-					Expression: "object != null",
+					Action: ActionAdmit,
 				},
-			}, nil, nil),
-			attributes: newValidAttribute(nil, false),
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionAdmit, "", ""),
-				generatedDecision(ActionAdmit, "", ""),
+			},
+			failPolicy: &ignore,
+		},
+		{
+			name: "test error with failurepolicy nil",
+			evaluations: []cel.EvaluationResult{
+				{
+					Error:              errors.New(""),
+					ExpressionAccessor: &ValidationCondition{},
+				},
+			},
+			policyDecision: []PolicyDecision{
+				{
+					Action: ActionDeny,
+				},
 			},
 		},
 		{
-			name: "valid syntax for request",
-			policy: getValidPolicy([]v1alpha1.Validation{
-				{Expression: "request.operation == 'CREATE'"},
-			}, nil, nil),
-			attributes: newValidAttribute(nil, false),
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionAdmit, "", ""),
+			name: "test fail with failurepolicy fail",
+			evaluations: []cel.EvaluationResult{
+				{
+					Error:              errors.New(""),
+					ExpressionAccessor: &ValidationCondition{},
+				},
+			},
+			policyDecision: []PolicyDecision{
+				{
+					Action: ActionDeny,
+				},
+			},
+			failPolicy: &fail,
+		},
+		{
+			name: "test fail with failurepolicy ignore with multiple validations",
+			evaluations: []cel.EvaluationResult{
+				{
+					EvalResult:         celtypes.True,
+					ExpressionAccessor: &ValidationCondition{},
+				},
+				{
+					Error:              errors.New(""),
+					ExpressionAccessor: &ValidationCondition{},
+				},
+			},
+			policyDecision: []PolicyDecision{
+				{
+					Action: ActionAdmit,
+				},
+				{
+					Action: ActionAdmit,
+				},
+			},
+			failPolicy: &ignore,
+		},
+		{
+			name: "test fail with failurepolicy nil with multiple validations",
+			evaluations: []cel.EvaluationResult{
+				{
+					EvalResult:         celtypes.True,
+					ExpressionAccessor: &ValidationCondition{},
+				},
+				{
+					Error:              errors.New(""),
+					ExpressionAccessor: &ValidationCondition{},
+				},
+			},
+			policyDecision: []PolicyDecision{
+				{
+					Action: ActionAdmit,
+				},
+				{
+					Action: ActionDeny,
+				},
 			},
 		},
 		{
-			name: "valid syntax for configMap",
-			policy: getValidPolicy([]v1alpha1.Validation{
-				{Expression: "request.namespace != params.data.fakeString"},
-			}, hasParamKind, nil),
-			attributes: newValidAttribute(nil, false),
-			params:     configMapParams,
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionAdmit, "", ""),
+			name: "test fail with failurepolicy fail with multiple validations",
+			evaluations: []cel.EvaluationResult{
+				{
+					EvalResult:         celtypes.True,
+					ExpressionAccessor: &ValidationCondition{},
+				},
+				{
+					Error:              errors.New(""),
+					ExpressionAccessor: &ValidationCondition{},
+				},
+			},
+			policyDecision: []PolicyDecision{
+				{
+					Action: ActionAdmit,
+				},
+				{
+					Action: ActionDeny,
+				},
+			},
+			failPolicy: &fail,
+		},
+		{
+			name: "test fail with failurepolicy ignore with multiple failed validations",
+			evaluations: []cel.EvaluationResult{
+				{
+					Error:              errors.New(""),
+					ExpressionAccessor: &ValidationCondition{},
+				},
+				{
+					Error:              errors.New(""),
+					ExpressionAccessor: &ValidationCondition{},
+				},
+			},
+			policyDecision: []PolicyDecision{
+				{
+					Action: ActionAdmit,
+				},
+				{
+					Action: ActionAdmit,
+				},
+			},
+			failPolicy: &ignore,
+		},
+		{
+			name: "test fail with failurepolicy nil with multiple failed validations",
+			evaluations: []cel.EvaluationResult{
+				{
+					Error:              errors.New(""),
+					ExpressionAccessor: &ValidationCondition{},
+				},
+				{
+					Error:              errors.New(""),
+					ExpressionAccessor: &ValidationCondition{},
+				},
+			},
+			policyDecision: []PolicyDecision{
+				{
+					Action: ActionDeny,
+				},
+				{
+					Action: ActionDeny,
+				},
 			},
 		},
 		{
-			name: "test failure policy with Ignore",
-			policy: getValidPolicy([]v1alpha1.Validation{
-				{Expression: "object.subsets.size() > 2"},
-			}, hasParamKind, ignorePolicy),
-			attributes: newValidAttribute(nil, false),
-			params: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
+			name: "test fail with failurepolicy fail with multiple failed validations",
+			evaluations: []cel.EvaluationResult{
+				{
+					Error:              errors.New(""),
+					ExpressionAccessor: &ValidationCondition{},
 				},
-				Data: map[string]string{
-					"fakeString": "fake",
+				{
+					Error:              errors.New(""),
+					ExpressionAccessor: &ValidationCondition{},
 				},
 			},
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionDeny, "failed expression: object.subsets.size() > 2", metav1.StatusReasonInvalid),
+			policyDecision: []PolicyDecision{
+				{
+					Action: ActionDeny,
+				},
+				{
+					Action: ActionDeny,
+				},
 			},
+			failPolicy: &fail,
 		},
 		{
-			name: "test failure policy with multiple validations",
-			policy: getValidPolicy([]v1alpha1.Validation{
+			name: "test reason for fail no reason set",
+			evaluations: []cel.EvaluationResult{
 				{
-					Expression: "has(object.subsets)",
+					EvalResult: celtypes.False,
+					ExpressionAccessor: &ValidationCondition{
+						Expression: "this.expression == unit.test",
+					},
 				},
-				{
-					Expression: "object.subsets.size() > 2",
-				},
-			}, hasParamKind, ignorePolicy),
-			attributes: newValidAttribute(nil, false),
-			params:     configMapParams,
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionAdmit, "", ""),
-				generatedDecision(ActionDeny, "failed expression: object.subsets.size() > 2", metav1.StatusReasonInvalid),
 			},
+			policyDecision: []PolicyDecision{
+				{
+					Action:  ActionDeny,
+					Reason:  metav1.StatusReasonInvalid,
+					Message: "failed expression: this.expression == unit.test",
+				},
+			},
+			failPolicy: &fail,
 		},
 		{
-			name: "test failure policy with multiple failed validations",
-			policy: getValidPolicy([]v1alpha1.Validation{
+			name: "test reason for fail reason set",
+			evaluations: []cel.EvaluationResult{
 				{
-					Expression: "oldObject != null",
+					EvalResult: celtypes.False,
+					ExpressionAccessor: &ValidationCondition{
+						Reason:     &forbiddenReason,
+						Expression: "this.expression == unit.test",
+					},
 				},
-				{
-					Expression: "object.subsets.size() > 2",
-				},
-			}, hasParamKind, nil),
-			attributes: newValidAttribute(nil, false),
-			params:     configMapParams,
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionDeny, "failed expression: oldObject != null", metav1.StatusReasonInvalid),
-				generatedDecision(ActionDeny, "failed expression: object.subsets.size() > 2", metav1.StatusReasonInvalid),
 			},
+			policyDecision: []PolicyDecision{
+				{
+					Action:  ActionDeny,
+					Reason:  metav1.StatusReasonForbidden,
+					Message: "failed expression: this.expression == unit.test",
+				},
+			},
+			failPolicy: &fail,
 		},
 		{
-			name: "test Object nul in delete",
-			policy: getValidPolicy([]v1alpha1.Validation{
+			name: "test reason for failed validations multiple validations",
+			evaluations: []cel.EvaluationResult{
 				{
-					Expression: "oldObject != null",
+					EvalResult: celtypes.False,
+					ExpressionAccessor: &ValidationCondition{
+						Reason:     &forbiddenReason,
+						Expression: "this.expression == unit.test",
+					},
 				},
 				{
-					Expression: "object == null",
+					EvalResult: celtypes.False,
+					ExpressionAccessor: &ValidationCondition{
+						Reason:     &unauthorizedReason,
+						Expression: "this.expression.2 == unit.test.2",
+					},
 				},
-			}, hasParamKind, nil),
-			attributes: newValidAttribute(nil, true),
-			params:     configMapParams,
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionAdmit, "", ""),
-				generatedDecision(ActionAdmit, "", ""),
 			},
+			policyDecision: []PolicyDecision{
+				{
+					Action:  ActionDeny,
+					Reason:  metav1.StatusReasonForbidden,
+					Message: "failed expression: this.expression == unit.test",
+				},
+				{
+					Action:  ActionDeny,
+					Reason:  metav1.StatusReasonUnauthorized,
+					Message: "failed expression: this.expression.2 == unit.test.2",
+				},
+			},
+			failPolicy: &fail,
 		},
 		{
-			name: "test reason for failed validation",
-			policy: getValidPolicy([]v1alpha1.Validation{
+			name: "test message for failed validations",
+			evaluations: []cel.EvaluationResult{
 				{
-					Expression: "oldObject == null",
-					Reason:     forbiddenReason,
+					EvalResult: celtypes.False,
+					ExpressionAccessor: &ValidationCondition{
+						Reason:     &forbiddenReason,
+						Expression: "this.expression == unit.test",
+						Message:    "test",
+					},
 				},
-			}, hasParamKind, nil),
-			attributes: newValidAttribute(nil, true),
-			params:     configMapParams,
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionDeny, "failed expression: oldObject == null", metav1.StatusReasonForbidden),
 			},
+			policyDecision: []PolicyDecision{
+				{
+					Action:  ActionDeny,
+					Reason:  metav1.StatusReasonForbidden,
+					Message: "test",
+				},
+			},
+			failPolicy: &fail,
 		},
 		{
-			name: "test message for failed validation",
-			policy: getValidPolicy([]v1alpha1.Validation{
+			name: "test message for failed validations multiple validations",
+			evaluations: []cel.EvaluationResult{
 				{
-					Expression: "oldObject == null",
-					Reason:     forbiddenReason,
-					Message:    "old object should be present",
+					EvalResult: celtypes.False,
+					ExpressionAccessor: &ValidationCondition{
+						Reason:     &forbiddenReason,
+						Expression: "this.expression == unit.test",
+						Message:    "test1",
+					},
 				},
-			}, hasParamKind, nil),
-			attributes: newValidAttribute(nil, true),
-			params:     configMapParams,
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionDeny, "old object should be present", metav1.StatusReasonForbidden),
+				{
+					EvalResult: celtypes.False,
+					ExpressionAccessor: &ValidationCondition{
+						Reason:     &forbiddenReason,
+						Expression: "this.expression == unit.test",
+						Message:    "test2",
+					},
+				},
 			},
+			policyDecision: []PolicyDecision{
+				{
+					Action:  ActionDeny,
+					Reason:  metav1.StatusReasonForbidden,
+					Message: "test1",
+				},
+				{
+					Action:  ActionDeny,
+					Reason:  metav1.StatusReasonForbidden,
+					Message: "test2",
+				},
+			},
+			failPolicy: &fail,
 		},
 		{
-			name: "test runtime error",
-			policy: getValidPolicy([]v1alpha1.Validation{
+			name: "test filter error",
+			evaluations: []cel.EvaluationResult{
 				{
-					Expression: "oldObject.x == 100",
+					EvalResult: celtypes.False,
+					ExpressionAccessor: &ValidationCondition{
+						Reason:     &forbiddenReason,
+						Expression: "this.expression == unit.test",
+						Message:    "test1",
+					},
 				},
-			}, hasParamKind, nil),
-			attributes: newValidAttribute(nil, true),
-			params:     configMapParams,
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionDeny, "resulted in error", ""),
 			},
+			policyDecision: []PolicyDecision{
+				{
+					Action:  ActionDeny,
+					Message: "test error",
+				},
+			},
+			failPolicy: &fail,
+			throwError: true,
 		},
 		{
-			name: "test against crd param",
-			policy: getValidPolicy([]v1alpha1.Validation{
+			name: "test filter error multiple evaluations",
+			evaluations: []cel.EvaluationResult{
 				{
-					Expression: "object.subsets.size() < params.spec.testSize",
+					EvalResult: celtypes.False,
+					ExpressionAccessor: &ValidationCondition{
+						Reason:     &forbiddenReason,
+						Expression: "this.expression == unit.test",
+						Message:    "test1",
+					},
 				},
-			}, hasParamKind, nil),
-			attributes: newValidAttribute(nil, false),
-			params:     crdParams,
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionAdmit, "", ""),
+				{
+					EvalResult: celtypes.False,
+					ExpressionAccessor: &ValidationCondition{
+						Reason:     &forbiddenReason,
+						Expression: "this.expression == unit.test",
+						Message:    "test2",
+					},
+				},
 			},
-		},
-		{
-			name: "test compile failure with FailurePolicy Fail",
-			policy: getValidPolicy([]v1alpha1.Validation{
+			policyDecision: []PolicyDecision{
 				{
-					Expression: "fail to compile test",
+					Action:  ActionDeny,
+					Message: "test error",
 				},
-				{
-					Expression: "object.subsets.size() > params.spec.testSize",
-				},
-			}, hasParamKind, nil),
-			attributes: newValidAttribute(nil, false),
-			params:     crdParams,
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionDeny, "compilation error: compilation failed: ERROR: <input>:1:6: Syntax error:", ""),
-				generatedDecision(ActionDeny, "failed expression: object.subsets.size() > params.spec.testSize", metav1.StatusReasonInvalid),
 			},
-		},
-		{
-			name: "test compile failure with FailurePolicy Ignore",
-			policy: getValidPolicy([]v1alpha1.Validation{
-				{
-					Expression: "fail to compile test",
-				},
-				{
-					Expression: "object.subsets.size() > params.spec.testSize",
-				},
-			}, hasParamKind, ignorePolicy),
-			attributes: newValidAttribute(nil, false),
-			params:     crdParams,
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionAdmit, "compilation error: compilation failed: ERROR:", ""),
-				generatedDecision(ActionDeny, "failed expression: object.subsets.size() > params.spec.testSize", metav1.StatusReasonInvalid),
-			},
-		},
-		{
-			name: "test pod",
-			policy: getValidPolicy([]v1alpha1.Validation{
-				{
-					Expression: "object.spec.nodeName == 'testnode'",
-				},
-			}, nil, nil),
-			attributes: newValidAttribute(&podObject, false),
-			params:     crdParams,
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionAdmit, "", ""),
-			},
-		},
-		{
-			name: "test deny paramKind without paramRef",
-			policy: getValidPolicy([]v1alpha1.Validation{
-				{
-					Expression: "params != null",
-					Reason:     forbiddenReason,
-					Message:    "params as required",
-				},
-			}, hasParamKind, nil),
-			attributes: newValidAttribute(nil, true),
-			// Simulate a interface holding a nil pointer, since this is how param is passed to Validate
-			// if paramRef is unset on a binding
-			params: runtime.Object(nilUnstructured),
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionDeny, "params as required", metav1.StatusReasonForbidden),
-			},
-		},
-		{
-			name: "test allow paramKind without paramRef",
-			policy: getValidPolicy([]v1alpha1.Validation{
-				{
-					Expression: "params == null",
-					Reason:     forbiddenReason,
-				},
-			}, hasParamKind, nil),
-			attributes: newValidAttribute(nil, true),
-			// Simulate a interface holding a nil pointer, since this is how param is passed to Validate
-			// if paramRef is unset on a binding
-			params: runtime.Object(nilUnstructured),
-			policyDecisions: []PolicyDecision{
-				generatedDecision(ActionAdmit, "", ""),
-			},
+			failPolicy: &fail,
+			throwError: true,
 		},
 	}
-
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := CELValidatorCompiler{}
-			validator := c.Compile(tc.policy)
-			if validator == nil {
-				t.Fatalf("unexpected nil validator")
+			v := validator{
+				failPolicy: tc.failPolicy,
+				filter: &fakeCelFilter{
+					evaluations: tc.evaluations,
+					throwError:  tc.throwError,
+				},
 			}
-			validations := tc.policy.Spec.Validations
-			CompilationResults := validator.(*CELValidator).compilationResults
-			require.Equal(t, len(validations), len(CompilationResults))
+			policyResults := v.Validate(fakeVersionedAttr, nil)
 
-			versionedAttr, err := generic.NewVersionedAttributes(tc.attributes, tc.attributes.GetKind(), newObjectInterfacesForTest())
-			if err != nil {
-				t.Fatalf("unexpected error on conversion: %v", err)
-			}
+			require.Equal(t, len(policyResults), len(tc.policyDecision))
 
-			policyResults, err := validator.Validate(versionedAttr, tc.params)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			require.Equal(t, len(policyResults), len(tc.policyDecisions))
-			for i, policyDecision := range tc.policyDecisions {
+			for i, policyDecision := range tc.policyDecision {
 				if policyDecision.Action != policyResults[i].Action {
 					t.Errorf("Expected policy decision kind '%v' but got '%v'", policyDecision.Action, policyResults[i].Action)
 				}
@@ -574,40 +482,4 @@ func TestValidate(t *testing.T) {
 			}
 		})
 	}
-}
-
-// newObjectInterfacesForTest returns an ObjectInterfaces appropriate for test cases in this file.
-func newObjectInterfacesForTest() admission.ObjectInterfaces {
-	scheme := runtime.NewScheme()
-	corev1.AddToScheme(scheme)
-	return admission.NewObjectInterfacesFromScheme(scheme)
-}
-
-func newValidAttribute(object runtime.Object, isDelete bool) admission.Attributes {
-	var oldObject runtime.Object
-	if !isDelete {
-		if object == nil {
-			object = &corev1.Endpoints{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "endpoints1",
-				},
-				Subsets: []corev1.EndpointSubset{
-					{
-						Addresses: []corev1.EndpointAddress{{IP: "127.0.0.0"}},
-					},
-				},
-			}
-		}
-	} else {
-		object = nil
-		oldObject = &corev1.Endpoints{
-			Subsets: []corev1.EndpointSubset{
-				{
-					Addresses: []corev1.EndpointAddress{{IP: "127.0.0.0"}},
-				},
-			},
-		}
-	}
-	return admission.NewAttributesRecord(object, oldObject, schema.GroupVersionKind{}, "default", "foo", schema.GroupVersionResource{}, "", admission.Create, &metav1.CreateOptions{}, false, nil)
-
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1450,6 +1450,7 @@ k8s.io/apiserver/pkg/admission/cel
 k8s.io/apiserver/pkg/admission/configuration
 k8s.io/apiserver/pkg/admission/initializer
 k8s.io/apiserver/pkg/admission/metrics
+k8s.io/apiserver/pkg/admission/plugin/cel
 k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle
 k8s.io/apiserver/pkg/admission/plugin/resourcequota
 k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota


### PR DESCRIPTION
Will update tests once approach and interface contracts are solidified but integration tests are passing

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Refactoring ValidatingAdmissionPolicy cel logic to be reusable
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Makes cel components from validatingadmissionpolicy reusable so that it can be reused for the cel logic when adding MatchConditions to admission webhooks for https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3716-admission-webhook-match-conditions 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

WIP, initial feedback on initial full implementation of the kep is here: https://github.com/kubernetes/kubernetes/pull/115771

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3716-admission-webhook-match-conditions
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3716-admission-webhook-match-conditions
- [Additional Feedback]:https://github.com/kubernetes/kubernetes/pull/115771
```
