### PR TITLE
start to count time since the connection was actually established

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/connection_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/connection_test.go
@@ -247,12 +247,12 @@ func TestConnectionPings(t *testing.T) {
 		t.Fatalf("client: error connecting to proxy: %v", err)
 	}
 	defer clConn.Close()
-	start := time.Now()
 	clSPDYConn, err := NewClientConnection(clConn)
 	if err != nil {
 		t.Fatalf("client: error creating spdy connection: %v", err)
 	}
 	defer clSPDYConn.Close()
+	start := time.Now()
 	clSPDYStream, err := clSPDYConn.CreateStream(http.Header{})
 	if err != nil {
 		t.Fatalf("client: error creating stream: %v", err)


### PR DESCRIPTION

/kind flake
```release-note
NONE
```

The time to start pings should account the time needed to create the connection, hence, we should start counting AFTER the connection has. been established

Fixes: #116165