### PR TITLE
migrating component-helpers

### DIFF
--- a/staging/src/k8s.io/component-helpers/apimachinery/lease/controller_test.go
+++ b/staging/src/k8s.io/component-helpers/apimachinery/lease/controller_test.go
@@ -443,7 +443,7 @@ func TestUpdateUsingLatestLease(t *testing.T) {
 
 // setNodeOwnerFunc helps construct a newLeasePostProcessFunc which sets
 // a node OwnerReference to the given lease object
-func setNodeOwnerFunc(c clientset.Interface, nodeName string) func(lease *coordinationv1.Lease) error {
+func setNodeOwnerFunc(ctx context.Context, c clientset.Interface, nodeName string) func(lease *coordinationv1.Lease) error {
 	return func(lease *coordinationv1.Lease) error {
 		// Setting owner reference needs node's UID. Note that it is different from
 		// kubelet.nodeRef.UID. When lease is initially created, it is possible that
@@ -460,7 +460,7 @@ func setNodeOwnerFunc(c clientset.Interface, nodeName string) func(lease *coordi
 					},
 				}
 			} else {
-				klog.Errorf("failed to get node %q when trying to set owner ref to the node lease: %v", nodeName, err)
+				klog.FromContext(ctx).Error(err, "failed to get node when trying to set owner ref to the node lease", "nodeName", nodeName)
 				return err
 			}
 		}

--- a/staging/src/k8s.io/component-helpers/node/util/cidr.go
+++ b/staging/src/k8s.io/component-helpers/node/util/cidr.go
@@ -37,8 +37,9 @@ type nodeSpecForMergePatch struct {
 }
 
 // PatchNodeCIDRs patches the specified node.CIDR=cidrs[0] and node.CIDRs to the given value.
-func PatchNodeCIDRs(c clientset.Interface, node types.NodeName, cidrs []string) error {
+func PatchNodeCIDRs(ctx context.Context, c clientset.Interface, node types.NodeName, cidrs []string) error {
 	// set the pod cidrs list and set the old pod cidr field
+	logger := klog.FromContext(ctx)
 	patch := nodeForCIDRMergePatch{
 		Spec: nodeSpecForMergePatch{
 			PodCIDR:  cidrs[0],
@@ -50,7 +51,7 @@ func PatchNodeCIDRs(c clientset.Interface, node types.NodeName, cidrs []string) 
 	if err != nil {
 		return fmt.Errorf("failed to json.Marshal CIDR: %v", err)
 	}
-	klog.V(4).Infof("cidrs patch bytes are:%s", string(patchBytes))
+	logger.V(4).Info("cidrs patch bytes", "patch bytes", string(patchBytes))
 	if _, err := c.CoreV1().Nodes().Patch(context.TODO(), string(node), types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
 		return fmt.Errorf("failed to patch node CIDR: %v", err)
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
migrate `staging/src/k8s.io/component-helpers`

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/enhancements/issues/3077

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
```docs
Migrate `staging/src/k8s.io/component-helpers` to contextual logging
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/3077-contextual-logging
```
