### PR TITLE
Encapsulating probe run logic

### DIFF
--- a/pkg/kubelet/prober/dummy_runner.go
+++ b/pkg/kubelet/prober/dummy_runner.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"context"
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/probe"
+)
+
+// unknownProbeTypeError is used by dummyProbeRunner for returning error.
+var unknownProbeTypeError = fmt.Errorf("unknown probe type")
+
+// unknownProbeError is used by dummyProbeRunner for returning error.
+var unknownProbeHandlerError = fmt.Errorf("missing probe handler")
+
+// dummyProbeRunner covers three corner/hypothetical cases:
+// 1. Unknown Probe Type
+// 2. Nil Probe Spec
+// 3. Unknown Probe Handler
+type dummyProbeRunner struct {
+	isProbeTypeUnknown bool
+	isProbeNil         bool
+	isHandlerUnknown   bool
+}
+
+// newDummyProbeRunner returns dummyProbeRunner which implements probeRunner.
+func newDummyProbeRunner(isProbeTypeUnknown, isProbeNil, isHandlerUnknown bool) *dummyProbeRunner {
+	return &dummyProbeRunner{
+		isProbeTypeUnknown: isProbeTypeUnknown, isProbeNil: isProbeNil, isHandlerUnknown: isHandlerUnknown}
+}
+
+func (dp *dummyProbeRunner) sync(_ v1.Container, _ v1.PodStatus, _ probeType) error {
+	return nil
+}
+
+func (dp *dummyProbeRunner) run(_ context.Context, _ v1.Container, _ v1.PodStatus, _ probeType, _ *prober) (probe.Result, string, error) {
+	// case 1: unknown probe type
+	if dp.isProbeTypeUnknown {
+		return probe.Failure, "", unknownProbeTypeError
+	}
+
+	// case 2: probe is nil
+	if dp.isProbeNil {
+		return probe.Success, "", nil
+	}
+
+	// case 3: unknown handler / empty probe
+	if dp.isHandlerUnknown {
+		return probe.Unknown, "", unknownProbeHandlerError
+	}
+
+	// default: returning true as we have covered all the corner cases.
+	return probe.Success, "", nil
+
+}

--- a/pkg/kubelet/prober/exec_runner.go
+++ b/pkg/kubelet/prober/exec_runner.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"context"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/probe"
+	"time"
+)
+
+// execProbeRunner holds state and logic for running Exec probes.
+type execProbeRunner struct {
+	synced      bool
+	containerID kubecontainer.ContainerID
+	command     []string
+	timeout     time.Duration
+}
+
+// newExecProbeRunner returns execProbeRunner which implements probeRunner.
+func newExecProbeRunner() *execProbeRunner {
+	return &execProbeRunner{}
+}
+
+func (ep *execProbeRunner) sync(container v1.Container, status v1.PodStatus, probeType probeType) error {
+	// we only need to sync execProberRunner once as it doesn't depend on podIP and all other
+	// required objects are immutable, not using sync.Once here to avoid un-necessary mutexes.
+	if ep.synced {
+		return nil
+	}
+
+	// no need to handle error here, factory will handle this case.
+	probeSpec, _ := getProbeSpecFromContainer(container, probeType)
+
+	command := kubecontainer.ExpandContainerCommandOnlyStatic(probeSpec.Exec.Command, container.Env)
+	timeout := time.Duration(probeSpec.TimeoutSeconds) * time.Second
+
+	c, _ := podutil.GetContainerStatus(status.ContainerStatuses, container.Name)
+	containerID := kubecontainer.ParseContainerID(c.ContainerID)
+
+	// persist
+	ep.synced = true
+	ep.command = command
+	ep.timeout = timeout
+	ep.containerID = containerID
+	return nil
+}
+
+func (ep *execProbeRunner) run(ctx context.Context, container v1.Container, status v1.PodStatus, probeType probeType, prober *prober) (probe.Result, string, error) {
+	err := ep.sync(container, status, probeType)
+	if err != nil {
+		return probe.Unknown, "", err
+	}
+
+	klog.V(4).InfoS("Exec-Probe", "execCommand", ep.command, "containerID", ep.containerID.String())
+	return prober.exec.Probe(&execInContainer{run: func() ([]byte, error) {
+		return prober.runner.RunInContainer(ctx, ep.containerID, ep.command, ep.timeout)
+	}})
+}

