### PR TITLE
clean up kube-proxy nodeport address handling (part 3)

### DIFF
--- a/pkg/proxy/healthcheck/healthcheck_test.go
+++ b/pkg/proxy/healthcheck/healthcheck_test.go
@@ -178,7 +178,7 @@ func TestServer(t *testing.T) {
 	if len(listener.openPorts) != 1 {
 		t.Errorf("expected 1 open port, got %d\n%s", len(listener.openPorts), dump.Pretty(listener.openPorts))
 	}
-	if !listener.hasPort(":9376") {
+	if !listener.hasPort("0.0.0.0:9376") {
 		t.Errorf("expected port :9376 to be open\n%s", dump.Pretty(listener.openPorts))
 	}
 	// test the handler

--- a/pkg/proxy/healthcheck/healthcheck_test.go
+++ b/pkg/proxy/healthcheck/healthcheck_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/dump"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -140,7 +141,7 @@ func (fake fakeProxierHealthChecker) IsHealthy() bool {
 func TestServer(t *testing.T) {
 	listener := newFakeListener()
 	httpFactory := newFakeHTTPServerFactory()
-	nodePortAddresses := utilproxy.NewNodePortAddresses([]string{})
+	nodePortAddresses := utilproxy.NewNodePortAddresses(v1.IPv4Protocol, []string{})
 	proxyChecker := &fakeProxierHealthChecker{true}
 
 	hcsi := newServiceHealthServer("hostname", nil, listener, httpFactory, nodePortAddresses, proxyChecker)
@@ -470,7 +471,7 @@ func TestServerWithSelectiveListeningAddress(t *testing.T) {
 
 	// limiting addresses to loop back. We don't want any cleverness here around getting IP for
 	// machine nor testing ipv6 || ipv4. using loop back guarantees the test will work on any machine
-	nodePortAddresses := utilproxy.NewNodePortAddresses([]string{"127.0.0.0/8"})
+	nodePortAddresses := utilproxy.NewNodePortAddresses(v1.IPv4Protocol, []string{"127.0.0.0/8"})
 
 	hcsi := newServiceHealthServer("hostname", nil, listener, httpFactory, nodePortAddresses, proxyChecker)
 	hcs := hcsi.(*server)

--- a/pkg/proxy/healthcheck/service_health.go
+++ b/pkg/proxy/healthcheck/service_health.go
@@ -59,20 +59,18 @@ type proxierHealthChecker interface {
 }
 
 func newServiceHealthServer(hostname string, recorder events.EventRecorder, listener listener, factory httpServerFactory, nodePortAddresses *utilproxy.NodePortAddresses, healthzServer proxierHealthChecker) ServiceHealthServer {
-
-	nodeAddresses, err := nodePortAddresses.GetNodeAddresses(utilproxy.RealNetwork{})
-	if err != nil || nodeAddresses.Len() == 0 {
-		klog.ErrorS(err, "Failed to get node ip address matching node port addresses, health check port will listen to all node addresses", "nodePortAddresses", nodePortAddresses)
-		nodeAddresses = sets.New[string]()
-		nodeAddresses.Insert(utilproxy.IPv4ZeroCIDR)
-	}
+	var nodeAddresses sets.Set[string]
 
 	// if any of the addresses is zero cidr then we listen
 	// to old style :<port>
-	for _, addr := range nodeAddresses.UnsortedList() {
-		if utilproxy.IsZeroCIDR(addr) {
-			nodeAddresses = sets.New[string]("")
-			break
+	if nodePortAddresses.MatchAll() {
+		nodeAddresses = sets.New("")
+	} else {
+		var err error
+		nodeAddresses, err = nodePortAddresses.GetNodeAddresses(utilproxy.RealNetwork{})
+		if err != nil || nodeAddresses.Len() == 0 {
+			klog.ErrorS(err, "Failed to get node ip address matching node port addresses, health check port will listen to all node addresses", "nodePortAddresses", nodePortAddresses)
+			nodeAddresses = sets.New(utilproxy.IPv4ZeroCIDR)
 		}
 	}
 

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -240,7 +240,7 @@ func NewProxier(ipFamily v1.IPFamily,
 	healthzServer healthcheck.ProxierHealthUpdater,
 	nodePortAddressStrings []string,
 ) (*Proxier, error) {
-	nodePortAddresses := utilproxy.NewNodePortAddresses(nodePortAddressStrings)
+	nodePortAddresses := utilproxy.NewNodePortAddresses(ipFamily, nodePortAddressStrings)
 
 	if !nodePortAddresses.ContainsIPv4Loopback() {
 		localhostNodePorts = false
@@ -334,17 +334,16 @@ func NewDualStackProxier(
 	nodePortAddresses []string,
 ) (proxy.Provider, error) {
 	// Create an ipv4 instance of the single-stack proxier
-	ipFamilyMap := utilproxy.MapCIDRsByIPFamily(nodePortAddresses)
 	ipv4Proxier, err := NewProxier(v1.IPv4Protocol, ipt[0], sysctl,
 		exec, syncPeriod, minSyncPeriod, masqueradeAll, localhostNodePorts, masqueradeBit, localDetectors[0], hostname,
-		nodeIP[0], recorder, healthzServer, ipFamilyMap[v1.IPv4Protocol])
+		nodeIP[0], recorder, healthzServer, nodePortAddresses)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create ipv4 proxier: %v", err)
 	}
 
 	ipv6Proxier, err := NewProxier(v1.IPv6Protocol, ipt[1], sysctl,
 		exec, syncPeriod, minSyncPeriod, masqueradeAll, false, masqueradeBit, localDetectors[1], hostname,
-		nodeIP[1], recorder, healthzServer, ipFamilyMap[v1.IPv6Protocol])
+		nodeIP[1], recorder, healthzServer, nodePortAddresses)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create ipv6 proxier: %v", err)
 	}
@@ -1420,15 +1419,6 @@ func (proxier *Proxier) syncProxyRules() {
 	if err != nil {
 		klog.ErrorS(err, "Failed to get node ip address matching nodeport cidrs, services with nodeport may not work as intended", "CIDRs", proxier.nodePortAddresses)
 	}
-	// nodeAddresses may contain dual-stack zero-CIDRs if proxier.nodePortAddresses is empty.
-	// Ensure nodeAddresses only contains the addresses for this proxier's IP family.
-	for addr := range nodeAddresses {
-		if utilproxy.IsZeroCIDR(addr) && isIPv6 == netutils.IsIPv6CIDRString(addr) {
-			// if any of the addresses is zero cidr of this IP family, non-zero IPs can be excluded.
-			nodeAddresses = sets.New[string](addr)
-			break
-		}
-	}
 
 	for address := range nodeAddresses {
 		if utilproxy.IsZeroCIDR(address) {
@@ -1453,12 +1443,6 @@ func (proxier *Proxier) syncProxyRules() {
 				destinations,
 				"-j", string(kubeNodePortsChain))
 			break
-		}
-
-		// Ignore IP addresses with incorrect version
-		if isIPv6 && !netutils.IsIPv6String(address) || !isIPv6 && netutils.IsIPv6String(address) {
-			klog.ErrorS(nil, "IP has incorrect IP version", "IP", address)
-			continue
 		}
 
 		// For ipv6, Regardless of the value of localhostNodePorts is true or false, we should disallow access

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1004,22 +1004,15 @@ func (proxier *Proxier) syncProxyRules() {
 		}
 	}
 
-	// Both nodeAddresses and nodeIPs can be reused for all nodePort services
-	// and only need to be computed if we have at least one nodePort service.
-	var (
-		// List of node addresses to listen on if a nodePort is set.
-		nodeAddresses []string
-		// List of node IP addresses to be used as IPVS services if nodePort is set.
-		nodeIPs []net.IP
-	)
-
+	// List of node IP addresses to be used as IPVS services if nodePort is set. This
+	// can be reused for all nodePort services.
+	var nodeIPs []net.IP
 	if hasNodePort {
 		nodeAddrSet, err := proxier.nodePortAddresses.GetNodeAddresses(proxier.networkInterfacer)
 		if err != nil {
 			klog.ErrorS(err, "Failed to get node IP address matching nodeport cidr")
 		} else {
-			nodeAddresses = nodeAddrSet.UnsortedList()
-			for _, address := range nodeAddresses {
+			for _, address := range nodeAddrSet.UnsortedList() {
 				a := netutils.ParseIPSloppy(address)
 				if a.IsLoopback() {
 					continue
@@ -1292,7 +1285,7 @@ func (proxier *Proxier) syncProxyRules() {
 		}
 
 		if svcInfo.NodePort() != 0 {
-			if len(nodeAddresses) == 0 || len(nodeIPs) == 0 {
+			if len(nodeIPs) == 0 {
 				// Skip nodePort configuration since an error occurred when
 				// computing nodeAddresses or nodeIPs.
 				continue

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1011,16 +1011,14 @@ func (proxier *Proxier) syncProxyRules() {
 				nodeIPs = append(nodeIPs, netutils.ParseIPSloppy(ipStr))
 			}
 		} else {
-			nodeAddrSet, err := proxier.nodePortAddresses.GetNodeAddresses(proxier.networkInterfacer)
+			allNodeIPs, err := proxier.nodePortAddresses.GetNodeIPs(proxier.networkInterfacer)
 			if err != nil {
 				klog.ErrorS(err, "Failed to get node IP address matching nodeport cidr")
 			} else {
-				for address := range nodeAddrSet {
-					a := netutils.ParseIPSloppy(address)
-					if a.IsLoopback() {
-						continue
+				for _, ip := range allNodeIPs {
+					if !ip.IsLoopback() {
+						nodeIPs = append(nodeIPs, ip)
 					}
-					nodeIPs = append(nodeIPs, a)
 				}
 			}
 		}

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -169,7 +169,7 @@ func NewFakeProxier(ipt utiliptables.Interface, ipvs utilipvs.Interface, ipset u
 		filterRules:           utilproxy.LineBuffer{},
 		netlinkHandle:         netlinkHandle,
 		ipsetList:             ipsetList,
-		nodePortAddresses:     utilproxy.NewNodePortAddresses(nil),
+		nodePortAddresses:     utilproxy.NewNodePortAddresses(ipFamily, nil),
 		networkInterfacer:     proxyutiltest.NewFakeNetwork(),
 		gracefuldeleteManager: NewGracefulTerminationManager(ipvs),
 		ipFamily:              ipFamily,
@@ -960,7 +960,7 @@ func TestNodePortIPv4(t *testing.T) {
 			ipvs := ipvstest.NewFake()
 			ipset := ipsettest.NewFake(testIPSetVersion)
 			fp := NewFakeProxier(ipt, ipvs, ipset, test.nodeIPs, nil, v1.IPv4Protocol)
-			fp.nodePortAddresses = utilproxy.NewNodePortAddresses(test.nodePortAddresses)
+			fp.nodePortAddresses = utilproxy.NewNodePortAddresses(v1.IPv4Protocol, test.nodePortAddresses)
 
 			makeServiceMap(fp, test.services...)
 			populateEndpointSlices(fp, test.endpoints...)
@@ -1305,7 +1305,7 @@ func TestNodePortIPv6(t *testing.T) {
 			ipvs := ipvstest.NewFake()
 			ipset := ipsettest.NewFake(testIPSetVersion)
 			fp := NewFakeProxier(ipt, ipvs, ipset, test.nodeIPs, nil, v1.IPv6Protocol)
-			fp.nodePortAddresses = utilproxy.NewNodePortAddresses(test.nodePortAddresses)
+			fp.nodePortAddresses = utilproxy.NewNodePortAddresses(v1.IPv6Protocol, test.nodePortAddresses)
 
 			makeServiceMap(fp, test.services...)
 			populateEndpointSlices(fp, test.endpoints...)
@@ -2068,7 +2068,7 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 	addrs1 := []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("2001:db8::"), Mask: net.CIDRMask(64, 128)}}
 	fp.networkInterfacer.(*proxyutiltest.FakeNetwork).AddInterfaceAddr(&itf, addrs)
 	fp.networkInterfacer.(*proxyutiltest.FakeNetwork).AddInterfaceAddr(&itf1, addrs1)
-	fp.nodePortAddresses = utilproxy.NewNodePortAddresses([]string{"100.101.102.0/24"})
+	fp.nodePortAddresses = utilproxy.NewNodePortAddresses(v1.IPv4Protocol, []string{"100.101.102.0/24"})
 
 	fp.syncProxyRules()
 
@@ -2156,7 +2156,7 @@ func TestHealthCheckNodePort(t *testing.T) {
 	addrs1 := []net.Addr{&net.IPNet{IP: netutils.ParseIPSloppy("2001:db8::"), Mask: net.CIDRMask(64, 128)}}
 	fp.networkInterfacer.(*proxyutiltest.FakeNetwork).AddInterfaceAddr(&itf, addrs)
 	fp.networkInterfacer.(*proxyutiltest.FakeNetwork).AddInterfaceAddr(&itf1, addrs1)
-	fp.nodePortAddresses = utilproxy.NewNodePortAddresses([]string{"100.101.102.0/24"})
+	fp.nodePortAddresses = utilproxy.NewNodePortAddresses(v1.IPv4Protocol, []string{"100.101.102.0/24"})
 
 	fp.syncProxyRules()
 

--- a/pkg/proxy/util/nodeport_addresses_test.go
+++ b/pkg/proxy/util/nodeport_addresses_test.go
@@ -33,7 +33,8 @@ type InterfaceAddrsPair struct {
 
 func TestGetNodeAddresses(t *testing.T) {
 	type expectation struct {
-		ips sets.Set[string]
+		matchAll bool
+		ips      sets.Set[string]
 	}
 
 	testCases := []struct {
@@ -60,7 +61,8 @@ func TestGetNodeAddresses(t *testing.T) {
 					ips: sets.New[string]("10.20.30.51"),
 				},
 				v1.IPv6Protocol: {
-					ips: sets.New[string]("::/0"),
+					matchAll: true,
+					ips:      nil,
 				},
 			},
 		},
@@ -79,10 +81,12 @@ func TestGetNodeAddresses(t *testing.T) {
 			},
 			expected: map[v1.IPFamily]expectation{
 				v1.IPv4Protocol: {
-					ips: sets.New[string]("0.0.0.0/0"),
+					matchAll: true,
+					ips:      sets.New[string]("10.20.30.51", "127.0.0.1"),
 				},
 				v1.IPv6Protocol: {
-					ips: sets.New[string]("::/0"),
+					matchAll: true,
+					ips:      nil,
 				},
 			},
 		},
@@ -101,7 +105,8 @@ func TestGetNodeAddresses(t *testing.T) {
 			},
 			expected: map[v1.IPFamily]expectation{
 				v1.IPv4Protocol: {
-					ips: sets.New[string]("0.0.0.0/0"),
+					matchAll: true,
+					ips:      nil,
 				},
 				v1.IPv6Protocol: {
 					ips: sets.New[string]("2001:db8::1", "::1"),
@@ -123,10 +128,12 @@ func TestGetNodeAddresses(t *testing.T) {
 			},
 			expected: map[v1.IPFamily]expectation{
 				v1.IPv4Protocol: {
-					ips: sets.New[string]("0.0.0.0/0"),
+					matchAll: true,
+					ips:      nil,
 				},
 				v1.IPv6Protocol: {
-					ips: sets.New[string]("::/0"),
+					matchAll: true,
+					ips:      sets.New[string]("2001:db8::1", "::1"),
 				},
 			},
 		},
@@ -148,7 +155,8 @@ func TestGetNodeAddresses(t *testing.T) {
 					ips: sets.New[string]("127.0.0.1"),
 				},
 				v1.IPv6Protocol: {
-					ips: sets.New[string]("::/0"),
+					matchAll: true,
+					ips:      nil,
 				},
 			},
 		},
@@ -166,7 +174,8 @@ func TestGetNodeAddresses(t *testing.T) {
 					ips: sets.New[string]("127.0.1.1"),
 				},
 				v1.IPv6Protocol: {
-					ips: sets.New[string]("::/0"),
+					matchAll: true,
+					ips:      nil,
 				},
 			},
 		},
@@ -188,7 +197,8 @@ func TestGetNodeAddresses(t *testing.T) {
 					ips: sets.New[string]("10.20.30.51", "100.200.201.1"),
 				},
 				v1.IPv6Protocol: {
-					ips: sets.New[string]("::/0"),
+					matchAll: true,
+					ips:      nil,
 				},
 			},
 		},
@@ -210,7 +220,8 @@ func TestGetNodeAddresses(t *testing.T) {
 					ips: nil,
 				},
 				v1.IPv6Protocol: {
-					ips: sets.New[string]("::/0"),
+					matchAll: true,
+					ips:      nil,
 				},
 			},
 		},
@@ -229,10 +240,12 @@ func TestGetNodeAddresses(t *testing.T) {
 			},
 			expected: map[v1.IPFamily]expectation{
 				v1.IPv4Protocol: {
-					ips: sets.New[string]("0.0.0.0/0"),
+					matchAll: true,
+					ips:      sets.New[string]("192.168.1.2", "127.0.0.1"),
 				},
 				v1.IPv6Protocol: {
-					ips: sets.New[string]("::/0"),
+					matchAll: true,
+					ips:      nil,
 				},
 			},
 		},
@@ -251,10 +264,12 @@ func TestGetNodeAddresses(t *testing.T) {
 			},
 			expected: map[v1.IPFamily]expectation{
 				v1.IPv4Protocol: {
-					ips: sets.New[string]("0.0.0.0/0"),
+					matchAll: true,
+					ips:      nil,
 				},
 				v1.IPv6Protocol: {
-					ips: sets.New[string]("::/0"),
+					matchAll: true,
+					ips:      sets.New[string]("2001:db8::1", "::1"),
 				},
 			},
 		},
@@ -269,10 +284,12 @@ func TestGetNodeAddresses(t *testing.T) {
 			},
 			expected: map[v1.IPFamily]expectation{
 				v1.IPv4Protocol: {
-					ips: sets.New[string]("0.0.0.0/0"),
+					matchAll: true,
+					ips:      sets.New[string]("1.2.3.4"),
 				},
 				v1.IPv6Protocol: {
-					ips: sets.New[string]("::/0"),
+					matchAll: true,
+					ips:      nil,
 				},
 			},
 		},
@@ -297,7 +314,8 @@ func TestGetNodeAddresses(t *testing.T) {
 			},
 			expected: map[v1.IPFamily]expectation{
 				v1.IPv4Protocol: {
-					ips: sets.New[string]("0.0.0.0/0"),
+					matchAll: true,
+					ips:      sets.New[string]("1.2.3.4", "127.0.0.1"),
 				},
 				v1.IPv6Protocol: {
 					ips: sets.New[string]("2001:db8::1"),
@@ -328,7 +346,8 @@ func TestGetNodeAddresses(t *testing.T) {
 					ips: sets.New[string]("1.2.3.4"),
 				},
 				v1.IPv6Protocol: {
-					ips: sets.New[string]("::/0"),
+					matchAll: true,
+					ips:      sets.New[string]("2001:db8::1", "::1"),
 				},
 			},
 		},
@@ -344,11 +363,15 @@ func TestGetNodeAddresses(t *testing.T) {
 			for _, family := range []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol} {
 				npa := NewNodePortAddresses(family, tc.cidrs)
 
+				if npa.MatchAll() != tc.expected[family].matchAll {
+					t.Errorf("unexpected MatchAll(%s), expected: %v", family, tc.expected[family].matchAll)
+				}
+
 				addrList, err := npa.GetNodeAddresses(nw)
 				// The fake InterfaceAddrs() never returns an error, so
 				// the only error GetNodeAddresses will return is "no
 				// addresses found".
-				if err != nil && tc.expected[family].ips != nil {
+				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig network
/priority important-longterm

#### What this PR does / why we need it:
Continuing from #115244 and #115256. This fixes the API ugliness with the `NodePortAddresses` abstraction that was inherited from the original API:

1. Get rid of filtering-by-IP-family in each proxy
2. Get rid of filtering localhost in each proxy
3. Get rid of the awful magic special-case out-of-band "matches all IPs" value

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @aojea