### PR TITLE
fix terminationGracePeriod blocked by preStop

### DIFF
--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -515,4 +515,84 @@ var _ = SIGDescribe("[NodeConformance] Containers Lifecycle ", func() {
 		// while the regular container did
 		framework.ExpectNoError(results.HasRestarted(regular1))
 	})
+
+	ginkgo.When("a pod cannot terminate gracefully", func() {
+		testPod := func(name string, gracePeriod int64) *v1.Pod {
+			return &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "busybox",
+							Image: imageutils.GetE2EImage(imageutils.BusyBox),
+							Command: []string{
+								"sleep",
+								"10000",
+							},
+						},
+					},
+					TerminationGracePeriodSeconds: &gracePeriod,
+				},
+			}
+		}
+
+		// To account for the time it takes to delete the pod, we add a 10 second
+		// buffer. The 10 second buffer is arbitrary, but it should be enough to
+		// account for the time it takes to delete the pod.
+		bufferSeconds := int64(10)
+
+		ginkgo.It("should respect termination grace period seconds [NodeConformance]", func() {
+			client := e2epod.NewPodClient(f)
+			gracePeriod := int64(30)
+
+			ginkgo.By("creating a pod with a termination grace period seconds")
+			pod := testPod("pod-termination-grace-period", gracePeriod)
+			pod = client.Create(context.TODO(), pod)
+
+			ginkgo.By("ensuring the pod is running")
+			err := e2epod.WaitForPodRunningInNamespace(context.TODO(), f.ClientSet, pod)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("deleting the pod gracefully")
+			err = client.Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("ensuring the pod is terminated within the grace period seconds + buffer seconds")
+			err = e2epod.WaitForPodNotFoundInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace, time.Duration(gracePeriod+bufferSeconds)*time.Second)
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should respect termination grace period seconds with long-running preStop hook [NodeConformance]", func() {
+			client := e2epod.NewPodClient(f)
+			gracePeriod := int64(30)
+
+			ginkgo.By("creating a pod with a termination grace period seconds and long-running preStop hook")
+			pod := testPod("pod-termination-grace-period", gracePeriod)
+			pod.Spec.Containers[0].Lifecycle = &v1.Lifecycle{
+				PreStop: &v1.LifecycleHandler{
+					Exec: &v1.ExecAction{
+						Command: []string{
+							"sleep",
+							"10000",
+						},
+					},
+				},
+			}
+			pod = client.Create(context.TODO(), pod)
+
+			ginkgo.By("ensuring the pod is running")
+			err := e2epod.WaitForPodRunningInNamespace(context.TODO(), f.ClientSet, pod)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("deleting the pod gracefully")
+			err = client.Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("ensuring the pod is terminated within the grace period seconds + buffer seconds")
+			err = e2epod.WaitForPodNotFoundInNamespace(context.TODO(), f.ClientSet, pod.Name, pod.Namespace, time.Duration(gracePeriod+bufferSeconds)*time.Second)
+			framework.ExpectNoError(err)
+		})
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
fix unreasonable hang caused by preStopHook after terminationGracePeriodSeconds, which is different from what is described in https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115817

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed the preStop hook will block the pod termination grace period
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
