### PR TITLE
update github.com/coredns/corefile-migration v1.0.20

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -285,7 +285,11 @@ func isCoreDNSConfigMapMigrationRequired(corefile, currentInstalledCoreDNSVersio
 		return isMigrationRequired, nil
 	}
 	currentInstalledCoreDNSVersion = strings.TrimLeft(currentInstalledCoreDNSVersion, "v")
-	deprecated, err := migration.Deprecated(currentInstalledCoreDNSVersion, strings.TrimLeft(kubeadmconstants.CoreDNSVersion, "v"), corefile)
+	targetCoreDNSVersion := strings.TrimLeft(kubeadmconstants.CoreDNSVersion, "v")
+	if currentInstalledCoreDNSVersion == targetCoreDNSVersion {
+		return isMigrationRequired, nil
+	}
+	deprecated, err := migration.Deprecated(currentInstalledCoreDNSVersion, targetCoreDNSVersion, corefile)
 	if err != nil {
 		return isMigrationRequired, errors.Wrap(err, "unable to get list of changes to the configuration.")
 	}

--- a/cmd/kubeadm/app/phases/upgrade/preflight.go
+++ b/cmd/kubeadm/app/phases/upgrade/preflight.go
@@ -81,7 +81,11 @@ func checkUnsupportedPlugins(client clientset.Interface) error {
 	}
 
 	currentInstalledCoreDNSversion = strings.TrimLeft(currentInstalledCoreDNSversion, "v")
-	unsupportedCoreDNS, err := migration.Unsupported(currentInstalledCoreDNSversion, currentInstalledCoreDNSversion, corefile)
+	targetCoreDNSVersion := strings.TrimLeft(kubeadmconstants.CoreDNSVersion, "v")
+	if currentInstalledCoreDNSversion == targetCoreDNSVersion {
+		return nil
+	}
+	unsupportedCoreDNS, err := migration.Unsupported(currentInstalledCoreDNSversion, targetCoreDNSVersion, corefile)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.147
 	github.com/blang/semver/v4 v4.0.0
 	github.com/container-storage-interface/spec v1.7.0
-	github.com/coredns/corefile-migration v1.0.18
+	github.com/coredns/corefile-migration v1.0.20
 	github.com/coreos/go-oidc v2.1.0+incompatible
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/cpuguy83/go-md2man/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/containerd/typeurl v1.0.2 h1:Chlt8zIieDbzQFzXzAeBEF92KhExuE4p9p92/QmY
 github.com/containerd/typeurl v1.0.2/go.mod h1:9trJWW2sRlGub4wZJRTW83VtbOLS6hwcDZXTn6oPz9s=
 github.com/coredns/caddy v1.1.0 h1:ezvsPrT/tA/7pYDBZxu0cT0VmWk75AfIaf6GSYCNMf0=
 github.com/coredns/caddy v1.1.0/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
-github.com/coredns/corefile-migration v1.0.18 h1:zs5PJm/VGZVje1ESRj6ZqyUuVsVfagExkbLU2QKV5mI=
-github.com/coredns/corefile-migration v1.0.18/go.mod h1:XnhgULOEouimnzgn0t4WPuFDN2/PJQcTxdWKC5eXNGE=
+github.com/coredns/corefile-migration v1.0.20 h1:MdOkT6F3ehju/n9tgxlGct8XAajOX2vN+wG7To4BWSI=
+github.com/coredns/corefile-migration v1.0.20/go.mod h1:XnhgULOEouimnzgn0t4WPuFDN2/PJQcTxdWKC5eXNGE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/vendor/github.com/coredns/corefile-migration/migration/migrate.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/migrate.go
@@ -20,12 +20,18 @@ import (
 // any deprecated, removed, or ignored plugins/directives present in the Corefile.  Notifications are also returned for
 // any new default plugins that would be added in a migration.
 func Deprecated(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string) ([]Notice, error) {
+	if fromCoreDNSVersion == toCoreDNSVersion {
+		return nil, nil
+	}
 	return getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, SevAll)
 }
 
 // Unsupported returns a list notifications of plugins/options that are not handled supported by this migration tool,
 // but may still be valid in CoreDNS.
 func Unsupported(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string) ([]Notice, error) {
+	if fromCoreDNSVersion == toCoreDNSVersion {
+		return nil, nil
+	}
 	return getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, SevUnsupported)
 }
 

--- a/vendor/github.com/coredns/corefile-migration/migration/versions.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/versions.go
@@ -30,7 +30,13 @@ type release struct {
 
 // Versions holds a map of plugin/option migrations per CoreDNS release (since 1.1.4)
 var Versions = map[string]release{
+	"1.10.1": {
+		priorVersion:   "1.10.0",
+		dockerImageSHA: "a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e",
+		plugins:        plugins_1_9_3,
+	},
 	"1.10.0": {
+		nextVersion:    "1.10.1",
 		priorVersion:   "1.9.4",
 		dockerImageSHA: "017727efcfeb7d053af68e51436ce8e65edbc6ca573720afb4f79c8594036955",
 		plugins:        plugins_1_9_3,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -199,7 +199,7 @@ github.com/containerd/ttrpc
 # github.com/coredns/caddy v1.1.0
 ## explicit; go 1.13
 github.com/coredns/caddy/caddyfile
-# github.com/coredns/corefile-migration v1.0.18
+# github.com/coredns/corefile-migration v1.0.20
 ## explicit; go 1.14
 github.com/coredns/corefile-migration/migration
 github.com/coredns/corefile-migration/migration/corefile


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:

1. [commit1](https://github.com/kubernetes/kubernetes/pull/116060/commits/744d9bfda3f4df7059f9ea8d5154ea45e3f4cb23):  upgrade https://github.com/coredns/corefile-migration/releases/tag/v1.0.20
- - Minor change: Don't return Unsupported/Deprecated plugins for non-migration cases, i.e. when the start version is the same as the end version.
2. [commit2](https://github.com/kubernetes/kubernetes/pull/116060/commits/b1ee8c8b82da0fb3ee61e98b00b0fef1add71c7b): try to fix the problem in kubeadm side as well

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubeadm/issues/2830

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

/cc @chrisohaver  @neolit123 