### PR TITLE
svc: Support pods with same address

### DIFF
--- a/pkg/controller/util/endpointslice/endpointset.go
+++ b/pkg/controller/util/endpointslice/endpointset.go
@@ -25,11 +25,13 @@ import (
 
 // endpointHash is used to uniquely identify endpoints. Only including addresses
 // and hostnames as unique identifiers allows us to do more in place updates
-// should attributes such as topology, conditions, or targetRef change.
+// should attributes such as topology or conditions change.
 type endpointHash string
 type endpointHashObj struct {
 	Addresses []string
 	Hostname  string
+	Namespace string
+	Name      string
 }
 
 func hashEndpoint(endpoint *discovery.Endpoint) endpointHash {
@@ -37,6 +39,10 @@ func hashEndpoint(endpoint *discovery.Endpoint) endpointHash {
 	hashObj := endpointHashObj{Addresses: endpoint.Addresses}
 	if endpoint.Hostname != nil {
 		hashObj.Hostname = *endpoint.Hostname
+	}
+	if endpoint.TargetRef != nil {
+		hashObj.Namespace = endpoint.TargetRef.Namespace
+		hashObj.Name = endpoint.TargetRef.Name
 	}
 
 	return endpointHash(endpointutil.DeepHashObjectToString(hashObj))


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
If different pods with same address are exposed by the same service if some of the endpointslices endpoints are overwriten. This change add the pod name to the hash function to ensure that all the endpoints are in place.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed an EndpointSlice Controller hashing bug that could cause EndpointSlices to incorrectly handle Pods with duplicate IP addresses. For example this could happen when a new Pod reused an IP that was also assigned to a Pod in a completed state.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
