### PR TITLE
Codegen: streamline code for subproject generation

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/hack/update-codegen.sh
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/hack/update-codegen.sh
@@ -25,7 +25,7 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-
 # --output-base    because this script should also be able to run inside the vendor dir of
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
-"${CODEGEN_PKG}/generate-groups.sh" all \
+"${CODEGEN_PKG}/generate-groups.sh" "applyconfiguration,client,deepcopy,informer,lister" \
   k8s.io/apiextensions-apiserver/examples/client-go/pkg/client \
   k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis \
   cr:v1 \

--- a/staging/src/k8s.io/apiextensions-apiserver/hack/update-codegen.sh
+++ b/staging/src/k8s.io/apiextensions-apiserver/hack/update-codegen.sh
@@ -23,7 +23,7 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-
 
 CLIENTSET_NAME_VERSIONED=clientset \
 CLIENTSET_PKG_NAME=clientset \
-"${CODEGEN_PKG}/generate-groups.sh" "deepcopy,client,lister,informer" \
+"${CODEGEN_PKG}/generate-groups.sh" "deepcopy,defaulter,client,lister,informer" \
   k8s.io/apiextensions-apiserver/pkg/client \
   k8s.io/apiextensions-apiserver/pkg/apis \
   "apiextensions:v1beta1,v1" \

--- a/staging/src/k8s.io/code-generator/generate-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-groups.sh
@@ -25,7 +25,7 @@ if [ "$#" -lt 4 ] || [ "${1}" == "--help" ]; then
   cat <<EOF
 Usage: $(basename "$0") <generators> <output-package> <apis-package> <groups-versions> ...
 
-  <generators>        the generators comma separated to run (deepcopy, defaulter,applyconfiguration,client,lister,informer).
+  <generators>        the generators comma separated to run (deepcopy,defaulter,applyconfiguration,client,lister,informer).
   <output-package>    the output package name (e.g. github.com/example/project/pkg/generated).
   <apis-package>      the external types dir (e.g. github.com/example/api or github.com/example/project/pkg/apis).
   <groups-versions>   the groups and their versions in the format "groupA:v1,v2 groupB:v1 groupC:v2", relative
@@ -58,81 +58,5 @@ if [ "${GENS}" = "all" ] || grep -qw "all" <<<"${GENS}"; then
     GENS="${ALL}"
 fi
 
-(
-  # To support running this script from anywhere, first cd into this directory,
-  # and then install with forced module mode on and fully qualified name.
-  cd "$(dirname "${0}")"
-  GO111MODULE=on go install k8s.io/code-generator/cmd/{applyconfiguration-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,defaulter-gen}
-)
-# Go installs the above commands to get installed in $GOBIN if defined, and $GOPATH/bin otherwise:
-GOBIN="$(go env GOBIN)"
-gobin="${GOBIN:-$(go env GOPATH)/bin}"
-
-function codegen::join() { local IFS="$1"; shift; echo "$*"; }
-
-# enumerate group versions
-FQ_APIS=() # e.g. k8s.io/api/apps/v1
-for GVs in ${GROUPS_WITH_VERSIONS}; do
-  IFS=: read -r G Vs <<<"${GVs}"
-
-  # enumerate versions
-  for V in ${Vs//,/ }; do
-    FQ_APIS+=("${APIS_PKG}/${G}/${V}")
-  done
-done
-
-if grep -qw "deepcopy" <<<"${GENS}"; then
-  echo "Generating deepcopy funcs"
-  "${gobin}/deepcopy-gen" \
-      --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" \
-      -O zz_generated.deepcopy \
-      "$@"
-fi
-
-if grep -qw "defaulter" <<<"${GENS}"; then
-  echo "Generating defaulters"
-  "${gobin}/defaulter-gen"  \
-      --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" \
-      -O zz_generated.defaults \
-      "$@"
-fi
-
-if grep -qw "applyconfiguration" <<<"${GENS}"; then
-  echo "Generating apply configuration for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/${APPLYCONFIGURATION_PKG_NAME:-applyconfiguration}"
-  "${gobin}/applyconfiguration-gen" \
-      --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" \
-      --output-package "${OUTPUT_PKG}/${APPLYCONFIGURATION_PKG_NAME:-applyconfiguration}" \
-      "$@"
-fi
-
-if grep -qw "client" <<<"${GENS}"; then
-  echo "Generating clientset for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}"
-  if grep -qw "applyconfiguration" <<<"${GENS}"; then
-    APPLY_CONFIGURATION_PACKAGE="${OUTPUT_PKG}/${APPLYCONFIGURATION_PKG_NAME:-applyconfiguration}"
-  fi
-  "${gobin}/client-gen" \
-      --clientset-name "${CLIENTSET_NAME_VERSIONED:-versioned}" \
-      --input-base "" \
-      --input "$(codegen::join , "${FQ_APIS[@]}")" \
-      --output-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}" \
-      --apply-configuration-package "${APPLY_CONFIGURATION_PACKAGE:-}" \
-      "$@"
-fi
-
-if grep -qw "lister" <<<"${GENS}"; then
-  echo "Generating listers for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/listers"
-  "${gobin}/lister-gen" \
-      --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" \
-      --output-package "${OUTPUT_PKG}/listers" \
-      "$@"
-fi
-
-if grep -qw "informer" <<<"${GENS}"; then
-  echo "Generating informers for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/informers"
-  "${gobin}/informer-gen" \
-      --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" \
-      --versioned-clientset-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}/${CLIENTSET_NAME_VERSIONED:-versioned}" \
-      --listers-package "${OUTPUT_PKG}/listers" \
-      --output-package "${OUTPUT_PKG}/informers" \
-      "$@"
-fi
+INT_APIS_PKG=""
+exec "$(dirname "${BASH_SOURCE[0]}")/generate-internal-groups.sh" "${GENS}" "${OUTPUT_PKG}" "${INT_APIS_PKG}" "${APIS_PKG}" "${GROUPS_WITH_VERSIONS}" "$@"

