### PR TITLE
golangci-lint improvements

### DIFF
--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -34,7 +34,7 @@ linters-settings: # please keep this alphabetized
       # Installed there by hack/verify-golangci-lint.sh.
       path: ../_output/local/bin/logcheck.so
       description: structured logging checker
-      original-url: k8s.io/klog/hack/tools
+      original-url: k8s.io/logtools/logcheck
   gocritic:
     enabled-checks:
       - equalFold

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -32,7 +32,7 @@ linters-settings: # please keep this alphabetized
   custom:
     logcheck:
       # Installed there by hack/verify-golangci-lint.sh.
-      path: _output/local/bin/logcheck.so
+      path: ../_output/local/bin/logcheck.so
       description: structured logging checker
       original-url: k8s.io/klog/hack/tools
   gocritic:

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -26,11 +26,24 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 source "${KUBE_ROOT}/hack/lib/util.sh"
 
-kube::golang::verify_go_version
-
 # Ensure that we find the binaries we build before anything else.
 export GOBIN="${KUBE_OUTPUT_BINPATH}"
 PATH="${GOBIN}:${PATH}"
+
+invocation=(./hack/verify-golangci-lint.sh "$@")
+
+# The logcheck plugin currently has to be configured via env variables
+# (https://github.com/golangci/golangci-lint/issues/1512).
+#
+# Remember to clean the golangci-lint cache when changing
+# the configuration and running this script multiple times,
+# otherwise golangci-lint will report stale results:
+# _output/local/bin/golangci-lint cache clean
+golangci=(env LOGCHECK_CONFIG="${KUBE_ROOT}/hack/logcheck.conf" "${GOBIN}/golangci-lint" run)
+golangci_config="${KUBE_ROOT}/.golangci.yaml"
+golangci+=(--config="${golangci_config}")
+
+kube::golang::verify_go_version
 
 # Explicitly opt into go modules, even though we're inside a GOPATH directory
 export GO111MODULE=on
@@ -44,29 +57,18 @@ popd >/dev/null
 
 cd "${KUBE_ROOT}"
 
-## The config is in ${KUBE_ROOT}/.golangci.yaml where it will be found
-## even when golangci-lint is invoked in a sub-directory.
-##
-## The logcheck plugin currently has to be configured via env variables
-## (https://github.com/golangci/golangci-lint/issues/1512).
-##
-## Remember to clean the golangci-lint cache when changing
-## the configuration and running this script multiple times,
-## otherwise golangci-lint will report stale results:
-## _output/local/bin/golangci-lint cache clean
-export LOGCHECK_CONFIG="${KUBE_ROOT}/hack/logcheck.conf"
-
-echo 'running golangci-lint ' >&2
 res=0
 if [[ "$#" -gt 0 ]]; then
-    golangci-lint run "$@" >&2 || res=$?
+    echo "running ${golangci[*]} $*" >&2
+    "${golangci[@]}" "$@" >&2 || res=$?
 else
-    golangci-lint run ./... >&2 || res=$?
+    echo "running ${golangci[*]} ./..." >&2
+    "${golangci[@]}" ./... >&2 || res=$?
     for d in staging/src/k8s.io/*; do
         MODPATH="staging/src/k8s.io/$(basename "${d}")"
-        echo "running golangci-lint for ${KUBE_ROOT}/${MODPATH}"
+        echo "running ( cd ${KUBE_ROOT}/${MODPATH}; ${golangci[*]} --path-prefix ${MODPATH} ./... )"
         pushd "${KUBE_ROOT}/${MODPATH}" >/dev/null
-            golangci-lint --path-prefix "${MODPATH}" run ./... >&2 || res=$?
+            "${golangci[@]}" --path-prefix "${MODPATH}" ./... >&2 || res=$?
         popd >/dev/null
     done
 fi
@@ -77,7 +79,7 @@ if [ "$res" -eq 0 ]; then
 else
   {
     echo
-    echo 'Please review the above warnings. You can test via "./hack/verify-golangci-lint.sh"'
+    echo "Please review the above warnings. You can test via \"${invocation[*]}\""
     echo 'If the above warnings do not make sense, you can exempt this warning with a comment'
     echo ' (if your reviewer is okay with it).'
     echo 'In general please prefer to fix the error, we have already disabled specific lints'

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -40,7 +40,7 @@ invocation=(./hack/verify-golangci-lint.sh "$@")
 # otherwise golangci-lint will report stale results:
 # _output/local/bin/golangci-lint cache clean
 golangci=(env LOGCHECK_CONFIG="${KUBE_ROOT}/hack/logcheck.conf" "${GOBIN}/golangci-lint" run)
-golangci_config="${KUBE_ROOT}/.golangci.yaml"
+golangci_config="${KUBE_ROOT}/hack/golangci.yaml"
 golangci+=(--config="${golangci_config}")
 
 kube::golang::verify_go_version


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This prepares for https://github.com/kubernetes/kubernetes/pull/109728 and integrating "go vet" into golangci-lint.

For a longer discussion around moving the config file see https://github.com/kubernetes/kubernetes/pull/109728#discussion_r862070905

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @dims