### PR TITLE
kubeadm: modify '--config' flag from required to optional for 'kubeadm kubeconfig user'

### DIFF
--- a/cmd/kubeadm/app/cmd/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/kubeconfig.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"k8s.io/klog/v2"
@@ -43,6 +42,9 @@ var (
 	`)
 
 	userKubeconfigExample = cmdutil.Examples(`
+	# Output a kubeconfig file for an additional user named foo
+	kubeadm kubeconfig user --client-name=foo
+
 	# Output a kubeconfig file for an additional user named foo using a kubeadm config file bar
 	kubeadm kubeconfig user --client-name=foo --config=bar
 	`)
@@ -79,9 +81,6 @@ func newCmdUserKubeConfig(out io.Writer) *cobra.Command {
 		Long:    userKubeconfigLongDesc,
 		Example: userKubeconfigExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(cfgPath) == 0 {
-				return errors.New("the kubeadm configuration path cannot be empty")
-			}
 			// This call returns the ready-to-use configuration based on the defaults populated by flags
 			internalCfg, err := configutil.LoadOrDefaultInitConfiguration(cfgPath, initCfg, clusterCfg)
 			if err != nil {
@@ -114,7 +113,6 @@ func newCmdUserKubeConfig(out io.Writer) *cobra.Command {
 	cmd.Flags().StringSliceVar(&organizations, "org", organizations, "The organizations of the client certificate. It will be used as the O if client certificates are created")
 	cmd.Flags().DurationVar(&validityPeriod, "validity-period", kubeadmconstants.CertificateValidity, "The validity period of the client certificate. It is an offset from the current time.")
 
-	cmd.MarkFlagRequired(options.CfgPath)
 	cmd.MarkFlagRequired("client-name")
 	return cmd
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Our initial intention is to guide users to use the kubeadm configuration file rather than the CLI flags, but it is not mandatory. 
If the user does not specify a configuration file when initializing the cluster, but kubeadm asks for one when executing `kubeadm kubeconfig user` command, it will cause confusion for the user. 

In fact, `kubeadm kubeconfig user` supports automatic generation of default configuration when `cfgPath` is empty:
https://github.com/kubernetes/kubernetes/blob/0e077bb7ac898555b7bb968fee8115aa738bde34/cmd/kubeadm/app/cmd/kubeconfig.go#L86

By the way, if we have forced the user to provide `--config` flag, we should use `LoadInitConfigurationFromFile`, not `LoadOrDefaultInitConfiguration`. But I wish we could both support passing in `--config` or just use the default configuration.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #94879 #105649

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: modify '--config' flag from required to optional for 'kubeadm kubeconfig user' command
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