--- a/pkg/kubelet/prober/exec_runner_test.go
+++ b/pkg/kubelet/prober/exec_runner_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestNewExecProbeRunner(t *testing.T) {
+	runner := newExecProbeRunner()
+
+	pod := newPod(v1.ProbeHandler{Exec: &v1.ExecAction{
+		Command: []string{"test", "-f", "/app/run.lock"},
+	}})
+
+	// runner.synced should be false, as we haven't synced it yet.
+	assert.False(t, runner.synced)
+	_ = runner.sync(pod.Spec.Containers[0], pod.Status, liveness)
+	command := runner.command
+
+	// runner.synced should be true, after first sync.
+	assert.True(t, runner.synced)
+
+	// command should not be recreated after calling sync again
+	_ = runner.sync(pod.Spec.Containers[0], pod.Status, liveness)
+	for i := 0; i < len(command); i++ {
+		assert.Same(t, &command[i], &runner.command[i])
+	}
+}

--- a/pkg/kubelet/prober/grpc_runner.go
+++ b/pkg/kubelet/prober/grpc_runner.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"context"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/probe"
+	"time"
+)
+
+// grpcProbeRunner holds state and logic for running GRPC probes.
+type grpcProbeRunner struct {
+	host    string
+	service string
+	port    int
+	timeout time.Duration
+}
+
+// newGRPCProbeRunner returns grpcProbeRunner which implements probeRunner.
+func newGRPCProbeRunner() *grpcProbeRunner {
+	return &grpcProbeRunner{}
+}
+
+func (gp *grpcProbeRunner) sync(container v1.Container, status v1.PodStatus, probeType probeType) error {
+	if gp.host == status.PodIP {
+		// no sync required, podIP hasn't changed.
+		return nil
+	}
+
+	// no need to handle error here, factory will handle this case.
+	probeSpec, _ := getProbeSpecFromContainer(container, probeType)
+
+	timeout := time.Duration(probeSpec.TimeoutSeconds) * time.Second
+
+	host := status.PodIP
+	service := ""
+	if probeSpec.GRPC.Service != nil {
+		service = *probeSpec.GRPC.Service
+	}
+
+	// persist
+	gp.host = host
+	gp.service = service
+	gp.port = int(probeSpec.GRPC.Port)
+	gp.timeout = timeout
+	return nil
+}
+
+func (gp *grpcProbeRunner) run(_ context.Context, container v1.Container, status v1.PodStatus, probeType probeType, prober *prober) (probe.Result, string, error) {
+	err := gp.sync(container, status, probeType)
+	if err != nil {
+		return probe.Unknown, "", err
+	}
+
+	klog.V(4).InfoS("GRPC-Probe", "host", gp.host, "service", gp.service, "port", gp.port, "timeout", gp.timeout)
+	return prober.grpc.Probe(gp.host, gp.service, gp.port, gp.timeout)
+}

--- a/pkg/kubelet/prober/grpc_runner_test.go
+++ b/pkg/kubelet/prober/grpc_runner_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	utilpointer "k8s.io/utils/pointer"
+	"testing"
+)
+
+func TestNewGRPCProbeRunner(t *testing.T) {
+	runner := newGRPCProbeRunner()
+
+	pod := newPod(v1.ProbeHandler{GRPC: &v1.GRPCAction{
+		Port:    int32(5000),
+		Service: utilpointer.String(""),
+	}})
+
+	_ = runner.sync(pod.Spec.Containers[0], pod.Status, liveness)
+	assert.Equal(t, runner.host, pod.Status.PodIP)
+
+	// change ip address
+	pod.Status.PodIP = "192.168.1.11"
+	_ = runner.sync(pod.Spec.Containers[0], pod.Status, liveness)
+	assert.Equal(t, runner.host, pod.Status.PodIP)
+}

