### PR TITLE
Add a warning event when pdb has found a unmanaged pod

### DIFF
--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -19,7 +19,6 @@ package disruption
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	apps "k8s.io/api/apps/v1beta1"
@@ -706,8 +705,11 @@ func (dc *DisruptionController) trySync(ctx context.Context, pdb *policy.PodDisr
 	}
 	// We have unmamanged pods, instead of erroring and hotlooping in disruption controller, log and continue.
 	if len(unmanagedPods) > 0 {
-		klog.V(4).Infof("found unmanaged pods associated with this PDB: %v",
-			strings.Join(unmanagedPods, ",'"))
+		klog.V(4).Infof("found unmanaged pods associated with this PDB: %v", unmanagedPods)
+		dc.recorder.Eventf(pdb, v1.EventTypeWarning, "UnmanagedPods", "Pods selected by this PodDisruptionBudget (selector: %v) were found "+
+			"to be unmanaged or managed by an unsupported controller (missing a /scale subresource). As a result, the status of the PDB "+
+			"cannot be calculated correctly, which may result in undefined behavior. To account for these pods please set \".spec.minAvailable\" "+
+			"field of the PDB to an integer value.", pdb.Spec.Selector)
 	}
 
 	currentTime := dc.clock.Now()


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR adds an event to be emitted to help inform the user of an unsupported PDB configuration. Otherwise a warning is only logged in the kube-controller-manager.

#### Which issue(s) this PR fixes:

Fixes: https://github.com/kubernetes/kubernetes/issues/115435

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
When an unsupported PodDisruptionBudget configuration is found, an event and log will be emitted to inform users of the misconfiguration.
```

