### PR TITLE
Automated cherry pick of #116089: fix: should not set default storageclass if annotation "volume.beta.kubernetes.io/storage-class" is set

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -930,7 +930,7 @@ func (ctrl *PersistentVolumeController) updateVolumePhaseWithEvent(volume *v1.Pe
 // Ignores claims that already have a storage class.
 // TODO: if resync is ever changed to a larger period, we might need to change how we set the default class on existing unbound claims
 func (ctrl *PersistentVolumeController) assignDefaultStorageClass(claim *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
-	if claim.Spec.StorageClassName != nil {
+	if storagehelpers.GetPersistentVolumeClaimClass(claim) != "" {
 		return claim, nil
 	}
 

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -855,6 +855,24 @@ func TestRetroactiveStorageClassAssignment(t *testing.T) {
 				},
 			},
 		},
+		{
+			storageClasses: []*storagev1.StorageClass{
+				makeDefaultStorageClass(classGold, &modeImmediate),
+				makeStorageClass(classCopper, &modeImmediate),
+			},
+			tests: []controllerTest{
+				{
+					name:            "15-7 - pvc storage class is not changed if claim is not bound but already set annotation \"volume.beta.kubernetes.io/storage-class\"",
+					initialVolumes:  novolumes,
+					expectedVolumes: novolumes,
+					initialClaims:   newClaimArray("claim15-7", "uid15-7", "1Gi", "", v1.ClaimPending, nil, v1.BetaStorageClassAnnotation),
+					expectedClaims:  newClaimArray("claim15-7", "uid15-7", "1Gi", "", v1.ClaimPending, nil, v1.BetaStorageClassAnnotation),
+					expectedEvents:  noevents,
+					errors:          noerrors,
+					test:            testSyncClaim,
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		runSyncTests(t, test.tests, test.storageClasses, nil)


### PR DESCRIPTION
Cherry pick of #116089 on release-1.25.

#116089: fix 116028

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a bug where Kubernetes would apply a default StorageClass to a PersistentVolumeClaim,
even when the deprecated annotation `volume.beta.kubernetes.io/storage-class` was set.
```
