### PR TITLE
kubectl: use pointer.Bool instead of deprecated pointer.BoolPtr

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles.go
@@ -252,7 +252,7 @@ func useHostNamespaces(p *corev1.Pod) {
 // shareProcessNamespace configures all containers in the pod to share the
 // process namespace.
 func shareProcessNamespace(p *corev1.Pod) {
-	p.Spec.ShareProcessNamespace = pointer.BoolPtr(true)
+	p.Spec.ShareProcessNamespace = pointer.Bool(true)
 }
 
 // clearSecurityContext clears the security context for the container.
@@ -275,7 +275,7 @@ func setPrivileged(p *corev1.Pod, containerName string) {
 		if c.SecurityContext == nil {
 			c.SecurityContext = &corev1.SecurityContext{}
 		}
-		c.SecurityContext.Privileged = pointer.BoolPtr(true)
+		c.SecurityContext.Privileged = pointer.Bool(true)
 		return false
 	})
 }
@@ -287,7 +287,7 @@ func disallowRoot(p *corev1.Pod, containerName string) {
 			return true
 		}
 		c.SecurityContext = &corev1.SecurityContext{
-			RunAsNonRoot: pointer.BoolPtr(true),
+			RunAsNonRoot: pointer.Bool(true),
 		}
 		return false
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replace deprecated pointer.BoolPtr in kubectl debug profiles.

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/kubectl/issues/1108

followup from this comment: https://github.com/kubernetes/kubernetes/pull/115712/#discussion_r1108059878

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
