### PR TITLE
Fix API field references for autoscaling v1, v2 and v2beta2

### DIFF
--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -155,7 +155,7 @@
               }
             ],
             "default": {},
-            "description": "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status."
+            "description": "spec defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status."
           },
           "status": {
             "allOf": [
@@ -164,7 +164,7 @@
               }
             ],
             "default": {},
-            "description": "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only."
+            "description": "status is the current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only."
           }
         },
         "type": "object",
@@ -180,7 +180,7 @@
         "description": "ScaleSpec describes the attributes of a scale subresource.",
         "properties": {
           "replicas": {
-            "description": "desired number of instances for the scaled object.",
+            "description": "replicas is the desired number of instances for the scaled object.",
             "format": "int32",
             "type": "integer"
           }
@@ -192,12 +192,12 @@
         "properties": {
           "replicas": {
             "default": 0,
-            "description": "actual number of observed instances of the scaled object.",
+            "description": "replicas is the actual number of observed instances of the scaled object.",
             "format": "int32",
             "type": "integer"
           },
           "selector": {
-            "description": "label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+            "description": "selector is the label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
             "type": "string"
           }
         },

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -1272,7 +1272,7 @@
               }
             ],
             "default": {},
-            "description": "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status."
+            "description": "spec defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status."
           },
           "status": {
             "allOf": [
@@ -1281,7 +1281,7 @@
               }
             ],
             "default": {},
-            "description": "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only."
+            "description": "status is the current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only."
           }
         },
         "type": "object",
@@ -1297,7 +1297,7 @@
         "description": "ScaleSpec describes the attributes of a scale subresource.",
         "properties": {
           "replicas": {
-            "description": "desired number of instances for the scaled object.",
+            "description": "replicas is the desired number of instances for the scaled object.",
             "format": "int32",
             "type": "integer"
           }
@@ -1309,12 +1309,12 @@
         "properties": {
           "replicas": {
             "default": 0,
-            "description": "actual number of observed instances of the scaled object.",
+            "description": "replicas is the actual number of observed instances of the scaled object.",
             "format": "int32",
             "type": "integer"
           },
           "selector": {
-            "description": "label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+            "description": "selector is the label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
             "type": "string"
           }
         },

--- a/api/openapi-spec/v3/apis__autoscaling__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__autoscaling__v1_openapi.json
@@ -5,17 +5,17 @@
         "description": "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
         "properties": {
           "apiVersion": {
-            "description": "API version of the referent",
+            "description": "apiVersion is the API version of the referent",
             "type": "string"
           },
           "kind": {
             "default": "",
-            "description": "Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "description": "kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
             "type": "string"
           },
           "name": {
             "default": "",
-            "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+            "description": "name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
             "type": "string"
           }
         },
@@ -53,7 +53,7 @@
               }
             ],
             "default": {},
-            "description": "behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status."
+            "description": "spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status."
           },
           "status": {
             "allOf": [
@@ -62,7 +62,7 @@
               }
             ],
             "default": {},
-            "description": "current information about the autoscaler."
+            "description": "status is the current information about the autoscaler."
           }
         },
         "type": "object",
@@ -82,7 +82,7 @@
             "type": "string"
           },
           "items": {
-            "description": "list of horizontal pod autoscaler objects.",
+            "description": "items is the list of horizontal pod autoscaler objects.",
             "items": {
               "allOf": [
                 {
@@ -124,7 +124,7 @@
         "properties": {
           "maxReplicas": {
             "default": 0,
-            "description": "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
+            "description": "maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
             "format": "int32",
             "type": "integer"
           },
@@ -143,7 +143,7 @@
             "description": "reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource."
           },
           "targetCPUUtilizationPercentage": {
-            "description": "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.",
+            "description": "targetCPUUtilizationPercentage is the target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.",
             "format": "int32",
             "type": "integer"
           }
@@ -158,19 +158,19 @@
         "description": "current status of a horizontal pod autoscaler",
         "properties": {
           "currentCPUUtilizationPercentage": {
-            "description": "current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
+            "description": "currentCPUUtilizationPercentage is the current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
             "format": "int32",
             "type": "integer"
           },
           "currentReplicas": {
             "default": 0,
-            "description": "current number of replicas of pods managed by this autoscaler.",
+            "description": "currentReplicas is the current number of replicas of pods managed by this autoscaler.",
             "format": "int32",
             "type": "integer"
           },
           "desiredReplicas": {
             "default": 0,
-            "description": "desired number of replicas of pods managed by this autoscaler.",
+            "description": "desiredReplicas is the  desired number of replicas of pods managed by this autoscaler.",
             "format": "int32",
             "type": "integer"
           },
@@ -180,10 +180,10 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
               }
             ],
-            "description": "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed."
+            "description": "lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed."
           },
           "observedGeneration": {
-            "description": "most recent generation observed by this autoscaler.",
+            "description": "observedGeneration is the most recent generation observed by this autoscaler.",
             "format": "int64",
             "type": "integer"
           }

--- a/api/openapi-spec/v3/apis__autoscaling__v2_openapi.json
+++ b/api/openapi-spec/v3/apis__autoscaling__v2_openapi.json
@@ -36,7 +36,7 @@
         "properties": {
           "container": {
             "default": "",
-            "description": "Container is the name of the container in the pods of the scaling target",
+            "description": "container is the name of the container in the pods of the scaling target",
             "type": "string"
           },
           "current": {
@@ -50,7 +50,7 @@
           },
           "name": {
             "default": "",
-            "description": "Name is the name of the resource in question.",
+            "description": "name is the name of the resource in question.",
             "type": "string"
           }
         },
@@ -65,17 +65,17 @@
         "description": "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
         "properties": {
           "apiVersion": {
-            "description": "API version of the referent",
+            "description": "apiVersion is the API version of the referent",
             "type": "string"
           },
           "kind": {
             "default": "",
-            "description": "Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "description": "kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
             "type": "string"
           },
           "name": {
             "default": "",
-            "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+            "description": "name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
             "type": "string"
           }
         },
@@ -146,18 +146,18 @@
         "properties": {
           "periodSeconds": {
             "default": 0,
-            "description": "PeriodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+            "description": "periodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
             "format": "int32",
             "type": "integer"
           },
           "type": {
             "default": "",
-            "description": "Type is used to specify the scaling policy.",
+            "description": "type is used to specify the scaling policy.",
             "type": "string"
           },
           "value": {
             "default": 0,
-            "description": "Value contains the amount of change which is permitted by the policy. It must be greater than zero",
+            "description": "value contains the amount of change which is permitted by the policy. It must be greater than zero",
             "format": "int32",
             "type": "integer"
           }
@@ -190,7 +190,7 @@
             "type": "string"
           },
           "stabilizationWindowSeconds": {
-            "description": "StabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
+            "description": "stabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
             "format": "int32",
             "type": "integer"
           }
@@ -826,7 +826,7 @@
           },
           "name": {
             "default": "",
-            "description": "Name is the name of the resource in question.",
+            "description": "name is the name of the resource in question.",
             "type": "string"
           }
         },

--- a/pkg/apis/autoscaling/types.go
+++ b/pkg/apis/autoscaling/types.go
@@ -31,25 +31,25 @@ type Scale struct {
 	// +optional
 	metav1.ObjectMeta
 
-	// defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+	// spec defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
 	// +optional
 	Spec ScaleSpec
 
-	// current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.
+	// status represents the current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.
 	// +optional
 	Status ScaleStatus
 }
 
 // ScaleSpec describes the attributes of a scale subresource.
 type ScaleSpec struct {
-	// desired number of instances for the scaled object.
+	// replicas is the desired number of instances for the scaled object.
 	// +optional
 	Replicas int32
 }
 
 // ScaleStatus represents the current status of a scale subresource.
 type ScaleStatus struct {
-	// actual number of observed instances of the scaled object.
+	// replicas is the actual number of observed instances of the scaled object.
 	Replicas int32
 
 	// label query over pods that should match the replicas count. This is same
@@ -62,20 +62,23 @@ type ScaleStatus struct {
 
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
 type CrossVersionObjectReference struct {
-	// Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+	// kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
 	Kind string
-	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+	// name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
 	Name string
-	// API version of the referent
+
+	// apiVersion is the API version of the referent
 	// +optional
 	APIVersion string
 }
 
 // HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.
 type HorizontalPodAutoscalerSpec struct {
-	// ScaleTargetRef points to the target resource to scale, and is used to the pods for which metrics
+	// scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics
 	// should be collected, as well as to actually change the replica count.
 	ScaleTargetRef CrossVersionObjectReference
+
 	// minReplicas is the lower limit for the number of replicas to which the autoscaler
 	// can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the
 	// alpha feature gate HPAScaleToZero is enabled and at least one Object or External
@@ -83,10 +86,12 @@ type HorizontalPodAutoscalerSpec struct {
 	// available.
 	// +optional
 	MinReplicas *int32
-	// MaxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
+
+	// maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
 	// It cannot be less that minReplicas.
 	MaxReplicas int32
-	// Metrics contains the specifications for which to use to calculate the
+
+	// metrics contains the specifications for which to use to calculate the
 	// desired replica count (the maximum replica count across all metrics will
 	// be used).  The desired replica count is calculated multiplying the
 	// ratio between the target value and the current value by the current
@@ -487,7 +492,7 @@ type PodsMetricStatus struct {
 // Kubernetes, and have special scaling options on top of those available to
 // normal per-pod metrics using the "pods" source.
 type ResourceMetricStatus struct {
-	// Name is the name of the resource in question.
+	// name is the name of the resource in question.
 	Name    api.ResourceName
 	Current MetricValueStatus
 }
@@ -498,7 +503,7 @@ type ResourceMetricStatus struct {
 // Kubernetes, and have special scaling options on top of those available to
 // normal per-pod metrics using the "pods" source.
 type ContainerResourceMetricStatus struct {
-	// Name is the name of the resource in question.
+	// name is the name of the resource in question.
 	Name      api.ResourceName
 	Container string
 	Current   MetricValueStatus
@@ -530,12 +535,12 @@ type HorizontalPodAutoscaler struct {
 	// +optional
 	metav1.ObjectMeta
 
-	// Spec is the specification for the behaviour of the autoscaler.
+	// spec is the specification for the behaviour of the autoscaler.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
 	// +optional
 	Spec HorizontalPodAutoscalerSpec
 
-	// Status is the current information about the autoscaler.
+	// status is the current information about the autoscaler.
 	// +optional
 	Status HorizontalPodAutoscalerStatus
 }
@@ -549,6 +554,6 @@ type HorizontalPodAutoscalerList struct {
 	// +optional
 	metav1.ListMeta
 
-	// Items is the list of horizontal pod autoscaler objects.
+	// items is the list of horizontal pod autoscaler objects.
 	Items []HorizontalPodAutoscaler
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -9989,7 +9989,7 @@ func schema_k8sio_api_autoscaling_v1_CrossVersionObjectReference(ref common.Refe
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Description: "kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -9997,7 +9997,7 @@ func schema_k8sio_api_autoscaling_v1_CrossVersionObjectReference(ref common.Refe
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+							Description: "name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -10005,7 +10005,7 @@ func schema_k8sio_api_autoscaling_v1_CrossVersionObjectReference(ref common.Refe
 					},
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "API version of the referent",
+							Description: "apiVersion is the API version of the referent",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -10137,14 +10137,14 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscaler(ref common.Referenc
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
+							Description: "spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/autoscaling/v1.HorizontalPodAutoscalerSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "current information about the autoscaler.",
+							Description: "status is the current information about the autoscaler.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/autoscaling/v1.HorizontalPodAutoscalerStatus"),
 						},
@@ -10240,7 +10240,7 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerList(ref common.Refe
 					},
 					"items": {
 						SchemaProps: spec.SchemaProps{
-							Description: "list of horizontal pod autoscaler objects.",
+							Description: "items is the list of horizontal pod autoscaler objects.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -10284,7 +10284,7 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerSpec(ref common.Refe
 					},
 					"maxReplicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
+							Description: "maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -10292,7 +10292,7 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerSpec(ref common.Refe
 					},
 					"targetCPUUtilizationPercentage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.",
+							Description: "targetCPUUtilizationPercentage is the target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -10315,20 +10315,20 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerStatus(ref common.Re
 				Properties: map[string]spec.Schema{
 					"observedGeneration": {
 						SchemaProps: spec.SchemaProps{
-							Description: "most recent generation observed by this autoscaler.",
+							Description: "observedGeneration is the most recent generation observed by this autoscaler.",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},
 					},
 					"lastScaleTime": {
 						SchemaProps: spec.SchemaProps{
-							Description: "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.",
+							Description: "lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"currentReplicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "current number of replicas of pods managed by this autoscaler.",
+							Description: "currentReplicas is the current number of replicas of pods managed by this autoscaler.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -10336,7 +10336,7 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerStatus(ref common.Re
 					},
 					"desiredReplicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "desired number of replicas of pods managed by this autoscaler.",
+							Description: "desiredReplicas is the  desired number of replicas of pods managed by this autoscaler.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -10344,7 +10344,7 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerStatus(ref common.Re
 					},
 					"currentCPUUtilizationPercentage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
+							Description: "currentCPUUtilizationPercentage is the current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -10394,7 +10394,7 @@ func schema_k8sio_api_autoscaling_v1_MetricSpec(ref common.ReferenceCallback) co
 					},
 					"containerResource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.",
+							Description: "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.",
 							Ref:         ref("k8s.io/api/autoscaling/v1.ContainerResourceMetricSource"),
 						},
 					},
@@ -10449,7 +10449,7 @@ func schema_k8sio_api_autoscaling_v1_MetricStatus(ref common.ReferenceCallback) 
 					},
 					"containerResource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
+							Description: "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
 							Ref:         ref("k8s.io/api/autoscaling/v1.ContainerResourceMetricStatus"),
 						},
 					},
@@ -10747,14 +10747,14 @@ func schema_k8sio_api_autoscaling_v1_Scale(ref common.ReferenceCallback) common.
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
+							Description: "spec defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/autoscaling/v1.ScaleSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.",
+							Description: "status is the current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/autoscaling/v1.ScaleStatus"),
 						},
