### PR TITLE
Applyset dry run tests + ID value

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -418,8 +418,6 @@ func (o *ApplyOptions) Validate() error {
 				return fmt.Errorf("--selector is incompatible with --applyset")
 			} else if len(o.PruneResources) > 0 {
 				return fmt.Errorf("--prune-allowlist is incompatible with --applyset")
-			} else {
-				klog.Warning("WARNING: --prune --applyset is not fully implemented and does not yet prune any resources.")
 			}
 		} else {
 			if !o.All && o.Selector == "" {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -313,7 +313,6 @@ func (flags *ApplyFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, baseNa
 		if enforceNamespace && parent.IsNamespaced() {
 			parent.Namespace = namespace
 		}
-		// TODO: is version.Get() the right thing? Does it work for non-kubectl package consumers?
 		tooling := ApplySetTooling{name: baseName, version: ApplySetToolVersion}
 		restClient, err := f.ClientForMapping(parent.RESTMapping)
 		if err != nil || restClient == nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -2527,7 +2527,7 @@ metadata:
     applyset.k8s.io/tooling: kubectl/v0.0.0-master+$Format:%H$
   creationTimestamp: null
   labels:
-    applyset.k8s.io/id: placeholder-todo
+    applyset.k8s.io/id: applyset-nqNkDlL072a9O3FBtGMDroXnF18TNtgUetAA6vsaglI-v1
   name: mySet
   namespace: test
 `, string(updatedSecret))
@@ -3148,16 +3148,8 @@ func fatalNoExit(t *testing.T, ioStreams genericclioptions.IOStreams) func(msg s
 	}
 }
 
-
 func TestApplySetDryRun(t *testing.T) {
-	// TODO: replace with cmdtesting.InitTestErrorHandler() when the feature is fully implemented
-	cmdutil.BehaviorOnFatal(func(s string, i int) {
-		if s != "error: ApplySet-based pruning is not yet implemented" {
-			t.Fatalf("unexpected exit %d: %s", i, s)
-		}
-	})
-	defer cmdutil.DefaultBehaviorOnFatal()
-
+	cmdtesting.InitTestErrorHandler(t)
 	nameRC, rc := readReplicationController(t, filenameRC)
 	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
 	nameParentSecret := "mySet"

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -2435,7 +2435,7 @@ metadata:
     applyset.k8s.io/tooling: kubectl/v0.0.0-master+$Format:%H$
   creationTimestamp: null
   labels:
-    applyset.k8s.io/id: placeholder-todo
+    applyset.k8s.io/id: bXlTZXQudGVzdC5TZWNyZXQu
   name: mySet
   namespace: test
 `, string(createdSecret))
@@ -2465,7 +2465,7 @@ metadata:
     applyset.k8s.io/tooling: kubectl/v0.0.0-master+$Format:%H$
   creationTimestamp: null
   labels:
-    applyset.k8s.io/id: placeholder-todo
+    applyset.k8s.io/id: bXlTZXQudGVzdC5TZWNyZXQu
   name: mySet
   namespace: test
 `, string(updatedSecret))
@@ -2496,7 +2496,7 @@ metadata:
     applyset.k8s.io/tooling: kubectl/v0.0.0-master+$Format:%H$
   creationTimestamp: null
   labels:
-    applyset.k8s.io/id: placeholder-todo
+    applyset.k8s.io/id: bXlTZXQudGVzdC5TZWNyZXQu
   name: mySet
   namespace: test
 `, string(updatedSecret))
@@ -2577,7 +2577,7 @@ func TestApplySetInvalidLiveParent(t *testing.T) {
 			}),
 		}
 	}
-	validIDLabel := "placeholder-todo"
+	validIDLabel := "bXlTZXQudGVzdC5TZWNyZXQu"
 	validToolingAnnotation := "kubectl/v1.27.0"
 	validGrsAnnotation := "deployments.apps,namespaces,secrets"
 
@@ -2866,7 +2866,7 @@ metadata:
     applyset.k8s.io/tooling: kubectl/v0.0.0-master+$Format:%H$
   creationTimestamp: null
   labels:
