### PR TITLE
Add alternative to kubelet's --cloud-provider=external

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	cloudproviderapi "k8s.io/cloud-provider/api"
 	cliflag "k8s.io/component-base/cli/flag"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/kubelet/config/v1beta1"
@@ -317,8 +318,8 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 	fs.MarkDeprecated("keep-terminated-pod-volumes", "will be removed in a future version")
 	fs.StringVar(&f.ExperimentalMounterPath, "experimental-mounter-path", f.ExperimentalMounterPath, "[Experimental] Path of mounter binary. Leave empty to use the default mount.")
 	fs.MarkDeprecated("experimental-mounter-path", "will be removed in 1.25 or later. in favor of using CSI.")
-	fs.StringVar(&f.CloudProvider, "cloud-provider", f.CloudProvider, "The provider for cloud services. Set to empty string for running with no cloud provider. If set, the cloud provider determines the name of the node (consult cloud provider documentation to determine if and how the hostname is used).")
-	fs.MarkDeprecated("cloud-provider", "will be removed in 1.25 or later, in favor of removing cloud provider code from Kubelet.")
+	fs.StringVar(&f.CloudProvider, "cloud-provider", f.CloudProvider, fmt.Sprintf("The provider for cloud services. Set to empty string for running with no cloud provider. If set, the cloud provider determines the name of the node (consult cloud provider documentation to determine if and how the hostname is used).  If set to 'external', then kubelet will taint nodes with %s.", cloudproviderapi.TaintExternalCloudProvider))
+	fs.MarkDeprecated("cloud-provider", "will be removed in 1.25 or later. Enabling taints for an external cloud provider should be done with KubeletConfiguration.ExternalCloudProvider.")
 	fs.StringVar(&f.CloudConfigFile, "cloud-config", f.CloudConfigFile, "The path to the cloud provider configuration file. Empty string for no configuration file.")
 	fs.MarkDeprecated("cloud-config", "will be removed in 1.25 or later, in favor of removing cloud provider code from Kubelet.")
 	fs.BoolVar(&f.ExperimentalNodeAllocatableIgnoreEvictionThreshold, "experimental-allocatable-ignore-eviction", f.ExperimentalNodeAllocatableIgnoreEvictionThreshold, "When set to 'true', Hard Eviction Thresholds will be ignored while calculating Node Allocatable. See https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/ for more details. [default=false]")

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -58845,6 +58845,13 @@ func schema_k8sio_kubelet_config_v1beta1_KubeletConfiguration(ref common.Referen
 							Format:      "",
 						},
 					},
