### PR TITLE
skip special features in TestPodSecurityGAOnly

### DIFF
--- a/test/integration/auth/podsecurity_test.go
+++ b/test/integration/auth/podsecurity_test.go
@@ -75,7 +75,11 @@ func TestPodSecurity(t *testing.T) {
 func TestPodSecurityGAOnly(t *testing.T) {
 	// Disable all alpha and beta features
 	for k, v := range utilfeature.DefaultFeatureGate.DeepCopy().GetAll() {
-		if v.PreRelease == featuregate.Alpha || v.PreRelease == featuregate.Beta {
+		if k == "AllAlpha" || k == "AllBeta" {
+			// Skip special features. When processed first, special features may
+			// erroneously disable other features.
+			continue
+		} else if v.PreRelease == featuregate.Alpha || v.PreRelease == featuregate.Beta {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, k, false)()
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Skips AllAlpha/AllBeta special features so that the list of features is properly restored for other tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #116151

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig auth
/assign @liggitt 