### PR TITLE
Deflake tests in `staging/src/k8s.io/kube-aggregator/pkg/apiserver`

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery_test.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -38,19 +39,22 @@ import (
 	discoveryendpoint "k8s.io/apiserver/pkg/endpoints/discovery/aggregated"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
 
 func newDiscoveryManager(rm discoveryendpoint.ResourceManager) *discoveryManager {
-	return NewDiscoveryManager(rm).(*discoveryManager)
+	dm := NewDiscoveryManager(rm).(*discoveryManager)
+	dm.dirtyAPIServiceQueue = newCompleterWorkqueue(dm.dirtyAPIServiceQueue)
+
+	return dm
 }
 
-// Returns true if the queue of services to sync empty this means everything has
-// been reconciled and placed into merged document
-func waitForEmptyQueue(stopCh <-chan struct{}, dm *discoveryManager) bool {
+// Returns true if the queue of services to sync is complete which means
+// everything has been reconciled and placed into merged document
+func waitForQueueComplete(stopCh <-chan struct{}, dm *discoveryManager) bool {
 	return cache.WaitForCacheSync(stopCh, func() bool {
-		// Once items have successfully synced they are removed from queue.
-		return dm.dirtyAPIServiceQueue.Len() == 0
+		return dm.dirtyAPIServiceQueue.(*completerWorkqueue).isComplete()
 	})
 }
 
@@ -104,7 +108,7 @@ func TestBasic(t *testing.T) {
 
 	go aggregatedManager.Run(testCtx.Done())
 
-	require.True(t, waitForEmptyQueue(testCtx.Done(), aggregatedManager))
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	response, _, parsed := fetchPath(aggregatedResourceManager, "")
 	if response.StatusCode != 200 {
@@ -160,7 +164,44 @@ func TestDirty(t *testing.T) {
 	defer cancel()
 
 	go aggregatedManager.Run(testCtx.Done())
-	require.True(t, waitForEmptyQueue(testCtx.Done(), aggregatedManager))
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
+
+	// immediately check for ping, since Run() should block for local services
+	if !pinged.Load() {
+		t.Errorf("service handler never pinged")
+	}
+}
+
+// Shows that waitForQueueComplete also waits for syncing to
+// complete by artificially making the sync handler take a long time
+func TestWaitForSync(t *testing.T) {
+	pinged := atomic.Bool{}
+	service := discoveryendpoint.NewResourceManager()
+	aggregatedResourceManager := discoveryendpoint.NewResourceManager()
+
+	aggregatedManager := newDiscoveryManager(aggregatedResourceManager)
+
+	aggregatedManager.AddAPIService(&apiregistrationv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "v1.stable.example.com",
+		},
+		Spec: apiregistrationv1.APIServiceSpec{
+			Group:   "stable.example.com",
+			Version: "v1",
+			Service: &apiregistrationv1.ServiceReference{
+				Name: "test-service",
+			},
+		},
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(3 * time.Second)
+		pinged.Store(true)
+		service.ServeHTTP(w, r)
+	}))
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go aggregatedManager.Run(testCtx.Done())
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// immediately check for ping, since Run() should block for local services
 	if !pinged.Load() {
@@ -212,7 +253,7 @@ func TestRemoveAPIService(t *testing.T) {
 		aggregatedManager.RemoveAPIService(s.Name)
 	}
 
-	require.True(t, waitForEmptyQueue(testCtx.Done(), aggregatedManager))
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	response, _, parsed := fetchPath(aggyService, "")
 	if response.StatusCode != 200 {
@@ -356,7 +397,7 @@ func TestLegacyFallbackNoCache(t *testing.T) {
 	defer cancel()
 
 	go aggregatedManager.Run(testCtx.Done())
-	require.True(t, waitForEmptyQueue(testCtx.Done(), aggregatedManager))
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// At this point external services have synced. Check if discovery document
 	// includes the legacy resources
@@ -465,7 +506,7 @@ func TestLegacyFallback(t *testing.T) {
 	defer cancel()
 
 	go aggregatedManager.Run(testCtx.Done())
-	require.True(t, waitForEmptyQueue(testCtx.Done(), aggregatedManager))
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// At this point external services have synced. Check if discovery document
 	// includes the legacy resources
@@ -534,10 +575,10 @@ func TestNotModified(t *testing.T) {
 
 	// Important to wait here to ensure we prime the cache with the initial list
 	// of documents in order to exercise 304 Not Modified
-	require.True(t, waitForEmptyQueue(testCtx.Done(), aggregatedManager))
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
-	// Now add all groups. We excluded one group before so that AllServicesSynced
-	// could include it in this round. Now, if AllServicesSynced ever returns
+	// Now add all groups. We excluded one group before so that waitForQueueIsComplete
+	// could include it in this round. Now, if waitForQueueIsComplete ever returns
 	// true, it must have synced all the pre-existing groups before, which would
 	// return 304 Not Modified
 	for _, s := range apiServices {
@@ -545,7 +586,7 @@ func TestNotModified(t *testing.T) {
 	}
 
 	// This would wait the full timeout on 1.26.0.
-	require.True(t, waitForEmptyQueue(testCtx.Done(), aggregatedManager))
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 }
 
 // copied from staging/src/k8s.io/apiserver/pkg/endpoints/discovery/v2/handler_test.go
@@ -609,4 +650,49 @@ func fetchPath(handler http.Handler, etag string) (*http.Response, []byte, *apid
 	}
 
 	return w.Result(), bytes, decoded
+}
+
+// completerWorkqueue is a workqueue.RateLimitingInterface that implements
+// isComplete
+type completerWorkqueue struct {
+	lock sync.Mutex
+	workqueue.RateLimitingInterface
+	processing map[interface{}]struct{}
+}
+
+var _ = workqueue.RateLimitingInterface(&completerWorkqueue{})
+
+func newCompleterWorkqueue(wq workqueue.RateLimitingInterface) *completerWorkqueue {
+	return &completerWorkqueue{
+		RateLimitingInterface: wq,
+		processing:            make(map[interface{}]struct{}),
+	}
+}
+
+func (q *completerWorkqueue) Add(item interface{}) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	q.processing[item] = struct{}{}
+	q.RateLimitingInterface.Add(item)
+}
+
+func (q *completerWorkqueue) AddAfter(item interface{}, duration time.Duration) {
+	q.Add(item)
+}
+
+func (q *completerWorkqueue) AddRateLimited(item interface{}) {
+	q.Add(item)
+}
+
+func (q *completerWorkqueue) Done(item interface{}) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	delete(q.processing, item)
+	q.RateLimitingInterface.Done(item)
+}
+
+func (q *completerWorkqueue) isComplete() bool {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	return q.Len() == 0 && len(q.processing) == 0
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR addresses two issues in `handler_discovery_test.go`.
1. Updating and reading the bool-type variable is not thread-safe. We can simply fix this one.
2. (This is quite tricky to address) It is hard to know that `discoveryManager` completes the sync on all items in the queue.

More details on issue 2 below:
`waitForEmptyQueue` cannot guarantee that `discoveryManager` completes the sync on all items in the queue. It just guarantee that all items have been started to sync.

This PR adds `waitForQueueComplete` and implements `completerWorkqueue` to check if the workqueue is complete.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115858 

```sh
$ stress ./apiserver.test                    
5s: 0 runs so far, 0 failures       
10s: 12 runs so far, 0 failures     
15s: 24 runs so far, 0 failures     
...
3m50s: 445 runs so far, 0 failures
3m55s: 456 runs so far, 0 failures
4m0s: 461 runs so far, 0 failures
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
