### PR TITLE
verify: include "govet-levee" in normal "make verify"

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -33,7 +33,6 @@ source "${KUBE_ROOT}/third_party/forked/shell2junit/sh2ju.sh"
 EXCLUDED_PATTERNS=(
   "verify-all.sh"                # this script calls the make rule and would cause a loop
   "verify-*-dockerized.sh"       # Don't run any scripts that intended to be run dockerized
-  "verify-govet-levee.sh"        # Do not run levee analysis by default while KEP-1933 implementation is in alpha.
   "verify-licenses.sh"           # runs in a separate job to monitor availability of the dependencies periodically
   )
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The corresponding feature was already moved to stable:

https://github.com/kubernetes/enhancements/blob/master/keps/sig-security/1933-secret-logging-static-analysis/kep.yaml

See also https://github.com/kubernetes/enhancements/issues/1933#issuecomment-1448557615

#### Special notes for your reviewer:

Including this check in the normal "make verify" and "pull-kubernetes-verify" is the first step. The next step is to remove the separate "pull-kubernetes-verify-govet-levee".

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
