### PR TITLE
Belatedly remove controller-manager IPv6DualStack feature gate

### DIFF
--- a/staging/src/k8s.io/cloud-provider/app/core.go
+++ b/staging/src/k8s.io/cloud-provider/app/core.go
@@ -33,7 +33,6 @@ import (
 	servicecontroller "k8s.io/cloud-provider/controllers/service"
 	controllermanagerapp "k8s.io/controller-manager/app"
 	"k8s.io/controller-manager/controller"
-	"k8s.io/controller-manager/pkg/features"
 	"k8s.io/klog/v2"
 	netutils "k8s.io/utils/net"
 
@@ -117,11 +116,6 @@ func startRouteController(ctx context.Context, initContext ControllerInitContext
 	clusterCIDRs, dualStack, err := processCIDRs(completedConfig.ComponentConfig.KubeCloudShared.ClusterCIDR)
 	if err != nil {
 		return nil, false, err
-	}
-
-	// failure: more than one cidr and dual stack is not enabled
-	if len(clusterCIDRs) > 1 && !utilfeature.DefaultFeatureGate.Enabled(features.IPv6DualStack) {
-		return nil, false, fmt.Errorf("len of ClusterCIDRs==%v and dualstack feature is not enabled", len(clusterCIDRs))
 	}
 
 	// failure: more than one cidr but they are not configured as dual stack

--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -21,23 +21,16 @@ import (
 )
 
 const (
-	// Every feature gate should add method here following this template:
-	//
-	// // owner: @username
-	// // alpha: v1.4
-	// MyFeature featuregate.Feature = "MyFeature"
-	//
-	// Feature gates should be listed in alphabetical, case-sensitive
-	// (upper before any lower case character) order. This reduces the risk
-	// of code conflicts because changes are more likely to be scattered
-	// across the file.
-
-	// owner: @khenidak
-	// alpha: v1.15
-	//
-	// Enables ipv6 dual stack
-	// Original copy from k8s.io/kubernetes/pkg/features/kube_features.go
-	IPv6DualStack featuregate.Feature = "IPv6DualStack"
+// Every feature gate should add method here following this template:
+//
+// // owner: @username
+// // alpha: v1.4
+// MyFeature featuregate.Feature = "MyFeature"
+//
+// Feature gates should be listed in alphabetical, case-sensitive
+// (upper before any lower case character) order. This reduces the risk
+// of code conflicts because changes are more likely to be scattered
+// across the file.
 )
 
 func SetupCurrentKubernetesSpecificFeatureGates(featuregates featuregate.MutableFeatureGate) error {
@@ -46,6 +39,4 @@ func SetupCurrentKubernetesSpecificFeatureGates(featuregates featuregate.Mutable
 
 // cloudPublicFeatureGates consists of cloud-specific feature keys.
 // To add a new feature, define a key for it at k8s.io/api/pkg/features and add it here.
-var cloudPublicFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	IPv6DualStack: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-}
+var cloudPublicFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
controller-manager still had an `IPv6DualStack` feature gate, which cloud-provider still checked. This feature went GA in 1.23.

#### Does this PR introduce a user-facing change?
```release-note
The `IPv6DualStack` feature gate for external cloud providers was removed.
(The feature became GA in 1.23 and the gate was removed for all other
components several releases ago.) Action required: If you were still manually
enabling it you must stop now.
```

/cc @khenidak 