### PR TITLE
Codegen: set LC_ALL and unset GREP_OPTIONS

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -38,6 +38,12 @@ PRJ_SRC_PATH="k8s.io/kubernetes"
 BOILERPLATE_FILENAME="vendor/k8s.io/code-generator/hack/boilerplate.go.txt"
 APPLYCONFIG_PKG="k8s.io/client-go/applyconfigurations"
 
+# Any time we call sort, we want it in the same locale.
+export LC_ALL="C"
+
+# Work around for older grep tools which might have options we don't want.
+unset GREP_OPTIONS
+
 if [[ "${DBG_CODEGEN}" == 1 ]]; then
     kube::log::status "DBG: starting generated_files"
 fi
@@ -101,7 +107,7 @@ function codegen::protobuf() {
             cmd pkg staging \
             | xargs -0 -n1 dirname \
             | sed 's|^|k8s.io/kubernetes/|;s|k8s.io/kubernetes/staging/src/||' \
-            | LC_ALL=C sort -u)
+            | sort -u)
 
     kube::log::status "Generating protobufs for ${#apis[@]} targets"
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
@@ -221,9 +227,9 @@ function codegen::prerelease() {
     fi
     local tag_dirs=()
     kube::util::read-array tag_dirs < <( \
-        grep -l --null --color=never '+k8s:prerelease-lifecycle-gen=true' "${ALL_K8S_TAG_FILES[@]}" \
+        grep -l --null '+k8s:prerelease-lifecycle-gen=true' "${ALL_K8S_TAG_FILES[@]}" \
             | xargs -0 -n1 dirname \
-            | LC_ALL=C sort -u)
+            | sort -u)
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "DBG: found ${#tag_dirs[@]} +k8s:prerelease-lifecycle-gen tagged dirs"
     fi
@@ -284,9 +290,9 @@ function codegen::deepcopy() {
     fi
     local tag_dirs=()
     kube::util::read-array tag_dirs < <( \
-        grep -l --null --color=never '+k8s:deepcopy-gen=' "${ALL_K8S_TAG_FILES[@]}" \
+        grep -l --null '+k8s:deepcopy-gen=' "${ALL_K8S_TAG_FILES[@]}" \
             | xargs -0 -n1 dirname \
-            | LC_ALL=C sort -u)
+            | sort -u)
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "DBG: found ${#tag_dirs[@]} +k8s:deepcopy-gen tagged dirs"
     fi
@@ -354,9 +360,9 @@ function codegen::defaults() {
     fi
     local tag_dirs=()
     kube::util::read-array tag_dirs < <( \
-        grep -l --null --color=never '+k8s:defaulter-gen=' "${ALL_K8S_TAG_FILES[@]}" \
+        grep -l --null '+k8s:defaulter-gen=' "${ALL_K8S_TAG_FILES[@]}" \
             | xargs -0 -n1 dirname \
-            | LC_ALL=C sort -u)
+            | sort -u)
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "DBG: found ${#tag_dirs[@]} +k8s:defaulter-gen tagged dirs"
     fi
@@ -429,9 +435,9 @@ function codegen::conversions() {
     fi
     local tag_dirs=()
     kube::util::read-array tag_dirs < <(\
-        grep -l --null --color=never '^// *+k8s:conversion-gen=' "${ALL_K8S_TAG_FILES[@]}" \
+        grep -l --null '^// *+k8s:conversion-gen=' "${ALL_K8S_TAG_FILES[@]}" \
             | xargs -0 -n1 dirname \
-            | LC_ALL=C sort -u)
+            | sort -u)
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "DBG: found ${#tag_dirs[@]} +k8s:conversion-gen tagged dirs"
     fi
@@ -645,9 +651,9 @@ function codegen::openapi() {
 
         local tag_dirs=()
         kube::util::read-array tag_dirs < <(
-            grep -l --null --color=never '+k8s:openapi-gen=' $(indirect_array "${prefix}_tag_files") \
+            grep -l --null '+k8s:openapi-gen=' $(indirect_array "${prefix}_tag_files") \
                 | xargs -0 -n1 dirname \
-                | LC_ALL=C sort -u)
+                | sort -u)
 
         if [[ "${DBG_CODEGEN}" == 1 ]]; then
             kube::log::status "DBG: found ${#tag_dirs[@]} +k8s:openapi-gen tagged dirs for ${prefix}"
@@ -707,7 +713,7 @@ function codegen::applyconfigs() {
         cd "${KUBE_ROOT}/staging/src"
         git_find -z ':(glob)k8s.io/api/**/types.go' \
             | xargs -0 -n1 dirname \
-            | LC_ALL=C sort -u)
+            | sort -u)
     ext_apis+=("k8s.io/apimachinery/pkg/apis/meta/v1")
 
     kube::log::status "Generating apply-config code for ${#ext_apis[@]} targets"
@@ -803,7 +809,7 @@ function codegen::listers() {
         cd "${KUBE_ROOT}/staging/src"
         git_find -z ':(glob)k8s.io/api/**/types.go' \
             | xargs -0 -n1 dirname \
-            | LC_ALL=C sort -u)
+            | sort -u)
 
     kube::log::status "Generating lister code for ${#ext_apis[@]} targets"
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
@@ -843,7 +849,7 @@ function codegen::informers() {
         cd "${KUBE_ROOT}/staging/src"
         git_find -z ':(glob)k8s.io/api/**/types.go' \
             | xargs -0 -n1 dirname \
-            | LC_ALL=C sort -u)
+            | sort -u)
 
     kube::log::status "Generating informer code for ${#ext_apis[@]} targets"
     if [[ "${DBG_CODEGEN}" == 1 ]]; then


### PR DESCRIPTION
Peeling off my last few commits wrt codegen.

LC_ALL is always wanted and GREP_OPTIONS is never wanted.  The `grep --color=never` dates back to 2016, an issue with OLD grep on Macs, which was hard to deal with when this was all Makefile magic.  Now that it's a script, we can do it more simply.

xref https://github.com/thockin/kubernetes/commit/0cf59707bd46b13c1d49d509e50da6519f1126fa by @dims 

/kind cleanup
```release-note
NONE
```
