### PR TITLE
Relax the HPA validation for compatibility in prior releases

### DIFF
--- a/pkg/apis/autoscaling/validation/validation.go
+++ b/pkg/apis/autoscaling/validation/validation.go
@@ -442,15 +442,15 @@ func validateMetricTarget(mt autoscaling.MetricTarget, fldPath *field.Path) fiel
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("type"), mt.Type, "must be either Utilization, Value, or AverageValue"))
 	}
 
-	if mt.Value != nil && mt.Value.Sign() != 1 {
+	if mt.Type == autoscaling.ValueMetricType && mt.Value != nil && mt.Value.Sign() != 1 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("value"), mt.Value, "must be positive"))
 	}
 
-	if mt.AverageValue != nil && mt.AverageValue.Sign() != 1 {
+	if mt.Type == autoscaling.AverageValueMetricType && mt.AverageValue != nil && mt.AverageValue.Sign() != 1 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("averageValue"), mt.AverageValue, "must be positive"))
 	}
 
-	if mt.AverageUtilization != nil && *mt.AverageUtilization < 1 {
+	if mt.Type == autoscaling.UtilizationMetricType && mt.AverageUtilization != nil && *mt.AverageUtilization < 1 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("averageUtilization"), mt.AverageUtilization, "must be greater than 0"))
 	}
 


### PR DESCRIPTION
Previous versions (<=1.26) may store the HPA object using V1 schema which adds an extra TargetValue with default value "0" to the store. It fails the HPA validation and prevent any further modifications on the same object unless the TargetValue is set to a positive value.

The issue does not impact 1.26 as the default store version is v2.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The patch mainly delivers a fix for HPA compatibility in earlier releases (<1.26) which updating HPA may result in a validation failure.
K8s >= 1.26 is not affected by the issue.
The PR should be cherry-picked to version prior to 1.26.

#### Which issue(s) this PR fixes:
Fixes #87733

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```
Relax API validation to allow Value in HPA metrics to be set with a default zero value in prior releases for compatibility.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