--- a/pkg/kubelet/prober/http_runner.go
+++ b/pkg/kubelet/prober/http_runner.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"context"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/probe"
+	httpprobe "k8s.io/kubernetes/pkg/probe/http"
+	"net/http"
+	"time"
+)
+
+// httpProbeRunner holds state and logic for running HTTP probes.
+type httpProbeRunner struct {
+	host        string
+	timeout     time.Duration
+	httpRequest *http.Request
+}
+
+// newHTTPProbeRunner returns httpProbeRunner which implements probeRunner.
+func newHTTPProbeRunner() *httpProbeRunner {
+	return &httpProbeRunner{}
+}
+
+func (hp *httpProbeRunner) sync(container v1.Container, status v1.PodStatus, probeType probeType) error {
+	if hp.host == status.PodIP {
+		// no sync required, podIP hasn't changed.
+		return nil
+	}
+
+	// no need to handle error here, factory will handle this case.
+	probeSpec, _ := getProbeSpecFromContainer(container, probeType)
+
+	timeout := time.Duration(probeSpec.TimeoutSeconds) * time.Second
+	req, err := httpprobe.NewRequestForHTTPGetAction(probeSpec.HTTPGet, &container, status.PodIP, "probe")
+	if err != nil {
+		return err
+	}
+
+	// persist
+	hp.host = status.PodIP
+	hp.timeout = timeout
+	hp.httpRequest = req
+	return err
+}
+
+func (hp *httpProbeRunner) run(_ context.Context, container v1.Container, status v1.PodStatus, probeType probeType, prober *prober) (probe.Result, string, error) {
+	err := hp.sync(container, status, probeType)
+	if err != nil {
+		return probe.Unknown, "", err
+	}
+
+	klog.V(4).InfoS("HTTP-Probe", "scheme", hp.httpRequest.URL.Scheme, "host", hp.host,
+		"port", hp.httpRequest.URL.Port(), "path", hp.httpRequest.URL.Path, "timeout", hp.timeout,
+		"headers", hp.httpRequest.Header)
+	return prober.http.Probe(hp.httpRequest, hp.timeout)
+}

--- a/pkg/kubelet/prober/http_runner_test.go
+++ b/pkg/kubelet/prober/http_runner_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"testing"
+)
+
+func TestNewHTTPProbeRunner(t *testing.T) {
+	runner := newHTTPProbeRunner()
+
+	pod := newPod(v1.ProbeHandler{HTTPGet: &v1.HTTPGetAction{
+		Path:   "/test",
+		Port:   intstr.FromInt(5000),
+		Scheme: "http",
+	}})
+
+	_ = runner.sync(pod.Spec.Containers[0], pod.Status, liveness)
+	assert.Equal(t, runner.host, pod.Status.PodIP)
+
+	// test if http request object is not being recreated after
+	// sync call as podIP hasn't changed.
+	httpReqObject := runner.httpRequest
+	for i := 0; i < 25; i++ {
+		_ = runner.sync(pod.Spec.Containers[0], pod.Status, liveness)
+		assert.Same(t, httpReqObject, runner.httpRequest)
+	}
+
+	// change ip address
+	pod.Status.PodIP = "192.168.1.11"
+	_ = runner.sync(pod.Spec.Containers[0], pod.Status, liveness)
+
+	// test if http request object is recreated after
+	// sync call as podIP is changed now.
+	assert.NotSame(t, httpReqObject, runner.httpRequest)
+	assert.Equal(t, runner.host, pod.Status.PodIP)
+}

--- a/pkg/kubelet/prober/runner.go
+++ b/pkg/kubelet/prober/runner.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"context"
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/probe"
+)
+
+// probeRunner is an interface for running probes, objects implementing
+// probeRunner encapsulates the logic of running probes.
+type probeRunner interface {
+
+	// sync ensures objects required for running probe are in sync, with probe
+	// specification and latest pod status (podIP can mutate for running pod).
+	sync(v1.Container, v1.PodStatus, probeType) error
+
+	// run holds the logic of running probe, run takes prober as a dependency
+	// to run the probe on http.Prober, tcp.Prober, grpc.Prober or exec.Prober.
+	run(context.Context, v1.Container, v1.PodStatus, probeType, *prober) (probe.Result, string, error)
+}
+
+// newProbeRunner is a factory which returns concrete implementation of probeRunner
+// depending on the probe handler (tcp, http, grpc and exec).
+func newProbeRunner(container v1.Container, probeType probeType) probeRunner {
+	probeSpec, err := getProbeSpecFromContainer(container, probeType)
+	if err != nil {
+		// return dummyProbeRunner which on run returns failure status and error.
+		return newDummyProbeRunner(true, false, false)
+	}
+
+	// return dummyProbeRunner which on run returns successful status and no error.
+	if probeSpec == nil {
+		return newDummyProbeRunner(false, true, false)
+	}
+
+	// return tcpProbeRunner for running TCP probes.
+	if probeSpec.TCPSocket != nil {
+		return newTCPProbeRunner()
+	}
+
+	// return httpProbeRunner for running HTTP probes.
+	if probeSpec.HTTPGet != nil {
+		return newHTTPProbeRunner()
+	}
+
+	// return grpcProbeRunner for running GRPC probes.
+	if probeSpec.GRPC != nil {
+		return newGRPCProbeRunner()
+	}
+
+	// return execProbeRunner for running Exec probes.
+	if probeSpec.Exec != nil {
+		return newExecProbeRunner()
+	}
+
+	// return dummyProbeRunner which on run returns unknown status and error.
+	return newDummyProbeRunner(false, false, true)
+}
+
+func getProbeSpecFromContainer(container v1.Container, probeType probeType) (*v1.Probe, error) {
+	var probeSpec *v1.Probe
+	switch probeType {
+	case startup:
+		probeSpec = container.StartupProbe
+	case liveness:
+		probeSpec = container.LivenessProbe
+	case readiness:
+		probeSpec = container.ReadinessProbe
+	default:
+		return nil, fmt.Errorf("unknown probe type: %q", probeType)
+	}
+	return probeSpec, nil
+}

