### PR TITLE
Improve performance of method haveAllNodes

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -45,8 +45,6 @@ const (
 	Name = names.DynamicResources
 
 	stateKey framework.StateKey = Name
-	// haveAllNodesThreshold is the threshold for using different lookup algorithms in the method (haveAllNodes)
-	haveAllNodesThreshold = 50
 )
 
 // The state is initialized in PreFilter phase. Because we save the pointer in
@@ -586,31 +584,14 @@ func haveAllNodes(nodeNames []string, nodes []*v1.Node) bool {
 	if len(nodeNames) < len(nodes) {
 		return false
 	}
-	// The time complexity is O(n)
-	if len(nodeNames) > haveAllNodesThreshold {
-		m := sets.New(nodeNames...)
-		for _, node := range nodes {
-			if !m.Has(node.Name) {
-				return false
-			}
-		}
-	} else { // The time complexity is O(n*n)
-		for _, node := range nodes {
-			if !haveNode(nodeNames, node.Name) {
-				return false
-			}
+	sort.Strings(nodeNames)
+	for _, node := range nodes {
+		i := sort.SearchStrings(nodeNames, node.Name)
+		if i == len(nodeNames) || nodeNames[i] != node.Name {
+			return false
 		}
 	}
 	return true
-}
-
-func haveNode(nodeNames []string, nodeName string) bool {
-	for _, n := range nodeNames {
-		if n == nodeName {
-			return true
-		}
-	}
-	return false
 }
 
 // Reserve reserves claims for the pod.

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -590,7 +590,7 @@ func haveAllNodes(nodeNames []string, nodes []*v1.Node) bool {
 	if len(nodeNames) > haveAllNodesThreshold {
 		m := sets.New(nodeNames...)
 		for _, node := range nodes {
-			if _, ok := m[node.Name]; !ok {
+			if !m.Has(node.Name) {
 				return false
 			}
 		}

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -199,38 +199,17 @@ type prepare struct {
 }
 
 func BenchmarkHaveAllNodes(b *testing.B) {
-	tests := []*struct {
-		name      string
-		nodeNames []string
-		nodes     []*v1.Node
-		nodeCount int
-	}{
-		{
-			name:      "have-nodes-10",
-			nodeCount: 10,
-		},
-		{
-			name:      "have-nodes-50",
-			nodeCount: 50,
-		},
-		{
-			name:      "have-nodes-100",
-			nodeCount: 100,
-		},
-		{
-			name:      "have-nodes-500",
-			nodeCount: 500,
-		},
-	}
-	for _, test := range tests {
-		for i := test.nodeCount; i > 0; i-- {
-			test.nodeNames = append(test.nodeNames, "worker-"+strconv.Itoa(i))
-			test.nodes = append(test.nodes, &st.MakeNode().Name("worker-"+strconv.Itoa(i)).Node)
+	for nodeCount := 10; nodeCount < 200; nodeCount += 10 {
+		var nodeNames []string
+		var nodes []*v1.Node
+		for i := nodeCount; i > 0; i-- {
+			nodeNames = append(nodeNames, "worker-"+strconv.Itoa(i))
+			nodes = append(nodes, &st.MakeNode().Name("worker-"+strconv.Itoa(i)).Node)
 		}
 		b.ResetTimer()
-		b.Run(test.name, func(b *testing.B) {
+		b.Run(fmt.Sprintf("have-nodes-%d", nodeCount), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				haveAllNodes(test.nodeNames, test.nodes)
+				haveAllNodes(nodeNames, nodes)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -198,6 +198,43 @@ type prepare struct {
 	postfilter change
 }
 
+func BenchmarkHaveAllNodes(b *testing.B) {
+	tests := []*struct {
+		name      string
+		nodeNames []string
+		nodes     []*v1.Node
+		nodeCount int
+	}{
+		{
+			name:      "have-nodes-10",
+			nodeCount: 10,
+		},
+		{
+			name:      "have-nodes-50",
+			nodeCount: 50,
+		},
+		{
+			name:      "have-nodes-100",
+			nodeCount: 100,
+		},
+		{
+			name:      "have-nodes-500",
+			nodeCount: 500,
+		},
+	}
+	for _, test := range tests {
+		for i := 0; i < test.nodeCount; i++ {
+			test.nodeNames = append(test.nodeNames, "worker-"+strconv.Itoa(i))
+			test.nodes = append(test.nodes, &st.MakeNode().Name("worker-"+strconv.Itoa(i)).Node)
+		}
+		b.Run(test.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				haveAllNodes(test.nodeNames, test.nodes)
+			}
+		})
+	}
+}
+
 func TestHaveAllNodes(t *testing.T) {
 	tests := []*struct {
 		name      string
@@ -237,30 +274,24 @@ func TestHaveAllNodes(t *testing.T) {
 			test.nodeNames = append(test.nodeNames, "worker-"+strconv.Itoa(i))
 			test.nodes = append(test.nodes, &st.MakeNode().Name("worker-"+strconv.Itoa(i)).Node)
 		}
-	}
-	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.has != haveAllNodes(test.nodeNames, test.nodes) {
 				t.Errorf("test haveAllNodes wrong, test name is: %s", test.name)
 			}
 		})
 	}
-
 	// Test for the time complexity is O(n)
 	for _, test := range tests {
 		for i := 40; i < 100; i++ {
 			test.nodeNames = append(test.nodeNames, "worker-"+strconv.Itoa(i))
 			test.nodes = append(test.nodes, &st.MakeNode().Name("worker-"+strconv.Itoa(i)).Node)
 		}
-	}
-	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.has != haveAllNodes(test.nodeNames, test.nodes) {
 				t.Errorf("test haveAllNodes wrong, test name is: %s", test.name)
 			}
 		})
 	}
-
 }
 
 func TestPlugin(t *testing.T) {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -223,7 +223,7 @@ func BenchmarkHaveAllNodes(b *testing.B) {
 		},
 	}
 	for _, test := range tests {
-		for i := 0; i < test.nodeCount; i++ {
+		for i := test.nodeCount; i > 0; i-- {
 			test.nodeNames = append(test.nodeNames, "worker-"+strconv.Itoa(i))
 			test.nodes = append(test.nodes, &st.MakeNode().Name("worker-"+strconv.Itoa(i)).Node)
 		}
@@ -279,10 +279,6 @@ func TestHaveAllNodes(t *testing.T) {
 	}
 	// Test for the time complexity is O(n)
 	for _, test := range tests {
-		for i := 0; i < haveAllNodesThreshold; i++ {
-			test.nodeNames = append(test.nodeNames, "worker-"+strconv.Itoa(i))
-			test.nodes = append(test.nodes, &st.MakeNode().Name("worker-"+strconv.Itoa(i)).Node)
-		}
 		t.Run(test.name, func(t *testing.T) {
 			if test.has != haveAllNodes(test.nodeNames, test.nodes) {
 				t.Errorf("test haveAllNodes wrong, test name is: %s", test.name)

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -227,6 +227,7 @@ func BenchmarkHaveAllNodes(b *testing.B) {
 			test.nodeNames = append(test.nodeNames, "worker-"+strconv.Itoa(i))
 			test.nodes = append(test.nodes, &st.MakeNode().Name("worker-"+strconv.Itoa(i)).Node)
 		}
+		b.ResetTimer()
 		b.Run(test.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				haveAllNodes(test.nodeNames, test.nodes)
@@ -270,10 +271,6 @@ func TestHaveAllNodes(t *testing.T) {
 	}
 	// Test for the time complexity is O(n*n)
 	for _, test := range tests {
-		for i := 0; i < 40; i++ {
-			test.nodeNames = append(test.nodeNames, "worker-"+strconv.Itoa(i))
-			test.nodes = append(test.nodes, &st.MakeNode().Name("worker-"+strconv.Itoa(i)).Node)
-		}
 		t.Run(test.name, func(t *testing.T) {
 			if test.has != haveAllNodes(test.nodeNames, test.nodes) {
 				t.Errorf("test haveAllNodes wrong, test name is: %s", test.name)
@@ -282,7 +279,7 @@ func TestHaveAllNodes(t *testing.T) {
 	}
 	// Test for the time complexity is O(n)
 	for _, test := range tests {
-		for i := 40; i < 100; i++ {
+		for i := 0; i < haveAllNodesThreshold; i++ {
 			test.nodeNames = append(test.nodeNames, "worker-"+strconv.Itoa(i))
 			test.nodes = append(test.nodes, &st.MakeNode().Name("worker-"+strconv.Itoa(i)).Node)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig scheduling
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Because the time complexity of the previous haveAllNodes method is O(n*n), when there are too many elements to compare, the execution time will increase rapidly.

The changes are as follows:
**First:** use the length of two slices to quickly judge
```
	if len(nodeNames) < len(nodes) {
		return false
	}
```
**Second:** Depending on the number of elements, two comparison algorithms are used

**Third:** The value for haveAllNodesThreshold is from a benchmark in my local environment, when the value is 50:

**fouth** The benchmark result, the nodes num is: 10 50 100 500 :
before:
```
BenchmarkHaveAllNodes/have-nodes-10-16         	 5319110	       214.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkHaveAllNodes/have-nodes-50-16         	  336820	      3602 ns/op	       0 B/op	       0 allocs/op
BenchmarkHaveAllNodes/have-nodes-100-16        	   81951	     14545 ns/op	       0 B/op	       0 allocs/op
BenchmarkHaveAllNodes/have-nodes-500-16        	    4078	    293049 ns/op	       0 B/op	       0 allocs/op
```
after:
```
BenchmarkHaveAllNodes/have-nodes-10-16         	 5723989	       207.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkHaveAllNodes/have-nodes-50-16         	  317394	      3879 ns/op	       0 B/op	       0 allocs/op
BenchmarkHaveAllNodes/have-nodes-100-16        	  158844	      7405 ns/op	    2888 B/op	       3 allocs/op
BenchmarkHaveAllNodes/have-nodes-500-16        	   34837	     34149 ns/op	   20552 B/op	       3 allocs/op
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