+					"externalCloudProvider": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ExternalCloudProvider replaces --cloud-provider=external.  When set to true, an external cloud provider is expected to be used.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"kernelMemcgNotification": {
 						SchemaProps: spec.SchemaProps{
 							Description: "kernelMemcgNotification, if set, instructs the kubelet to integrate with the kernel memcg notification for determining if memory eviction thresholds are exceeded rather than polling. Default: false",

--- a/pkg/kubelet/apis/config/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/config/fuzzer/fuzzer.go
@@ -116,6 +116,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.EnableSystemLogHandler = true
 			obj.MemoryThrottlingFactor = utilpointer.Float64(rand.Float64())
 			obj.LocalStorageCapacityIsolation = true
+			obj.ExternalCloudProvider = true
 		},
 	}
 }

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -203,6 +203,7 @@ var (
 		"EvictionPressureTransitionPeriod.Duration",
 		"EvictionSoft[*]",
 		"EvictionSoftGracePeriod[*]",
+		"ExternalCloudProvider",
 		"FailSwapOn",
 		"FeatureGates[*]",
 		"FileCheckFrequency.Duration",

--- a/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1.yaml
@@ -35,6 +35,7 @@ enforceNodeAllocatable:
 eventBurst: 100
 eventRecordQPS: 50
 evictionPressureTransitionPeriod: 5m0s
+externalCloudProvider: false
 failSwapOn: true
 fileCheckFrequency: 20s
 hairpinMode: promiscuous-bridge

--- a/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/roundtrip/default/v1beta1.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/roundtrip/default/v1beta1.yaml
@@ -35,6 +35,7 @@ enforceNodeAllocatable:
 eventBurst: 10
 eventRecordQPS: 5
 evictionPressureTransitionPeriod: 5m0s
+externalCloudProvider: false
 failSwapOn: true
 fileCheckFrequency: 20s
 hairpinMode: promiscuous-bridge

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -114,6 +114,9 @@ type KubeletConfiguration struct {
 	// providerID, if set, sets the unique id of the instance that an external provider (i.e. cloudprovider)
 	// can use to identify a specific node
 	ProviderID string
+	// ExternalCloudProvider replaces --cloud-provider=external.  When set to
+	// true, an external cloud provider is expected to be used
+	ExternalCloudProvider bool
 	// tlsCertFile is the file containing x509 Certificate for HTTPS.  (CA cert,
 	// if any, concatenated after server cert). If tlsCertFile and
 	// tlsPrivateKeyFile are not provided, a self-signed certificate

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -274,4 +274,7 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 	if obj.ContainerRuntimeEndpoint == "" {
 		obj.ContainerRuntimeEndpoint = "unix:///run/containerd/containerd.sock"
 	}
+	if obj.ExternalCloudProvider == nil {
+		obj.ExternalCloudProvider = utilpointer.BoolPtr(false)
+	}
 }

--- a/pkg/kubelet/apis/config/v1beta1/defaults_test.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults_test.go
@@ -124,6 +124,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				MemoryThrottlingFactor:        utilpointer.Float64(DefaultMemoryThrottlingFactor),
 				RegisterNode:                  utilpointer.Bool(true),
 				LocalStorageCapacityIsolation: utilpointer.Bool(true),
+				ExternalCloudProvider:         utilpointer.Bool(false),
 			},
 		},
 		{
@@ -251,6 +252,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				MemoryThrottlingFactor:          utilpointer.Float64(0),
 				RegisterNode:                    utilpointer.Bool(false),
 				LocalStorageCapacityIsolation:   utilpointer.Bool(false),
+				ExternalCloudProvider:           utilpointer.Bool(false),
 			},
 			&v1beta1.KubeletConfiguration{
 				EnableServer:       utilpointer.Bool(false),
@@ -349,6 +351,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				MemoryThrottlingFactor:        utilpointer.Float64(0),
 				RegisterNode:                  utilpointer.Bool(false),
 				LocalStorageCapacityIsolation: utilpointer.Bool(false),
+				ExternalCloudProvider:         utilpointer.Bool(false),
 			},
 		},
 		{
@@ -498,6 +501,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				MemoryThrottlingFactor:        utilpointer.Float64(1),
 				RegisterNode:                  utilpointer.Bool(true),
 				LocalStorageCapacityIsolation: utilpointer.Bool(true),
+				ExternalCloudProvider:         utilpointer.Bool(true),
 			},
 			&v1beta1.KubeletConfiguration{
 				EnableServer:       utilpointer.Bool(true),
@@ -644,6 +648,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				MemoryThrottlingFactor:        utilpointer.Float64(1),
 				RegisterNode:                  utilpointer.Bool(true),
 				LocalStorageCapacityIsolation: utilpointer.Bool(true),
+				ExternalCloudProvider:         utilpointer.Bool(true),
 			},
 		},
 		{
@@ -733,6 +738,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				MemoryThrottlingFactor:        utilpointer.Float64Ptr(DefaultMemoryThrottlingFactor),
 				RegisterNode:                  utilpointer.Bool(true),
 				LocalStorageCapacityIsolation: utilpointer.Bool(true),
+				ExternalCloudProvider:         utilpointer.Bool(false),
 			},
 		},
 		{
@@ -822,6 +828,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				MemoryThrottlingFactor:        utilpointer.Float64Ptr(DefaultMemoryThrottlingFactor),
 				RegisterNode:                  utilpointer.Bool(true),
 				LocalStorageCapacityIsolation: utilpointer.Bool(true),
+				ExternalCloudProvider:         utilpointer.Bool(false),
 			},
 		},
 		{
@@ -911,6 +918,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				MemoryThrottlingFactor:        utilpointer.Float64(DefaultMemoryThrottlingFactor),
 				RegisterNode:                  utilpointer.Bool(true),
 				LocalStorageCapacityIsolation: utilpointer.Bool(true),
+				ExternalCloudProvider:         utilpointer.Bool(false),
 			},
 		},
 	}

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -486,6 +486,9 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	out.AllowedUnsafeSysctls = *(*[]string)(unsafe.Pointer(&in.AllowedUnsafeSysctls))
 	out.VolumePluginDir = in.VolumePluginDir
 	out.ProviderID = in.ProviderID
