### PR TITLE
e2e: node: improve the reliability of e2e resource manager metrics tests

### DIFF
--- a/test/e2e_node/cpu_manager_metrics_test.go
+++ b/test/e2e_node/cpu_manager_metrics_test.go
@@ -111,9 +111,9 @@ var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager][LinuxOnly]
 			})
 
 			ginkgo.By("Giving the Kubelet time to start up and produce metrics")
-			gomega.Eventually(ctx, getKubeletMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
+			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
 			ginkgo.By("Ensuring the metrics match the expectations a few more times")
-			gomega.Consistently(ctx, getKubeletMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
+			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
 		})
 
 		ginkgo.It("should report pinning failures when the cpumanager allocation is known to fail", func(ctx context.Context) {
@@ -134,9 +134,9 @@ var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager][LinuxOnly]
 			})
 
 			ginkgo.By("Giving the Kubelet time to start up and produce metrics")
-			gomega.Eventually(ctx, getKubeletMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
+			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
 			ginkgo.By("Ensuring the metrics match the expectations a few more times")
-			gomega.Consistently(ctx, getKubeletMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
+			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
 		})
 
 		ginkgo.It("should not report any pinning failures when the cpumanager allocation is expected to succeed", func(ctx context.Context) {
@@ -157,9 +157,9 @@ var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager][LinuxOnly]
 			})
 
 			ginkgo.By("Giving the Kubelet time to start up and produce metrics")
-			gomega.Eventually(ctx, getKubeletMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
+			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
 			ginkgo.By("Ensuring the metrics match the expectations a few more times")
-			gomega.Consistently(ctx, getKubeletMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
+			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
 		})
 	})
 })

--- a/test/e2e_node/cpu_manager_metrics_test.go
+++ b/test/e2e_node/cpu_manager_metrics_test.go
@@ -198,11 +198,8 @@ func makeGuaranteedCPUExclusiveSleeperPod(name string, cpus int) *v1.Pod {
 }
 
 func timelessSample(value interface{}) types.GomegaMatcher {
-	return gstruct.PointTo(gstruct.MatchAllFields(gstruct.Fields{
+	return gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 		// We already check Metric when matching the Id
-		"Metric":    gstruct.Ignore(),
-		"Value":     gomega.BeNumerically("==", value),
-		"Timestamp": gstruct.Ignore(),
-		"Histogram": gstruct.Ignore(),
+		"Value": gomega.BeNumerically("==", value),
 	}))
 }

--- a/test/e2e_node/cpu_manager_metrics_test.go
+++ b/test/e2e_node/cpu_manager_metrics_test.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/utils/cpuset"
 )
 
-var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager]", func() {
+var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager][LinuxOnly]", func() {
 	f := framework.NewDefaultFramework("cpumanager-metrics")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
@@ -49,6 +49,8 @@ var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager]", func() {
 		var smtLevel int
 
 		ginkgo.BeforeEach(func(ctx context.Context) {
+			e2eskipper.SkipIfNodeOSDistroIs("windows")
+
 			var err error
 			if oldCfg == nil {
 				oldCfg, err = getCurrentKubeletConfig(ctx)

--- a/test/e2e_node/cpu_manager_metrics_test.go
+++ b/test/e2e_node/cpu_manager_metrics_test.go
@@ -111,9 +111,9 @@ var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager][LinuxOnly]
 			})
 
 			ginkgo.By("Giving the Kubelet time to start up and produce metrics")
-			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
+			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(matchResourceMetrics)
 			ginkgo.By("Ensuring the metrics match the expectations a few more times")
-			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
+			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(matchResourceMetrics)
 		})
 
 		ginkgo.It("should report pinning failures when the cpumanager allocation is known to fail", func(ctx context.Context) {
@@ -134,9 +134,9 @@ var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager][LinuxOnly]
 			})
 
 			ginkgo.By("Giving the Kubelet time to start up and produce metrics")
-			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
+			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(matchResourceMetrics)
 			ginkgo.By("Ensuring the metrics match the expectations a few more times")
-			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
+			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(matchResourceMetrics)
 		})
 
 		ginkgo.It("should not report any pinning failures when the cpumanager allocation is expected to succeed", func(ctx context.Context) {
@@ -157,9 +157,9 @@ var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager][LinuxOnly]
 			})
 
 			ginkgo.By("Giving the Kubelet time to start up and produce metrics")
-			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
+			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(matchResourceMetrics)
 			ginkgo.By("Ensuring the metrics match the expectations a few more times")
-			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
+			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(matchResourceMetrics)
 		})
 	})
 })

