### PR TITLE
e2e framework: deprecate gomega wrappers

### DIFF
--- a/hack/verify-test-code.sh
+++ b/hack/verify-test-code.sh
@@ -41,33 +41,6 @@ do
     fi
 done
 
-errors_expect_error=()
-for file in "${all_e2e_files[@]}"
-do
-    if grep "Expect(.*)\.To(.*HaveOccurred()" "${file}" > /dev/null
-    then
-        errors_expect_error+=( "${file}" )
-    fi
-done
-
-errors_expect_no_equal=()
-for file in "${all_e2e_files[@]}"
-do
-    if grep -E "Expect\(.*\)\.(NotTo|ToNot)\((gomega\.Equal|Equal)" "${file}" > /dev/null
-    then
-        errors_expect_no_equal+=( "${file}" )
-    fi
-done
-
-errors_expect_equal=()
-for file in "${all_e2e_files[@]}"
-do
-    if grep -E "Expect\(.*\)\.To\((gomega\.Equal|Equal)" "${file}" > /dev/null
-    then
-        errors_expect_equal+=( "${file}" )
-    fi
-done
-
 all_e2e_framework_files=()
 kube::util::read-array all_e2e_framework_files < <(find test/e2e/framework/ -name '*.go' | grep -v "_test.go")
 errors_framework_contains_tests=()
@@ -88,48 +61,6 @@ if [ ${#errors_expect_no_error[@]} -ne 0 ]; then
     echo
     echo 'The above files need to use framework.ExpectNoError(err) instead of '
     echo 'Expect(err).NotTo(HaveOccurred()) or gomega.Expect(err).NotTo(gomega.HaveOccurred())'
-    echo
-  } >&2
-  exit 1
-fi
-
-if [ ${#errors_expect_error[@]} -ne 0 ]; then
-  {
-    echo "Errors:"
-    for err in "${errors_expect_error[@]}"; do
-      echo "$err"
-    done
-    echo
-    echo 'The above files need to use framework.ExpectError(err) instead of '
-    echo 'Expect(err).To(HaveOccurred()) or gomega.Expect(err).To(gomega.HaveOccurred())'
-    echo
-  } >&2
-  exit 1
-fi
-
-if [ ${#errors_expect_no_equal[@]} -ne 0 ]; then
-  {
-    echo "Errors:"
-    for err in "${errors_expect_no_equal[@]}"; do
-      echo "$err"
-    done
-    echo
-    echo 'The above files need to use framework.ExpectNotEqual(foo, bar) instead of '
-    echo 'Expect(foo).NotTo(Equal(bar)) or gomega.Expect(foo).NotTo(gomega.Equal(bar))'
-    echo
-  } >&2
-  exit 1
-fi
-
-if [ ${#errors_expect_equal[@]} -ne 0 ]; then
-  {
-    echo "Errors:"
-    for err in "${errors_expect_equal[@]}"; do
-      echo "$err"
-    done
-    echo
-    echo 'The above files need to use framework.ExpectEqual(foo, bar) instead of '
-    echo 'Expect(foo).To(Equal(bar)) or gomega.Expect(foo).To(gomega.Equal(bar))'
     echo
   } >&2
   exit 1

--- a/test/e2e/framework/expect.go
+++ b/test/e2e/framework/expect.go
@@ -293,16 +293,24 @@ func (f *FailureError) backtrace() {
 var ErrFailure error = FailureError{}
 
 // ExpectEqual expects the specified two are the same, otherwise an exception raises
+//
+// Deprecated: use gomega.Expect().To(gomega.BeEqual())
 func ExpectEqual(actual interface{}, extra interface{}, explain ...interface{}) {
 	gomega.ExpectWithOffset(1, actual).To(gomega.Equal(extra), explain...)
 }
 
 // ExpectNotEqual expects the specified two are not the same, otherwise an exception raises
+//
+// Deprecated: use gomega.Expect().ToNot(gomega.BeEqual())
 func ExpectNotEqual(actual interface{}, extra interface{}, explain ...interface{}) {
 	gomega.ExpectWithOffset(1, actual).NotTo(gomega.Equal(extra), explain...)
 }
 
 // ExpectError expects an error happens, otherwise an exception raises
+//
+// Deprecated: use gomega.Expect().To(gomega.HaveOccurred()) or (better!) check
+// specifically for the error that is expected with
+// gomega.Expect().To(gomega.MatchError(gomega.ContainSubstring()))
 func ExpectError(err error, explain ...interface{}) {
 	gomega.ExpectWithOffset(1, err).To(gomega.HaveOccurred(), explain...)
 }
@@ -356,16 +364,22 @@ func ExpectNoErrorWithOffset(offset int, err error, explain ...interface{}) {
 }
 
 // ExpectConsistOf expects actual contains precisely the extra elements.  The ordering of the elements does not matter.
+//
+// Deprecated: use gomega.Expect().To(gomega.ConsistOf()) instead
 func ExpectConsistOf(actual interface{}, extra interface{}, explain ...interface{}) {
 	gomega.ExpectWithOffset(1, actual).To(gomega.ConsistOf(extra), explain...)
 }
 
 // ExpectHaveKey expects the actual map has the key in the keyset
+//
+// Deprecated: use gomega.Expect().To(gomega.HaveKey()) instead
 func ExpectHaveKey(actual interface{}, key interface{}, explain ...interface{}) {
 	gomega.ExpectWithOffset(1, actual).To(gomega.HaveKey(key), explain...)
 }
 
 // ExpectEmpty expects actual is empty
+//
+// Deprecated: use gomega.Expect().To(gomega.BeEmpty()) instead
 func ExpectEmpty(actual interface{}, explain ...interface{}) {
 	gomega.ExpectWithOffset(1, actual).To(gomega.BeEmpty(), explain...)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

All wrappers except for ExpectNoError are identical to their gomega counterparts. The only advantage that they have is that their invocations are shorter.

That advantage does not outweigh their disadvantages:

- cannot be used in combination with gomega.Eventually/Consistently

- not a full replacement for gomega, so we just end up using both

- don't support passing a stack offset and thus cannot be used in helper functions

- [ginkgolinter](https://github.com/kubernetes/kubernetes/pull/115953) does not work for them, so sub-optimal calls like this one are not reported:

      framework.ExpectEqual(len(items), 0)
      ->
      gomega.Expect(items).To(gomega.BeEmpty())

- developers try to make do with what's available in the framework, leading to sub-optimal checks like this:

      framework.ExpectEqual(true, strings.Contains(event.Message, expectedEventError), "Event error should indicate non-root policy caused container to not start")
      ->
      gomega.Expect(event.Message).To(gomega.ContainSubstring(expectedEventError), "Event error should indicate non-root policy caused container to not start")

So let's remove these wrappers. As a first step they get marked as deprecated. This enables stricter
linting (https://github.com/kubernetes/kubernetes/pull/109728) to report new code which uses them, once enabled.

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/issues/115234

#### Special notes for your reviewer:

See https://github.com/kubernetes/kubernetes/compare/master...pohly:test-e2e-gomega-wrapper-removal?expand=1 for the removal of `framework.ExpectEqual` calls.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
