### PR TITLE
Forbid creating CronJob with TZ or CRON_TZ, but allow updates

### DIFF
--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -523,7 +523,11 @@ func validateCronJobSpec(spec, oldSpec *batch.CronJobSpec, fldPath *field.Path, 
 	if len(spec.Schedule) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("schedule"), ""))
 	} else {
-		allErrs = append(allErrs, validateScheduleFormat(spec.Schedule, spec.TimeZone, fldPath.Child("schedule"))...)
+		allowTZInSchedule := false
+		if oldSpec != nil {
+			allowTZInSchedule = strings.Contains(oldSpec.Schedule, "TZ")
+		}
+		allErrs = append(allErrs, validateScheduleFormat(spec.Schedule, allowTZInSchedule, spec.TimeZone, fldPath.Child("schedule"))...)
 	}
 
 	if spec.StartingDeadlineSeconds != nil {
@@ -564,13 +568,16 @@ func validateConcurrencyPolicy(concurrencyPolicy *batch.ConcurrencyPolicy, fldPa
 	return allErrs
 }
 
-func validateScheduleFormat(schedule string, timeZone *string, fldPath *field.Path) field.ErrorList {
+func validateScheduleFormat(schedule string, allowTZInSchedule bool, timeZone *string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if _, err := cron.ParseStandard(schedule); err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath, schedule, err.Error()))
 	}
-	if strings.Contains(schedule, "TZ") && timeZone != nil {
+	switch {
+	case allowTZInSchedule && strings.Contains(schedule, "TZ") && timeZone != nil:
 		allErrs = append(allErrs, field.Invalid(fldPath, schedule, "cannot use both timeZone field and TZ or CRON_TZ in schedule"))
+	case !allowTZInSchedule && strings.Contains(schedule, "TZ"):
+		allErrs = append(allErrs, field.Invalid(fldPath, schedule, "cannot use TZ or CRON_TZ in schedule, use timeZone field instead"))
 	}
 
 	return allErrs

--- a/pkg/registry/batch/cronjob/strategy.go
+++ b/pkg/registry/batch/cronjob/strategy.go
@@ -123,9 +123,6 @@ func (cronJobStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object)
 		warnings = append(warnings, fmt.Sprintf("metadata.name: this is used in Pod names and hostnames, which can result in surprising behavior; a DNS label is recommended: %v", msgs))
 	}
 	warnings = append(warnings, job.WarningsForJobSpec(ctx, field.NewPath("spec", "jobTemplate", "spec"), &newCronJob.Spec.JobTemplate.Spec, nil)...)
-	if strings.Contains(newCronJob.Spec.Schedule, "TZ") {
-		warnings = append(warnings, fmt.Sprintf("CRON_TZ or TZ used in %s is not officially supported, see https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/ for more details", field.NewPath("spec", "spec", "schedule")))
-	}
 	return warnings
 }
 
@@ -160,7 +157,7 @@ func (cronJobStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Ob
 		warnings = job.WarningsForJobSpec(ctx, field.NewPath("spec", "jobTemplate", "spec"), &newCronJob.Spec.JobTemplate.Spec, &oldCronJob.Spec.JobTemplate.Spec)
 	}
 	if strings.Contains(newCronJob.Spec.Schedule, "TZ") {
-		warnings = append(warnings, fmt.Sprintf("CRON_TZ or TZ used in %s is not officially supported, see https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/ for more details", field.NewPath("spec", "spec", "schedule")))
+		warnings = append(warnings, fmt.Sprintf("cannot use TZ or CRON_TZ in %s, use timeZone instead, see https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/ for more details", field.NewPath("spec", "spec", "schedule")))
 	}
 	return warnings
 }

--- a/pkg/registry/batch/cronjob/strategy_test.go
+++ b/pkg/registry/batch/cronjob/strategy_test.go
@@ -273,20 +273,6 @@ func TestCronJobStrategy_WarningsOnCreate(t *testing.T) {
 				},
 			},
 		},
-		"timezone invalid": {
-			wantWarningsCount: 1,
-			cronjob: &batch.CronJob{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "mycronjob",
-					Namespace:       metav1.NamespaceDefault,
-					ResourceVersion: "9",
-				},
-				Spec: cronjobSpecWithTZinSchedule,
-				Status: batch.CronJobStatus{
-					LastScheduleTime: &now,
-				},
-			},
-		},
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind api-change

#### What this PR does / why we need it:
Back in #106455 (k8s 1.23) after we've upgraded github.com/robfig/cron (in #102735) we've accidentally exposed internal details of the library allowing users to set `TZ` or `CRON_TZ` variable in `.spec.schedule` to affect TimeZone of a CronJob. 

Now that https://github.com/kubernetes/enhancements/issues/3140 is becoming GA we're proposing failing creating a new CronJobs with `TZ` or `CRON_TZ` in `.spec.Schedule` in favor of setting `.spec.timeZone`, but leave the warning and allow updates not to break users.

#### Special notes for your reviewer:
/assign @liggitt @sftim 

#### Does this PR introduce a user-facing change?
```release-note
Creation of new CronJob objects containing `TZ` or `CRON_TZ` in `.spec.schedule`, accidentally enabled in 1.22, is now disallowed. Use the `.spec.timeZone` field instead, supported in 1.25+ clusters in default configurations. See https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#unsupported-timezone-specification for more information.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3140
```