--- a/test/e2e_node/cpu_manager_metrics_test.go
+++ b/test/e2e_node/cpu_manager_metrics_test.go
@@ -118,7 +118,7 @@ var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager][LinuxOnly]
 
 		ginkgo.It("should report pinning failures when the cpumanager allocation is known to fail", func(ctx context.Context) {
 			ginkgo.By("Creating the test pod which will be rejected for SMTAlignmentError")
-			testPod = e2epod.NewPodClient(f).Create(ctx, makeGuaranteedCPUExclusiveSleeperPod("smt-align-err", 1))
+			testPod = e2epod.NewPodClient(f).CreateSync(ctx, makeGuaranteedCPUExclusiveSleeperPod("smt-align-err", 1))
 
 			// we updated the kubelet config in BeforeEach, so we can assume we start fresh.
 			// being [Serial], we can also assume noone else but us is running pods.
@@ -141,7 +141,7 @@ var _ = SIGDescribe("CPU Manager Metrics [Serial][Feature:CPUManager][LinuxOnly]
 
 		ginkgo.It("should not report any pinning failures when the cpumanager allocation is expected to succeed", func(ctx context.Context) {
 			ginkgo.By("Creating the test pod")
-			testPod = e2epod.NewPodClient(f).Create(ctx, makeGuaranteedCPUExclusiveSleeperPod("smt-align-ok", smtLevel))
+			testPod = e2epod.NewPodClient(f).CreateSync(ctx, makeGuaranteedCPUExclusiveSleeperPod("smt-align-ok", smtLevel))
 
 			// we updated the kubelet config in BeforeEach, so we can assume we start fresh.
 			// being [Serial], we can also assume noone else but us is running pods.

--- a/test/e2e_node/topology_manager_metrics_test.go
+++ b/test/e2e_node/topology_manager_metrics_test.go
@@ -101,7 +101,7 @@ var _ = SIGDescribe("Topology Manager Metrics [Serial][Feature:TopologyManager][
 
 		ginkgo.It("should report admission failures when the topology manager alignment is known to fail", func(ctx context.Context) {
 			ginkgo.By("Creating the test pod which will be rejected for TopologyAffinity")
-			testPod = e2epod.NewPodClient(f).Create(ctx, makeGuaranteedCPUExclusiveSleeperPod("topology-affinity-err", cpusNumPerNUMA+1))
+			testPod = e2epod.NewPodClient(f).CreateSync(ctx, makeGuaranteedCPUExclusiveSleeperPod("topology-affinity-err", cpusNumPerNUMA+1))
 
 			// we updated the kubelet config in BeforeEach, so we can assume we start fresh.
 			// being [Serial], we can also assume noone else but us is running pods.
@@ -127,7 +127,7 @@ var _ = SIGDescribe("Topology Manager Metrics [Serial][Feature:TopologyManager][
 
 		ginkgo.It("should not report any admission failures when the topology manager alignment is expected to succeed", func(ctx context.Context) {
 			ginkgo.By("Creating the test pod")
-			testPod = e2epod.NewPodClient(f).Create(ctx, makeGuaranteedCPUExclusiveSleeperPod("topology-alignment-ok", cpusNumPerNUMA))
+			testPod = e2epod.NewPodClient(f).CreateSync(ctx, makeGuaranteedCPUExclusiveSleeperPod("topology-alignment-ok", cpusNumPerNUMA))
 
 			// we updated the kubelet config in BeforeEach, so we can assume we start fresh.
 			// being [Serial], we can also assume noone else but us is running pods.

--- a/test/e2e_node/topology_manager_metrics_test.go
+++ b/test/e2e_node/topology_manager_metrics_test.go
@@ -94,9 +94,9 @@ var _ = SIGDescribe("Topology Manager Metrics [Serial][Feature:TopologyManager][
 			})
 
 			ginkgo.By("Giving the Kubelet time to start up and produce metrics")
-			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
+			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(matchResourceMetrics)
 			ginkgo.By("Ensuring the metrics match the expectations a few more times")
-			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
+			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(matchResourceMetrics)
 		})
 
 		ginkgo.It("should report admission failures when the topology manager alignment is known to fail", func(ctx context.Context) {
@@ -120,9 +120,9 @@ var _ = SIGDescribe("Topology Manager Metrics [Serial][Feature:TopologyManager][
 			})
 
 			ginkgo.By("Giving the Kubelet time to start up and produce metrics")
-			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
+			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(matchResourceMetrics)
 			ginkgo.By("Ensuring the metrics match the expectations a few more times")
-			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
+			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(matchResourceMetrics)
 		})
 
 		ginkgo.It("should not report any admission failures when the topology manager alignment is expected to succeed", func(ctx context.Context) {
@@ -146,9 +146,9 @@ var _ = SIGDescribe("Topology Manager Metrics [Serial][Feature:TopologyManager][
 			})
 
 			ginkgo.By("Giving the Kubelet time to start up and produce metrics")
-			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
+			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(matchResourceMetrics)
 			ginkgo.By("Ensuring the metrics match the expectations a few more times")
-			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
+			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(2 * time.Second).Should(matchResourceMetrics)
 		})
 	})
 })

--- a/test/e2e_node/topology_manager_metrics_test.go
+++ b/test/e2e_node/topology_manager_metrics_test.go
@@ -171,11 +171,8 @@ func hostCheck() (int, int) {
 }
 
 func checkMetricValueGreaterThan(value interface{}) types.GomegaMatcher {
-	return gstruct.PointTo(gstruct.MatchAllFields(gstruct.Fields{
+	return gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 		// We already check Metric when matching the Id
-		"Metric":    gstruct.Ignore(),
-		"Value":     gomega.BeNumerically(">", value),
-		"Timestamp": gstruct.Ignore(),
-		"Histogram": gstruct.Ignore(),
+		"Value": gomega.BeNumerically(">", value),
 	}))
 }

--- a/test/e2e_node/topology_manager_metrics_test.go
+++ b/test/e2e_node/topology_manager_metrics_test.go
@@ -94,9 +94,9 @@ var _ = SIGDescribe("Topology Manager Metrics [Serial][Feature:TopologyManager][
 			})
 
 			ginkgo.By("Giving the Kubelet time to start up and produce metrics")
-			gomega.Eventually(ctx, getKubeletMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
+			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
 			ginkgo.By("Ensuring the metrics match the expectations a few more times")
-			gomega.Consistently(ctx, getKubeletMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
+			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
 		})
 
 		ginkgo.It("should report admission failures when the topology manager alignment is known to fail", func(ctx context.Context) {
@@ -120,9 +120,9 @@ var _ = SIGDescribe("Topology Manager Metrics [Serial][Feature:TopologyManager][
 			})
 
 			ginkgo.By("Giving the Kubelet time to start up and produce metrics")
-			gomega.Eventually(ctx, getKubeletMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
+			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
 			ginkgo.By("Ensuring the metrics match the expectations a few more times")
-			gomega.Consistently(ctx, getKubeletMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
+			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
 		})
 
 		ginkgo.It("should not report any admission failures when the topology manager alignment is expected to succeed", func(ctx context.Context) {
@@ -146,9 +146,9 @@ var _ = SIGDescribe("Topology Manager Metrics [Serial][Feature:TopologyManager][
 			})
 
 			ginkgo.By("Giving the Kubelet time to start up and produce metrics")
-			gomega.Eventually(ctx, getKubeletMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
+			gomega.Eventually(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
 			ginkgo.By("Ensuring the metrics match the expectations a few more times")
-			gomega.Consistently(ctx, getKubeletMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
+			gomega.Consistently(ctx, getKubeletMetrics).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(matchResourceMetrics)
 		})
 	})
 })

