### PR TITLE
remove redundant interface meta.List and meta.Type

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/interfaces.go
@@ -17,23 +17,10 @@ limitations under the License.
 package meta
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
-
-type ListMetaAccessor interface {
-	GetListMeta() List
-}
-
-// List lets you work with list metadata from any of the versioned or
-// internal API objects. Attempting to set or retrieve a field on an object that does
-// not support that field will be a no-op and return a default value.
-type List metav1.ListInterface
-
-// Type exposes the type and APIVersion of versioned or internal API objects.
-type Type metav1.Type
 
 // MetadataAccessor lets you work with object and list metadata from any of the versioned or
 // internal API objects. Attempting to set or retrieve a field on an object that does

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/meta.go
@@ -38,13 +38,8 @@ var errNotCommon = fmt.Errorf("object does not implement the common interface fo
 // not provide List.
 func CommonAccessor(obj interface{}) (metav1.Common, error) {
 	switch t := obj.(type) {
-	case List:
+	case metav1.ListInterface:
 		return t, nil
-	case ListMetaAccessor:
-		if m := t.GetListMeta(); m != nil {
-			return m, nil
-		}
-		return nil, errNotCommon
 	case metav1.ListMetaAccessor:
 		if m := t.GetListMeta(); m != nil {
 			return m, nil
@@ -66,15 +61,10 @@ func CommonAccessor(obj interface{}) (metav1.Common, error) {
 // not provide List.
 // IMPORTANT: Objects are NOT a superset of lists. Do not use this check to determine whether an
 // object *is* a List.
-func ListAccessor(obj interface{}) (List, error) {
+func ListAccessor(obj interface{}) (metav1.ListInterface, error) {
 	switch t := obj.(type) {
-	case List:
+	case metav1.ListInterface:
 		return t, nil
-	case ListMetaAccessor:
-		if m := t.GetListMeta(); m != nil {
-			return m, nil
-		}
-		return nil, errNotList
 	case metav1.ListMetaAccessor:
 		if m := t.GetListMeta(); m != nil {
 			return m, nil
@@ -141,7 +131,7 @@ func AsPartialObjectMetadata(m metav1.Object) *metav1.PartialObjectMetadata {
 // TODO: this interface is used to test code that does not have ObjectMeta or ListMeta
 // in round tripping (objects which can use apiVersion/kind, but do not fit the Kube
 // api conventions).
-func TypeAccessor(obj interface{}) (Type, error) {
+func TypeAccessor(obj interface{}) (metav1.Type, error) {
 	if typed, ok := obj.(runtime.Object); ok {
 		return objectAccessor{typed}, nil
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
meta.List and meta.Type is same as metav1.ListInterface and metav1.Type.
A bit redundant and hard to understand.
Also, They are not be used in other component of k8s.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
I have no idea why they are defined. This code is too far from now. 
Should we consider carefully whether it is used by a third party?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
