### PR TITLE
cleanup: remove ProbeTerminationGracePeriod feature tag on test

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2232,22 +2232,6 @@
     every time health check fails, measure up to 5 restart.
   release: v1.9
   file: test/e2e/common/node/container_probe.go
-- testname: Set terminationGracePeriodSeconds for livenessProbe
-  codename: '[sig-node] Probing container should override timeoutGracePeriodSeconds
-    when LivenessProbe field is set [Conformance]'
-  description: A pod with a long terminationGracePeriod is created with a shorter
-    livenessProbe-level terminationGracePeriodSeconds. We confirm the shorter termination
-    period is used.
-  release: v1.21
-  file: test/e2e/common/node/container_probe.go
-- testname: Set terminationGracePeriodSeconds for startupProbe
-  codename: '[sig-node] Probing container should override timeoutGracePeriodSeconds
-    when StartupProbe field is set [Conformance]'
-  description: A pod with a long terminationGracePeriod is created with a shorter
-    startupProbe-level terminationGracePeriodSeconds. We confirm the shorter termination
-    period is used.
-  release: v1.21
-  file: test/e2e/common/node/container_probe.go
 - testname: Pod readiness probe, with initial delay
   codename: '[sig-node] Probing container with readiness probe should not be ready
     before initial delay and never restart [NodeConformance] [Conformance]'

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2232,6 +2232,22 @@
     every time health check fails, measure up to 5 restart.
   release: v1.9
   file: test/e2e/common/node/container_probe.go
+- testname: Set terminationGracePeriodSeconds for livenessProbe
+  codename: '[sig-node] Probing container should override timeoutGracePeriodSeconds
+    when LivenessProbe field is set [Conformance]'
+  description: A pod with a long terminationGracePeriod is created with a shorter
+    livenessProbe-level terminationGracePeriodSeconds. We confirm the shorter termination
+    period is used.
+  release: v1.21
+  file: test/e2e/common/node/container_probe.go
+- testname: Set terminationGracePeriodSeconds for startupProbe
+  codename: '[sig-node] Probing container should override timeoutGracePeriodSeconds
+    when StartupProbe field is set [Conformance]'
+  description: A pod with a long terminationGracePeriod is created with a shorter
+    startupProbe-level terminationGracePeriodSeconds. We confirm the shorter termination
+    period is used.
+  release: v1.21
+  file: test/e2e/common/node/container_probe.go
 - testname: Pod readiness probe, with initial delay
   codename: '[sig-node] Probing container with readiness probe should not be ready
     before initial delay and never restart [NodeConformance] [Conformance]'

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -459,7 +459,7 @@ var _ = SIGDescribe("Probing container", func() {
 		Testname: Set terminationGracePeriodSeconds for livenessProbe
 		Description: A pod with a long terminationGracePeriod is created with a shorter livenessProbe-level terminationGracePeriodSeconds. We confirm the shorter termination period is used.
 	*/
-	ginkgo.It("should override timeoutGracePeriodSeconds when LivenessProbe field is set [Feature:ProbeTerminationGracePeriod]", func(ctx context.Context) {
+	framework.ConformanceIt("should override timeoutGracePeriodSeconds when LivenessProbe field is set", func(ctx context.Context) {
 		pod := e2epod.NewAgnhostPod(f.Namespace.Name, "liveness-override-"+string(uuid.NewUUID()), nil, nil, nil, "/bin/sh", "-c", "sleep 1000")
 		longGracePeriod := int64(500)
 		pod.Spec.TerminationGracePeriodSeconds = &longGracePeriod
@@ -487,7 +487,7 @@ var _ = SIGDescribe("Probing container", func() {
 		Testname: Set terminationGracePeriodSeconds for startupProbe
 		Description: A pod with a long terminationGracePeriod is created with a shorter startupProbe-level terminationGracePeriodSeconds. We confirm the shorter termination period is used.
 	*/
-	ginkgo.It("should override timeoutGracePeriodSeconds when StartupProbe field is set [Feature:ProbeTerminationGracePeriod]", func(ctx context.Context) {
+	framework.ConformanceIt("should override timeoutGracePeriodSeconds when StartupProbe field is set", func(ctx context.Context) {
 		pod := e2epod.NewAgnhostPod(f.Namespace.Name, "startup-override-"+string(uuid.NewUUID()), nil, nil, nil, "/bin/sh", "-c", "sleep 1000")
 		longGracePeriod := int64(500)
 		pod.Spec.TerminationGracePeriodSeconds = &longGracePeriod

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -970,7 +970,9 @@ func RunLivenessTest(ctx context.Context, f *framework.Framework, pod *v1.Pod, e
 	framework.Logf("Initial restart count of pod %s is %d", pod.Name, initialRestartCount)
 
 	// Wait for the restart state to be as desired.
-	deadline := time.Now().Add(timeout)
+	// If initialRestartCount is not zero, there is restarting back-off time.
+	deadline := time.Now().Add(timeout + time.Duration(initialRestartCount)*10*time.Second)
+
 	lastRestartCount := initialRestartCount
 	observedRestarts := int32(0)
 	for start := time.Now(); time.Now().Before(deadline); time.Sleep(2 * time.Second) {


### PR DESCRIPTION
We plan to promote `ProbeTerminationGracePeriod` promote to GA #114307
- test needs to be promoted to conformance as graduate criteria.