### PR TITLE
The event message will include the probe type and the unknown status

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -117,9 +117,9 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 	} else {
 		switch result {
 		case probe.Success:
-			pb.recordContainerEvent(pod, &container, v1.EventTypeNormal, events.ContainerProbeSucceeded, "%s probe succeeded", probeType)
+			pb.recordContainerEvent(pod, &container, v1.EventTypeNormal, events.ContainerHealthy, "%s probe succeeded", probeType)
 		case probe.Failure:
-			pb.recordContainerEvent(pod, &container, v1.EventTypeWarning, events.ContainerProbeFailed, "%s probe failed: %s", probeType, output)
+			pb.recordContainerEvent(pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
 		default:
 			// log the unknown status
 			klog.Warningf("Unknown probe result: %s", result)

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -115,15 +115,16 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 		pb.recordContainerEvent(pod, &container, v1.EventTypeWarning, events.ContainerProbeWarning, "%s probe warning: %s", probeType, output)
 		klog.V(3).InfoS("Probe succeeded with a warning", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "output", output)
 	} else {
-		if result != probe.Success && result != probe.Failure {
+		switch result {
+		case probe.Success:
+			pb.recordContainerEvent(pod, &container, v1.EventTypeNormal, events.ContainerProbeSucceeded, "%s probe succeeded", probeType)
+		case probe.Failure:
+			pb.recordContainerEvent(pod, &container, v1.EventTypeWarning, events.ContainerProbeFailed, "%s probe failed: %s", probeType, output)
+		default:
 			// log the unknown status
 			klog.Warningf("Unknown probe result: %s", result)
 			// record an event to expose the unknown status
 			pb.recordContainerEvent(pod, &container, v1.EventTypeWarning, events.ContainerProbeWarning, "Unknown %s probe status: %s", probeType, result)
-		} else if result == probe.Failure {
-			pb.recordContainerEvent(pod, &container, v1.EventTypeWarning, events.ContainerProbeFailed, "%s probe failed: %s", probeType, output)
-		} else {
-			pb.recordContainerEvent(pod, &container, v1.EventTypeNormal, events.ContainerProbeSucceeded, "%s probe succeeded", probeType)
 		}
 		klog.V(3).InfoS("Probe succeeded", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
 	}

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -128,7 +128,7 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 		}
 		klog.V(3).InfoS("Probe succeeded", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
 	}
-	return result, nil
+	return results.Success, nil
 	
 }
 

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/probe"
 	execprobe "k8s.io/kubernetes/pkg/probe/exec"
 	"k8s.io/apimachinery/pkg/types"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/util/events"
 )
 
 func TestGetURLParts(t *testing.T) {

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -34,6 +34,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util/ioutils"
 	"k8s.io/kubernetes/pkg/probe"
 	execprobe "k8s.io/kubernetes/pkg/probe/exec"
+	"k8s.io/apimachinery/pkg/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetURLParts(t *testing.T) {


### PR DESCRIPTION
What type of PR is this?

/kind good-first-issue
/kind priority backlog



What this PR does / why we need it:
This PR will log a warning message for any unknown probe results, and also record an event with the warning type to expose the unknown status. The event message will include the probe type and the unknown status. The code also records events for probe failures and successes as before.

Which issue(s) this PR fixes:
Fixes #116026

Special notes for your reviewer:
No

Does this PR introduce a user-facing change?
NONE

/cc @SergeyKanzhelev 