--- a/pkg/kubelet/prober/runner_test.go
+++ b/pkg/kubelet/prober/runner_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	utilpointer "k8s.io/utils/pointer"
+	"testing"
+)
+
+func newPod(handler v1.ProbeHandler) v1.Pod {
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID("pod"),
+			Name:      "pod",
+			Namespace: "test",
+		},
+		Spec: v1.PodSpec{},
+		Status: v1.PodStatus{
+			Phase:  v1.PodPhase(v1.PodReady),
+			PodIP:  "10.11.11.11",
+			PodIPs: []v1.PodIP{{IP: "10.11.11.11"}},
+		},
+	}
+
+	pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{
+		Name: "container",
+		LivenessProbe: &v1.Probe{
+			ProbeHandler: handler,
+		},
+	})
+
+	pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, v1.ContainerStatus{
+		Name:        "container",
+		ContainerID: "pod://container",
+		State: v1.ContainerState{
+			Running: &v1.ContainerStateRunning{
+				StartedAt: metav1.Now(),
+			},
+		},
+		Started: utilpointer.Bool(true),
+	})
+	return pod
+}
+
+func TestNewProbeRunner(t *testing.T) {
+	var pod v1.Pod
+	var runner probeRunner
+
+	// tcpProberRunner type
+	pod = newPod(v1.ProbeHandler{TCPSocket: &v1.TCPSocketAction{
+		Port: intstr.FromInt(5000),
+	}})
+	runner = newProbeRunner(pod.Spec.Containers[0], liveness)
+	assert.IsType(t, newTCPProbeRunner(), runner)
+	//
+
+	// httpProberRunner type
+	pod = newPod(v1.ProbeHandler{HTTPGet: &v1.HTTPGetAction{
+		Path:   "/test",
+		Port:   intstr.FromInt(5000),
+		Scheme: "http",
+	}})
+	runner = newProbeRunner(pod.Spec.Containers[0], liveness)
+	assert.IsType(t, newHTTPProbeRunner(), runner)
+	//
+
+	// grpcProberRunner type
+	pod = newPod(v1.ProbeHandler{GRPC: &v1.GRPCAction{
+		Port:    int32(5000),
+		Service: utilpointer.String(""),
+	}})
+	runner = newProbeRunner(pod.Spec.Containers[0], liveness)
+	assert.IsType(t, newGRPCProbeRunner(), runner)
+	//
+
+	// execProberRunner type
+	pod = newPod(v1.ProbeHandler{Exec: &v1.ExecAction{
+		Command: []string{"test", "-f", "/app/run.lock"},
+	}})
+	runner = newProbeRunner(pod.Spec.Containers[0], liveness)
+	assert.IsType(t, newExecProbeRunner(), runner)
+	//
+
+	// dummyProberRunner type
+	var dummyRunner *dummyProbeRunner
+	// case 1: unknown probe type
+	pod = newPod(v1.ProbeHandler{})
+	pod.Spec.Containers = []v1.Container{{
+		Name: "container",
+	}}
+	const unknownProbeType probeType = 100
+	runner = newProbeRunner(pod.Spec.Containers[0], unknownProbeType)
+	assert.IsType(t, newDummyProbeRunner(false, true, false), runner)
+
+	dummyRunner = any(runner).(*dummyProbeRunner)
+	assert.Equal(t, dummyRunner.isProbeTypeUnknown, true)
+	assert.Equal(t, dummyRunner.isProbeNil, false)
+	assert.Equal(t, dummyRunner.isHandlerUnknown, false)
+	//
+
+	// case 2: nil probe spec
+	pod = newPod(v1.ProbeHandler{})
+	pod.Spec.Containers[0].LivenessProbe = nil
+	runner = newProbeRunner(pod.Spec.Containers[0], liveness)
+	assert.IsType(t, newDummyProbeRunner(false, true, false), runner)
+
+	dummyRunner = any(runner).(*dummyProbeRunner)
+	assert.Equal(t, dummyRunner.isProbeTypeUnknown, false)
+	assert.Equal(t, dummyRunner.isProbeNil, true)
+	assert.Equal(t, dummyRunner.isHandlerUnknown, false)
+	//
+
+	// case 3: unknown handler / empty probe
+	pod = newPod(v1.ProbeHandler{})
+	runner = newProbeRunner(pod.Spec.Containers[0], liveness)
+	assert.IsType(t, newDummyProbeRunner(false, true, false), runner)
+
+	dummyRunner = any(runner).(*dummyProbeRunner)
+	assert.Equal(t, dummyRunner.isProbeTypeUnknown, false)
+	assert.Equal(t, dummyRunner.isProbeNil, false)
+	assert.Equal(t, dummyRunner.isHandlerUnknown, true)
+	//
+
+}