-    applyset.k8s.io/id: placeholder-todo
+    applyset.k8s.io/id: bXlTZXQudGVzdC5TZWNyZXQu
   name: mySet
   namespace: test
 `

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -2435,7 +2435,7 @@ metadata:
     applyset.k8s.io/tooling: kubectl/v0.0.0-master+$Format:%H$
   creationTimestamp: null
   labels:
-    applyset.k8s.io/id: bXlTZXQudGVzdC5TZWNyZXQu
+    applyset.k8s.io/id: applyset-nqNkDlL072a9O3FBtGMDroXnF18TNtgUetAA6vsaglI-v1
   name: mySet
   namespace: test
 `, string(createdSecret))
@@ -2465,7 +2465,7 @@ metadata:
     applyset.k8s.io/tooling: kubectl/v0.0.0-master+$Format:%H$
   creationTimestamp: null
   labels:
-    applyset.k8s.io/id: bXlTZXQudGVzdC5TZWNyZXQu
+    applyset.k8s.io/id: applyset-nqNkDlL072a9O3FBtGMDroXnF18TNtgUetAA6vsaglI-v1
   name: mySet
   namespace: test
 `, string(updatedSecret))
@@ -2496,7 +2496,7 @@ metadata:
     applyset.k8s.io/tooling: kubectl/v0.0.0-master+$Format:%H$
   creationTimestamp: null
   labels:
-    applyset.k8s.io/id: bXlTZXQudGVzdC5TZWNyZXQu
+    applyset.k8s.io/id: applyset-nqNkDlL072a9O3FBtGMDroXnF18TNtgUetAA6vsaglI-v1
   name: mySet
   namespace: test
 `, string(updatedSecret))
@@ -2577,7 +2577,7 @@ func TestApplySetInvalidLiveParent(t *testing.T) {
 			}),
 		}
 	}
-	validIDLabel := "bXlTZXQudGVzdC5TZWNyZXQu"
+	validIDLabel := "applyset-nqNkDlL072a9O3FBtGMDroXnF18TNtgUetAA6vsaglI-v1"
 	validToolingAnnotation := "kubectl/v1.27.0"
 	validGrsAnnotation := "deployments.apps,namespaces,secrets"
 
@@ -2866,7 +2866,7 @@ metadata:
     applyset.k8s.io/tooling: kubectl/v0.0.0-master+$Format:%H$
   creationTimestamp: null
   labels:
