### PR TITLE
Emit an event when the result of a probe for a container changes

### DIFF
--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -84,8 +84,10 @@ const (
 
 // Probe event reason list
 const (
-	ContainerUnhealthy    = "Unhealthy"
-	ContainerProbeWarning = "ProbeWarning"
+	ContainerUnhealthy          = "Unhealthy"
+	ContainerProbeWarning       = "ProbeWarning"
+	ContainerProbeResultFailure = "ContainerProbeResultFailure"
+	ContainerProbeResultSuccess = "ContainerProbeResultSuccess"
 )
 
 // Pod worker event reason list

--- a/pkg/kubelet/prober/common_test.go
+++ b/pkg/kubelet/prober/common_test.go
@@ -65,6 +65,9 @@ func getTestPod() *v1.Pod {
 		Name: testContainerName,
 	}
 	pod := v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Pod",
+		},
 		Spec: v1.PodSpec{
 			Containers:    []v1.Container{container},
 			RestartPolicy: v1.RestartPolicyNever,
@@ -125,23 +128,24 @@ func newTestManager() *manager {
 		&record.FakeRecorder{},
 	).(*manager)
 	// Don't actually execute probes.
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	return m
 }
 
 func newTestWorker(m *manager, probeType probeType, probeSpec v1.Probe) *worker {
 	pod := getTestPod()
 	setTestProbe(pod, probeType, probeSpec)
-	return newWorker(m, probeType, pod, pod.Spec.Containers[0])
+	return newWorker(m, m.recorder, probeType, pod, pod.Spec.Containers[0])
 }
 
 type fakeExecProber struct {
 	result probe.Result
+	output string
 	err    error
 }
 
 func (p fakeExecProber) Probe(c exec.Cmd) (probe.Result, string, error) {
-	return p.result, "", p.err
+	return p.result, p.output, p.err
 }
 
 type syncExecProber struct {

--- a/pkg/kubelet/prober/events.go
+++ b/pkg/kubelet/prober/events.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+)
+
+// RecordContainerEvent should be used by the prober for all container related events.
+func RecordContainerEvent(recorder record.EventRecorder, pod *v1.Pod, container *v1.Container, eventType, reason, message string, args ...interface{}) {
+	ref, err := kubecontainer.GenerateContainerRef(pod, container)
+	if err != nil {
+		klog.ErrorS(err, "Can't make a ref to pod and container", "pod", klog.KObj(pod), "containerName", container.Name)
+		return
+	}
+	recorder.Eventf(ref, eventType, reason, message, args...)
+}

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -68,18 +68,10 @@ func newProber(
 	}
 }
 
