### PR TITLE
controller-manager: can exclude controllers that do not exist

### DIFF
--- a/staging/src/k8s.io/controller-manager/options/generic.go
+++ b/staging/src/k8s.io/controller-manager/options/generic.go
@@ -113,9 +113,13 @@ func (o *GenericControllerManagerConfigurationOptions) Validate(allControllers [
 		if controller == "*" {
 			continue
 		}
-		controller = strings.TrimPrefix(controller, "-")
-		if !allControllersSet.Has(controller) {
-			errs = append(errs, fmt.Errorf("%q is not in the list of known controllers", controller))
+		if strings.HasPrefix(controller, "-") {
+			// We allow exclusion of a non-existent controller,
+			// so that it is easier to introduce new controllers.
+		} else {
+			if !allControllersSet.Has(controller) {
+				errs = append(errs, fmt.Errorf("%q is not in the list of known controllers", controller))
+			}
 		}
 	}
 

--- a/staging/src/k8s.io/controller-manager/options/generic_test.go
+++ b/staging/src/k8s.io/controller-manager/options/generic_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	cmconfig "k8s.io/controller-manager/config"
+)
+
+func TestValidateControllers(t *testing.T) {
+	allControllers := []string{"defaulton1", "defaulton2", "defaultoff1", "defaultoff2"}
+	disabledByDefaultControllers := []string{"defaultoff1", "defaultoff2"}
+
+	grid := []struct {
+		Name           string
+		Controllers    []string
+		ExpectedErrors []string
+	}{
+		{
+			Name:           "exclude-known-controller",
+			Controllers:    []string{"-defaulton1"},
+			ExpectedErrors: nil,
+		},
+		{
+			Name:           "exclude-unknown-controller",
+			Controllers:    []string{"-notacontroller"},
+			ExpectedErrors: nil,
+		},
+		{
+			Name:        "include-unknown-controller",
+			Controllers: []string{"notacontroller"},
+			ExpectedErrors: []string{
+				`"notacontroller" is not in the list of known controllers`,
+			},
+		},
+	}
+
+	for _, g := range grid {
+		t.Run(g.Name, func(t *testing.T) {
+			options := GenericControllerManagerConfigurationOptions{
+				GenericControllerManagerConfiguration: &cmconfig.GenericControllerManagerConfiguration{
+					Controllers: g.Controllers,
+				},
+			}
+
+			errors := options.Validate(allControllers, disabledByDefaultControllers)
+			var errorStrings []string
+			for _, err := range errors {
+				errorStrings = append(errorStrings, err.Error())
+			}
+			got := strings.Join(errorStrings, "\n")
+			want := strings.Join(g.ExpectedErrors, "\n")
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("unexpected output from Validate (-want, +got): %v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Users should be able to exclude a controller, and it should not be an
error if that controller is compiled-out or not yet compiled-in.

This allows for the flags to be more stable when new controllers are
introduced, we don't have to match the flags to an image version.

Issue #116186

/kind cleanup

```release-note

Users can exclude controllers that do not exist from binaries using k8s.io/controller-manager/options.
```