### PR TITLE
prunev2: Add labels for objects that we apply

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -452,7 +452,15 @@ func (o *ApplyOptions) GetObjects() ([]*resource.Info, error) {
 			LabelSelectorParam(o.Selector).
 			Flatten().
 			Do()
+
 		o.objects, err = r.Infos()
+
+		if o.ApplySet != nil {
+			if err := o.ApplySet.addLabels(o.objects); err != nil {
+				return nil, err
+			}
+		}
+
 		o.objectsCached = true
 	}
 	return o.objects, err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/expected-manifest1-getobjects.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/expected-manifest1-getobjects.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    applyset.k8s.io/part-of: placeholder-todo
+  name: foo
+
+---
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    applyset.k8s.io/part-of: placeholder-todo
+  name: bar

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/manifest1.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/manifest1.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo
+
+---
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bar


### PR DESCRIPTION
As we apply objects when using apply/prune v2, we want to be sure they include the label that ties them back to the applyset they are part of.

Builds on #115979

/kind feature