### PR TITLE
Add volume reconstruction metrics

### DIFF
--- a/pkg/kubelet/volumemanager/metrics/metrics.go
+++ b/pkg/kubelet/volumemanager/metrics/metrics.go
@@ -30,9 +30,11 @@ const (
 	pluginNameNotAvailable = "N/A"
 
 	// Metric keys for Volume Manager.
-	volumeManagerTotalVolumes       = "volume_manager_total_volumes"
-	reconstructedVolumesTotal       = "reconstructed_volumes_total"
-	reconstructedVolumesErrorsTotal = "reconstructed_volumes_errors_total"
+	volumeManagerTotalVolumes                     = "volume_manager_total_volumes"
+	reconstructVolumeOperationsTotal              = "reconstruct_volume_operations_total"
+	reconstructVolumeOperationsErrorsTotal        = "reconstruct_volume_operations_errors_total"
+	forceCleanedFailedVolumeOperationsTotal       = "force_cleaned_failed_volume_operations_total"
+	forceCleanedFailedVolumeOperationsErrorsTotal = "force_cleaned_failed_volume_operation_errors_total"
 )
 
 var (
@@ -46,17 +48,32 @@ var (
 		metrics.ALPHA, "",
 	)
 
-	ReconstructedVolumesTotal = metrics.NewCounter(
+	ReconstructVolumeOperationsTotal = metrics.NewCounter(
 		&metrics.CounterOpts{
-			Name:           reconstructedVolumesTotal,
+			Name:           reconstructVolumeOperationsTotal,
 			Help:           "The number of volumes that were attempted to be reconstructed from the operating system during kubelet startup. This includes both successful and failed reconstruction.",
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
-	ReconstructedVolumesErrorsTotal = metrics.NewCounter(
+	ReconstructVolumeOperationsErrorsTotal = metrics.NewCounter(
 		&metrics.CounterOpts{
-			Name:           reconstructedVolumesErrorsTotal,
+			Name:           reconstructVolumeOperationsErrorsTotal,
 			Help:           "The number of volumes that failed reconstruction from the operating system during kubelet startup.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	ForceCleanedFailedVolumeOperationsTotal = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Name:           forceCleanedFailedVolumeOperationsTotal,
+			Help:           "The number of volumes that were force cleaned after their reconstruction failed during kubelet startup. This includes both successful and failed cleanups.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+	ForceCleanedFailedVolumeOperationsErrorsTotal = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Name:           forceCleanedFailedVolumeOperationsErrorsTotal,
+			Help:           "The number of volumes that failed force cleanup after their reconstruction failed during kubelet startup.",
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
@@ -78,8 +95,10 @@ func (v volumeCount) add(state, plugin string) {
 func Register(asw cache.ActualStateOfWorld, dsw cache.DesiredStateOfWorld, pluginMgr *volume.VolumePluginMgr) {
 	registerMetrics.Do(func() {
 		legacyregistry.CustomMustRegister(&totalVolumesCollector{asw: asw, dsw: dsw, pluginMgr: pluginMgr})
-		legacyregistry.MustRegister(ReconstructedVolumesTotal)
-		legacyregistry.MustRegister(ReconstructedVolumesErrorsTotal)
+		legacyregistry.MustRegister(ReconstructVolumeOperationsTotal)
+		legacyregistry.MustRegister(ReconstructVolumeOperationsErrorsTotal)
+		legacyregistry.MustRegister(ForceCleanedFailedVolumeOperationsTotal)
+		legacyregistry.MustRegister(ForceCleanedFailedVolumeOperationsErrorsTotal)
 	})
 }
 

--- a/pkg/kubelet/volumemanager/metrics/metrics.go
+++ b/pkg/kubelet/volumemanager/metrics/metrics.go
@@ -30,7 +30,9 @@ const (
 	pluginNameNotAvailable = "N/A"
 
 	// Metric keys for Volume Manager.
-	volumeManagerTotalVolumes = "volume_manager_total_volumes"
+	volumeManagerTotalVolumes       = "volume_manager_total_volumes"
+	reconstructedVolumesTotal       = "reconstructed_volumes_total"
+	reconstructedVolumesErrorsTotal = "reconstructed_volumes_errors_total"
 )
 
 var (
@@ -42,6 +44,21 @@ var (
 		[]string{"plugin_name", "state"},
 		nil,
 		metrics.ALPHA, "",
+	)
+
+	ReconstructedVolumesTotal = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Name:           reconstructedVolumesTotal,
+			Help:           "The number of volumes that were attempted to be reconstructed from the operating system during kubelet startup. This includes both successful and failed reconstruction.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+	ReconstructedVolumesErrorsTotal = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Name:           reconstructedVolumesErrorsTotal,
+			Help:           "The number of volumes that failed reconstruction from the operating system during kubelet startup.",
+			StabilityLevel: metrics.ALPHA,
+		},
 	)
 )
 
@@ -61,6 +78,8 @@ func (v volumeCount) add(state, plugin string) {
 func Register(asw cache.ActualStateOfWorld, dsw cache.DesiredStateOfWorld, pluginMgr *volume.VolumePluginMgr) {
 	registerMetrics.Do(func() {
 		legacyregistry.CustomMustRegister(&totalVolumesCollector{asw: asw, dsw: dsw, pluginMgr: pluginMgr})
+		legacyregistry.MustRegister(ReconstructedVolumesTotal)
+		legacyregistry.MustRegister(ReconstructedVolumesErrorsTotal)
 	})
 }
 

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct_common.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct_common.go
@@ -95,10 +95,12 @@ func (rc *reconciler) cleanupMounts(volume podVolume) {
 		PluginName:          volume.pluginName,
 		PodUID:              types.UID(volume.podName),
 	}
+	metrics.ForceCleanedFailedVolumeOperationsTotal.Inc()
 	// TODO: Currently cleanupMounts only includes UnmountVolume operation. In the next PR, we will add
 	// to unmount both volume and device in the same routine.
 	err := rc.operationExecutor.UnmountVolume(mountedVolume, rc.actualStateOfWorld, rc.kubeletPodsDir)
 	if err != nil {
+		metrics.ForceCleanedFailedVolumeOperationsErrorsTotal.Inc()
 		klog.ErrorS(err, mountedVolume.GenerateErrorDetailed("volumeHandler.UnmountVolumeHandler for UnmountVolume failed", err).Error())
 		return
 	}
@@ -179,10 +181,10 @@ func getVolumesFromPodDir(podDir string) ([]podVolume, error) {
 
 // Reconstruct volume data structure by reading the pod's volume directories
 func (rc *reconciler) reconstructVolume(volume podVolume) (rvolume *reconstructedVolume, rerr error) {
-	metrics.ReconstructedVolumesTotal.Inc()
+	metrics.ReconstructVolumeOperationsTotal.Inc()
 	defer func() {
 		if rerr != nil {
-			metrics.ReconstructedVolumesErrorsTotal.Inc()
+			metrics.ReconstructVolumeOperationsErrorsTotal.Inc()
 		}
 	}()
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This is implementation of new metrics proposed in [volume reconstruction kep](https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/3756-volume-reconstruction/README.md).

It counts:

* nr. of total / failed volume reconstructions during kubelet startup.
* nr. of total / failed forced unmounts after failed volume reconstructions during kubelet startup (an admin should check the failed ones, a volume can be still mounted and kubelet is not able to unmount it).

Note: In the KEP I proposed `reconstructed_volumes_total` and `force_cleaned_failed_volumes_total`  with success/failure label. Here I am using new metrics with `..._errors_total` instead of the label to match other kubelet metrics. I'm updating the KEP here: https://github.com/kubernetes/enhancements/pull/3884.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added metrics for volume reconstruction during kubelet startup.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/3756-volume-reconstruction/README.md
```