-    applyset.k8s.io/id: bXlTZXQudGVzdC5TZWNyZXQu
+    applyset.k8s.io/id: applyset-nqNkDlL072a9O3FBtGMDroXnF18TNtgUetAA6vsaglI-v1
   name: mySet
   namespace: test
 `

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
@@ -17,7 +17,7 @@ limitations under the License.
 package apply
 
 import (
-	"bytes"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -61,9 +61,14 @@ const (
 	ApplySetGRsAnnotation = "applyset.k8s.io/contains-group-resources"
 
 	// ApplySetParentIDLabel is the key of the label that makes object an ApplySet parent object.
-	// Its value MUST be the base64 encoding of the hash of the GKNN of the object it is on,
-	// in the form base64(sha256(<name>.<namespace>.<kind>.<group>)), using the URL safe encoding of RFC4648.
+	// Its value MUST use the format specified in V1ApplySetIdFormat below
 	ApplySetParentIDLabel = "applyset.k8s.io/id"
+
+	// V1ApplySetIdFormat is the format required for the value of ApplySetParentIDLabel (and ApplysetPartOfLabel).
+	// The %s segment is the unique ID of the object itself, which MUST be the base64 encoding
+	// (using the URL safe encoding of RFC4648) of the hash of the GKNN of the object it is on, in the form:
+	// base64(sha256(<name>.<namespace>.<kind>.<group>)).
+	V1ApplySetIdFormat = "applyset-%s-v1"
 
 	// ApplysetPartOfLabel is the key of the label which indicates that the object is a member of an ApplySet.
 	// The value of the label MUST match the value of ApplySetParentIDLabel on the parent object.
@@ -147,20 +152,13 @@ const applySetIDPartDelimiter = "."
 
 // ID is the label value that we are using to identify this applyset.
 // Format: base64(sha256(<name>.<namespace>.<kind>.<group>)), using the URL safe encoding of RFC4648.
+
 func (a ApplySet) ID() string {
-	var unencoded string
-	if a.parentRef.IsNamespaced() {
-		unencoded = strings.Join([]string{a.parentRef.Name, a.parentRef.Namespace, a.parentRef.GroupVersionKind.Kind, a.parentRef.GroupVersionKind.Group}, applySetIDPartDelimiter)
-	} else {
-		unencoded = strings.Join([]string{a.parentRef.Name, a.parentRef.GroupVersionKind.Kind, a.parentRef.GroupVersionKind.Group}, applySetIDPartDelimiter)
-	}
-	w := bytes.Buffer{}
-	encoder := base64.NewEncoder(base64.URLEncoding, &w)
-	_, err := encoder.Write([]byte(unencoded))
-	if err != nil {
-		klog.Fatalf("failed to encode parent ID %s: %w", unencoded, err)
-	}
-	return w.String()
+	unencoded := strings.Join([]string{a.parentRef.Name, a.parentRef.Namespace, a.parentRef.GroupVersionKind.Kind, a.parentRef.GroupVersionKind.Group}, applySetIDPartDelimiter)
+	hashed := sha256.Sum256([]byte(unencoded))
+	b64 := base64.RawURLEncoding.EncodeToString(hashed[:])
+	// Label values must start and end with alphanumeric values, so add a known-safe prefix and suffix.
+	return fmt.Sprintf(V1ApplySetIdFormat, b64)
 }
 
 // Validate imposes restrictions on the parent object that is used to track the applyset.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/manifest1-expected-getobjects.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/manifest1-expected-getobjects.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    applyset.k8s.io/part-of: placeholder-todo
+    applyset.k8s.io/part-of: c2ltcGxlLnRlc3QuU2VjcmV0
   name: foo
 
 ---
@@ -11,5 +11,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    applyset.k8s.io/part-of: placeholder-todo
+    applyset.k8s.io/part-of: c2ltcGxlLnRlc3QuU2VjcmV0
   name: bar

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/manifest1-expected-getobjects.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/manifest1-expected-getobjects.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    applyset.k8s.io/part-of: c2ltcGxlLnRlc3QuU2VjcmV0
+    applyset.k8s.io/part-of: applyset-bjd1LnyQq0mtUu-riZCqjDQOmh0iNb9O2RcuT12WR0k-v1
   name: foo
 
 ---
@@ -11,5 +11,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    applyset.k8s.io/part-of: c2ltcGxlLnRlc3QuU2VjcmV0
+    applyset.k8s.io/part-of: applyset-bjd1LnyQq0mtUu-riZCqjDQOmh0iNb9O2RcuT12WR0k-v1
   name: bar

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/manifest2-expected-getobjects.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/manifest2-expected-getobjects.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    applyset.k8s.io/part-of: placeholder-todo
+    applyset.k8s.io/part-of: applyset-bjd1LnyQq0mtUu-riZCqjDQOmh0iNb9O2RcuT12WR0k-v1
   name: foo


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is part of a series of PRs to implement the ApplySet KEP in kubectl: http://git.k8s.io/enhancements/keps/sig-cli/3659-kubectl-apply-prune. 

This one fixes a few of the small tasks on our new project board: https://github.com/orgs/kubernetes/projects/128/views/1

Related PRs: 
- https://github.com/kubernetes/kubernetes/pull/115979
- https://github.com/kubernetes/kubernetes/pull/116243
- #116009 / #116205 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/42a4b1c8a18780cf1d5c2460113d59b246002548/keps/sig-cli/3659-kubectl-apply-prune
```

/cc @justinsb @soltysh 
/sig cli
