### PR TITLE
Add check to fix Cap ALL and allowPrivileged false scenario

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6427,6 +6427,9 @@ func ValidateSecurityContext(sc *core.SecurityContext, fldPath *field.Path) fiel
 				if string(cap) == "CAP_SYS_ADMIN" {
 					allErrs = append(allErrs, field.Invalid(fldPath, sc, "cannot set `allowPrivilegeEscalation` to false and `capabilities.Add` CAP_SYS_ADMIN"))
 				}
+				if string(cap) == "ALL" {
+					allErrs = append(allErrs, field.Invalid(fldPath, sc, "cannot set `allowPrivilegeEscalation` to false and `capabilities.Add` ALL"))
+				}
 			}
 		}
 	}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -18941,6 +18941,10 @@ func TestValidateSecurityContext(t *testing.T) {
 	capSysAdminWithoutEscalation.Capabilities.Add = []core.Capability{"CAP_SYS_ADMIN"}
 	capSysAdminWithoutEscalation.AllowPrivilegeEscalation = utilpointer.Bool(false)
 
+	allWithoutEscalation := fullValidSC()
+	allWithoutEscalation.Capabilities.Add = []core.Capability{"ALL"}
+	allWithoutEscalation.AllowPrivilegeEscalation = utilpointer.Bool(false)
+
 	errorCases := map[string]struct {
 		sc           *core.SecurityContext
 		errorType    field.ErrorType
@@ -18961,6 +18965,11 @@ func TestValidateSecurityContext(t *testing.T) {
 			sc:          capSysAdminWithoutEscalation,
 			errorType:   "FieldValueInvalid",
 			errorDetail: "cannot set `allowPrivilegeEscalation` to false and `capabilities.Add` CAP_SYS_ADMIN",
+		},
+		"with ALL and allowPrivilegeEscalation false": {
+			sc:          allWithoutEscalation,
+			errorType:   "FieldValueInvalid",
+			errorDetail: "cannot set `allowPrivilegeEscalation` to false and `capabilities.Add` ALL",
 		},
 		"with privileged and allowPrivilegeEscalation false": {
 			sc:           privWithoutEscalation,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR fixes a securityContext validation issue that would allow the capability=`ALL` to be added while privileged= `false`. This was a contradiction to the behavior defined for when capability added =`CAP_SYS_ADMIN`, while privileged=`false` would fail with an error. 

Capability `ALL` should fail also as it includes `CAP_SYS_ADMIN`.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/115142

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug in securityContext validation that would allow a secuirtyContext to add `ALL` while privilege escalation was disabled.
```