@@ -10776,7 +10776,7 @@ func schema_k8sio_api_autoscaling_v1_ScaleSpec(ref common.ReferenceCallback) com
 				Properties: map[string]spec.Schema{
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "desired number of instances for the scaled object.",
+							Description: "replicas is the desired number of instances for the scaled object.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -10796,7 +10796,7 @@ func schema_k8sio_api_autoscaling_v1_ScaleStatus(ref common.ReferenceCallback) c
 				Properties: map[string]spec.Schema{
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "actual number of observed instances of the scaled object.",
+							Description: "replicas is the actual number of observed instances of the scaled object.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -10804,7 +10804,7 @@ func schema_k8sio_api_autoscaling_v1_ScaleStatus(ref common.ReferenceCallback) c
 					},
 					"selector": {
 						SchemaProps: spec.SchemaProps{
-							Description: "label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+							Description: "selector is the label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -10864,7 +10864,7 @@ func schema_k8sio_api_autoscaling_v2_ContainerResourceMetricStatus(ref common.Re
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is the name of the resource in question.",
+							Description: "name is the name of the resource in question.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -10879,7 +10879,7 @@ func schema_k8sio_api_autoscaling_v2_ContainerResourceMetricStatus(ref common.Re
 					},
 					"container": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Container is the name of the container in the pods of the scaling target",
+							Description: "container is the name of the container in the pods of the scaling target",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -10903,7 +10903,7 @@ func schema_k8sio_api_autoscaling_v2_CrossVersionObjectReference(ref common.Refe
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Description: "kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -10911,7 +10911,7 @@ func schema_k8sio_api_autoscaling_v2_CrossVersionObjectReference(ref common.Refe
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+							Description: "name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -10919,7 +10919,7 @@ func schema_k8sio_api_autoscaling_v2_CrossVersionObjectReference(ref common.Refe
 					},
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "API version of the referent",
+							Description: "apiVersion is the API version of the referent",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -11000,7 +11000,7 @@ func schema_k8sio_api_autoscaling_v2_HPAScalingPolicy(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Type is used to specify the scaling policy.",
+							Description: "type is used to specify the scaling policy.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -11008,7 +11008,7 @@ func schema_k8sio_api_autoscaling_v2_HPAScalingPolicy(ref common.ReferenceCallba
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Value contains the amount of change which is permitted by the policy. It must be greater than zero",
+							Description: "value contains the amount of change which is permitted by the policy. It must be greater than zero",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -11016,7 +11016,7 @@ func schema_k8sio_api_autoscaling_v2_HPAScalingPolicy(ref common.ReferenceCallba
 					},
 					"periodSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PeriodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+							Description: "periodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -11038,7 +11038,7 @@ func schema_k8sio_api_autoscaling_v2_HPAScalingRules(ref common.ReferenceCallbac
 				Properties: map[string]spec.Schema{
 					"stabilizationWindowSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "StabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
+							Description: "stabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -11797,7 +11797,7 @@ func schema_k8sio_api_autoscaling_v2_ResourceMetricStatus(ref common.ReferenceCa
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is the name of the resource in question.",
+							Description: "name is the name of the resource in question.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -12716,7 +12716,7 @@ func schema_k8sio_api_autoscaling_v2beta2_ContainerResourceMetricStatus(ref comm
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is the name of the resource in question.",
+							Description: "name is the name of the resource in question.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -12731,7 +12731,7 @@ func schema_k8sio_api_autoscaling_v2beta2_ContainerResourceMetricStatus(ref comm
 					},
 					"container": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Container is the name of the container in the pods of the scaling target",
+							Description: "container is the name of the container in the pods of the scaling target",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -12755,7 +12755,7 @@ func schema_k8sio_api_autoscaling_v2beta2_CrossVersionObjectReference(ref common
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Description: "kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -12763,7 +12763,7 @@ func schema_k8sio_api_autoscaling_v2beta2_CrossVersionObjectReference(ref common
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+							Description: "name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -12771,7 +12771,7 @@ func schema_k8sio_api_autoscaling_v2beta2_CrossVersionObjectReference(ref common
 					},
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "API version of the referent",
+							Description: "apiVersion is the API version of the referent",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -12852,7 +12852,7 @@ func schema_k8sio_api_autoscaling_v2beta2_HPAScalingPolicy(ref common.ReferenceC
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Type is used to specify the scaling policy.",
+							Description: "type is used to specify the scaling policy.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -12860,7 +12860,7 @@ func schema_k8sio_api_autoscaling_v2beta2_HPAScalingPolicy(ref common.ReferenceC
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Value contains the amount of change which is permitted by the policy. It must be greater than zero",
+							Description: "value contains the amount of change which is permitted by the policy. It must be greater than zero",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -12868,7 +12868,7 @@ func schema_k8sio_api_autoscaling_v2beta2_HPAScalingPolicy(ref common.ReferenceC
 					},
 					"periodSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PeriodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+							Description: "periodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -12890,7 +12890,7 @@ func schema_k8sio_api_autoscaling_v2beta2_HPAScalingRules(ref common.ReferenceCa
 				Properties: map[string]spec.Schema{
 					"stabilizationWindowSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "StabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
+							Description: "stabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -13355,7 +13355,7 @@ func schema_k8sio_api_autoscaling_v2beta2_MetricStatus(ref common.ReferenceCallb
 					},
 					"containerResource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
+							Description: "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
 							Ref:         ref("k8s.io/api/autoscaling/v2beta2.ContainerResourceMetricStatus"),
 						},
 					},
@@ -13438,7 +13438,7 @@ func schema_k8sio_api_autoscaling_v2beta2_MetricValueStatus(ref common.Reference
 					},
 					"averageUtilization": {
 						SchemaProps: spec.SchemaProps{
-							Description: "currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.",
+							Description: "averageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -13623,7 +13623,7 @@ func schema_k8sio_api_autoscaling_v2beta2_ResourceMetricStatus(ref common.Refere
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is the name of the resource in question.",
+							Description: "name is the name of the resource in question.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/staging/src/k8s.io/api/autoscaling/v1/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v1/generated.proto
@@ -87,13 +87,13 @@ message ContainerResourceMetricStatus {
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
 // +structType=atomic
 message CrossVersionObjectReference {
-  // Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+  // kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   optional string kind = 1;
 
-  // Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+  // name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
   optional string name = 2;
 
-  // API version of the referent
+  // apiVersion is the API version of the referent
   // +optional
   optional string apiVersion = 3;
 }
@@ -147,11 +147,11 @@ message HorizontalPodAutoscaler {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+  // spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
   // +optional
   optional HorizontalPodAutoscalerSpec spec = 2;
 
-  // current information about the autoscaler.
+  // status is the current information about the autoscaler.
   // +optional
   optional HorizontalPodAutoscalerStatus status = 3;
 }
@@ -186,7 +186,7 @@ message HorizontalPodAutoscalerList {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
-  // list of horizontal pod autoscaler objects.
+  // items is the list of horizontal pod autoscaler objects.
   repeated HorizontalPodAutoscaler items = 2;
 }
 
@@ -204,10 +204,10 @@ message HorizontalPodAutoscalerSpec {
   // +optional
   optional int32 minReplicas = 2;
 
-  // upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+  // maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
   optional int32 maxReplicas = 3;
 
-  // target average CPU utilization (represented as a percentage of requested CPU) over all the pods;
+  // targetCPUUtilizationPercentage is the target average CPU utilization (represented as a percentage of requested CPU) over all the pods;
   // if not specified the default autoscaling policy will be used.
   // +optional
   optional int32 targetCPUUtilizationPercentage = 4;
@@ -215,22 +215,22 @@ message HorizontalPodAutoscalerSpec {
 
 // current status of a horizontal pod autoscaler
 message HorizontalPodAutoscalerStatus {
-  // most recent generation observed by this autoscaler.
+  // observedGeneration is the most recent generation observed by this autoscaler.
   // +optional
   optional int64 observedGeneration = 1;
 
-  // last time the HorizontalPodAutoscaler scaled the number of pods;
+  // lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods;
   // used by the autoscaler to control how often the number of pods is changed.
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastScaleTime = 2;
 
-  // current number of replicas of pods managed by this autoscaler.
+  // currentReplicas is the current number of replicas of pods managed by this autoscaler.
   optional int32 currentReplicas = 3;
 
-  // desired number of replicas of pods managed by this autoscaler.
+  // desiredReplicas is the  desired number of replicas of pods managed by this autoscaler.
   optional int32 desiredReplicas = 4;
 
-  // current average CPU utilization over all pods, represented as a percentage of requested CPU,
+  // currentCPUUtilizationPercentage is the current average CPU utilization over all pods, represented as a percentage of requested CPU,
   // e.g. 70 means that an average pod is using now 70% of its requested CPU.
   // +optional
   optional int32 currentCPUUtilizationPercentage = 5;
@@ -264,7 +264,7 @@ message MetricSpec {
   // +optional
   optional ResourceMetricSource resource = 4;
 
-  // container resource refers to a resource metric (such as those specified in
+  // containerResource refers to a resource metric (such as those specified in
   // requests and limits) known to Kubernetes describing a single container in each pod of the
   // current scale target (e.g. CPU or memory). Such metrics are built in to
   // Kubernetes, and have special scaling options on top of those available
@@ -309,7 +309,7 @@ message MetricStatus {
   // +optional
   optional ResourceMetricStatus resource = 4;
 
-  // container resource refers to a resource metric (such as those specified in
+  // containerResource refers to a resource metric (such as those specified in
   // requests and limits) known to Kubernetes describing a single container in each pod in the
   // current scale target (e.g. CPU or memory). Such metrics are built in to
   // Kubernetes, and have special scaling options on top of those available
@@ -464,28 +464,28 @@ message Scale {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+  // spec defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
   // +optional
   optional ScaleSpec spec = 2;
 
-  // current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.
+  // status is the current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.
   // +optional
   optional ScaleStatus status = 3;
 }
 
 // ScaleSpec describes the attributes of a scale subresource.
 message ScaleSpec {
-  // desired number of instances for the scaled object.
+  // replicas is the desired number of instances for the scaled object.
   // +optional
   optional int32 replicas = 1;
 }
 
 // ScaleStatus represents the current status of a scale subresource.
 message ScaleStatus {
-  // actual number of observed instances of the scaled object.
+  // replicas is the actual number of observed instances of the scaled object.
   optional int32 replicas = 1;
 
-  // label query over pods that should match the replicas count. This is same
+  // selector is the label query over pods that should match the replicas count. This is same
   // as the label selector but in the string format to avoid introspection
   // by clients. The string will be in the same format as the query-param syntax.
   // More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -25,11 +25,13 @@ import (
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
 // +structType=atomic
 type CrossVersionObjectReference struct {
-	// Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
-	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+	// name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
-	// API version of the referent
+
+	// apiVersion is the API version of the referent
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,3,opt,name=apiVersion"`
 }
@@ -46,9 +48,11 @@ type HorizontalPodAutoscalerSpec struct {
 	// available.
 	// +optional
 	MinReplicas *int32 `json:"minReplicas,omitempty" protobuf:"varint,2,opt,name=minReplicas"`
-	// upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+
+	// maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
 	MaxReplicas int32 `json:"maxReplicas" protobuf:"varint,3,opt,name=maxReplicas"`
-	// target average CPU utilization (represented as a percentage of requested CPU) over all the pods;
+
+	// targetCPUUtilizationPercentage is the target average CPU utilization (represented as a percentage of requested CPU) over all the pods;
 	// if not specified the default autoscaling policy will be used.
 	// +optional
 	TargetCPUUtilizationPercentage *int32 `json:"targetCPUUtilizationPercentage,omitempty" protobuf:"varint,4,opt,name=targetCPUUtilizationPercentage"`
@@ -56,22 +60,22 @@ type HorizontalPodAutoscalerSpec struct {
 
 // current status of a horizontal pod autoscaler
 type HorizontalPodAutoscalerStatus struct {
-	// most recent generation observed by this autoscaler.
+	// observedGeneration is the most recent generation observed by this autoscaler.
 	// +optional
 	ObservedGeneration *int64 `json:"observedGeneration,omitempty" protobuf:"varint,1,opt,name=observedGeneration"`
 
-	// last time the HorizontalPodAutoscaler scaled the number of pods;
+	// lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods;
 	// used by the autoscaler to control how often the number of pods is changed.
 	// +optional
 	LastScaleTime *metav1.Time `json:"lastScaleTime,omitempty" protobuf:"bytes,2,opt,name=lastScaleTime"`
 
-	// current number of replicas of pods managed by this autoscaler.
+	// currentReplicas is the current number of replicas of pods managed by this autoscaler.
 	CurrentReplicas int32 `json:"currentReplicas" protobuf:"varint,3,opt,name=currentReplicas"`
 
-	// desired number of replicas of pods managed by this autoscaler.
+	// desiredReplicas is the  desired number of replicas of pods managed by this autoscaler.
 	DesiredReplicas int32 `json:"desiredReplicas" protobuf:"varint,4,opt,name=desiredReplicas"`
 
-	// current average CPU utilization over all pods, represented as a percentage of requested CPU,
+	// currentCPUUtilizationPercentage is the current average CPU utilization over all pods, represented as a percentage of requested CPU,
 	// e.g. 70 means that an average pod is using now 70% of its requested CPU.
 	// +optional
 	CurrentCPUUtilizationPercentage *int32 `json:"currentCPUUtilizationPercentage,omitempty" protobuf:"varint,5,opt,name=currentCPUUtilizationPercentage"`
@@ -87,11 +91,11 @@ type HorizontalPodAutoscaler struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+	// spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
 	// +optional
 	Spec HorizontalPodAutoscalerSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
-	// current information about the autoscaler.
+	// status is the current information about the autoscaler.
 	// +optional
 	Status HorizontalPodAutoscalerStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
@@ -105,7 +109,7 @@ type HorizontalPodAutoscalerList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// list of horizontal pod autoscaler objects.
+	// items is the list of horizontal pod autoscaler objects.
 	Items []HorizontalPodAutoscaler `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
@@ -118,28 +122,28 @@ type Scale struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+	// spec defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
 	// +optional
 	Spec ScaleSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
-	// current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.
+	// status is the current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.
 	// +optional
 	Status ScaleStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
 // ScaleSpec describes the attributes of a scale subresource.
 type ScaleSpec struct {
-	// desired number of instances for the scaled object.
+	// replicas is the desired number of instances for the scaled object.
 	// +optional
 	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 }
 
 // ScaleStatus represents the current status of a scale subresource.
 type ScaleStatus struct {
-	// actual number of observed instances of the scaled object.
+	// replicas is the actual number of observed instances of the scaled object.
 	Replicas int32 `json:"replicas" protobuf:"varint,1,opt,name=replicas"`
 
-	// label query over pods that should match the replicas count. This is same
+	// selector is the label query over pods that should match the replicas count. This is same
 	// as the label selector but in the string format to avoid introspection
 	// by clients. The string will be in the same format as the query-param syntax.
 	// More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
@@ -194,11 +198,13 @@ type MetricSpec struct {
 	// (for example, hits-per-second on an Ingress object).
 	// +optional
 	Object *ObjectMetricSource `json:"object,omitempty" protobuf:"bytes,2,opt,name=object"`
+
 	// pods refers to a metric describing each pod in the current scale target
 	// (for example, transactions-processed-per-second).  The values will be
 	// averaged together before being compared to the target value.
 	// +optional
 	Pods *PodsMetricSource `json:"pods,omitempty" protobuf:"bytes,3,opt,name=pods"`
+
 	// resource refers to a resource metric (such as those specified in
 	// requests and limits) known to Kubernetes describing each pod in the
 	// current scale target (e.g. CPU or memory). Such metrics are built in to
@@ -206,7 +212,8 @@ type MetricSpec struct {
 	// to normal per-pod metrics using the "pods" source.
 	// +optional
 	Resource *ResourceMetricSource `json:"resource,omitempty" protobuf:"bytes,4,opt,name=resource"`
-	// container resource refers to a resource metric (such as those specified in
+
+	// containerResource refers to a resource metric (such as those specified in
 	// requests and limits) known to Kubernetes describing a single container in each pod of the
 	// current scale target (e.g. CPU or memory). Such metrics are built in to
 	// Kubernetes, and have special scaling options on top of those available
@@ -214,6 +221,7 @@ type MetricSpec struct {
 	// This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
 	// +optional
 	ContainerResource *ContainerResourceMetricSource `json:"containerResource,omitempty" protobuf:"bytes,7,opt,name=containerResource"`
+
 	// external refers to a global metric that is not associated
 	// with any Kubernetes object. It allows autoscaling based on information
 	// coming from components running outside of cluster
@@ -231,6 +239,7 @@ type ObjectMetricSource struct {
 
 	// metricName is the name of the metric in question.
 	MetricName string `json:"metricName" protobuf:"bytes,2,name=metricName"`
+
 	// targetValue is the target value of the metric (as a quantity).
 	TargetValue resource.Quantity `json:"targetValue" protobuf:"bytes,3,name=targetValue"`
 
@@ -239,6 +248,7 @@ type ObjectMetricSource struct {
 	// When unset, just the metricName will be used to gather metrics.
 	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,4,name=selector"`
+
 	// averageValue is the target value of the average of the
 	// metric across all relevant pods (as a quantity)
 	// +optional
@@ -252,6 +262,7 @@ type ObjectMetricSource struct {
 type PodsMetricSource struct {
 	// metricName is the name of the metric in question
 	MetricName string `json:"metricName" protobuf:"bytes,1,name=metricName"`
+
 	// targetAverageValue is the target value of the average of the
 	// metric across all relevant pods (as a quantity)
 	TargetAverageValue resource.Quantity `json:"targetAverageValue" protobuf:"bytes,2,name=targetAverageValue"`
@@ -273,11 +284,13 @@ type PodsMetricSource struct {
 type ResourceMetricSource struct {
 	// name is the name of the resource in question.
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
+
 	// targetAverageUtilization is the target value of the average of the
 	// resource metric across all relevant pods, represented as a percentage of
 	// the requested value of the resource for the pods.
 	// +optional
 	TargetAverageUtilization *int32 `json:"targetAverageUtilization,omitempty" protobuf:"varint,2,opt,name=targetAverageUtilization"`
+
 	// targetAverageValue is the target value of the average of the
 	// resource metric across all relevant pods, as a raw value (instead of as
 	// a percentage of the request), similar to the "pods" metric source type.
@@ -295,16 +308,19 @@ type ResourceMetricSource struct {
 type ContainerResourceMetricSource struct {
 	// name is the name of the resource in question.
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
+
 	// targetAverageUtilization is the target value of the average of the
 	// resource metric across all relevant pods, represented as a percentage of
 	// the requested value of the resource for the pods.
 	// +optional
 	TargetAverageUtilization *int32 `json:"targetAverageUtilization,omitempty" protobuf:"varint,2,opt,name=targetAverageUtilization"`
+
 	// targetAverageValue is the target value of the average of the
 	// resource metric across all relevant pods, as a raw value (instead of as
 	// a percentage of the request), similar to the "pods" metric source type.
 	// +optional
 	TargetAverageValue *resource.Quantity `json:"targetAverageValue,omitempty" protobuf:"bytes,3,opt,name=targetAverageValue"`
+
 	// container is the name of the container in the pods of the scaling target.
 	Container string `json:"container" protobuf:"bytes,5,opt,name=container"`
 }
@@ -315,14 +331,17 @@ type ContainerResourceMetricSource struct {
 type ExternalMetricSource struct {
 	// metricName is the name of the metric in question.
 	MetricName string `json:"metricName" protobuf:"bytes,1,name=metricName"`
+
 	// metricSelector is used to identify a specific time series
 	// within a given metric.
 	// +optional
 	MetricSelector *metav1.LabelSelector `json:"metricSelector,omitempty" protobuf:"bytes,2,opt,name=metricSelector"`
+
 	// targetValue is the target value of the metric (as a quantity).
 	// Mutually exclusive with TargetAverageValue.
 	// +optional
 	TargetValue *resource.Quantity `json:"targetValue,omitempty" protobuf:"bytes,3,opt,name=targetValue"`
+
 	// targetAverageValue is the target per-pod value of global metric (as a quantity).
 	// Mutually exclusive with TargetValue.
 	// +optional
@@ -341,11 +360,13 @@ type MetricStatus struct {
 	// (for example, hits-per-second on an Ingress object).
 	// +optional
 	Object *ObjectMetricStatus `json:"object,omitempty" protobuf:"bytes,2,opt,name=object"`
+
 	// pods refers to a metric describing each pod in the current scale target
 	// (for example, transactions-processed-per-second).  The values will be
 	// averaged together before being compared to the target value.
 	// +optional
 	Pods *PodsMetricStatus `json:"pods,omitempty" protobuf:"bytes,3,opt,name=pods"`
+
 	// resource refers to a resource metric (such as those specified in
 	// requests and limits) known to Kubernetes describing each pod in the
 	// current scale target (e.g. CPU or memory). Such metrics are built in to
@@ -353,13 +374,15 @@ type MetricStatus struct {
 	// to normal per-pod metrics using the "pods" source.
 	// +optional
 	Resource *ResourceMetricStatus `json:"resource,omitempty" protobuf:"bytes,4,opt,name=resource"`
-	// container resource refers to a resource metric (such as those specified in
+
+	// containerResource refers to a resource metric (such as those specified in
 	// requests and limits) known to Kubernetes describing a single container in each pod in the
 	// current scale target (e.g. CPU or memory). Such metrics are built in to
 	// Kubernetes, and have special scaling options on top of those available
 	// to normal per-pod metrics using the "pods" source.
 	// +optional
 	ContainerResource *ContainerResourceMetricStatus `json:"containerResource,omitempty" protobuf:"bytes,7,opt,name=containerResource"`
+
 	// external refers to a global metric that is not associated
 	// with any Kubernetes object. It allows autoscaling based on information
 	// coming from components running outside of cluster
@@ -390,15 +413,19 @@ const (
 type HorizontalPodAutoscalerCondition struct {
 	// type describes the current condition
 	Type HorizontalPodAutoscalerConditionType `json:"type" protobuf:"bytes,1,name=type"`
+
 	// status is the status of the condition (True, False, Unknown)
 	Status v1.ConditionStatus `json:"status" protobuf:"bytes,2,name=status"`
+
 	// lastTransitionTime is the last time the condition transitioned from
 	// one status to another
 	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,3,opt,name=lastTransitionTime"`
+
 	// reason is the reason for the condition's last transition.
 	// +optional
 	Reason string `json:"reason,omitempty" protobuf:"bytes,4,opt,name=reason"`
+
 	// message is a human-readable explanation containing details about
 	// the transition
 	// +optional
@@ -413,6 +440,7 @@ type ObjectMetricStatus struct {
 
 	// metricName is the name of the metric in question.
 	MetricName string `json:"metricName" protobuf:"bytes,2,name=metricName"`
+
 	// currentValue is the current value of the metric (as a quantity).
 	CurrentValue resource.Quantity `json:"currentValue" protobuf:"bytes,3,name=currentValue"`
 
@@ -421,6 +449,7 @@ type ObjectMetricStatus struct {
 	// When unset, just the metricName will be used to gather metrics.
 	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,4,name=selector"`
+
 	// averageValue is the current value of the average of the
 	// metric across all relevant pods (as a quantity)
 	// +optional
@@ -432,6 +461,7 @@ type ObjectMetricStatus struct {
 type PodsMetricStatus struct {
 	// metricName is the name of the metric in question
 	MetricName string `json:"metricName" protobuf:"bytes,1,name=metricName"`
+
 	// currentAverageValue is the current value of the average of the
 	// metric across all relevant pods (as a quantity)
 	CurrentAverageValue resource.Quantity `json:"currentAverageValue" protobuf:"bytes,2,name=currentAverageValue"`
@@ -451,6 +481,7 @@ type PodsMetricStatus struct {
 type ResourceMetricStatus struct {
 	// name is the name of the resource in question.
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
+
 	// currentAverageUtilization is the current value of the average of the
 	// resource metric across all relevant pods, represented as a percentage of
 	// the requested value of the resource for the pods.  It will only be
@@ -458,6 +489,7 @@ type ResourceMetricStatus struct {
 	// specification.
 	// +optional
 	CurrentAverageUtilization *int32 `json:"currentAverageUtilization,omitempty" protobuf:"bytes,2,opt,name=currentAverageUtilization"`
+
 	// currentAverageValue is the current value of the average of the
 	// resource metric across all relevant pods, as a raw value (instead of as
 	// a percentage of the request), similar to the "pods" metric source type.
@@ -473,6 +505,7 @@ type ResourceMetricStatus struct {
 type ContainerResourceMetricStatus struct {
 	// name is the name of the resource in question.
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
+
 	// currentAverageUtilization is the current value of the average of the
 	// resource metric across all relevant pods, represented as a percentage of
 	// the requested value of the resource for the pods.  It will only be
@@ -480,11 +513,13 @@ type ContainerResourceMetricStatus struct {
 	// specification.
 	// +optional
 	CurrentAverageUtilization *int32 `json:"currentAverageUtilization,omitempty" protobuf:"bytes,2,opt,name=currentAverageUtilization"`
+
 	// currentAverageValue is the current value of the average of the
 	// resource metric across all relevant pods, as a raw value (instead of as
 	// a percentage of the request), similar to the "pods" metric source type.
 	// It will always be set, regardless of the corresponding metric specification.
 	CurrentAverageValue resource.Quantity `json:"currentAverageValue" protobuf:"bytes,3,name=currentAverageValue"`
+
 	// container is the name of the container in the pods of the scaling taget
 	Container string `json:"container" protobuf:"bytes,4,opt,name=container"`
 }
@@ -495,12 +530,14 @@ type ExternalMetricStatus struct {
 	// metricName is the name of a metric used for autoscaling in
 	// metric system.
 	MetricName string `json:"metricName" protobuf:"bytes,1,name=metricName"`
+
 	// metricSelector is used to identify a specific time series
 	// within a given metric.
 	// +optional
 	MetricSelector *metav1.LabelSelector `json:"metricSelector,omitempty" protobuf:"bytes,2,opt,name=metricSelector"`
 	// currentValue is the current value of the metric (as a quantity)
 	CurrentValue resource.Quantity `json:"currentValue" protobuf:"bytes,3,name=currentValue"`
+
 	// currentAverageValue is the current value of metric averaged over autoscaled pods.
 	// +optional
 	CurrentAverageValue *resource.Quantity `json:"currentAverageValue,omitempty" protobuf:"bytes,4,opt,name=currentAverageValue"`

--- a/staging/src/k8s.io/api/autoscaling/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types_swagger_doc_generated.go
@@ -53,9 +53,9 @@ func (ContainerResourceMetricStatus) SwaggerDoc() map[string]string {
 
 var map_CrossVersionObjectReference = map[string]string{
 	"":           "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
-	"kind":       "Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-	"name":       "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
-	"apiVersion": "API version of the referent",
+	"kind":       "kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+	"name":       "name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+	"apiVersion": "apiVersion is the API version of the referent",
 }
 
 func (CrossVersionObjectReference) SwaggerDoc() map[string]string {
@@ -89,8 +89,8 @@ func (ExternalMetricStatus) SwaggerDoc() map[string]string {
 var map_HorizontalPodAutoscaler = map[string]string{
 	"":         "configuration of a horizontal pod autoscaler.",
 	"metadata": "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-	"spec":     "behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
-	"status":   "current information about the autoscaler.",
+	"spec":     "spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
+	"status":   "status is the current information about the autoscaler.",
 }
 
 func (HorizontalPodAutoscaler) SwaggerDoc() map[string]string {
@@ -113,7 +113,7 @@ func (HorizontalPodAutoscalerCondition) SwaggerDoc() map[string]string {
 var map_HorizontalPodAutoscalerList = map[string]string{
 	"":         "list of horizontal pod autoscaler objects.",
 	"metadata": "Standard list metadata.",
-	"items":    "list of horizontal pod autoscaler objects.",
+	"items":    "items is the list of horizontal pod autoscaler objects.",
 }
 
 func (HorizontalPodAutoscalerList) SwaggerDoc() map[string]string {
@@ -124,8 +124,8 @@ var map_HorizontalPodAutoscalerSpec = map[string]string{
 	"":                               "specification of a horizontal pod autoscaler.",
 	"scaleTargetRef":                 "reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource.",
 	"minReplicas":                    "minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.",
-	"maxReplicas":                    "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
-	"targetCPUUtilizationPercentage": "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.",
+	"maxReplicas":                    "maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
+	"targetCPUUtilizationPercentage": "targetCPUUtilizationPercentage is the target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.",
 }
 
 func (HorizontalPodAutoscalerSpec) SwaggerDoc() map[string]string {
@@ -134,11 +134,11 @@ func (HorizontalPodAutoscalerSpec) SwaggerDoc() map[string]string {
 
 var map_HorizontalPodAutoscalerStatus = map[string]string{
 	"":                                "current status of a horizontal pod autoscaler",
-	"observedGeneration":              "most recent generation observed by this autoscaler.",
-	"lastScaleTime":                   "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.",
-	"currentReplicas":                 "current number of replicas of pods managed by this autoscaler.",
-	"desiredReplicas":                 "desired number of replicas of pods managed by this autoscaler.",
-	"currentCPUUtilizationPercentage": "current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
+	"observedGeneration":              "observedGeneration is the most recent generation observed by this autoscaler.",
+	"lastScaleTime":                   "lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.",
+	"currentReplicas":                 "currentReplicas is the current number of replicas of pods managed by this autoscaler.",
+	"desiredReplicas":                 "desiredReplicas is the  desired number of replicas of pods managed by this autoscaler.",
+	"currentCPUUtilizationPercentage": "currentCPUUtilizationPercentage is the current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
 }
 
 func (HorizontalPodAutoscalerStatus) SwaggerDoc() map[string]string {
@@ -151,7 +151,7 @@ var map_MetricSpec = map[string]string{
 	"object":            "object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).",
 	"pods":              "pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.",
 	"resource":          "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
-	"containerResource": "container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.",
+	"containerResource": "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.",
 	"external":          "external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).",
 }
 
@@ -165,7 +165,7 @@ var map_MetricStatus = map[string]string{
 	"object":            "object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).",
 	"pods":              "pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.",
 	"resource":          "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
-	"containerResource": "container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
+	"containerResource": "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
 	"external":          "external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).",
 }
 
@@ -246,8 +246,8 @@ func (ResourceMetricStatus) SwaggerDoc() map[string]string {
 var map_Scale = map[string]string{
 	"":         "Scale represents a scaling request for a resource.",
 	"metadata": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.",
-	"spec":     "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
-	"status":   "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.",
+	"spec":     "spec defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
+	"status":   "status is the current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.",
 }
 
 func (Scale) SwaggerDoc() map[string]string {
@@ -256,7 +256,7 @@ func (Scale) SwaggerDoc() map[string]string {
 
 var map_ScaleSpec = map[string]string{
 	"":         "ScaleSpec describes the attributes of a scale subresource.",
-	"replicas": "desired number of instances for the scaled object.",
+	"replicas": "replicas is the desired number of instances for the scaled object.",
 }
 
 func (ScaleSpec) SwaggerDoc() map[string]string {
@@ -265,8 +265,8 @@ func (ScaleSpec) SwaggerDoc() map[string]string {
 
 var map_ScaleStatus = map[string]string{
 	"":         "ScaleStatus represents the current status of a scale subresource.",
-	"replicas": "actual number of observed instances of the scaled object.",
-	"selector": "label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+	"replicas": "replicas is the actual number of observed instances of the scaled object.",
+	"selector": "selector is the label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
 }
 
 func (ScaleStatus) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/autoscaling/v2/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2/generated.proto
@@ -54,25 +54,25 @@ message ContainerResourceMetricSource {
 // Kubernetes, and have special scaling options on top of those available to
 // normal per-pod metrics using the "pods" source.
 message ContainerResourceMetricStatus {
-  // Name is the name of the resource in question.
+  // name is the name of the resource in question.
   optional string name = 1;
 
   // current contains the current value for the given metric
   optional MetricValueStatus current = 2;
 
-  // Container is the name of the container in the pods of the scaling target
+  // container is the name of the container in the pods of the scaling target
   optional string container = 3;
 }
 
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
 message CrossVersionObjectReference {
-  // Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+  // kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   optional string kind = 1;
 
-  // Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+  // name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
   optional string name = 2;
 
-  // API version of the referent
+  // apiVersion is the API version of the referent
   // +optional
   optional string apiVersion = 3;
 }
@@ -100,14 +100,14 @@ message ExternalMetricStatus {
 
 // HPAScalingPolicy is a single policy which must hold true for a specified past interval.
 message HPAScalingPolicy {
-  // Type is used to specify the scaling policy.
+  // type is used to specify the scaling policy.
   optional string type = 1;
 
-  // Value contains the amount of change which is permitted by the policy.
+  // value contains the amount of change which is permitted by the policy.
   // It must be greater than zero
   optional int32 value = 2;
 
-  // PeriodSeconds specifies the window of time for which the policy should hold true.
+  // periodSeconds specifies the window of time for which the policy should hold true.
   // PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
   optional int32 periodSeconds = 3;
 }
@@ -119,7 +119,7 @@ message HPAScalingPolicy {
 // number of replicas is not set instantly, instead, the safest value from the stabilization
 // window is chosen.
 message HPAScalingRules {
-  // StabilizationWindowSeconds is the number of seconds for which past recommendations should be
+  // stabilizationWindowSeconds is the number of seconds for which past recommendations should be
   // considered while scaling up or scaling down.
   // StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
   // If not set, use the default values:
@@ -495,7 +495,7 @@ message ResourceMetricSource {
 // Kubernetes, and have special scaling options on top of those available to
 // normal per-pod metrics using the "pods" source.
 message ResourceMetricStatus {
-  // Name is the name of the resource in question.
+  // name is the name of the resource in question.
   optional string name = 1;
 
   // current contains the current value for the given metric

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -59,9 +59,11 @@ type HorizontalPodAutoscalerSpec struct {
 	// available.
 	// +optional
 	MinReplicas *int32 `json:"minReplicas,omitempty" protobuf:"varint,2,opt,name=minReplicas"`
+
 	// maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
 	// It cannot be less that minReplicas.
 	MaxReplicas int32 `json:"maxReplicas" protobuf:"varint,3,opt,name=maxReplicas"`
+
 	// metrics contains the specifications for which to use to calculate the
 	// desired replica count (the maximum replica count across all metrics will
 	// be used).  The desired replica count is calculated multiplying the
@@ -83,11 +85,13 @@ type HorizontalPodAutoscalerSpec struct {
 
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
 type CrossVersionObjectReference struct {
-	// Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
-	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+	// name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
-	// API version of the referent
+
+	// apiVersion is the API version of the referent
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,3,opt,name=apiVersion"`
 }
@@ -105,11 +109,13 @@ type MetricSpec struct {
 	// (for example, hits-per-second on an Ingress object).
 	// +optional
 	Object *ObjectMetricSource `json:"object,omitempty" protobuf:"bytes,2,opt,name=object"`
+
 	// pods refers to a metric describing each pod in the current scale target
 	// (for example, transactions-processed-per-second).  The values will be
 	// averaged together before being compared to the target value.
 	// +optional
 	Pods *PodsMetricSource `json:"pods,omitempty" protobuf:"bytes,3,opt,name=pods"`
+
 	// resource refers to a resource metric (such as those specified in
 	// requests and limits) known to Kubernetes describing each pod in the
 	// current scale target (e.g. CPU or memory). Such metrics are built in to
@@ -117,6 +123,7 @@ type MetricSpec struct {
 	// to normal per-pod metrics using the "pods" source.
 	// +optional
 	Resource *ResourceMetricSource `json:"resource,omitempty" protobuf:"bytes,4,opt,name=resource"`
+
 	// containerResource refers to a resource metric (such as those specified in
 	// requests and limits) known to Kubernetes describing a single container in
 	// each pod of the current scale target (e.g. CPU or memory). Such metrics are
@@ -125,6 +132,7 @@ type MetricSpec struct {
 	// This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
 	// +optional
 	ContainerResource *ContainerResourceMetricSource `json:"containerResource,omitempty" protobuf:"bytes,7,opt,name=containerResource"`
+
 	// external refers to a global metric that is not associated
 	// with any Kubernetes object. It allows autoscaling based on information
 	// coming from components running outside of cluster
@@ -144,6 +152,7 @@ type HorizontalPodAutoscalerBehavior struct {
 	// No stabilization is used.
 	// +optional
 	ScaleUp *HPAScalingRules `json:"scaleUp,omitempty" protobuf:"bytes,1,opt,name=scaleUp"`
+
 	// scaleDown is scaling policy for scaling Down.
 	// If not set, the default value is to allow to scale down to minReplicas pods, with a
 	// 300 second stabilization window (i.e., the highest recommendation for
@@ -171,7 +180,7 @@ const (
 // number of replicas is not set instantly, instead, the safest value from the stabilization
 // window is chosen.
 type HPAScalingRules struct {
-	// StabilizationWindowSeconds is the number of seconds for which past recommendations should be
+	// stabilizationWindowSeconds is the number of seconds for which past recommendations should be
 	// considered while scaling up or scaling down.
 	// StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
 	// If not set, use the default values:
@@ -179,10 +188,12 @@ type HPAScalingRules struct {
 	// - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
 	// +optional
 	StabilizationWindowSeconds *int32 `json:"stabilizationWindowSeconds,omitempty" protobuf:"varint,3,opt,name=stabilizationWindowSeconds"`
+
 	// selectPolicy is used to specify which policy should be used.
 	// If not set, the default value Max is used.
 	// +optional
 	SelectPolicy *ScalingPolicySelect `json:"selectPolicy,omitempty" protobuf:"bytes,1,opt,name=selectPolicy"`
+
 	// policies is a list of potential scaling polices which can be used during scaling.
 	// At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
 	// +listType=atomic
@@ -203,12 +214,14 @@ const (
 
 // HPAScalingPolicy is a single policy which must hold true for a specified past interval.
 type HPAScalingPolicy struct {
-	// Type is used to specify the scaling policy.
+	// type is used to specify the scaling policy.
 	Type HPAScalingPolicyType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=HPAScalingPolicyType"`
-	// Value contains the amount of change which is permitted by the policy.
+
+	// value contains the amount of change which is permitted by the policy.
 	// It must be greater than zero
 	Value int32 `json:"value" protobuf:"varint,2,opt,name=value"`
-	// PeriodSeconds specifies the window of time for which the policy should hold true.
+
+	// periodSeconds specifies the window of time for which the policy should hold true.
 	// PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
 	PeriodSeconds int32 `json:"periodSeconds" protobuf:"varint,3,opt,name=periodSeconds"`
 }
@@ -249,8 +262,10 @@ const (
 type ObjectMetricSource struct {
 	// describedObject specifies the descriptions of a object,such as kind,name apiVersion
 	DescribedObject CrossVersionObjectReference `json:"describedObject" protobuf:"bytes,1,name=describedObject"`
+
 	// target specifies the target value for the given metric
 	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
+
 	// metric identifies the target metric by name and selector
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,3,name=metric"`
 }
@@ -262,6 +277,7 @@ type ObjectMetricSource struct {
 type PodsMetricSource struct {
 	// metric identifies the target metric by name and selector
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
+
 	// target specifies the target value for the given metric
 	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
 }
@@ -276,6 +292,7 @@ type PodsMetricSource struct {
 type ResourceMetricSource struct {
 	// name is the name of the resource in question.
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
+
 	// target specifies the target value for the given metric
 	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
 }
@@ -290,8 +307,10 @@ type ResourceMetricSource struct {
 type ContainerResourceMetricSource struct {
 	// name is the name of the resource in question.
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
+
 	// target specifies the target value for the given metric
 	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
+
 	// container is the name of the container in the pods of the scaling target
 	Container string `json:"container" protobuf:"bytes,3,opt,name=container"`
 }
@@ -302,6 +321,7 @@ type ContainerResourceMetricSource struct {
 type ExternalMetricSource struct {
 	// metric identifies the target metric by name and selector
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
+
 	// target specifies the target value for the given metric
 	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
 }
@@ -310,6 +330,7 @@ type ExternalMetricSource struct {
 type MetricIdentifier struct {
 	// name is the name of the given metric
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
+
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric
 	// When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
 	// When unset, just the metricName will be used to gather metrics.
@@ -321,13 +342,16 @@ type MetricIdentifier struct {
 type MetricTarget struct {
 	// type represents whether the metric type is Utilization, Value, or AverageValue
 	Type MetricTargetType `json:"type" protobuf:"bytes,1,name=type"`
+
 	// value is the target value of the metric (as a quantity).
 	// +optional
 	Value *resource.Quantity `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"`
+
 	// averageValue is the target value of the average of the
 	// metric across all relevant pods (as a quantity)
 	// +optional
 	AverageValue *resource.Quantity `json:"averageValue,omitempty" protobuf:"bytes,3,opt,name=averageValue"`
+
 	// averageUtilization is the target value of the average of the
 	// resource metric across all relevant pods, represented as a percentage of
 	// the requested value of the resource for the pods.
@@ -405,15 +429,19 @@ const (
 type HorizontalPodAutoscalerCondition struct {
 	// type describes the current condition
 	Type HorizontalPodAutoscalerConditionType `json:"type" protobuf:"bytes,1,name=type"`
+
 	// status is the status of the condition (True, False, Unknown)
 	Status v1.ConditionStatus `json:"status" protobuf:"bytes,2,name=status"`
+
 	// lastTransitionTime is the last time the condition transitioned from
 	// one status to another
 	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,3,opt,name=lastTransitionTime"`
+
 	// reason is the reason for the condition's last transition.
 	// +optional
 	Reason string `json:"reason,omitempty" protobuf:"bytes,4,opt,name=reason"`
+
 	// message is a human-readable explanation containing details about
 	// the transition
 	// +optional
@@ -432,11 +460,13 @@ type MetricStatus struct {
 	// (for example, hits-per-second on an Ingress object).
 	// +optional
 	Object *ObjectMetricStatus `json:"object,omitempty" protobuf:"bytes,2,opt,name=object"`
+
 	// pods refers to a metric describing each pod in the current scale target
 	// (for example, transactions-processed-per-second).  The values will be
 	// averaged together before being compared to the target value.
 	// +optional
 	Pods *PodsMetricStatus `json:"pods,omitempty" protobuf:"bytes,3,opt,name=pods"`
+
 	// resource refers to a resource metric (such as those specified in
 	// requests and limits) known to Kubernetes describing each pod in the
 	// current scale target (e.g. CPU or memory). Such metrics are built in to
@@ -444,6 +474,7 @@ type MetricStatus struct {
 	// to normal per-pod metrics using the "pods" source.
 	// +optional
 	Resource *ResourceMetricStatus `json:"resource,omitempty" protobuf:"bytes,4,opt,name=resource"`
+
 	// container resource refers to a resource metric (such as those specified in
 	// requests and limits) known to Kubernetes describing a single container in each pod in the
 	// current scale target (e.g. CPU or memory). Such metrics are built in to
@@ -451,6 +482,7 @@ type MetricStatus struct {
 	// to normal per-pod metrics using the "pods" source.
 	// +optional
 	ContainerResource *ContainerResourceMetricStatus `json:"containerResource,omitempty" protobuf:"bytes,7,opt,name=containerResource"`
+
 	// external refers to a global metric that is not associated
 	// with any Kubernetes object. It allows autoscaling based on information
 	// coming from components running outside of cluster
@@ -465,8 +497,10 @@ type MetricStatus struct {
 type ObjectMetricStatus struct {
 	// metric identifies the target metric by name and selector
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
+
 	// current contains the current value for the given metric
 	Current MetricValueStatus `json:"current" protobuf:"bytes,2,name=current"`
+
 	// DescribedObject specifies the descriptions of a object,such as kind,name apiVersion
 	DescribedObject CrossVersionObjectReference `json:"describedObject" protobuf:"bytes,3,name=describedObject"`
 }
@@ -476,6 +510,7 @@ type ObjectMetricStatus struct {
 type PodsMetricStatus struct {
 	// metric identifies the target metric by name and selector
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
+
 	// current contains the current value for the given metric
 	Current MetricValueStatus `json:"current" protobuf:"bytes,2,name=current"`
 }
@@ -486,8 +521,9 @@ type PodsMetricStatus struct {
 // Kubernetes, and have special scaling options on top of those available to
 // normal per-pod metrics using the "pods" source.
 type ResourceMetricStatus struct {
-	// Name is the name of the resource in question.
+	// name is the name of the resource in question.
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
+
 	// current contains the current value for the given metric
 	Current MetricValueStatus `json:"current" protobuf:"bytes,2,name=current"`
 }
@@ -498,11 +534,13 @@ type ResourceMetricStatus struct {
 // Kubernetes, and have special scaling options on top of those available to
 // normal per-pod metrics using the "pods" source.
 type ContainerResourceMetricStatus struct {
-	// Name is the name of the resource in question.
+	// name is the name of the resource in question.
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
+
 	// current contains the current value for the given metric
 	Current MetricValueStatus `json:"current" protobuf:"bytes,2,name=current"`
-	// Container is the name of the container in the pods of the scaling target
+
+	// container is the name of the container in the pods of the scaling target
 	Container string `json:"container" protobuf:"bytes,3,opt,name=container"`
 }
 
@@ -511,6 +549,7 @@ type ContainerResourceMetricStatus struct {
 type ExternalMetricStatus struct {
 	// metric identifies the target metric by name and selector
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
+
 	// current contains the current value for the given metric
 	Current MetricValueStatus `json:"current" protobuf:"bytes,2,name=current"`
 }
@@ -520,10 +559,12 @@ type MetricValueStatus struct {
 	// value is the current value of the metric (as a quantity).
 	// +optional
 	Value *resource.Quantity `json:"value,omitempty" protobuf:"bytes,1,opt,name=value"`
+
 	// averageValue is the current value of the average of the
 	// metric across all relevant pods (as a quantity)
 	// +optional
 	AverageValue *resource.Quantity `json:"averageValue,omitempty" protobuf:"bytes,2,opt,name=averageValue"`
+
 	// currentAverageUtilization is the current value of the average of the
 	// resource metric across all relevant pods, represented as a percentage of
 	// the requested value of the resource for the pods.

--- a/staging/src/k8s.io/api/autoscaling/v2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types_swagger_doc_generated.go
@@ -40,9 +40,9 @@ func (ContainerResourceMetricSource) SwaggerDoc() map[string]string {
 
 var map_ContainerResourceMetricStatus = map[string]string{
 	"":          "ContainerResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing a single container in each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
-	"name":      "Name is the name of the resource in question.",
+	"name":      "name is the name of the resource in question.",
 	"current":   "current contains the current value for the given metric",
-	"container": "Container is the name of the container in the pods of the scaling target",
+	"container": "container is the name of the container in the pods of the scaling target",
 }
 
 func (ContainerResourceMetricStatus) SwaggerDoc() map[string]string {
@@ -51,9 +51,9 @@ func (ContainerResourceMetricStatus) SwaggerDoc() map[string]string {
 
 var map_CrossVersionObjectReference = map[string]string{
 	"":           "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
-	"kind":       "Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-	"name":       "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
-	"apiVersion": "API version of the referent",
+	"kind":       "kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+	"name":       "name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+	"apiVersion": "apiVersion is the API version of the referent",
 }
 
 func (CrossVersionObjectReference) SwaggerDoc() map[string]string {
@@ -82,9 +82,9 @@ func (ExternalMetricStatus) SwaggerDoc() map[string]string {
 
 var map_HPAScalingPolicy = map[string]string{
 	"":              "HPAScalingPolicy is a single policy which must hold true for a specified past interval.",
-	"type":          "Type is used to specify the scaling policy.",
-	"value":         "Value contains the amount of change which is permitted by the policy. It must be greater than zero",
-	"periodSeconds": "PeriodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+	"type":          "type is used to specify the scaling policy.",
+	"value":         "value contains the amount of change which is permitted by the policy. It must be greater than zero",
+	"periodSeconds": "periodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
 }
 
 func (HPAScalingPolicy) SwaggerDoc() map[string]string {
@@ -93,7 +93,7 @@ func (HPAScalingPolicy) SwaggerDoc() map[string]string {
 
 var map_HPAScalingRules = map[string]string{
 	"":                           "HPAScalingRules configures the scaling behavior for one direction. These Rules are applied after calculating DesiredReplicas from metrics for the HPA. They can limit the scaling velocity by specifying scaling policies. They can prevent flapping by specifying the stabilization window, so that the number of replicas is not set instantly, instead, the safest value from the stabilization window is chosen.",
-	"stabilizationWindowSeconds": "StabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
+	"stabilizationWindowSeconds": "stabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
 	"selectPolicy":               "selectPolicy is used to specify which policy should be used. If not set, the default value Max is used.",
 	"policies":                   "policies is a list of potential scaling polices which can be used during scaling. At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid",
 }
@@ -288,7 +288,7 @@ func (ResourceMetricSource) SwaggerDoc() map[string]string {
 
 var map_ResourceMetricStatus = map[string]string{
 	"":        "ResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
-	"name":    "Name is the name of the resource in question.",
+	"name":    "name is the name of the resource in question.",
 	"current": "current contains the current value for the given metric",
 }
 

--- a/staging/src/k8s.io/api/autoscaling/v2beta2/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2beta2/generated.proto
@@ -54,25 +54,25 @@ message ContainerResourceMetricSource {
 // Kubernetes, and have special scaling options on top of those available to
 // normal per-pod metrics using the "pods" source.
 message ContainerResourceMetricStatus {
-  // Name is the name of the resource in question.
+  // name is the name of the resource in question.
   optional string name = 1;
 
   // current contains the current value for the given metric
   optional MetricValueStatus current = 2;
 
-  // Container is the name of the container in the pods of the scaling target
+  // container is the name of the container in the pods of the scaling target
   optional string container = 3;
 }
 
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
 message CrossVersionObjectReference {
-  // Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+  // kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   optional string kind = 1;
 
-  // Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+  // name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
   optional string name = 2;
 
-  // API version of the referent
+  // apiVersion is the API version of the referent
   // +optional
   optional string apiVersion = 3;
 }
@@ -100,14 +100,14 @@ message ExternalMetricStatus {
 
 // HPAScalingPolicy is a single policy which must hold true for a specified past interval.
 message HPAScalingPolicy {
-  // Type is used to specify the scaling policy.
+  // type is used to specify the scaling policy.
   optional string type = 1;
 
-  // Value contains the amount of change which is permitted by the policy.
+  // value contains the amount of change which is permitted by the policy.
   // It must be greater than zero
   optional int32 value = 2;
 
-  // PeriodSeconds specifies the window of time for which the policy should hold true.
+  // periodSeconds specifies the window of time for which the policy should hold true.
   // PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
   optional int32 periodSeconds = 3;
 }
@@ -119,7 +119,7 @@ message HPAScalingPolicy {
 // number of replicas is not set instantly, instead, the safest value from the stabilization
 // window is chosen.
 message HPAScalingRules {
-  // StabilizationWindowSeconds is the number of seconds for which past recommendations should be
+  // stabilizationWindowSeconds is the number of seconds for which past recommendations should be
   // considered while scaling up or scaling down.
   // StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
   // If not set, use the default values:
@@ -361,7 +361,7 @@ message MetricStatus {
   // +optional
   optional ResourceMetricStatus resource = 4;
 
-  // container resource refers to a resource metric (such as those specified in
+  // containerResource refers to a resource metric (such as those specified in
   // requests and limits) known to Kubernetes describing a single container in each pod in the
   // current scale target (e.g. CPU or memory). Such metrics are built in to
   // Kubernetes, and have special scaling options on top of those available
@@ -411,7 +411,7 @@ message MetricValueStatus {
   // +optional
   optional k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 2;
 
-  // currentAverageUtilization is the current value of the average of the
+  // averageUtilization is the current value of the average of the
   // resource metric across all relevant pods, represented as a percentage of
   // the requested value of the resource for the pods.
   // +optional
@@ -485,7 +485,7 @@ message ResourceMetricSource {
 // Kubernetes, and have special scaling options on top of those available to
 // normal per-pod metrics using the "pods" source.
 message ResourceMetricStatus {
-  // Name is the name of the resource in question.
+  // name is the name of the resource in question.
   optional string name = 1;
 
   // current contains the current value for the given metric

--- a/staging/src/k8s.io/api/autoscaling/v2beta2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2beta2/types.go
@@ -62,9 +62,11 @@ type HorizontalPodAutoscalerSpec struct {
 	// available.
 	// +optional
 	MinReplicas *int32 `json:"minReplicas,omitempty" protobuf:"varint,2,opt,name=minReplicas"`
+
 	// maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
 	// It cannot be less that minReplicas.
 	MaxReplicas int32 `json:"maxReplicas" protobuf:"varint,3,opt,name=maxReplicas"`
+
 	// metrics contains the specifications for which to use to calculate the
 	// desired replica count (the maximum replica count across all metrics will
 	// be used).  The desired replica count is calculated multiplying the
@@ -85,11 +87,13 @@ type HorizontalPodAutoscalerSpec struct {
 
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.
 type CrossVersionObjectReference struct {
-	// Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
-	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+	// name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
-	// API version of the referent
+
+	// apiVersion is the API version of the referent
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,3,opt,name=apiVersion"`
 }
@@ -107,11 +111,13 @@ type MetricSpec struct {
 	// (for example, hits-per-second on an Ingress object).
 	// +optional
 	Object *ObjectMetricSource `json:"object,omitempty" protobuf:"bytes,2,opt,name=object"`
+
 	// pods refers to a metric describing each pod in the current scale target
 	// (for example, transactions-processed-per-second).  The values will be
 	// averaged together before being compared to the target value.
 	// +optional
 	Pods *PodsMetricSource `json:"pods,omitempty" protobuf:"bytes,3,opt,name=pods"`
+
 	// resource refers to a resource metric (such as those specified in
 	// requests and limits) known to Kubernetes describing each pod in the
 	// current scale target (e.g. CPU or memory). Such metrics are built in to
@@ -119,6 +125,7 @@ type MetricSpec struct {
 	// to normal per-pod metrics using the "pods" source.
 	// +optional
 	Resource *ResourceMetricSource `json:"resource,omitempty" protobuf:"bytes,4,opt,name=resource"`
+
 	// container resource refers to a resource metric (such as those specified in
 	// requests and limits) known to Kubernetes describing a single container in
 	// each pod of the current scale target (e.g. CPU or memory). Such metrics are
@@ -127,6 +134,7 @@ type MetricSpec struct {
 	// This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
 	// +optional
 	ContainerResource *ContainerResourceMetricSource `json:"containerResource,omitempty" protobuf:"bytes,7,opt,name=containerResource"`
+
 	// external refers to a global metric that is not associated
 	// with any Kubernetes object. It allows autoscaling based on information
 	// coming from components running outside of cluster
@@ -146,6 +154,7 @@ type HorizontalPodAutoscalerBehavior struct {
 	// No stabilization is used.
 	// +optional
 	ScaleUp *HPAScalingRules `json:"scaleUp,omitempty" protobuf:"bytes,1,opt,name=scaleUp"`
+
 	// scaleDown is scaling policy for scaling Down.
 	// If not set, the default value is to allow to scale down to minReplicas pods, with a
 	// 300 second stabilization window (i.e., the highest recommendation for
@@ -173,7 +182,7 @@ const (
 // number of replicas is not set instantly, instead, the safest value from the stabilization
 // window is chosen.
 type HPAScalingRules struct {
-	// StabilizationWindowSeconds is the number of seconds for which past recommendations should be
+	// stabilizationWindowSeconds is the number of seconds for which past recommendations should be
 	// considered while scaling up or scaling down.
 	// StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
 	// If not set, use the default values:
@@ -181,10 +190,12 @@ type HPAScalingRules struct {
 	// - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
 	// +optional
 	StabilizationWindowSeconds *int32 `json:"stabilizationWindowSeconds,omitempty" protobuf:"varint,3,opt,name=stabilizationWindowSeconds"`
+
 	// selectPolicy is used to specify which policy should be used.
 	// If not set, the default value MaxPolicySelect is used.
 	// +optional
 	SelectPolicy *ScalingPolicySelect `json:"selectPolicy,omitempty" protobuf:"bytes,1,opt,name=selectPolicy"`
+
 	// policies is a list of potential scaling polices which can be used during scaling.
 	// At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
 	// +optional
@@ -204,12 +215,14 @@ const (
 
 // HPAScalingPolicy is a single policy which must hold true for a specified past interval.
 type HPAScalingPolicy struct {
-	// Type is used to specify the scaling policy.
+	// type is used to specify the scaling policy.
 	Type HPAScalingPolicyType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=HPAScalingPolicyType"`
-	// Value contains the amount of change which is permitted by the policy.
+
+	// value contains the amount of change which is permitted by the policy.
 	// It must be greater than zero
 	Value int32 `json:"value" protobuf:"varint,2,opt,name=value"`
-	// PeriodSeconds specifies the window of time for which the policy should hold true.
+
+	// periodSeconds specifies the window of time for which the policy should hold true.
 	// PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
 	PeriodSeconds int32 `json:"periodSeconds" protobuf:"varint,3,opt,name=periodSeconds"`
 }
@@ -251,6 +264,7 @@ type ObjectMetricSource struct {
 	DescribedObject CrossVersionObjectReference `json:"describedObject" protobuf:"bytes,1,name=describedObject"`
 	// target specifies the target value for the given metric
 	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
+
 	// metric identifies the target metric by name and selector
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,3,name=metric"`
 }
@@ -262,6 +276,7 @@ type ObjectMetricSource struct {
 type PodsMetricSource struct {
 	// metric identifies the target metric by name and selector
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
+
 	// target specifies the target value for the given metric
 	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
 }
@@ -276,6 +291,7 @@ type PodsMetricSource struct {
 type ResourceMetricSource struct {
 	// name is the name of the resource in question.
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
+
 	// target specifies the target value for the given metric
 	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
 }
@@ -290,8 +306,10 @@ type ResourceMetricSource struct {
 type ContainerResourceMetricSource struct {
 	// name is the name of the resource in question.
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
+
 	// target specifies the target value for the given metric
 	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
+
 	// container is the name of the container in the pods of the scaling target
 	Container string `json:"container" protobuf:"bytes,3,opt,name=container"`
 }
@@ -302,6 +320,7 @@ type ContainerResourceMetricSource struct {
 type ExternalMetricSource struct {
 	// metric identifies the target metric by name and selector
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
+
 	// target specifies the target value for the given metric
 	Target MetricTarget `json:"target" protobuf:"bytes,2,name=target"`
 }
@@ -310,6 +329,7 @@ type ExternalMetricSource struct {
 type MetricIdentifier struct {
 	// name is the name of the given metric
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
+
 	// selector is the string-encoded form of a standard kubernetes label selector for the given metric
 	// When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
 	// When unset, just the metricName will be used to gather metrics.
@@ -321,13 +341,16 @@ type MetricIdentifier struct {
 type MetricTarget struct {
 	// type represents whether the metric type is Utilization, Value, or AverageValue
 	Type MetricTargetType `json:"type" protobuf:"bytes,1,name=type"`
+
 	// value is the target value of the metric (as a quantity).
 	// +optional
 	Value *resource.Quantity `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"`
+
 	// averageValue is the target value of the average of the
 	// metric across all relevant pods (as a quantity)
 	// +optional
 	AverageValue *resource.Quantity `json:"averageValue,omitempty" protobuf:"bytes,3,opt,name=averageValue"`
+
 	// averageUtilization is the target value of the average of the
 	// resource metric across all relevant pods, represented as a percentage of
 	// the requested value of the resource for the pods.
@@ -399,15 +422,19 @@ const (
 type HorizontalPodAutoscalerCondition struct {
 	// type describes the current condition
 	Type HorizontalPodAutoscalerConditionType `json:"type" protobuf:"bytes,1,name=type"`
+
 	// status is the status of the condition (True, False, Unknown)
 	Status v1.ConditionStatus `json:"status" protobuf:"bytes,2,name=status"`
+
 	// lastTransitionTime is the last time the condition transitioned from
 	// one status to another
 	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,3,opt,name=lastTransitionTime"`
+
 	// reason is the reason for the condition's last transition.
 	// +optional
 	Reason string `json:"reason,omitempty" protobuf:"bytes,4,opt,name=reason"`
+
 	// message is a human-readable explanation containing details about
 	// the transition
 	// +optional
@@ -426,6 +453,7 @@ type MetricStatus struct {
 	// (for example, hits-per-second on an Ingress object).
 	// +optional
 	Object *ObjectMetricStatus `json:"object,omitempty" protobuf:"bytes,2,opt,name=object"`
+
 	// pods refers to a metric describing each pod in the current scale target
 	// (for example, transactions-processed-per-second).  The values will be
 	// averaged together before being compared to the target value.
@@ -438,13 +466,15 @@ type MetricStatus struct {
 	// to normal per-pod metrics using the "pods" source.
 	// +optional
 	Resource *ResourceMetricStatus `json:"resource,omitempty" protobuf:"bytes,4,opt,name=resource"`
-	// container resource refers to a resource metric (such as those specified in
+
+	// containerResource refers to a resource metric (such as those specified in
 	// requests and limits) known to Kubernetes describing a single container in each pod in the
 	// current scale target (e.g. CPU or memory). Such metrics are built in to
 	// Kubernetes, and have special scaling options on top of those available
 	// to normal per-pod metrics using the "pods" source.
 	// +optional
 	ContainerResource *ContainerResourceMetricStatus `json:"containerResource,omitempty" protobuf:"bytes,7,opt,name=containerResource"`
+
 	// external refers to a global metric that is not associated
 	// with any Kubernetes object. It allows autoscaling based on information
 	// coming from components running outside of cluster
@@ -459,6 +489,7 @@ type MetricStatus struct {
 type ObjectMetricStatus struct {
 	// metric identifies the target metric by name and selector
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
+
 	// current contains the current value for the given metric
 	Current MetricValueStatus `json:"current" protobuf:"bytes,2,name=current"`
 
@@ -470,6 +501,7 @@ type ObjectMetricStatus struct {
 type PodsMetricStatus struct {
 	// metric identifies the target metric by name and selector
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
+
 	// current contains the current value for the given metric
 	Current MetricValueStatus `json:"current" protobuf:"bytes,2,name=current"`
 }
@@ -480,8 +512,9 @@ type PodsMetricStatus struct {
 // Kubernetes, and have special scaling options on top of those available to
 // normal per-pod metrics using the "pods" source.
 type ResourceMetricStatus struct {
-	// Name is the name of the resource in question.
+	// name is the name of the resource in question.
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
+
 	// current contains the current value for the given metric
 	Current MetricValueStatus `json:"current" protobuf:"bytes,2,name=current"`
 }
@@ -492,11 +525,13 @@ type ResourceMetricStatus struct {
 // Kubernetes, and have special scaling options on top of those available to
 // normal per-pod metrics using the "pods" source.
 type ContainerResourceMetricStatus struct {
-	// Name is the name of the resource in question.
+	// name is the name of the resource in question.
 	Name v1.ResourceName `json:"name" protobuf:"bytes,1,name=name"`
+
 	// current contains the current value for the given metric
 	Current MetricValueStatus `json:"current" protobuf:"bytes,2,name=current"`
-	// Container is the name of the container in the pods of the scaling target
+
+	// container is the name of the container in the pods of the scaling target
 	Container string `json:"container" protobuf:"bytes,3,opt,name=container"`
 }
 
@@ -505,6 +540,7 @@ type ContainerResourceMetricStatus struct {
 type ExternalMetricStatus struct {
 	// metric identifies the target metric by name and selector
 	Metric MetricIdentifier `json:"metric" protobuf:"bytes,1,name=metric"`
+
 	// current contains the current value for the given metric
 	Current MetricValueStatus `json:"current" protobuf:"bytes,2,name=current"`
 }
@@ -514,11 +550,13 @@ type MetricValueStatus struct {
 	// value is the current value of the metric (as a quantity).
 	// +optional
 	Value *resource.Quantity `json:"value,omitempty" protobuf:"bytes,1,opt,name=value"`
+
 	// averageValue is the current value of the average of the
 	// metric across all relevant pods (as a quantity)
 	// +optional
 	AverageValue *resource.Quantity `json:"averageValue,omitempty" protobuf:"bytes,2,opt,name=averageValue"`
-	// currentAverageUtilization is the current value of the average of the
+
+	// averageUtilization is the current value of the average of the
 	// resource metric across all relevant pods, represented as a percentage of
 	// the requested value of the resource for the pods.
 	// +optional

--- a/staging/src/k8s.io/api/autoscaling/v2beta2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/autoscaling/v2beta2/types_swagger_doc_generated.go
@@ -40,9 +40,9 @@ func (ContainerResourceMetricSource) SwaggerDoc() map[string]string {
 
 var map_ContainerResourceMetricStatus = map[string]string{
 	"":          "ContainerResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing a single container in each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
-	"name":      "Name is the name of the resource in question.",
+	"name":      "name is the name of the resource in question.",
 	"current":   "current contains the current value for the given metric",
-	"container": "Container is the name of the container in the pods of the scaling target",
+	"container": "container is the name of the container in the pods of the scaling target",
 }
 
 func (ContainerResourceMetricStatus) SwaggerDoc() map[string]string {
@@ -51,9 +51,9 @@ func (ContainerResourceMetricStatus) SwaggerDoc() map[string]string {
 
 var map_CrossVersionObjectReference = map[string]string{
 	"":           "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
-	"kind":       "Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-	"name":       "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
-	"apiVersion": "API version of the referent",
+	"kind":       "kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+	"name":       "name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+	"apiVersion": "apiVersion is the API version of the referent",
 }
 
 func (CrossVersionObjectReference) SwaggerDoc() map[string]string {
@@ -82,9 +82,9 @@ func (ExternalMetricStatus) SwaggerDoc() map[string]string {
 
 var map_HPAScalingPolicy = map[string]string{
 	"":              "HPAScalingPolicy is a single policy which must hold true for a specified past interval.",
-	"type":          "Type is used to specify the scaling policy.",
-	"value":         "Value contains the amount of change which is permitted by the policy. It must be greater than zero",
-	"periodSeconds": "PeriodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+	"type":          "type is used to specify the scaling policy.",
+	"value":         "value contains the amount of change which is permitted by the policy. It must be greater than zero",
+	"periodSeconds": "periodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
 }
 
 func (HPAScalingPolicy) SwaggerDoc() map[string]string {
@@ -93,7 +93,7 @@ func (HPAScalingPolicy) SwaggerDoc() map[string]string {
 
 var map_HPAScalingRules = map[string]string{
 	"":                           "HPAScalingRules configures the scaling behavior for one direction. These Rules are applied after calculating DesiredReplicas from metrics for the HPA. They can limit the scaling velocity by specifying scaling policies. They can prevent flapping by specifying the stabilization window, so that the number of replicas is not set instantly, instead, the safest value from the stabilization window is chosen.",
-	"stabilizationWindowSeconds": "StabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
+	"stabilizationWindowSeconds": "stabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
 	"selectPolicy":               "selectPolicy is used to specify which policy should be used. If not set, the default value MaxPolicySelect is used.",
 	"policies":                   "policies is a list of potential scaling polices which can be used during scaling. At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid",
 }
@@ -203,7 +203,7 @@ var map_MetricStatus = map[string]string{
 	"object":            "object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).",
 	"pods":              "pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.",
 	"resource":          "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
-	"containerResource": "container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
+	"containerResource": "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
 	"external":          "external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).",
 }
 
@@ -227,7 +227,7 @@ var map_MetricValueStatus = map[string]string{
 	"":                   "MetricValueStatus holds the current value for a metric",
 	"value":              "value is the current value of the metric (as a quantity).",
 	"averageValue":       "averageValue is the current value of the average of the metric across all relevant pods (as a quantity)",
-	"averageUtilization": "currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.",
+	"averageUtilization": "averageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.",
 }
 
 func (MetricValueStatus) SwaggerDoc() map[string]string {
@@ -286,7 +286,7 @@ func (ResourceMetricSource) SwaggerDoc() map[string]string {
 
 var map_ResourceMetricStatus = map[string]string{
 	"":        "ResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
-	"name":    "Name is the name of the resource in question.",
+	"name":    "name is the name of the resource in question.",
 	"current": "current contains the current value for the given metric",
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -207,7 +207,7 @@ func schema_k8sio_api_autoscaling_v1_CrossVersionObjectReference(ref common.Refe
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Description: "kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -215,7 +215,7 @@ func schema_k8sio_api_autoscaling_v1_CrossVersionObjectReference(ref common.Refe
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+							Description: "name is the name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -223,7 +223,7 @@ func schema_k8sio_api_autoscaling_v1_CrossVersionObjectReference(ref common.Refe
 					},
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "API version of the referent",
+							Description: "apiVersion is the API version of the referent",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -355,14 +355,14 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscaler(ref common.Referenc
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
+							Description: "spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/autoscaling/v1.HorizontalPodAutoscalerSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "current information about the autoscaler.",
+							Description: "status is the current information about the autoscaler.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/autoscaling/v1.HorizontalPodAutoscalerStatus"),
 						},
@@ -458,7 +458,7 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerList(ref common.Refe
 					},
 					"items": {
 						SchemaProps: spec.SchemaProps{
-							Description: "list of horizontal pod autoscaler objects.",
+							Description: "items is the list of horizontal pod autoscaler objects.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -502,7 +502,7 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerSpec(ref common.Refe
 					},
 					"maxReplicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
+							Description: "maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -510,7 +510,7 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerSpec(ref common.Refe
 					},
 					"targetCPUUtilizationPercentage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.",
+							Description: "targetCPUUtilizationPercentage is the target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -533,20 +533,20 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerStatus(ref common.Re
 				Properties: map[string]spec.Schema{
 					"observedGeneration": {
 						SchemaProps: spec.SchemaProps{
-							Description: "most recent generation observed by this autoscaler.",
+							Description: "observedGeneration is the most recent generation observed by this autoscaler.",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},
 					},
 					"lastScaleTime": {
 						SchemaProps: spec.SchemaProps{
-							Description: "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.",
+							Description: "lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"currentReplicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "current number of replicas of pods managed by this autoscaler.",
+							Description: "currentReplicas is the current number of replicas of pods managed by this autoscaler.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -554,7 +554,7 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerStatus(ref common.Re
 					},
 					"desiredReplicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "desired number of replicas of pods managed by this autoscaler.",
+							Description: "desiredReplicas is the  desired number of replicas of pods managed by this autoscaler.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -562,7 +562,7 @@ func schema_k8sio_api_autoscaling_v1_HorizontalPodAutoscalerStatus(ref common.Re
 					},
 					"currentCPUUtilizationPercentage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
+							Description: "currentCPUUtilizationPercentage is the current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -612,7 +612,7 @@ func schema_k8sio_api_autoscaling_v1_MetricSpec(ref common.ReferenceCallback) co
 					},
 					"containerResource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.",
+							Description: "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.",
 							Ref:         ref("k8s.io/api/autoscaling/v1.ContainerResourceMetricSource"),
 						},
 					},
@@ -667,7 +667,7 @@ func schema_k8sio_api_autoscaling_v1_MetricStatus(ref common.ReferenceCallback) 
 					},
 					"containerResource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
+							Description: "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
 							Ref:         ref("k8s.io/api/autoscaling/v1.ContainerResourceMetricStatus"),
 						},
 					},
@@ -965,14 +965,14 @@ func schema_k8sio_api_autoscaling_v1_Scale(ref common.ReferenceCallback) common.
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
+							Description: "spec defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/autoscaling/v1.ScaleSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.",
+							Description: "status is the current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/autoscaling/v1.ScaleStatus"),
 						},
@@ -994,7 +994,7 @@ func schema_k8sio_api_autoscaling_v1_ScaleSpec(ref common.ReferenceCallback) com
 				Properties: map[string]spec.Schema{
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "desired number of instances for the scaled object.",
+							Description: "replicas is the desired number of instances for the scaled object.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -1014,7 +1014,7 @@ func schema_k8sio_api_autoscaling_v1_ScaleStatus(ref common.ReferenceCallback) c
 				Properties: map[string]spec.Schema{
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "actual number of observed instances of the scaled object.",
+							Description: "replicas is the actual number of observed instances of the scaled object.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -1022,7 +1022,7 @@ func schema_k8sio_api_autoscaling_v1_ScaleStatus(ref common.ReferenceCallback) c
 					},
 					"selector": {
 						SchemaProps: spec.SchemaProps{
-							Description: "label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+							Description: "selector is the label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
What type of PR is this?
/kind documentation

Which issue(s) this PR fixes:
#113438

Does this PR introduce a user-facing change?

The PR Changes API field references on API docs. It uses json field names instead of Golang type names.