### PR TITLE
refine: the server-side http Request Body is always non-nil

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
+++ b/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
@@ -171,7 +171,7 @@ func (s *Server) HandleValidate(w http.ResponseWriter, r *http.Request) {
 		defer cancel()
 	}
 
-	if r.Body == nil {
+	if r.Body == http.NoBody {
 		err = errors.New("request body is empty")
 		klog.ErrorS(err, "bad request")
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
+++ b/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
@@ -171,7 +171,7 @@ func (s *Server) HandleValidate(w http.ResponseWriter, r *http.Request) {
 		defer cancel()
 	}
 
-	if r.Body == http.NoBody {
+	if r.Body == nil || r.Body == http.NoBody {
 		err = errors.New("request body is empty")
 		klog.ErrorS(err, "bad request")
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/test/images/agnhost/net/main.go
+++ b/test/images/agnhost/net/main.go
@@ -159,7 +159,7 @@ func handleRunRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	runner := urlParts[2]
-	if r.Body == nil {
+	if r.Body == http.NoBody {
 		http.Error(w, "Missing request body", 400)
 		return
 	}

--- a/test/images/agnhost/net/main.go
+++ b/test/images/agnhost/net/main.go
@@ -159,7 +159,7 @@ func handleRunRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	runner := urlParts[2]
-	if r.Body == http.NoBody {
+	if r.Body == nil || r.Body == http.NoBody {
 		http.Error(w, "Missing request body", 400)
 		return
 	}

--- a/vendor/go.opencensus.io/plugin/ochttp/server.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/server.go
@@ -130,7 +130,7 @@ func (h *Handler) startTrace(w http.ResponseWriter, r *http.Request) (*http.Requ
 		}
 	}
 	span.AddAttributes(requestAttrs(r)...)
-	if r.Body == nil {
+	if r.Body == http.NoBody {
 		// TODO: Handle cases where ContentLength is not set.
 	} else if r.ContentLength > 0 {
 		span.AddMessageReceiveEvent(0, /* TODO: messageID */
@@ -156,7 +156,7 @@ func (h *Handler) startStats(w http.ResponseWriter, r *http.Request) (http.Respo
 		ctx:    ctx,
 		writer: w,
 	}
-	if r.Body == nil {
+	if r.Body == http.NoBody {
 		// TODO: Handle cases where ContentLength is not set.
 		track.reqSize = -1
 	} else if r.ContentLength > 0 {

--- a/vendor/go.opencensus.io/plugin/ochttp/server.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/server.go
@@ -130,7 +130,7 @@ func (h *Handler) startTrace(w http.ResponseWriter, r *http.Request) (*http.Requ
 		}
 	}
 	span.AddAttributes(requestAttrs(r)...)
-	if r.Body == http.NoBody {
+	if r.Body == nil {
 		// TODO: Handle cases where ContentLength is not set.
 	} else if r.ContentLength > 0 {
 		span.AddMessageReceiveEvent(0, /* TODO: messageID */
@@ -156,7 +156,7 @@ func (h *Handler) startStats(w http.ResponseWriter, r *http.Request) (http.Respo
 		ctx:    ctx,
 		writer: w,
 	}
-	if r.Body == http.NoBody {
+	if r.Body == nil {
 		// TODO: Handle cases where ContentLength is not set.
 		track.reqSize = -1
 	} else if r.ContentLength > 0 {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### Special notes for your reviewer:
```
	// For server requests, the Request Body is always non-nil
	// but will return EOF immediately when no body is present.
	// The Server will close the request body. The ServeHTTP
	// Handler does not need to.
	//
	// Body must allow Read to be called concurrently with Close.
	// In particular, calling Close should unblock a Read waiting
	// for input.
	Body io.ReadCloser
```
per `net/htp/request.go`, server-side http request body is always no-nil
we should use `http.NoBody` instead `nil` here

#### Does this PR introduce a user-facing change?
```release-note
NONE
``` 