-// recordContainerEvent should be used by the prober for all container related events.
-func (pb *prober) recordContainerEvent(pod *v1.Pod, container *v1.Container, eventType, reason, message string, args ...interface{}) {
-	ref, err := kubecontainer.GenerateContainerRef(pod, container)
-	if err != nil {
-		klog.ErrorS(err, "Can't make a ref to pod and container", "pod", klog.KObj(pod), "containerName", container.Name)
-		return
-	}
-	pb.recorder.Eventf(ref, eventType, reason, message, args...)
-}
-
-// probe probes the container.
-func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, error) {
+// probe probes the container and emits values on the container for probe failure or errors
+// returns a results.Result which gives the underlying result of the probe, a string containing the output from the probe
+// and an error. An error is only returned if the probe itself errors (not every results.Failure leads to an error).
+func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, string, error) {
 	var probeSpec *v1.Probe
 	switch probeType {
 	case readiness:
@@ -89,12 +81,12 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 	case startup:
 		probeSpec = container.StartupProbe
 	default:
-		return results.Failure, fmt.Errorf("unknown probe type: %q", probeType)
+		return results.Failure, "", fmt.Errorf("unknown probe type: %q", probeType)
 	}
 
 	if probeSpec == nil {
 		klog.InfoS("Probe is nil", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
-		return results.Success, nil
+		return results.Success, "", nil
 	}
 
 	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, maxProbeRetries)
@@ -102,20 +94,20 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 		// Probe failed in one way or another.
 		if err != nil {
 			klog.V(1).ErrorS(err, "Probe errored", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
-			pb.recordContainerEvent(pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored: %v", probeType, err)
+			RecordContainerEvent(pb.recorder, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored: %v", probeType, err)
 		} else { // result != probe.Success
 			klog.V(1).InfoS("Probe failed", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "output", output)
-			pb.recordContainerEvent(pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
+			RecordContainerEvent(pb.recorder, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
 		}
-		return results.Failure, err
+		return results.Failure, output, err
 	}
 	if result == probe.Warning {
-		pb.recordContainerEvent(pod, &container, v1.EventTypeWarning, events.ContainerProbeWarning, "%s probe warning: %s", probeType, output)
+		RecordContainerEvent(pb.recorder, pod, &container, v1.EventTypeWarning, events.ContainerProbeWarning, "%s probe warning: %s", probeType, output)
 		klog.V(3).InfoS("Probe succeeded with a warning", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "output", output)
 	} else {
 		klog.V(3).InfoS("Probe succeeded", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
 	}
-	return results.Success, nil
+	return results.Success, output, nil
 }
 
 // runProbeWithRetries tries to probe the container in a finite loop, it returns the last result

--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -108,6 +108,9 @@ type manager struct {
 	// prober executes the probe actions.
 	prober *prober
 
+	// recorder records events associated with the probe
+	recorder record.EventRecorder
+
 	start time.Time
 }
 
@@ -124,6 +127,7 @@ func NewManager(
 	return &manager{
 		statusManager:    statusManager,
 		prober:           prober,
+		recorder:         recorder,
 		readinessManager: readinessManager,
 		livenessManager:  livenessManager,
 		startupManager:   startupManager,
@@ -181,7 +185,7 @@ func (m *manager) AddPod(pod *v1.Pod) {
 					"pod", klog.KObj(pod), "containerName", c.Name)
 				return
 			}
-			w := newWorker(m, startup, pod, c)
+			w := newWorker(m, m.recorder, startup, pod, c)
 			m.workers[key] = w
 			go w.run()
 		}
@@ -193,7 +197,7 @@ func (m *manager) AddPod(pod *v1.Pod) {
 					"pod", klog.KObj(pod), "containerName", c.Name)
 				return
 			}
-			w := newWorker(m, readiness, pod, c)
+			w := newWorker(m, m.recorder, readiness, pod, c)
 			m.workers[key] = w
 			go w.run()
 		}
@@ -205,7 +209,7 @@ func (m *manager) AddPod(pod *v1.Pod) {
 					"pod", klog.KObj(pod), "containerName", c.Name)
 				return
 			}
-			w := newWorker(m, liveness, pod, c)
+			w := newWorker(m, m.recorder, liveness, pod, c)
 			m.workers[key] = w
 			go w.run()
 		}

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -231,12 +231,12 @@ func TestProbe(t *testing.T) {
 				testContainer.StartupProbe = test.probe
 			}
 			if test.execError {
-				prober.exec = fakeExecProber{test.execResult, errors.New("exec error")}
+				prober.exec = fakeExecProber{test.execResult, "", errors.New("exec error")}
 			} else {
-				prober.exec = fakeExecProber{test.execResult, nil}
+				prober.exec = fakeExecProber{test.execResult, "", nil}
 			}
 
-			result, err := prober.probe(ctx, probeType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+			result, _, err := prober.probe(ctx, probeType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
 			if test.expectError && err == nil {
 				t.Errorf("[%s] Expected probe error but no error was returned.", testID)
 			}
@@ -250,7 +250,7 @@ func TestProbe(t *testing.T) {
 			if len(test.expectCommand) > 0 {
 				prober.exec = execprobe.New()
 				prober.runner = &containertest.FakeContainerCommandRunner{}
-				_, err := prober.probe(ctx, probeType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+				_, _, err := prober.probe(ctx, probeType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
 				if err != nil {
 					t.Errorf("[%s] Didn't expect probe error but got: %v", testID, err)
 					continue

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -23,10 +23,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
@@ -207,7 +209,7 @@ func TestFailureThreshold(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		// First probe should succeed.
-		m.prober.exec = fakeExecProber{probe.Success, nil}
+		m.prober.exec = fakeExecProber{probe.Success, "", nil}
 
 		for j := 0; j < 3; j++ {
 			msg := fmt.Sprintf("%d success (%d)", j+1, i)
@@ -216,7 +218,7 @@ func TestFailureThreshold(t *testing.T) {
 		}
 
 		// Prober starts failing :(
-		m.prober.exec = fakeExecProber{probe.Failure, nil}
+		m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 
 		// Next 2 probes should still be "success".
 		for j := 0; j < 2; j++ {
@@ -259,13 +261,13 @@ func TestSuccessThreshold(t *testing.T) {
 		}
 
 		// Prober flakes :(
-		m.prober.exec = fakeExecProber{probe.Failure, nil}
+		m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 		msg := fmt.Sprintf("1 failure (%d)", i)
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Failure, msg)
 
 		// Back to success.
-		m.prober.exec = fakeExecProber{probe.Success, nil}
+		m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	}
 }
 
@@ -344,7 +346,7 @@ func TestOnHoldOnLivenessOrStartupCheckFailure(t *testing.T) {
 		m.statusManager.SetPodStatus(w.pod, status)
 
 		// First probe should fail.
-		m.prober.exec = fakeExecProber{probe.Failure, nil}
+		m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 		msg := "first probe"
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Failure, msg)
@@ -353,7 +355,7 @@ func TestOnHoldOnLivenessOrStartupCheckFailure(t *testing.T) {
 		}
 		// Set fakeExecProber to return success. However, the result will remain
 		// failure because the worker is on hold and won't probe.
-		m.prober.exec = fakeExecProber{probe.Success, nil}
+		m.prober.exec = fakeExecProber{probe.Success, "", nil}
 		msg = "while on hold"
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Failure, msg)
@@ -379,7 +381,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 3})
 	m.statusManager.SetPodStatus(w.pod, getTestRunningStatus())
 
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	msg := "initial probe success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -387,7 +389,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 		t.Errorf("Prober resultRun should be 1")
 	}
 
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -395,7 +397,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 		t.Errorf("Prober resultRun should be 1")
 	}
 
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "2nd probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -406,7 +408,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 	// Exceeding FailureThreshold should cause resultRun to
 	// reset to 0 so that the probe on the restarted pod
 	// also gets FailureThreshold attempts to succeed.
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "3rd probe failure, result failure"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
@@ -423,7 +425,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 
 	// Below FailureThreshold leaves probe state unchanged
 	// which is failed for startup at first.
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg := "probe failure, result unknown"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Unknown, msg)
@@ -431,7 +433,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 		t.Errorf("Prober resultRun should be 1")
 	}
 
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "2nd probe failure, result unknown"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Unknown, msg)
@@ -442,7 +444,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 	// Exceeding FailureThreshold should cause resultRun to
 	// reset to 0 so that the probe on the restarted pod
 	// also gets FailureThreshold attempts to succeed.
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "3rd probe failure, result failure"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
@@ -457,14 +459,14 @@ func TestLivenessProbeDisabledByStarted(t *testing.T) {
 	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 1})
 	m.statusManager.SetPodStatus(w.pod, getTestRunningStatusWithStarted(false))
 	// livenessProbe fails, but is disabled
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg := "Not started, probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
 	// setting started state
 	m.statusManager.SetContainerStartup(w.pod.UID, w.containerID, true)
 	// livenessProbe fails
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "Started, probe failure, result failure"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
@@ -476,19 +478,19 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: 1, FailureThreshold: 2})
 	m.statusManager.SetPodStatus(w.pod, getTestRunningStatusWithStarted(false))
 	// startupProbe fails < FailureThreshold, stays unknown
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg := "Not started, probe failure, result unknown"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Unknown, msg)
 	// startupProbe succeeds
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	msg = "Started, probe success, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
 	// setting started state
 	m.statusManager.SetContainerStartup(w.pod.UID, w.containerID, true)
 	// startupProbe fails, but is disabled
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "Started, probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -539,4 +541,87 @@ func TestGetPodLabelName(t *testing.T) {
 			t.Errorf("Expected %s, got %s", test.result, ret)
 		}
 	}