--- a/staging/src/k8s.io/code-generator/generate-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-groups.sh
@@ -53,7 +53,7 @@ if [ "${GENS}" = "all" ] || grep -qw "all" <<<"${GENS}"; then
     ALL="applyconfiguration,client,deepcopy,informer,lister"
     echo "WARNING: Specifying \"all\" as a generator is deprecated."
     echo "WARNING: Please list the specific generators needed."
-    echo "WARNING: \"all\" is now an alias for \"${ALL}\""
+    echo "WARNING: \"all\" is now an alias for \"${ALL}\"; new code generators WILL NOT be added to this set"
     echo
     GENS="${ALL}"
 fi

--- a/staging/src/k8s.io/code-generator/generate-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-groups.sh
@@ -25,7 +25,7 @@ if [ "$#" -lt 4 ] || [ "${1}" == "--help" ]; then
   cat <<EOF
 Usage: $(basename "$0") <generators> <output-package> <apis-package> <groups-versions> ...
 
-  <generators>        the generators comma separated to run (deepcopy,applyconfiguration,client,lister,informer) or "all".
+  <generators>        the generators comma separated to run (deepcopy, defaulter,applyconfiguration,client,lister,informer) or "all".
   <output-package>    the output package name (e.g. github.com/example/project/pkg/generated).
   <apis-package>      the external types dir (e.g. github.com/example/api or github.com/example/project/pkg/apis).
   <groups-versions>   the groups and their versions in the format "groupA:v1,v2 groupB:v1 groupC:v2", relative
@@ -50,7 +50,7 @@ shift 4
   # To support running this script from anywhere, first cd into this directory,
   # and then install with forced module mode on and fully qualified name.
   cd "$(dirname "${0}")"
-  GO111MODULE=on go install k8s.io/code-generator/cmd/{applyconfiguration-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
+  GO111MODULE=on go install k8s.io/code-generator/cmd/{applyconfiguration-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,defaulter-gen}
 )
 # Go installs the above commands to get installed in $GOBIN if defined, and $GOPATH/bin otherwise:
 GOBIN="$(go env GOBIN)"
@@ -74,6 +74,14 @@ if [ "${GENS}" = "all" ] || grep -qw "deepcopy" <<<"${GENS}"; then
   "${gobin}/deepcopy-gen" \
       --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" \
       -O zz_generated.deepcopy \
+      "$@"
+fi
+
+if [ "${GENS}" = "all" ] || grep -qw "defaulter" <<<"${GENS}"; then
+  echo "Generating defaulters"
+  "${gobin}/defaulter-gen"  \
+      --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" \
+      -O zz_generated.defaults \
       "$@"
 fi
 

--- a/staging/src/k8s.io/code-generator/generate-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-groups.sh
@@ -25,7 +25,7 @@ if [ "$#" -lt 4 ] || [ "${1}" == "--help" ]; then
   cat <<EOF
 Usage: $(basename "$0") <generators> <output-package> <apis-package> <groups-versions> ...
 
