### PR TITLE
[refactor] client-go/cache add DeletionHandlingCast to reduce duplica…

### DIFF
--- a/pkg/controller/certificates/certificate_controller.go
+++ b/pkg/controller/certificates/certificate_controller.go
@@ -84,18 +84,9 @@ func NewCertificateController(
 			cc.enqueueCertificateRequest(new)
 		},
 		DeleteFunc: func(obj interface{}) {
-			csr, ok := obj.(*certificates.CertificateSigningRequest)
+			csr, ok := cache.DeletionHandlingCast[*certificates.CertificateSigningRequest](obj)
 			if !ok {
-				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					logger.V(2).Info("Couldn't get object from tombstone", "object", obj)
-					return
-				}
-				csr, ok = tombstone.Obj.(*certificates.CertificateSigningRequest)
-				if !ok {
-					logger.V(2).Info("Tombstone contained object that is not a CSR", "object", obj)
-					return
-				}
+				return
 			}
 			logger.V(4).Info("Deleting certificate request", "csr", csr.Name)
 			cc.enqueueCertificateRequest(obj)

--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -325,22 +325,9 @@ func (jm *ControllerV2) updateJob(old, cur interface{}) {
 }
 
 func (jm *ControllerV2) deleteJob(obj interface{}) {
-	job, ok := obj.(*batchv1.Job)
-
-	// When a delete is dropped, the relist will notice a job in the store not
-	// in the list, leading to the insertion of a tombstone object which contains
-	// the deleted key/value. Note that this value might be stale.
+	job, ok := cache.DeletionHandlingCast[*batchv1.Job](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-			return
-		}
-		job, ok = tombstone.Obj.(*batchv1.Job)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Job %#v", obj))
-			return
-		}
+		return
 	}
 
 	controllerRef := metav1.GetControllerOf(job)

