### PR TITLE
Clean up FakeRecorder event emission

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/fake.go
+++ b/staging/src/k8s.io/client-go/tools/record/fake.go
@@ -41,29 +41,31 @@ func objectString(object runtime.Object, includeObject bool) string {
 	)
 }
 
-func (f *FakeRecorder) writeEvent(event string) {
+func annotationsString(annotations map[string]string) string {
+	if len(annotations) == 0 {
+		return ""
+	} else {
+		return " " + fmt.Sprint(annotations)
+	}
+}
+
+func (f *FakeRecorder) writeEvent(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
 	if f.Events != nil {
-		f.Events <- event
+		f.Events <- fmt.Sprintf(eventtype+" "+reason+" "+messageFmt, args...) +
+			objectString(object, f.IncludeObject) + annotationsString(annotations)
 	}
 }
 
 func (f *FakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
-	f.writeEvent(fmt.Sprintf("%s %s %s%s", eventtype, reason, message, objectString(object, f.IncludeObject)))
+	f.writeEvent(object, map[string]string{}, eventtype, reason, "%s", message)
 }
 
 func (f *FakeRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
-	f.writeEvent(
-		fmt.Sprintf(eventtype+" "+reason+" "+messageFmt, args...) +
-			objectString(object, f.IncludeObject),
-	)
+	f.writeEvent(object, map[string]string{}, eventtype, reason, messageFmt, args)
 }
 
 func (f *FakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
-	f.writeEvent(
-		fmt.Sprintf(eventtype+" "+reason+" "+messageFmt, args...) +
-			objectString(object, f.IncludeObject) +
-			" " + fmt.Sprint(annotations),
-	)
+	f.writeEvent(object, annotations, eventtype, reason, messageFmt, args)
 }
 
 // NewFakeRecorder creates new fake event recorder with event channel with

--- a/staging/src/k8s.io/client-go/tools/record/fake.go
+++ b/staging/src/k8s.io/client-go/tools/record/fake.go
@@ -57,15 +57,15 @@ func (f *FakeRecorder) writeEvent(object runtime.Object, annotations map[string]
 }
 
 func (f *FakeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
-	f.writeEvent(object, map[string]string{}, eventtype, reason, "%s", message)
+	f.writeEvent(object, nil, eventtype, reason, "%s", message)
 }
 
 func (f *FakeRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
-	f.writeEvent(object, map[string]string{}, eventtype, reason, messageFmt, args)
+	f.writeEvent(object, nil, eventtype, reason, messageFmt, args...)
 }
 
 func (f *FakeRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
-	f.writeEvent(object, annotations, eventtype, reason, messageFmt, args)
+	f.writeEvent(object, annotations, eventtype, reason, messageFmt, args...)
 }
 
 // NewFakeRecorder creates new fake event recorder with event channel with


### PR DESCRIPTION
/kind cleanup
/sig api-machinery
/cc @logicalhan 

This is a small cleanup to how the event recorder emits events coming off https://github.com/kubernetes/kubernetes/pull/115860

```release-note
NONE
```