--- a/test/e2e_node/topology_manager_metrics_test.go
+++ b/test/e2e_node/topology_manager_metrics_test.go
@@ -34,7 +34,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-var _ = SIGDescribe("Topology Manager Metrics [Serial][NodeFeature:TopologyManager]", func() {
+var _ = SIGDescribe("Topology Manager Metrics [Serial][Feature:TopologyManager][LinuxOnly]", func() {
 	f := framework.NewDefaultFramework("topologymanager-metrics")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
@@ -44,6 +44,8 @@ var _ = SIGDescribe("Topology Manager Metrics [Serial][NodeFeature:TopologyManag
 		var cpusNumPerNUMA, numaNodes int
 
 		ginkgo.BeforeEach(func(ctx context.Context) {
+			e2eskipper.SkipIfNodeOSDistroIs("windows")
+
 			var err error
 			if oldCfg == nil {
 				oldCfg, err = getCurrentKubeletConfig(ctx)


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
/kind flake

#### What this PR does / why we need it:
Flake **prevention** and readability improvements. We are seeing some flakes in some local test environments and we would like to cut off flakes, including possible project flakes.

#### Which issue(s) this PR fixes:
Fixes N/A

#### Special notes for your reviewer:
We also make explicit these tests are currently supported on linux. The tests themselves are generic, but the setup code use linuxisms (mostly for practical reasons, no actual dependency)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