--- a/pkg/controller/endpointslicemirroring/utils.go
+++ b/pkg/controller/endpointslicemirroring/utils.go
@@ -24,7 +24,6 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	endpointsliceutil "k8s.io/endpointslice/util"
@@ -154,19 +153,8 @@ func epPortsToEpsPorts(epPorts []corev1.EndpointPort) []discovery.EndpointPort {
 // getServiceFromDeleteAction parses a Service resource from a delete
 // action.
 func getServiceFromDeleteAction(obj interface{}) *corev1.Service {
-	if service, ok := obj.(*corev1.Service); ok {
-		return service
-	}
-	// If we reached here it means the Service was deleted but its final state
-	// is unrecorded.
-	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	 service, ok := cache.DeletionHandlingCast[*corev1.Service](obj)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-		return nil
-	}
-	service, ok := tombstone.Obj.(*corev1.Service)
-	if !ok {
-		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Service resource: %#v", obj))
 		return nil
 	}
 	return service
@@ -175,19 +163,8 @@ func getServiceFromDeleteAction(obj interface{}) *corev1.Service {
 // getEndpointsFromDeleteAction parses an Endpoints resource from a delete
 // action.
 func getEndpointsFromDeleteAction(obj interface{}) *corev1.Endpoints {
-	if endpoints, ok := obj.(*corev1.Endpoints); ok {
-		return endpoints
-	}
-	// If we reached here it means the Endpoints resource was deleted but its
-	// final state is unrecorded.
-	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	endpoints, ok := cache.DeletionHandlingCast[*corev1.Endpoints](obj)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-		return nil
-	}
-	endpoints, ok := tombstone.Obj.(*corev1.Endpoints)
-	if !ok {
-		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an Endpoints resource: %#v", obj))
 		return nil
 	}
 	return endpoints
@@ -195,19 +172,8 @@ func getEndpointsFromDeleteAction(obj interface{}) *corev1.Endpoints {
 
 // getEndpointSliceFromDeleteAction parses an EndpointSlice from a delete action.
 func getEndpointSliceFromDeleteAction(obj interface{}) *discovery.EndpointSlice {
-	if endpointSlice, ok := obj.(*discovery.EndpointSlice); ok {
-		return endpointSlice
-	}
-	// If we reached here it means the EndpointSlice was deleted but its final
-	// state is unrecorded.
-	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	endpointSlice, ok := cache.DeletionHandlingCast[*discovery.EndpointSlice](obj)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-		return nil
-	}
-	endpointSlice, ok := tombstone.Obj.(*discovery.EndpointSlice)
-	if !ok {
-		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an EndpointSlice resource: %#v", obj))
 		return nil
 	}
 	return endpointSlice

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -359,19 +359,9 @@ func NewNodeLifecycleController(
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			pod, isPod := obj.(*v1.Pod)
-			// We can get DeletedFinalStateUnknown instead of *v1.Pod here and we need to handle that correctly.
+			pod, isPod := cache.DeletionHandlingCast[*v1.Pod](obj)
 			if !isPod {
-				deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					logger.Error(nil, "Received unexpected object", "object", obj)
-					return
-				}
-				pod, ok = deletedState.Obj.(*v1.Pod)
-				if !ok {
-					logger.Error(nil, "DeletedFinalStateUnknown contained non-Pod object", "object", deletedState.Obj)
-					return
-				}
+				return
 			}
 			nc.podUpdated(pod, nil)
 			if nc.taintManager != nil {

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -206,13 +206,8 @@ func NewController(
 }
 
 func (ec *Controller) enqueuePod(logger klog.Logger, obj interface{}, deleted bool) {
-	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-		obj = d.Obj
-	}
-	pod, ok := obj.(*v1.Pod)
+	pod, ok := cache.DeletionHandlingCast[*v1.Pod](obj)
 	if !ok {
-		// Not a pod?!
-		logger.Error(nil, "enqueuePod called for unexpected object", "type", fmt.Sprintf("%T", obj))
 		return
 	}
 

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -124,18 +124,9 @@ func (c *ServiceAccountsController) Run(ctx context.Context, workers int) {
 
 // serviceAccountDeleted reacts to a ServiceAccount deletion by recreating a default ServiceAccount in the namespace if needed
 func (c *ServiceAccountsController) serviceAccountDeleted(obj interface{}) {
-	sa, ok := obj.(*v1.ServiceAccount)
+	sa, ok := cache.DeletionHandlingCast[*v1.ServiceAccount](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
-			return
-		}
-		sa, ok = tombstone.Obj.(*v1.ServiceAccount)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a ServiceAccount %#v", obj))
-			return
-		}
+		return
 	}
 	c.queue.Add(sa.Namespace)
 }

--- a/pkg/controller/storageversiongc/gc_controller.go
+++ b/pkg/controller/storageversiongc/gc_controller.go
@@ -247,18 +247,9 @@ func (c *Controller) enqueueStorageVersion(logger klog.Logger, obj *apiserverint
 }
 
 func (c *Controller) onDeleteLease(logger klog.Logger, obj interface{}) {
-	castObj, ok := obj.(*coordinationv1.Lease)
+	castObj, ok := cache.DeletionHandlingCast[*coordinationv1.Lease](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-			return
-		}
-		castObj, ok = tombstone.Obj.(*coordinationv1.Lease)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Lease %#v", obj))
-			return
-		}
+		return
 	}
 
 	if castObj.Namespace == metav1.NamespaceSystem &&

--- a/pkg/controller/ttl/ttl_controller.go
+++ b/pkg/controller/ttl/ttl_controller.go
@@ -169,18 +169,9 @@ func (ttlc *Controller) updateNode(logger klog.Logger, _, newObj interface{}) {
 }
 
 func (ttlc *Controller) deleteNode(obj interface{}) {
-	_, ok := obj.(*v1.Node)
+	_, ok := cache.DeletionHandlingCast[*v1.Node](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
-			return
-		}
-		_, ok = tombstone.Obj.(*v1.Node)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("unexpected object types: %v", obj))
-			return
-		}
+		return
 	}
 
 	func() {

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -359,18 +359,9 @@ func (*Controller) parsePod(obj interface{}) *v1.Pod {
 	if obj == nil {
 		return nil
 	}
-	pod, ok := obj.(*v1.Pod)
+	pod, ok := cache.DeletionHandlingCast[*v1.Pod](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-			return nil
-		}
-		pod, ok = tombstone.Obj.(*v1.Pod)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Pod %#v", obj))
-			return nil
-		}
+		return nil
 	}
 	return pod
 }

