### PR TITLE
RequestHeader authentication: add UID to recognized request headers

### DIFF
--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -214,6 +214,7 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 	}
 	s.SecureServing.ServerCert.CertDirectory = result.TmpDir
 
+	reqHeaderFromFlags := s.Authentication.RequestHeader
 	if instanceOptions.EnableCertAuth {
 		// set up default headers for request header auth
 		reqHeaders := serveroptions.NewDelegatingAuthenticationOptions()
@@ -345,6 +346,23 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 
 	if err := fs.Parse(customFlags); err != nil {
 		return result, err
+	}
+
+	// the RequestHeader options pointer gets replaced in the case of EnableCertAuth override
+	// and so flags are connected to a struct that no longer appears in the ServerOptions struct
+	// we're using.
+	// We still want to make it possible to configure the headers config for the RequestHeader authenticator.
+	if usernameHeaders := reqHeaderFromFlags.UsernameHeaders; len(usernameHeaders) > 0 {
+		s.Authentication.RequestHeader.UsernameHeaders = usernameHeaders
+	}
+	if uidHeaders := reqHeaderFromFlags.UIDHeaders; len(uidHeaders) > 0 {
+		s.Authentication.RequestHeader.UIDHeaders = uidHeaders
+	}
+	if groupHeaders := reqHeaderFromFlags.GroupHeaders; len(groupHeaders) > 0 {
+		s.Authentication.RequestHeader.GroupHeaders = groupHeaders
+	}
+	if extraHeaders := reqHeaderFromFlags.ExtraHeaderPrefixes; len(extraHeaders) > 0 {
+		s.Authentication.RequestHeader.ExtraHeaderPrefixes = extraHeaders
 	}
 
 	if err := utilversion.DefaultComponentGlobalsRegistry.Set(); err != nil {

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -430,6 +430,7 @@ func TestAddFlags(t *testing.T) {
 			ClientCert:          apiserveroptions.ClientCertAuthenticationOptions{},
 			RequestHeader: apiserveroptions.RequestHeaderAuthenticationOptions{
 				UsernameHeaders:     []string{"x-remote-user"},
+				UIDHeaders:          []string{"x-remote-uid"},
 				GroupHeaders:        []string{"x-remote-group"},
 				ExtraHeaderPrefixes: []string{"x-remote-extra-"},
 			},

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -430,7 +430,7 @@ func TestAddFlags(t *testing.T) {
 			ClientCert:          apiserveroptions.ClientCertAuthenticationOptions{},
 			RequestHeader: apiserveroptions.RequestHeaderAuthenticationOptions{
 				UsernameHeaders:     []string{"x-remote-user"},
-				UIDHeaders:          []string{"x-remote-uid"},
+				UIDHeaders:          nil,
 				GroupHeaders:        []string{"x-remote-group"},
 				ExtraHeaderPrefixes: []string{"x-remote-extra-"},
 			},

--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -337,6 +337,7 @@ func CreateConfig(
 		config.ClusterAuthenticationInfo.RequestHeaderExtraHeaderPrefixes = requestHeaderConfig.ExtraHeaderPrefixes
 		config.ClusterAuthenticationInfo.RequestHeaderGroupHeaders = requestHeaderConfig.GroupHeaders
 		config.ClusterAuthenticationInfo.RequestHeaderUsernameHeaders = requestHeaderConfig.UsernameHeaders
+		config.ClusterAuthenticationInfo.RequestHeaderUIDHeaders = requestHeaderConfig.UIDHeaders
 	}
 
 	// setup admission

--- a/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller.go
+++ b/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller.go
@@ -77,6 +77,8 @@ type ClusterAuthenticationInfo struct {
 
 	// RequestHeaderUsernameHeaders are the headers used by this kube-apiserver to determine username
 	RequestHeaderUsernameHeaders headerrequest.StringSliceProvider
+	// RequestHeaderUIDHeaders are the headers used by this kube-apiserver to determine UID
+	RequestHeaderUIDHeaders headerrequest.StringSliceProvider
 	// RequestHeaderGroupHeaders are the headers used by this kube-apiserver to determine groups
 	RequestHeaderGroupHeaders headerrequest.StringSliceProvider
 	// RequestHeaderExtraHeaderPrefixes are the headers used by this kube-apiserver to determine user.extra
@@ -224,6 +226,7 @@ func combinedClusterAuthenticationInfo(lhs, rhs ClusterAuthenticationInfo) (Clus
 		RequestHeaderExtraHeaderPrefixes: combineUniqueStringSlices(lhs.RequestHeaderExtraHeaderPrefixes, rhs.RequestHeaderExtraHeaderPrefixes),
 		RequestHeaderGroupHeaders:        combineUniqueStringSlices(lhs.RequestHeaderGroupHeaders, rhs.RequestHeaderGroupHeaders),
 		RequestHeaderUsernameHeaders:     combineUniqueStringSlices(lhs.RequestHeaderUsernameHeaders, rhs.RequestHeaderUsernameHeaders),
+		RequestHeaderUIDHeaders:          combineUniqueStringSlices(lhs.RequestHeaderUIDHeaders, rhs.RequestHeaderUIDHeaders),
 	}
 
 	var err error
@@ -256,6 +259,10 @@ func getConfigMapDataFor(authenticationInfo ClusterAuthenticationInfo) (map[stri
 
 		// encoding errors aren't going to get better, so just fail on them.
 		data["requestheader-username-headers"], err = jsonSerializeStringSlice(authenticationInfo.RequestHeaderUsernameHeaders.Value())
+		if err != nil {
+			return nil, err
+		}
+		data["requestheader-uid-headers"], err = jsonSerializeStringSlice(authenticationInfo.RequestHeaderUIDHeaders.Value())
 		if err != nil {
 			return nil, err
 		}
@@ -295,6 +302,10 @@ func getClusterAuthenticationInfoFor(data map[string]string) (ClusterAuthenticat
 		return ClusterAuthenticationInfo{}, err
 	}
 	ret.RequestHeaderUsernameHeaders, err = jsonDeserializeStringSlice(data["requestheader-username-headers"])
+	if err != nil {
+		return ClusterAuthenticationInfo{}, err
+	}
+	ret.RequestHeaderUIDHeaders, err = jsonDeserializeStringSlice(data["requestheader-uid-headers"])
 	if err != nil {
 		return ClusterAuthenticationInfo{}, err
 	}

--- a/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller_test.go
+++ b/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller_test.go
@@ -101,6 +101,7 @@ func TestWriteClientCAs(t *testing.T) {
 			clusterAuthInfo: ClusterAuthenticationInfo{
 				ClientCA:                         someRandomCAProvider,
 				RequestHeaderUsernameHeaders:     headerrequest.StaticStringSlice{"alfa", "bravo", "charlie"},
+				RequestHeaderUIDHeaders:          headerrequest.StaticStringSlice{"golf", "hotel", "india"},
 				RequestHeaderGroupHeaders:        headerrequest.StaticStringSlice{"delta"},
 				RequestHeaderExtraHeaderPrefixes: headerrequest.StaticStringSlice{"echo", "foxtrot"},
 				RequestHeaderCA:                  anotherRandomCAProvider,
@@ -112,6 +113,7 @@ func TestWriteClientCAs(t *testing.T) {
 					Data: map[string]string{
 						"client-ca-file":                     string(someRandomCA),
 						"requestheader-username-headers":     `["alfa","bravo","charlie"]`,
+						"requestheader-uid-headers":          `["golf","hotel","india"]`,
 						"requestheader-group-headers":        `["delta"]`,
 						"requestheader-extra-headers-prefix": `["echo","foxtrot"]`,
 						"requestheader-client-ca-file":       string(anotherRandomCA),
@@ -132,6 +134,7 @@ func TestWriteClientCAs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
 						"requestheader-username-headers":     `[]`,
+						"requestheader-uid-headers":          `[]`,
 						"requestheader-group-headers":        `[]`,
 						"requestheader-extra-headers-prefix": `[]`,
 						"requestheader-client-ca-file":       string(anotherRandomCA),
@@ -166,6 +169,7 @@ func TestWriteClientCAs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
 						"requestheader-username-headers":     `[]`,
+						"requestheader-uid-headers":          `[]`,
 						"requestheader-group-headers":        `[]`,
 						"requestheader-extra-headers-prefix": `[]`,
 						"requestheader-client-ca-file":       string(anotherRandomCA),
@@ -201,6 +205,7 @@ func TestWriteClientCAs(t *testing.T) {
 			name: "overwrite extension-apiserver-authentication requestheader",
 			clusterAuthInfo: ClusterAuthenticationInfo{
 				RequestHeaderUsernameHeaders:     headerrequest.StaticStringSlice{},
+				RequestHeaderUIDHeaders:          headerrequest.StaticStringSlice{},
 				RequestHeaderGroupHeaders:        headerrequest.StaticStringSlice{},
 				RequestHeaderExtraHeaderPrefixes: headerrequest.StaticStringSlice{},
 				RequestHeaderCA:                  anotherRandomCAProvider,
@@ -211,6 +216,7 @@ func TestWriteClientCAs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
 						"requestheader-username-headers":     `[]`,
+						"requestheader-uid-headers":          `[]`,
 						"requestheader-group-headers":        `[]`,
 						"requestheader-extra-headers-prefix": `[]`,
 						"requestheader-client-ca-file":       string(someRandomCA),
@@ -223,6 +229,7 @@ func TestWriteClientCAs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
 						"requestheader-username-headers":     `[]`,
+						"requestheader-uid-headers":          `[]`,
 						"requestheader-group-headers":        `[]`,
 						"requestheader-extra-headers-prefix": `[]`,
 						"requestheader-client-ca-file":       string(someRandomCA) + string(anotherRandomCA),
@@ -253,6 +260,7 @@ func TestWriteClientCAs(t *testing.T) {
 			name: "skip on no change",
 			clusterAuthInfo: ClusterAuthenticationInfo{
 				RequestHeaderUsernameHeaders:     headerrequest.StaticStringSlice{},
+				RequestHeaderUIDHeaders:          headerrequest.StaticStringSlice{},
 				RequestHeaderGroupHeaders:        headerrequest.StaticStringSlice{},
 				RequestHeaderExtraHeaderPrefixes: headerrequest.StaticStringSlice{},
 				RequestHeaderCA:                  anotherRandomCAProvider,
@@ -263,6 +271,7 @@ func TestWriteClientCAs(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 					Data: map[string]string{
 						"requestheader-username-headers":     `[]`,
+						"requestheader-uid-headers":          `[]`,
 						"requestheader-group-headers":        `[]`,
 						"requestheader-extra-headers-prefix": `[]`,
 						"requestheader-client-ca-file":       string(anotherRandomCA),
@@ -332,6 +341,7 @@ func TestWriteConfigMapDeleted(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
 		Data: map[string]string{
 			"requestheader-username-headers":     `[]`,
+			"requestheader-uid-headers":          `[]`,
 			"requestheader-group-headers":        `[]`,
 			"requestheader-extra-headers-prefix": `[]`,
 			"requestheader-client-ca-file":       string(anotherRandomCA),

--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -110,6 +110,7 @@ func (config Config) New(serverLifecycle context.Context) (authenticator.Request
 			config.RequestHeaderConfig.CAContentProvider.VerifyOptions,
 			config.RequestHeaderConfig.AllowedClientNames,
 			config.RequestHeaderConfig.UsernameHeaders,
+			config.RequestHeaderConfig.UIDHeaders,
 			config.RequestHeaderConfig.GroupHeaders,
 			config.RequestHeaderConfig.ExtraHeaderPrefixes,
 		)

--- a/pkg/kubeapiserver/options/authentication_test.go
+++ b/pkg/kubeapiserver/options/authentication_test.go
@@ -303,6 +303,7 @@ func TestToAuthenticationConfig(t *testing.T) {
 		},
 		RequestHeader: &apiserveroptions.RequestHeaderAuthenticationOptions{
 			UsernameHeaders:     []string{"x-remote-user"},
+			UIDHeaders:          []string{"x-remote-uid"},
 			GroupHeaders:        []string{"x-remote-group"},
 			ExtraHeaderPrefixes: []string{"x-remote-extra-"},
 			ClientCAFile:        "testdata/root.pem",
@@ -352,6 +353,7 @@ func TestToAuthenticationConfig(t *testing.T) {
 
 		RequestHeaderConfig: &authenticatorfactory.RequestHeaderConfig{
 			UsernameHeaders:     headerrequest.StaticStringSlice{"x-remote-user"},
+			UIDHeaders:          headerrequest.StaticStringSlice{"x-remote-uid"},
 			GroupHeaders:        headerrequest.StaticStringSlice{"x-remote-group"},
 			ExtraHeaderPrefixes: headerrequest.StaticStringSlice{"x-remote-extra-"},
 			CAContentProvider:   nil, // this is nil because you can't compare functions
@@ -397,6 +399,7 @@ func TestBuiltInAuthenticationOptionsAddFlags(t *testing.T) {
 		"--client-ca-file=client-cacert",
 		"--requestheader-client-ca-file=testdata/root.pem",
 		"--requestheader-username-headers=x-remote-user-custom",
+		"--requestheader-uid-headers=x-remote-uid-custom",
 		"--requestheader-group-headers=x-remote-group-custom",
 		"--requestheader-allowed-names=kube-aggregator",
 		"--service-account-key-file=cert",
@@ -430,6 +433,7 @@ func TestBuiltInAuthenticationOptionsAddFlags(t *testing.T) {
 		RequestHeader: &apiserveroptions.RequestHeaderAuthenticationOptions{
 			ClientCAFile:    "testdata/root.pem",
 			UsernameHeaders: []string{"x-remote-user-custom"},
+			UIDHeaders:      []string{"x-remote-uid-custom"},
 			GroupHeaders:    []string{"x-remote-group-custom"},
 			AllowedNames:    []string{"kube-aggregator"},
 		},

--- a/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/delegating.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/delegating.go
@@ -77,6 +77,7 @@ func (c DelegatingAuthenticatorConfig) New() (authenticator.Request, *spec.Secur
 			c.RequestHeaderConfig.CAContentProvider.VerifyOptions,
 			c.RequestHeaderConfig.AllowedClientNames,
 			c.RequestHeaderConfig.UsernameHeaders,
+			c.RequestHeaderConfig.UIDHeaders,
 			c.RequestHeaderConfig.GroupHeaders,
 			c.RequestHeaderConfig.ExtraHeaderPrefixes,
 		)

--- a/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/requestheader.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/requestheader.go
@@ -24,6 +24,8 @@ import (
 type RequestHeaderConfig struct {
 	// UsernameHeaders are the headers to check (in order, case-insensitively) for an identity. The first header with a value wins.
 	UsernameHeaders headerrequest.StringSliceProvider
+	// UsernameHeaders are the headers to check (in order, case-insensitively) for an identity UID. The first header with a value wins.
+	UIDHeaders headerrequest.StringSliceProvider
 	// GroupHeaders are the headers to check (case-insensitively) for a group names.  All values will be used.
 	GroupHeaders headerrequest.StringSliceProvider
 	// ExtraHeaderPrefixes are the head prefixes to check (case-insentively) for filling in

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
@@ -53,6 +53,9 @@ type requestHeaderAuthRequestHandler struct {
 	// nameHeaders are the headers to check (in order, case-insensitively) for an identity. The first header with a value wins.
 	nameHeaders StringSliceProvider
 
+	// nameHeaders are the headers to check (in order, case-insensitively) for an identity UID. The first header with a value wins.
+	uidHeaders StringSliceProvider
+
 	// groupHeaders are the headers to check (case-insensitively) for group membership.  All values of all headers will be added.
 	groupHeaders StringSliceProvider
 
@@ -61,8 +64,12 @@ type requestHeaderAuthRequestHandler struct {
 	extraHeaderPrefixes StringSliceProvider
 }
 
-func New(nameHeaders, groupHeaders, extraHeaderPrefixes []string) (authenticator.Request, error) {
+func New(nameHeaders, uidHeaders, groupHeaders, extraHeaderPrefixes []string) (authenticator.Request, error) {
 	trimmedNameHeaders, err := trimHeaders(nameHeaders...)
+	if err != nil {
+		return nil, err
+	}
+	trimmedUIDHeaders, err := trimHeaders(uidHeaders...)
 	if err != nil {
 		return nil, err
 	}
@@ -77,14 +84,16 @@ func New(nameHeaders, groupHeaders, extraHeaderPrefixes []string) (authenticator
 
 	return NewDynamic(
 		StaticStringSlice(trimmedNameHeaders),
+		StaticStringSlice(trimmedUIDHeaders),
 		StaticStringSlice(trimmedGroupHeaders),
 		StaticStringSlice(trimmedExtraHeaderPrefixes),
 	), nil
 }
 
-func NewDynamic(nameHeaders, groupHeaders, extraHeaderPrefixes StringSliceProvider) authenticator.Request {
+func NewDynamic(nameHeaders, uidHeaders, groupHeaders, extraHeaderPrefixes StringSliceProvider) authenticator.Request {
 	return &requestHeaderAuthRequestHandler{
 		nameHeaders:         nameHeaders,
+		uidHeaders:          uidHeaders,
 		groupHeaders:        groupHeaders,
 		extraHeaderPrefixes: extraHeaderPrefixes,
 	}
@@ -103,8 +112,8 @@ func trimHeaders(headerNames ...string) ([]string, error) {
 	return ret, nil
 }
 
-func NewDynamicVerifyOptionsSecure(verifyOptionFn x509request.VerifyOptionFunc, proxyClientNames, nameHeaders, groupHeaders, extraHeaderPrefixes StringSliceProvider) authenticator.Request {
-	headerAuthenticator := NewDynamic(nameHeaders, groupHeaders, extraHeaderPrefixes)
+func NewDynamicVerifyOptionsSecure(verifyOptionFn x509request.VerifyOptionFunc, proxyClientNames, nameHeaders, uidHeaders, groupHeaders, extraHeaderPrefixes StringSliceProvider) authenticator.Request {
+	headerAuthenticator := NewDynamic(nameHeaders, uidHeaders, groupHeaders, extraHeaderPrefixes)
 
 	return x509request.NewDynamicCAVerifier(verifyOptionFn, headerAuthenticator, proxyClientNames)
 }
@@ -114,23 +123,28 @@ func (a *requestHeaderAuthRequestHandler) AuthenticateRequest(req *http.Request)
 	if len(name) == 0 {
 		return nil, false, nil
 	}
+	uid := headerValue(req.Header, a.uidHeaders.Value())
 	groups := allHeaderValues(req.Header, a.groupHeaders.Value())
 	extra := newExtra(req.Header, a.extraHeaderPrefixes.Value())
 
 	// clear headers used for authentication
-	ClearAuthenticationHeaders(req.Header, a.nameHeaders, a.groupHeaders, a.extraHeaderPrefixes)
+	ClearAuthenticationHeaders(req.Header, a.nameHeaders, a.uidHeaders, a.groupHeaders, a.extraHeaderPrefixes)
 
 	return &authenticator.Response{
 		User: &user.DefaultInfo{
 			Name:   name,
+			UID:    uid,
 			Groups: groups,
 			Extra:  extra,
 		},
 	}, true, nil
 }
 
-func ClearAuthenticationHeaders(h http.Header, nameHeaders, groupHeaders, extraHeaderPrefixes StringSliceProvider) {
+func ClearAuthenticationHeaders(h http.Header, nameHeaders, uidHeaders, groupHeaders, extraHeaderPrefixes StringSliceProvider) {
 	for _, headerName := range nameHeaders.Value() {
+		h.Del(headerName)
+	}
+	for _, headerName := range uidHeaders.Value() {
 		h.Del(headerName)
 	}
 	for _, headerName := range groupHeaders.Value() {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication.go
@@ -54,6 +54,7 @@ func withAuthentication(handler http.Handler, auth authenticator.Request, failed
 	}
 	standardRequestHeaderConfig := &authenticatorfactory.RequestHeaderConfig{
 		UsernameHeaders:     headerrequest.StaticStringSlice{"X-Remote-User"},
+		UIDHeaders:          headerrequest.StaticStringSlice{"X-Remote-Uid"},
 		GroupHeaders:        headerrequest.StaticStringSlice{"X-Remote-Group"},
 		ExtraHeaderPrefixes: headerrequest.StaticStringSlice{"X-Remote-Extra-"},
 	}
@@ -90,6 +91,7 @@ func withAuthentication(handler http.Handler, auth authenticator.Request, failed
 		headerrequest.ClearAuthenticationHeaders(
 			req.Header,
 			standardRequestHeaderConfig.UsernameHeaders,
+			standardRequestHeaderConfig.UIDHeaders,
 			standardRequestHeaderConfig.GroupHeaders,
 			standardRequestHeaderConfig.ExtraHeaderPrefixes,
 		)
@@ -99,6 +101,7 @@ func withAuthentication(handler http.Handler, auth authenticator.Request, failed
 			headerrequest.ClearAuthenticationHeaders(
 				req.Header,
 				requestHeaderConfig.UsernameHeaders,
+				requestHeaderConfig.UIDHeaders,
 				requestHeaderConfig.GroupHeaders,
 				requestHeaderConfig.ExtraHeaderPrefixes,
 			)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication_test.go
@@ -285,6 +285,7 @@ func TestAuthenticateRequestError(t *testing.T) {
 func TestAuthenticateRequestClearHeaders(t *testing.T) {
 	testcases := map[string]struct {
 		nameHeaders        []string
+		uidHeaders         []string
 		groupHeaders       []string
 		extraPrefixHeaders []string
 		requestHeaders     http.Header
@@ -334,13 +335,39 @@ func TestAuthenticateRequestClearHeaders(t *testing.T) {
 				"X-Remote-Group": {"Users"},
 			},
 		},
+		"uid none": {
+			nameHeaders: []string{"X-Remote-User"},
+			uidHeaders:  []string{"X-Remote-Uid"},
+			requestHeaders: http.Header{
+				"X-Remote-User": {"Alice"},
+			},
+		},
+		"uid all matches": {
+			nameHeaders: []string{"X-Remote-User"},
+			uidHeaders:  []string{"X-Remote-Uid-1", "X-Remote-Uid-2"},
+			requestHeaders: http.Header{
+				"X-Remote-User":  {"Alice"},
+				"X-Remote-Uid-1": {"one"},
+				"X-Remote-Uid-2": {"two", "three"},
+			},
+		},
+		"uid case-insensitive": {
+			nameHeaders: []string{"X-Remote-USER"},
+			uidHeaders:  []string{"X-REMOTE-UID-1"},
+			requestHeaders: http.Header{
+				"X-Remote-User":  {"Alice"},
+				"X-Remote-Uid-1": {"one"},
+			},
+		},
 
 		"extra prefix matches case-insensitive": {
 			nameHeaders:        []string{"X-Remote-User"},
+			uidHeaders:         []string{"X-Remote-Uid-1"},
 			groupHeaders:       []string{"X-Remote-Group-1", "X-Remote-Group-2"},
 			extraPrefixHeaders: []string{"X-Remote-Extra-1-", "X-Remote-Extra-2-"},
 			requestHeaders: http.Header{
 				"X-Remote-User":         {"Bob"},
+				"X-Remote-Uid-1":        {"bobs-uid"},
 				"X-Remote-Group-1":      {"one-a", "one-b"},
 				"X-Remote-Group-2":      {"two-a", "two-b"},
 				"X-Remote-extra-1-key1": {"alfa", "bravo"},
@@ -354,12 +381,15 @@ func TestAuthenticateRequestClearHeaders(t *testing.T) {
 
 		"extra prefix matches case-insensitive with unrelated headers": {
 			nameHeaders:        []string{"X-Remote-User"},
+			uidHeaders:         []string{"X-Remote-Uid"},
 			groupHeaders:       []string{"X-Remote-Group-1", "X-Remote-Group-2"},
 			extraPrefixHeaders: []string{"X-Remote-Extra-1-", "X-Remote-Extra-2-"},
 			requestHeaders: http.Header{
 				"X-Group-Remote":        {"snorlax"}, // unrelated header
 				"X-Group-Bear":          {"panda"},   // another unrelated header
+				"X-Uid-Remote":          {"bobs-unrelated-uid"},
 				"X-Remote-User":         {"Bob"},
+				"X-Remote-Uid":          {"bobs-uid"},
 				"X-Remote-Group-1":      {"one-a", "one-b"},
 				"X-Remote-Group-2":      {"two-a", "two-b"},
 				"X-Remote-extra-1-key1": {"alfa", "bravo"},
@@ -372,15 +402,18 @@ func TestAuthenticateRequestClearHeaders(t *testing.T) {
 			finalHeaders: http.Header{
 				"X-Group-Remote": {"snorlax"},
 				"X-Group-Bear":   {"panda"},
+				"X-Uid-Remote":   {"bobs-unrelated-uid"},
 			},
 		},
 
 		"custom config but request contains standard headers": {
 			nameHeaders:        []string{"foo"},
+			uidHeaders:         []string{"footoo"},
 			groupHeaders:       []string{"bar"},
 			extraPrefixHeaders: []string{"baz"},
 			requestHeaders: http.Header{
 				"X-Remote-User":         {"Bob"},
+				"X-Remote-Uid":          {"bobs-uid"},
 				"X-Remote-Group-1":      {"one-a", "one-b"},
 				"X-Remote-Group-2":      {"two-a", "two-b"},
 				"X-Remote-extra-1-key1": {"alfa", "bravo"},
@@ -398,10 +431,12 @@ func TestAuthenticateRequestClearHeaders(t *testing.T) {
 
 		"custom config but request contains standard and custom headers": {
 			nameHeaders:        []string{"one"},
+			uidHeaders:         []string{"onetoo"},
 			groupHeaders:       []string{"two"},
 			extraPrefixHeaders: []string{"three-"},
 			requestHeaders: http.Header{
 				"X-Remote-User":         {"Bob"},
+				"X-Remote-Uid":          {"bobs-uid"},
 				"X-Remote-Group-3":      {"one-a", "one-b"},
 				"X-Remote-Group-4":      {"two-a", "two-b"},
 				"X-Remote-extra-1-key1": {"alfa", "bravo"},
@@ -422,10 +457,12 @@ func TestAuthenticateRequestClearHeaders(t *testing.T) {
 
 		"escaped extra keys": {
 			nameHeaders:        []string{"X-Remote-User"},
+			uidHeaders:         []string{"X-Remote-Uid"},
 			groupHeaders:       []string{"X-Remote-Group"},
 			extraPrefixHeaders: []string{"X-Remote-Extra-"},
 			requestHeaders: http.Header{
 				"X-Remote-User":                                            {"Bob"},
+				"X-Remote-Uid":                                             {"bobs-uid"},
 				"X-Remote-Group":                                           {"one-a", "one-b"},
 				"X-Remote-Extra-Alpha":                                     {"alphabetical"},
 				"X-Remote-Extra-Alph4num3r1c":                              {"alphanumeric"},
@@ -455,6 +492,7 @@ func TestAuthenticateRequestClearHeaders(t *testing.T) {
 				nil,
 				&authenticatorfactory.RequestHeaderConfig{
 					UsernameHeaders:     headerrequest.StaticStringSlice(testcase.nameHeaders),
+					UIDHeaders:          headerrequest.StaticStringSlice(testcase.uidHeaders),
 					GroupHeaders:        headerrequest.StaticStringSlice(testcase.groupHeaders),
 					ExtraHeaderPrefixes: headerrequest.StaticStringSlice(testcase.extraPrefixHeaders),
 				},

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -245,8 +245,13 @@ func NewDelegatingAuthenticationOptions() *DelegatingAuthenticationOptions {
 		CacheTTL:   10 * time.Second,
 		ClientCert: ClientCertAuthenticationOptions{},
 		RequestHeader: RequestHeaderAuthenticationOptions{
-			UsernameHeaders:     []string{"x-remote-user"},
-			UIDHeaders:          []string{"x-remote-uid"},
+			UsernameHeaders: []string{"x-remote-user"},
+			// we specifically don't default UID headers as these were introduced
+			// later (kube 1.32) and we don't want 3rd parties to be trusting the default headers
+			// before we can safely say that all KAS instances know they should
+			// remove them from an incoming request in its WithAuthentication handler.
+			// The defaulting will be enabled in a future (1.33+) version.
+			UIDHeaders:          nil,
 			GroupHeaders:        []string{"x-remote-group"},
 			ExtraHeaderPrefixes: []string{"x-remote-extra-"},
 		},

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication_dynamic_request_header.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication_dynamic_request_header.go
@@ -55,6 +55,7 @@ func newDynamicRequestHeaderController(client kubernetes.Interface) (*DynamicReq
 		authenticationConfigMapNamespace,
 		client,
 		"requestheader-username-headers",
+		"requestheader-uid-headers",
 		"requestheader-group-headers",
 		"requestheader-extra-headers-prefix",
 		"requestheader-allowed-names",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication_test.go
@@ -39,6 +39,7 @@ func TestToAuthenticationRequestHeaderConfig(t *testing.T) {
 			name: "test when ClientCAFile is nil",
 			testOptions: &RequestHeaderAuthenticationOptions{
 				UsernameHeaders:     headerrequest.StaticStringSlice{"x-remote-user"},
+				UIDHeaders:          headerrequest.StaticStringSlice{"x-remote-uid"},
 				GroupHeaders:        headerrequest.StaticStringSlice{"x-remote-group"},
 				ExtraHeaderPrefixes: headerrequest.StaticStringSlice{"x-remote-extra-"},
 				AllowedNames:        headerrequest.StaticStringSlice{"kube-aggregator"},
@@ -49,12 +50,14 @@ func TestToAuthenticationRequestHeaderConfig(t *testing.T) {
 			testOptions: &RequestHeaderAuthenticationOptions{
 				ClientCAFile:        "testdata/root.pem",
 				UsernameHeaders:     headerrequest.StaticStringSlice{"x-remote-user"},
+				UIDHeaders:          headerrequest.StaticStringSlice{"x-remote-uid"},
 				GroupHeaders:        headerrequest.StaticStringSlice{"x-remote-group"},
 				ExtraHeaderPrefixes: headerrequest.StaticStringSlice{"x-remote-extra-"},
 				AllowedNames:        headerrequest.StaticStringSlice{"kube-aggregator"},
 			},
 			expectConfig: &authenticatorfactory.RequestHeaderConfig{
 				UsernameHeaders:     headerrequest.StaticStringSlice{"x-remote-user"},
+				UIDHeaders:          headerrequest.StaticStringSlice{"x-remote-uid"},
 				GroupHeaders:        headerrequest.StaticStringSlice{"x-remote-group"},
 				ExtraHeaderPrefixes: headerrequest.StaticStringSlice{"x-remote-extra-"},
 				CAContentProvider:   nil, // this is nil because you can't compare functions

--- a/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peerproxy_handler.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peerproxy_handler.go
@@ -251,7 +251,7 @@ func (h *peerProxyHandler) proxyRequestToDestinationAPIServer(req *http.Request,
 	newReq.Header.Add(PeerProxiedHeader, "true")
 	defer cancelFn()
 
-	proxyRoundTripper := transport.NewAuthProxyRoundTripper(user.GetName(), user.GetGroups(), user.GetExtra(), h.proxyTransport)
+	proxyRoundTripper := transport.NewAuthProxyRoundTripper(user.GetName(), user.GetUID(), user.GetGroups(), user.GetExtra(), h.proxyTransport)
 
 	delegate := &epmetrics.ResponseWriterDelegator{ResponseWriter: rw}
 	w := responsewriter.WrapForHTTP1Or2(delegate)

--- a/staging/src/k8s.io/cloud-provider/options/options_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/options_test.go
@@ -133,6 +133,7 @@ func TestDefaultFlags(t *testing.T) {
 			ClientCert:          apiserveroptions.ClientCertAuthenticationOptions{},
 			RequestHeader: apiserveroptions.RequestHeaderAuthenticationOptions{
 				UsernameHeaders:     []string{"x-remote-user"},
+				UIDHeaders:          []string{"x-remote-uid"},
 				GroupHeaders:        []string{"x-remote-group"},
 				ExtraHeaderPrefixes: []string{"x-remote-extra-"},
 			},
@@ -293,6 +294,7 @@ func TestAddFlags(t *testing.T) {
 			ClientCert:          apiserveroptions.ClientCertAuthenticationOptions{},
 			RequestHeader: apiserveroptions.RequestHeaderAuthenticationOptions{
 				UsernameHeaders:     []string{"x-remote-user"},
+				UIDHeaders:          []string{"x-remote-uid"},
 				GroupHeaders:        []string{"x-remote-group"},
 				ExtraHeaderPrefixes: []string{"x-remote-extra-"},
 			},

--- a/staging/src/k8s.io/cloud-provider/options/options_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/options_test.go
@@ -133,7 +133,7 @@ func TestDefaultFlags(t *testing.T) {
 			ClientCert:          apiserveroptions.ClientCertAuthenticationOptions{},
 			RequestHeader: apiserveroptions.RequestHeaderAuthenticationOptions{
 				UsernameHeaders:     []string{"x-remote-user"},
-				UIDHeaders:          []string{"x-remote-uid"},
+				UIDHeaders:          nil,
 				GroupHeaders:        []string{"x-remote-group"},
 				ExtraHeaderPrefixes: []string{"x-remote-extra-"},
 			},
@@ -294,7 +294,7 @@ func TestAddFlags(t *testing.T) {
 			ClientCert:          apiserveroptions.ClientCertAuthenticationOptions{},
 			RequestHeader: apiserveroptions.RequestHeaderAuthenticationOptions{
 				UsernameHeaders:     []string{"x-remote-user"},
-				UIDHeaders:          []string{"x-remote-uid"},
+				UIDHeaders:          nil,
 				GroupHeaders:        []string{"x-remote-group"},
 				ExtraHeaderPrefixes: []string{"x-remote-extra-"},
 			},

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -159,7 +159,7 @@ func (r *proxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	proxyRoundTripper := handlingInfo.proxyRoundTripper
 	upgrade := httpstream.IsUpgradeRequest(req)
 
-	proxyRoundTripper = transport.NewAuthProxyRoundTripper(user.GetName(), user.GetGroups(), user.GetExtra(), proxyRoundTripper)
+	proxyRoundTripper = transport.NewAuthProxyRoundTripper(user.GetName(), user.GetUID(), user.GetGroups(), user.GetExtra(), proxyRoundTripper)
 
 	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIServerTracing) && !upgrade {
 		tracingWrapper := tracing.WrapperFor(r.tracerProvider)
@@ -170,7 +170,7 @@ func (r *proxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// NOT use the proxyRoundTripper.  It's a direct dial that bypasses the proxyRoundTripper.  This means that we have to
 	// attach the "correct" user headers to the request ahead of time.
 	if upgrade {
-		transport.SetAuthProxyHeaders(newReq, user.GetName(), user.GetGroups(), user.GetExtra())
+		transport.SetAuthProxyHeaders(newReq, user.GetName(), user.GetUID(), user.GetGroups(), user.GetExtra())
 	}
 
 	handler := proxy.NewUpgradeAwareHandler(location, proxyRoundTripper, true, upgrade, &responder{w: w})

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/remote/remote_available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/remote/remote_available_controller.go
@@ -305,7 +305,7 @@ func (c *AvailableConditionController) sync(key string) error {
 					}
 
 					// setting the system-masters identity ensures that we will always have access rights
-					transport.SetAuthProxyHeaders(newReq, "system:kube-aggregator", []string{"system:masters"}, nil)
+					transport.SetAuthProxyHeaders(newReq, "system:kube-aggregator", "", []string{"system:masters"}, nil)
 					resp, err := discoveryClient.Do(newReq)
 					if resp != nil {
 						resp.Body.Close()

--- a/test/integration/auth/requestheader_test.go
+++ b/test/integration/auth/requestheader_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"os"
+	"testing"
+	"time"
+
+	authnv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	"k8s.io/kubernetes/test/integration/framework"
+	testutils "k8s.io/kubernetes/test/utils"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+func TestAuthnToKAS(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
+	frontProxyCA, frontProxyClient, frontProxyKey, err := newTestCAWithClient(
+		pkix.Name{
+			CommonName: "test-front-proxy-ca",
+		},
+		pkix.Name{
+			CommonName: "test-aggregated-apiserver",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	modifyOpts := func(setUIDHeaders bool) func(opts *options.ServerRunOptions) {
+		return func(opts *options.ServerRunOptions) {
+			opts.GenericServerRunOptions.MaxRequestBodyBytes = 1024 * 1024
+
+			// rewrite the client + request header CA certs with our own content
+			frontProxyCAFilename := opts.Authentication.RequestHeader.ClientCAFile
+			if err := os.WriteFile(frontProxyCAFilename, frontProxyCA, 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			opts.Authentication.RequestHeader.AllowedNames = append(opts.Authentication.RequestHeader.AllowedNames, "test-aggregated-apiserver")
+			if setUIDHeaders {
+				opts.Authentication.RequestHeader.UIDHeaders = []string{"X-Remote-Uid"}
+			}
+		}
+	}
+
+	for _, tt := range []struct {
+		name   string
+		setUID bool
+	}{
+		{
+			name:   "KAS without UID config",
+			setUID: false,
+		},
+		{
+			name:   "KAS with UID config",
+			setUID: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, kubeConfig, tearDownFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{
+				ModifyServerRunOptions: modifyOpts(tt.setUID),
+			})
+			defer tearDownFn()
+
+			// Test an aggregated apiserver client (signed by the new front proxy CA) is authorized
+			extensionApiserverClient, err := kubernetes.NewForConfig(&rest.Config{
+				Host: kubeConfig.Host,
+				TLSClientConfig: rest.TLSClientConfig{
+					CAData:     kubeConfig.TLSClientConfig.CAData,
+					CAFile:     kubeConfig.TLSClientConfig.CAFile,
+					ServerName: kubeConfig.TLSClientConfig.ServerName,
+					KeyData:    frontProxyKey,
+					CertData:   frontProxyClient,
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			selfInfo := &authnv1.SelfSubjectReview{}
+			err = extensionApiserverClient.AuthenticationV1().RESTClient().
+				Post().
+				Resource("selfsubjectreviews").
+				VersionedParams(&metav1.CreateOptions{}, scheme.ParameterCodec).
+				Body(&authnv1.SelfSubjectReview{}).
+				SetHeader("X-Remote-Uid", "test-uid").
+				SetHeader("X-Remote-User", "testuser").
+				SetHeader("X-Remote-Groups", "group1", "group2").
+				Do(tCtx).
+				Into(selfInfo)
+			if err != nil {
+				t.Fatalf("failed to retrieve self-info: %v", err)
+			}
+
+			if selfUID := selfInfo.Status.UserInfo.UID; (len(selfUID) != 0) != tt.setUID {
+				t.Errorf("UID should be set: %v, but we got %v", tt.setUID, selfUID)
+			}
+		})
+	}
+
+}
+
+func newTestCAWithClient(caSubject pkix.Name, clientSubject pkix.Name) (caPEMBytes, clientCertPEMBytes, clientKeyPEMBytes []byte, err error) {
+	caPrivateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	newCA, err := certutil.NewSelfSignedCACert(certutil.Config{
+		CommonName:   caSubject.CommonName,
+		Organization: caSubject.Organization,
+		NotBefore:    time.Now().Add(-time.Minute),
+	}, caPrivateKey)
+
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	clientCertPrivateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	clientCertPrivateKeyPEM, err := keyutil.MarshalPrivateKeyToPEM(clientCertPrivateKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	clientCert, err := testutils.NewSignedCert(&certutil.Config{
+		CommonName:   clientSubject.CommonName,
+		Organization: clientSubject.Organization,
+		NotBefore:    time.Now().Add(-time.Minute),
+		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}, clientCertPrivateKey, newCA, caPrivateKey)
+
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	caPEMBytes = testutils.EncodeCertPEM(newCA)
+	clientCertPEMBytes = testutils.EncodeCertPEM(clientCert)
+	return caPEMBytes,
+		clientCertPEMBytes,
+		clientCertPrivateKeyPEM,
+		nil
+}

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -29,16 +29,22 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
+	v1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+	"k8s.io/apiserver/pkg/authentication/user"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
 	utilversion "k8s.io/apiserver/pkg/util/version"
@@ -46,6 +52,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/component-base/featuregate"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -246,6 +253,124 @@ func TestAggregatedAPIServer(t *testing.T) {
 	t.Run("WithWardleFeatureGateAtV1.0", func(t *testing.T) {
 		testAggregatedAPIServer(t, true, true, "1.1", "1.0")
 	})
+}
+
+// TestFrontProxyConfig tests that the RequestHeader configuration is consumed
+// correctly by the aggregated API servers.
+func TestFrontProxyConfig(t *testing.T) {
+	const testNamespace = "integration-test-front-proxy-config"
+	const wardleBinaryVersion = "1.1"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	t.Cleanup(cancel)
+
+	// each wardle binary is bundled with a specific kube binary.
+	kubeBinaryVersion := sampleserver.WardleVersionToKubeVersion(version.MustParse(wardleBinaryVersion)).String()
+
+	// start up the KAS and prepare the options for the wardle API server
+	testKAS, wardleOptions, wardlePort := prepareAggregatedWardleAPIServer(ctx, t, testNamespace, kubeBinaryVersion, wardleBinaryVersion)
+	kubeConfig := getKubeConfig(testKAS)
+
+	// create the SA that we will use to query the aggregated API
+	kubeClient := client.NewForConfigOrDie(kubeConfig)
+	expectedSA, err := kubeClient.CoreV1().ServiceAccounts(testNamespace).Create(ctx, &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "wardle-client-sa",
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedSAUserInfo := serviceaccount.UserInfo(expectedSA.Namespace, expectedSA.Name, string(expectedSA.UID))
+	expectedRealSAGroups := append(expectedSAUserInfo.GetGroups(), user.AllAuthenticated)
+
+	saTokenReq, err := kubeClient.CoreV1().ServiceAccounts(testNamespace).CreateToken(ctx, "wardle-client-sa", &v1.TokenRequest{}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	saToken := saTokenReq.Status.Token
+	if len(saToken) == 0 {
+		t.Fatal("empty SA token in token request response")
+	}
+
+	saClientConfig := rest.AnonymousClientConfig(kubeConfig)
+	saClientConfig.BearerToken = saToken
+
+	saKubeClient := client.NewForConfigOrDie(saClientConfig)
+	saDetails, err := saKubeClient.AuthenticationV1().SelfSubjectReviews().Create(ctx, &v1.SelfSubjectReview{}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to retrieve details about the SA: %v", err)
+	}
+	expectedExtra := expectedSAUserInfo.GetExtra()
+	if expectedExtra == nil {
+		expectedExtra = map[string][]string{}
+	}
+	expectedExtra[user.CredentialIDKey] = saDetails.Status.UserInfo.Extra[user.CredentialIDKey]
+
+	var checksProcessed atomic.Uint32
+
+	// wrap the authz round tripper to catch the request for our SA SAR to the KAS
+	wardleOptions.RecommendedOptions.Authorization.WithCustomRoundTripper(
+		// adding a round tripper wrapper to test default RequestHeader configuration
+		transport.WrapperFunc(func(rt http.RoundTripper) http.RoundTripper {
+			return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				gotUser, ok := genericapirequest.UserFrom(req.Context())
+				if !ok {
+					return nil, fmt.Errorf("got an unauthenticated request")
+				}
+
+				// this is likely the KAS checking the OpenAPI endpoints
+				if gotUser.GetName() == "system:anonymous" || gotUser.GetName() == "system:aggregator" {
+					return rt.RoundTrip(req)
+				}
+
+				if len(gotUser.GetUID()) == 0 {
+					t.Errorf("expected UID to be non-empty for user %q", gotUser.GetName())
+				}
+				if got, expected := gotUser.GetUID(), expectedSAUserInfo.GetUID(); expected != got {
+					t.Errorf("expected UID: %q, got: %q", expected, got)
+				}
+				if got, expected := gotUser.GetName(), expectedSAUserInfo.GetName(); expected != got {
+					t.Errorf("expected name: %q, got: %q", expected, got)
+				}
+				if got := gotUser.GetGroups(); !reflect.DeepEqual(expectedRealSAGroups, got) {
+					t.Errorf("expected groups: %v, got: %v", expectedRealSAGroups, got)
+				}
+				if got := gotUser.GetExtra(); !apiequality.Semantic.DeepEqual(expectedExtra, got) {
+					t.Errorf("expected extra to be %v, but got %v", expectedExtra, got)
+				}
+
+				checksProcessed.Add(1)
+				return rt.RoundTrip(req)
+			})
+		}),
+	)
+
+	wardleCertDir, _ := os.MkdirTemp("", "test-integration-wardle-server")
+	defer os.RemoveAll(wardleCertDir)
+
+	runPreparedWardleServer(ctx, t, wardleOptions, wardleCertDir, wardlePort, false, true, wardleBinaryVersion, kubeConfig)
+	waitForWardleAPIServiceReady(ctx, t, kubeConfig, wardleCertDir, testNamespace)
+
+	// get the wardle API client using our SA token
+	wardleClientConfig := rest.AnonymousClientConfig(kubeConfig)
+	wardleClientConfig.BearerToken = saToken
+	wardleClient := wardlev1alpha1client.NewForConfigOrDie(wardleClientConfig)
+
+	_, err = wardleClient.Flunders(metav1.NamespaceSystem).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if checksProcessed.Load() != 1 {
+		t.Errorf("the request is in fact not being tested")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func testAggregatedAPIServer(t *testing.T, setWardleFeatureGate, banFlunder bool, wardleBinaryVersion, wardleEmulationVersion string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds the ability to set a UID header in order to be recognized in the RequestHeader authentication. It pushes the new header configuration into the `kube-system/extension-apiserver-authentication` CM, and makes the client-go AuthProxyRoundTripper add user UID to the requests it handles.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #93699

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver: a new `--requestheader-uid-headers` flag allows configuring request header authentication to obtain the authenticating user's UID from the specified headers. The suggested value for the new option is `X-Remote-Uid`. When specified, the `kube-system/extension-apiserver-authentication` configmap will include the value in its `.data[requestheader-uid-headers]` field.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
