### PR TITLE
add unit tests for probe errors and ExecProbeTimeout

### DIFF
--- a/pkg/probe/exec/errors_test.go
+++ b/pkg/probe/exec/errors_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestErrors(t *testing.T) {
+	tests := []struct {
+		err     error
+		timeout time.Duration
+		message string
+	}{
+		{
+			err:     errors.New("some error message"),
+			timeout: time.Hour * 8,
+			message: "some error message",
+		},
+	}
+
+	for i, test := range tests {
+		testErr := NewTimeoutError(test.err, test.timeout)
+
+		if testErr == nil {
+			t.Errorf("[%d] expected error a TimeoutError, got nil", i)
+		}
+		if msg := testErr.Error(); msg != test.message {
+			t.Errorf("[%d] expected error message %q, got %q", i, test.message, msg)
+		}
+		if timeout := testErr.Timeout(); timeout != test.timeout {
+			t.Errorf("[%d] expected timeout %q, got %q", i, test.timeout, timeout)
+		}
+	}
+}

--- a/pkg/probe/exec/exec_test.go
+++ b/pkg/probe/exec/exec_test.go
@@ -23,6 +23,9 @@ import (
 	"testing"
 	"time"
 
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/probe"
 )
 
@@ -107,26 +110,31 @@ func TestExec(t *testing.T) {
 	elevenKilobyte := strings.Repeat("logs-123", 8*128*11) // 8*128*11=11264 = 11KB of text.
 
 	tests := []struct {
-		expectedStatus probe.Result
-		expectError    bool
-		input          string
-		output         string
-		err            error
+		expectedStatus   probe.Result
+		expectError      bool
+		execProbeTimeout bool
+		input            string
+		output           string
+		err              error
 	}{
 		// Ok
-		{probe.Success, false, "OK", "OK", nil},
+		{probe.Success, false, true, "OK", "OK", nil},
 		// Ok
-		{probe.Success, false, "OK", "OK", &fakeExitError{true, 0}},
+		{probe.Success, false, true, "OK", "OK", &fakeExitError{true, 0}},
 		// Ok - truncated output
-		{probe.Success, false, elevenKilobyte, tenKilobyte, nil},
+		{probe.Success, false, true, elevenKilobyte, tenKilobyte, nil},
 		// Run returns error
-		{probe.Unknown, true, "", "", fmt.Errorf("test error")},
+		{probe.Unknown, true, true, "", "", fmt.Errorf("test error")},
 		// Unhealthy
-		{probe.Failure, false, "Fail", "", &fakeExitError{true, 1}},
+		{probe.Failure, false, true, "Fail", "", &fakeExitError{true, 1}},
 		// Timeout
-		{probe.Failure, false, "", "command testcmd timed out", NewTimeoutError(fmt.Errorf("command testcmd timed out"), time.Second)},
+		{probe.Failure, false, true, "", "command testcmd timed out", NewTimeoutError(fmt.Errorf("command testcmd timed out"), time.Second)},
+		// ExecProbeTimeout
+		{probe.Unknown, true, false, "", "", NewTimeoutError(fmt.Errorf("command testcmd timed out"), time.Second)},
 	}
+
 	for i, test := range tests {
+		defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ExecProbeTimeout, test.execProbeTimeout)()
 		fake := FakeCmd{
 			out: []byte(test.output),
 			err: test.err,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds some unit tests.

#### Special notes for your reviewer:
I love k8s and I cloned the repo today for the first time and had a first look on the code. I would love to really contribute in the future, but this is my first contribution to a big open source project ever. Please accept my PR :)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
