### PR TITLE
`SecurityContextDeny` admission plugin: add warning on creation and disable feature by default via a feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -691,6 +691,14 @@ const (
 	// Enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
 	SeccompDefault featuregate.Feature = "SeccompDefault"
 
+	// owner: @mtardy
+	// alpha: v1.0
+	//
+	// Putting this admission plugin behind a feature gate is part of the
+	// deprecation process. For details about the removal see:
+	// https://github.com/kubernetes/kubernetes/issues/111516
+	SecurityContextDeny featuregate.Feature = "SecurityContextDeny"
+
 	// owner: @maplain @andrewsykim
 	// kep: https://kep.k8s.io/2086
 	// alpha: v1.21
@@ -1021,6 +1029,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	RotateKubeletServerCertificate: {Default: true, PreRelease: featuregate.Beta},
 
 	SeccompDefault: {Default: true, PreRelease: featuregate.Beta},
+
+	SecurityContextDeny: {Default: false, PreRelease: featuregate.Alpha},
 
 	ServiceIPStaticSubrange: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.28
 

--- a/plugin/pkg/admission/securitycontext/scdeny/admission.go
+++ b/plugin/pkg/admission/securitycontext/scdeny/admission.go
@@ -23,17 +23,25 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/admission"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 // PluginName indicates name of admission plugin.
 const PluginName = "SecurityContextDeny"
 
+const docLink = "https://k8s.io/docs/reference/access-authn-authz/admission-controllers/#securitycontextdeny"
+
 // Register registers a plugin
 func Register(plugins *admission.Plugins) {
 	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
-		return NewSecurityContextDeny(), nil
+		if utilfeature.DefaultFeatureGate.Enabled(features.SecurityContextDeny) {
+			return NewSecurityContextDeny(), nil
+		} else {
+			return nil, fmt.Errorf("%s admission controller is an alpha feature, planned to be removed, and requires the SecurityContextDeny feature gate to be enabled, see %s for more information", PluginName, docLink)
+		}
 	})
 }
 
@@ -49,8 +57,8 @@ func NewSecurityContextDeny() *Plugin {
 	// DEPRECATED: SecurityContextDeny will be removed in favor of PodSecurity admission.
 	klog.Warningf("%s admission controller is deprecated. "+
 		"Please remove this controller from your configuration files and scripts. "+
-		"See https://k8s.io/docs/reference/access-authn-authz/admission-controllers/#securitycontextdeny for more information.",
-		PluginName)
+		"See %s for more information.",
+		PluginName, docLink)
 	return &Plugin{
 		Handler: admission.NewHandler(admission.Create, admission.Update),
 	}

--- a/plugin/pkg/admission/securitycontext/scdeny/admission.go
+++ b/plugin/pkg/admission/securitycontext/scdeny/admission.go
@@ -23,6 +23,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/klog/v2"
 	api "k8s.io/kubernetes/pkg/apis/core"
 )
 
@@ -45,6 +46,11 @@ var _ admission.ValidationInterface = &Plugin{}
 
 // NewSecurityContextDeny creates a new instance of the SecurityContextDeny admission controller
 func NewSecurityContextDeny() *Plugin {
+	// DEPRECATED: SecurityContextDeny will be removed in favor of PodSecurity admission.
+	klog.Warningf("%s admission controller is deprecated. "+
+		"Please remove this controller from your configuration files and scripts. "+
+		"See https://k8s.io/docs/reference/access-authn-authz/admission-controllers/#securitycontextdeny for more information.",
+		PluginName)
 	return &Plugin{
 		Handler: admission.NewHandler(admission.Create, admission.Update),
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind deprecation

#### What this PR does / why we need it:

This PR adds a warning when enabling the `SecurityContextDeny` admission plugin because it's going to be removed. See https://github.com/kubernetes/kubernetes/issues/111516.

#### Which issue(s) this PR fixes:

This is step two of https://github.com/kubernetes/kubernetes/issues/111516.

#### Special notes for your reviewer:

~~I would need help on how to use [the warning system](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/1693-warnings/README.md) in order to issue a message when a Pod is created in a cluster with this admission plugin activated. See this message for more context:~~

> > Add a warning at runtime if the admission plugin is used with a reference to the docs of shortcomings
> 
> To me, I think the deprecation is strong enough that we could set a warning header on any Pod create that happens when the plugin is merely active (no matter whether the Pod was admitted or denied).
> 
> _Originally posted by @sftim in https://github.com/kubernetes/kubernetes/issues/111516#issuecomment-1408448738_

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The SecurityContextDeny admission plugin is going deprecated and will be removed in future versions.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3785
- [Other doc]: https://k8s.io/docs/reference/access-authn-authz/admission-controllers/#securitycontextdeny
- [Issue]: https://github.com/kubernetes/kubernetes/issues/111516
```

