### PR TITLE
Add a Clear() function to generic sets

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/set.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/set.go
@@ -64,6 +64,20 @@ func (s Set[T]) Delete(items ...T) Set[T] {
 	return s
 }
 
+// Clear empties the set.
+// It is preferable to replace the set with a newly constructed set,
+// but not all callers can do that (when there are other references to the map).
+// In some cases the set *won't* be fully cleared, e.g. a Set[float32] containing NaN
+// can't be cleared because NaN can't be removed.
+// For sets containing items of a type that is reflexive for ==,
+// this is optimized to a single call to runtime.mapclear().
+func (s Set[T]) Clear() Set[T] {
+	for key := range s {
+		delete(s, key)
+	}
+	return s
+}
+
 // Has returns true if and only if item is contained in the set.
 func (s Set[T]) Has(item T) bool {
 	_, contained := s[item]

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/set_generic_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/set_generic_test.go
@@ -84,6 +84,57 @@ func TestSetDeleteMultiples(t *testing.T) {
 
 }
 
+func TestSetClear(t *testing.T) {
+	s := sets.Set[string]{}
+	s.Insert("a", "b", "c")
+	if s.Len() != 3 {
+		t.Errorf("Expected len=3: %d", s.Len())
+	}
+
+	s.Clear()
+	if s.Len() != 0 {
+		t.Errorf("Expected len=0: %d", s.Len())
+	}
+}
+
+func TestSetClearWithSharedReference(t *testing.T) {
+	s := sets.Set[string]{}
+	s.Insert("a", "b", "c")
+	if s.Len() != 3 {
+		t.Errorf("Expected len=3: %d", s.Len())
+	}
+
+	m := s
+	s.Clear()
+	if s.Len() != 0 {
+		t.Errorf("Expected len=0 on the cleared set: %d", s.Len())
+	}
+	if m.Len() != 0 {
+		t.Errorf("Expected len=0 on the shared reference: %d", m.Len())
+	}
+}
+
+func TestSetClearInSeparateFunction(t *testing.T) {
+	s := sets.Set[string]{}
+	s.Insert("a", "b", "c")
+	if s.Len() != 3 {
+		t.Errorf("Expected len=3: %d", s.Len())
+	}
+
+	clearSetAndAdd(s, "d")
+	if s.Len() != 1 {
+		t.Errorf("Expected len=1: %d", s.Len())
+	}
+	if !s.Has("d") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+}
+
+func clearSetAndAdd[T comparable](s sets.Set[T], a T) {
+	s.Clear()
+	s.Insert(a)
+}
+
 func TestNewSet(t *testing.T) {
 	s := sets.New("a", "b", "c")
 	if len(s) != 3 {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

This adds a `Clear()` function to empty a generic set.

This is useful when a given set is shared through pointers, and therefore can't be replaced with a new empty set. It replaces `set.Delete(set.UnsortedList()...)`.

I suspect this is of debatable value, especially since Go maps don’t have any equivalent function and the general idea _is_ to use new maps instead of clearing existing maps. We’ve found this useful [in our own implementation of string sets](https://pkg.go.dev/github.com/submariner-io/admiral@v0.14.2/pkg/stringset), which I’d like to drop in favour of k8s.io’s generic sets; for now I’ve replace this with `set.Delete(set.UnsortedList()...)` but having a dedicated function would be nicer.

In many cases this optimises to a call to `runtime.mapclear()`, which is faster than generating the list of items and iterating over them to delete them; see https://godbolt.org/z/7YEvYcGbv

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