+}
+
+func TestChangeInResultToErrorIsReportedByWorker(t *testing.T) {
+	ctx := context.Background()
+
+	m := newTestManager()
+	m.prober.exec = fakeExecProber{probe.Failure, "oh no!", nil}
+
+	w := newTestWorker(m, liveness, v1.Probe{})
+	w.lastResult = results.Success
+
+	m.statusManager.SetPodStatus(w.pod, getTestRunningStatusWithStarted(true))
+
+	recorder := record.NewFakeRecorder(2)
+	m.recorder = recorder
+	w.recorder = recorder
+
+	_ = w.doProbe(ctx)
+
+	require.Len(t, recorder.Events, 1)
+	require.Equal(t, "Warning ContainerProbeResultFailure Liveness probe result changed to Failure: oh no!", <-recorder.Events)
+}
+
+func TestLackOfOutputIsHandledProperly(t *testing.T) {
+	ctx := context.Background()
+
+	m := newTestManager()
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
+
+	w := newTestWorker(m, liveness, v1.Probe{})
+	w.lastResult = results.Success
+
+	m.statusManager.SetPodStatus(w.pod, getTestRunningStatusWithStarted(true))
+
+	recorder := record.NewFakeRecorder(2)
+	m.recorder = recorder
+	w.recorder = recorder
+
+	_ = w.doProbe(ctx)
+
+	require.Len(t, recorder.Events, 1)
+	require.Equal(t, "Warning ContainerProbeResultFailure Liveness probe result changed to Failure", <-recorder.Events)
+}
+
+func TestOutputIgnoredForChangeToSuccess(t *testing.T) {
+	ctx := context.Background()
+
+	m := newTestManager()
+	m.prober.exec = fakeExecProber{probe.Success, "foobar", nil}
+
+	w := newTestWorker(m, liveness, v1.Probe{})
+	w.lastResult = results.Failure
+
+	m.statusManager.SetPodStatus(w.pod, getTestRunningStatusWithStarted(true))
+
+	recorder := record.NewFakeRecorder(2)
+	m.recorder = recorder
+	w.recorder = recorder
+
+	_ = w.doProbe(ctx)
+
+	require.Len(t, recorder.Events, 1)
+	require.Equal(t, "Normal ContainerProbeResultSuccess Liveness probe result changed to Success", <-recorder.Events)
+}
+
+func TestNoEventIfResultDoesNotChange(t *testing.T) {
+	ctx := context.Background()
+
+	m := newTestManager()
+	m.prober.exec = fakeExecProber{probe.Success, "foobar", nil}
+
+	w := newTestWorker(m, liveness, v1.Probe{})
+	w.lastResult = results.Success
+
+	m.statusManager.SetPodStatus(w.pod, getTestRunningStatusWithStarted(true))
+
+	recorder := record.NewFakeRecorder(2)
+	m.recorder = recorder
+	w.recorder = recorder
+
+	_ = w.doProbe(ctx)
+
+	require.Len(t, recorder.Events, 0)
 }


### PR DESCRIPTION
/kind feature
/kind api-change
/sig node
/hold

#### What this PR does / why we need it:
This PR introduces a new event that is emitted by the probe worker when the result of the probe changes. End-users can watch this new event to learn when their probes entered the Sucess or Failure state and in the case of Failure they gain some contextual information in the form of the output from the last probe.

Fixes https://github.com/kubernetes/kubernetes/issues/115823 by dealing with the lack of information on when a probe fails (as users can now just look at this event)

#### Does this PR introduce a user-facing change?
```release-note
A new event is emitted on containers when their readiness, liveness or startup probes change result from Success to Failure or vice-versa. In the case of Failure information on why the probe failed may be included.
```