-  <generators>        the generators comma separated to run (deepcopy,defaulter,applyconfiguration,client,lister,informer) or "all".
+  <generators>        the generators comma separated to run (deepcopy,applyconfiguration,client,lister,informer) or "all".
   <output-package>    the output package name (e.g. github.com/example/project/pkg/generated).
   <apis-package>      the external types dir (e.g. github.com/example/api or github.com/example/project/pkg/apis).
   <groups-versions>   the groups and their versions in the format "groupA:v1,v2 groupB:v1 groupC:v2", relative
@@ -50,7 +50,7 @@ shift 4
   # To support running this script from anywhere, first cd into this directory,
   # and then install with forced module mode on and fully qualified name.
   cd "$(dirname "${0}")"
-  GO111MODULE=on go install k8s.io/code-generator/cmd/{applyconfiguration-gen,defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
+  GO111MODULE=on go install k8s.io/code-generator/cmd/{applyconfiguration-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
 )
 # Go installs the above commands to get installed in $GOBIN if defined, and $GOPATH/bin otherwise:
 GOBIN="$(go env GOBIN)"

--- a/staging/src/k8s.io/code-generator/generate-internal-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-internal-groups.sh
@@ -55,7 +55,7 @@ if [ "${GENS}" = "all" ] || grep -qw "all" <<<"${GENS}"; then
     ALL="client,conversion,deepcopy,defaulter,informer,lister,openapi"
     echo "WARNING: Specifying \"all\" as a generator is deprecated."
     echo "WARNING: Please list the specific generators needed."
-    echo "WARNING: \"all\" is now an alias for \"${ALL}\""
+    echo "WARNING: \"all\" is now an alias for \"${ALL}\"; new code generators WILL NOT be added to this set"
     echo
     GENS="${ALL}"
 fi

--- a/staging/src/k8s.io/code-generator/generate-internal-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-internal-groups.sh
@@ -80,21 +80,24 @@ done
 if [ "${GENS}" = "all" ] || grep -qw "deepcopy" <<<"${GENS}"; then
   echo "Generating deepcopy funcs"
   "${gobin}/deepcopy-gen" \
-      --input-dirs "$(codegen::join , "${ALL_FQ_APIS[@]}")" -O zz_generated.deepcopy \
+      --input-dirs "$(codegen::join , "${ALL_FQ_APIS[@]}")" \
+      -O zz_generated.deepcopy \
       "$@"
 fi
 
 if [ "${GENS}" = "all" ] || grep -qw "defaulter" <<<"${GENS}"; then
   echo "Generating defaulters"
   "${gobin}/defaulter-gen"  \
-      --input-dirs "$(codegen::join , "${EXT_FQ_APIS[@]}")" -O zz_generated.defaults \
+      --input-dirs "$(codegen::join , "${EXT_FQ_APIS[@]}")" \
+      -O zz_generated.defaults \
       "$@"
 fi
 
 if [ "${GENS}" = "all" ] || grep -qw "conversion" <<<"${GENS}"; then
   echo "Generating conversions"
   "${gobin}/conversion-gen" \
-      --input-dirs "$(codegen::join , "${ALL_FQ_APIS[@]}")" -O zz_generated.conversion \
+      --input-dirs "$(codegen::join , "${ALL_FQ_APIS[@]}")" \
+      -O zz_generated.conversion \
       "$@"
 fi
 

--- a/staging/src/k8s.io/code-generator/hack/update-codegen.sh
+++ b/staging/src/k8s.io/code-generator/hack/update-codegen.sh
@@ -31,19 +31,19 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
   "example:v1 example2:v1 example3.io:v1" \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
   --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
-"${SCRIPT_ROOT}/generate-groups.sh" "applyconfiguration,client,deepcopy,informer,lister" \
+"${SCRIPT_ROOT}/generate-groups.sh" "applyconfiguration,client,deepcopy,defaulter,informer,lister" \
   k8s.io/code-generator/examples/crd \
   k8s.io/code-generator/examples/crd/apis \
   "example:v1 example2:v1" \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
   --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
-"${SCRIPT_ROOT}/generate-groups.sh" "applyconfiguration,client,deepcopy,informer,lister" \
+"${SCRIPT_ROOT}/generate-groups.sh" "applyconfiguration,client,deepcopy,defaulter,informer,lister" \
   k8s.io/code-generator/examples/MixedCase \
   k8s.io/code-generator/examples/MixedCase/apis \
   "example:v1" \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
   --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
-"${SCRIPT_ROOT}/generate-groups.sh" "applyconfiguration,client,deepcopy,informer,lister" \
+"${SCRIPT_ROOT}/generate-groups.sh" "applyconfiguration,client,deepcopy,defaulter,informer,lister" \
   k8s.io/code-generator/examples/HyphenGroup \
   k8s.io/code-generator/examples/HyphenGroup/apis \
   "example:v1" \

--- a/staging/src/k8s.io/code-generator/hack/update-codegen.sh
+++ b/staging/src/k8s.io/code-generator/hack/update-codegen.sh
@@ -24,26 +24,26 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 # - --output-base because this script should also be able to run inside the vendor dir of
 #   k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #   instead of the $GOPATH directly. For normal projects this can be dropped.
-"${SCRIPT_ROOT}/generate-internal-groups.sh" all \
+"${SCRIPT_ROOT}/generate-internal-groups.sh" "client,conversion,deepcopy,defaulter,informer,lister,openapi" \
   k8s.io/code-generator/examples/apiserver \
   k8s.io/code-generator/examples/apiserver/apis \
   k8s.io/code-generator/examples/apiserver/apis \
   "example:v1 example2:v1 example3.io:v1" \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
   --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
-"${SCRIPT_ROOT}/generate-groups.sh" all \
+"${SCRIPT_ROOT}/generate-groups.sh" "applyconfiguration,client,deepcopy,informer,lister" \
   k8s.io/code-generator/examples/crd \
   k8s.io/code-generator/examples/crd/apis \
   "example:v1 example2:v1" \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
   --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
-"${SCRIPT_ROOT}/generate-groups.sh" all \
+"${SCRIPT_ROOT}/generate-groups.sh" "applyconfiguration,client,deepcopy,informer,lister" \
   k8s.io/code-generator/examples/MixedCase \
   k8s.io/code-generator/examples/MixedCase/apis \
   "example:v1" \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
   --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
-"${SCRIPT_ROOT}/generate-groups.sh" all \
+"${SCRIPT_ROOT}/generate-groups.sh" "applyconfiguration,client,deepcopy,informer,lister" \
   k8s.io/code-generator/examples/HyphenGroup \
   k8s.io/code-generator/examples/HyphenGroup/apis \
   "example:v1" \

--- a/staging/src/k8s.io/kube-aggregator/hack/update-codegen.sh
+++ b/staging/src/k8s.io/kube-aggregator/hack/update-codegen.sh
@@ -23,7 +23,7 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-
 
 CLIENTSET_NAME_VERSIONED=clientset \
 CLIENTSET_PKG_NAME=clientset_generated \
-"${CODEGEN_PKG}/generate-groups.sh" "deepcopy,client,lister,informer" \
+"${CODEGEN_PKG}/generate-groups.sh" "deepcopy,defaulter,client,lister,informer" \
   k8s.io/kube-aggregator/pkg/client \
   k8s.io/kube-aggregator/pkg/apis \
   "apiregistration:v1beta1,v1" \

--- a/staging/src/k8s.io/metrics/hack/update-codegen.sh
+++ b/staging/src/k8s.io/metrics/hack/update-codegen.sh
@@ -32,7 +32,7 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-
   k8s.io/metrics/pkg/client \
   k8s.io/metrics/pkg/apis \
   k8s.io/metrics/pkg/apis \
-  "metrics:v1alpha1,v1beta1 custom_metrics:v1beta1 external_metrics:v1beta1" \
+  "metrics:v1alpha1,v1beta1 custom_metrics:v1beta1,v1beta2 external_metrics:v1beta1" \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
   --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
 "${CODEGEN_PKG}/generate-groups.sh" "client" \

--- a/staging/src/k8s.io/sample-apiserver/hack/update-codegen.sh
+++ b/staging/src/k8s.io/sample-apiserver/hack/update-codegen.sh
@@ -25,7 +25,7 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-
 # --output-base    because this script should also be able to run inside the vendor dir of
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
-"${CODEGEN_PKG}/generate-groups.sh" all \
+"${CODEGEN_PKG}/generate-groups.sh" "applyconfiguration,client,deepcopy,informer,lister" \
   k8s.io/sample-apiserver/pkg/generated \
   k8s.io/sample-apiserver/pkg/apis \
   "wardle:v1alpha1,v1beta1" \


### PR DESCRIPTION
1) change "all" into explicit lists of generators
2) make generate-internal-groups be a superset of generate-groups
4) call internal from generate-groups

I also have an idea to followup with a new generate-kube-code.sh script which is more friendly and automatic (maybe no more open-coded lists of versions), and convert callers to that (and deprecate old scripts)

There will be several followups to this.  One that I'd like to pursue is getting rid of the update-codegen bash code which deals with indirect arrays for openapi - specifically for subprojects.  Several of them *want* openapi generation, but the generate-groups logic does not produce the same results.  I don't know enough about it to dig in yet.

/kind cleanup

```release-note
NONE
```
