### PR TITLE
add patch meta to applyconfigurations

### DIFF
--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhook.go
@@ -37,7 +37,7 @@ type MutatingWebhookApplyConfiguration struct {
 	TimeoutSeconds          *int32                                          `json:"timeoutSeconds,omitempty"`
 	AdmissionReviewVersions []string                                        `json:"admissionReviewVersions,omitempty"`
 	ReinvocationPolicy      *admissionregistrationv1.ReinvocationPolicyType `json:"reinvocationPolicy,omitempty"`
-	MatchConditions         []MatchConditionApplyConfiguration              `json:"matchConditions,omitempty"`
+	MatchConditions         []MatchConditionApplyConfiguration              `json:"matchConditions,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // MutatingWebhookApplyConfiguration constructs an declarative configuration of the MutatingWebhook type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -32,7 +32,7 @@ import (
 type MutatingWebhookConfigurationApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Webhooks                         []MutatingWebhookApplyConfiguration `json:"webhooks,omitempty"`
+	Webhooks                         []MutatingWebhookApplyConfiguration `json:"webhooks,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // MutatingWebhookConfiguration constructs an declarative configuration of the MutatingWebhookConfiguration type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhook.go
@@ -36,7 +36,7 @@ type ValidatingWebhookApplyConfiguration struct {
 	SideEffects             *admissionregistrationv1.SideEffectClass   `json:"sideEffects,omitempty"`
 	TimeoutSeconds          *int32                                     `json:"timeoutSeconds,omitempty"`
 	AdmissionReviewVersions []string                                   `json:"admissionReviewVersions,omitempty"`
-	MatchConditions         []MatchConditionApplyConfiguration         `json:"matchConditions,omitempty"`
+	MatchConditions         []MatchConditionApplyConfiguration         `json:"matchConditions,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // ValidatingWebhookApplyConfiguration constructs an declarative configuration of the ValidatingWebhook type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -32,7 +32,7 @@ import (
 type ValidatingWebhookConfigurationApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Webhooks                         []ValidatingWebhookApplyConfiguration `json:"webhooks,omitempty"`
+	Webhooks                         []ValidatingWebhookApplyConfiguration `json:"webhooks,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // ValidatingWebhookConfiguration constructs an declarative configuration of the ValidatingWebhookConfiguration type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicyspec.go
@@ -30,7 +30,7 @@ type ValidatingAdmissionPolicySpecApplyConfiguration struct {
 	Validations      []ValidationApplyConfiguration                   `json:"validations,omitempty"`
 	FailurePolicy    *admissionregistrationv1alpha1.FailurePolicyType `json:"failurePolicy,omitempty"`
 	AuditAnnotations []AuditAnnotationApplyConfiguration              `json:"auditAnnotations,omitempty"`
-	MatchConditions  []MatchConditionApplyConfiguration               `json:"matchConditions,omitempty"`
+	MatchConditions  []MatchConditionApplyConfiguration               `json:"matchConditions,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // ValidatingAdmissionPolicySpecApplyConfiguration constructs an declarative configuration of the ValidatingAdmissionPolicySpec type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhook.go
@@ -38,7 +38,7 @@ type MutatingWebhookApplyConfiguration struct {
 	TimeoutSeconds          *int32                                               `json:"timeoutSeconds,omitempty"`
 	AdmissionReviewVersions []string                                             `json:"admissionReviewVersions,omitempty"`
 	ReinvocationPolicy      *admissionregistrationv1beta1.ReinvocationPolicyType `json:"reinvocationPolicy,omitempty"`
-	MatchConditions         []MatchConditionApplyConfiguration                   `json:"matchConditions,omitempty"`
+	MatchConditions         []MatchConditionApplyConfiguration                   `json:"matchConditions,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // MutatingWebhookApplyConfiguration constructs an declarative configuration of the MutatingWebhook type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -32,7 +32,7 @@ import (
 type MutatingWebhookConfigurationApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Webhooks                         []MutatingWebhookApplyConfiguration `json:"webhooks,omitempty"`
+	Webhooks                         []MutatingWebhookApplyConfiguration `json:"webhooks,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // MutatingWebhookConfiguration constructs an declarative configuration of the MutatingWebhookConfiguration type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhook.go
@@ -37,7 +37,7 @@ type ValidatingWebhookApplyConfiguration struct {
 	SideEffects             *admissionregistrationv1beta1.SideEffectClass   `json:"sideEffects,omitempty"`
 	TimeoutSeconds          *int32                                          `json:"timeoutSeconds,omitempty"`
 	AdmissionReviewVersions []string                                        `json:"admissionReviewVersions,omitempty"`
-	MatchConditions         []MatchConditionApplyConfiguration              `json:"matchConditions,omitempty"`
+	MatchConditions         []MatchConditionApplyConfiguration              `json:"matchConditions,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // ValidatingWebhookApplyConfiguration constructs an declarative configuration of the ValidatingWebhook type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -32,7 +32,7 @@ import (
 type ValidatingWebhookConfigurationApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Webhooks                         []ValidatingWebhookApplyConfiguration `json:"webhooks,omitempty"`
+	Webhooks                         []ValidatingWebhookApplyConfiguration `json:"webhooks,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // ValidatingWebhookConfiguration constructs an declarative configuration of the ValidatingWebhookConfiguration type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonsetstatus.go
@@ -30,7 +30,7 @@ type DaemonSetStatusApplyConfiguration struct {
 	NumberAvailable        *int32                                 `json:"numberAvailable,omitempty"`
 	NumberUnavailable      *int32                                 `json:"numberUnavailable,omitempty"`
 	CollisionCount         *int32                                 `json:"collisionCount,omitempty"`
-	Conditions             []DaemonSetConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions             []DaemonSetConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // DaemonSetStatusApplyConfiguration constructs an declarative configuration of the DaemonSetStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deploymentspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deploymentspec.go
@@ -29,7 +29,7 @@ type DeploymentSpecApplyConfiguration struct {
 	Replicas                *int32                                    `json:"replicas,omitempty"`
 	Selector                *v1.LabelSelectorApplyConfiguration       `json:"selector,omitempty"`
 	Template                *corev1.PodTemplateSpecApplyConfiguration `json:"template,omitempty"`
-	Strategy                *DeploymentStrategyApplyConfiguration     `json:"strategy,omitempty"`
+	Strategy                *DeploymentStrategyApplyConfiguration     `json:"strategy,omitempty" patchStrategy:"retainKeys"`
 	MinReadySeconds         *int32                                    `json:"minReadySeconds,omitempty"`
 	RevisionHistoryLimit    *int32                                    `json:"revisionHistoryLimit,omitempty"`
 	Paused                  *bool                                     `json:"paused,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deploymentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deploymentstatus.go
@@ -27,7 +27,7 @@ type DeploymentStatusApplyConfiguration struct {
 	ReadyReplicas       *int32                                  `json:"readyReplicas,omitempty"`
 	AvailableReplicas   *int32                                  `json:"availableReplicas,omitempty"`
 	UnavailableReplicas *int32                                  `json:"unavailableReplicas,omitempty"`
-	Conditions          []DeploymentConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions          []DeploymentConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	CollisionCount      *int32                                  `json:"collisionCount,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicasetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicasetstatus.go
@@ -26,7 +26,7 @@ type ReplicaSetStatusApplyConfiguration struct {
 	ReadyReplicas        *int32                                  `json:"readyReplicas,omitempty"`
 	AvailableReplicas    *int32                                  `json:"availableReplicas,omitempty"`
 	ObservedGeneration   *int64                                  `json:"observedGeneration,omitempty"`
-	Conditions           []ReplicaSetConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions           []ReplicaSetConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // ReplicaSetStatusApplyConfiguration constructs an declarative configuration of the ReplicaSetStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetstatus.go
@@ -29,7 +29,7 @@ type StatefulSetStatusApplyConfiguration struct {
 	CurrentRevision    *string                                  `json:"currentRevision,omitempty"`
 	UpdateRevision     *string                                  `json:"updateRevision,omitempty"`
 	CollisionCount     *int32                                   `json:"collisionCount,omitempty"`
-	Conditions         []StatefulSetConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions         []StatefulSetConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	AvailableReplicas  *int32                                   `json:"availableReplicas,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deploymentspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deploymentspec.go
@@ -29,7 +29,7 @@ type DeploymentSpecApplyConfiguration struct {
 	Replicas                *int32                                    `json:"replicas,omitempty"`
 	Selector                *v1.LabelSelectorApplyConfiguration       `json:"selector,omitempty"`
 	Template                *corev1.PodTemplateSpecApplyConfiguration `json:"template,omitempty"`
-	Strategy                *DeploymentStrategyApplyConfiguration     `json:"strategy,omitempty"`
+	Strategy                *DeploymentStrategyApplyConfiguration     `json:"strategy,omitempty" patchStrategy:"retainKeys"`
 	MinReadySeconds         *int32                                    `json:"minReadySeconds,omitempty"`
 	RevisionHistoryLimit    *int32                                    `json:"revisionHistoryLimit,omitempty"`
 	Paused                  *bool                                     `json:"paused,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deploymentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deploymentstatus.go
@@ -27,7 +27,7 @@ type DeploymentStatusApplyConfiguration struct {
 	ReadyReplicas       *int32                                  `json:"readyReplicas,omitempty"`
 	AvailableReplicas   *int32                                  `json:"availableReplicas,omitempty"`
 	UnavailableReplicas *int32                                  `json:"unavailableReplicas,omitempty"`
-	Conditions          []DeploymentConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions          []DeploymentConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	CollisionCount      *int32                                  `json:"collisionCount,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetstatus.go
@@ -29,7 +29,7 @@ type StatefulSetStatusApplyConfiguration struct {
 	CurrentRevision    *string                                  `json:"currentRevision,omitempty"`
 	UpdateRevision     *string                                  `json:"updateRevision,omitempty"`
 	CollisionCount     *int32                                   `json:"collisionCount,omitempty"`
-	Conditions         []StatefulSetConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions         []StatefulSetConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	AvailableReplicas  *int32                                   `json:"availableReplicas,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonsetstatus.go
@@ -30,7 +30,7 @@ type DaemonSetStatusApplyConfiguration struct {
 	NumberAvailable        *int32                                 `json:"numberAvailable,omitempty"`
 	NumberUnavailable      *int32                                 `json:"numberUnavailable,omitempty"`
 	CollisionCount         *int32                                 `json:"collisionCount,omitempty"`
-	Conditions             []DaemonSetConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions             []DaemonSetConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // DaemonSetStatusApplyConfiguration constructs an declarative configuration of the DaemonSetStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deploymentspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deploymentspec.go
@@ -29,7 +29,7 @@ type DeploymentSpecApplyConfiguration struct {
 	Replicas                *int32                                    `json:"replicas,omitempty"`
 	Selector                *v1.LabelSelectorApplyConfiguration       `json:"selector,omitempty"`
 	Template                *corev1.PodTemplateSpecApplyConfiguration `json:"template,omitempty"`
-	Strategy                *DeploymentStrategyApplyConfiguration     `json:"strategy,omitempty"`
+	Strategy                *DeploymentStrategyApplyConfiguration     `json:"strategy,omitempty" patchStrategy:"retainKeys"`
 	MinReadySeconds         *int32                                    `json:"minReadySeconds,omitempty"`
 	RevisionHistoryLimit    *int32                                    `json:"revisionHistoryLimit,omitempty"`
 	Paused                  *bool                                     `json:"paused,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deploymentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deploymentstatus.go
@@ -27,7 +27,7 @@ type DeploymentStatusApplyConfiguration struct {
 	ReadyReplicas       *int32                                  `json:"readyReplicas,omitempty"`
 	AvailableReplicas   *int32                                  `json:"availableReplicas,omitempty"`
 	UnavailableReplicas *int32                                  `json:"unavailableReplicas,omitempty"`
-	Conditions          []DeploymentConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions          []DeploymentConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	CollisionCount      *int32                                  `json:"collisionCount,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicasetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicasetstatus.go
@@ -26,7 +26,7 @@ type ReplicaSetStatusApplyConfiguration struct {
 	ReadyReplicas        *int32                                  `json:"readyReplicas,omitempty"`
 	AvailableReplicas    *int32                                  `json:"availableReplicas,omitempty"`
 	ObservedGeneration   *int64                                  `json:"observedGeneration,omitempty"`
-	Conditions           []ReplicaSetConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions           []ReplicaSetConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // ReplicaSetStatusApplyConfiguration constructs an declarative configuration of the ReplicaSetStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetstatus.go
@@ -29,7 +29,7 @@ type StatefulSetStatusApplyConfiguration struct {
 	CurrentRevision    *string                                  `json:"currentRevision,omitempty"`
 	UpdateRevision     *string                                  `json:"updateRevision,omitempty"`
 	CollisionCount     *int32                                   `json:"collisionCount,omitempty"`
-	Conditions         []StatefulSetConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions         []StatefulSetConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	AvailableReplicas  *int32                                   `json:"availableReplicas,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalerstatus.go
@@ -30,7 +30,7 @@ type HorizontalPodAutoscalerStatusApplyConfiguration struct {
 	CurrentReplicas    *int32                                               `json:"currentReplicas,omitempty"`
 	DesiredReplicas    *int32                                               `json:"desiredReplicas,omitempty"`
 	CurrentMetrics     []MetricStatusApplyConfiguration                     `json:"currentMetrics,omitempty"`
-	Conditions         []HorizontalPodAutoscalerConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions         []HorizontalPodAutoscalerConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // HorizontalPodAutoscalerStatusApplyConfiguration constructs an declarative configuration of the HorizontalPodAutoscalerStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobstatus.go
@@ -25,7 +25,7 @@ import (
 // JobStatusApplyConfiguration represents an declarative configuration of the JobStatus type for use
 // with apply.
 type JobStatusApplyConfiguration struct {
-	Conditions              []JobConditionApplyConfiguration           `json:"conditions,omitempty"`
+	Conditions              []JobConditionApplyConfiguration           `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	StartTime               *metav1.Time                               `json:"startTime,omitempty"`
 	CompletionTime          *metav1.Time                               `json:"completionTime,omitempty"`
 	Active                  *int32                                     `json:"active,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/componentstatus.go
@@ -32,7 +32,7 @@ import (
 type ComponentStatusApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Conditions                       []ComponentConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions                       []ComponentConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // ComponentStatus constructs an declarative configuration of the ComponentStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/container.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/container.go
@@ -30,13 +30,13 @@ type ContainerApplyConfiguration struct {
 	Command                  []string                                  `json:"command,omitempty"`
 	Args                     []string                                  `json:"args,omitempty"`
 	WorkingDir               *string                                   `json:"workingDir,omitempty"`
-	Ports                    []ContainerPortApplyConfiguration         `json:"ports,omitempty"`
+	Ports                    []ContainerPortApplyConfiguration         `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"containerPort"`
 	EnvFrom                  []EnvFromSourceApplyConfiguration         `json:"envFrom,omitempty"`
-	Env                      []EnvVarApplyConfiguration                `json:"env,omitempty"`
+	Env                      []EnvVarApplyConfiguration                `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	Resources                *ResourceRequirementsApplyConfiguration   `json:"resources,omitempty"`
 	ResizePolicy             []ContainerResizePolicyApplyConfiguration `json:"resizePolicy,omitempty"`
-	VolumeMounts             []VolumeMountApplyConfiguration           `json:"volumeMounts,omitempty"`
-	VolumeDevices            []VolumeDeviceApplyConfiguration          `json:"volumeDevices,omitempty"`
+	VolumeMounts             []VolumeMountApplyConfiguration           `json:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"mountPath"`
+	VolumeDevices            []VolumeDeviceApplyConfiguration          `json:"volumeDevices,omitempty" patchStrategy:"merge" patchMergeKey:"devicePath"`
 	LivenessProbe            *ProbeApplyConfiguration                  `json:"livenessProbe,omitempty"`
 	ReadinessProbe           *ProbeApplyConfiguration                  `json:"readinessProbe,omitempty"`
 	StartupProbe             *ProbeApplyConfiguration                  `json:"startupProbe,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralcontainercommon.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralcontainercommon.go
@@ -30,13 +30,13 @@ type EphemeralContainerCommonApplyConfiguration struct {
 	Command                  []string                                  `json:"command,omitempty"`
 	Args                     []string                                  `json:"args,omitempty"`
 	WorkingDir               *string                                   `json:"workingDir,omitempty"`
-	Ports                    []ContainerPortApplyConfiguration         `json:"ports,omitempty"`
+	Ports                    []ContainerPortApplyConfiguration         `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"containerPort"`
 	EnvFrom                  []EnvFromSourceApplyConfiguration         `json:"envFrom,omitempty"`
-	Env                      []EnvVarApplyConfiguration                `json:"env,omitempty"`
+	Env                      []EnvVarApplyConfiguration                `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	Resources                *ResourceRequirementsApplyConfiguration   `json:"resources,omitempty"`
 	ResizePolicy             []ContainerResizePolicyApplyConfiguration `json:"resizePolicy,omitempty"`
-	VolumeMounts             []VolumeMountApplyConfiguration           `json:"volumeMounts,omitempty"`
-	VolumeDevices            []VolumeDeviceApplyConfiguration          `json:"volumeDevices,omitempty"`
+	VolumeMounts             []VolumeMountApplyConfiguration           `json:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"mountPath"`
+	VolumeDevices            []VolumeDeviceApplyConfiguration          `json:"volumeDevices,omitempty" patchStrategy:"merge" patchMergeKey:"devicePath"`
 	LivenessProbe            *ProbeApplyConfiguration                  `json:"livenessProbe,omitempty"`
 	ReadinessProbe           *ProbeApplyConfiguration                  `json:"readinessProbe,omitempty"`
 	StartupProbe             *ProbeApplyConfiguration                  `json:"startupProbe,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespacestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespacestatus.go
@@ -26,7 +26,7 @@ import (
 // with apply.
 type NamespaceStatusApplyConfiguration struct {
 	Phase      *v1.NamespacePhase                     `json:"phase,omitempty"`
-	Conditions []NamespaceConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions []NamespaceConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // NamespaceStatusApplyConfiguration constructs an declarative configuration of the NamespaceStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodespec.go
@@ -22,7 +22,7 @@ package v1
 // with apply.
 type NodeSpecApplyConfiguration struct {
 	PodCIDR            *string                             `json:"podCIDR,omitempty"`
-	PodCIDRs           []string                            `json:"podCIDRs,omitempty"`
+	PodCIDRs           []string                            `json:"podCIDRs,omitempty" patchStrategy:"merge"`
 	ProviderID         *string                             `json:"providerID,omitempty"`
 	Unschedulable      *bool                               `json:"unschedulable,omitempty"`
 	Taints             []TaintApplyConfiguration           `json:"taints,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodestatus.go
@@ -28,8 +28,8 @@ type NodeStatusApplyConfiguration struct {
 	Capacity        *v1.ResourceList                       `json:"capacity,omitempty"`
 	Allocatable     *v1.ResourceList                       `json:"allocatable,omitempty"`
 	Phase           *v1.NodePhase                          `json:"phase,omitempty"`
-	Conditions      []NodeConditionApplyConfiguration      `json:"conditions,omitempty"`
-	Addresses       []NodeAddressApplyConfiguration        `json:"addresses,omitempty"`
+	Conditions      []NodeConditionApplyConfiguration      `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+	Addresses       []NodeAddressApplyConfiguration        `json:"addresses,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	DaemonEndpoints *NodeDaemonEndpointsApplyConfiguration `json:"daemonEndpoints,omitempty"`
 	NodeInfo        *NodeSystemInfoApplyConfiguration      `json:"nodeInfo,omitempty"`
 	Images          []ContainerImageApplyConfiguration     `json:"images,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimstatus.go
@@ -28,7 +28,7 @@ type PersistentVolumeClaimStatusApplyConfiguration struct {
 	Phase              *v1.PersistentVolumeClaimPhase                     `json:"phase,omitempty"`
 	AccessModes        []v1.PersistentVolumeAccessMode                    `json:"accessModes,omitempty"`
 	Capacity           *v1.ResourceList                                   `json:"capacity,omitempty"`
-	Conditions         []PersistentVolumeClaimConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions         []PersistentVolumeClaimConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	AllocatedResources *v1.ResourceList                                   `json:"allocatedResources,omitempty"`
 	ResizeStatus       *v1.PersistentVolumeClaimResizeStatus              `json:"resizeStatus,omitempty"`
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podspec.go
@@ -25,10 +25,10 @@ import (
 // PodSpecApplyConfiguration represents an declarative configuration of the PodSpec type for use
 // with apply.
 type PodSpecApplyConfiguration struct {
-	Volumes                       []VolumeApplyConfiguration                   `json:"volumes,omitempty"`
-	InitContainers                []ContainerApplyConfiguration                `json:"initContainers,omitempty"`
-	Containers                    []ContainerApplyConfiguration                `json:"containers,omitempty"`
-	EphemeralContainers           []EphemeralContainerApplyConfiguration       `json:"ephemeralContainers,omitempty"`
+	Volumes                       []VolumeApplyConfiguration                   `json:"volumes,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
+	InitContainers                []ContainerApplyConfiguration                `json:"initContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	Containers                    []ContainerApplyConfiguration                `json:"containers,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	EphemeralContainers           []EphemeralContainerApplyConfiguration       `json:"ephemeralContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	RestartPolicy                 *corev1.RestartPolicy                        `json:"restartPolicy,omitempty"`
 	TerminationGracePeriodSeconds *int64                                       `json:"terminationGracePeriodSeconds,omitempty"`
 	ActiveDeadlineSeconds         *int64                                       `json:"activeDeadlineSeconds,omitempty"`
@@ -43,13 +43,13 @@ type PodSpecApplyConfiguration struct {
 	HostIPC                       *bool                                        `json:"hostIPC,omitempty"`
 	ShareProcessNamespace         *bool                                        `json:"shareProcessNamespace,omitempty"`
 	SecurityContext               *PodSecurityContextApplyConfiguration        `json:"securityContext,omitempty"`
-	ImagePullSecrets              []LocalObjectReferenceApplyConfiguration     `json:"imagePullSecrets,omitempty"`
+	ImagePullSecrets              []LocalObjectReferenceApplyConfiguration     `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	Hostname                      *string                                      `json:"hostname,omitempty"`
 	Subdomain                     *string                                      `json:"subdomain,omitempty"`
 	Affinity                      *AffinityApplyConfiguration                  `json:"affinity,omitempty"`
 	SchedulerName                 *string                                      `json:"schedulerName,omitempty"`
 	Tolerations                   []TolerationApplyConfiguration               `json:"tolerations,omitempty"`
-	HostAliases                   []HostAliasApplyConfiguration                `json:"hostAliases,omitempty"`
+	HostAliases                   []HostAliasApplyConfiguration                `json:"hostAliases,omitempty" patchStrategy:"merge" patchMergeKey:"ip"`
 	PriorityClassName             *string                                      `json:"priorityClassName,omitempty"`
 	Priority                      *int32                                       `json:"priority,omitempty"`
 	DNSConfig                     *PodDNSConfigApplyConfiguration              `json:"dnsConfig,omitempty"`
@@ -58,12 +58,12 @@ type PodSpecApplyConfiguration struct {
 	EnableServiceLinks            *bool                                        `json:"enableServiceLinks,omitempty"`
 	PreemptionPolicy              *corev1.PreemptionPolicy                     `json:"preemptionPolicy,omitempty"`
 	Overhead                      *corev1.ResourceList                         `json:"overhead,omitempty"`
-	TopologySpreadConstraints     []TopologySpreadConstraintApplyConfiguration `json:"topologySpreadConstraints,omitempty"`
+	TopologySpreadConstraints     []TopologySpreadConstraintApplyConfiguration `json:"topologySpreadConstraints,omitempty" patchStrategy:"merge" patchMergeKey:"topologyKey"`
 	SetHostnameAsFQDN             *bool                                        `json:"setHostnameAsFQDN,omitempty"`
 	OS                            *PodOSApplyConfiguration                     `json:"os,omitempty"`
 	HostUsers                     *bool                                        `json:"hostUsers,omitempty"`
-	SchedulingGates               []PodSchedulingGateApplyConfiguration        `json:"schedulingGates,omitempty"`
-	ResourceClaims                []PodResourceClaimApplyConfiguration         `json:"resourceClaims,omitempty"`
+	SchedulingGates               []PodSchedulingGateApplyConfiguration        `json:"schedulingGates,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	ResourceClaims                []PodResourceClaimApplyConfiguration         `json:"resourceClaims,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
 }
 
 // PodSpecApplyConfiguration constructs an declarative configuration of the PodSpec type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podstatus.go
@@ -27,13 +27,13 @@ import (
 // with apply.
 type PodStatusApplyConfiguration struct {
 	Phase                      *v1.PodPhase                        `json:"phase,omitempty"`
-	Conditions                 []PodConditionApplyConfiguration    `json:"conditions,omitempty"`
+	Conditions                 []PodConditionApplyConfiguration    `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	Message                    *string                             `json:"message,omitempty"`
 	Reason                     *string                             `json:"reason,omitempty"`
 	NominatedNodeName          *string                             `json:"nominatedNodeName,omitempty"`
 	HostIP                     *string                             `json:"hostIP,omitempty"`
 	PodIP                      *string                             `json:"podIP,omitempty"`
-	PodIPs                     []PodIPApplyConfiguration           `json:"podIPs,omitempty"`
+	PodIPs                     []PodIPApplyConfiguration           `json:"podIPs,omitempty" patchStrategy:"merge" patchMergeKey:"ip"`
 	StartTime                  *metav1.Time                        `json:"startTime,omitempty"`
 	InitContainerStatuses      []ContainerStatusApplyConfiguration `json:"initContainerStatuses,omitempty"`
 	ContainerStatuses          []ContainerStatusApplyConfiguration `json:"containerStatuses,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontrollerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontrollerstatus.go
@@ -26,7 +26,7 @@ type ReplicationControllerStatusApplyConfiguration struct {
 	ReadyReplicas        *int32                                             `json:"readyReplicas,omitempty"`
 	AvailableReplicas    *int32                                             `json:"availableReplicas,omitempty"`
 	ObservedGeneration   *int64                                             `json:"observedGeneration,omitempty"`
-	Conditions           []ReplicationControllerConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions           []ReplicationControllerConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // ReplicationControllerStatusApplyConfiguration constructs an declarative configuration of the ReplicationControllerStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceaccount.go
@@ -32,7 +32,7 @@ import (
 type ServiceAccountApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Secrets                          []ObjectReferenceApplyConfiguration      `json:"secrets,omitempty"`
+	Secrets                          []ObjectReferenceApplyConfiguration      `json:"secrets,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	ImagePullSecrets                 []LocalObjectReferenceApplyConfiguration `json:"imagePullSecrets,omitempty"`
 	AutomountServiceAccountToken     *bool                                    `json:"automountServiceAccountToken,omitempty"`
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/servicespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/servicespec.go
@@ -25,7 +25,7 @@ import (
 // ServiceSpecApplyConfiguration represents an declarative configuration of the ServiceSpec type for use
 // with apply.
 type ServiceSpecApplyConfiguration struct {
-	Ports                         []ServicePortApplyConfiguration          `json:"ports,omitempty"`
+	Ports                         []ServicePortApplyConfiguration          `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"port"`
 	Selector                      map[string]string                        `json:"selector,omitempty"`
 	ClusterIP                     *string                                  `json:"clusterIP,omitempty"`
 	ClusterIPs                    []string                                 `json:"clusterIPs,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/servicestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/servicestatus.go
@@ -26,7 +26,7 @@ import (
 // with apply.
 type ServiceStatusApplyConfiguration struct {
 	LoadBalancer *LoadBalancerStatusApplyConfiguration `json:"loadBalancer,omitempty"`
-	Conditions   []metav1.ConditionApplyConfiguration  `json:"conditions,omitempty"`
+	Conditions   []metav1.ConditionApplyConfiguration  `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // ServiceStatusApplyConfiguration constructs an declarative configuration of the ServiceStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonsetstatus.go
@@ -30,7 +30,7 @@ type DaemonSetStatusApplyConfiguration struct {
 	NumberAvailable        *int32                                 `json:"numberAvailable,omitempty"`
 	NumberUnavailable      *int32                                 `json:"numberUnavailable,omitempty"`
 	CollisionCount         *int32                                 `json:"collisionCount,omitempty"`
-	Conditions             []DaemonSetConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions             []DaemonSetConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // DaemonSetStatusApplyConfiguration constructs an declarative configuration of the DaemonSetStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deploymentspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deploymentspec.go
@@ -29,7 +29,7 @@ type DeploymentSpecApplyConfiguration struct {
 	Replicas                *int32                                    `json:"replicas,omitempty"`
 	Selector                *v1.LabelSelectorApplyConfiguration       `json:"selector,omitempty"`
 	Template                *corev1.PodTemplateSpecApplyConfiguration `json:"template,omitempty"`
-	Strategy                *DeploymentStrategyApplyConfiguration     `json:"strategy,omitempty"`
+	Strategy                *DeploymentStrategyApplyConfiguration     `json:"strategy,omitempty" patchStrategy:"retainKeys"`
 	MinReadySeconds         *int32                                    `json:"minReadySeconds,omitempty"`
 	RevisionHistoryLimit    *int32                                    `json:"revisionHistoryLimit,omitempty"`
 	Paused                  *bool                                     `json:"paused,omitempty"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deploymentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deploymentstatus.go
@@ -27,7 +27,7 @@ type DeploymentStatusApplyConfiguration struct {
 	ReadyReplicas       *int32                                  `json:"readyReplicas,omitempty"`
 	AvailableReplicas   *int32                                  `json:"availableReplicas,omitempty"`
 	UnavailableReplicas *int32                                  `json:"unavailableReplicas,omitempty"`
-	Conditions          []DeploymentConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions          []DeploymentConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	CollisionCount      *int32                                  `json:"collisionCount,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicystatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicystatus.go
@@ -25,7 +25,7 @@ import (
 // NetworkPolicyStatusApplyConfiguration represents an declarative configuration of the NetworkPolicyStatus type for use
 // with apply.
 type NetworkPolicyStatusApplyConfiguration struct {
-	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // NetworkPolicyStatusApplyConfiguration constructs an declarative configuration of the NetworkPolicyStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicasetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicasetstatus.go
@@ -26,7 +26,7 @@ type ReplicaSetStatusApplyConfiguration struct {
 	ReadyReplicas        *int32                                  `json:"readyReplicas,omitempty"`
 	AvailableReplicas    *int32                                  `json:"availableReplicas,omitempty"`
 	ObservedGeneration   *int64                                  `json:"observedGeneration,omitempty"`
-	Conditions           []ReplicaSetConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions           []ReplicaSetConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // ReplicaSetStatusApplyConfiguration constructs an declarative configuration of the ReplicaSetStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschemastatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschemastatus.go
@@ -21,7 +21,7 @@ package v1beta3
 // FlowSchemaStatusApplyConfiguration represents an declarative configuration of the FlowSchemaStatus type for use
 // with apply.
 type FlowSchemaStatusApplyConfiguration struct {
-	Conditions []FlowSchemaConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions []FlowSchemaConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // FlowSchemaStatusApplyConfiguration constructs an declarative configuration of the FlowSchemaStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfigurationstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfigurationstatus.go
@@ -21,7 +21,7 @@ package v1beta3
 // PriorityLevelConfigurationStatusApplyConfiguration represents an declarative configuration of the PriorityLevelConfigurationStatus type for use
 // with apply.
 type PriorityLevelConfigurationStatusApplyConfiguration struct {
-	Conditions []PriorityLevelConfigurationConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions []PriorityLevelConfigurationConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // PriorityLevelConfigurationStatusApplyConfiguration constructs an declarative configuration of the PriorityLevelConfigurationStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/labelselectorrequirement.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/labelselectorrequirement.go
@@ -25,7 +25,7 @@ import (
 // LabelSelectorRequirementApplyConfiguration represents an declarative configuration of the LabelSelectorRequirement type for use
 // with apply.
 type LabelSelectorRequirementApplyConfiguration struct {
-	Key      *string                   `json:"key,omitempty"`
+	Key      *string                   `json:"key,omitempty" patchStrategy:"merge" patchMergeKey:"key"`
 	Operator *v1.LabelSelectorOperator `json:"operator,omitempty"`
 	Values   []string                  `json:"values,omitempty"`
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/objectmeta.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/objectmeta.go
@@ -37,8 +37,8 @@ type ObjectMetaApplyConfiguration struct {
 	DeletionGracePeriodSeconds *int64                             `json:"deletionGracePeriodSeconds,omitempty"`
 	Labels                     map[string]string                  `json:"labels,omitempty"`
 	Annotations                map[string]string                  `json:"annotations,omitempty"`
-	OwnerReferences            []OwnerReferenceApplyConfiguration `json:"ownerReferences,omitempty"`
-	Finalizers                 []string                           `json:"finalizers,omitempty"`
+	OwnerReferences            []OwnerReferenceApplyConfiguration `json:"ownerReferences,omitempty" patchStrategy:"merge" patchMergeKey:"uid"`
+	Finalizers                 []string                           `json:"finalizers,omitempty" patchStrategy:"merge"`
 }
 
 // ObjectMetaApplyConfiguration constructs an declarative configuration of the ObjectMeta type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicystatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicystatus.go
@@ -25,7 +25,7 @@ import (
 // NetworkPolicyStatusApplyConfiguration represents an declarative configuration of the NetworkPolicyStatus type for use
 // with apply.
 type NetworkPolicyStatusApplyConfiguration struct {
-	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // NetworkPolicyStatusApplyConfiguration constructs an declarative configuration of the NetworkPolicyStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudgetspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudgetspec.go
@@ -28,7 +28,7 @@ import (
 // with apply.
 type PodDisruptionBudgetSpecApplyConfiguration struct {
 	MinAvailable               *intstr.IntOrString                      `json:"minAvailable,omitempty"`
-	Selector                   *v1.LabelSelectorApplyConfiguration      `json:"selector,omitempty"`
+	Selector                   *v1.LabelSelectorApplyConfiguration      `json:"selector,omitempty" patchStrategy:"replace"`
 	MaxUnavailable             *intstr.IntOrString                      `json:"maxUnavailable,omitempty"`
 	UnhealthyPodEvictionPolicy *policyv1.UnhealthyPodEvictionPolicyType `json:"unhealthyPodEvictionPolicy,omitempty"`
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudgetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudgetstatus.go
@@ -32,7 +32,7 @@ type PodDisruptionBudgetStatusApplyConfiguration struct {
 	CurrentHealthy     *int32                               `json:"currentHealthy,omitempty"`
 	DesiredHealthy     *int32                               `json:"desiredHealthy,omitempty"`
 	ExpectedPods       *int32                               `json:"expectedPods,omitempty"`
-	Conditions         []metav1.ConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions         []metav1.ConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // PodDisruptionBudgetStatusApplyConfiguration constructs an declarative configuration of the PodDisruptionBudgetStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudgetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudgetstatus.go
@@ -32,7 +32,7 @@ type PodDisruptionBudgetStatusApplyConfiguration struct {
 	CurrentHealthy     *int32                               `json:"currentHealthy,omitempty"`
 	DesiredHealthy     *int32                               `json:"desiredHealthy,omitempty"`
 	ExpectedPods       *int32                               `json:"expectedPods,omitempty"`
-	Conditions         []metav1.ConditionApplyConfiguration `json:"conditions,omitempty"`
+	Conditions         []metav1.ConditionApplyConfiguration `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // PodDisruptionBudgetStatusApplyConfiguration constructs an declarative configuration of the PodDisruptionBudgetStatus type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinodespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinodespec.go
@@ -21,7 +21,7 @@ package v1
 // CSINodeSpecApplyConfiguration represents an declarative configuration of the CSINodeSpec type for use
 // with apply.
 type CSINodeSpecApplyConfiguration struct {
-	Drivers []CSINodeDriverApplyConfiguration `json:"drivers,omitempty"`
+	Drivers []CSINodeDriverApplyConfiguration `json:"drivers,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // CSINodeSpecApplyConfiguration constructs an declarative configuration of the CSINodeSpec type for use with

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinodespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinodespec.go
@@ -21,7 +21,7 @@ package v1beta1
 // CSINodeSpecApplyConfiguration represents an declarative configuration of the CSINodeSpec type for use
 // with apply.
 type CSINodeSpecApplyConfiguration struct {
-	Drivers []CSINodeDriverApplyConfiguration `json:"drivers,omitempty"`
+	Drivers []CSINodeDriverApplyConfiguration `json:"drivers,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // CSINodeSpecApplyConfiguration constructs an declarative configuration of the CSINodeSpec type for use with


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

ApplyConfiguration objects were missing `patchStrategy` and `patchMergeKey` fields from the underlying API types, which meant that strategic merge patch performs operations differently on ApplyConfiguration objects than it does on regular API types.

#### Special notes for your reviewer:
PatchStrategies is parsed as a `[]string` in most other parts of the codebase; I kept it as a `string` since we're just copying the tag value over to another tag (to be split into a slice by SMP processing later).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```