### PR TITLE
kubectl run: add container name flag `--container`

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -126,6 +126,7 @@ type RunOptions struct {
 	fieldManager   string
 
 	Namespace        string
+	ContainerName    string
 	EnforceNamespace bool
 
 	genericclioptions.IOStreams
@@ -165,6 +166,8 @@ func NewCmdRun(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Co
 	addRunFlags(cmd, o)
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodAttachTimeout)
+
+	cmdutil.AddContainerVarFlags(cmd, &o.ContainerName, o.ContainerName)
 
 	// Deprecate the cascade flag. If set, it has no practical effect since the created pod has no dependents.
 	// TODO: Remove the cascade flag from the run command in kubectl 1.29
@@ -345,10 +348,11 @@ func (o *RunOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 
 		opts := &attach.AttachOptions{
 			StreamOptions: exec.StreamOptions{
-				IOStreams: o.IOStreams,
-				Stdin:     o.Interactive,
-				TTY:       o.TTY,
-				Quiet:     o.Quiet,
+				IOStreams:     o.IOStreams,
+				Stdin:         o.Interactive,
+				TTY:           o.TTY,
+				Quiet:         o.Quiet,
+				ContainerName: o.ContainerName,
 			},
 			GetPodTimeout: timeout,
 			CommandName:   cmd.Parent().CommandPath() + " attach",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

It adds the same `--container`, `-c` flag to specify the container name to attach to that `exec` and `attach` have. It's especially important in the presence of webhooks that inject additional containers.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added `--container` flag to `kubectl run` to specify the container name to attach to.
```