+	if err := v1.Convert_Pointer_bool_To_bool(&in.ExternalCloudProvider, &out.ExternalCloudProvider, s); err != nil {
+		return err
+	}
 	out.KernelMemcgNotification = in.KernelMemcgNotification
 	out.Logging = in.Logging
 	if err := v1.Convert_Pointer_bool_To_bool(&in.EnableSystemLogHandler, &out.EnableSystemLogHandler, s); err != nil {
@@ -541,6 +544,9 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	out.ReadOnlyPort = in.ReadOnlyPort
 	out.VolumePluginDir = in.VolumePluginDir
 	out.ProviderID = in.ProviderID
+	if err := v1.Convert_bool_To_Pointer_bool(&in.ExternalCloudProvider, &out.ExternalCloudProvider, s); err != nil {
+		return err
+	}
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	out.TLSCipherSuites = *(*[]string)(unsafe.Pointer(&in.TLSCipherSuites))

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -676,6 +676,10 @@ type KubeletConfiguration struct {
 	// Default: ""
 	// +optional
 	ProviderID string `json:"providerID,omitempty"`
+	// ExternalCloudProvider replaces --cloud-provider=external.  When set to
+	// true, an external cloud provider is expected to be used.
+	// +optional
+	ExternalCloudProvider *bool `json:"externalCloudProvider,omitempty"`
 	// kernelMemcgNotification, if set, instructs the kubelet to integrate with the
 	// kernel memcg notification for determining if memory eviction thresholds are
 	// exceeded rather than polling.

--- a/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
@@ -407,6 +407,11 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExternalCloudProvider != nil {
+		in, out := &in.ExternalCloudProvider, &out.ExternalCloudProvider
+		*out = new(bool)
+		**out = **in
+	}
 	in.Logging.DeepCopyInto(&out.Logging)
 	if in.EnableSystemLogHandler != nil {
 		in, out := &in.EnableSystemLogHandler, &out.EnableSystemLogHandler


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind documentation
/kind deprecation

#### What this PR does / why we need it:

This is a continuation of #110066.

The intended removal of kubelet's `--cloud-provider` string flag, after all in-tree cloud providers are removed, will result in kubelet having no way to toggle the behavior associated with external cloud providers.

This PR adds a boolean option, `KubeletConfiguration.ExternalCloudProvider`, which will ultimately replace the `--cloud-provider` flag once the only-remaining acceptable values are `external` and the empty string.

#### Which issue(s) this PR fixes:

Fixes #110018

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Yes.

```release-note
A boolean alternative to kubelet's deprecated `--cloud-provider` flag was added (`ExternalCloudProvider`), because only the in-tree values are deprecated.  The need to specify whether or not an external cloud provider is running is still necessary. When migrating from an in-tree to external cloud provider, this option should be preferred over `--cloud-provider=external`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Other doc]: https://github.com/kubernetes/website/blob/9137c09b0a38bcbe248e749458542931c9b28c93/content/en/docs/tasks/administer-cluster/running-cloud-controller.md?plain=1#L34-L44
```
