### PR TITLE
support PreBind for scheduling extender

### DIFF
--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -53296,6 +53296,20 @@ func schema_k8sio_kube_scheduler_config_v1_Extender(ref common.ReferenceCallback
 							Format:      "int64",
 						},
 					},
+					"preBindVerb": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Verb for the preBind call, empty if not supported. This verb is appended to the URLPrefix when issuing the preBind call to extender.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"unreserveVerb": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Verb for the unreserve call, empty if not supported. This verb is appended to the URLPrefix when issuing the unreserve call to extender.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"bindVerb": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender. If this method is implemented by the extender, it is the extender's responsibility to bind the pod to apiserver. Only one extender can implement this function.",
@@ -54424,6 +54438,20 @@ func schema_k8sio_kube_scheduler_config_v1beta2_Extender(ref common.ReferenceCal
 							Format:      "int64",
 						},
 					},
+					"preBindVerb": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Verb for the preBind call, empty if not supported. This verb is appended to the URLPrefix when issuing the preBind call to extender.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"unreserveVerb": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Verb for the unreserve call, empty if not supported. This verb is appended to the URLPrefix when issuing the unreserve call to extender.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"bindVerb": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender. If this method is implemented by the extender, it is the extender's responsibility to bind the pod to apiserver. Only one extender can implement this function.",
@@ -55542,6 +55570,20 @@ func schema_k8sio_kube_scheduler_config_v1beta3_Extender(ref common.ReferenceCal
 							Description: "The numeric multiplier for the node scores that the prioritize call generates. The weight should be a positive integer",
 							Type:        []string{"integer"},
 							Format:      "int64",
+						},
+					},
+					"preBindVerb": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Verb for the preBind call, empty if not supported. This verb is appended to the URLPrefix when issuing the preBind call to extender.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"unreserveVerb": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Verb for the unreserve call, empty if not supported. This verb is appended to the URLPrefix when issuing the unreserve call to extender.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"bindVerb": {

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -270,6 +270,10 @@ type Extender struct {
 	// The numeric multiplier for the node scores that the prioritize call generates.
 	// The weight should be a positive integer
 	Weight int64
+	// Verb for the preBind call, empty if not supported. This verb is appended to the URLPrefix when issuing the preBind call to extender.
+	PreBindVerb string
+	// Verb for the unreserve call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
+	UnreserveVerb string
 	// Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
 	// If this method is implemented by the extender, it is the extender's responsibility to bind the pod to apiserver. Only one extender
 	// can implement this function.

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -279,6 +279,8 @@ func autoConvert_v1_Extender_To_config_Extender(in *v1.Extender, out *config.Ext
 	out.PreemptVerb = in.PreemptVerb
 	out.PrioritizeVerb = in.PrioritizeVerb
 	out.Weight = in.Weight
+	out.PreBindVerb = in.PreBindVerb
+	out.UnreserveVerb = in.UnreserveVerb
 	out.BindVerb = in.BindVerb
 	out.EnableHTTPS = in.EnableHTTPS
 	out.TLSConfig = (*config.ExtenderTLSConfig)(unsafe.Pointer(in.TLSConfig))
@@ -300,6 +302,8 @@ func autoConvert_config_Extender_To_v1_Extender(in *config.Extender, out *v1.Ext
 	out.PreemptVerb = in.PreemptVerb
 	out.PrioritizeVerb = in.PrioritizeVerb
 	out.Weight = in.Weight
+	out.PreBindVerb = in.PreBindVerb
+	out.UnreserveVerb = in.UnreserveVerb
 	out.BindVerb = in.BindVerb
 	out.EnableHTTPS = in.EnableHTTPS
 	out.TLSConfig = (*v1.ExtenderTLSConfig)(unsafe.Pointer(in.TLSConfig))

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
@@ -279,6 +279,8 @@ func autoConvert_v1beta2_Extender_To_config_Extender(in *v1beta2.Extender, out *
 	out.PreemptVerb = in.PreemptVerb
 	out.PrioritizeVerb = in.PrioritizeVerb
 	out.Weight = in.Weight
+	out.PreBindVerb = in.PreBindVerb
+	out.UnreserveVerb = in.UnreserveVerb
 	out.BindVerb = in.BindVerb
 	out.EnableHTTPS = in.EnableHTTPS
 	out.TLSConfig = (*config.ExtenderTLSConfig)(unsafe.Pointer(in.TLSConfig))
@@ -300,6 +302,8 @@ func autoConvert_config_Extender_To_v1beta2_Extender(in *config.Extender, out *v
 	out.PreemptVerb = in.PreemptVerb
 	out.PrioritizeVerb = in.PrioritizeVerb
 	out.Weight = in.Weight
+	out.PreBindVerb = in.PreBindVerb
+	out.UnreserveVerb = in.UnreserveVerb
 	out.BindVerb = in.BindVerb
 	out.EnableHTTPS = in.EnableHTTPS
 	out.TLSConfig = (*v1beta2.ExtenderTLSConfig)(unsafe.Pointer(in.TLSConfig))

--- a/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
@@ -279,6 +279,8 @@ func autoConvert_v1beta3_Extender_To_config_Extender(in *v1beta3.Extender, out *
 	out.PreemptVerb = in.PreemptVerb
 	out.PrioritizeVerb = in.PrioritizeVerb
 	out.Weight = in.Weight
+	out.PreBindVerb = in.PreBindVerb
+	out.UnreserveVerb = in.UnreserveVerb
 	out.BindVerb = in.BindVerb
 	out.EnableHTTPS = in.EnableHTTPS
 	out.TLSConfig = (*config.ExtenderTLSConfig)(unsafe.Pointer(in.TLSConfig))
@@ -300,6 +302,8 @@ func autoConvert_config_Extender_To_v1beta3_Extender(in *config.Extender, out *v
 	out.PreemptVerb = in.PreemptVerb
 	out.PrioritizeVerb = in.PrioritizeVerb
 	out.Weight = in.Weight
+	out.PreBindVerb = in.PreBindVerb
+	out.UnreserveVerb = in.UnreserveVerb
 	out.BindVerb = in.BindVerb
 	out.EnableHTTPS = in.EnableHTTPS
 	out.TLSConfig = (*v1beta3.ExtenderTLSConfig)(unsafe.Pointer(in.TLSConfig))

--- a/pkg/scheduler/framework/extender.go
+++ b/pkg/scheduler/framework/extender.go
@@ -40,6 +40,12 @@ type Extender interface {
 	// the scores computed by Kubernetes scheduler. The total scores are used to do the host selection.
 	Prioritize(pod *v1.Pod, nodes []*v1.Node) (hostPriorities *extenderv1.HostPriorityList, weight int64, err error)
 
+	// Prebind delegates the action of preBinding a pod to a node to the extender.
+	PreBind(binding *v1.Binding) error
+
+	// Unreserve delegates the action of unreserving resources assinged to a pod by preBind action to the extender.
+	Unreserve(binding *v1.Binding) error
+
 	// Bind delegates the action of binding a pod to a node to the extender.
 	Bind(binding *v1.Binding) error
 
@@ -69,4 +75,10 @@ type Extender interface {
 	// IsIgnorable returns true indicates scheduling should not fail when this extender
 	// is unavailable. This gives scheduler ability to fail fast and tolerate non-critical extenders as well.
 	IsIgnorable() bool
+
+	// SupportsPreBind returns if the scheduler extender support prebind or not.
+	SupportsPreBind() bool
+
+	// SupportsUnreserve returns if the scheduler extender support unreserve or not.
+	SupportsUnreserve() bool
 }

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -135,6 +135,22 @@ func (f *fakeExtender) IsInterested(pod *v1.Pod) bool {
 	return pod != nil && pod.Name == f.interestedPodName
 }
 
+func (f *fakeExtender) PreBind(binding *v1.Binding) error {
+	return nil
+}
+
+func (f *fakeExtender) Unreserve(binding *v1.Binding) error {
+	return nil
+}
+
+func (f *fakeExtender) SupportsPreBind() bool {
+	return false
+}
+
+func (f *fakeExtender) SupportsUnreserve() bool {
+	return false
+}
+
 type falseMapPlugin struct{}
 
 func newFalseMapPlugin() frameworkruntime.PluginFactory {

--- a/pkg/scheduler/testing/fake_extender.go
+++ b/pkg/scheduler/testing/fake_extender.go
@@ -377,4 +377,26 @@ func (f *FakeExtender) IsInterested(pod *v1.Pod) bool {
 	return !f.UnInterested
 }
 
+// PreBind implements the extender PreBind function.
+func (f *FakeExtender) PreBind(binding *v1.Binding) error {
+	return nil
+}
+
+// Unreserve implements the extender Unreserve function.
+func (f *FakeExtender) Unreserve(binding *v1.Binding) error {
+	return nil
+}
+
+// SupportsPreBind returns true if an extender supports preBind.
+// An extender should have preBind verb defined and enabled its own node cache.
+func (h *FakeExtender) SupportsPreBind() bool {
+	return false
+}
+
+// SupportsUnreserve returns true if an extender supports unreserve.
+// An extender should have unreserve verb defined and enabled its own node cache.
+func (h *FakeExtender) SupportsUnreserve() bool {
+	return false
+}
+
 var _ framework.Extender = &FakeExtender{}

--- a/staging/src/k8s.io/kube-scheduler/config/v1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/types.go
@@ -319,6 +319,10 @@ type Extender struct {
 	// The numeric multiplier for the node scores that the prioritize call generates.
 	// The weight should be a positive integer
 	Weight int64 `json:"weight,omitempty"`
+	// Verb for the preBind call, empty if not supported. This verb is appended to the URLPrefix when issuing the preBind call to extender.
+	PreBindVerb string `json:"preBindVerb,omitempty"`
+	// Verb for the unreserve call, empty if not supported. This verb is appended to the URLPrefix when issuing the unreserve call to extender.
+	UnreserveVerb string `json:"unreserveVerb,omitempty"`
 	// Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
 	// If this method is implemented by the extender, it is the extender's responsibility to bind the pod to apiserver. Only one extender
 	// can implement this function.

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta2/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta2/types.go
@@ -300,6 +300,10 @@ type Extender struct {
 	// The numeric multiplier for the node scores that the prioritize call generates.
 	// The weight should be a positive integer
 	Weight int64 `json:"weight,omitempty"`
+	// Verb for the preBind call, empty if not supported. This verb is appended to the URLPrefix when issuing the preBind call to extender.
+	PreBindVerb string `json:"preBindVerb,omitempty"`
+	// Verb for the unreserve call, empty if not supported. This verb is appended to the URLPrefix when issuing the unreserve call to extender.
+	UnreserveVerb string `json:"unreserveVerb,omitempty"`
 	// Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
 	// If this method is implemented by the extender, it is the extender's responsibility to bind the pod to apiserver. Only one extender
 	// can implement this function.

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta3/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta3/types.go
@@ -308,6 +308,10 @@ type Extender struct {
 	// The numeric multiplier for the node scores that the prioritize call generates.
 	// The weight should be a positive integer
 	Weight int64 `json:"weight,omitempty"`
+	// Verb for the preBind call, empty if not supported. This verb is appended to the URLPrefix when issuing the preBind call to extender.
+	PreBindVerb string `json:"preBindVerb,omitempty"`
+	// Verb for the unreserve call, empty if not supported. This verb is appended to the URLPrefix when issuing the unreserve call to extender.
+	UnreserveVerb string `json:"unreserveVerb,omitempty"`
 	// Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
 	// If this method is implemented by the extender, it is the extender's responsibility to bind the pod to apiserver. Only one extender
 	// can implement this function.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

For now, only one scheduling extender could enable bindVerb and perform binding operations. However, we have multiple extenders which all need to do something, such as updating annotations, just before binding in the bind method. 

Intead of rewriting our extenders with scheduling framework, support of Prebind in extender mechanism would be much better for us.

This PR addresses this problem by adding PreBind and Unreserve verbs to  scheduling extender. We can move bind logics to the prebind method of extenders which can work well together. If there are any problem during the prebind/bind stages, the Unreserve method of successful extenders will be called.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Scheduling extenders now support PreBind and Unreserve verbs. If multiple extenders all need to do some operations before binding, they can do it in PreBind  stage. And if there are any problem during the prebind/bind stages, the Unreserve method of successful extenders will be called.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
