### PR TITLE
cleanup: replace deprecated sets.String

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -121,8 +121,8 @@ type ApplyOptions struct {
 
 	// Stores visited objects/namespaces for later use
 	// calculating the set of objects to prune.
-	VisitedUids       sets.String
-	VisitedNamespaces sets.String
+	VisitedUids       sets.Set[types.UID]
+	VisitedNamespaces sets.Set[string]
 
 	// Function run after the objects are generated and
 	// stored in the "objects" field, but before the
@@ -352,8 +352,8 @@ func (flags *ApplyFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, baseNa
 		objects:       []*resource.Info{},
 		objectsCached: false,
 
-		VisitedUids:       sets.NewString(),
-		VisitedNamespaces: sets.NewString(),
+		VisitedUids:       sets.New[types.UID](),
+		VisitedNamespaces: sets.New[string](),
 
 		ApplySet: applySet,
 	}
@@ -981,7 +981,7 @@ func (o *ApplyOptions) MarkObjectVisited(info *resource.Info) error {
 	if err != nil {
 		return err
 	}
-	o.VisitedUids.Insert(string(metadata.GetUID()))
+	o.VisitedUids.Insert(metadata.GetUID())
 	return nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/dynamic"
@@ -35,8 +36,8 @@ type pruner struct {
 	mapper        meta.RESTMapper
 	dynamicClient dynamic.Interface
 
-	visitedUids       sets.String
-	visitedNamespaces sets.String
+	visitedUids       sets.Set[types.UID]
+	visitedNamespaces sets.Set[string]
 	labelSelector     string
 	fieldSelector     string
 
@@ -119,7 +120,7 @@ func (p *pruner) prune(namespace string, mapping *meta.RESTMapping) error {
 			continue
 		}
 		uid := metadata.GetUID()
-		if p.visitedUids.Has(string(uid)) {
+		if p.visitedUids.Has(uid) {
 			continue
 		}
 		name := metadata.GetName()


### PR DESCRIPTION
Replace with generics, including using the more-accurate type
types.UID for visitedUids.
