### PR TITLE
Alternative approach for #115988

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -434,16 +434,21 @@ func isIncompatibleServerError(err error) bool {
 func (o *ApplyOptions) GetObjects() ([]*resource.Info, error) {
 	var err error = nil
 	if !o.objectsCached {
-		r := o.Builder.
+		b := o.Builder.
 			Unstructured().
 			Schema(o.Validator).
 			ContinueOnError().
 			NamespaceParam(o.Namespace).DefaultNamespace().
 			FilenameParam(o.EnforceNamespace, &o.DeleteOptions.FilenameOptions).
 			LabelSelectorParam(o.Selector).
-			Flatten().
-			Do()
-		o.objects, err = r.Infos()
+			Flatten()
+
+		if o.ApplySet != nil {
+			b = b.RequireLabels(o.ApplySet.LabelsForMember())
+		}
+
+		o.objects, err = b.Do().Infos()
+
 		o.objectsCached = true
 	}
 	return o.objects, err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -64,6 +64,7 @@ type ApplyFlags struct {
 	Selector       string
 	Prune          bool
 	PruneResources []prune.Resource
+	ApplySetRef    string
 	All            bool
 	Overwrite      bool
 	OpenAPIPatch   bool
@@ -130,6 +131,10 @@ type ApplyOptions struct {
 	// Function run after all objects have been applied.
 	// The standard PostProcessorFn is "PrintAndPrunePostProcessor()".
 	PostProcessorFn func() error
+
+	// ApplySet tracks the set of objects that have been applied, for the purposes of pruning.
+	// See git.k8s.io/enhancements/keps/sig-cli/3659-kubectl-apply-prune
+	ApplySet *ApplySet
 }
 
 var (
@@ -223,13 +228,9 @@ func (flags *ApplyFlags) AddFlags(cmd *cobra.Command) {
 	cmdutil.AddServerSideApplyFlags(cmd)
 	cmdutil.AddFieldManagerFlagVar(cmd, &flags.FieldManager, FieldManagerClientSideApply)
 	cmdutil.AddLabelSelectorFlagVar(cmd, &flags.Selector)
+	cmdutil.AddPruningFlags(cmd, &flags.Prune, &flags.PruneAllowlist, &flags.PruneWhitelist, &flags.All, &flags.ApplySetRef)
 
 	cmd.Flags().BoolVar(&flags.Overwrite, "overwrite", flags.Overwrite, "Automatically resolve conflicts between the modified and live configuration by using values from the modified configuration")
-	cmd.Flags().BoolVar(&flags.Prune, "prune", flags.Prune, "Automatically delete resource objects, that do not appear in the configs and are created by either apply or create --save-config. Should be used with either -l or --all.")
-	cmd.Flags().BoolVar(&flags.All, "all", flags.All, "Select all resources in the namespace of the specified resource types.")
-	cmd.Flags().StringArrayVar(&flags.PruneAllowlist, "prune-allowlist", flags.PruneAllowlist, "Overwrite the default allowlist with <group/version/kind> for --prune")
-	cmd.Flags().StringArrayVar(&flags.PruneWhitelist, "prune-whitelist", flags.PruneWhitelist, "Overwrite the default whitelist with <group/version/kind> for --prune") // TODO: Remove this in kubectl 1.28 or later
-	cmd.Flags().MarkDeprecated("prune-whitelist", "Use --prune-allowlist instead.")
 	cmd.Flags().BoolVar(&flags.OpenAPIPatch, "openapi-patch", flags.OpenAPIPatch, "If true, use openapi to calculate diff when the openapi presents and the resource can be found in the openapi spec. Otherwise, fall back to use baked-in types.")
 }
 
@@ -297,6 +298,13 @@ func (flags *ApplyFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, baseNa
 		return nil, err
 	}
 
+	var applySet *ApplySet
+	if flags.ApplySetRef != "" {
+		applySet, err = NewApplySet(flags.ApplySetRef, namespace, mapper)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if flags.Prune {
 		pruneAllowlist := slice.ToSet(flags.PruneAllowlist, flags.PruneWhitelist)
 		flags.PruneResources, err = prune.ParseResources(mapper, pruneAllowlist)
@@ -342,6 +350,8 @@ func (flags *ApplyFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, baseNa
 
 		VisitedUids:       sets.NewString(),
 		VisitedNamespaces: sets.NewString(),
+
+		ApplySet: applySet,
 	}
 
 	o.PostProcessorFn = o.PrintAndPrunePostProcessor()
@@ -371,19 +381,35 @@ func (o *ApplyOptions) Validate() error {
 		return fmt.Errorf("cannot set --all and --selector at the same time")
 	}
 
-	if o.Prune && !o.All && o.Selector == "" {
-		return fmt.Errorf("all resources selected for prune without explicitly passing --all. To prune all resources, pass the --all flag. If you did not mean to prune all resources, specify a label selector")
+	if o.ApplySet != nil && !o.Prune {
+		return fmt.Errorf("--applyset requires --prune")
 	}
+	if o.Prune {
+		// Do not force the recreation of an object(s) if we're pruning; this can cause
+		// undefined behavior since object UID's change.
+		if o.DeleteOptions.ForceDeletion {
+			return fmt.Errorf("--force cannot be used with --prune")
+		}
 
-	// Do not force the recreation of an object(s) if we're pruning; this can cause
-	// undefined behavior since object UID's change.
-	if o.Prune && o.DeleteOptions.ForceDeletion {
-		return fmt.Errorf("--force cannot be used with --prune")
-	}
-
-	// Currently do not support pruning objects which are server-side applied.
-	if o.Prune && o.ServerSideApply {
-		return fmt.Errorf("--prune is in alpha and doesn't currently work on objects created by server-side apply")
+		if o.ApplySet != nil {
+			if o.All {
+				return fmt.Errorf("--all is incompatible with --applyset")
+			} else if o.Selector != "" {
+				return fmt.Errorf("--selector is incompatible with --applyset")
+			} else if len(o.PruneResources) > 0 {
+				return fmt.Errorf("--prune-allowlist is incompatible with --applyset")
+			} else {
+				// TODO: remove this once ApplySet implementation is complete
+				return fmt.Errorf("--applyset is not yet supported")
+			}
+		} else {
+			if !o.All && o.Selector == "" {
+				return fmt.Errorf("all resources selected for prune without explicitly passing --all. To prune all resources, pass the --all flag. If you did not mean to prune all resources, specify a label selector")
+			}
+			if o.ServerSideApply {
+				return fmt.Errorf("--prune is in alpha and doesn't currently work on objects created by server-side apply")
+			}
+		}
 	}
 
 	return nil
@@ -955,8 +981,13 @@ func (o *ApplyOptions) PrintAndPrunePostProcessor() func() error {
 		}
 
 		if o.Prune {
-			p := newPruner(o)
-			return p.pruneAll(o)
+			if cmdutil.AlphaEnabled(cmdutil.ApplySetEnv) && o.ApplySet != nil {
+				p := newApplySetPruner(o)
+				return p.pruneAll()
+			} else {
+				p := newPruner(o)
+				return p.pruneAll(o)
+			}
 		}
 
 		return nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
@@ -54,6 +55,7 @@ import (
 	"k8s.io/kubectl/pkg/util/openapi"
 	utilpointer "k8s.io/utils/pointer"
 	"k8s.io/utils/strings/slices"
+	"sigs.k8s.io/yaml"
 )
 
 var (
@@ -2068,4 +2070,59 @@ func TestDontAllowApplyWithPodGeneratedName(t *testing.T) {
 	cmd.Flags().Set("filename", filenamePodGeneratedName)
 	cmd.Flags().Set("dry-run", "client")
 	cmd.Run(cmd, []string{})
+}
+
+func TestLoadObjects(t *testing.T) {
+	f := cmdtesting.NewTestFactory()
+	defer f.Cleanup()
+
+	testdirs := []string{"testdata/prune/simple"}
+	for _, testdir := range testdirs {
+		t.Run(testdir, func(t *testing.T) {
+			cmdtesting.WithAlphaEnv(cmdutil.ApplySetEnv, t, func(t *testing.T) {
+				cmd := &cobra.Command{}
+				flags := NewApplyFlags(genericclioptions.NewTestIOStreamsDiscard())
+				flags.AddFlags(cmd)
+				cmd.Flags().Set("filename", filepath.Join(testdir, "manifest1.yaml"))
+				cmd.Flags().Set("applyset", filepath.Base(testdir))
+				cmd.Flags().Set("prune", "true")
+
+				o, err := flags.ToOptions(f, cmd, "kubectl", []string{})
+				if err != nil {
+					t.Fatalf("unexpected error creating apply options: %v", err)
+				}
+
+				// TODO(justinsb): Enable validation once we unblock --applyset
+				// err = o.Validate()
+				// if err != nil {
+				// 	t.Fatalf("unexpected error from validate: %v", err)
+				// }
+
+				resources, err := o.GetObjects()
+				if err != nil {
+					t.Fatalf("GetObjects gave unexpected error %v", err)
+				}
+
+				var objectYAMLs []string
+				for _, obj := range resources {
+					y, err := yaml.Marshal(obj.Object)
+					if err != nil {
+						t.Fatalf("error marshaling object: %v", err)
+					}
+					objectYAMLs = append(objectYAMLs, string(y))
+				}
+				got := strings.Join(objectYAMLs, "\n---\n\n")
+
+				p := filepath.Join(testdir, "expected-manifest1-getobjects.yaml")
+				wantBytes, err := os.ReadFile(p)
+				if err != nil {
+					t.Fatalf("error reading file %q: %v", p, err)
+				}
+				want := string(wantBytes)
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("GetObjects returned unexpected diff (-want +got):\n%s", diff)
+				}
+			})
+		})
+	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apply
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const defaultApplySetParentResource = "secrets"
+const defaultApplySetParentVersion = "v1"
+
+// ApplySet tracks the information about an applyset apply/prune
+type ApplySet struct {
+	// ParentRef is the reference to the parent object that is used to track the applyset.
+	ParentRef *ApplySetParentRef
+
+	// resources is the set of all the resources that (might) be part of this applyset.
+	resources map[schema.GroupVersionResource]struct{}
+
+	// namespaces is the set of all namespaces that (might) contain objects that are part of this applyset.
+	namespaces map[string]struct{}
+}
+
+// ApplySetParentRef stores object and type meta for the parent object that is used to track the applyset.
+type ApplySetParentRef struct {
+	Name        string
+	Namespace   string
+	RESTMapping *meta.RESTMapping
+}
+
+const invalidParentRefFmt = "invalid parent reference %q: %w"
+
+// NewApplySet creates a new ApplySet object from a parent reference in the format [RESOURCE][.GROUP]/NAME
+func NewApplySet(parentRefStr string, namespace string, mapper meta.RESTMapper) (*ApplySet, error) {
+	var parent *ApplySetParentRef
+	var err error
+
+	if parent, err = parentRefFromStr(parentRefStr, mapper); err != nil {
+		return nil, fmt.Errorf(invalidParentRefFmt, parentRefStr, err)
+	}
+	parent.Namespace = namespace
+	if err := parent.Validate(); err != nil {
+		return nil, fmt.Errorf(invalidParentRefFmt, parentRefStr, err)
+	}
+
+	return &ApplySet{
+		resources:  make(map[schema.GroupVersionResource]struct{}),
+		namespaces: make(map[string]struct{}),
+		ParentRef:  parent,
+	}, nil
+}
+
+// ID is the label value that we are using to identify this applyset.
+func (a ApplySet) ID() string {
+	// TODO: base64(sha256(gknn))
+	return "placeholder-todo"
+}
+
+func (p *ApplySetParentRef) IsNamespaced() bool {
+	return p.RESTMapping.Scope.Name() == meta.RESTScopeNameNamespace
+}
+
+func (p *ApplySetParentRef) Validate() error {
+	if p.Name == "" {
+		return fmt.Errorf("name cannot be blank")
+	}
+	if p.IsNamespaced() && p.Namespace == "" {
+		// TODO: Can this actually happen? We seem to get the value 'default' here when the namespace flag unspecified or even blank. May need KEP update.
+		return fmt.Errorf("namespace is required to use namespace-scoped ApplySet")
+	}
+	return nil
+}
+
+// parentRefFromStr creates a new ApplySetParentRef from a parent reference in the format [RESOURCE][.GROUP]/NAME
+func parentRefFromStr(parentRefStr string, mapper meta.RESTMapper) (*ApplySetParentRef, error) {
+	var gvr schema.GroupVersionResource
+	var name string
+
+	if groupRes, nameSuffix, hasTypeInfo := strings.Cut(parentRefStr, "/"); hasTypeInfo {
+		name = nameSuffix
+		gvr = schema.ParseGroupResource(groupRes).WithVersion("")
+	} else {
+		name = parentRefStr
+		gvr = schema.GroupVersionResource{Version: defaultApplySetParentVersion, Resource: defaultApplySetParentResource}
+	}
+
+	gvk, err := mapper.KindFor(gvr)
+	if err != nil {
+		return nil, err
+	}
+	mapping, err := mapper.RESTMapping(gvk.GroupKind())
+	if err != nil {
+		return nil, err
+	}
+	return &ApplySetParentRef{Name: name, RESTMapping: mapping}, nil
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
@@ -74,6 +74,12 @@ func (a ApplySet) ID() string {
 	return "placeholder-todo"
 }
 
+func (a *ApplySet) LabelsForMember() map[string]string {
+	return map[string]string{
+		"applyset.k8s.io/part-of": a.ID(),
+	}
+}
+
 func (p *ApplySetParentRef) IsNamespaced() bool {
 	return p.RESTMapping.Scope.Name() == meta.RESTScopeNameNamespace
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset_pruner.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset_pruner.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apply
+
+import "fmt"
+
+type applySetPruner struct {
+}
+
+func newApplySetPruner(_ *ApplyOptions) *applySetPruner {
+	return &applySetPruner{}
+}
+
+func (p *applySetPruner) pruneAll() error {
+	return fmt.Errorf("ApplySet-based pruning is not yet implemented")
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/expected-manifest1-getobjects.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/expected-manifest1-getobjects.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    applyset.k8s.io/part-of: placeholder-todo
+  name: foo
+
+---
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    applyset.k8s.io/part-of: placeholder-todo
+  name: bar

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/manifest1.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/manifest1.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo
+
+---
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bar

--- a/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
@@ -18,7 +18,6 @@ package explain
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -82,7 +81,7 @@ func NewExplainOptions(parent string, streams genericclioptions.IOStreams) *Expl
 	return &ExplainOptions{
 		IOStreams:       streams,
 		CmdParent:       parent,
-		EnableOpenAPIV3: os.Getenv("KUBECTL_EXPLAIN_OPENAPIV3") == "true",
+		EnableOpenAPIV3: cmdutil.AlphaEnabled(cmdutil.ExplainOpenapiV3Env),
 		OutputFormat:    "plaintext",
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain_test.go
@@ -21,10 +21,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	sptest "k8s.io/apimachinery/pkg/util/strategicpatch/testing"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/openapi"
 )
 
@@ -148,5 +150,23 @@ func TestExplain(t *testing.T) {
 	cmd.Run(cmd, []string{"cronjobs"})
 	if !strings.Contains(buf.String(), "VERSION:  batch/v1beta1") {
 		t.Fatalf("expected output should include pod batch/v1beta1")
+	}
+}
+
+func TestAlphaEnablement(t *testing.T) {
+	alphas := map[string]string{
+		cmdutil.ExplainOpenapiV3Env: "output",
+	}
+	for env, flag := range alphas {
+		f := cmdtesting.NewTestFactory()
+		defer f.Cleanup()
+
+		cmd := NewCmdExplain("kubectl", f, genericclioptions.NewTestIOStreamsDiscard())
+		require.Nil(t, cmd.Flags().Lookup(flag), "flag %q should not be registered without the %q alpha env var set", flag, env)
+
+		cmdtesting.WithAlphaEnv(env, t, func(t *testing.T) {
+			cmd := NewCmdExplain("kubectl", f, genericclioptions.NewTestIOStreamsDiscard())
+			require.NotNil(t, cmd.Flags().Lookup(flag), "flag %q should be registered with the %q alpha env var set", flag, env)
+		})
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/util.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/util.go
@@ -21,8 +21,10 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -177,4 +179,14 @@ func InitTestErrorHandler(t *testing.T) {
 	cmdutil.BehaviorOnFatal(func(str string, code int) {
 		t.Errorf("Error running command (exit code %d): %s", code, str)
 	})
+}
+
+func WithAlphaEnv(key string, t *testing.T, f func(*testing.T)) {
+	if key != "" {
+		oldValue := os.Getenv(key)
+		err := os.Setenv(key, "true")
+		require.NoError(t, err, "unexpected error setting alpha env")
+		defer os.Setenv(key, oldValue)
+	}
+	f(t)
 }


### PR DESCRIPTION
Alternative approach for #115988

As we apply objects when using apply/prune v2, we want to be sure they include the label that ties them back to the applyset they are part of.

Builds on https://github.com/kubernetes/kubernetes/pull/115979

/kind feature