### PR TITLE
Default to sandbox `Seccomp` field instead of `SeccompProfilePath`

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -168,11 +168,8 @@ func (m *kubeGenericRuntimeManager) generatePodSandboxLinuxConfig(pod *v1.Pod) (
 		SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{
 			Privileged: kubecontainer.HasPrivilegedContainer(pod),
 
-			// TODO: Deprecated, remove after we switch to Seccomp field
 			// Forcing sandbox to run as `runtime/default` allow users to
 			// use least privileged seccomp profiles at pod level. Issue #84623
-			SeccompProfilePath: v1.SeccompProfileRuntimeDefault,
-
 			Seccomp: &runtimeapi.SecurityProfile{
 				ProfileType: runtimeapi.SecurityProfile_RuntimeDefault,
 			},

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
@@ -67,39 +67,39 @@ func TestGeneratePodSandboxLinuxConfigSeccomp(t *testing.T) {
 	tests := []struct {
 		description     string
 		pod             *v1.Pod
-		expectedProfile string
+		expectedProfile v1.SeccompProfileType
 	}{
 		{
 			description:     "no seccomp defined at pod level should return runtime/default",
 			pod:             newSeccompPod(nil, nil, "", "runtime/default"),
-			expectedProfile: "runtime/default",
+			expectedProfile: v1.SeccompProfileTypeRuntimeDefault,
 		},
 		{
 			description:     "seccomp field defined at pod level should not be honoured",
 			pod:             newSeccompPod(&v1.SeccompProfile{Type: v1.SeccompProfileTypeUnconfined}, nil, "", ""),
-			expectedProfile: "runtime/default",
+			expectedProfile: v1.SeccompProfileTypeRuntimeDefault,
 		},
 		{
 			description:     "seccomp field defined at container level should not be honoured",
 			pod:             newSeccompPod(nil, &v1.SeccompProfile{Type: v1.SeccompProfileTypeUnconfined}, "", ""),
-			expectedProfile: "runtime/default",
+			expectedProfile: v1.SeccompProfileTypeRuntimeDefault,
 		},
 		{
 			description:     "seccomp annotation defined at pod level should not be honoured",
 			pod:             newSeccompPod(nil, nil, "unconfined", ""),
-			expectedProfile: "runtime/default",
+			expectedProfile: v1.SeccompProfileTypeRuntimeDefault,
 		},
 		{
 			description:     "seccomp annotation defined at container level should not be honoured",
 			pod:             newSeccompPod(nil, nil, "", "unconfined"),
-			expectedProfile: "runtime/default",
+			expectedProfile: v1.SeccompProfileTypeRuntimeDefault,
 		},
 	}
 
 	for i, test := range tests {
 		config, _ := m.generatePodSandboxLinuxConfig(test.pod)
-		actualProfile := config.SecurityContext.SeccompProfilePath
-		assert.Equal(t, test.expectedProfile, actualProfile, "TestCase[%d]: %s", i, test.description)
+		actualProfile := config.SecurityContext.Seccomp.ProfileType.String()
+		assert.EqualValues(t, test.expectedProfile, actualProfile, "TestCase[%d]: %s", i, test.description)
 	}
 }
 


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
The seccomp field is the new default since a couple of releases, means we can stop using `SeccompProfilePath`.



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Follow-up on https://github.com/kubernetes/kubernetes/pull/96281

#### Special notes for your reviewer:
Per https://github.com/kubernetes/kubernetes/pull/115719#issuecomment-1434262361
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
