### PR TITLE
Fix nil pointer access panic in kubelet from uninitialized pod allocation checkpoint manager in standalone kubelet scenario

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2105,30 +2105,20 @@ func (kl *Kubelet) canAdmitPod(pods []*v1.Pod, pod *v1.Pod) (bool, string, strin
 	// TODO: out of resource eviction should have a pod admitter call-out
 	attrs := &lifecycle.PodAdmitAttributes{Pod: pod, OtherPods: pods}
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
-		// If pod resource allocation checkpoint manager (checkpointState) is nil, it is likely because
-		// kubelet is bootstrapping kube-system pods on master node. In this scenario, pod resource resize
-		// is neither expected nor can be handled. Fall back to regular 'canAdmitPod' processing.
-		// TODO(vinaykul,InPlacePodVerticalScaling): Investigate if we can toss out all this checkpointing
-		// code and instead rely on ResourceAllocation / Resize values persisted in PodStatus. (Ref: KEP 2527)
 		// Use allocated resources values from checkpoint store (source of truth) to determine fit
-		checkpointState := kl.statusManager.State()
-		if checkpointState != nil {
-			otherPods := make([]*v1.Pod, 0, len(pods))
-			for _, p := range pods {
-				op := p.DeepCopy()
-				for _, c := range op.Spec.Containers {
-					resourcesAllocated, found := checkpointState.GetContainerResourceAllocation(string(p.UID), c.Name)
-					if c.Resources.Requests != nil && found {
-						c.Resources.Requests[v1.ResourceCPU] = resourcesAllocated[v1.ResourceCPU]
-						c.Resources.Requests[v1.ResourceMemory] = resourcesAllocated[v1.ResourceMemory]
-					}
+		otherPods := make([]*v1.Pod, 0, len(pods))
+		for _, p := range pods {
+			op := p.DeepCopy()
+			for _, c := range op.Spec.Containers {
+				resourcesAllocated, found := kl.statusManager.GetContainerResourceAllocation(string(p.UID), c.Name)
+				if c.Resources.Requests != nil && found {
+					c.Resources.Requests[v1.ResourceCPU] = resourcesAllocated[v1.ResourceCPU]
+					c.Resources.Requests[v1.ResourceMemory] = resourcesAllocated[v1.ResourceMemory]
 				}
-				otherPods = append(otherPods, op)
 			}
-			attrs.OtherPods = otherPods
-		} else {
-			klog.ErrorS(nil, "pod resource allocation checkpoint manager is not initialized.")
+			otherPods = append(otherPods, op)
 		}
+		attrs.OtherPods = otherPods
 	}
 	for _, podAdmitHandler := range kl.admitHandlers {
 		if result := podAdmitHandler.Admit(attrs); !result.Admit {
@@ -2413,39 +2403,25 @@ func (kl *Kubelet) HandlePodAdditions(pods []*v1.Pod) {
 			activePods := kl.filterOutInactivePods(existingPods)
 
 			if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
-				// If pod resource allocation checkpoint manager (checkpointState) is nil, it is likely because
-				// kubelet is bootstrapping kube-system pods on master node. In this scenario, pod resource resize
-				// is neither expected nor can be handled. Fall back to regular 'canAdmitPod' processing.
-				// TODO(vinaykul,InPlacePodVerticalScaling): Investigate if we can toss out all this checkpointing
-				// code and instead rely on ResourceAllocation / Resize values persisted in PodStatus. (Ref: KEP 2527)
-				checkpointState := kl.statusManager.State()
-				if checkpointState != nil {
-					// To handle kubelet restarts, test pod admissibility using ResourcesAllocated values
-					// (for cpu & memory) from checkpoint store. If found, that is the source of truth.
-					podCopy := pod.DeepCopy()
-					for _, c := range podCopy.Spec.Containers {
-						resourcesAllocated, found := checkpointState.GetContainerResourceAllocation(string(pod.UID), c.Name)
-						if c.Resources.Requests != nil && found {
-							c.Resources.Requests[v1.ResourceCPU] = resourcesAllocated[v1.ResourceCPU]
-							c.Resources.Requests[v1.ResourceMemory] = resourcesAllocated[v1.ResourceMemory]
-						}
+				// To handle kubelet restarts, test pod admissibility using ResourcesAllocated values
+				// (for cpu & memory) from checkpoint store. If found, that is the source of truth.
+				podCopy := pod.DeepCopy()
+				for _, c := range podCopy.Spec.Containers {
+					resourcesAllocated, found := kl.statusManager.GetContainerResourceAllocation(string(pod.UID), c.Name)
+					if c.Resources.Requests != nil && found {
+						c.Resources.Requests[v1.ResourceCPU] = resourcesAllocated[v1.ResourceCPU]
+						c.Resources.Requests[v1.ResourceMemory] = resourcesAllocated[v1.ResourceMemory]
 					}
-					// Check if we can admit the pod; if not, reject it.
-					if ok, reason, message := kl.canAdmitPod(activePods, podCopy); !ok {
-						kl.rejectPod(pod, reason, message)
-						continue
-					}
-					// For new pod, checkpoint the resource values at which the Pod has been admitted
-					if err := kl.statusManager.SetPodAllocation(podCopy); err != nil {
-						//TODO(vinaykul,InPlacePodVerticalScaling): Can we recover from this in some way? Investigate
-						klog.ErrorS(err, "SetPodAllocation failed", "pod", klog.KObj(pod))
-					}
-				} else {
-					// Check if we can admit the pod; if not, reject it.
-					if ok, reason, message := kl.canAdmitPod(activePods, pod); !ok {
-						kl.rejectPod(pod, reason, message)
-						continue
-					}
+				}
+				// Check if we can admit the pod; if not, reject it.
+				if ok, reason, message := kl.canAdmitPod(activePods, podCopy); !ok {
+					kl.rejectPod(pod, reason, message)
+					continue
+				}
+				// For new pod, checkpoint the resource values at which the Pod has been admitted
+				if err := kl.statusManager.SetPodAllocation(podCopy); err != nil {
+					//TODO(vinaykul,InPlacePodVerticalScaling): Can we recover from this in some way? Investigate
+					klog.ErrorS(err, "SetPodAllocation failed", "pod", klog.KObj(pod))
 				}
 			} else {
 				// Check if we can admit the pod; if not, reject it.

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1472,13 +1472,8 @@ func (kl *Kubelet) determinePodResizeStatus(pod *v1.Pod, podStatus *v1.PodStatus
 			klog.ErrorS(err, "SetPodResizeStatus failed", "pod", pod.Name)
 		}
 	} else {
-		checkpointState := kl.statusManager.State()
-		if checkpointState != nil {
-			if resizeStatus, found := checkpointState.GetPodResizeStatus(string(pod.UID)); found {
-				podResizeStatus = resizeStatus
-			}
-		} else {
-			klog.ErrorS(nil, "pod resource allocation checkpoint manager is not initialized.")
+		if resizeStatus, found := kl.statusManager.GetPodResizeStatus(string(pod.UID)); found {
+			podResizeStatus = resizeStatus
 		}
 	}
 	return podResizeStatus
@@ -1773,12 +1768,7 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 		container := kubecontainer.GetContainerSpec(pod, cName)
 		// ResourcesAllocated values come from checkpoint. It is the source-of-truth.
 		found := false
-		checkpointState := kl.statusManager.State()
-		if checkpointState != nil {
-			status.ResourcesAllocated, found = checkpointState.GetContainerResourceAllocation(string(pod.UID), cName)
-		} else {
-			klog.ErrorS(nil, "pod resource allocation checkpoint manager is not initialized.")
-		}
+		status.ResourcesAllocated, found = kl.statusManager.GetContainerResourceAllocation(string(pod.UID), cName)
 		if !(container.Resources.Requests == nil && container.Resources.Limits == nil) && !found {
 			// Log error and fallback to ResourcesAllocated in oldStatus if it exists
 			klog.ErrorS(nil, "resource allocation not found in checkpoint store", "pod", pod.Name, "container", cName)

--- a/pkg/kubelet/status/fake_status_manager.go
+++ b/pkg/kubelet/status/fake_status_manager.go
@@ -68,6 +68,16 @@ func (m *fakeManager) State() state.Reader {
 	return m.state
 }
 
+func (m *fakeManager) GetContainerResourceAllocation(podUID string, containerName string) (v1.ResourceList, bool) {
+	klog.InfoS("GetContainerResourceAllocation()")
+	return m.state.GetContainerResourceAllocation(podUID, containerName)
+}
+
+func (m *fakeManager) GetPodResizeStatus(podUID string) (v1.PodResizeStatus, bool) {
+	klog.InfoS("GetPodResizeStatus()")
+	return "", false
+}
+
 func (m *fakeManager) SetPodAllocation(pod *v1.Pod) error {
 	klog.InfoS("SetPodAllocation()")
 	for _, container := range pod.Spec.Containers {

--- a/pkg/kubelet/status/fake_status_manager.go
+++ b/pkg/kubelet/status/fake_status_manager.go
@@ -63,11 +63,6 @@ func (m *fakeManager) RemoveOrphanedStatuses(podUIDs map[types.UID]bool) {
 	return
 }
 
-func (m *fakeManager) State() state.Reader {
-	klog.InfoS("State()")
-	return m.state
-}
-
 func (m *fakeManager) GetContainerResourceAllocation(podUID string, containerName string) (v1.ResourceList, bool) {
 	klog.InfoS("GetContainerResourceAllocation()")
 	return m.state.GetContainerResourceAllocation(podUID, containerName)

--- a/pkg/kubelet/status/testing/mock_pod_status_provider.go
+++ b/pkg/kubelet/status/testing/mock_pod_status_provider.go
@@ -27,7 +27,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	container "k8s.io/kubernetes/pkg/kubelet/container"
-	state "k8s.io/kubernetes/pkg/kubelet/status/state"
 )
 
 // MockPodStatusProvider is a mock of PodStatusProvider interface.
@@ -320,20 +319,6 @@ func (m *MockManager) Start() {
 func (mr *MockManagerMockRecorder) Start() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockManager)(nil).Start))
-}
-
-// State mocks base method.
-func (m *MockManager) State() state.Reader {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "State")
-	ret0, _ := ret[0].(state.Reader)
-	return ret0
-}
-
-// State indicates an expected call of State.
-func (mr *MockManagerMockRecorder) State() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockManager)(nil).State))
 }
 
 // TerminatePod mocks base method.

--- a/pkg/kubelet/status/testing/mock_pod_status_provider.go
+++ b/pkg/kubelet/status/testing/mock_pod_status_provider.go
@@ -189,6 +189,36 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
+// GetContainerResourceAllocation mocks base method.
+func (m *MockManager) GetContainerResourceAllocation(podUID, containerName string) (v1.ResourceList, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetContainerResourceAllocation", podUID, containerName)
+	ret0, _ := ret[0].(v1.ResourceList)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetContainerResourceAllocation indicates an expected call of GetContainerResourceAllocation.
+func (mr *MockManagerMockRecorder) GetContainerResourceAllocation(podUID, containerName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerResourceAllocation", reflect.TypeOf((*MockManager)(nil).GetContainerResourceAllocation), podUID, containerName)
+}
+
+// GetPodResizeStatus mocks base method.
+func (m *MockManager) GetPodResizeStatus(podUID string) (v1.PodResizeStatus, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPodResizeStatus", podUID)
+	ret0, _ := ret[0].(v1.PodResizeStatus)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetPodResizeStatus indicates an expected call of GetPodResizeStatus.
+func (mr *MockManagerMockRecorder) GetPodResizeStatus(podUID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodResizeStatus", reflect.TypeOf((*MockManager)(nil).GetPodResizeStatus), podUID)
+}
+
 // GetPodStatus mocks base method.
 func (m *MockManager) GetPodStatus(uid types.UID) (v1.PodStatus, bool) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it: In-place pod resize checkpoint store code panics when standalone kubelet attempts to start. The current code has nil pointer access bug. This PR fixes the issue.

#### Which issue(s) this PR fixes: https://github.com/kubernetes/kubernetes/issues/116262

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #116262

#### Special notes for your reviewer:
Testing done:
1. Hacky way but not initializing checpoint manager
2. Pods come up normally with local cluster.
3. Verified local cluster pod resize E2E tests work.
4. Unit tests
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
