### PR TITLE
Fix a bug where the KubeletConfiguration is not printed correctly in the log

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -256,7 +256,7 @@ is checked every 20 seconds (also configurable with a flag).`,
 				config.StaticPodURLHeader[k] = []string{"<masked>"}
 			}
 			// log the kubelet's config for inspection
-			klog.V(5).InfoS("KubeletConfiguration", "configuration", config)
+			klog.V(5).InfoS("KubeletConfiguration", "configuration", klog.Format(config))
 
 			// set up signal context for kubelet shutdown
 			ctx := genericapiserver.SetupSignalContext()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix a bug where the `KubeletConfiguration` is not printed correctly in the log.

Without this patch, only the TypeMeta information can be printed, the output like this:
```
I0222 09:03:38.494769    1711 server.go:267] "KubeletConfiguration" configuration="&TypeMeta{Kind:,APIVersion:,}"
```
This is because `KubeletConfiguration` does not implement `String()` method, and the `String()` method of the nested `metav1.TypeMeta` will be called incorrectly.

With this patch:
```sh
I0510 14:24:12.992457     800 server.go:260] "KubeletConfiguration" configuration=<
        {
          "EnableServer": true,
          "StaticPodPath": "/etc/kubernetes/manifests",
          "SyncFrequency": "1m0s",
          "FileCheckFrequency": "20s",
          "HTTPCheckFrequency": "20s",
          "StaticPodURL": "",
          "StaticPodURLHeader": null,
          "Address": "0.0.0.0",
          "Port": 10250,
          "ReadOnlyPort": 0,
          "VolumePluginDir": "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/",
          "ProviderID": "kind://docker/kind/kind-worker",
          "TLSCertFile": "/var/lib/kubelet/pki/kubelet.crt",
          "TLSPrivateKeyFile": "/var/lib/kubelet/pki/kubelet.key",
          "TLSCipherSuites": null,
          "TLSMinVersion": "",
          "RotateCertificates": true,
          "ServerTLSBootstrap": false,
          "Authentication": {
            "X509": {
              "ClientCAFile": "/etc/kubernetes/pki/ca.crt"
            },
            "Webhook": {
              "Enabled": true,
              "CacheTTL": "2m0s"
            },
            "Anonymous": {
              "Enabled": false
            }
          },
          "Authorization": {
            "Mode": "Webhook",
            "Webhook": {
              "CacheAuthorizedTTL": "5m0s",
              "CacheUnauthorizedTTL": "30s"
            }
          },
          "RegistryPullQPS": 5,
          "RegistryBurst": 10,
          "EventRecordQPS": 50,
          "EventBurst": 100,
          "EnableDebuggingHandlers": true,
          "EnableContentionProfiling": false,
          "HealthzPort": 10248,
          "HealthzBindAddress": "127.0.0.1",
          "OOMScoreAdj": -999,
          "ClusterDomain": "cluster.local",
          "ClusterDNS": [
            "10.96.0.10"
          ],
          "StreamingConnectionIdleTimeout": "4h0m0s",
          "NodeStatusUpdateFrequency": "10s",
          "NodeStatusReportFrequency": "5m0s",
          "NodeLeaseDurationSeconds": 40,
          "ImageMinimumGCAge": "2m0s",
          "ImageGCHighThresholdPercent": 100,
          "ImageGCLowThresholdPercent": 80,
          "VolumeStatsAggPeriod": "1m0s",
          "KubeletCgroups": "",
          "SystemCgroups": "",
          "CgroupRoot": "/kubelet",
          "CgroupsPerQOS": true,
          "CgroupDriver": "systemd",
          "CPUManagerPolicy": "none",
          "CPUManagerPolicyOptions": null,
          "CPUManagerReconcilePeriod": "10s",
          "MemoryManagerPolicy": "None",
          "TopologyManagerPolicy": "none",
          "TopologyManagerScope": "container",
          "TopologyManagerPolicyOptions": null,
          "QOSReserved": null,
          "RuntimeRequestTimeout": "2m0s",
          "HairpinMode": "promiscuous-bridge",
          "MaxPods": 110,
          "PodCIDR": "",
          "PodPidsLimit": -1,
          "ResolverConfig": "/etc/resolv.conf",
          "RunOnce": false,
          "CPUCFSQuota": true,
          "CPUCFSQuotaPeriod": "100ms",
          "MaxOpenFiles": 1000000,
          "NodeStatusMaxImages": 50,
          "ContentType": "application/vnd.kubernetes.protobuf",
          "KubeAPIQPS": 50,
          "KubeAPIBurst": 100,
          "SerializeImagePulls": true,
          "MaxParallelImagePulls": null,
          "EvictionHard": {
            "imagefs.available": "0%",
            "nodefs.available": "0%",
            "nodefs.inodesFree": "0%"
          },
          "EvictionSoft": null,
          "EvictionSoftGracePeriod": null,
          "EvictionPressureTransitionPeriod": "5m0s",
          "EvictionMaxPodGracePeriod": 0,
          "EvictionMinimumReclaim": null,
          "PodsPerCore": 0,
          "EnableControllerAttachDetach": true,
          "ProtectKernelDefaults": false,
          "MakeIPTablesUtilChains": true,
          "IPTablesMasqueradeBit": 14,
          "IPTablesDropBit": 15,
          "FeatureGates": null,
          "FailSwapOn": false,
          "MemorySwap": {
            "SwapBehavior": ""
          },
          "ContainerLogMaxSize": "10Mi",
          "ContainerLogMaxFiles": 5,
          "ConfigMapAndSecretChangeDetectionStrategy": "Watch",
          "AllowedUnsafeSysctls": null,
          "KernelMemcgNotification": false,
          "SystemReserved": null,
          "KubeReserved": null,
          "SystemReservedCgroup": "",
          "KubeReservedCgroup": "",
          "EnforceNodeAllocatable": [
            "pods"
          ],
          "ReservedSystemCPUs": "",
          "ShowHiddenMetricsForVersion": "",
          "Logging": {
            "format": "text",
            "flushFrequency": 5000000000,
            "verbosity": 5,
            "options": {
              "json": {
                "infoBufferSize": "0"
              }
            }
          },
          "EnableSystemLogHandler": true,
          "EnableSystemLogQuery": false,
          "ShutdownGracePeriod": "0s",
          "ShutdownGracePeriodCriticalPods": "0s",
          "ShutdownGracePeriodByPodPriority": null,
          "ReservedMemory": null,
          "EnableProfilingHandler": true,
          "EnableDebugFlagsHandler": true,
          "SeccompDefault": false,
          "MemoryThrottlingFactor": 0.9,
          "RegisterWithTaints": null,
          "RegisterNode": true,
          "Tracing": null,
          "LocalStorageCapacityIsolation": true,
          "ContainerRuntimeEndpoint": "unix:///run/containerd/containerd.sock",
          "ImageServiceEndpoint": ""
        }
 >
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
