### PR TITLE
DRA: fix CDI spec version

### DIFF
--- a/test/e2e/dra/test-driver/app/kubeletplugin.go
+++ b/test/e2e/dra/test-driver/app/kubeletplugin.go
@@ -145,7 +145,7 @@ func (ex *ExamplePlugin) NodePrepareResource(ctx context.Context, req *drapbv1.N
 	vendor := ex.driverName
 	class := "test"
 	spec := &spec{
-		Version: "0.2.0", // This has to be a version accepted by the runtimes.
+		Version: "0.3.0", // This has to be a version accepted by the runtimes.
 		Kind:    vendor + "/" + class,
 		// At least one device is required and its entry must have more
 		// than just the name.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The latest CDI release includes spec version check that fails if version is less than 0.3.0:
  https://github.com/container-orchestrated-devices/container-device-interface/blob/v0.5.4/pkg/cdi/version.go#L42

Updating CDI spec version to 0.3.0 in the test kubelet plugin code should fix e2e test failures on the CRI runtimes that use CDI >= 0.5.4 (Containerd master atm, CRI-O soon).

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```