### PR TITLE
Add custom error struct for Group/Version not found

### DIFF
--- a/staging/src/k8s.io/client-go/openapi3/root.go
+++ b/staging/src/k8s.io/client-go/openapi3/root.go
@@ -125,7 +125,7 @@ func (r *root) retrieveGVBytes(gv schema.GroupVersion) ([]byte, error) {
 	apiPath := gvToAPIPath(gv)
 	gvOpenAPI, found := paths[apiPath]
 	if !found {
-		return nil, fmt.Errorf("GroupVersion (%s) not found in OpenAPI V3 root document", gv)
+		return nil, &GroupVersionNotFoundError{gv: gv}
 	}
 	return gvOpenAPI.Schema(runtime.ContentTypeJSON)
 }
@@ -169,4 +169,14 @@ func pathToGroupVersion(path string) (schema.GroupVersion, error) {
 		return gv, fmt.Errorf("Unable to parse api relative path: %s", path)
 	}
 	return gv, nil
+}
+
+// Encapsulates GroupVersion not found as one of the paths
+// at OpenAPI V3 endpoint.
+type GroupVersionNotFoundError struct {
+	gv schema.GroupVersion
+}
+
+func (r *GroupVersionNotFoundError) Error() string {
+	return fmt.Sprintf("GroupVersion (%v) not found as OpenAPI V3 path", r.gv)
 }

--- a/staging/src/k8s.io/client-go/openapi3/root_test.go
+++ b/staging/src/k8s.io/client-go/openapi3/root_test.go
@@ -113,7 +113,7 @@ func TestOpenAPIV3Root_GVSpec(t *testing.T) {
 		name          string
 		gv            schema.GroupVersion
 		expectedPaths []string
-		err           bool
+		err           error
 	}{
 		{
 			name: "OpenAPI V3 for apps/v1 works",
@@ -144,7 +144,7 @@ func TestOpenAPIV3Root_GVSpec(t *testing.T) {
 		{
 			name: "OpenAPI V3 spec not found",
 			gv:   schema.GroupVersion{Group: "not", Version: "found"},
-			err:  true,
+			err:  &GroupVersionNotFoundError{gv: schema.GroupVersion{Group: "not", Version: "found"}},
 		},
 	}
 
@@ -153,8 +153,8 @@ func TestOpenAPIV3Root_GVSpec(t *testing.T) {
 			client := openapitest.NewFileClient(t)
 			root := NewRoot(client)
 			gvSpec, err := root.GVSpec(test.gv)
-			if test.err {
-				require.Error(t, err)
+			if test.err != nil {
+				assert.True(t, reflect.DeepEqual(test.err, err))
 				return
 			}
 			require.NoError(t, err)
@@ -172,7 +172,7 @@ func TestOpenAPIV3Root_GVSpecAsMap(t *testing.T) {
 		name          string
 		gv            schema.GroupVersion
 		expectedPaths []string
-		err           bool
+		err           error
 	}{
 		{
 			name: "OpenAPI V3 for apps/v1 works",
@@ -203,7 +203,7 @@ func TestOpenAPIV3Root_GVSpecAsMap(t *testing.T) {
 		{
 			name: "OpenAPI V3 spec not found",
 			gv:   schema.GroupVersion{Group: "not", Version: "found"},
-			err:  true,
+			err:  &GroupVersionNotFoundError{gv: schema.GroupVersion{Group: "not", Version: "found"}},
 		},
 	}
 
@@ -212,8 +212,8 @@ func TestOpenAPIV3Root_GVSpecAsMap(t *testing.T) {
 			client := openapitest.NewFileClient(t)
 			root := NewRoot(client)
 			gvSpecAsMap, err := root.GVSpecAsMap(test.gv)
-			if test.err {
-				require.Error(t, err)
+			if test.err != nil {
+				assert.True(t, reflect.DeepEqual(test.err, err))
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
* Adds custom error struct `GroupVersionNotFoundError` for OpenAPI V3 `Root`, instead of current unstructured error string. Allows users of `Root` to more accurately and reliably check this error condition.
* Adds unit tests to validate the error is returned in the proper situations.
* Unit test coverage: `96.2%`

/kind cleanup

```release-note
NONE
```
