### PR TITLE
Automated cherry pick of #114863: Use label selector for filtering out resources when pruning.

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -663,7 +663,7 @@ func (o *DiffOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []str
 		if err != nil {
 			return err
 		}
-		o.pruner = newPruner(o.DynamicClient, mapper, resources)
+		o.pruner = newPruner(o.DynamicClient, mapper, resources, o.Selector)
 	}
 
 	o.Builder = f.NewBuilder()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/prune.go
@@ -40,13 +40,14 @@ type pruner struct {
 	resources         []prune.Resource
 }
 
-func newPruner(dc dynamic.Interface, m meta.RESTMapper, r []prune.Resource) *pruner {
+func newPruner(dc dynamic.Interface, m meta.RESTMapper, r []prune.Resource, selector string) *pruner {
 	return &pruner{
 		visitedUids:       sets.NewString(),
 		visitedNamespaces: sets.NewString(),
 		dynamicClient:     dc,
 		mapper:            m,
 		resources:         r,
+		labelSelector:     selector,
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #114863 on release-1.26.

#114863: Use label selector for filtering out resources when pruning.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```