### PR TITLE
Revert "Merge pull request #115324 from alexzielenski/apiserver/smd/use-openapiv3

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
@@ -1023,15 +1023,9 @@ func TestBuildOpenAPIModelsForApply(t *testing.T) {
 		},
 	}
 
-	convertedDefs := map[string]*spec.Schema{}
-	for k, v := range staticSpec.Definitions {
-		vCopy := v
-		convertedDefs[k] = &vCopy
-	}
-
 	for i, test := range tests {
 		crd.Spec.Versions[0].Schema = &test
-		models, err := buildOpenAPIModelsForApply(convertedDefs, &crd)
+		models, err := buildOpenAPIModelsForApply(staticSpec, &crd)
 		if err != nil {
 			t.Fatalf("failed to convert to apply model: %v", err)
 		}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/testdata/swagger.json
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/testdata/swagger.json
@@ -1,585 +1,269 @@
 {
-  "swagger": "2.0",
-  "info": { "title": "Kubernetes", "version": "v1.27.0" },
-  "paths": {},
   "definitions": {
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition": {
-      "description": "CustomResourceColumnDefinition specifies a column for server side printing.",
-      "type": "object",
-      "required": ["name", "type", "jsonPath"],
-      "properties": {
-        "description": {
-          "description": "description is a human readable description of this column.",
-          "type": "string"
-        },
-        "format": {
-          "description": "format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.",
-          "type": "string"
-        },
-        "jsonPath": {
-          "description": "jsonPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.",
-          "type": "string",
-          "default": ""
-        },
-        "name": {
-          "description": "name is a human readable name for the column.",
-          "type": "string",
-          "default": ""
-        },
-        "priority": {
-          "description": "priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "type": {
-          "description": "type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.",
-          "type": "string",
-          "default": ""
-        }
-      }
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceConversion": {
-      "description": "CustomResourceConversion describes how to convert different versions of a CR.",
-      "type": "object",
-      "required": ["strategy"],
-      "properties": {
-        "strategy": {
-          "description": "strategy specifies how custom resources are converted between versions. Allowed values are: - `None`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `Webhook`: API Server will call to an external webhook to do the conversion. Additional information\n  is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhook to be set.",
-          "type": "string",
-          "default": ""
-        },
-        "webhook": {
-          "description": "webhook describes how to call the conversion webhook. Required when `strategy` is set to `Webhook`.",
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookConversion"
-        }
-      }
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition": {
-      "description": "CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format \u003c.spec.name\u003e.\u003c.spec.group\u003e.",
-      "type": "object",
-      "required": ["spec"],
+    "io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
+      "description": "DeleteOptions may be provided when deleting an API object.",
       "properties": {
         "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
           "type": "string"
+        },
+        "dryRun": {
+          "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "gracePeriodSeconds": {
+          "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+          "format": "int64",
+          "type": "integer"
         },
         "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
           "type": "string"
         },
-        "metadata": {
-          "description": "Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-          "default": {},
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        "orphanDependents": {
+          "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+          "type": "boolean"
         },
-        "spec": {
-          "description": "spec describes how the user wants the resources to appear",
-          "default": {},
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec"
+        "preconditions": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions",
+          "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned."
         },
-        "status": {
-          "description": "status indicates the actual state of the CustomResourceDefinition",
-          "default": {},
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionStatus"
+        "propagationPolicy": {
+          "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+          "type": "string"
         }
       },
+      "type": "object",
       "x-kubernetes-group-version-kind": [
         {
-          "group": "apiextensions.k8s.io",
-          "kind": "CustomResourceDefinition",
+          "group": "",
+          "kind": "DeleteOptions",
           "version": "v1"
+        },
+        {
+          "group": "admission.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "admissionregistration.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "admissionregistration.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "apiextensions.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "apiregistration.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "apiregistration.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "apps",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "apps",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "apps",
+          "kind": "DeleteOptions",
+          "version": "v1beta2"
+        },
+        {
+          "group": "auditregistration.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "authentication.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "authentication.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "authorization.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "authorization.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "autoscaling",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "autoscaling",
+          "kind": "DeleteOptions",
+          "version": "v2beta1"
+        },
+        {
+          "group": "autoscaling",
+          "kind": "DeleteOptions",
+          "version": "v2beta2"
+        },
+        {
+          "group": "batch",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "batch",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "batch",
+          "kind": "DeleteOptions",
+          "version": "v2alpha1"
+        },
+        {
+          "group": "certificates.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "coordination.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "coordination.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "events.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "extensions",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "imagepolicy.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "networking.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "networking.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "node.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "node.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "policy",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "rbac.authorization.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "scheduling.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "scheduling.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "scheduling.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+        },
+        {
+          "group": "settings.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "storage.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "storage.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+        },
+        {
+          "group": "storage.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
         }
       ]
     },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition": {
-      "description": "CustomResourceDefinitionCondition contains details for the current condition of this pod.",
-      "type": "object",
-      "required": ["type", "status"],
-      "properties": {
-        "lastTransitionTime": {
-          "description": "lastTransitionTime last time the condition transitioned from one status to another.",
-          "default": {},
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "message": {
-          "description": "message is a human-readable message indicating details about last transition.",
-          "type": "string"
-        },
-        "reason": {
-          "description": "reason is a unique, one-word, CamelCase reason for the condition's last transition.",
-          "type": "string"
-        },
-        "status": {
-          "description": "status is the status of the condition. Can be True, False, Unknown.",
-          "type": "string",
-          "default": ""
-        },
-        "type": {
-          "description": "type is the type of the condition. Types include Established, NamesAccepted and Terminating.",
-          "type": "string",
-          "default": ""
-        }
-      }
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames": {
-      "description": "CustomResourceDefinitionNames indicates the names to serve this CustomResourceDefinition",
-      "type": "object",
-      "required": ["plural", "kind"],
-      "properties": {
-        "categories": {
-          "description": "categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.",
-          "type": "array",
-          "items": { "type": "string", "default": "" }
-        },
-        "kind": {
-          "description": "kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.",
-          "type": "string",
-          "default": ""
-        },
-        "listKind": {
-          "description": "listKind is the serialized kind of the list for this resource. Defaults to \"`kind`List\".",
-          "type": "string"
-        },
-        "plural": {
-          "description": "plural is the plural name of the resource to serve. The custom resources are served under `/apis/\u003cgroup\u003e/\u003cversion\u003e/.../\u003cplural\u003e`. Must match the name of the CustomResourceDefinition (in the form `\u003cnames.plural\u003e.\u003cgroup\u003e`). Must be all lowercase.",
-          "type": "string",
-          "default": ""
-        },
-        "shortNames": {
-          "description": "shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get \u003cshortname\u003e`. It must be all lowercase.",
-          "type": "array",
-          "items": { "type": "string", "default": "" }
-        },
-        "singular": {
-          "description": "singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec": {
-      "description": "CustomResourceDefinitionSpec describes how a user wants their resource to appear",
-      "type": "object",
-      "required": ["group", "names", "scope", "versions"],
-      "properties": {
-        "conversion": {
-          "description": "conversion defines conversion settings for the CRD.",
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceConversion"
-        },
-        "group": {
-          "description": "group is the API group of the defined custom resource. The custom resources are served under `/apis/\u003cgroup\u003e/...`. Must match the name of the CustomResourceDefinition (in the form `\u003cnames.plural\u003e.\u003cgroup\u003e`).",
-          "type": "string",
-          "default": ""
-        },
-        "names": {
-          "description": "names specify the resource and kind names for the custom resource.",
-          "default": {},
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames"
-        },
-        "preserveUnknownFields": {
-          "description": "preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`. See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning for details.",
-          "type": "boolean"
-        },
-        "scope": {
-          "description": "scope indicates whether the defined custom resource is cluster- or namespace-scoped. Allowed values are `Cluster` and `Namespaced`.",
-          "type": "string",
-          "default": ""
-        },
-        "versions": {
-          "description": "versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA \u003e beta \u003e alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.",
-          "type": "array",
-          "items": {
-            "default": {},
-            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion"
-          }
-        }
-      }
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionStatus": {
-      "description": "CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition",
-      "type": "object",
-      "properties": {
-        "acceptedNames": {
-          "description": "acceptedNames are the names that are actually being used to serve discovery. They may be different than the names in spec.",
-          "default": {},
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames"
-        },
-        "conditions": {
-          "description": "conditions indicate state for particular aspects of a CustomResourceDefinition",
-          "type": "array",
-          "items": {
-            "default": {},
-            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition"
-          },
-          "x-kubernetes-list-map-keys": ["type"],
-          "x-kubernetes-list-type": "map"
-        },
-        "storedVersions": {
-          "description": "storedVersions lists all versions of CustomResources that were ever persisted. Tracking these versions allows a migration path for stored versions in etcd. The field is mutable so a migration controller can finish a migration to another version (ensuring no old objects are left in storage), and then remove the rest of the versions from this list. Versions may not be removed from `spec.versions` while they exist in this list.",
-          "type": "array",
-          "items": { "type": "string", "default": "" }
-        }
-      }
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion": {
-      "description": "CustomResourceDefinitionVersion describes a version for CRD.",
-      "type": "object",
-      "required": ["name", "served", "storage"],
-      "properties": {
-        "additionalPrinterColumns": {
-          "description": "additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If no columns are specified, a single column displaying the age of the custom resource is used.",
-          "type": "array",
-          "items": {
-            "default": {},
-            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition"
-          }
-        },
-        "deprecated": {
-          "description": "deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.",
-          "type": "boolean"
-        },
-        "deprecationWarning": {
-          "description": "deprecationWarning overrides the default warning returned to API clients. May only be set when `deprecated` is true. The default warning indicates this version is deprecated and recommends use of the newest served version of equal or greater stability, if one exists.",
-          "type": "string"
-        },
-        "name": {
-          "description": "name is the version name, e.g. “v1”, “v2beta1”, etc. The custom resources are served under this version at `/apis/\u003cgroup\u003e/\u003cversion\u003e/...` if `served` is true.",
-          "type": "string",
-          "default": ""
-        },
-        "schema": {
-          "description": "schema describes the schema used for validation, pruning, and defaulting of this version of the custom resource.",
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation"
-        },
-        "served": {
-          "description": "served is a flag enabling/disabling this version from being served via REST APIs",
-          "type": "boolean",
-          "default": false
-        },
-        "storage": {
-          "description": "storage indicates this version should be used when persisting custom resources to storage. There must be exactly one version with storage=true.",
-          "type": "boolean",
-          "default": false
-        },
-        "subresources": {
-          "description": "subresources specify what subresources this version of the defined custom resource have.",
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresources"
-        }
-      }
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceScale": {
-      "description": "CustomResourceSubresourceScale defines how to serve the scale subresource for CustomResources.",
-      "type": "object",
-      "required": ["specReplicasPath", "statusReplicasPath"],
-      "properties": {
-        "labelSelectorPath": {
-          "description": "labelSelectorPath defines the JSON path inside of a custom resource that corresponds to Scale `status.selector`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status` or `.spec`. Must be set to work with HorizontalPodAutoscaler. The field pointed by this JSON path must be a string field (not a complex selector struct) which contains a serialized label selector in string form. More info: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions#scale-subresource If there is no value under the given path in the custom resource, the `status.selector` value in the `/scale` subresource will default to the empty string.",
-          "type": "string"
-        },
-        "specReplicasPath": {
-          "description": "specReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `spec.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.spec`. If there is no value under the given path in the custom resource, the `/scale` subresource will return an error on GET.",
-          "type": "string",
-          "default": ""
-        },
-        "statusReplicasPath": {
-          "description": "statusReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `status.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status`. If there is no value under the given path in the custom resource, the `status.replicas` value in the `/scale` subresource will default to 0.",
-          "type": "string",
-          "default": ""
-        }
-      }
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceStatus": {
-      "description": "CustomResourceSubresourceStatus defines how to serve the status subresource for CustomResources. Status is represented by the `.status` JSON path inside of a CustomResource. When set, * exposes a /status subresource for the custom resource * PUT requests to the /status subresource take a custom resource object, and ignore changes to anything except the status stanza * PUT/POST/PATCH requests to the custom resource ignore changes to the status stanza",
-      "type": "object"
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresources": {
-      "description": "CustomResourceSubresources defines the status and scale subresources for CustomResources.",
-      "type": "object",
-      "properties": {
-        "scale": {
-          "description": "scale indicates the custom resource should serve a `/scale` subresource that returns an `autoscaling/v1` Scale object.",
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceScale"
-        },
-        "status": {
-          "description": "status indicates the custom resource should serve a `/status` subresource. When enabled: 1. requests to the custom resource primary endpoint ignore changes to the `status` stanza of the object. 2. requests to the custom resource `/status` subresource ignore changes to anything other than the `status` stanza of the object.",
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceStatus"
-        }
-      }
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation": {
-      "description": "CustomResourceValidation is a list of validation methods for CustomResources.",
-      "type": "object",
-      "properties": {
-        "openAPIV3Schema": {
-          "description": "openAPIV3Schema is the OpenAPI v3 schema to use for validation and pruning.",
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
-        }
-      }
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ExternalDocumentation": {
-      "description": "ExternalDocumentation allows referencing an external resource for extended documentation.",
-      "type": "object",
-      "properties": {
-        "description": { "type": "string" },
-        "url": { "type": "string" }
-      }
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON": {
-      "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil."
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps": {
-      "description": "JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).",
-      "type": "object",
-      "properties": {
-        "$ref": { "type": "string" },
-        "$schema": { "type": "string" },
-        "additionalItems": {
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool"
-        },
-        "additionalProperties": {
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool"
-        },
-        "allOf": {
-          "type": "array",
-          "items": {
-            "default": {},
-            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
-          }
-        },
-        "anyOf": {
-          "type": "array",
-          "items": {
-            "default": {},
-            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
-          }
-        },
-        "default": {
-          "description": "default is a default value for undefined object fields. Defaulting is a beta feature under the CustomResourceDefaulting feature gate. Defaulting requires spec.preserveUnknownFields to be false.",
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
-        },
-        "definitions": {
-          "type": "object",
-          "additionalProperties": {
-            "default": {},
-            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
-          }
-        },
-        "dependencies": {
-          "type": "object",
-          "additionalProperties": {
-            "default": {},
-            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrStringArray"
-          }
-        },
-        "description": { "type": "string" },
-        "enum": {
-          "type": "array",
-          "items": {
-            "default": {},
-            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
-          }
-        },
-        "example": {
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
-        },
-        "exclusiveMaximum": { "type": "boolean" },
-        "exclusiveMinimum": { "type": "boolean" },
-        "externalDocs": {
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ExternalDocumentation"
-        },
-        "format": {
-          "description": "format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:\n\n- bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like \"0321751043\" or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\" - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\d{3}[- ]?\\d{2}[- ]?\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded binary data - password: any kind of string - date: a date string like \"2006-01-02\" as defined by full-date in RFC3339 - duration: a duration string like \"22 ns\" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like \"2014-12-15T19:30:20.000Z\" as defined by date-time in RFC3339.",
-          "type": "string"
-        },
-        "id": { "type": "string" },
-        "items": {
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrArray"
-        },
-        "maxItems": { "type": "integer", "format": "int64" },
-        "maxLength": { "type": "integer", "format": "int64" },
-        "maxProperties": { "type": "integer", "format": "int64" },
-        "maximum": { "type": "number", "format": "double" },
-        "minItems": { "type": "integer", "format": "int64" },
-        "minLength": { "type": "integer", "format": "int64" },
-        "minProperties": { "type": "integer", "format": "int64" },
-        "minimum": { "type": "number", "format": "double" },
-        "multipleOf": { "type": "number", "format": "double" },
-        "not": {
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
-        },
-        "nullable": { "type": "boolean" },
-        "oneOf": {
-          "type": "array",
-          "items": {
-            "default": {},
-            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
-          }
-        },
-        "pattern": { "type": "string" },
-        "patternProperties": {
-          "type": "object",
-          "additionalProperties": {
-            "default": {},
-            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
-          }
-        },
-        "properties": {
-          "type": "object",
-          "additionalProperties": {
-            "default": {},
-            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
-          }
-        },
-        "required": {
-          "type": "array",
-          "items": { "type": "string", "default": "" }
-        },
-        "title": { "type": "string" },
-        "type": { "type": "string" },
-        "uniqueItems": { "type": "boolean" },
-        "x-kubernetes-embedded-resource": {
-          "description": "x-kubernetes-embedded-resource defines that the value is an embedded Kubernetes runtime.Object, with TypeMeta and ObjectMeta. The type must be object. It is allowed to further restrict the embedded object. kind, apiVersion and metadata are validated automatically. x-kubernetes-preserve-unknown-fields is allowed to be true, but does not have to be if the object is fully specified (up to kind, apiVersion, metadata).",
-          "type": "boolean"
-        },
-        "x-kubernetes-int-or-string": {
-          "description": "x-kubernetes-int-or-string specifies that this value is either an integer or a string. If this is true, an empty type is allowed and type as child of anyOf is permitted if following one of the following patterns:\n\n1) anyOf:\n   - type: integer\n   - type: string\n2) allOf:\n   - anyOf:\n     - type: integer\n     - type: string\n   - ... zero or more",
-          "type": "boolean"
-        },
-        "x-kubernetes-list-map-keys": {
-          "description": "x-kubernetes-list-map-keys annotates an array with the x-kubernetes-list-type `map` by specifying the keys used as the index of the map.\n\nThis tag MUST only be used on lists that have the \"x-kubernetes-list-type\" extension set to \"map\". Also, the values specified for this attribute must be a scalar typed field of the child structure (no nesting is supported).\n\nThe properties specified must either be required or have a default value, to ensure those properties are present for all list items.",
-          "type": "array",
-          "items": { "type": "string", "default": "" }
-        },
-        "x-kubernetes-list-type": {
-          "description": "x-kubernetes-list-type annotates an array to further describe its topology. This extension must only be used on lists and may have 3 possible values:\n\n1) `atomic`: the list is treated as a single entity, like a scalar.\n     Atomic lists will be entirely replaced when updated. This extension\n     may be used on any type of list (struct, scalar, ...).\n2) `set`:\n     Sets are lists that must not have multiple items with the same value. Each\n     value must be a scalar, an object with x-kubernetes-map-type `atomic` or an\n     array with x-kubernetes-list-type `atomic`.\n3) `map`:\n     These lists are like maps in that their elements have a non-index key\n     used to identify them. Order is preserved upon merge. The map tag\n     must only be used on a list with elements of type object.\nDefaults to atomic for arrays.",
-          "type": "string"
-        },
-        "x-kubernetes-map-type": {
-          "description": "x-kubernetes-map-type annotates an object to further describe its topology. This extension must only be used when type is object and may have 2 possible values:\n\n1) `granular`:\n     These maps are actual maps (key-value pairs) and each fields are independent\n     from each other (they can each be manipulated by separate actors). This is\n     the default behaviour for all maps.\n2) `atomic`: the list is treated as a single entity, like a scalar.\n     Atomic maps will be entirely replaced when updated.",
-          "type": "string"
-        },
-        "x-kubernetes-preserve-unknown-fields": {
-          "description": "x-kubernetes-preserve-unknown-fields stops the API server decoding step from pruning fields which are not specified in the validation schema. This affects fields recursively, but switches back to normal pruning behaviour if nested properties or additionalProperties are specified in the schema. This can either be true or undefined. False is forbidden.",
-          "type": "boolean"
-        },
-        "x-kubernetes-validations": {
-          "description": "x-kubernetes-validations describes a list of validation rules written in the CEL expression language. This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.",
-          "type": "array",
-          "items": {
-            "default": {},
-            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule"
-          },
-          "x-kubernetes-list-map-keys": ["rule"],
-          "x-kubernetes-list-type": "map",
-          "x-kubernetes-patch-merge-key": "rule",
-          "x-kubernetes-patch-strategy": "merge"
-        }
-      }
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrArray": {
-      "description": "JSONSchemaPropsOrArray represents a value that can either be a JSONSchemaProps or an array of JSONSchemaProps. Mainly here for serialization purposes."
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool": {
-      "description": "JSONSchemaPropsOrBool represents JSONSchemaProps or a boolean value. Defaults to true for the boolean property."
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrStringArray": {
-      "description": "JSONSchemaPropsOrStringArray represents a JSONSchemaProps or a string array."
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ServiceReference": {
-      "description": "ServiceReference holds a reference to Service.legacy.k8s.io",
-      "type": "object",
-      "required": ["namespace", "name"],
-      "properties": {
-        "name": {
-          "description": "name is the name of the service. Required",
-          "type": "string",
-          "default": ""
-        },
-        "namespace": {
-          "description": "namespace is the namespace of the service. Required",
-          "type": "string",
-          "default": ""
-        },
-        "path": {
-          "description": "path is an optional URL path at which the webhook will be contacted.",
-          "type": "string"
-        },
-        "port": {
-          "description": "port is an optional service port at which the webhook will be contacted. `port` should be a valid port number (1-65535, inclusive). Defaults to 443 for backward compatibility.",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule": {
-      "description": "ValidationRule describes a validation rule written in the CEL expression language.",
-      "type": "object",
-      "required": ["rule"],
-      "properties": {
-        "message": {
-          "description": "Message represents the message displayed when validation fails. The message is required if the Rule contains line breaks. The message must not contain line breaks. If unset, the message is \"failed rule: {Rule}\". e.g. \"must be a URL with the host matching spec.host\"",
-          "type": "string"
-        },
-        "rule": {
-          "description": "Rule represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec The Rule is scoped to the location of the x-kubernetes-validations extension in the schema. The `self` variable in the CEL expression is bound to the scoped value. Example: - Rule scoped to the root of a resource with a status subresource: {\"rule\": \"self.status.actual \u003c= self.spec.maxDesired\"}\n\nIf the Rule is scoped to an object with properties, the accessible properties of the object are field selectable via `self.field` and field presence can be checked via `has(self.field)`. Null valued fields are treated as absent fields in CEL expressions. If the Rule is scoped to an object with additionalProperties (i.e. a map) the value of the map are accessible via `self[mapKey]`, map containment can be checked via `mapKey in self` and all entries of the map are accessible via CEL macros and functions such as `self.all(...)`. If the Rule is scoped to an array, the elements of the array are accessible via `self[i]` and also by macros and functions. If the Rule is scoped to a scalar, `self` is bound to the scalar value. Examples: - Rule scoped to a map of objects: {\"rule\": \"self.components['Widget'].priority \u003c 10\"} - Rule scoped to a list of integers: {\"rule\": \"self.values.all(value, value \u003e= 0 \u0026\u0026 value \u003c 100)\"} - Rule scoped to a string value: {\"rule\": \"self.startsWith('kube')\"}\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object and from any x-kubernetes-embedded-resource annotated objects. No other metadata properties are accessible.\n\nUnknown data preserved in custom resources via x-kubernetes-preserve-unknown-fields is not accessible in CEL expressions. This includes: - Unknown field values that are preserved by object schemas with x-kubernetes-preserve-unknown-fields. - Object properties where the property schema is of an \"unknown type\". An \"unknown type\" is recursively defined as:\n  - A schema with no type and x-kubernetes-preserve-unknown-fields set to true\n  - An array where the items schema is of an \"unknown type\"\n  - An object where the additionalProperties schema is of an \"unknown type\"\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Rule accessing a property named \"namespace\": {\"rule\": \"self.__namespace__ \u003e 0\"}\n  - Rule accessing a property named \"x-prop\": {\"rule\": \"self.x__dash__prop \u003e 0\"}\n  - Rule accessing a property named \"redact__d\": {\"rule\": \"self.redact__underscores__d \u003e 0\"}\n\nEquality on arrays with x-kubernetes-list-type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.",
-          "type": "string",
-          "default": ""
-        }
-      }
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookClientConfig": {
-      "description": "WebhookClientConfig contains the information to make a TLS connection with the webhook.",
-      "type": "object",
-      "properties": {
-        "caBundle": {
-          "description": "caBundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.",
-          "type": "string",
-          "format": "byte"
-        },
-        "service": {
-          "description": "service is a reference to the service for this webhook. Either service or url must be specified.\n\nIf the webhook is running within the cluster, then you should use `service`.",
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ServiceReference"
-        },
-        "url": {
-          "description": "url gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.\n\nThe `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.\n\nPlease note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.\n\nThe scheme must be \"https\"; the URL must begin with \"https://\".\n\nA path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.\n\nAttempting to use a user or basic auth e.g. \"user:password@\" is not allowed. Fragments (\"#...\") and query parameters (\"?...\") are not allowed, either.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookConversion": {
-      "description": "WebhookConversion describes how to call a conversion webhook",
-      "type": "object",
-      "required": ["conversionReviewVersions"],
-      "properties": {
-        "clientConfig": {
-          "description": "clientConfig is the instructions for how to call the webhook if strategy is `Webhook`.",
-          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookClientConfig"
-        },
-        "conversionReviewVersions": {
-          "description": "conversionReviewVersions is an ordered list of preferred `ConversionReview` versions the Webhook expects. The API server will use the first version in the list which it supports. If none of the versions specified in this list are supported by API server, conversion will fail for the custom resource. If a persisted Webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail.",
-          "type": "array",
-          "items": { "type": "string", "default": "" }
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
-      "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+    "io.k8s.apimachinery.pkg.apis.meta.v1.Fields": {
+      "description": "Fields stores a set of fields in a data structure like a Trie. To understand how this is used, see: https://github.com/kubernetes-sigs/structured-merge-diff",
       "type": "object"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
       "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
-      "type": "object",
       "properties": {
         "apiVersion": {
           "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
           "type": "string"
         },
-        "fieldsType": {
-          "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
-          "type": "string"
-        },
-        "fieldsV1": {
-          "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1"
+        "fields": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Fields",
+          "description": "Fields identifies a set of fields."
         },
         "manager": {
           "description": "Manager is an identifier of the workflow managing these fields.",
@@ -589,111 +273,117 @@
           "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
           "type": "string"
         },
-        "subresource": {
-          "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
-          "type": "string"
-        },
         "time": {
-          "description": "Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'"
         }
-      }
+      },
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+      "description": "MicroTime is version of Time with microsecond level precision.",
+      "format": "date-time",
+      "type": "string"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
       "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
-      "type": "object",
       "properties": {
         "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
           "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
-          "type": "object",
-          "additionalProperties": { "type": "string", "default": "" }
+          "type": "object"
+        },
+        "clusterName": {
+          "description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.",
+          "type": "string"
         },
         "creationTimestamp": {
-          "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-          "default": {},
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
         },
         "deletionGracePeriodSeconds": {
           "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
-          "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "type": "integer"
         },
         "deletionTimestamp": {
-          "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
         },
         "finalizers": {
-          "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+          "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed.",
+          "items": {
+            "type": "string"
+          },
           "type": "array",
-          "items": { "type": "string", "default": "" },
           "x-kubernetes-patch-strategy": "merge"
         },
         "generateName": {
-          "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+          "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency",
           "type": "string"
         },
         "generation": {
           "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
-          "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "type": "integer"
         },
         "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
           "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
-          "type": "object",
-          "additionalProperties": { "type": "string", "default": "" }
+          "type": "object"
         },
         "managedFields": {
-          "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
-          "type": "array",
+          "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.\n\nThis field is alpha and can be changed or removed without notice.",
           "items": {
-            "default": {},
             "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
-          }
+          },
+          "type": "array"
         },
         "name": {
           "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
           "type": "string"
         },
         "namespace": {
-          "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+          "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
           "type": "string"
         },
         "ownerReferences": {
           "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
-          "type": "array",
           "items": {
-            "default": {},
             "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
           },
+          "type": "array",
           "x-kubernetes-patch-merge-key": "uid",
           "x-kubernetes-patch-strategy": "merge"
         },
         "resourceVersion": {
-          "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+          "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
           "type": "string"
         },
         "selfLink": {
-          "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+          "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.",
           "type": "string"
         },
         "uid": {
           "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
       "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
-      "type": "object",
-      "required": ["apiVersion", "kind", "name", "uid"],
       "properties": {
         "apiVersion": {
           "description": "API version of the referent.",
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "blockOwnerDeletion": {
-          "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+          "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
           "type": "boolean"
         },
         "controller": {
@@ -701,36 +391,55 @@
           "type": "boolean"
         },
         "kind": {
-          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "type": "string",
-          "default": ""
+          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "type": "string"
         },
         "name": {
           "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "uid": {
           "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
-          "type": "string",
-          "default": ""
+          "type": "string"
         }
       },
-      "x-kubernetes-map-type": "atomic"
+      "required": [
+        "apiVersion",
+        "kind",
+        "name",
+        "uid"
+      ],
+      "type": "object"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
       "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-      "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "type": "string"
+    },
+    "io.k8s.apimachinery.pkg.util.intstr.IntOrString": {
+      "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+      "format": "int-or-string",
+      "type": "string"
     }
   },
+  "info": {
+    "title": "Kubernetes",
+    "version": "v1.16.0"
+  },
+  "paths": {
+  },
+  "security": [
+    {
+      "BearerToken": []
+    }
+  ],
   "securityDefinitions": {
     "BearerToken": {
       "description": "Bearer Token authentication",
-      "type": "apiKey",
+      "in": "header",
       "name": "authorization",
-      "in": "header"
+      "type": "apiKey"
     }
   },
-  "security": [{ "BearerToken": [] }]
+  "swagger": "2.0"
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storageversion"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // ConvertabilityChecker indicates what versions a GroupKind is available in.
@@ -93,6 +94,9 @@ type APIGroupVersion struct {
 	Admit admission.Interface
 
 	MinRequestTimeout time.Duration
+
+	// OpenAPIModels exposes the OpenAPI models to each individual handler.
+	OpenAPIModels *spec.Swagger
 
 	// The limit on the request body size that would be accepted and decoded in a write request.
 	// 0 means no limit.

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -47,16 +47,11 @@ var fakeTypeConverter = func() fieldmanager.TypeConverter {
 	if err != nil {
 		panic(err)
 	}
-	swag := spec.Swagger{}
-	if err := json.Unmarshal(data, &swag); err != nil {
+	spec := spec.Swagger{}
+	if err := json.Unmarshal(data, &spec); err != nil {
 		panic(err)
 	}
-	convertedDefs := map[string]*spec.Schema{}
-	for k, v := range swag.Definitions {
-		vCopy := v
-		convertedDefs[k] = &vCopy
-	}
-	typeConverter, err := fieldmanager.NewTypeConverter(convertedDefs, false)
+	typeConverter, err := fieldmanager.NewTypeConverter(&spec, false)
 	if err != nil {
 		panic(err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/fieldmanager_test.go
@@ -33,18 +33,11 @@ var fakeTypeConverter = func() internal.TypeConverter {
 	if err != nil {
 		panic(err)
 	}
-	convertedDefs := map[string]*spec.Schema{}
 	spec := spec.Swagger{}
 	if err := json.Unmarshal(data, &spec); err != nil {
 		panic(err)
 	}
-
-	for k, v := range spec.Definitions {
-		vCopy := v
-		convertedDefs[k] = &vCopy
-	}
-
-	typeConverter, err := internal.NewTypeConverter(convertedDefs, false)
+	typeConverter, err := internal.NewTypeConverter(&spec, false)
 	if err != nil {
 		panic(err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/versionconverter_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/versionconverter_test.go
@@ -36,17 +36,11 @@ var testTypeConverter = func() TypeConverter {
 	if err != nil {
 		panic(err)
 	}
-	swag := spec.Swagger{}
-	if err := json.Unmarshal(data, &swag); err != nil {
+	spec := spec.Swagger{}
+	if err := json.Unmarshal(data, &spec); err != nil {
 		panic(err)
 	}
-
-	convertedDefs := map[string]*spec.Schema{}
-	for k, v := range swag.Definitions {
-		vCopy := v
-		convertedDefs[k] = &vCopy
-	}
-	typeConverter, err := NewTypeConverter(convertedDefs, false)
+	typeConverter, err := NewTypeConverter(&spec, false)
 	if err != nil {
 		panic(err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/typeconverter.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/typeconverter.go
@@ -34,14 +34,9 @@ func NewDeducedTypeConverter() TypeConverter {
 	return internal.NewDeducedTypeConverter()
 }
 
-// NewTypeConverter builds a TypeConverter from a map of OpenAPIV3 schemas.
-// This will automatically find the proper version of the object, and the
+// NewTypeConverter builds a TypeConverter from a proto.Models. This
+// will automatically find the proper version of the object, and the
 // corresponding schema information.
-// The keys to the map must be consistent with the names
-// used by Refs within the schemas.
-// The schemas should conform to the Kubernetes Structural Schema OpenAPI
-// restrictions found in docs:
-// https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema
-func NewTypeConverter(openapiSpec map[string]*spec.Schema, preserveUnknownFields bool) (TypeConverter, error) {
+func NewTypeConverter(openapiSpec *spec.Swagger, preserveUnknownFields bool) (TypeConverter, error) {
 	return internal.NewTypeConverter(openapiSpec, preserveUnknownFields)
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -345,6 +345,13 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		isCreater = true
 	}
 
+	var resetFields map[fieldpath.APIVersion]*fieldpath.Set
+	if a.group.OpenAPIModels != nil {
+		if resetFieldsStrategy, isResetFieldsStrategy := storage.(rest.ResetFieldsStrategy); isResetFieldsStrategy {
+			resetFields = resetFieldsStrategy.GetResetFields()
+		}
+	}
+
 	var versionedList interface{}
 	if isLister {
 		list := lister.NewList()
@@ -673,16 +680,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 	if a.group.MetaGroupVersion != nil {
 		reqScope.MetaGroupVersion = *a.group.MetaGroupVersion
 	}
-
-	// Use TypeConverter's nil-ness as a proxy for whether SSA/OpenAPI is enabled
-	// This should be removed in the future and made unconditional
-	// https://github.com/kubernetes/kubernetes/pull/114998
-	if a.group.TypeConverter != nil {
-		var resetFields map[fieldpath.APIVersion]*fieldpath.Set
-		if resetFieldsStrategy, isResetFieldsStrategy := storage.(rest.ResetFieldsStrategy); isResetFieldsStrategy {
-			resetFields = resetFieldsStrategy.GetResetFields()
-		}
-
+	if a.group.OpenAPIModels != nil {
 		reqScope.FieldManager, err = fieldmanager.NewDefaultFieldManager(
 			a.group.TypeConverter,
 			a.group.UnsafeConvertor,
@@ -697,7 +695,6 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			return nil, nil, fmt.Errorf("failed to create field manager: %v", err)
 		}
 	}
-
 	for _, action := range actions {
 		producedObject := storageMeta.ProducesObject(action.Verb)
 		if producedObject == nil {


### PR DESCRIPTION
This reverts commit 7efa62dfdf96890f7f3cf95d957c7561e09055c4

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Reverts https://github.com/kubernetes/kubernetes/pull/115324
Fixes https://github.com/kubernetes/kubernetes/issues/116061

#### Special notes for your reviewer:

Integration tests started failing with intermittent panics like this after https://github.com/kubernetes/kubernetes/pull/115324 merged:

```
E0225 16:52:07.362025   82355 runtime.go:77] Observed a panic: FieldManager must be installed to run apply
goroutine 137185 [running]:
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/handlers/finisher.finishRequest.func1.1()
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/handlers/finisher/finisher.go:105 +0xa5
panic({0x4399ba0, 0x5a88890})
	/home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.20.1.linux.amd64/src/runtime/panic.go:884 +0x213
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/handlers.(*applyPatcher).applyPatchToCurrentObject(0xc0002378f0?, {0x5ac56c8?, 0xc009b23b90?}, {0x5aa0fc8?, 0xc0012a45a0?})
	/home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/handlers/patch.go:469 +0x449
k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/handlers.(*applyPatcher).createNewObject(0xc0039c50e0, {0x5ac56c8, 0xc009b23b90})

```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/assign @alexzielenski @apelisse @lavalamp 