### PR TITLE
Create and update the ApplySet parent object

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apply
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -38,6 +39,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/csaupgrade"
+	"k8s.io/component-base/version"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/cmd/delete"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -300,14 +302,22 @@ func (flags *ApplyFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, baseNa
 
 	var applySet *ApplySet
 	if flags.ApplySetRef != "" {
-		var applySetNs string
+		parent, err := ParseApplySetParentRef(flags.ApplySetRef, mapper)
+		if err != nil {
+			return nil, fmt.Errorf("invalid parent reference %q: %w", flags.ApplySetRef, err)
+		}
 		// ApplySet uses the namespace value from the flag, but not from the kubeconfig or defaults
-		if enforceNamespace {
-			applySetNs = namespace
+		// This means the namespace flag is required when using a namespaced parent.
+		if enforceNamespace && parent.IsNamespaced() {
+			parent.Namespace = namespace
 		}
-		if applySet, err = NewApplySet(flags.ApplySetRef, applySetNs, mapper); err != nil {
-			return nil, err
+		// TODO: is version.Get() the right thing? Does it work for non-kubectl package consumers?
+		tooling := ApplySetTooling{name: baseName, version: version.Get().String()}
+		restClient, err := f.ClientForMapping(parent.RESTMapping)
+		if err != nil || restClient == nil {
+			return nil, fmt.Errorf("failed to initialize RESTClient for ApplySet: %w", err)
 		}
+		applySet = NewApplySet(parent, tooling, mapper, restClient)
 	}
 	if flags.Prune {
 		pruneAllowlist := slice.ToSet(flags.PruneAllowlist, flags.PruneWhitelist)
@@ -408,8 +418,7 @@ func (o *ApplyOptions) Validate() error {
 			} else if len(o.PruneResources) > 0 {
 				return fmt.Errorf("--prune-allowlist is incompatible with --applyset")
 			} else {
-				// TODO: remove this once ApplySet implementation is complete
-				return fmt.Errorf("--applyset is not yet supported")
+				klog.Warning("WARNING: --prune --applyset is not fully implemented and does not yet prune any resources.")
 			}
 		} else {
 			if !o.All && o.Selector == "" {
@@ -496,6 +505,12 @@ func (o *ApplyOptions) Run() error {
 	}
 	if len(infos) == 0 && len(errs) == 0 {
 		return fmt.Errorf("no objects passed to apply")
+	}
+
+	if o.ApplySet != nil {
+		if err := o.ApplySet.FetchParent(); err != nil {
+			return err
+		}
 	}
 	// Iterate through all objects, applying each one.
 	for _, info := range infos {
@@ -982,6 +997,10 @@ func (o *ApplyOptions) MarkObjectVisited(info *resource.Info) error {
 		return err
 	}
 	o.VisitedUids.Insert(metadata.GetUID())
+
+	if o.ApplySet != nil {
+		o.ApplySet.MarkObjectVisited(info.Mapping, info.Namespace)
+	}
 	return nil
 }
 
@@ -993,14 +1012,21 @@ func (o *ApplyOptions) MarkObjectVisited(info *resource.Info) error {
 func (o *ApplyOptions) PrintAndPrunePostProcessor() func() error {
 
 	return func() error {
+		ctx := context.TODO()
 		if err := o.printObjects(); err != nil {
 			return err
 		}
 
 		if o.Prune {
 			if cmdutil.ApplySet.IsEnabled() && o.ApplySet != nil {
-				p := newApplySetPruner(o)
-				return p.pruneAll()
+				pruner := newApplySetPruner(o)
+				if err := pruner.pruneAll(ctx, o.ApplySet); err != nil {
+					applySetErr := o.ApplySet.UpdateParent(SetUpdateIncomplete, o.DryRunStrategy, o.ValidationDirective)
+					return utilerrors.NewAggregate([]error{err, applySetErr})
+				}
+				if err := o.ApplySet.UpdateParent(SetUpdateSuccessful, o.DryRunStrategy, o.ValidationDirective); err != nil {
+					return fmt.Errorf("apply and prune succeeded, but ApplySet update failed: %w", err)
+				}
 			} else {
 				p := newPruner(o)
 				return p.pruneAll(o)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -335,20 +335,6 @@ func readReplicationController(t *testing.T, filenameRC string) (string, []byte)
 	return metaAccessor.GetName(), rcBytes
 }
 
-func readService(t *testing.T, filenameSVC string) (string, []byte) {
-	svcObj := readServiceFromFile(t, filenameSVC)
-	metaAccessor, err := meta.Accessor(svcObj)
-	if err != nil {
-		t.Fatal(err)
-	}
-	svcBytes, err := runtime.Encode(codec, svcObj)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return metaAccessor.GetName(), svcBytes
-}
-
 func readReplicationControllerFromFile(t *testing.T, filename string) *corev1.ReplicationController {
 	data := readBytesFromFile(t, filename)
 	rc := corev1.ReplicationController{}
@@ -2205,8 +2191,8 @@ func TestApplySetParentValidation(t *testing.T) {
 					return
 				}
 
-				assert.Equal(t, expectedParentNs, o.ApplySet.parent.Namespace)
-				assert.Equal(t, test.expectParentKind, o.ApplySet.parent.GroupVersionKind.Kind)
+				assert.Equal(t, expectedParentNs, o.ApplySet.parentRef.Namespace)
+				assert.Equal(t, test.expectParentKind, o.ApplySet.parentRef.GroupVersionKind.Kind)
 
 				err = o.Validate()
 				if test.expectErr != "" {
@@ -2486,19 +2472,19 @@ func TestApplySetInvalidLiveParent(t *testing.T) {
 			grsAnnotation:     validGrsAnnotation,
 			toolingAnnotation: "helm/v3",
 			idLabel:           validIDLabel,
-			expectErr:         "error: ApplySet parent object \"secrets./mySet\" already exists and is managed by tooling helm instead of kubectl",
+			expectErr:         "error: ApplySet parent object \"secrets./mySet\" already exists and is managed by tooling \"helm\" instead of \"kubectl\"",
 		},
 		"tooling annotation with invalid prefix with one segment can be parsed": {
 			grsAnnotation:     validGrsAnnotation,
 			toolingAnnotation: "helm",
 			idLabel:           validIDLabel,
-			expectErr:         "error: ApplySet parent object \"secrets./mySet\" already exists and is managed by tooling helm instead of kubectl",
+			expectErr:         "error: ApplySet parent object \"secrets./mySet\" already exists and is managed by tooling \"helm\" instead of \"kubectl\"",
 		},
 		"tooling annotation with invalid prefix with many segments can be parsed": {
 			grsAnnotation:     validGrsAnnotation,
 			toolingAnnotation: "example.com/tool/why/v1",
 			idLabel:           validIDLabel,
-			expectErr:         "error: ApplySet parent object \"secrets./mySet\" already exists and is managed by tooling example.com/tool/why instead of kubectl",
+			expectErr:         "error: ApplySet parent object \"secrets./mySet\" already exists and is managed by tooling \"example.com/tool/why\" instead of \"kubectl\"",
 		},
 		"ID label is required": {
 			grsAnnotation:     validGrsAnnotation,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
@@ -17,27 +17,83 @@ limitations under the License.
 package apply
 
 import (
+	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/klog/v2"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+// Label and annotation keys from the ApplySet specification.
+// https://git.k8s.io/enhancements/keps/sig-cli/3659-kubectl-apply-prune#design-details-applyset-specification
+const (
+	// ApplySetToolingAnnotation is the key of the label that indicates which tool is used to manage this ApplySet.
+	// Tooling should refuse to mutate ApplySets belonging to other tools.
+	// The value must be in the format <toolname>/<semver>.
+	// Example value: "kubectl/v1.27" or "helm/v3" or "kpt/v1.0.0"
+	ApplySetToolingAnnotation = "applyset.k8s.io/tooling"
+
+	// ApplySetAdditionalNamespacesAnnotation annotation extends the scope of the ApplySet beyond the parent
+	// object's own namespace (if any) to include the listed namespaces. The value is a comma-separated
+	// list of the names of namespaces other than the parent's namespace in which objects are found
+	// Example value: "kube-system,ns1,ns2".
+	ApplySetAdditionalNamespacesAnnotation = "applyset.k8s.io/additional-namespaces"
+
+	// ApplySetGRsAnnotation is a list of group-resources used to optimize listing of ApplySet member objects.
+	// It is optional in the ApplySet specification, as tools can perform discovery or use a different optimization.
+	// However, it is currently required in kubectl.
+	// When present, the value of this annotation must be a comma separated list of the group-kinds,
+	// in the fully-qualified name format, i.e. <resourcename>.<group>.
+	// Example value: "certificates.cert-manager.io,configmaps,deployments.apps,secrets,services"
+	ApplySetGRsAnnotation = "applyset.k8s.io/contains-group-resources"
+
+	// ApplySetParentIDLabel is the key of the label that makes object an ApplySet parent object.
+	// Its value MUST be the base64 encoding of the hash of the GKNN of the object it is on,
+	// in the form base64(sha256(<name>.<namespace>.<kind>.<group>)), using the URL safe encoding of RFC4648.
+	ApplySetParentIDLabel = "applyset.k8s.io/id"
+
+	// ApplysetPartOfLabel is the key of the label which indicates that the object is a member of an ApplySet.
+	// The value of the label MUST match the value of ApplySetParentIDLabel on the parent object.
+	ApplysetPartOfLabel = "applyset.k8s.io/part-of"
 )
 
 var defaultApplySetParentGVR = schema.GroupVersionResource{Version: "v1", Resource: "secrets"}
 
 // ApplySet tracks the information about an applyset apply/prune
 type ApplySet struct {
-	// ParentRef is the reference to the parent object that is used to track the applyset.
-	ParentRef *ApplySetParentRef
+	// parent is the reference to the parent object that is used to track the applyset.
+	parent *ApplySetParent
 
-	// resources is the set of all the resources that (might) be part of this applyset.
-	resources map[schema.GroupVersionResource]struct{}
+	// toolingID is the value to be used and validated in the applyset.k8s.io/tooling annotation.
+	toolingID ApplySetTooling
 
-	// namespaces is the set of all namespaces that (might) contain objects that are part of this applyset.
-	namespaces map[string]struct{}
+	// currentResources is the set of resources that are part of the sever-side set as of when the current operation started.
+	currentResources map[schema.GroupVersionResource]*meta.RESTMapping
+
+	// currentNamespaces is the set of namespaces that contain objects in this applyset as of when the current operation started.
+	currentNamespaces sets.Set[string]
+
+	// updatedResources is the set of resources that will be part of the set as of when the current operation completes.
+	updatedResources map[schema.GroupVersionResource]*meta.RESTMapping
+
+	// updatedNamespaces is the set of namespaces that will contain objects in this applyset as of when the current operation completes.
+	updatedNamespaces sets.Set[string]
+
+	restMapper meta.RESTMapper
+
+	// client is a client specific to the parent's type
+	client resource.RESTClient
 }
 
 var builtinApplySetParentGVRs = map[schema.GroupVersionResource]bool{
@@ -45,27 +101,44 @@ var builtinApplySetParentGVRs = map[schema.GroupVersionResource]bool{
 	{Version: "v1", Resource: "configmaps"}: true,
 }
 
-// ApplySetParentRef stores object and type meta for the parent object that is used to track the applyset.
-type ApplySetParentRef struct {
-	Name        string
-	Namespace   string
-	RESTMapping *meta.RESTMapping
+// ApplySetParent stores object and type meta for the parent object that is used to track the applyset.
+type ApplySetParent struct {
+	Name      string
+	Namespace string
+	*meta.RESTMapping
 }
 
-// NewApplySet creates a new ApplySet object from a parent reference in the format [RESOURCE][.GROUP]/NAME
-func NewApplySet(parentRefStr string, nsFromFlag string, mapper meta.RESTMapper) (*ApplySet, error) {
-	parent, err := parentRefFromStr(parentRefStr, mapper)
-	if err != nil {
-		return nil, fmt.Errorf("invalid parent reference %q: %w", parentRefStr, err)
-	}
-	if parent.IsNamespaced() {
-		parent.Namespace = nsFromFlag
-	}
+func (p ApplySetParent) IsNamespaced() bool {
+	return p.Scope.Name() == meta.RESTScopeNameNamespace
+}
+
+type ApplySetTooling struct {
+	name    string
+	version string
+}
+
+func (t ApplySetTooling) String() string {
+	return fmt.Sprintf("%s/%s", t.name, t.version)
+}
+
+// NewApplySet creates a new ApplySet object tracked by the given parent object.
+func NewApplySet(parent *ApplySetParent, tooling ApplySetTooling, mapper meta.RESTMapper, client resource.RESTClient) *ApplySet {
 	return &ApplySet{
-		resources:  make(map[schema.GroupVersionResource]struct{}),
-		namespaces: make(map[string]struct{}),
-		ParentRef:  parent,
-	}, nil
+		currentResources:  make(map[schema.GroupVersionResource]*meta.RESTMapping),
+		currentNamespaces: make(sets.Set[string]),
+		updatedResources:  make(map[schema.GroupVersionResource]*meta.RESTMapping),
+		updatedNamespaces: make(sets.Set[string]),
+		parent:            parent,
+		toolingID:         tooling,
+		restMapper:        mapper,
+		client:            client,
+	}
+}
+
+// ParentRef returns the string representation of the parent object using the same format
+// that we expect to receive in the --applyset flag on the CLI.
+func (a *ApplySet) ParentRef() string {
+	return fmt.Sprintf("%s.%s/%s", a.parent.Resource.Resource, a.parent.Resource.Group, a.parent.Name)
 }
 
 // ID is the label value that we are using to identify this applyset.
@@ -78,10 +151,10 @@ func (a ApplySet) ID() string {
 func (a ApplySet) Validate() error {
 	var errors []error
 	// TODO: permit CRDs that have the annotation required by the ApplySet specification
-	if !builtinApplySetParentGVRs[a.ParentRef.RESTMapping.Resource] {
-		errors = append(errors, fmt.Errorf("resource %q is not permitted as an ApplySet parent", a.ParentRef.RESTMapping.Resource))
+	if !builtinApplySetParentGVRs[a.parent.Resource] {
+		errors = append(errors, fmt.Errorf("resource %q is not permitted as an ApplySet parent", a.parent.Resource))
 	}
-	if a.ParentRef.IsNamespaced() && a.ParentRef.Namespace == "" {
+	if a.parent.IsNamespaced() && a.parent.Namespace == "" {
 		errors = append(errors, fmt.Errorf("namespace is required to use namespace-scoped ApplySet"))
 	}
 	return utilerrors.NewAggregate(errors)
@@ -89,7 +162,7 @@ func (a ApplySet) Validate() error {
 
 func (a *ApplySet) LabelsForMember() map[string]string {
 	return map[string]string{
-		"applyset.k8s.io/part-of": a.ID(),
+		ApplysetPartOfLabel: a.ID(),
 	}
 }
 
@@ -107,7 +180,7 @@ func (a *ApplySet) addLabels(objects []*resource.Info) error {
 		}
 		for k, v := range applysetLabels {
 			if _, found := labels[k]; found {
-				return fmt.Errorf("applyset label %q already set in input data", k)
+				return fmt.Errorf("ApplySet label %q already set in input data", k)
 			}
 			labels[k] = v
 		}
@@ -117,12 +190,223 @@ func (a *ApplySet) addLabels(objects []*resource.Info) error {
 	return nil
 }
 
-func (p *ApplySetParentRef) IsNamespaced() bool {
-	return p.RESTMapping.Scope.Name() == meta.RESTScopeNameNamespace
+// MarkObjectVisited keeps track of the applied objects, so that we can update the list of in-use namespaces
+// and resouce kinds, and so that we can prune objects not applied.
+func (a *ApplySet) MarkObjectVisited(resource *meta.RESTMapping, namespace string) {
+	a.updatedResources[resource.Resource] = resource
+	if namespace != "" {
+		a.updatedNamespaces.Insert(namespace)
+	}
 }
 
-// parentRefFromStr creates a new ApplySetParentRef from a parent reference in the format [RESOURCE][.GROUP]/NAME
-func parentRefFromStr(parentRefStr string, mapper meta.RESTMapper) (*ApplySetParentRef, error) {
+func (a *ApplySet) FetchParent() error {
+	helper := resource.NewHelper(a.client, a.parent.RESTMapping)
+	obj, err := helper.Get(a.parent.Namespace, a.parent.Name)
+	if errors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to fetch ApplySet parent object %q from server: %w", a.ParentRef(), err)
+	} else if obj == nil {
+		return fmt.Errorf("failed to fetch ApplySet parent object %q from server", a.ParentRef())
+	}
+
+	labels, annotations := getLabelsAndAnnotations(obj)
+
+	toolAnnotation, hasToolAnno := annotations[ApplySetToolingAnnotation]
+	if !hasToolAnno {
+		return fmt.Errorf("ApplySet parent object %q already exists and is missing required annotation %q", a.ParentRef(), ApplySetToolingAnnotation)
+	}
+	if managedBy := toolingBaseName(toolAnnotation); managedBy != a.toolingID.name {
+		return fmt.Errorf("ApplySet parent object %q already exists and is managed by tooling %s instead of %s", a.ParentRef(), managedBy, a.toolingID.name)
+	}
+
+	idLabel, hasIDLabel := labels[ApplySetParentIDLabel]
+	if !hasIDLabel {
+		return fmt.Errorf("ApplySet parent object %q exists and does not have required label %s", a.ParentRef(), ApplySetParentIDLabel)
+	}
+	if idLabel != a.ID() {
+		return fmt.Errorf("ApplySet parent object %q exists and has incorrect value for label %q (got: %s, want: %s)", a.ParentRef(), ApplySetParentIDLabel, idLabel, a.ID())
+	}
+
+	if a.currentResources, err = parseResourcesAnnotation(annotations, a.restMapper); err != nil {
+		// TODO: handle GVRs for now-deleted CRDs
+		return fmt.Errorf("parsing ApplySet annotation on %q: %w", a.ParentRef(), err)
+	}
+	a.currentNamespaces = parseNamespacesAnnotation(annotations)
+	if a.parent.IsNamespaced() {
+		a.currentNamespaces.Insert(a.parent.Namespace)
+	}
+	return nil
+}
+
+func getLabelsAndAnnotations(obj runtime.Object) (map[string]string, map[string]string) {
+	accessor := meta.NewAccessor()
+	annotations := make(map[string]string)
+	labels := make(map[string]string)
+
+	if data, err := accessor.Annotations(obj); err == nil {
+		annotations = data
+	}
+	if data, err := accessor.Labels(obj); err == nil {
+		labels = data
+	}
+	return labels, annotations
+}
+
+func toolingBaseName(toolAnnotation string) string {
+	parts := strings.Split(toolAnnotation, "/")
+	if len(parts) >= 2 {
+		return strings.Join(parts[:len(parts)-1], "/")
+	}
+	return toolAnnotation
+}
+
+func parseResourcesAnnotation(annotations map[string]string, mapper meta.RESTMapper) (map[schema.GroupVersionResource]*meta.RESTMapping, error) {
+	annotation, ok := annotations[ApplySetGRsAnnotation]
+	if !ok {
+		// The spec does not require this annotation. However, 'missing' means 'perform discovery' (as opposed to 'present but empty', which means ' this is an empty set').
+		// We return an error because we do not currently support dynamic discovery in kubectl apply.
+		return nil, fmt.Errorf("kubectl requires the %q annotation to be set on all ApplySet parent objects", ApplySetGRsAnnotation)
+	}
+	mappings := make(map[schema.GroupVersionResource]*meta.RESTMapping)
+	for _, grString := range strings.Split(annotation, ",") {
+		gr := schema.ParseGroupResource(grString)
+		gvk, err := mapper.KindFor(gr.WithVersion(""))
+		if err != nil {
+			return nil, fmt.Errorf("invalid group resource in %q annotation: %w", ApplySetGRsAnnotation, err)
+		}
+		mapping, err := mapper.RESTMapping(gvk.GroupKind())
+		if err != nil {
+			return nil, fmt.Errorf("could not find kind for resource in %q annotation: %w", ApplySetGRsAnnotation, err)
+		}
+		mappings[mapping.Resource] = mapping
+	}
+	return mappings, nil
+}
+
+func parseNamespacesAnnotation(annotations map[string]string) sets.Set[string] {
+	namespaces := make(sets.Set[string])
+	annotation, ok := annotations[ApplySetAdditionalNamespacesAnnotation]
+	if !ok { // this annotation is completely optional
+		return namespaces
+	}
+	for _, ns := range strings.Split(annotation, ",") {
+		namespaces.Insert(ns)
+	}
+	return namespaces
+}
+
+type ApplySetUpdateMode string
+
+var SetUpdateSuccessful ApplySetUpdateMode = "latest"
+var SetUpdateIncomplete ApplySetUpdateMode = "superset"
+
+func (a *ApplySet) UpdateParent(mode ApplySetUpdateMode, dryRun cmdutil.DryRunStrategy, validation string) error {
+	data, err := json.Marshal(a.buildParentPatch(mode))
+	if err != nil {
+		return fmt.Errorf("failed to encode patch for ApplySet parent: %w", err)
+	}
+	err = serverSideApplyRequest(a, data, dryRun, validation, false)
+	if err != nil && errors.IsConflict(err) {
+		// Try again with conflicts forced
+		klog.Warningf("WARNING: failed to update ApplySet: %s\nApplySet field manager %s should own these fields. Retrying with conflicts forced.", err.Error(), a.FieldManager())
+		err = serverSideApplyRequest(a, data, dryRun, validation, true)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to update ApplySet: %w", err)
+	}
+	return nil
+}
+
+func serverSideApplyRequest(a *ApplySet, data []byte, dryRun cmdutil.DryRunStrategy, validation string, forceConficts bool) error {
+	if dryRun == cmdutil.DryRunClient {
+		return nil
+	}
+	helper := resource.NewHelper(a.client, a.parent.RESTMapping).
+		DryRun(dryRun == cmdutil.DryRunServer).
+		WithFieldManager(a.FieldManager()).
+		WithFieldValidation(validation)
+
+	options := metav1.PatchOptions{
+		Force: &forceConficts,
+	}
+	_, err := helper.Patch(
+		a.parent.Namespace,
+		a.parent.Name,
+		types.ApplyPatchType,
+		data,
+		&options,
+	)
+	return err
+}
+
+func (a *ApplySet) buildParentPatch(mode ApplySetUpdateMode) *metav1.PartialObjectMetadata {
+	var newGRsAnnotation, newNsAnnotation string
+	switch mode {
+	case SetUpdateIncomplete:
+		// If the apply succeeded but pruning failed, the set of group resources that
+		// the ApplySet should track is the superset of the previous and current resources.
+		// This ensures that the resources that failed to be pruned are not orphaned from the set.
+		grSuperset := make(map[schema.GroupVersionResource]*meta.RESTMapping)
+		for versionResource, mapping := range a.currentResources {
+			grSuperset[versionResource] = mapping
+		}
+		for versionResource, mapping := range a.updatedResources {
+			grSuperset[versionResource] = mapping
+		}
+		newGRsAnnotation = generateResourcesAnnotation(grSuperset)
+		newNsAnnotation = generateNamespacesAnnotation(a.currentNamespaces.Union(a.updatedNamespaces), a.parent.Namespace)
+	case SetUpdateSuccessful:
+		newGRsAnnotation = generateResourcesAnnotation(a.updatedResources)
+		newNsAnnotation = generateNamespacesAnnotation(a.updatedNamespaces, a.parent.Namespace)
+	}
+
+	return &metav1.PartialObjectMetadata{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       a.parent.GroupVersionKind.Kind,
+			APIVersion: a.parent.GroupVersionKind.GroupVersion().String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      a.parent.Name,
+			Namespace: a.parent.Namespace,
+			Annotations: map[string]string{
+				ApplySetToolingAnnotation:              a.toolingID.String(),
+				ApplySetGRsAnnotation:                  newGRsAnnotation,
+				ApplySetAdditionalNamespacesAnnotation: newNsAnnotation,
+			},
+			Labels: map[string]string{
+				ApplySetParentIDLabel: a.ID(),
+			},
+		},
+	}
+}
+
+func generateNamespacesAnnotation(namespaces sets.Set[string], skip string) string {
+	var ns []string
+	for n := range namespaces {
+		if n != "" && n != skip {
+			ns = append(ns, n)
+		}
+	}
+	sort.Strings(ns)
+	return strings.Join(ns, ",")
+}
+
+func generateResourcesAnnotation(resources map[schema.GroupVersionResource]*meta.RESTMapping) string {
+	var grs []string
+	for gvr := range resources {
+		grs = append(grs, gvr.GroupResource().String())
+	}
+	sort.Strings(grs)
+	return strings.Join(grs, ",")
+}
+
+func (a ApplySet) FieldManager() string {
+	return fmt.Sprintf("%s-applyset-%s", a.toolingID.name, a.ID()) // TODO: validate this choice
+}
+
+// ParseApplySetParentRef creates a new ApplySetParentRef from a parent reference in the format [RESOURCE][.GROUP]/NAME
+func ParseApplySetParentRef(parentRefStr string, mapper meta.RESTMapper) (*ApplySetParent, error) {
 	var gvr schema.GroupVersionResource
 	var name string
 
@@ -146,5 +430,5 @@ func parentRefFromStr(parentRefStr string, mapper meta.RESTMapper) (*ApplySetPar
 	if err != nil {
 		return nil, err
 	}
-	return &ApplySetParentRef{Name: name, RESTMapping: mapping}, nil
+	return &ApplySetParent{Name: name, RESTMapping: mapping}, nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset_pruner.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset_pruner.go
@@ -28,6 +28,6 @@ func newApplySetPruner(_ *ApplyOptions) *applySetPruner {
 	return &applySetPruner{}
 }
 
-func (p *applySetPruner) pruneAll(_ context.Context, _ *ApplySet) error {
+func (p *applySetPruner) pruneAll(context.Context, *ApplySet) error {
 	return fmt.Errorf("ApplySet-based pruning is not yet implemented")
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset_pruner.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset_pruner.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package apply
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 type applySetPruner struct {
 }
@@ -25,6 +28,6 @@ func newApplySetPruner(_ *ApplyOptions) *applySetPruner {
 	return &applySetPruner{}
 }
 
-func (p *applySetPruner) pruneAll() error {
+func (p *applySetPruner) pruneAll(_ context.Context, _ *ApplySet) error {
 	return fmt.Errorf("ApplySet-based pruning is not yet implemented")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is part of a series of PRs to implement the ApplySet KEP in kubectl: http://git.k8s.io/enhancements/keps/sig-cli/3659-kubectl-apply-prune. Justin and I would like to merge our work in smaller chunks like this for ease of iteration and review. 

The first piece was https://github.com/kubernetes/kubernetes/pull/115979
https://github.com/kubernetes/kubernetes/pull/116205 is also currently open. Between that PR and this one, the basic behaviour on apply will work correctly. Several smaller PRs will still be needed to achieve all the features of the MVP listed in the KEP (e.g. CRD support, and kubectl diff support).

Specifically, this PR introduces the code to mange the ApplySet parent object that we use to track set membership: it creates it if needed, it retrieves its data for (as of this PR, future) use in determining what to prune, and it updates it with the new set data once pruning completes (though that doesn't actually happen until #115979 merges as well). 

#### Does this PR introduce a user-facing change?

The code no longer throws an error when the alpha flag is on, but it still warns the user that the feature does not really work. For example:

```
> KUBECTL_APPLYSET=true kk apply -f ~/scratch/resources.yaml --applyset=new-secret --prune -n kverey
W0303 00:22:43.381915   55251 apply.go:421] WARNING: --prune --applyset is not fully implemented and does not yet prune any resources.
configmap/test-object unchanged
error: ApplySet-based pruning is not yet implemented

> kubectl get secret new-secret -o yaml
apiVersion: v1
kind: Secret
metadata:
  annotations:
    applyset.k8s.io/additional-namespaces: ""
    applyset.k8s.io/contains-group-resources: configmaps,replicasets.apps,secrets
    applyset.k8s.io/tooling: kubectl/v1.27.0-alpha.2.457+3fa62b85f4132b-dirty
  creationTimestamp: "2023-02-25T10:30:18Z"
  labels:
    applyset.k8s.io/id: placeholder-todo
  name: new-secret
  namespace: kverey
  resourceVersion: "278411"
  uid: 11634fcc-5809-45d3-a439-dc7b8ed25f26
type: Opaque
```

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/42a4b1c8a18780cf1d5c2460113d59b246002548/keps/sig-cli/3659-kubectl-apply-prune
```
