### PR TITLE
Fixes bug with Root not handling Group without Version

### DIFF
--- a/staging/src/k8s.io/client-go/openapi3/root.go
+++ b/staging/src/k8s.io/client-go/openapi3/root.go
@@ -157,6 +157,10 @@ func pathToGroupVersion(path string) (schema.GroupVersion, error) {
 	}
 	apiPrefix := parts[0]
 	if apiPrefix == "apis" {
+		// Example: apis/apps (without version)
+		if len(parts) < 3 {
+			return gv, fmt.Errorf("Group without Version not allowed")
+		}
 		gv.Group = parts[1]
 		gv.Version = parts[2]
 	} else if apiPrefix == "api" {


### PR DESCRIPTION
* Fixes bug with `Root.GroupVersions()`. It should handle the case where OpenAPI V3 returns a path of a Group without a Version. For example, the following OpenAPI V3 path is valid, but should not return a `Group/Version`: `apis/apps`. Without this fix, the example path causes a crash.
* Unit test coverage: `98.1%`.

/kind bug

```release-note
NONE
```
