### PR TITLE
Wait for pod to be running before expanding

### DIFF
--- a/test/e2e/storage/flexvolume_mounted_volume_resize.go
+++ b/test/e2e/storage/flexvolume_mounted_volume_resize.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	// total time to wait for cloudprovider or file system resize to finish
-	totalResizeWaitPeriod = 5 * time.Minute
+	totalResizeWaitPeriod = 10 * time.Minute
 )
 
 var _ = utils.SIGDescribe("[Feature:Flexvolumes] Mounted flexvolume expand[Slow]", func() {

--- a/test/e2e/storage/mounted_volume_resize.go
+++ b/test/e2e/storage/mounted_volume_resize.go
@@ -121,6 +121,14 @@ var _ = utils.SIGDescribe("Mounted volume expand [Feature:StorageProvider]", fun
 		framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
 		framework.ExpectEqual(len(pvs), 1)
 
+		ginkgo.By("Wait for a pod from deployment to be running")
+		podList, err := e2edeployment.GetPodsForDeployment(ctx, c, deployment)
+		framework.ExpectNoError(err, "While getting pods from deployment")
+		gomega.Expect(podList.Items).NotTo(gomega.BeEmpty())
+		pod := podList.Items[0]
+		err = e2epod.WaitTimeoutForPodRunningInNamespace(ctx, c, pod.Name, pod.Namespace, f.Timeouts.PodStart)
+		framework.ExpectNoError(err, "While waiting for pods to be ready")
+
 		ginkgo.By("Expanding current pvc")
 		newSize := resource.MustParse("6Gi")
 		newPVC, err := testsuites.ExpandPVCSize(ctx, pvc, newSize, c)
@@ -138,10 +146,10 @@ var _ = utils.SIGDescribe("Mounted volume expand [Feature:StorageProvider]", fun
 		framework.ExpectNoError(err, "While waiting for pvc resize to finish")
 
 		ginkgo.By("Getting a pod from deployment")
-		podList, err := e2edeployment.GetPodsForDeployment(ctx, c, deployment)
+		podList, err = e2edeployment.GetPodsForDeployment(ctx, c, deployment)
 		framework.ExpectNoError(err, "While getting pods from deployment")
 		gomega.Expect(podList.Items).NotTo(gomega.BeEmpty())
-		pod := podList.Items[0]
+		pod = podList.Items[0]
 
 		ginkgo.By("Deleting the pod from deployment")
 		err = e2epod.DeletePodWithWait(ctx, c, &pod)


### PR DESCRIPTION
This fixes a flake that sometimes happens when expansion is called before volume is attached.
