### PR TITLE
QueryParamVerifier V3 does not support List

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier_v3.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier_v3.go
@@ -57,6 +57,9 @@ var namespaceGVK = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Name
 // or if another error occurred. If the Open API V3 spec for a CRD is not
 // found, then the spec for Namespace is checked for query param support instead.
 func (v *queryParamVerifierV3) HasSupport(gvk schema.GroupVersionKind) error {
+	if (gvk == schema.GroupVersionKind{Version: "v1", Kind: "List"}) {
+		return NewParamUnsupportedError(gvk, v.queryParam)
+	}
 	gvSpec, err := v.root.GVSpec(gvk.GroupVersion())
 	if err == nil {
 		if supports := supportsQueryParamV3(gvSpec, gvk, v.queryParam); supports {

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier_v3_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier_v3_test.go
@@ -104,6 +104,16 @@ func TestV3SupportsQueryParamBatchV1(t *testing.T) {
 			queryParam:       QueryParamFieldValidation,
 			expectedSupports: false,
 		},
+		"List GVK is specifically unsupported": {
+			crds: []schema.GroupKind{},
+			gvk: schema.GroupVersionKind{
+				Group:   "",
+				Version: "v1",
+				Kind:    "List",
+			},
+			queryParam:       QueryParamFieldValidation,
+			expectedSupports: false,
+		},
 	}
 
 	root := openapi3.NewRoot(cached.NewClient(openapitest.NewFileClient(t)))


### PR DESCRIPTION
* Specifically exclude `queryParamVerifierV3` support for any param when the GVK is a `List`. When `List` is not found in OpenAPI, ensures there is no CRD check in `HasSupport`.
* Follows the same check introduced for the `QueryParamVerifier`: https://github.com/kubernetes/kubernetes/pull/116247
* Adds unit test. Coverage: 71.3%

/kind bug

```release-note
NONE
```
