### PR TITLE
Allow inclusion of annotations in channel events when using FakeRecorder

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/fake.go
+++ b/staging/src/k8s.io/client-go/tools/record/fake.go
@@ -28,7 +28,8 @@ import (
 type FakeRecorder struct {
 	Events chan string
 
-	IncludeObject bool
+	IncludeObject      bool
+	IncludeAnnotations bool
 }
 
 func objectString(object runtime.Object, includeObject bool) string {
@@ -54,7 +55,12 @@ func (f *FakeRecorder) Eventf(object runtime.Object, eventtype, reason, messageF
 }
 
 func (f *FakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
-	f.Eventf(object, eventtype, reason, messageFmt, args...)
+	if f.IncludeAnnotations {
+		args = append(args, fmt.Sprint(annotations))
+		f.Eventf(object, eventtype, reason, messageFmt+" %s", args...)
+	} else {
+		f.Eventf(object, eventtype, reason, messageFmt, args...)
+	}
 }
 
 // NewFakeRecorder creates new fake event recorder with event channel with

--- a/staging/src/k8s.io/client-go/tools/record/fake.go
+++ b/staging/src/k8s.io/client-go/tools/record/fake.go
@@ -28,8 +28,7 @@ import (
 type FakeRecorder struct {
 	Events chan string
 
-	IncludeObject      bool
-	IncludeAnnotations bool
+	IncludeObject bool
 }
 
 func objectString(object runtime.Object, includeObject bool) string {
@@ -42,13 +41,6 @@ func objectString(object runtime.Object, includeObject bool) string {
 	)
 }
 
-func annotationString(annotations map[string]string, includeAnnotations bool) string {
-	if !includeAnnotations {
-		return ""
-	}
-	return " " + fmt.Sprint(annotations)
-}
-
 func (f *FakeRecorder) writeEvent(event string) {
 	if f.Events != nil {
 		f.Events <- event
@@ -57,7 +49,6 @@ func (f *FakeRecorder) writeEvent(event string) {
 
 func (f *FakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
 	f.writeEvent(fmt.Sprintf("%s %s %s%s", eventtype, reason, message, objectString(object, f.IncludeObject)))
-
 }
 
 func (f *FakeRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
@@ -71,7 +62,7 @@ func (f *FakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[st
 	f.writeEvent(
 		fmt.Sprintf(eventtype+" "+reason+" "+messageFmt, args...) +
 			objectString(object, f.IncludeObject) +
-			annotationString(annotations, f.IncludeAnnotations),
+			" " + fmt.Sprint(annotations),
 	)
 }
 


### PR DESCRIPTION
/kind feature

Fixes https://github.com/kubernetes/client-go/issues/1230

This PR adds annotations to event output from the fake recorder. This changes output from AnnotatedEventf for existing users.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
