### PR TITLE
initialize ContainerStatus.Started on creation

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -77,6 +77,8 @@ const (
 	ContainerCreating = "ContainerCreating"
 )
 
+var boolFalse = false
+
 // Get a list of pods that have data directories.
 func (kl *Kubelet) listPodsFromDisk() ([]types.UID, error) {
 	podInfos, err := os.ReadDir(kl.getPodsDir())
@@ -1669,6 +1671,7 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			Image:        cs.Image,
 			ImageID:      cs.ImageID,
 			ContainerID:  cid,
+			Started:      &boolFalse,
 		}
 		switch {
 		case cs.State == kubecontainer.ContainerStateRunning:
@@ -1730,9 +1733,10 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 
 	for _, container := range containers {
 		status := &v1.ContainerStatus{
-			Name:  container.Name,
-			Image: container.Image,
-			State: defaultWaitingState,
+			Name:    container.Name,
+			Image:   container.Image,
+			State:   defaultWaitingState,
+			Started: &boolFalse,
 		}
 		oldStatus, found := oldStatuses[container.Name]
 		if found {

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -1766,6 +1766,7 @@ func waitingStateWithReason(cName, reason string) v1.ContainerStatus {
 		State: v1.ContainerState{
 			Waiting: &v1.ContainerStateWaiting{Reason: reason},
 		},
+		Started: &boolFalse,
 	}
 }
 func waitingStateWithLastTermination(cName string) v1.ContainerStatus {
@@ -1779,6 +1780,7 @@ func waitingStateWithLastTermination(cName string) v1.ContainerStatus {
 				ExitCode: 0,
 			},
 		},
+		Started: &boolFalse,
 	}
 }
 func waitingStateWithNonZeroTermination(cName string) v1.ContainerStatus {
@@ -1792,6 +1794,7 @@ func waitingStateWithNonZeroTermination(cName string) v1.ContainerStatus {
 				ExitCode: -1,
 			},
 		},
+		Started: &boolFalse,
 	}
 }
 func runningState(cName string) v1.ContainerStatus {
@@ -1800,6 +1803,7 @@ func runningState(cName string) v1.ContainerStatus {
 		State: v1.ContainerState{
 			Running: &v1.ContainerStateRunning{},
 		},
+		Started: &boolFalse,
 	}
 }
 func runningStateWithStartedAt(cName string, startedAt time.Time) v1.ContainerStatus {
@@ -1808,6 +1812,7 @@ func runningStateWithStartedAt(cName string, startedAt time.Time) v1.ContainerSt
 		State: v1.ContainerState{
 			Running: &v1.ContainerStateRunning{StartedAt: metav1.Time{Time: startedAt}},
 		},
+		Started: &boolFalse,
 	}
 }
 func stoppedState(cName string) v1.ContainerStatus {
@@ -1816,6 +1821,7 @@ func stoppedState(cName string) v1.ContainerStatus {
 		State: v1.ContainerState{
 			Terminated: &v1.ContainerStateTerminated{},
 		},
+		Started: &boolFalse,
 	}
 }
 func succeededState(cName string) v1.ContainerStatus {
@@ -1826,6 +1832,7 @@ func succeededState(cName string) v1.ContainerStatus {
 				ExitCode: 0,
 			},
 		},
+		Started: &boolFalse,
 	}
 }
 func failedState(cName string) v1.ContainerStatus {
@@ -1836,6 +1843,7 @@ func failedState(cName string) v1.ContainerStatus {
 				ExitCode: -1,
 			},
 		},
+		Started: &boolFalse,
 	}
 }
 func waitingWithLastTerminationUnknown(cName string, restartCount int32) v1.ContainerStatus {
@@ -1852,6 +1860,7 @@ func waitingWithLastTerminationUnknown(cName string, restartCount int32) v1.Cont
 			},
 		},
 		RestartCount: restartCount,
+		Started:      &boolFalse,
 	}
 }
 func ready(status v1.ContainerStatus) v1.ContainerStatus {
@@ -2867,6 +2876,8 @@ func Test_generateAPIPodStatus(t *testing.T) {
 					ready(waitingStateWithReason("containerA", "ContainerCreating")),
 					ready(withID(runningStateWithStartedAt("containerB", time.Unix(1, 0).UTC()), "://foo")),
 				},
+				InitContainerStatuses:      []v1.ContainerStatus{},
+				EphemeralContainerStatuses: []v1.ContainerStatus{},
 			},
 			expectedPodHasNetworkCondition: v1.PodCondition{
 				Type:   kubetypes.PodHasNetwork,
@@ -2925,6 +2936,7 @@ func Test_generateAPIPodStatus(t *testing.T) {
 					ready(withID(runningStateWithStartedAt("containerA", time.Unix(1, 0).UTC()), "://c1")),
 					ready(withID(runningStateWithStartedAt("containerB", time.Unix(2, 0).UTC()), "://c2")),
 				},
+				InitContainerStatuses: []v1.ContainerStatus{},
 			},
 			expectedPodHasNetworkCondition: v1.PodCondition{
 				Type:   kubetypes.PodHasNetwork,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In the context of preparing implementation for the [sidecar KEP](https://github.com/kubernetes/enhancements/issues/753) we need a clearly defined behavior for the `Started` field of `ContainerStatus`.
This is documented in #115463 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115553 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/753
- [Usage]: https://github.com/kubernetes/kubernetes/pull/115463
```
