### PR TITLE
add SeccompProfile to Pod and Container accessors/mutators

### DIFF
--- a/pkg/securitycontext/accessors.go
+++ b/pkg/securitycontext/accessors.go
@@ -31,6 +31,7 @@ type PodSecurityContextAccessor interface {
 	RunAsUser() *int64
 	RunAsGroup() *int64
 	RunAsNonRoot() *bool
+	SeccompProfile() *api.SeccompProfile
 	SupplementalGroups() []int64
 	FSGroup() *int64
 }
@@ -46,6 +47,7 @@ type PodSecurityContextMutator interface {
 	SetRunAsUser(*int64)
 	SetRunAsGroup(*int64)
 	SetRunAsNonRoot(*bool)
+	SetSeccompProfile(*api.SeccompProfile)
 	SetSupplementalGroups([]int64)
 	SetFSGroup(*int64)
 
@@ -171,6 +173,19 @@ func (w *podSecurityContextWrapper) SetRunAsNonRoot(v *bool) {
 	w.ensurePodSC()
 	w.podSC.RunAsNonRoot = v
 }
+func (w *podSecurityContextWrapper) SeccompProfile() *api.SeccompProfile {
+	if w.podSC == nil {
+		return nil
+	}
+	return w.podSC.SeccompProfile
+}
+func (w *podSecurityContextWrapper) SetSeccompProfile(p *api.SeccompProfile) {
+	if w.podSC == nil && p == nil {
+		return
+	}
+	w.ensurePodSC()
+	w.podSC.SeccompProfile = p
+}
 func (w *podSecurityContextWrapper) SupplementalGroups() []int64 {
 	if w.podSC == nil {
 		return nil
@@ -211,6 +226,7 @@ type ContainerSecurityContextAccessor interface {
 	RunAsGroup() *int64
 	RunAsNonRoot() *bool
 	ReadOnlyRootFilesystem() *bool
+	SeccompProfile() *api.SeccompProfile
 	AllowPrivilegeEscalation() *bool
 }
 
@@ -227,6 +243,7 @@ type ContainerSecurityContextMutator interface {
 	SetRunAsGroup(*int64)
 	SetRunAsNonRoot(*bool)
 	SetReadOnlyRootFilesystem(*bool)
+	SetSeccompProfile(*api.SeccompProfile)
 	SetAllowPrivilegeEscalation(*bool)
 }
 
@@ -357,6 +374,20 @@ func (w *containerSecurityContextWrapper) SetReadOnlyRootFilesystem(v *bool) {
 	w.ensureContainerSC()
 	w.containerSC.ReadOnlyRootFilesystem = v
 }
+func (w *containerSecurityContextWrapper) SeccompProfile() *api.SeccompProfile {
+	if w.containerSC == nil {
+		return nil
+	}
+	return w.containerSC.SeccompProfile
+}
+func (w *containerSecurityContextWrapper) SetSeccompProfile(p *api.SeccompProfile) {
+	if w.containerSC == nil && p == nil {
+		return
+	}
+	w.ensureContainerSC()
+	w.containerSC.SeccompProfile = p
+}
+
 func (w *containerSecurityContextWrapper) AllowPrivilegeEscalation() *bool {
 	if w.containerSC == nil {
 		return nil
@@ -462,6 +493,14 @@ func (w *effectiveContainerSecurityContextWrapper) ReadOnlyRootFilesystem() *boo
 func (w *effectiveContainerSecurityContextWrapper) SetReadOnlyRootFilesystem(v *bool) {
 	if !reflect.DeepEqual(w.ReadOnlyRootFilesystem(), v) {
 		w.containerSC.SetReadOnlyRootFilesystem(v)
+	}
+}
+func (w *effectiveContainerSecurityContextWrapper) SeccompProfile() *api.SeccompProfile {
+	return w.containerSC.SeccompProfile()
+}
+func (w *effectiveContainerSecurityContextWrapper) SetSeccompProfile(p *api.SeccompProfile) {
+	if !reflect.DeepEqual(w.SeccompProfile(), p) {
+		w.containerSC.SetSeccompProfile(p)
 	}
 }
 func (w *effectiveContainerSecurityContextWrapper) AllowPrivilegeEscalation() *bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds the `SeccompProfile` field into the pod and container security context accessor/mutator to maintain the securityContext workflow.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes/kubernetes/issues/91286

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @saschagrunert @tallclair
since you seem to have been active at the referenced issue