### PR TITLE
KEP-3705 cloud dual-stack --node-ip

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1120,7 +1120,7 @@ func RunKubelet(kubeServer *options.KubeletServer, kubeDeps *kubelet.Dependencie
 	// Setup event recorder if required.
 	makeEventRecorder(kubeDeps, nodeName)
 
-	nodeIPs, err := nodeutil.ParseNodeIPArgument(kubeServer.NodeIP, kubeServer.CloudProvider)
+	nodeIPs, err := nodeutil.ParseNodeIPArgument(kubeServer.NodeIP, kubeServer.CloudProvider, false)
 	if err != nil {
 		return fmt.Errorf("bad --node-ip %q: %v", kubeServer.NodeIP, err)
 	}

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1120,24 +1120,9 @@ func RunKubelet(kubeServer *options.KubeletServer, kubeDeps *kubelet.Dependencie
 	// Setup event recorder if required.
 	makeEventRecorder(kubeDeps, nodeName)
 
-	var nodeIPs []net.IP
-	if kubeServer.NodeIP != "" {
-		for _, ip := range strings.Split(kubeServer.NodeIP, ",") {
-			parsedNodeIP := netutils.ParseIPSloppy(strings.TrimSpace(ip))
-			if parsedNodeIP == nil {
-				klog.InfoS("Could not parse --node-ip ignoring", "IP", ip)
-			} else {
-				nodeIPs = append(nodeIPs, parsedNodeIP)
-			}
-		}
-	}
-
-	if len(nodeIPs) > 2 || (len(nodeIPs) == 2 && netutils.IsIPv6(nodeIPs[0]) == netutils.IsIPv6(nodeIPs[1])) {
-		return fmt.Errorf("bad --node-ip %q; must contain either a single IP or a dual-stack pair of IPs", kubeServer.NodeIP)
-	} else if len(nodeIPs) == 2 && kubeServer.CloudProvider != "" {
-		return fmt.Errorf("dual-stack --node-ip %q not supported when using a cloud provider", kubeServer.NodeIP)
-	} else if len(nodeIPs) == 2 && (nodeIPs[0].IsUnspecified() || nodeIPs[1].IsUnspecified()) {
-		return fmt.Errorf("dual-stack --node-ip %q cannot include '0.0.0.0' or '::'", kubeServer.NodeIP)
+	nodeIPs, err := nodeutil.ParseNodeIPArgument(kubeServer.NodeIP, kubeServer.CloudProvider)
+	if err != nil {
+		return fmt.Errorf("bad --node-ip %q: %v", kubeServer.NodeIP, err)
 	}
 
 	capabilities.Initialize(capabilities.Capabilities{

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1120,7 +1120,7 @@ func RunKubelet(kubeServer *options.KubeletServer, kubeDeps *kubelet.Dependencie
 	// Setup event recorder if required.
 	makeEventRecorder(kubeDeps, nodeName)
 
-	nodeIPs, err := nodeutil.ParseNodeIPArgument(kubeServer.NodeIP, kubeServer.CloudProvider, false)
+	nodeIPs, err := nodeutil.ParseNodeIPArgument(kubeServer.NodeIP, kubeServer.CloudProvider, utilfeature.DefaultFeatureGate.Enabled(features.CloudDualStackNodeIPs))
 	if err != nil {
 		return fmt.Errorf("bad --node-ip %q: %v", kubeServer.NodeIP, err)
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -61,6 +61,12 @@ const (
 	// beta: v1.4
 	AppArmor featuregate.Feature = "AppArmor"
 
+	// owner: @danwinship
+	// alpha: v1.27
+	//
+	// Enables dual-stack --node-ip in kubelet with external cloud providers
+	CloudDualStackNodeIPs featuregate.Feature = "CloudDualStackNodeIPs"
+
 	// owner: @szuecs
 	// alpha: v1.12
 	//
@@ -925,6 +931,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	APISelfSubjectReview: {Default: true, PreRelease: featuregate.Beta}, // on by default in 1.27
 
 	AppArmor: {Default: true, PreRelease: featuregate.Beta},
+
+	CloudDualStackNodeIPs: {Default: false, PreRelease: featuregate.Alpha},
 
 	CPUCFSQuotaPeriod: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -131,7 +131,7 @@ func NodeAddress(nodeIPs []net.IP, // typically Kubelet.nodeIPs
 				return err
 			}
 
-			nodeAddresses, err := cloudprovidernodeutil.PreferNodeIP(nodeIP, cloudNodeAddresses)
+			nodeAddresses, err := cloudprovidernodeutil.GetNodeAddressesFromNodeIPLegacy(nodeIP, cloudNodeAddresses)
 			if err != nil {
 				return err
 			}

--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
@@ -45,7 +45,6 @@ import (
 	controllersmetrics "k8s.io/component-base/metrics/prometheus/controllers"
 	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/klog/v2"
-	netutils "k8s.io/utils/net"
 )
 
 // labelReconcileInfo lists Node labels to reconcile, and how to reconcile them.
@@ -756,9 +755,9 @@ func getNodeProvidedIP(node *v1.Node) (net.IP, error) {
 		return nil, nil
 	}
 
-	nodeIP := netutils.ParseIPSloppy(providedIP)
-	if nodeIP == nil {
-		return nil, fmt.Errorf("failed to parse node IP %q for node %q", providedIP, node.Name)
+	nodeIP, err := nodeutil.ParseNodeIPAnnotation(providedIP)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse node IP %q for node %q: %v", providedIP, node.Name, err)
 	}
 
 	return nodeIP, nil

--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
@@ -739,7 +739,7 @@ func updateNodeAddressesFromNodeIP(node *v1.Node, nodeAddresses []v1.NodeAddress
 
 	providedNodeIP, exists := node.ObjectMeta.Annotations[cloudproviderapi.AnnotationAlphaProvidedIPAddr]
 	if exists {
-		nodeAddresses, err = cloudnodeutil.GetNodeAddressesFromNodeIP(providedNodeIP, nodeAddresses)
+		nodeAddresses, err = cloudnodeutil.GetNodeAddressesFromNodeIP(providedNodeIP, nodeAddresses, false)
 	}
 
 	return nodeAddresses, err

--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
@@ -391,7 +391,7 @@ func (cnc *CloudNodeController) updateNodeAddress(ctx context.Context, node *v1.
 	}
 
 	if nodeIP != nil {
-		nodeAddresses, err = cloudnodeutil.PreferNodeIP(nodeIP, nodeAddresses)
+		nodeAddresses, err = cloudnodeutil.GetNodeAddressesFromNodeIP(nodeIP, nodeAddresses)
 		if err != nil {
 			klog.Errorf("Failed to update node addresses for node %q: %v", node.Name, err)
 			return
@@ -539,7 +539,7 @@ func (cnc *CloudNodeController) getNodeModifiersFromCloudProvider(
 	}
 
 	if nodeIP != nil {
-		_, err := cloudnodeutil.PreferNodeIP(nodeIP, instanceMeta.NodeAddresses)
+		_, err := cloudnodeutil.GetNodeAddressesFromNodeIP(nodeIP, instanceMeta.NodeAddresses)
 		if err != nil {
 			return nil, fmt.Errorf("provided node ip for node %q is not valid: %w", node.Name, err)
 		}

--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -43,6 +44,7 @@ import (
 	cloudnodeutil "k8s.io/cloud-provider/node/helpers"
 	controllersmetrics "k8s.io/component-base/metrics/prometheus/controllers"
 	nodeutil "k8s.io/component-helpers/node/util"
+	"k8s.io/controller-manager/pkg/features"
 	"k8s.io/klog/v2"
 )
 
@@ -739,7 +741,7 @@ func updateNodeAddressesFromNodeIP(node *v1.Node, nodeAddresses []v1.NodeAddress
 
 	providedNodeIP, exists := node.ObjectMeta.Annotations[cloudproviderapi.AnnotationAlphaProvidedIPAddr]
 	if exists {
-		nodeAddresses, err = cloudnodeutil.GetNodeAddressesFromNodeIP(providedNodeIP, nodeAddresses, false)
+		nodeAddresses, err = cloudnodeutil.GetNodeAddressesFromNodeIP(providedNodeIP, nodeAddresses, utilfeature.DefaultFeatureGate.Enabled(features.CloudDualStackNodeIPs))
 	}
 
 	return nodeAddresses, err

--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
@@ -38,6 +38,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	cloudproviderapi "k8s.io/cloud-provider/api"
 	fakecloud "k8s.io/cloud-provider/fake"
+	_ "k8s.io/controller-manager/pkg/features/register"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"

--- a/staging/src/k8s.io/cloud-provider/node/helpers/address_test.go
+++ b/staging/src/k8s.io/cloud-provider/node/helpers/address_test.go
@@ -316,14 +316,14 @@ func TestGetNodeAddressesFromNodeIPLegacy(t *testing.T) {
 func TestGetNodeAddressesFromNodeIP(t *testing.T) {
 	cases := []struct {
 		name              string
-		nodeIP            net.IP
+		nodeIP            string
 		nodeAddresses     []v1.NodeAddress
 		expectedAddresses []v1.NodeAddress
 		shouldError       bool
 	}{
 		{
 			name:   "A single InternalIP",
-			nodeIP: netutils.ParseIPSloppy("10.1.1.1"),
+			nodeIP: "10.1.1.1",
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeHostName, Address: testKubeletHostname},
@@ -336,7 +336,7 @@ func TestGetNodeAddressesFromNodeIP(t *testing.T) {
 		},
 		{
 			name:   "NodeIP is external",
-			nodeIP: netutils.ParseIPSloppy("55.55.55.55"),
+			nodeIP: "55.55.55.55",
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
@@ -352,7 +352,7 @@ func TestGetNodeAddressesFromNodeIP(t *testing.T) {
 		{
 			// Accommodating #45201 and #49202
 			name:   "InternalIP and ExternalIP are the same",
-			nodeIP: netutils.ParseIPSloppy("55.55.55.55"),
+			nodeIP: "55.55.55.55",
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "44.44.44.44"},
 				{Type: v1.NodeExternalIP, Address: "44.44.44.44"},
@@ -369,7 +369,7 @@ func TestGetNodeAddressesFromNodeIP(t *testing.T) {
 		},
 		{
 			name:   "An Internal/ExternalIP, an Internal/ExternalDNS",
-			nodeIP: netutils.ParseIPSloppy("10.1.1.1"),
+			nodeIP: "10.1.1.1",
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
@@ -388,7 +388,7 @@ func TestGetNodeAddressesFromNodeIP(t *testing.T) {
 		},
 		{
 			name:   "An Internal with multiple internal IPs",
-			nodeIP: netutils.ParseIPSloppy("10.1.1.1"),
+			nodeIP: "10.1.1.1",
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeInternalIP, Address: "10.2.2.2"},
@@ -405,7 +405,7 @@ func TestGetNodeAddressesFromNodeIP(t *testing.T) {
 		},
 		{
 			name:   "An InternalIP that isn't valid: should error",
-			nodeIP: netutils.ParseIPSloppy("10.2.2.2"),
+			nodeIP: "10.2.2.2",
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
@@ -416,7 +416,7 @@ func TestGetNodeAddressesFromNodeIP(t *testing.T) {
 		},
 		{
 			name:   "Dual-stack cloud, with nodeIP, different IPv6 formats",
-			nodeIP: netutils.ParseIPSloppy("2600:1f14:1d4:d101::ba3d"),
+			nodeIP: "2600:1f14:1d4:d101::ba3d",
 			nodeAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeInternalIP, Address: "2600:1f14:1d4:d101:0:0:0:ba3d"},
@@ -424,34 +424,6 @@ func TestGetNodeAddressesFromNodeIP(t *testing.T) {
 			},
 			expectedAddresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "2600:1f14:1d4:d101:0:0:0:ba3d"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			shouldError: false,
-		},
-		{
-			name: "Dual-stack cloud, IPv4 first, no nodeIP",
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeInternalIP, Address: "fc01:1234::5678"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeInternalIP, Address: "fc01:1234::5678"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			shouldError: false,
-		},
-		{
-			name: "Dual-stack cloud, IPv6 first, no nodeIP",
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "fc01:1234::5678"},
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "fc01:1234::5678"},
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
 				{Type: v1.NodeHostName, Address: testKubeletHostname},
 			},
 			shouldError: false,

--- a/staging/src/k8s.io/component-helpers/node/util/ips.go
+++ b/staging/src/k8s.io/component-helpers/node/util/ips.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
+)
+
+const (
+	cloudProviderNone     = ""
+	cloudProviderExternal = "external"
+)
+
+// parseNodeIP implements ParseNodeIPArgument and ParseNodeIPAnnotation
+func parseNodeIP(nodeIP string, allowDual, sloppy bool) ([]net.IP, error) {
+	var nodeIPs []net.IP
+	if nodeIP != "" || !sloppy {
+		for _, ip := range strings.Split(nodeIP, ",") {
+			if sloppy {
+				ip = strings.TrimSpace(ip)
+			}
+			parsedNodeIP := netutils.ParseIPSloppy(ip)
+			if parsedNodeIP == nil {
+				if sloppy {
+					klog.InfoS("Could not parse node IP. Ignoring", "IP", ip)
+				} else {
+					return nil, fmt.Errorf("could not parse %q", ip)
+				}
+			} else {
+				nodeIPs = append(nodeIPs, parsedNodeIP)
+			}
+		}
+	}
+
+	if len(nodeIPs) > 2 || (len(nodeIPs) == 2 && netutils.IsIPv6(nodeIPs[0]) == netutils.IsIPv6(nodeIPs[1])) {
+		return nil, fmt.Errorf("must contain either a single IP or a dual-stack pair of IPs")
+	} else if len(nodeIPs) == 2 && !allowDual {
+		return nil, fmt.Errorf("dual-stack not supported in this configuration")
+	} else if len(nodeIPs) == 2 && (nodeIPs[0].IsUnspecified() || nodeIPs[1].IsUnspecified()) {
+		return nil, fmt.Errorf("dual-stack node IP cannot include '0.0.0.0' or '::'")
+	}
+
+	return nodeIPs, nil
+}
+
+// ParseNodeIPArgument parses kubelet's --node-ip argument. If nodeIP contains invalid
+// values, they will be logged and ignored. Dual-stack node IPs are only supported if
+// cloudProvider is unset.
+func ParseNodeIPArgument(nodeIP, cloudProvider string) ([]net.IP, error) {
+	return parseNodeIP(nodeIP, cloudProvider == cloudProviderNone, true)
+}
+
+// ParseNodeIPAnnotation parses the `alpha.kubernetes.io/provided-node-ip` annotation,
+// which should be a single IP address. Unlike with ParseNodeIPArgument, invalid values
+// are considered an error.
+func ParseNodeIPAnnotation(nodeIP string) (net.IP, error) {
+	ips, err := parseNodeIP(nodeIP, false, false)
+	if err != nil || len(ips) == 0 {
+		return nil, err
+	}
+	return ips[0], nil
+}

--- a/staging/src/k8s.io/component-helpers/node/util/ips.go
+++ b/staging/src/k8s.io/component-helpers/node/util/ips.go
@@ -63,10 +63,14 @@ func parseNodeIP(nodeIP string, allowDual, sloppy bool) ([]net.IP, error) {
 }
 
 // ParseNodeIPArgument parses kubelet's --node-ip argument. If nodeIP contains invalid
-// values, they will be logged and ignored. Dual-stack node IPs are only supported if
-// cloudProvider is unset.
-func ParseNodeIPArgument(nodeIP, cloudProvider string) ([]net.IP, error) {
-	return parseNodeIP(nodeIP, cloudProvider == cloudProviderNone, true)
+// values, they will be logged and ignored. Dual-stack node IPs are allowed if
+// cloudProvider is unset, or if it is `"external"` and allowCloudDualStack is true.
+func ParseNodeIPArgument(nodeIP, cloudProvider string, allowCloudDualStack bool) ([]net.IP, error) {
+	var allowDualStack bool
+	if (cloudProvider == cloudProviderNone) || (cloudProvider == cloudProviderExternal && allowCloudDualStack) {
+		allowDualStack = true
+	}
+	return parseNodeIP(nodeIP, allowDualStack, true)
 }
 
 // ParseNodeIPAnnotation parses the `alpha.kubernetes.io/provided-node-ip` annotation,

--- a/staging/src/k8s.io/component-helpers/node/util/ips.go
+++ b/staging/src/k8s.io/component-helpers/node/util/ips.go
@@ -74,12 +74,9 @@ func ParseNodeIPArgument(nodeIP, cloudProvider string, allowCloudDualStack bool)
 }
 
 // ParseNodeIPAnnotation parses the `alpha.kubernetes.io/provided-node-ip` annotation,
-// which should be a single IP address. Unlike with ParseNodeIPArgument, invalid values
+// which can be either a single IP address or (if allowDualStack is true) a
+// comma-separated pair of IP addresses. Unlike with ParseNodeIPArgument, invalid values
 // are considered an error.
-func ParseNodeIPAnnotation(nodeIP string) (net.IP, error) {
-	ips, err := parseNodeIP(nodeIP, false, false)
-	if err != nil || len(ips) == 0 {
-		return nil, err
-	}
-	return ips[0], nil
+func ParseNodeIPAnnotation(nodeIP string, allowDualStack bool) ([]net.IP, error) {
+	return parseNodeIP(nodeIP, allowDualStack, false)
 }

--- a/staging/src/k8s.io/component-helpers/node/util/ips_test.go
+++ b/staging/src/k8s.io/component-helpers/node/util/ips_test.go
@@ -1,0 +1,330 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"strings"
+	"testing"
+
+	netutils "k8s.io/utils/net"
+)
+
+func TestParseNodeIPArgument(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		in    string
+		out   []net.IP
+		err   string
+		ssErr string
+	}{
+		{
+			desc: "empty --node-ip",
+			in:   "",
+			out:  nil,
+		},
+		{
+			desc: "just whitespace (ignored)",
+			in:   " ",
+			out:  nil,
+		},
+		{
+			desc: "garbage (ignored)",
+			in:   "blah",
+			out:  nil,
+		},
+		{
+			desc: "single IPv4",
+			in:   "1.2.3.4",
+			out: []net.IP{
+				netutils.ParseIPSloppy("1.2.3.4"),
+			},
+		},
+		{
+			desc: "single IPv4 with whitespace",
+			in:   " 1.2.3.4   ",
+			out: []net.IP{
+				netutils.ParseIPSloppy("1.2.3.4"),
+			},
+		},
+		{
+			desc: "single IPv4 non-canonical",
+			in:   "01.2.3.004",
+			out: []net.IP{
+				netutils.ParseIPSloppy("1.2.3.4"),
+			},
+		},
+		{
+			desc: "single IPv4 invalid (ignored)",
+			in:   "1.2.3",
+			out:  nil,
+		},
+		{
+			desc: "single IPv4 CIDR (ignored)",
+			in:   "1.2.3.0/24",
+			out:  nil,
+		},
+		{
+			desc: "single IPv4 unspecified",
+			in:   "0.0.0.0",
+			out: []net.IP{
+				net.IPv4zero,
+			},
+		},
+		{
+			desc: "single IPv4 plus ignored garbage",
+			in:   "1.2.3.4,not-an-IPv6-address",
+			out: []net.IP{
+				netutils.ParseIPSloppy("1.2.3.4"),
+			},
+		},
+		{
+			desc: "single IPv6",
+			in:   "abcd::ef01",
+			out: []net.IP{
+				netutils.ParseIPSloppy("abcd::ef01"),
+			},
+		},
+		{
+			desc: "single IPv6 non-canonical",
+			in:   "abcd:0abc:00ab:0000:0000::1",
+			out: []net.IP{
+				netutils.ParseIPSloppy("abcd:abc:ab::1"),
+			},
+		},
+		{
+			desc: "simple dual-stack",
+			in:   "1.2.3.4,abcd::ef01",
+			out: []net.IP{
+				netutils.ParseIPSloppy("1.2.3.4"),
+				netutils.ParseIPSloppy("abcd::ef01"),
+			},
+			ssErr: "not supported in this configuration",
+		},
+		{
+			desc: "dual-stack with whitespace",
+			in:   "abcd::ef01 , 1.2.3.4",
+			out: []net.IP{
+				netutils.ParseIPSloppy("abcd::ef01"),
+				netutils.ParseIPSloppy("1.2.3.4"),
+			},
+			ssErr: "not supported in this configuration",
+		},
+		{
+			desc: "double IPv4",
+			in:   "1.2.3.4,5.6.7.8",
+			err:  "either a single IP or a dual-stack pair of IPs",
+		},
+		{
+			desc: "double IPv6",
+			in:   "abcd::1,abcd::2",
+			err:  "either a single IP or a dual-stack pair of IPs",
+		},
+		{
+			desc:  "dual-stack with unspecified",
+			in:    "1.2.3.4,::",
+			err:   "cannot include '0.0.0.0' or '::'",
+			ssErr: "not supported in this configuration",
+		},
+		{
+			desc:  "dual-stack with unspecified",
+			in:    "0.0.0.0,abcd::1",
+			err:   "cannot include '0.0.0.0' or '::'",
+			ssErr: "not supported in this configuration",
+		},
+		{
+			desc: "dual-stack plus ignored garbage",
+			in:   "abcd::ef01 , 1.2.3.4, something else",
+			out: []net.IP{
+				netutils.ParseIPSloppy("abcd::ef01"),
+				netutils.ParseIPSloppy("1.2.3.4"),
+			},
+			ssErr: "not supported in this configuration",
+		},
+		{
+			desc: "triple stack!",
+			in:   "1.2.3.4,abcd::1,5.6.7.8",
+			err:  "either a single IP or a dual-stack pair of IPs",
+		},
+	}
+
+	for _, tc := range testCases {
+		for _, cloudProvider := range []string{cloudProviderNone, cloudProviderExternal, "gce"} {
+			desc := fmt.Sprintf("%s, cloudProvider=%q", tc.desc, cloudProvider)
+			t.Run(desc, func(t *testing.T) {
+				parsed, err := ParseNodeIPArgument(tc.in, cloudProvider)
+
+				expectedOut := tc.out
+				expectedErr := tc.err
+
+				// Dual-stack is only supported with no cloudProvider
+				if cloudProvider != "" {
+					if len(tc.out) == 2 {
+						expectedOut = nil
+					}
+					if tc.ssErr != "" {
+						expectedErr = tc.ssErr
+					}
+				}
+
+				if !reflect.DeepEqual(parsed, expectedOut) {
+					t.Errorf("expected %#v, got %#v", expectedOut, parsed)
+				}
+				if err != nil {
+					if expectedErr == "" {
+						t.Errorf("unexpected error %v", err)
+					} else if !strings.Contains(err.Error(), expectedErr) {
+						t.Errorf("expected error with %q, got %v", expectedErr, err)
+					}
+				} else if expectedErr != "" {
+					t.Errorf("expected error with %q, got no error", expectedErr)
+				}
+			})
+		}
+	}
+}
+
+func TestParseNodeIPAnnotation(t *testing.T) {
+	testCases := []struct {
+		desc string
+		in   string
+		out  net.IP
+		err  string
+	}{
+		{
+			desc: "empty --node-ip",
+			in:   "",
+			err:  "could not parse",
+		},
+		{
+			desc: "just whitespace",
+			in:   " ",
+			err:  "could not parse",
+		},
+		{
+			desc: "garbage",
+			in:   "blah",
+			err:  "could not parse",
+		},
+		{
+			desc: "single IPv4",
+			in:   "1.2.3.4",
+			out:  netutils.ParseIPSloppy("1.2.3.4"),
+		},
+		{
+			desc: "single IPv4 with whitespace",
+			in:   " 1.2.3.4   ",
+			err:  "could not parse",
+		},
+		{
+			desc: "single IPv4 non-canonical",
+			in:   "01.2.3.004",
+			out:  netutils.ParseIPSloppy("1.2.3.4"),
+		},
+		{
+			desc: "single IPv4 invalid",
+			in:   "1.2.3",
+			err:  "could not parse",
+		},
+		{
+			desc: "single IPv4 CIDR",
+			in:   "1.2.3.0/24",
+			err:  "could not parse",
+		},
+		{
+			desc: "single IPv4 unspecified",
+			in:   "0.0.0.0",
+			out:  net.IPv4zero,
+		},
+		{
+			desc: "single IPv4 plus garbage",
+			in:   "1.2.3.4,not-an-IPv6-address",
+			err:  "could not parse",
+		},
+		{
+			desc: "single IPv6",
+			in:   "abcd::ef01",
+			out:  netutils.ParseIPSloppy("abcd::ef01"),
+		},
+		{
+			desc: "single IPv6 non-canonical",
+			in:   "abcd:0abc:00ab:0000:0000::1",
+			out:  netutils.ParseIPSloppy("abcd:abc:ab::1"),
+		},
+		{
+			desc: "simple dual-stack",
+			in:   "1.2.3.4,abcd::ef01",
+			err:  "not supported in this configuration",
+		},
+		{
+			desc: "dual-stack with whitespace",
+			in:   "abcd::ef01 , 1.2.3.4",
+			err:  "could not parse",
+		},
+		{
+			desc: "double IPv4",
+			in:   "1.2.3.4,5.6.7.8",
+			err:  "either a single IP or a dual-stack pair of IPs",
+		},
+		{
+			desc: "double IPv6",
+			in:   "abcd::1,abcd::2",
+			err:  "either a single IP or a dual-stack pair of IPs",
+		},
+		{
+			desc: "dual-stack with unspecified",
+			in:   "1.2.3.4,::",
+			err:  "not supported in this configuration",
+		},
+		{
+			desc: "dual-stack with unspecified",
+			in:   "0.0.0.0,abcd::1",
+			err:  "not supported in this configuration",
+		},
+		{
+			desc: "dual-stack plus garbage",
+			in:   "abcd::ef01 , 1.2.3.4, something else",
+			err:  "could not parse",
+		},
+		{
+			desc: "triple stack!",
+			in:   "1.2.3.4,abcd::1,5.6.7.8",
+			err:  "either a single IP or a dual-stack pair of IPs",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			parsed, err := ParseNodeIPAnnotation(tc.in)
+
+			if !reflect.DeepEqual(parsed, tc.out) {
+				t.Errorf("expected %#v, got %#v", tc.out, parsed)
+			}
+			if err != nil {
+				if tc.err == "" {
+					t.Errorf("unexpected error %v", err)
+				} else if !strings.Contains(err.Error(), tc.err) {
+					t.Errorf("expected error with %q, got %v", tc.err, err)
+				}
+			} else if tc.err != "" {
+				t.Errorf("expected error with %q, got no error", tc.err)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/component-helpers/node/util/ips_test.go
+++ b/staging/src/k8s.io/component-helpers/node/util/ips_test.go
@@ -164,17 +164,29 @@ func TestParseNodeIPArgument(t *testing.T) {
 		},
 	}
 
+	configurations := []struct {
+		cloudProvider       string
+		allowCloudDualStack bool
+		dualStackSupported  bool
+	}{
+		{cloudProviderNone, false, true},
+		{cloudProviderNone, true, true},
+		{cloudProviderExternal, false, false},
+		{cloudProviderExternal, true, true},
+		{"gce", false, false},
+		{"gce", true, false},
+	}
+
 	for _, tc := range testCases {
-		for _, cloudProvider := range []string{cloudProviderNone, cloudProviderExternal, "gce"} {
-			desc := fmt.Sprintf("%s, cloudProvider=%q", tc.desc, cloudProvider)
+		for _, conf := range configurations {
+			desc := fmt.Sprintf("%s, cloudProvider=%q, allowCloudDualStack=%v", tc.desc, conf.cloudProvider, conf.allowCloudDualStack)
 			t.Run(desc, func(t *testing.T) {
-				parsed, err := ParseNodeIPArgument(tc.in, cloudProvider)
+				parsed, err := ParseNodeIPArgument(tc.in, conf.cloudProvider, conf.allowCloudDualStack)
 
 				expectedOut := tc.out
 				expectedErr := tc.err
 
-				// Dual-stack is only supported with no cloudProvider
-				if cloudProvider != "" {
+				if !conf.dualStackSupported {
 					if len(tc.out) == 2 {
 						expectedOut = nil
 					}

--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -32,6 +32,19 @@ const (
 	// of code conflicts because changes are more likely to be scattered
 	// across the file.
 
+	// owner: @nckturner
+	// kep:  http://kep.k8s.io/2699
+	// alpha: v1.27
+	// Enable webhook in cloud controller manager
+	CloudControllerManagerWebhook featuregate.Feature = "CloudControllerManagerWebhook"
+
+	// owner: @danwinship
+	// alpha: v1.27
+	//
+	// Enables dual-stack values in the
+	// `alpha.kubernetes.io/provided-node-ip` annotation
+	CloudDualStackNodeIPs featuregate.Feature = "CloudDualStackNodeIPs"
+
 	// owner: @alexanderConstantinescu
 	// kep: http://kep.k8s.io/3458
 	// beta: v1.27
@@ -39,12 +52,6 @@ const (
 	// Enables less load balancer re-configurations by the service controller
 	// (KCCM) as an effect of changing node state.
 	StableLoadBalancerNodeSet featuregate.Feature = "StableLoadBalancerNodeSet"
-
-	// owner: @nckturner
-	// kep:  http://kep.k8s.io/2699
-	// alpha: v1.27
-	// Enable webhook in cloud controller manager
-	CloudControllerManagerWebhook featuregate.Feature = "CloudControllerManagerWebhook"
 )
 
 func SetupCurrentKubernetesSpecificFeatureGates(featuregates featuregate.MutableFeatureGate) error {
@@ -54,6 +61,7 @@ func SetupCurrentKubernetesSpecificFeatureGates(featuregates featuregate.Mutable
 // cloudPublicFeatureGates consists of cloud-specific feature keys.
 // To add a new feature, define a key for it at k8s.io/api/pkg/features and add it here.
 var cloudPublicFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	StableLoadBalancerNodeSet:     {Default: true, PreRelease: featuregate.Beta},
 	CloudControllerManagerWebhook: {Default: false, PreRelease: featuregate.Alpha},
+	CloudDualStackNodeIPs:         {Default: false, PreRelease: featuregate.Alpha},
+	StableLoadBalancerNodeSet:     {Default: true, PreRelease: featuregate.Beta},
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/go.mod
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.mod
@@ -85,6 +85,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/component-helpers v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20230308215209-15aac26d736a // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Implements the first part of KEP-3705, with the as-yet-unmerged simplification from https://github.com/kubernetes/enhancements/pull/3898. (Meaning, it _just_ makes external clouds allow `--node-ip` with two specific IPs, and doesn't add the other stuff like `--node-ip IPv6` etc from the currently-merged version of the KEP.)

#### Special notes for your reviewer:

- Not sure about location of code.
  - I moved the `--node-ip` parsing code to component-helpers since it's semi-shared between kubelet and cloud-provider. Since it's used even when there is no cloud provider, it didn't seem right to move it into cloud-provider with `PreferNodeIP`.
  - I was originally going to move `PreferNodeIP` to component-helpers too, but then I realized it doesn't get used in the no-cloud-provider case so maybe it makes more sense where it is in cloud-provider. OTOH, if we add more complicated node IP stuff later, it's likely there would be shared code between the cloud and "bare metal" cases.

- Feature gate:
  - I was thinking the shared APIs cannot call `utilfeature.DefaultFeatureGate.Enabled` themselves, because kubelet and cloud-provider are using different feature gates with the same name... but maybe that's not true since `featuregate.Feature` is just a string, so it would work anyway?
  - Should we rename it to `CloudDualStackNodeIPs` rather than just `CloudNodeIPs`?

- The reorganization in node_controller.go is partly assuming there will be future changes that will make the new `updateNodeAddressesFromNodeIP` more complicated and thus the refactoring is more worthwhile. (eg, dealing with the possibility of two different annotations being set.)

#### Does this PR introduce a user-facing change?
```release-note
By enabling the alpha `CloudNodeIPs` feature gate in kubelet and the cloud
provider, you can now specify a dual-stack `--node-ip` value (when using an
external cloud provider that supports that functionality).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3705
```

/priority important-soon
/sig network
/sig cloud-provider