### PR TITLE
Mutable pod scheduling directives

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -395,6 +395,7 @@ func GetValidationOptionsFromPodSpecAndMeta(podSpec, oldPodSpec *api.PodSpec, po
 		AllowExpandedDNSConfig:                            utilfeature.DefaultFeatureGate.Enabled(features.ExpandedDNSConfig) || haveSameExpandedDNSConfig(podSpec, oldPodSpec),
 		AllowInvalidLabelValueInSelector:                  false,
 		AllowInvalidTopologySpreadConstraintLabelSelector: false,
+		AllowMutableNodeSelectorAndNodeAffinity:           utilfeature.DefaultFeatureGate.Enabled(features.PodSchedulingReadiness),
 	}
 
 	if oldPodSpec != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig scheduling

Optionally add one or more of the following kinds if applicable:
/kind api-change


#### What this PR does / why we need it:
See [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3838-pod-mutable-scheduling-directives) for context.

#### Which issue(s) this PR fixes:
Fixes #116160

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Relax API validation to allow pod node selector to be mutable for gated pods (additions only, no deletions or mutations).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
[KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/3838-pod-mutable-scheduling-directives)
```
