### PR TITLE
Improve the performance of method CandidatesToVictimsMap

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -127,7 +127,7 @@ func (pl *DefaultPreemption) GetOffsetAndNumCandidates(numNodes int32) (int32, i
 // This function is not applicable for out-of-tree preemption plugins that exercise
 // different preemption candidates on the same nominated node.
 func (pl *DefaultPreemption) CandidatesToVictimsMap(candidates []preemption.Candidate) map[string]*extenderv1.Victims {
-	m := make(map[string]*extenderv1.Victims)
+	m := make(map[string]*extenderv1.Victims, len(candidates))
 	for _, c := range candidates {
 		m[c.Name()] = c.Victims()
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/sig scheduling
#### What this PR does / why we need it:
Benchmark in my local, like this:
```
func BenchmarkCandidatesToVictimsMap(b *testing.B) {
	var candidates []preemption.Candidate
	pl := &DefaultPreemption{}
	for i := 0; i < 100; i++ {
		candi := &candidate{name: strconv.Itoa(i)}
		candidates = append(candidates, candi)
	}
	for i := 0; i < b.N; i++ {
		pl.CandidatesToVictimsMap(candidates)
	}
}
```
before change :
```
BenchmarkCandidatesToVictimsMap-16    	  144380	      8200 ns/op	    8073 B/op	       9 allocs/op
BenchmarkCandidatesToVictimsMap-16    	  143512	      8277 ns/op	    8073 B/op	       9 allocs/op
BenchmarkCandidatesToVictimsMap-16    	  142384	      8281 ns/op	    8073 B/op	       9 allocs/op
BenchmarkCandidatesToVictimsMap-16    	  143898	      8344 ns/op	    8073 B/op	       9 allocs/op
BenchmarkCandidatesToVictimsMap-16    	  140905	      8219 ns/op	    8073 B/op	       9 allocs/op
```
after change:
```
BenchmarkCandidatesToVictimsMap-16    	  239732	      4387 ns/op	    4229 B/op	       3 allocs/op
BenchmarkCandidatesToVictimsMap-16    	  282350	      4382 ns/op	    4228 B/op	       3 allocs/op
BenchmarkCandidatesToVictimsMap-16    	  285952	      4296 ns/op	    4228 B/op	       3 allocs/op
BenchmarkCandidatesToVictimsMap-16    	  256210	      4520 ns/op	    4229 B/op	       3 allocs/op
BenchmarkCandidatesToVictimsMap-16    	  275517	      4336 ns/op	    4229 B/op	       3 allocs/op
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
