### PR TITLE
storage: Remove TestWatchDeprecated

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -104,6 +104,9 @@ type Config struct {
 	Codec runtime.Codec
 
 	Clock clock.Clock
+
+	// For injecting into watch cache to test resource expired errors.
+	WatchCacheResourceExpiredChecker func() bool
 }
 
 type watchersMap map[int]*cacheWatcher
@@ -399,6 +402,7 @@ func NewCacherFromConfig(config Config) (*Cacher, error) {
 
 	watchCache := newWatchCache(
 		config.KeyFunc, cacher.processEvent, config.GetAttrsFunc, config.Versioner, config.Indexers, config.Clock, config.GroupResource)
+	watchCache.resourceExpiredChecker = config.WatchCacheResourceExpiredChecker
 	listerWatcher := NewCacherListerWatcher(config.Storage, config.ResourcePrefix, config.NewListFunc)
 	reflectorName := "storage/cacher.go:" + config.ResourcePrefix
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -51,7 +51,7 @@ func TestDeleteTriggerWatch(t *testing.T) {
 
 func TestWatchFromZero(t *testing.T) {
 	ctx, store, client := testSetup(t)
-	storagetesting.RunTestWatchFromZero(ctx, t, store, compactStorage(client))
+	storagetesting.RunTestWatchFromZero(ctx, t, store, false, compactStorage(client))
 }
 
 // TestWatchFromNoneZero tests that

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -61,9 +61,9 @@ func TestWatchFromNoneZero(t *testing.T) {
 	storagetesting.RunTestWatchFromNoneZero(ctx, t, store)
 }
 
-func TestWatchError(t *testing.T) {
+func TestWatchErrorResourceExpired(t *testing.T) {
 	ctx, store, _ := testSetup(t)
-	storagetesting.RunTestWatchError(ctx, t, &storeWithPrefixTransformer{store})
+	storagetesting.RunTestWatchErrorResourceExpired(ctx, t, false, &storeWithPrefixTransformer{store})
 }
 
 func TestWatchContextCancel(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
@@ -315,11 +315,15 @@ func (rt *reproducingTransformer) createObject(ctx context.Context) error {
 }
 
 // failingTransformer is a custom test-only transformer that always returns
-// an error on transforming data from storage.
+// an error (that maybe injected) on transforming data from storage.
 type failingTransformer struct {
+	err error
 }
 
 func (ft *failingTransformer) TransformFromStorage(ctx context.Context, data []byte, dataCtx value.Context) ([]byte, bool, error) {
+	if ft.err != nil {
+		return nil, false, ft.err
+	}
 	return nil, false, fmt.Errorf("failed transformation")
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
@@ -225,9 +225,7 @@ func TestWatchFromZero(t *testing.T) {
 	storagetesting.RunTestWatchFromZero(ctx, t, cacher, true, nil)
 }
 
-// TODO(wojtek-t,MadhavJivrajani): We should extend the generic RunTestWatch test to cover the
-// scenarios that are not yet covered by it and get rid of this test.
-func TestWatchDeprecated(t *testing.T) {
+func TestWatchErrorResourceExpired(t *testing.T) {
 	server, etcdStorage := newEtcdTestStorage(t, etcd3testing.PathPrefix())
 	defer server.Terminate(t)
 	fakeClock := testingclock.NewFakeClock(time.Now())


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The main aim of this PR is to get rid of TestWatchDeprecated. This is done in 3 commits:

#### Commit 1: Partially get rid of it

There exists a storage test to test for rv=0 and production
of ADDED events. This commit adapts the test to be used for
the watch cache as well.

This commit removes part of the TestWatchDeprecated test.
The removed part either is tested in TestWatch or in the
new test TestWatchFromZero.

#### Commit 2: 

Rename the TestWatchDeprecated test to indicate
that it is now testing for resource version expired

#### Commit 3:

This commit allows testing etcd and watch cache for the resource
expired error. Cacher now enabled injecting a custom check that
is invoked to simulate a resource expired error.

etcd PrefixTransformer storage now allows injecting errors and we
inject a compaction error to trigger an expired error.

Sinec we didn't check for the type of error earlier and only for
an error event occuring, we recycle that test but also make it more
specific to test for resource expired errors.

Adding this test also allows us to fully remove TestWatchDeprecated.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Towards https://github.com/kubernetes/kubernetes/issues/109831

#### Special notes for your reviewer:

I reused the RunTestWatchError test to test for both error AND resource expired since we anyway did not check for what type of error was returned, this way we achieve both.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @wojtek-t 
