### PR TITLE
Migrate /pkg/controller/disruption to structured and contextual logging

### DIFF
--- a/cmd/kube-controller-manager/app/policy.go
+++ b/cmd/kube-controller-manager/app/policy.go
@@ -25,10 +25,12 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/scale"
 	"k8s.io/controller-manager/controller"
+	klog "k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/disruption"
 )
 
 func startDisruptionController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+	ctx = klog.NewContext(ctx, klog.LoggerWithName(klog.FromContext(ctx), "disruption"))
 	client := controllerContext.ClientBuilder.ClientOrDie("disruption-controller")
 	config := controllerContext.ClientBuilder.ConfigOrDie("disruption-controller")
 	scaleKindResolver := scale.NewDiscoveryScaleKindResolver(client.Discovery())
@@ -38,6 +40,7 @@ func startDisruptionController(ctx context.Context, controllerContext Controller
 	}
 
 	go disruption.NewDisruptionController(
+		ctx,
 		controllerContext.InformerFactory.Core().V1().Pods(),
 		controllerContext.InformerFactory.Policy().V1().PodDisruptionBudgets(),
 		controllerContext.InformerFactory.Core().V1().ReplicationControllers(),

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -41,7 +41,6 @@ contextual k8s.io/kubernetes/test/e2e/dra/.*
 -contextual k8s.io/kubernetes/pkg/controller/controller_ref_manager.go
 -contextual k8s.io/kubernetes/pkg/controller/controller_utils.go
 -contextual k8s.io/kubernetes/pkg/controller/deployment/.*
--contextual k8s.io/kubernetes/pkg/controller/disruption/.*
 -contextual k8s.io/kubernetes/pkg/controller/endpoint/.*
 -contextual k8s.io/kubernetes/pkg/controller/endpointslice/.*
 -contextual k8s.io/kubernetes/pkg/controller/endpointslicemirroring/.*

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -50,7 +50,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	pdbhelper "k8s.io/component-helpers/apps/poddisruptionbudget"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 	apipod "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/utils/clock"
@@ -134,6 +134,7 @@ type controllerAndScale struct {
 type podControllerFinder func(ctx context.Context, controllerRef *metav1.OwnerReference, namespace string) (*controllerAndScale, error)
 
 func NewDisruptionController(
+	ctx context.Context,
 	podInformer coreinformers.PodInformer,
 	pdbInformer policyinformers.PodDisruptionBudgetInformer,
 	rcInformer coreinformers.ReplicationControllerInformer,
@@ -146,6 +147,7 @@ func NewDisruptionController(
 	discoveryClient discovery.DiscoveryInterface,
 ) *DisruptionController {
 	return NewDisruptionControllerInternal(
+		ctx,
 		podInformer,
 		pdbInformer,
 		rcInformer,
@@ -163,7 +165,7 @@ func NewDisruptionController(
 // NewDisruptionControllerInternal allows to set a clock and
 // stalePodDisruptionTimeout
 // It is only supposed to be used by tests.
-func NewDisruptionControllerInternal(
+func NewDisruptionControllerInternal(ctx context.Context,
 	podInformer coreinformers.PodInformer,
 	pdbInformer policyinformers.PodDisruptionBudgetInformer,
 	rcInformer coreinformers.ReplicationControllerInformer,
@@ -177,6 +179,7 @@ func NewDisruptionControllerInternal(
 	clock clock.WithTicker,
 	stalePodDisruptionTimeout time.Duration,
 ) *DisruptionController {
+	logger := klog.FromContext(ctx)
 	dc := &DisruptionController{
 		kubeClient:                kubeClient,
 		queue:                     workqueue.NewRateLimitingQueueWithDelayingInterface(workqueue.NewDelayingQueueWithCustomClock(clock, "disruption"), workqueue.DefaultControllerRateLimiter()),
@@ -190,20 +193,30 @@ func NewDisruptionControllerInternal(
 	dc.getUpdater = func() updater { return dc.writePdbStatus }
 
 	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    dc.addPod,
-		UpdateFunc: dc.updatePod,
-		DeleteFunc: dc.deletePod,
+		AddFunc: func(obj interface{}) {
+			dc.addPod(logger, obj)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			dc.updatePod(logger, oldObj, newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			dc.deletePod(logger, obj)
+		},
 	})
 	dc.podLister = podInformer.Lister()
 	dc.podListerSynced = podInformer.Informer().HasSynced
 
-	pdbInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc:    dc.addDb,
-			UpdateFunc: dc.updateDb,
-			DeleteFunc: dc.removeDb,
+	pdbInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			dc.addDB(logger, obj)
 		},
-	)
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			dc.updateDB(logger, oldObj, newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			dc.removeDB(logger, obj)
+		},
+	})
 	dc.pdbLister = pdbInformer.Lister()
 	dc.pdbListerSynced = pdbInformer.Informer().HasSynced
 
@@ -418,12 +431,13 @@ func verifyGroupKind(controllerRef *metav1.OwnerReference, expectedKind string, 
 func (dc *DisruptionController) Run(ctx context.Context) {
 	defer utilruntime.HandleCrash()
 
+	logger := klog.FromContext(ctx)
 	// Start events processing pipeline.
 	if dc.kubeClient != nil {
-		klog.Infof("Sending events to api server.")
+		logger.Info("Sending events to api server.")
 		dc.broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: dc.kubeClient.CoreV1().Events("")})
 	} else {
-		klog.Infof("No api server defined - no events will be sent to API server.")
+		logger.Info("No api server defined - no events will be sent to API server.")
 	}
 	defer dc.broadcaster.Shutdown()
 
@@ -431,8 +445,8 @@ func (dc *DisruptionController) Run(ctx context.Context) {
 	defer dc.recheckQueue.ShutDown()
 	defer dc.stalePodDisruptionQueue.ShutDown()
 
-	klog.Infof("Starting disruption controller")
-	defer klog.Infof("Shutting down disruption controller")
+	logger.Info("Starting disruption controller")
+	defer logger.Info("Shutting down disruption controller")
 
 	if !cache.WaitForNamedCacheSync("disruption", ctx.Done(), dc.podListerSynced, dc.pdbListerSynced, dc.rcListerSynced, dc.rsListerSynced, dc.dListerSynced, dc.ssListerSynced) {
 		return
@@ -445,68 +459,68 @@ func (dc *DisruptionController) Run(ctx context.Context) {
 	<-ctx.Done()
 }
 
-func (dc *DisruptionController) addDb(obj interface{}) {
+func (dc *DisruptionController) addDB(logger klog.Logger, obj interface{}) {
 	pdb := obj.(*policy.PodDisruptionBudget)
-	klog.V(4).Infof("add DB %q", pdb.Name)
-	dc.enqueuePdb(pdb)
+	logger.V(4).Info("Add DB", "podDisruptionBudget", klog.KObj(pdb))
+	dc.enqueuePdb(logger, pdb)
 }
 
-func (dc *DisruptionController) updateDb(old, cur interface{}) {
+func (dc *DisruptionController) updateDB(logger klog.Logger, old, cur interface{}) {
 	// TODO(mml) ignore updates where 'old' is equivalent to 'cur'.
 	pdb := cur.(*policy.PodDisruptionBudget)
-	klog.V(4).Infof("update DB %q", pdb.Name)
-	dc.enqueuePdb(pdb)
+	logger.V(4).Info("Update DB", "podDisruptionBudget", klog.KObj(pdb))
+	dc.enqueuePdb(logger, pdb)
 }
 
-func (dc *DisruptionController) removeDb(obj interface{}) {
+func (dc *DisruptionController) removeDB(logger klog.Logger, obj interface{}) {
 	pdb, ok := obj.(*policy.PodDisruptionBudget)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			klog.Errorf("Couldn't get object from tombstone %+v", obj)
+			logger.Error(nil, "Couldn't get object from tombstone", "obj", obj)
 			return
 		}
 		pdb, ok = tombstone.Obj.(*policy.PodDisruptionBudget)
 		if !ok {
-			klog.Errorf("Tombstone contained object that is not a pdb %+v", obj)
+			logger.Error(nil, "Tombstone contained object that is not a PDB", "obj", obj)
 			return
 		}
 	}
-	klog.V(4).Infof("remove DB %q", pdb.Name)
-	dc.enqueuePdb(pdb)
+	logger.V(4).Info("Remove DB", "podDisruptionBudget", klog.KObj(pdb))
+	dc.enqueuePdb(logger, pdb)
 }
 
-func (dc *DisruptionController) addPod(obj interface{}) {
+func (dc *DisruptionController) addPod(logger klog.Logger, obj interface{}) {
 	pod := obj.(*v1.Pod)
-	klog.V(4).Infof("addPod called on pod %q", pod.Name)
-	pdb := dc.getPdbForPod(pod)
+	logger.V(4).Info("AddPod called on pod", "pod", klog.KObj(pod))
+	pdb := dc.getPdbForPod(logger, pod)
 	if pdb == nil {
-		klog.V(4).Infof("No matching pdb for pod %q", pod.Name)
+		logger.V(4).Info("No matching PDB for pod", "pod", klog.KObj(pod))
 	} else {
-		klog.V(4).Infof("addPod %q -> PDB %q", pod.Name, pdb.Name)
-		dc.enqueuePdb(pdb)
+		logger.V(4).Info("addPod -> PDB", "pod", klog.KObj(pod), "podDisruptionBudget", klog.KObj(pdb))
+		dc.enqueuePdb(logger, pdb)
 	}
 	if has, cleanAfter := dc.nonTerminatingPodHasStaleDisruptionCondition(pod); has {
-		dc.enqueueStalePodDisruptionCleanup(pod, cleanAfter)
+		dc.enqueueStalePodDisruptionCleanup(logger, pod, cleanAfter)
 	}
 }
 
-func (dc *DisruptionController) updatePod(_, cur interface{}) {
+func (dc *DisruptionController) updatePod(logger klog.Logger, _, cur interface{}) {
 	pod := cur.(*v1.Pod)
-	klog.V(4).Infof("updatePod called on pod %q", pod.Name)
-	pdb := dc.getPdbForPod(pod)
+	logger.V(4).Info("UpdatePod called on pod", "pod", klog.KObj(pod))
+	pdb := dc.getPdbForPod(logger, pod)
 	if pdb == nil {
-		klog.V(4).Infof("No matching pdb for pod %q", pod.Name)
+		logger.V(4).Info("No matching PDB for pod", "pod", klog.KObj(pod))
 	} else {
-		klog.V(4).Infof("updatePod %q -> PDB %q", pod.Name, pdb.Name)
-		dc.enqueuePdb(pdb)
+		logger.V(4).Info("updatePod -> PDB", "pod", klog.KObj(pod), "podDisruptionBudget", klog.KObj(pdb))
+		dc.enqueuePdb(logger, pdb)
 	}
 	if has, cleanAfter := dc.nonTerminatingPodHasStaleDisruptionCondition(pod); has {
-		dc.enqueueStalePodDisruptionCleanup(pod, cleanAfter)
+		dc.enqueueStalePodDisruptionCleanup(logger, pod, cleanAfter)
 	}
 }
 
-func (dc *DisruptionController) deletePod(obj interface{}) {
+func (dc *DisruptionController) deletePod(logger klog.Logger, obj interface{}) {
 	pod, ok := obj.(*v1.Pod)
 	// When a delete is dropped, the relist will notice a pod in the store not
 	// in the list, leading to the insertion of a tombstone object which contains
@@ -516,66 +530,66 @@ func (dc *DisruptionController) deletePod(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			klog.Errorf("Couldn't get object from tombstone %+v", obj)
+			logger.Error(nil, "Couldn't get object from tombstone", "obj", obj)
 			return
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			klog.Errorf("Tombstone contained object that is not a pod %+v", obj)
+			logger.Error(nil, "Tombstone contained object that is not a pod", "obj", obj)
 			return
 		}
 	}
-	klog.V(4).Infof("deletePod called on pod %q", pod.Name)
-	pdb := dc.getPdbForPod(pod)
+	logger.V(4).Info("DeletePod called on pod", "pod", klog.KObj(pod))
+	pdb := dc.getPdbForPod(logger, pod)
 	if pdb == nil {
-		klog.V(4).Infof("No matching pdb for pod %q", pod.Name)
+		logger.V(4).Info("No matching PDB for pod", "pod", klog.KObj(pod))
 		return
 	}
-	klog.V(4).Infof("deletePod %q -> PDB %q", pod.Name, pdb.Name)
-	dc.enqueuePdb(pdb)
+	logger.V(4).Info("DeletePod -> PDB", "pod", klog.KObj(pod), "podDisruptionBudget", klog.KObj(pdb))
+	dc.enqueuePdb(logger, pdb)
 }
 
-func (dc *DisruptionController) enqueuePdb(pdb *policy.PodDisruptionBudget) {
+func (dc *DisruptionController) enqueuePdb(logger klog.Logger, pdb *policy.PodDisruptionBudget) {
 	key, err := controller.KeyFunc(pdb)
 	if err != nil {
-		klog.Errorf("Couldn't get key for PodDisruptionBudget object %+v: %v", pdb, err)
+		logger.Error(err, "Couldn't get key for PodDisruptionBudget", "podDisruptionBudget", klog.KObj(pdb))
 		return
 	}
 	dc.queue.Add(key)
 }
 
-func (dc *DisruptionController) enqueuePdbForRecheck(pdb *policy.PodDisruptionBudget, delay time.Duration) {
+func (dc *DisruptionController) enqueuePdbForRecheck(logger klog.Logger, pdb *policy.PodDisruptionBudget, delay time.Duration) {
 	key, err := controller.KeyFunc(pdb)
 	if err != nil {
-		klog.Errorf("Couldn't get key for PodDisruptionBudget object %+v: %v", pdb, err)
+		logger.Error(err, "Couldn't get key for PodDisruptionBudget", "podDisruptionBudget", klog.KObj(pdb))
 		return
 	}
 	dc.recheckQueue.AddAfter(key, delay)
 }
 
-func (dc *DisruptionController) enqueueStalePodDisruptionCleanup(pod *v1.Pod, d time.Duration) {
+func (dc *DisruptionController) enqueueStalePodDisruptionCleanup(logger klog.Logger, pod *v1.Pod, d time.Duration) {
 	key, err := controller.KeyFunc(pod)
 	if err != nil {
-		klog.ErrorS(err, "Couldn't get key for Pod object", "pod", klog.KObj(pod))
+		logger.Error(err, "Couldn't get key for Pod object", "pod", klog.KObj(pod))
 		return
 	}
 	dc.stalePodDisruptionQueue.AddAfter(key, d)
-	klog.V(4).InfoS("Enqueued pod to cleanup stale DisruptionTarget condition", "pod", klog.KObj(pod))
+	logger.V(4).Info("Enqueued pod to cleanup stale DisruptionTarget condition", "pod", klog.KObj(pod))
 }
 
-func (dc *DisruptionController) getPdbForPod(pod *v1.Pod) *policy.PodDisruptionBudget {
+func (dc *DisruptionController) getPdbForPod(logger klog.Logger, pod *v1.Pod) *policy.PodDisruptionBudget {
 	// GetPodPodDisruptionBudgets returns an error only if no
 	// PodDisruptionBudgets are found.  We don't return that as an error to the
 	// caller.
 	pdbs, err := dc.pdbLister.GetPodPodDisruptionBudgets(pod)
 	if err != nil {
-		klog.V(4).Infof("No PodDisruptionBudgets found for pod %v, PodDisruptionBudget controller will avoid syncing.", pod.Name)
+		logger.V(4).Info("No PodDisruptionBudgets found for pod, PodDisruptionBudget controller will avoid syncing.", "pod", klog.KObj(pod))
 		return nil
 	}
 
 	if len(pdbs) > 1 {
 		msg := fmt.Sprintf("Pod %q/%q matches multiple PodDisruptionBudgets.  Chose %q arbitrarily.", pod.Namespace, pod.Name, pdbs[0].Name)
-		klog.Warning(msg)
+		logger.Info(msg)
 		dc.recorder.Event(pod, v1.EventTypeWarning, "MultiplePodDisruptionBudgets", msg)
 	}
 	return pdbs[0]
@@ -656,9 +670,10 @@ func (dc *DisruptionController) processNextStalePodDisruptionWorkItem(ctx contex
 }
 
 func (dc *DisruptionController) sync(ctx context.Context, key string) error {
+	logger := klog.FromContext(ctx)
 	startTime := dc.clock.Now()
 	defer func() {
-		klog.V(4).Infof("Finished syncing PodDisruptionBudget %q (%v)", key, dc.clock.Since(startTime))
+		logger.V(4).Info("Finished syncing PodDisruptionBudget", "key", key, "startTime", dc.clock.Since(startTime))
 	}()
 
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
@@ -667,7 +682,7 @@ func (dc *DisruptionController) sync(ctx context.Context, key string) error {
 	}
 	pdb, err := dc.pdbLister.PodDisruptionBudgets(namespace).Get(name)
 	if errors.IsNotFound(err) {
-		klog.V(4).Infof("PodDisruptionBudget %q has been deleted", key)
+		logger.V(4).Info("podDisruptionBudget has been deleted", "key", key)
 		return nil
 	}
 	if err != nil {
@@ -681,7 +696,7 @@ func (dc *DisruptionController) sync(ctx context.Context, key string) error {
 		return err
 	}
 	if err != nil {
-		klog.Errorf("Failed to sync pdb %s/%s: %v", pdb.Namespace, pdb.Name, err)
+		logger.Error(err, "Failed to sync PDB", "podDisruptionObject", klog.KRef(namespace, name))
 		return dc.failSafe(ctx, pdb, err)
 	}
 
@@ -689,6 +704,7 @@ func (dc *DisruptionController) sync(ctx context.Context, key string) error {
 }
 
 func (dc *DisruptionController) trySync(ctx context.Context, pdb *policy.PodDisruptionBudget) error {
+	logger := klog.FromContext(ctx)
 	pods, err := dc.getPodsForPdb(pdb)
 	if err != nil {
 		dc.recorder.Eventf(pdb, v1.EventTypeWarning, "NoPods", "Failed to get pods: %v", err)
@@ -705,15 +721,11 @@ func (dc *DisruptionController) trySync(ctx context.Context, pdb *policy.PodDisr
 	}
 	// We have unmamanged pods, instead of erroring and hotlooping in disruption controller, log and continue.
 	if len(unmanagedPods) > 0 {
-		klog.Warningf("found unmanaged pods associated with this PDB: %v", unmanagedPods)
-		dc.recorder.Eventf(pdb, v1.EventTypeWarning, "UnmanagedPods", "Pods selected by this PodDisruptionBudget (selector: %v) were found "+
-			"to be unmanaged. As a result, the status of the PDB cannot be calculated correctly, which may result in undefined behavior. "+
-			"To account for these pods please set \".spec.minAvailable\" "+
-			"field of the PDB to an integer value.", pdb.Spec.Selector)
+		logger.V(4).Info("Found unmanaged pods associated with this PDB", "pods", unmanagedPods)
 	}
 
 	currentTime := dc.clock.Now()
-	disruptedPods, recheckTime := dc.buildDisruptedPodMap(pods, pdb, currentTime)
+	disruptedPods, recheckTime := dc.buildDisruptedPodMap(logger, pods, pdb, currentTime)
 	currentHealthy := countHealthyPods(pods, disruptedPods, currentTime)
 	err = dc.updatePdbStatus(ctx, pdb, currentHealthy, desiredHealthy, expectedCount, disruptedPods)
 
@@ -721,23 +733,24 @@ func (dc *DisruptionController) trySync(ctx context.Context, pdb *policy.PodDisr
 		// There is always at most one PDB waiting with a particular name in the queue,
 		// and each PDB in the queue is associated with the lowest timestamp
 		// that was supplied when a PDB with that name was added.
-		dc.enqueuePdbForRecheck(pdb, recheckTime.Sub(currentTime))
+		dc.enqueuePdbForRecheck(logger, pdb, recheckTime.Sub(currentTime))
 	}
 	return err
 }
 
 func (dc *DisruptionController) syncStalePodDisruption(ctx context.Context, key string) error {
+	logger := klog.FromContext(ctx)
 	startTime := dc.clock.Now()
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
 	}
 	defer func() {
-		klog.V(4).InfoS("Finished syncing Pod to clear DisruptionTarget condition", "pod", klog.KRef(namespace, name), "duration", dc.clock.Since(startTime))
+		logger.V(4).Info("Finished syncing Pod to clear DisruptionTarget condition", "pod", klog.KRef(namespace, name), "duration", dc.clock.Since(startTime))
 	}()
 	pod, err := dc.podLister.Pods(namespace).Get(name)
 	if errors.IsNotFound(err) {
-		klog.V(4).InfoS("Skipping clearing DisruptionTarget condition because pod was deleted", "pod", klog.KObj(pod))
+		logger.V(4).Info("Skipping clearing DisruptionTarget condition because pod was deleted", "pod", klog.KObj(pod))
 		return nil
 	}
 	if err != nil {
@@ -749,7 +762,7 @@ func (dc *DisruptionController) syncStalePodDisruption(ctx context.Context, key 
 		return nil
 	}
 	if cleanAfter > 0 {
-		dc.enqueueStalePodDisruptionCleanup(pod, cleanAfter)
+		dc.enqueueStalePodDisruptionCleanup(logger, pod, cleanAfter)
 		return nil
 	}
 
@@ -765,7 +778,7 @@ func (dc *DisruptionController) syncStalePodDisruption(ctx context.Context, key 
 	if _, err := dc.kubeClient.CoreV1().Pods(pod.Namespace).ApplyStatus(ctx, podApply, metav1.ApplyOptions{FieldManager: fieldManager, Force: true}); err != nil {
 		return err
 	}
-	klog.V(2).InfoS("Reset stale DisruptionTarget condition to False", "pod", klog.KObj(pod))
+	logger.V(2).Info("Reset stale DisruptionTarget condition to False", "pod", klog.KObj(pod))
 	return nil
 }
 
@@ -895,7 +908,7 @@ func countHealthyPods(pods []*v1.Pod, disruptedPods map[string]metav1.Time, curr
 
 // Builds new PodDisruption map, possibly removing items that refer to non-existing, already deleted
 // or not-deleted at all items. Also returns an information when this check should be repeated.
-func (dc *DisruptionController) buildDisruptedPodMap(pods []*v1.Pod, pdb *policy.PodDisruptionBudget, currentTime time.Time) (map[string]metav1.Time, *time.Time) {
+func (dc *DisruptionController) buildDisruptedPodMap(logger klog.Logger, pods []*v1.Pod, pdb *policy.PodDisruptionBudget, currentTime time.Time) (map[string]metav1.Time, *time.Time) {
 	disruptedPods := pdb.Status.DisruptedPods
 	result := make(map[string]metav1.Time)
 	var recheckTime *time.Time
@@ -915,8 +928,8 @@ func (dc *DisruptionController) buildDisruptedPodMap(pods []*v1.Pod, pdb *policy
 		}
 		expectedDeletion := disruptionTime.Time.Add(DeletionTimeout)
 		if expectedDeletion.Before(currentTime) {
-			klog.V(1).Infof("Pod %s/%s was expected to be deleted at %s but it wasn't, updating pdb %s/%s",
-				pod.Namespace, pod.Name, disruptionTime.String(), pdb.Namespace, pdb.Name)
+			logger.V(1).Info("pod was expected to be deleted but it wasn't, updating PDB",
+				"pod", klog.KObj(pod), "deletionTime", disruptionTime, "podDisruptionObject", klog.KObj(pdb))
 			dc.recorder.Eventf(pod, v1.EventTypeWarning, "NotDeleted", "Pod was expected by PDB %s/%s to be deleted but it wasn't",
 				pdb.Namespace, pdb.Namespace)
 		} else {

--- a/pkg/controller/disruption/disruption_test.go
+++ b/pkg/controller/disruption/disruption_test.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/controller"
 	clocktesting "k8s.io/utils/clock/testing"
@@ -168,6 +169,7 @@ func newFakeDisruptionControllerWithTime(ctx context.Context, now time.Time) (*d
 	fakeClock := clocktesting.NewFakeClock(now)
 
 	dc := NewDisruptionControllerInternal(
+		ctx,
 		informerFactory.Core().V1().Pods(),
 		informerFactory.Policy().V1().PodDisruptionBudgets(),
 		informerFactory.Core().V1().ReplicationControllers(),
@@ -1380,7 +1382,8 @@ func TestUpdatePDBStatusRetries(t *testing.T) {
 }
 
 func TestInvalidSelectors(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	testCases := map[string]struct {
 		labelSelector *metav1.LabelSelector
@@ -1536,7 +1539,8 @@ func TestStalePodDisruption(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			dc, _ := newFakeDisruptionControllerWithTime(ctx, now)
 			go dc.Run(ctx)

--- a/test/integration/disruption/disruption_test.go
+++ b/test/integration/disruption/disruption_test.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2/ktesting"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/pkg/controller/disruption"
 	"k8s.io/kubernetes/test/integration/etcd"
@@ -56,7 +57,7 @@ import (
 
 const stalePodDisruptionTimeout = 3 * time.Second
 
-func setup(t *testing.T) (*kubeapiservertesting.TestServer, *disruption.DisruptionController, informers.SharedInformerFactory, clientset.Interface, *apiextensionsclientset.Clientset, dynamic.Interface) {
+func setup(ctx context.Context, t *testing.T) (*kubeapiservertesting.TestServer, *disruption.DisruptionController, informers.SharedInformerFactory, clientset.Interface, *apiextensionsclientset.Clientset, dynamic.Interface) {
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins", "ServiceAccount"}, framework.SharedEtcd())
 
 	clientSet, err := clientset.NewForConfig(server.ClientConfig)
@@ -88,6 +89,7 @@ func setup(t *testing.T) (*kubeapiservertesting.TestServer, *disruption.Disrupti
 	}
 
 	pdbc := disruption.NewDisruptionControllerInternal(
+		ctx,
 		informers.Core().V1().Pods(),
 		informers.Policy().V1().PodDisruptionBudgets(),
 		informers.Core().V1().ReplicationControllers(),
@@ -105,11 +107,13 @@ func setup(t *testing.T) (*kubeapiservertesting.TestServer, *disruption.Disrupti
 }
 
 func TestPDBWithScaleSubresource(t *testing.T) {
-	s, pdbc, informers, clientSet, apiExtensionClient, dynamicClient := setup(t)
-	defer s.TearDownFn()
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	s, pdbc, informers, clientSet, apiExtensionClient, dynamicClient := setup(ctx, t)
+	defer s.TearDownFn()
 	defer cancel()
+
 	nsName := "pdb-scale-subresource"
 	createNs(ctx, t, nsName, clientSet)
 
@@ -238,10 +242,11 @@ func TestEmptySelector(t *testing.T) {
 
 	for i, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			s, pdbc, informers, clientSet, _, _ := setup(t)
-			defer s.TearDownFn()
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
 
-			ctx, cancel := context.WithCancel(context.Background())
+			s, pdbc, informers, clientSet, _, _ := setup(ctx, t)
+			defer s.TearDownFn()
 			defer cancel()
 
 			nsName := fmt.Sprintf("pdb-empty-selector-%d", i)
@@ -354,10 +359,11 @@ func TestSelectorsForPodsWithoutLabels(t *testing.T) {
 
 	for i, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			s, pdbc, informers, clientSet, _, _ := setup(t)
-			defer s.TearDownFn()
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
 
-			ctx, cancel := context.WithCancel(context.Background())
+			s, pdbc, informers, clientSet, _, _ := setup(ctx, t)
+			defer s.TearDownFn()
 			defer cancel()
 
 			nsName := fmt.Sprintf("pdb-selectors-%d", i)
@@ -508,13 +514,15 @@ func waitToObservePods(t *testing.T, podInformer cache.SharedIndexInformer, podN
 }
 
 func TestPatchCompatibility(t *testing.T) {
-	s, pdbc, _, clientSet, _, _ := setup(t)
-	defer s.TearDownFn()
-
 	// Even though pdbc isn't used in this test, its creation is already
 	// spawning some goroutines. So we need to run it to ensure they won't leak.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+
+	s, pdbc, _, clientSet, _, _ := setup(ctx, t)
+	defer s.TearDownFn()
+	defer cancel()
+
 	pdbc.Run(ctx)
 
 	testcases := []struct {
@@ -653,10 +661,11 @@ func TestPatchCompatibility(t *testing.T) {
 }
 
 func TestStalePodDisruption(t *testing.T) {
-	s, pdbc, informers, clientSet, _, _ := setup(t)
-	defer s.TearDownFn()
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	s, pdbc, informers, clientSet, _, _ := setup(ctx, t)
+	defer s.TearDownFn()
 	defer cancel()
 
 	nsName := "pdb-stale-pod-disruption"

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	pvutil "k8s.io/component-helpers/storage/volume"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kube-scheduler/config/v1beta3"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -455,6 +456,8 @@ func PodScheduled(c clientset.Interface, podNamespace, podName string) wait.Cond
 // InitDisruptionController initializes and runs a Disruption Controller to properly
 // update PodDisuptionBudget objects.
 func InitDisruptionController(t *testing.T, testCtx *TestContext) *disruption.DisruptionController {
+
+	_, ctx := ktesting.NewTestContext(t)
 	informers := informers.NewSharedInformerFactory(testCtx.ClientSet, 12*time.Hour)
 
 	discoveryClient := cacheddiscovery.NewMemCacheClient(testCtx.ClientSet.Discovery())
@@ -468,6 +471,7 @@ func InitDisruptionController(t *testing.T, testCtx *TestContext) *disruption.Di
 	}
 
 	dc := disruption.NewDisruptionController(
+		ctx,
 		informers.Core().V1().Pods(),
 		informers.Policy().V1().PodDisruptionBudgets(),
 		informers.Core().V1().ReplicationControllers(),


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Switch the disruption controller code to use contextual and structured logging.

#### Which issue(s) this PR fixes:
Fixes #
Part of https://github.com/kubernetes/enhancements/issues/3077

#### Does this PR introduce a user-facing change?
<!--

-->


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--

-->

```release-note
Migrated the disruption controller (within `kube-controller-manager`) to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging).
```

/wg structured-logging
/area logging
/priority important-longterm
/kind cleanup
/cc @kubernetes/wg-structured-logging-reviews