### PR TITLE
Sort apidiscovery versions in aggregated discovery test

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery_test.go
@@ -265,6 +265,7 @@ func TestLegacyFallbackNoCache(t *testing.T) {
 		"v1beta1":  generateVersionResource("v1beta1"),
 		"v1alpha1": generateVersionResource("v1alpha1"),
 	}
+	sortedVersionOrder := []string{"v1", "v1beta1", "v1alpha1"}
 
 	legacyResourceHandlerV1 := discovery.NewAPIVersionHandler(scheme.Codecs, schema.GroupVersion{
 		Group:   "stable.example.com",
@@ -361,11 +362,11 @@ func TestLegacyFallbackNoCache(t *testing.T) {
 	_, _, doc := fetchPath(aggregatedResourceManager, "")
 
 	aggregatedVersions := []apidiscoveryv2beta1.APIVersionDiscovery{}
-	for _, resource := range resources {
-		converted, err := endpoints.ConvertGroupVersionIntoToDiscovery([]metav1.APIResource{resource})
+	for _, version := range sortedVersionOrder {
+		converted, err := endpoints.ConvertGroupVersionIntoToDiscovery([]metav1.APIResource{resources[version]})
 		require.NoError(t, err)
 		aggregatedVersions = append(aggregatedVersions, apidiscoveryv2beta1.APIVersionDiscovery{
-			Version:   resource.Version,
+			Version:   resources[version].Version,
 			Resources: converted,
 			Freshness: apidiscoveryv2beta1.DiscoveryFreshnessCurrent,
 		})


### PR DESCRIPTION
/kind flake

#### What this PR does / why we need it:

Sort versions returned in aggregated discovery test. Golang map iteration order is not stable and should not be treated as such.

```
jying@jefftree ❯❯❯ go test ./... -run=TestLegacyFallbackNoCache -count=100
ok      k8s.io/kube-aggregator/pkg/apiserver    10.342s
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes flake discovered in https://storage.googleapis.com/k8s-triage/index.html?text=TestLegacyFallbackNoCache#1bf2be60ce0078971afe

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @pacoxu @deads2k 