### PR TITLE
test: Add log artifact for ginkgo node e2e and tune default ginkgo flags

### DIFF
--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -166,8 +166,6 @@ type GCEImage struct {
 	Metadata        string    `json:"metadata"`
 	Machine         string    `json:"machine,omitempty"`
 	Resources       Resources `json:"resources,omitempty"`
-	// This test is for benchmark (no limit verification, more result log, node name has format 'machine-image-uuid') if 'Tests' is non-empty.
-	Tests []string `json:"tests,omitempty"`
 }
 
 type internalImageConfig struct {
@@ -185,7 +183,6 @@ type internalGCEImage struct {
 	resources       Resources
 	metadata        *compute.Metadata
 	machine         string
-	tests           []string
 }
 
 func main() {
@@ -359,7 +356,6 @@ func prepareGceImages() (*internalImageConfig, error) {
 				metadata:        getImageMetadata(metadata),
 				kernelArguments: imageConfig.KernelArguments,
 				machine:         imageConfig.Machine,
-				tests:           imageConfig.Tests,
 				resources:       imageConfig.Resources,
 			}
 			if gceImage.imageDesc == "" {
@@ -962,17 +958,4 @@ func machineType(machine string) string {
 		machine = defaultMachine
 	}
 	return fmt.Sprintf("zones/%s/machineTypes/%s", *zone, machine)
-}
-
-// testsToGinkgoFocus converts the test string list to Ginkgo focus
-func testsToGinkgoFocus(tests []string) string {
-	focus := "--focus=\""
-	for i, test := range tests {
-		if i == 0 {
-			focus += test
-		} else {
-			focus += ("|" + test)
-		}
-	}
-	return focus + "\""
 }

--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -289,9 +289,9 @@ func main() {
 		fmt.Printf("%s\n", tr.output)
 		if tr.err != nil {
 			errCount++
-			fmt.Printf("Failure Finished Test Suite on Host %s\n%v\n", host, tr.err)
+			fmt.Printf("Failure Finished Test Suite on Host %s. Refer to artifacts directory for ginkgo log for this host.\n%v\n", host, tr.err)
 		} else {
-			fmt.Printf("Success Finished Test Suite on Host %s\n", host)
+			fmt.Printf("Success Finished Test Suite on Host %s. Refer to artifacts directory for ginkgo log for this host.\n", host)
 		}
 		exitOk = exitOk && tr.exitOk
 		fmt.Printf("%s<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<%s\n", blue, noColour)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


/kind cleanup

#### What this PR does / why we need it:

This PR makes a few updates to the node e2e runner to make debugging the tests easier. Please review commit by commit.

The main changes are:

1. Emit a ginkgo log for each node. Currently when a node e2e image config has multiple images defined, the test is run in parallel for each image, and the results are all concatenated into a huge log file. Searching this log file becomes difficult, as some pod names/other artifacts are re-used across the tests on different hosts. As a result, to make debugging simpler, emit a log file for each node that contains just the ginkgo log that was run on that node.
2. Add some defaults flags for ginkgo. Specifically, `--no-color` to disable color as it makes examining the logs harder in prow and in text editors, and `-v` to enable verbose logs, so even if tests pass we receive the test output. This is helpful to compare passing runs to failed runs.   

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