--- a/pkg/kubelet/prober/tcp_runner.go
+++ b/pkg/kubelet/prober/tcp_runner.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"context"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/probe"
+	"time"
+)
+
+// tcpProbeRunner holds state and logic for running TCP probes.
+type tcpProbeRunner struct {
+	host    string
+	port    int
+	timeout time.Duration
+}
+
+// newTCPProbeRunner returns tcpProbeRunner which implements probeRunner.
+func newTCPProbeRunner() *tcpProbeRunner {
+	return &tcpProbeRunner{}
+}
+
+func (tp *tcpProbeRunner) sync(container v1.Container, status v1.PodStatus, probeType probeType) error {
+	if tp.host == status.PodIP {
+		// no sync required, podIP hasn't changed.
+		return nil
+	}
+
+	// no need to handle error here, factory will handle this case.
+	probeSpec, _ := getProbeSpecFromContainer(container, probeType)
+
+	timeout := time.Duration(probeSpec.TimeoutSeconds) * time.Second
+	port, err := probe.ResolveContainerPort(probeSpec.TCPSocket.Port, &container)
+	if err != nil {
+		return err
+	}
+
+	host := probeSpec.TCPSocket.Host
+	if host == "" {
+		host = status.PodIP
+	}
+
+	// persist
+	tp.host = host
+	tp.port = port
+	tp.timeout = timeout
+	return err
+}
+
+func (tp *tcpProbeRunner) run(_ context.Context, container v1.Container, status v1.PodStatus, probeType probeType, prober *prober) (probe.Result, string, error) {
+	err := tp.sync(container, status, probeType)
+	if err != nil {
+		return probe.Unknown, "", err
+	}
+
+	klog.V(4).InfoS("TCP-Probe", "host", tp.host, "port", tp.port, "timeout", tp.timeout)
+	return prober.tcp.Probe(tp.host, tp.port, tp.timeout)
+}

--- a/pkg/kubelet/prober/tcp_runner_test.go
+++ b/pkg/kubelet/prober/tcp_runner_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"testing"
+)
+
+func TestNewTCPProbeRunner(t *testing.T) {
+	runner := newTCPProbeRunner()
+
+	pod := newPod(v1.ProbeHandler{TCPSocket: &v1.TCPSocketAction{
+		Port: intstr.FromInt(5000),
+	}})
+
+	_ = runner.sync(pod.Spec.Containers[0], pod.Status, liveness)
+	assert.Equal(t, runner.host, pod.Status.PodIP)
+
+	// change ip address
+	pod.Status.PodIP = "192.168.1.11"
+	_ = runner.sync(pod.Spec.Containers[0], pod.Status, liveness)
+	assert.Equal(t, runner.host, pod.Status.PodIP)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Today for each probe we construct all the required objects, this normally involves concatenating some strings, setting headers, parsing strings, port validation, etc. The majority of these objects can be cached and reused. 

This PR adds 
1. Interface `probeRunner` for running probes 
2. Concrete Implementation of `probeRunner`
  a. `httpProbeRunner`
  b. `tcpProbeRunner`
  c. `grpcProbeRunner`
  d. `execProbeRunner`
  e. `dummyProbeRunner`
3. Factory which returns the relevant implementation based on the specs of the probe.
 
With this approach, we can encapsulate the run logic of every probe kind, and cache the required objects saving CPU cycles and main memory.
 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115939

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
