### PR TITLE
Improve performance of method haveOverlap

### DIFF
--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
@@ -144,11 +144,7 @@ func haveOverlap(a1, a2 []string) bool {
 	if len(a1) > len(a2) {
 		a1, a2 = a2, a1
 	}
-	m := make(sets.String)
-
-	for _, val := range a1 {
-		m.Insert(val)
-	}
+	m := sets.New[string](a1...)
 	for _, val := range a2 {
 		if _, ok := m[val]; ok {
 			return true

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
@@ -144,7 +144,7 @@ func haveOverlap(a1, a2 []string) bool {
 	if len(a1) > len(a2) {
 		a1, a2 = a2, a1
 	}
-	m := sets.New[string](a1...)
+	m := sets.New(a1...)
 	for _, val := range a2 {
 		if _, ok := m[val]; ok {
 			return true

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
@@ -359,29 +359,6 @@ func TestAccessModeConflicts(t *testing.T) {
 	}
 }
 
-func BenchmarkHaveOverlap(b *testing.B) {
-	tests := []struct {
-		a1        []string
-		a2        []string
-		isOverlap bool
-	}{
-		{
-			a1:        []string{"ab", "ac", "abc", "abcd", "abcde", "abcd", "ab", "abcdef", "abcdefg", "1", "2", "3", "4", "5", "6"},
-			a2:        []string{"bc", "helloworld", "bcd", "bcdef", "bcde", "12", "23", "34", "45", "56", "67", "78", "89"},
-			isOverlap: false,
-		},
-	}
-	testError := false
-	for n := 0; n < b.N; n++ {
-		for _, test := range tests {
-			if !testError && haveOverlap(test.a1, test.a2) != test.isOverlap {
-				testError = true
-				b.Errorf("test haveOverlap wrong, test case is: %v", test)
-			}
-		}
-	}
-}
-
 func newPlugin(ctx context.Context, t *testing.T) framework.Plugin {
 	return newPluginWithListers(ctx, t, nil, nil, nil, true)
 }

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
@@ -359,6 +359,29 @@ func TestAccessModeConflicts(t *testing.T) {
 	}
 }
 
+func BenchmarkHaveOverlap(b *testing.B) {
+	tests := []struct {
+		a1        []string
+		a2        []string
+		isOverlap bool
+	}{
+		{
+			a1:        []string{"ab", "ac", "abc", "abcd", "abcde", "abcd", "ab", "abcdef", "abcdefg", "1", "2", "3", "4", "5", "6"},
+			a2:        []string{"bc", "helloworld", "bcd", "bcdef", "bcde", "12", "23", "34", "45", "56", "67", "78", "89"},
+			isOverlap: false,
+		},
+	}
+	testError := false
+	for n := 0; n < b.N; n++ {
+		for _, test := range tests {
+			if !testError && haveOverlap(test.a1, test.a2) != test.isOverlap {
+				testError = true
+				b.Errorf("test haveOverlap wrong, test case is: %v", test)
+			}
+		}
+	}
+}
+
 func newPlugin(ctx context.Context, t *testing.T) framework.Plugin {
 	return newPluginWithListers(ctx, t, nil, nil, nil, true)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig scheduling

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Execution time reduced by 33%, 28% reduction in memory usage

Before:
```
BenchmarkHaveOverlap-16    	  901118	      1285 ns/op	     518 B/op	       3 allocs/op
BenchmarkHaveOverlap-16    	 1000000	      1337 ns/op	     518 B/op	       3 allocs/op
BenchmarkHaveOverlap-16    	  817712	      1328 ns/op	     518 B/op	       3 allocs/op
```
After:
```
BenchmarkHaveOverlap-16    	 1385013	       874.2 ns/op	     374 B/op	       2 allocs/op
BenchmarkHaveOverlap-16    	 1385134	       866.7 ns/op	     374 B/op	       2 allocs/op
BenchmarkHaveOverlap-16    	 1375677	       870.0 ns/op	     374 B/op	       2 allocs/op
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