--- a/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller.go
+++ b/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller.go
@@ -105,13 +105,8 @@ func NewClusterAuthenticationTrustController(requiredAuthenticationData ClusterA
 
 	kubeSystemConfigMapInformer.AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
-			if cast, ok := obj.(*corev1.ConfigMap); ok {
+			if cast, ok := cache.DeletionHandlingCast[*corev1.ConfigMap](obj); ok {
 				return cast.Name == configMapName
-			}
-			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-				if cast, ok := tombstone.Obj.(*corev1.ConfigMap); ok {
-					return cast.Name == configMapName
-				}
 			}
 			return true // always return true just in case.  The checks are fairly cheap
 		},

--- a/pkg/controlplane/controller/crdregistration/crdregistration_controller.go
+++ b/pkg/controlplane/controller/crdregistration/crdregistration_controller.go
@@ -83,18 +83,9 @@ func NewCRDRegistrationController(crdinformer crdinformers.CustomResourceDefinit
 			c.enqueueCRD(newObj.(*apiextensionsv1.CustomResourceDefinition))
 		},
 		DeleteFunc: func(obj interface{}) {
-			cast, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+			cast, ok := cache.DeletionHandlingCast[*apiextensionsv1.CustomResourceDefinition](obj)
 			if !ok {
-				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					klog.V(2).Infof("Couldn't get object from tombstone %#v", obj)
-					return
-				}
-				cast, ok = tombstone.Obj.(*apiextensionsv1.CustomResourceDefinition)
-				if !ok {
-					klog.V(2).Infof("Tombstone contained unexpected object: %#v", obj)
-					return
-				}
+				return
 			}
 			c.enqueueCRD(cast)
 		},

