### PR TITLE
Updates old 403 and 404 discovery response tolerations

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/helper_blackbox_test.go
+++ b/staging/src/k8s.io/client-go/discovery/helper_blackbox_test.go
@@ -66,16 +66,27 @@ func TestServerSupportsVersion(t *testing.T) {
 			statusCode:      http.StatusOK,
 		},
 		{
+			name:            "Status 403 Forbidden for core/v1 group returns error and is unsupported",
+			requiredVersion: schema.GroupVersion{Version: "v1"},
+			serverVersions:  []string{"/version1", v1.SchemeGroupVersion.String()},
+			expectErr:       func(err error) bool { return strings.Contains(err.Error(), "unknown") },
+			statusCode:      http.StatusForbidden,
+		},
+		{
+			name:            "Status 404 Not Found for core/v1 group returns empty and is unsupported",
+			requiredVersion: schema.GroupVersion{Version: "v1"},
+			serverVersions:  []string{"/version1", v1.SchemeGroupVersion.String()},
+			expectErr: func(err error) bool {
+				return strings.Contains(err.Error(), "server could not find the requested resource")
+			},
+			statusCode: http.StatusNotFound,
+		},
+		{
 			name:           "connection refused error",
 			serverVersions: []string{"version1"},
 			sendErr:        errors.New("connection refused"),
 			expectErr:      func(err error) bool { return strings.Contains(err.Error(), "connection refused") },
 			statusCode:     http.StatusOK,
-		},
-		{
-			name:            "discovery fails due to 404 Not Found errors and thus serverVersions is empty, use requested GroupVersion",
-			requiredVersion: schema.GroupVersion{Version: "version1"},
-			statusCode:      http.StatusNotFound,
 		},
 	}
 


### PR DESCRIPTION
* Removes old toleration for `403 Forbidden` in discovery response at `/api` and `/apis`. Discovery now always errors for `403`.
* Removes old toleration for `404 Not Found` in discovery response at `/apis`. Retains toleration for `404` at `/api`, since this is a valid response for aggregated api servers.
* Removes old toleration for `403 Forbidden` in GroupVersion discovery response for core/v1. Retains toleration for `404` GroupVersion discovery response for core/v1.
* Adds/updates unit tests to validate the previously described functionality.

/kind cleanup

```release-note
NONE
```
