### PR TITLE
[WIP] test: configure NetworkPolicy e2e to sleep before probing

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -426,6 +426,7 @@ func RegisterClusterFlags(flags *flag.FlagSet) {
 	flags.DurationVar(&TestContext.timeouts.SystemPodsStartup, "system-pods-startup-timeout", TestContext.timeouts.SystemPodsStartup, "Timeout for waiting for all system pods to be running before starting tests.")
 	flags.DurationVar(&TestContext.timeouts.NodeSchedulable, "node-schedulable-timeout", TestContext.timeouts.NodeSchedulable, "Timeout for waiting for all nodes to be schedulable.")
 	flags.DurationVar(&TestContext.timeouts.SystemDaemonsetStartup, "system-daemonsets-startup-timeout", TestContext.timeouts.SystemDaemonsetStartup, "Timeout for waiting for all system daemonsets to be ready.")
+	flags.DurationVar(&TestContext.timeouts.NetPolSleepBeforeProbing, "netpol-sleep-before-probing", TestContext.timeouts.NetPolSleepBeforeProbing, "Time to wait before the first attempt probing Pod connectivity when validating a NetworkPolicy.")
 	flags.StringVar(&TestContext.EtcdUpgradeStorage, "etcd-upgrade-storage", "", "The storage version to upgrade to (either 'etcdv2' or 'etcdv3') if doing an etcd upgrade test.")
 	flags.StringVar(&TestContext.EtcdUpgradeVersion, "etcd-upgrade-version", "", "The etcd binary version to upgrade to (e.g., '3.0.14', '2.3.7') if doing an etcd upgrade test.")
 	flags.StringVar(&TestContext.GCEUpgradeScript, "gce-upgrade-script", "", "Script to use to upgrade a GCE cluster.")

--- a/test/e2e/framework/timeouts.go
+++ b/test/e2e/framework/timeouts.go
@@ -28,6 +28,7 @@ var defaultTimeouts = TimeoutContext{
 	ClaimProvisionShort:       1 * time.Minute,
 	DataSourceProvision:       5 * time.Minute,
 	ClaimBound:                3 * time.Minute,
+	NetPolSleepBeforeProbing:  0 * time.Second,
 	PVReclaim:                 3 * time.Minute,
 	PVBound:                   3 * time.Minute,
 	PVCreate:                  3 * time.Minute,
@@ -73,6 +74,9 @@ type TimeoutContext struct {
 
 	// ClaimBound is how long claims have to become bound.
 	ClaimBound time.Duration
+
+	// NetPolSleepBeforeProbing is how long to wait before probing when validating NetworkPolicy e2e tests.
+	NetPolSleepBeforeProbing time.Duration
 
 	// PVReclaim is how long PVs have to become reclaimed.
 	PVReclaim time.Duration

--- a/test/e2e/network/netpol/network_policy.go
+++ b/test/e2e/network/netpol/network_policy.go
@@ -114,19 +114,6 @@ var _ = common.SIGDescribe("Netpol", func() {
 	f.SkipNamespaceCreation = true // we create our own 3 test namespaces, we don't need the default one
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 
-	// TODO make boolean thread safe
-	hasAnyTestCaseFailed := false
-	ginkgo.BeforeEach(func() {
-		if hasAnyTestCaseFailed {
-			// TODO add feature gate
-			e2eskipper.Skipf("skipping test because previous test failed")
-		}
-	})
-
-	ginkgo.AfterEach(func() {
-		hasAnyTestCaseFailed = hasAnyTestCaseFailed || ginkgo.CurrentSpecReport().Failed()
-	})
-
 	ginkgo.Context("NetworkPolicy between server and client", func() {
 		var k8s *kubeManager
 
@@ -1250,21 +1237,9 @@ var _ = common.SIGDescribe("Netpol [LinuxOnly]", func() {
 	f.SkipNamespaceCreation = true
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 	var k8s *kubeManager
-
-	// TODO make boolean thread safe
-	hasAnyTestCaseFailed := false
 	ginkgo.BeforeEach(func() {
 		// Windows does not support UDP testing via agnhost.
 		e2eskipper.SkipIfNodeOSDistroIs("windows")
-
-		if hasAnyTestCaseFailed {
-			// TODO add feature gate
-			e2eskipper.Skipf("skipping test because previous test failed")
-		}
-	})
-
-	ginkgo.AfterEach(func() {
-		hasAnyTestCaseFailed = hasAnyTestCaseFailed || ginkgo.CurrentSpecReport().Failed()
 	})
 
 	ginkgo.Context("NetworkPolicy between server and client using UDP", func() {
@@ -1342,21 +1317,9 @@ var _ = common.SIGDescribe("Netpol [Feature:SCTPConnectivity][LinuxOnly]", func(
 	f.SkipNamespaceCreation = true
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 	var k8s *kubeManager
-
-	// TODO make boolean thread safe
-	hasAnyTestCaseFailed := false
 	ginkgo.BeforeEach(func() {
-		// Windows does not support SCTP for NetworkPolicy.
+		// Windows does not support network policies.
 		e2eskipper.SkipIfNodeOSDistroIs("windows")
-
-		if hasAnyTestCaseFailed {
-			// TODO add feature gate
-			e2eskipper.Skipf("skipping test because previous test failed")
-		}
-	})
-
-	ginkgo.AfterEach(func() {
-		hasAnyTestCaseFailed = hasAnyTestCaseFailed || ginkgo.CurrentSpecReport().Failed()
 	})
 
 	ginkgo.Context("NetworkPolicy between server and client using SCTP", func() {

--- a/test/e2e/network/netpol/test_helper.go
+++ b/test/e2e/network/netpol/test_helper.go
@@ -114,12 +114,25 @@ func ValidateOrFail(k8s *kubeManager, testCase *TestCase) {
 	// 1st try, exponential backoff (starting at 1s) will happen for every probe to accommodate infra that might be
 	// network-congested, as is common in some GH actions or other heavily oversubscribed CI systems.
 	ginkgo.By("Validating reachability matrix... (FIRST TRY)")
+
+	// TODO use feature gate and configured timeout
+	sleepDuration := 90 * time.Second
+	framework.Logf("Sleeping %+v before probing pod to pod connectivity...", sleepDuration)
+	time.Sleep(sleepDuration)
+	framework.Logf("Finished sleeping. Starting to probe pod to pod connectivity...")
+
 	ProbePodToPodConnectivity(k8s, k8s.AllPods(), k8s.DNSDomain(), testCase)
 
 	// the aforementioned individual probe's exponential retries (introduced in january 2023) might be able to obviate
 	//  this step, let's investigate removing this massive secondary polling of the matrix some day.
 	if _, wrong, _, _ := testCase.Reachability.Summary(ignoreLoopback); wrong != 0 {
 		framework.Logf("failed first probe %d wrong results ... retrying (SECOND TRY)", wrong)
+
+		// TODO use feature gate and configured timeout
+		framework.Logf("Sleeping %+v before probing pod to pod connectivity...", sleepDuration)
+		time.Sleep(sleepDuration)
+		framework.Logf("Finished sleeping. Starting to probe pod to pod connectivity...")
+
 		ProbePodToPodConnectivity(k8s, k8s.AllPods(), k8s.DNSDomain(), testCase)
 	}
 

--- a/test/e2e/network/netpol/test_helper.go
+++ b/test/e2e/network/netpol/test_helper.go
@@ -115,11 +115,12 @@ func ValidateOrFail(k8s *kubeManager, testCase *TestCase) {
 	// network-congested, as is common in some GH actions or other heavily oversubscribed CI systems.
 	ginkgo.By("Validating reachability matrix... (FIRST TRY)")
 
-	// TODO use feature gate and configured timeout
-	sleepDuration := 90 * time.Second
-	framework.Logf("Sleeping %+v before first attempt probing pod to pod connectivity...", sleepDuration)
-	time.Sleep(sleepDuration)
-	framework.Logf("Finished sleeping. Starting to probe pod to pod connectivity...")
+	sleepDuration := k8s.framework.Timeouts.NetPolSleepBeforeProbing
+	if sleepDuration != 0 {
+		framework.Logf("Sleeping %+v before first attempt probing pod to pod connectivity...", sleepDuration)
+		time.Sleep(sleepDuration)
+		framework.Logf("Finished sleeping. Starting to probe pod to pod connectivity...")
+	}
 
 	ProbePodToPodConnectivity(k8s, k8s.AllPods(), k8s.DNSDomain(), testCase)
 

--- a/test/e2e/network/netpol/test_helper.go
+++ b/test/e2e/network/netpol/test_helper.go
@@ -117,7 +117,7 @@ func ValidateOrFail(k8s *kubeManager, testCase *TestCase) {
 
 	// TODO use feature gate and configured timeout
 	sleepDuration := 90 * time.Second
-	framework.Logf("Sleeping %+v before probing pod to pod connectivity...", sleepDuration)
+	framework.Logf("Sleeping %+v before first attempt probing pod to pod connectivity...", sleepDuration)
 	time.Sleep(sleepDuration)
 	framework.Logf("Finished sleeping. Starting to probe pod to pod connectivity...")
 
@@ -127,11 +127,6 @@ func ValidateOrFail(k8s *kubeManager, testCase *TestCase) {
 	//  this step, let's investigate removing this massive secondary polling of the matrix some day.
 	if _, wrong, _, _ := testCase.Reachability.Summary(ignoreLoopback); wrong != 0 {
 		framework.Logf("failed first probe %d wrong results ... retrying (SECOND TRY)", wrong)
-
-		// TODO use feature gate and configured timeout
-		framework.Logf("Sleeping %+v before probing pod to pod connectivity...", sleepDuration)
-		time.Sleep(sleepDuration)
-		framework.Logf("Finished sleeping. Starting to probe pod to pod connectivity...")
 
 		ProbePodToPodConnectivity(k8s, k8s.AllPods(), k8s.DNSDomain(), testCase)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently, there are large latencies in Windows SysCalls that lead to e2e test failures for `--ginkgo.focus=NetworkPolicy` when using [Azure Network Policy Manager (NPM)](https://github.com/Azure/azure-container-networking/blob/master/docs/npm.md).

This PR adds a sleep before probing pod connectivity when validating a NetworkPolicy. The sleep duration is configurable with e.g. `--netpol-sleep-before-probing=1m30s`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
