### PR TITLE
Add field-level warning for deprecated spec.externalID of node

### DIFF
--- a/pkg/registry/core/node/strategy_test.go
+++ b/pkg/registry/core/node/strategy_test.go
@@ -298,6 +298,14 @@ func TestWarningOnUpdateAndCreate(t *testing.T) {
 			"spec.configSource"},
 		{api.Node{Spec: api.NodeSpec{ConfigSource: &api.NodeConfigSource{}}},
 			api.Node{}, ""},
+		{api.Node{},
+			api.Node{Spec: api.NodeSpec{DoNotUseExternalID: "externalID"}},
+			"spec.externalID"},
+		{api.Node{Spec: api.NodeSpec{DoNotUseExternalID: "externalID"}},
+			api.Node{Spec: api.NodeSpec{DoNotUseExternalID: "externalID"}},
+			"spec.externalID"},
+		{api.Node{Spec: api.NodeSpec{DoNotUseExternalID: "externalID"}},
+			api.Node{}, ""},
 	}
 	for i, test := range tests {
 		warnings := (nodeStrategy{}).WarningsOnUpdate(context.Background(), &test.node, &test.oldNode)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind deprecation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The Node `spec.externalID` field was already deprecated since #61877(v1.11), but it doesn't seem to have added server-side warnings yet.

This PR tries to add field-level warning for this deprecated field.

Sample output after adding this patch:
```sh
Warning: spec.externalID: this field is deprecated, and is unused by Kubernetes
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref: #94626 #61966


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a [warning](https://k8s.io/blog/2020/09/03/warnings/) response when handling requests that set the deprecated `spec.externalID` field for a Node.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