--- a/pkg/proxy/config/config.go
+++ b/pkg/proxy/config/config.go
@@ -136,17 +136,9 @@ func (c *EndpointSliceConfig) handleUpdateEndpointSlice(oldObj, newObj interface
 }
 
 func (c *EndpointSliceConfig) handleDeleteEndpointSlice(obj interface{}) {
-	endpointSlice, ok := obj.(*discovery.EndpointSlice)
+	endpointSlice, ok := cache.DeletionHandlingCast[*discovery.EndpointSlice](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("unexpected object type: %T", obj))
-			return
-		}
-		if endpointSlice, ok = tombstone.Obj.(*discovery.EndpointSlice); !ok {
-			utilruntime.HandleError(fmt.Errorf("unexpected object type: %T", obj))
-			return
-		}
+		return
 	}
 	for _, h := range c.eventHandlers {
 		klog.V(4).InfoS("Calling handler.OnEndpointsDelete")
@@ -227,17 +219,9 @@ func (c *ServiceConfig) handleUpdateService(oldObj, newObj interface{}) {
 }
 
 func (c *ServiceConfig) handleDeleteService(obj interface{}) {
-	service, ok := obj.(*v1.Service)
+	service, ok := cache.DeletionHandlingCast[*v1.Service](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
-			return
-		}
-		if service, ok = tombstone.Obj.(*v1.Service); !ok {
-			utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
-			return
-		}
+		return
 	}
 	for i := range c.eventHandlers {
 		klog.V(4).InfoS("Calling handler.OnServiceDelete")
@@ -354,17 +338,9 @@ func (c *NodeConfig) handleUpdateNode(oldObj, newObj interface{}) {
 }
 
 func (c *NodeConfig) handleDeleteNode(obj interface{}) {
-	node, ok := obj.(*v1.Node)
+	node, ok := cache.DeletionHandlingCast[*v1.Node](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
-			return
-		}
-		if node, ok = tombstone.Obj.(*v1.Node); !ok {
-			utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
-			return
-		}
+		return
 	}
 	for i := range c.eventHandlers {
 		klog.V(4).InfoS("Calling handler.OnNodeDelete")

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -98,22 +98,11 @@ func (sched *Scheduler) updateNodeInCache(oldObj, newObj interface{}) {
 }
 
 func (sched *Scheduler) deleteNodeFromCache(obj interface{}) {
-	logger := sched.logger
-	var node *v1.Node
-	switch t := obj.(type) {
-	case *v1.Node:
-		node = t
-	case cache.DeletedFinalStateUnknown:
-		var ok bool
-		node, ok = t.Obj.(*v1.Node)
-		if !ok {
-			logger.Error(nil, "Cannot convert to *v1.Node", "obj", t.Obj)
-			return
-		}
-	default:
-		logger.Error(nil, "Cannot convert to *v1.Node", "obj", t)
+	node, ok := cache.DeletionHandlingCast[*v1.Node](obj)
+	if !ok {
 		return
 	}
+	logger := sched.logger
 	logger.V(3).Info("Delete event for node", "node", klog.KObj(node))
 	if err := sched.Cache.RemoveNode(logger, node); err != nil {
 		logger.Error(err, "Scheduler cache RemoveNode failed")
@@ -152,22 +141,11 @@ func (sched *Scheduler) updatePodInSchedulingQueue(oldObj, newObj interface{}) {
 }
 
 func (sched *Scheduler) deletePodFromSchedulingQueue(obj interface{}) {
-	logger := sched.logger
-	var pod *v1.Pod
-	switch t := obj.(type) {
-	case *v1.Pod:
-		pod = obj.(*v1.Pod)
-	case cache.DeletedFinalStateUnknown:
-		var ok bool
-		pod, ok = t.Obj.(*v1.Pod)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("unable to convert object %T to *v1.Pod in %T", obj, sched))
-			return
-		}
-	default:
-		utilruntime.HandleError(fmt.Errorf("unable to handle object in %T: %T", sched, obj))
+	pod, ok := cache.DeletionHandlingCast[*v1.Pod](obj)
+	if !ok {
 		return
 	}
+	logger := sched.logger
 	logger.V(3).Info("Delete event for unscheduled pod", "pod", klog.KObj(pod))
 	if err := sched.SchedulingQueue.Delete(pod); err != nil {
 		utilruntime.HandleError(fmt.Errorf("unable to dequeue %T: %v", obj, err))
@@ -225,22 +203,11 @@ func (sched *Scheduler) updatePodInCache(oldObj, newObj interface{}) {
 }
 
 func (sched *Scheduler) deletePodFromCache(obj interface{}) {
-	logger := sched.logger
-	var pod *v1.Pod
-	switch t := obj.(type) {
-	case *v1.Pod:
-		pod = t
-	case cache.DeletedFinalStateUnknown:
-		var ok bool
-		pod, ok = t.Obj.(*v1.Pod)
-		if !ok {
-			logger.Error(nil, "Cannot convert to *v1.Pod", "obj", t.Obj)
-			return
-		}
-	default:
-		logger.Error(nil, "Cannot convert to *v1.Pod", "obj", t)
+	pod, ok := cache.DeletionHandlingCast[*v1.Pod](obj)
+	if !ok {
 		return
 	}
+	logger := sched.logger
 	logger.V(3).Info("Delete event for scheduled pod", "pod", klog.KObj(pod))
 	if err := sched.Cache.RemovePod(logger, pod); err != nil {
 		logger.Error(err, "Scheduler cache RemovePod failed", "pod", klog.KObj(pod))

--- a/plugin/pkg/auth/authorizer/node/graph_populator.go
+++ b/plugin/pkg/auth/authorizer/node/graph_populator.go
@@ -116,12 +116,8 @@ func resourceClaimStatusesEqual(statusA, statusB []corev1.PodResourceClaimStatus
 }
 
 func (g *graphPopulator) deletePod(obj interface{}) {
-	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-		obj = tombstone.Obj
-	}
-	pod, ok := obj.(*corev1.Pod)
+	pod, ok := cache.DeletionHandlingCast[*corev1.Pod](obj)
 	if !ok {
-		klog.Infof("unexpected type %T", obj)
 		return
 	}
 	if len(pod.Spec.NodeName) == 0 {
@@ -146,12 +142,8 @@ func (g *graphPopulator) updatePV(oldObj, obj interface{}) {
 }
 
 func (g *graphPopulator) deletePV(obj interface{}) {
-	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-		obj = tombstone.Obj
-	}
-	pv, ok := obj.(*corev1.PersistentVolume)
+	pv, ok := cache.DeletionHandlingCast[*corev1.PersistentVolume](obj)
 	if !ok {
-		klog.Infof("unexpected type %T", obj)
 		return
 	}
 	g.graph.DeletePV(pv.Name)
@@ -174,12 +166,8 @@ func (g *graphPopulator) updateVolumeAttachment(oldObj, obj interface{}) {
 }
 
 func (g *graphPopulator) deleteVolumeAttachment(obj interface{}) {
-	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-		obj = tombstone.Obj
-	}
-	attachment, ok := obj.(*storagev1.VolumeAttachment)
+	attachment, ok := cache.DeletionHandlingCast[*storagev1.VolumeAttachment](obj)
 	if !ok {
-		klog.Infof("unexpected type %T", obj)
 		return
 	}
 	g.graph.DeleteVolumeAttachment(attachment.Name)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
@@ -372,18 +372,9 @@ func (c *DiscoveryController) updateCustomResourceDefinition(oldObj, newObj inte
 }
 
 func (c *DiscoveryController) deleteCustomResourceDefinition(obj interface{}) {
-	castObj, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	castObj, ok := cache.DeletionHandlingCast[*apiextensionsv1.CustomResourceDefinition](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			klog.Errorf("Couldn't get object from tombstone %#v", obj)
-			return
-		}
-		castObj, ok = tombstone.Obj.(*apiextensionsv1.CustomResourceDefinition)
-		if !ok {
-			klog.Errorf("Tombstone contained object that is not expected %#v", obj)
-			return
-		}
+		return
 	}
 	klog.V(4).Infof("Deleting customresourcedefinition %q", castObj.Name)
 	c.enqueue(castObj)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/apiapproval/apiapproval_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/apiapproval/apiapproval_controller.go
@@ -245,18 +245,9 @@ func (c *KubernetesAPIApprovalPolicyConformantConditionController) updateCustomR
 }
 
 func (c *KubernetesAPIApprovalPolicyConformantConditionController) deleteCustomResourceDefinition(obj interface{}) {
-	castObj, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	castObj, ok := cache.DeletionHandlingCast[*apiextensionsv1.CustomResourceDefinition](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			klog.Errorf("Couldn't get object from tombstone %#v", obj)
-			return
-		}
-		castObj, ok = tombstone.Obj.(*apiextensionsv1.CustomResourceDefinition)
-		if !ok {
-			klog.Errorf("Tombstone contained object that is not expected %#v", obj)
-			return
-		}
+		return
 	}
 
 	c.lastSeenProtectedAnnotationLock.Lock()

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
@@ -251,18 +251,9 @@ func (c *ConditionController) updateCustomResourceDefinition(obj, _ interface{})
 }
 
 func (c *ConditionController) deleteCustomResourceDefinition(obj interface{}) {
-	castObj, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	castObj, ok := cache.DeletionHandlingCast[*apiextensionsv1.CustomResourceDefinition](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			klog.Errorf("Couldn't get object from tombstone %#v", obj)
-			return
-		}
-		castObj, ok = tombstone.Obj.(*apiextensionsv1.CustomResourceDefinition)
-		if !ok {
-			klog.Errorf("Tombstone contained object that is not expected %#v", obj)
-			return
-		}
+		return
 	}
 
 	c.lastSeenGenerationLock.Lock()

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
@@ -272,18 +272,9 @@ func (c *Controller) updateCustomResourceDefinition(oldObj, newObj interface{}) 
 }
 
 func (c *Controller) deleteCustomResourceDefinition(obj interface{}) {
-	castObj, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	castObj, ok := cache.DeletionHandlingCast[*apiextensionsv1.CustomResourceDefinition](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			klog.Errorf("Couldn't get object from tombstone %#v", obj)
-			return
-		}
-		castObj, ok = tombstone.Obj.(*apiextensionsv1.CustomResourceDefinition)
-		if !ok {
-			klog.Errorf("Tombstone contained object that is not expected %#v", obj)
-			return
-		}
+		return
 	}
 	klog.V(4).Infof("Deleting customresourcedefinition %q", castObj.Name)
 	c.enqueue(castObj)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapiv3/controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapiv3/controller.go
@@ -253,18 +253,9 @@ func (c *Controller) updateCustomResourceDefinition(oldObj, newObj interface{}) 
 }
 
 func (c *Controller) deleteCustomResourceDefinition(obj interface{}) {
-	castObj, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	castObj, ok := cache.DeletionHandlingCast[*apiextensionsv1.CustomResourceDefinition](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			klog.Errorf("Couldn't get object from tombstone %#v", obj)
-			return
-		}
-		castObj, ok = tombstone.Obj.(*apiextensionsv1.CustomResourceDefinition)
-		if !ok {
-			klog.Errorf("Tombstone contained object that is not expected %#v", obj)
-			return
-		}
+		return
 	}
 	klog.V(4).Infof("Deleting customresourcedefinition %q", castObj.Name)
 	c.enqueue(castObj)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
@@ -349,18 +349,9 @@ func (c *NamingConditionController) updateCustomResourceDefinition(obj, _ interf
 }
 
 func (c *NamingConditionController) deleteCustomResourceDefinition(obj interface{}) {
-	castObj, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	castObj, ok := cache.DeletionHandlingCast[*apiextensionsv1.CustomResourceDefinition](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			klog.Errorf("Couldn't get object from tombstone %#v", obj)
-			return
-		}
-		castObj, ok = tombstone.Obj.(*apiextensionsv1.CustomResourceDefinition)
-		if !ok {
-			klog.Errorf("Tombstone contained object that is not expected %#v", obj)
-			return
-		}
+		return
 	}
 	klog.V(4).Infof("Deleting %q", castObj.Name)
 	c.enqueue(castObj)

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_controller.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"time"
 
+	"sync/atomic"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -35,7 +37,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
-	"sync/atomic"
 )
 
 const (
@@ -114,13 +115,8 @@ func NewRequestHeaderAuthRequestController(
 
 	c.configmapInformer.AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
-			if cast, ok := obj.(*corev1.ConfigMap); ok {
+			if cast, ok := cache.DeletionHandlingCast[*corev1.ConfigMap](obj); ok {
 				return cast.Name == c.configmapName && cast.Namespace == c.configmapNamespace
-			}
-			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-				if cast, ok := tombstone.Obj.(*corev1.ConfigMap); ok {
-					return cast.Name == c.configmapName && cast.Namespace == c.configmapNamespace
-				}
 			}
 			return true // always return true just in case.  The checks are fairly cheap
 		},

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/configmap_cafile_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/configmap_cafile_content.go
@@ -100,13 +100,8 @@ func NewDynamicCAFromConfigMapController(purpose, namespace, name, key string, k
 
 	uncastConfigmapInformer.AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
-			if cast, ok := obj.(*corev1.ConfigMap); ok {
+			if cast, ok := cache.DeletionHandlingCast[*corev1.ConfigMap](obj); ok {
 				return cast.Name == c.configmapName && cast.Namespace == c.configmapNamespace
-			}
-			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-				if cast, ok := tombstone.Obj.(*corev1.ConfigMap); ok {
-					return cast.Name == c.configmapName && cast.Namespace == c.configmapNamespace
-				}
 			}
 			return true // always return true just in case.  The checks are fairly cheap
 		},

--- a/staging/src/k8s.io/endpointslice/util/controller_utils.go
+++ b/staging/src/k8s.io/endpointslice/util/controller_utils.go
@@ -195,20 +195,8 @@ func GetServicesToUpdateOnPodChange(serviceLister v1listers.ServiceLister, old, 
 // GetPodFromDeleteAction returns a pointer to a pod if one can be derived from
 // obj (could be a *v1.Pod, or a DeletionFinalStateUnknown marker item).
 func GetPodFromDeleteAction(obj interface{}) *v1.Pod {
-	if pod, ok := obj.(*v1.Pod); ok {
-		// Enqueue all the services that the pod used to be a member of.
-		// This is the same thing we do when we add a pod.
-		return pod
-	}
-	// If we reached here it means the pod was deleted but its final state is unrecorded.
-	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	pod, ok := cache.DeletionHandlingCast[*v1.Pod](obj)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-		return nil
-	}
-	pod, ok := tombstone.Obj.(*v1.Pod)
-	if !ok {
-		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Pod: %#v", obj))
 		return nil
 	}
 	return pod

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go
@@ -178,18 +178,9 @@ func (c *APIServiceRegistrationController) updateAPIService(obj, _ interface{}) 
 }
 
 func (c *APIServiceRegistrationController) deleteAPIService(obj interface{}) {
-	castObj, ok := obj.(*v1.APIService)
+	castObj, ok := cache.DeletionHandlingCast[*v1.APIService](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			klog.Errorf("Couldn't get object from tombstone %#v", obj)
-			return
-		}
-		castObj, ok = tombstone.Obj.(*v1.APIService)
-		if !ok {
-			klog.Errorf("Tombstone contained object that is not expected %#v", obj)
-			return
-		}
+		return
 	}
 	klog.V(4).Infof("Deleting %q", castObj.Name)
 	c.enqueueInternal(castObj)

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/autoregister_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/autoregister_controller.go
@@ -111,18 +111,9 @@ func NewAutoRegisterController(apiServiceInformer informers.APIServiceInformer, 
 			c.queue.Add(cast.Name)
 		},
 		DeleteFunc: func(obj interface{}) {
-			cast, ok := obj.(*v1.APIService)
+			cast, ok := cache.DeletionHandlingCast[*v1.APIService](obj)
 			if !ok {
-				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					klog.V(2).Infof("Couldn't get object from tombstone %#v", obj)
-					return
-				}
-				cast, ok = tombstone.Obj.(*v1.APIService)
-				if !ok {
-					klog.V(2).Infof("Tombstone contained unexpected object: %#v", obj)
-					return
-				}
+				return
 			}
 			c.queue.Add(cast.Name)
 		},

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -483,18 +483,9 @@ func (c *AvailableConditionController) updateAPIService(oldObj, newObj interface
 }
 
 func (c *AvailableConditionController) deleteAPIService(obj interface{}) {
-	castObj, ok := obj.(*apiregistrationv1.APIService)
+	castObj, ok := cache.DeletionHandlingCast[*apiregistrationv1.APIService](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			klog.Errorf("Couldn't get object from tombstone %#v", obj)
-			return
-		}
-		castObj, ok = tombstone.Obj.(*apiregistrationv1.APIService)
-		if !ok {
-			klog.Errorf("Tombstone contained object that is not expected %#v", obj)
-			return
-		}
+		return
 	}
 	klog.V(4).Infof("Deleting %q", castObj.Name)
 	if castObj.Spec.Service != nil {
@@ -550,18 +541,9 @@ func (c *AvailableConditionController) updateService(obj, _ interface{}) {
 }
 
 func (c *AvailableConditionController) deleteService(obj interface{}) {
-	castObj, ok := obj.(*v1.Service)
+	castObj, ok := cache.DeletionHandlingCast[*v1.Service](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			klog.Errorf("Couldn't get object from tombstone %#v", obj)
-			return
-		}
-		castObj, ok = tombstone.Obj.(*v1.Service)
-		if !ok {
-			klog.Errorf("Tombstone contained object that is not expected %#v", obj)
-			return
-		}
+		return
 	}
 	for _, apiService := range c.getAPIServicesFor(castObj) {
 		c.queue.Add(apiService)
@@ -581,18 +563,9 @@ func (c *AvailableConditionController) updateEndpoints(obj, _ interface{}) {
 }
 
 func (c *AvailableConditionController) deleteEndpoints(obj interface{}) {
-	castObj, ok := obj.(*v1.Endpoints)
+	castObj, ok := cache.DeletionHandlingCast[*v1.Endpoints](obj)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			klog.Errorf("Couldn't get object from tombstone %#v", obj)
-			return
-		}
-		castObj, ok = tombstone.Obj.(*v1.Endpoints)
-		if !ok {
-			klog.Errorf("Tombstone contained object that is not expected %#v", obj)
-			return
-		}
+		return
 	}
 	for _, apiService := range c.getAPIServicesFor(castObj) {
 		c.queue.Add(apiService)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -751,20 +751,9 @@ func (az *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 			az.updateNodeCaches(prevNode, newNode)
 		},
 		DeleteFunc: func(obj interface{}) {
-			node, isNode := obj.(*v1.Node)
-			// We can get DeletedFinalStateUnknown instead of *v1.Node here
-			// and we need to handle that correctly.
+			node, isNode := cache.DeletionHandlingCast[*v1.Node](obj)
 			if !isNode {
-				deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					klog.Errorf("Received unexpected object: %v", obj)
-					return
-				}
-				node, ok = deletedState.Obj.(*v1.Node)
-				if !ok {
-					klog.Errorf("DeletedFinalStateUnknown contained non-Node object: %v", deletedState.Obj)
-					return
-				}
+				return
 			}
 			az.updateNodeCaches(node, nil)
 		},

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go
@@ -43,7 +43,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
@@ -751,20 +751,9 @@ func (g *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 			g.updateNodeZones(prevNode, newNode)
 		},
 		DeleteFunc: func(obj interface{}) {
-			node, isNode := obj.(*v1.Node)
-			// We can get DeletedFinalStateUnknown instead of *v1.Node here
-			// and we need to handle that correctly.
+			node, isNode := cache.DeletionHandlingCast[*v1.Node](obj)
 			if !isNode {
-				deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					klog.Errorf("Received unexpected object: %v", obj)
-					return
-				}
-				node, ok = deletedState.Obj.(*v1.Node)
-				if !ok {
-					klog.Errorf("DeletedFinalStateUnknown contained non-Node object: %v", deletedState.Obj)
-					return
-				}
+				return
 			}
 			g.updateNodeZones(node, nil)
 		},


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

- What?: client-go/cache add DeletionHandlingCast
- Why?:  to reduce duplicated code for  handle DeletedFinalStateUnknown objects

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

no

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
