### PR TITLE
HPA: expose the metrics "metric_computation_duration_seconds" and "metric_computation_total" from HPA controller

### DIFF
--- a/pkg/controller/podautoscaler/monitor/metrics.go
+++ b/pkg/controller/podautoscaler/monitor/metrics.go
@@ -46,10 +46,27 @@ var (
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"action", "error"})
+	metricComputationTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      hpaControllerSubsystem,
+			Name:           "metric_computation_total",
+			Help:           "Number of metric computations. The label 'action' should be either 'scale_down', 'scale_up', or 'none'. Also, the label 'error' should be either 'spec', 'internal', or 'none'. The label 'metric_type' corresponds to HPA.spec.metrics[*].type",
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"action", "error", "metric_type"})
+	metricComputationDuration = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Subsystem:      hpaControllerSubsystem,
+			Name:           "metric_computation_duration_seconds",
+			Help:           "The time(seconds) that the HPA controller takes to calculate one metric. The label 'action' should be either 'scale_down', 'scale_up', or 'none'. The label 'error' should be either 'spec', 'internal', or 'none'. The label 'metric_type' corresponds to HPA.spec.metrics[*].type",
+			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"action", "error", "metric_type"})
 
 	metricsList = []metrics.Registerable{
 		reconciliationsTotal,
 		reconciliationsDuration,
+		metricComputationTotal,
+		metricComputationDuration,
 	}
 )
 

--- a/pkg/controller/podautoscaler/monitor/monitor.go
+++ b/pkg/controller/podautoscaler/monitor/monitor.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package monitor
 
-import "time"
+import (
+	"time"
+
+	v2 "k8s.io/api/autoscaling/v2"
+)
 
 type ActionLabel string
 type ErrorLabel string
@@ -36,6 +40,7 @@ const (
 // Monitor records some metrics so that people can monitor HPA controller.
 type Monitor interface {
 	ObserveReconciliationResult(action ActionLabel, err ErrorLabel, duration time.Duration)
+	ObserveMetricComputationResult(action ActionLabel, err ErrorLabel, duration time.Duration, metricType v2.MetricSourceType)
 }
 
 type monitor struct{}
@@ -48,4 +53,10 @@ func New() Monitor {
 func (r *monitor) ObserveReconciliationResult(action ActionLabel, err ErrorLabel, duration time.Duration) {
 	reconciliationsTotal.WithLabelValues(string(action), string(err)).Inc()
 	reconciliationsDuration.WithLabelValues(string(action), string(err)).Observe(duration.Seconds())
+}
+
+// ObserveMetricComputationResult observes some metrics from a metric computation result.
+func (r *monitor) ObserveMetricComputationResult(action ActionLabel, err ErrorLabel, duration time.Duration, metricType v2.MetricSourceType) {
+	metricComputationTotal.WithLabelValues(string(action), string(err), string(metricType)).Inc()
+	metricComputationDuration.WithLabelValues(string(action), string(err), string(metricType)).Observe(duration.Seconds())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/sig autoscaling
/sig instrumentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

expose the metrics "metric_computation_duration_seconds" and "metric_computation_total" from HPA controller.

- `metric_computation_duration_seconds`: The time(seconds) that the HPA controller takes to calculate one metric.
- `metric_computation_total`: Number of metric computations. 
These are must-to-have to meat the requirements from the production readiness review of [the container resource metrics](https://github.com/kubernetes/enhancements/issues/1610).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Related https://github.com/kubernetes/kubernetes/issues/115639
Related https://github.com/kubernetes/enhancements/issues/1610

#### Special notes for your reviewer:

This branch is based on [sanposhiho:hpa-metric-server](https://github.com/kubernetes/kubernetes/pull/116010).
I know, in usual case, it's better to just wait for [sanposhiho:hpa-metric-server](https://github.com/kubernetes/kubernetes/pull/116010) to get merged, but I created this now because the code freeze is approaching and it's better to get reviews on it ASAP... 🏃‍♂️ 

Please review 3b1cde1e7c95d94c75da02a09291a59bb86e1b6f only. Other commits are from [sanposhiho:hpa-metric-server](https://github.com/kubernetes/kubernetes/pull/116010) branch.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
HPA controller exposes the following metrics from the kube-controller-manager.
- `metric_computation_duration_seconds`: Number of metric computations. 
- `metric_computation_total`: The time(seconds) that the HPA controller takes to calculate one metric.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
