### PR TITLE
Graduate Evented PLEG to Beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -265,6 +265,7 @@ const (
 	// owner: @harche
 	// kep: http://kep.k8s.io/3386
 	// alpha: v1.25
+	// beta: v1.27
 	//
 	// Allows using event-driven PLEG (pod lifecycle event generator) through kubelet
 	// which avoids frequent relisting of containers which helps optimize performance.
@@ -925,7 +926,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	DynamicResourceAllocation: {Default: false, PreRelease: featuregate.Alpha},
 
-	EventedPLEG: {Default: false, PreRelease: featuregate.Alpha},
+	EventedPLEG: {Default: false, PreRelease: featuregate.Beta}, // off by default, requires CRI Runtime support
 
 	ExecProbeTimeout: {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
 

--- a/pkg/kubelet/cri/remote/remote_runtime.go
+++ b/pkg/kubelet/cri/remote/remote_runtime.go
@@ -37,8 +37,10 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/util"
 	"k8s.io/kubernetes/pkg/probe/exec"
+
 	utilexec "k8s.io/utils/exec"
 )
 
@@ -796,6 +798,9 @@ func (r *remoteRuntimeService) GetContainerEvents(containerEventsCh chan *runtim
 		klog.ErrorS(err, "GetContainerEvents failed to get streaming client")
 		return err
 	}
+
+	// The connection is successfully established and we have a streaming client ready for use.
+	metrics.EventedPLEGConn.Inc()
 
 	for {
 		resp, err := containerEventsStreamingClient.Recv()

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -43,6 +43,9 @@ const (
 	PLEGDiscardEventsKey               = "pleg_discard_events"
 	PLEGRelistIntervalKey              = "pleg_relist_interval_seconds"
 	PLEGLastSeenKey                    = "pleg_last_seen_seconds"
+	EventedPLEGConnErrKey              = "evented_pleg_connection_error_count"
+	EventedPLEGConnKey                 = "evented_pleg_connection_success_count"
+	EventedPLEGConnLatencyKey          = "evented_pleg_connection_latency_seconds"
 	EvictionsKey                       = "evictions"
 	EvictionStatsAgeKey                = "eviction_stats_age_seconds"
 	PreemptionsKey                     = "preemptions"
@@ -240,6 +243,41 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
+
+	// EventedPLEGConnErr is a Counter that tracks the number of errors encountered during
+	// the establishment of streaming connection with the CRI runtime.
+	EventedPLEGConnErr = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           EventedPLEGConnErrKey,
+			Help:           "The number of errors encountered during the establishment of streaming connection with the CRI runtime.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	// EventedPLEGConn is a Counter that tracks the number of times a streaming client
+	// was obtained to receive CRI Events.
+	EventedPLEGConn = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           EventedPLEGConnKey,
+			Help:           "The number of times a streaming client was obtained to receive CRI Events.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	// EventedPLEGConnLatency is a Histogram that tracks the latency of streaming connection
+	// with the CRI runtime, measured in seconds.
+	EventedPLEGConnLatency = metrics.NewHistogram(
+		&metrics.HistogramOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           EventedPLEGConnLatencyKey,
+			Help:           "The latency of streaming connection with the CRI runtime, measured in seconds.",
+			Buckets:        metrics.DefBuckets,
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
 	// RuntimeOperations is a Counter that tracks the cumulative number of remote runtime operations.
 	// Broken down by operation type.
 	RuntimeOperations = metrics.NewCounterVec(
@@ -605,6 +643,9 @@ func Register(collectors ...metrics.StableCollector) {
 		legacyregistry.MustRegister(PLEGDiscardEvents)
 		legacyregistry.MustRegister(PLEGRelistInterval)
 		legacyregistry.MustRegister(PLEGLastSeen)
+		legacyregistry.MustRegister(EventedPLEGConnErr)
+		legacyregistry.MustRegister(EventedPLEGConn)
+		legacyregistry.MustRegister(EventedPLEGConnLatency)
 		legacyregistry.MustRegister(RuntimeOperations)
 		legacyregistry.MustRegister(RuntimeOperationsDuration)
 		legacyregistry.MustRegister(RuntimeOperationsErrors)

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -190,6 +190,7 @@ func (e *EventedPLEG) watchEventsChannel() {
 
 			err := e.runtimeService.GetContainerEvents(containerEventsResponseCh)
 			if err != nil {
+				metrics.EventedPLEGConnErr.Inc()
 				numAttempts++
 				e.Relist() // Force a relist to get the latest container and pods running metric.
 				klog.V(4).InfoS("Evented PLEG: Failed to get container events, retrying: ", "err", err)
@@ -245,6 +246,7 @@ func (e *EventedPLEG) processCRIEvents(containerEventsResponseCh chan *runtimeap
 
 		e.updateRunningPodMetric(status)
 		e.updateRunningContainerMetric(status)
+		e.updateLatencyMetric(event)
 
 		if event.ContainerEventType == runtimeapi.ContainerEventType_CONTAINER_DELETED_EVENT {
 			for _, sandbox := range status.SandboxStatuses {
@@ -408,6 +410,11 @@ func (e *EventedPLEG) updateRunningContainerMetric(podStatus *kubecontainer.PodS
 			metrics.RunningContainerCount.WithLabelValues(string(state)).Add(float64(diff))
 		}
 	}
+}
+
+func (e *EventedPLEG) updateLatencyMetric(event *runtimeapi.ContainerEventResponse) {
+	duration := time.Duration(time.Now().UnixNano()-event.CreatedAt) * time.Nanosecond
+	metrics.EventedPLEGConnLatency.Observe(duration.Seconds())
 }
 
 func (e *EventedPLEG) UpdateCache(pod *kubecontainer.Pod, pid types.UID) (error, bool) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Graduate `Evented PLEG` feature to Beta

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/enhancements/issues/3386

#### Special notes for your reviewer:
As a part of graduating the `Evented PLEG` to Beta we had decided to add 4 new grpc connection related [metrics](https://github.com/kubernetes/enhancements/pull/3817/files#diff-4a48c7915d4769b7522c1c9711a927f4ebacfcefe8b2b60c9edf6ffd43e35498R421). However, while implementing I realized that we don't have to implement propsed [evented_pleg_notifications_received](https://github.com/kubernetes/enhancements/pull/3817/files#diff-4a48c7915d4769b7522c1c9711a927f4ebacfcefe8b2b60c9edf6ffd43e35498R424) metric because as a part of implementing [evented_pleg_connection_latency_seconds](https://github.com/kubernetes/enhancements/pull/3817/files#diff-4a48c7915d4769b7522c1c9711a927f4ebacfcefe8b2b60c9edf6ffd43e35498R423), a histogram metric, we automatically get a metric `kubelet_evented_pleg_connection_latency_seconds_count` that is capturing the total count of the events. 

```
# curl -k --cert /var/run/kubernetes/client-admin.crt --key /var/run/kubernetes/client-admin.key https://localhost:10250/metrics | grep -i evented_pleg_
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0# HELP kubelet_evented_pleg_connection_error_count [ALPHA] The number of errors encountered during the establishment of streaming connection with the CRI runtime.
# TYPE kubelet_evented_pleg_connection_error_count counter
kubelet_evented_pleg_connection_error_count 0
# HELP kubelet_evented_pleg_connection_latency_seconds [ALPHA] The latency of streaming connection with the CRI runtime, measured in seconds.
# TYPE kubelet_evented_pleg_connection_latency_seconds histogram
kubelet_evented_pleg_connection_latency_seconds_bucket{le="0.005"} 14
kubelet_evented_pleg_connection_latency_seconds_bucket{le="0.01"} 14
kubelet_evented_pleg_connection_latency_seconds_bucket{le="0.025"} 14
kubelet_evented_pleg_connection_latency_seconds_bucket{le="0.05"} 14
kubelet_evented_pleg_connection_latency_seconds_bucket{le="0.1"} 14
kubelet_evented_pleg_connection_latency_seconds_bucket{le="0.25"} 14
kubelet_evented_pleg_connection_latency_seconds_bucket{le="0.5"} 14
kubelet_evented_pleg_connection_latency_seconds_bucket{le="1"} 14
kubelet_evented_pleg_connection_latency_seconds_bucket{le="2.5"} 14
kubelet_evented_pleg_connection_latency_seconds_bucket{le="5"} 14
kubelet_evented_pleg_connection_latency_seconds_bucket{le="10"} 14
kubelet_evented_pleg_connection_latency_seconds_bucket{le="+Inf"} 14
kubelet_evented_pleg_connection_latency_seconds_sum 0.0044651019999999994
kubelet_evented_pleg_connection_latency_seconds_count 14
# HELP kubelet_evented_pleg_connection_success_count [ALPHA] The number of times the connection was successfully established with the CRI Runtime.
# TYPE kubelet_evented_pleg_connection_success_count counter
kubelet_evented_pleg_connection_success_count 1
100  130k    0  130k    0     0  11.0M      0 --:--:-- --:--:-- --:--:-- 11.5M
```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Graduate CRI Events driven Pod LifeCycle Event Generator (Evented PLEG) to Beta
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3386
```
