### PR TITLE
Skip hasSupport check for List type

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier.go
@@ -19,6 +19,7 @@ package resource
 import (
 	"errors"
 	"fmt"
+
 	openapi_v2 "github.com/google/gnostic/openapiv2"
 	yaml "gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier.go
@@ -19,7 +19,6 @@ package resource
 import (
 	"errors"
 	"fmt"
-
 	openapi_v2 "github.com/google/gnostic/openapiv2"
 	yaml "gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -72,6 +71,10 @@ const (
 
 // HasSupport checks if the given gvk supports the query param configured on v
 func (v *QueryParamVerifier) HasSupport(gvk schema.GroupVersionKind) error {
+	if (gvk == schema.GroupVersionKind{Version: "v1", Kind: "List"}) {
+		return NewParamUnsupportedError(gvk, v.queryParam)
+	}
+
 	oapi, err := v.openAPIGetter.OpenAPISchema()
 	if err != nil {
 		return fmt.Errorf("failed to download openapi: %v", err)

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier_test.go
@@ -69,6 +69,16 @@ func TestSupportsQueryParam(t *testing.T) {
 			supports:   false,
 			queryParam: QueryParamFieldValidation,
 		},
+		{
+			gvk: schema.GroupVersionKind{
+				Group:   "",
+				Version: "v1",
+				Kind:    "List",
+			},
+			success:    false,
+			supports:   false,
+			queryParam: QueryParamFieldValidation,
+		},
 	}
 
 	for _, test := range tests {
@@ -124,6 +134,11 @@ func TestFieldValidationVerifier(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Random doesn't support fieldValidation, yet no error found")
 	}
+
+	err = fieldValidationVerifier.HasSupport(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "List"})
+	if err == nil {
+		t.Fatalf("List does not support fieldValidation, yet no error found")
+	}
 }
 
 type EmptyOpenAPI struct{}
@@ -158,5 +173,10 @@ func TestFieldValidationVerifierNoOpenAPI(t *testing.T) {
 	err = fieldValidationVerifier.HasSupport(schema.GroupVersionKind{Group: "crd.com", Version: "v1", Kind: "MyCRD"})
 	if err == nil {
 		t.Fatalf("MyCRD doesn't support fieldValidation, yet no error found")
+	}
+
+	err = fieldValidationVerifier.HasSupport(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "List"})
+	if err == nil {
+		t.Fatalf("List does not support fieldValidation, yet no error found")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Currently, when user applies a List type resource, there is an unnecessary request to customresourcedefinitions endpoint by validation. The reason of this request is that validation can not find List type in OpenAPI schema and behaves this type as CRD.

This PR returns unsupported when List type is applied.

In terms of functionality, there is no bug or any issue, because eventually `schemaValidation` detects this List and executes `validateList` function. Only issue is unnecessary CRD enpoint request.

#### Which issue(s) this PR fixes:
Fixes #116245

#### Does this PR introduce a user-facing change?
```release-note
None
```