### PR TITLE
optimize watch-cache getlist

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -773,24 +773,28 @@ func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptio
 		return err
 	}
 	span.AddEvent("Listed items from cache", attribute.Int("count", len(objs)))
-	var filteredObjects []runtime.Object
+	// store pointer of eligible objects,
+	// Why not directly put object in the items of listObj?
+	//   the elements in ListObject are Struct type, making slice will bring excessive memory consumption.
+	//   so we try to delay this action as much as possible
+	var selectedObjects []runtime.Object
 	for _, obj := range objs {
 		elem, ok := obj.(*storeElement)
 		if !ok {
 			return fmt.Errorf("non *storeElement returned from storage: %v", obj)
 		}
 		if filter(elem.Key, elem.Labels, elem.Fields) {
-			filteredObjects = append(filteredObjects, elem.Object)
+			selectedObjects = append(selectedObjects, elem.Object)
 		}
 	}
-	if len(filteredObjects) == 0 {
+	if len(selectedObjects) == 0 {
 		// Ensure that we never return a nil Items pointer in the result for consistency.
 		listVal.Set(reflect.MakeSlice(listVal.Type(), 0, 0))
 	} else {
 		// Resize the slice appropriately, since we already know that size of result set
-		listVal.Set(reflect.MakeSlice(listVal.Type(), len(filteredObjects), len(filteredObjects)))
+		listVal.Set(reflect.MakeSlice(listVal.Type(), len(selectedObjects), len(selectedObjects)))
 		span.AddEvent("Resized result")
-		for i, o := range filteredObjects {
+		for i, o := range selectedObjects {
 			listVal.Index(i).Set(reflect.ValueOf(o).Elem())
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -18,6 +18,7 @@ package cacher
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"reflect"
@@ -114,11 +115,22 @@ func newTestCacher(s storage.Interface) (*Cacher, storage.Versioner, error) {
 		GroupResource:  schema.GroupResource{Resource: "pods"},
 		ResourcePrefix: prefix,
 		KeyFunc:        func(obj runtime.Object) (string, error) { return storage.NamespaceKeyFunc(prefix, obj) },
-		GetAttrsFunc:   storage.DefaultNamespaceScopedAttr,
-		NewFunc:        func() runtime.Object { return &example.Pod{} },
-		NewListFunc:    func() runtime.Object { return &example.PodList{} },
-		Codec:          codecs.LegacyCodec(examplev1.SchemeGroupVersion),
-		Clock:          clock.RealClock{},
+		GetAttrsFunc: func(obj runtime.Object) (labels.Set, fields.Set, error) {
+			pod, ok := obj.(*example.Pod)
+			if !ok {
+				return storage.DefaultNamespaceScopedAttr(obj)
+			}
+			labelsSet, fieldsSet, err := storage.DefaultNamespaceScopedAttr(obj)
+			if err != nil {
+				return nil, nil, err
+			}
+			fieldsSet["spec.nodeName"] = pod.Spec.NodeName
+			return labelsSet, fieldsSet, nil
+		},
+		NewFunc:     func() runtime.Object { return &example.Pod{} },
+		NewListFunc: func() runtime.Object { return &example.PodList{} },
+		Codec:       codecs.LegacyCodec(examplev1.SchemeGroupVersion),
+		Clock:       clock.RealClock{},
 	}
 	cacher, err := NewCacherFromConfig(config)
 	return cacher, testVersioner{}, err
@@ -1714,4 +1726,112 @@ func TestWaitUntilWatchCacheFreshAndForceAllEvents(t *testing.T) {
 	forceAllEvents, err = cacher.waitUntilWatchCacheFreshAndForceAllEvents(context.TODO(), 105, storage.ListOptions{SendInitialEvents: pointer.Bool(true)})
 	require.NoError(t, err)
 	require.True(t, forceAllEvents, "the target method should instruct the caller to ask for all events in the cache (full state)")
+}
+
+type fakeStorage struct {
+	pods []example.Pod
+	storage.Interface
+}
+
+func newObjectStorage(fakePods []example.Pod) *fakeStorage {
+	return &fakeStorage{
+		pods: fakePods,
+	}
+}
+
+func (m fakeStorage) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
+	podList := listObj.(*example.PodList)
+	podList.ListMeta = metav1.ListMeta{ResourceVersion: "12345"}
+	podList.Items = m.pods
+	return nil
+}
+func (m fakeStorage) Watch(_ context.Context, _ string, _ storage.ListOptions) (watch.Interface, error) {
+	return newDummyWatch(), nil
+}
+
+func BenchmarkCacher_GetList(b *testing.B) {
+	testCases := []struct {
+		name            string
+		totalObjectNum  int
+		expectObjectNum int
+	}{
+		{
+			name:            "totalObjectNum=5000, expectObjectNum=50",
+			totalObjectNum:  5000,
+			expectObjectNum: 50,
+		},
+		{
+			name:            "totalObjectNum=5000, expectObjectNum=500",
+			totalObjectNum:  5000,
+			expectObjectNum: 500,
+		},
+		{
+			name:            "totalObjectNum=5000, expectObjectNum=1000",
+			totalObjectNum:  5000,
+			expectObjectNum: 1000,
+		},
+		{
+			name:            "totalObjectNum=5000, expectObjectNum=2500",
+			totalObjectNum:  5000,
+			expectObjectNum: 2500,
+		},
+		{
+			name:            "totalObjectNum=5000, expectObjectNum=5000",
+			totalObjectNum:  5000,
+			expectObjectNum: 5000,
+		},
+	}
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			// create sample pods
+			fakePods := make([]example.Pod, tc.totalObjectNum, tc.totalObjectNum)
+			for i := range fakePods {
+				fakePods[i].Namespace = "default"
+				fakePods[i].Name = fmt.Sprintf("pod-%d", i)
+				fakePods[i].ResourceVersion = strconv.Itoa(i)
+				if i%(tc.totalObjectNum/tc.expectObjectNum) == 0 {
+					fakePods[i].Spec.NodeName = "node-0"
+				}
+				data := make([]byte, 1024*2, 1024*2) // 2k labels
+				rand.Read(data)
+				fakePods[i].Spec.NodeSelector = map[string]string{
+					"key": string(data),
+				}
+			}
+
+			// build test cacher
+			cacher, _, err := newTestCacher(newObjectStorage(fakePods))
+			if err != nil {
+				b.Fatalf("new cacher: %v", err)
+			}
+			defer cacher.Stop()
+
+			// prepare result and pred
+			parsedField, err := fields.ParseSelector("spec.nodeName=node-0")
+			if err != nil {
+				b.Fatalf("parse selector: %v", err)
+			}
+			pred := storage.SelectionPredicate{
+				Label: labels.Everything(),
+				Field: parsedField,
+			}
+
+			// now we start benchmarking
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result := &example.PodList{}
+				err = cacher.GetList(context.TODO(), "pods", storage.ListOptions{
+					Predicate:       pred,
+					Recursive:       true,
+					ResourceVersion: "12345",
+				}, result)
+				if err != nil {
+					b.Fatalf("GetList cache: %v", err)
+				}
+				if len(result.Items) != tc.expectObjectNum {
+					b.Fatalf("expect %d but got %d", tc.expectObjectNum, len(result.Items))
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Faster watch-cache get-list.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

In order to facilitate verification, I split it into two commits:

- Add benchmarks
- Optimize GetList

> Here are my own benchmark results. FIY...

```bash
# before
$ go test -bench=BenchmarkCacher_GetList  -count 5 . -run=none --benchmem
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/storage/cacher
cpu: AMD EPYC 7K62 48-Core Processor
BenchmarkCacher_GetList-16    	14	 137743757 ns/op	129016510 B/op	   67975 allocs/op
BenchmarkCacher_GetList-16    	15	 121673849 ns/op	151072125 B/op	   66776 allocs/op
BenchmarkCacher_GetList-16    	15	  88535782 ns/op	151072186 B/op	   66774 allocs/op
BenchmarkCacher_GetList-16    	18	  83706540 ns/op	126228029 B/op	   63987 allocs/op
BenchmarkCacher_GetList-16    	19	 124967934 ns/op	149816737 B/op	   63252 allocs/op
PASS

# after

$ go test -bench=BenchmarkCacher_GetList  . -run=none --benchmem --count=5
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/storage/cacher
cpu: AMD EPYC 7K62 48-Core Processor
BenchmarkCacher_GetList-16    	      44	  24302640 ns/op	 2528573 B/op	    5749 allocs/op
BenchmarkCacher_GetList-16    	      45	  23997310 ns/op	 2490390 B/op	    5623 allocs/op
BenchmarkCacher_GetList-16    	      46	  23521017 ns/op	 2453680 B/op	    5501 allocs/op
BenchmarkCacher_GetList-16    	      48	  23682351 ns/op	 2384704 B/op	    5273 allocs/op
BenchmarkCacher_GetList-16    	      49	  23772900 ns/op	 2352476 B/op	    5166 allocs/op
PASS

# compare
benchcmp before.text after.text                                                                      
benchmark                      old ns/op     new ns/op     delta
BenchmarkCacher_GetList-16     137743757     24302640      -82.36%
BenchmarkCacher_GetList-16     121673849     23997310      -80.28%
BenchmarkCacher_GetList-16     88535782      23521017      -73.43%
BenchmarkCacher_GetList-16     83706540      23682351      -71.71%
BenchmarkCacher_GetList-16     124967934     23772900      -80.98%

benchmark                      old allocs     new allocs     delta
BenchmarkCacher_GetList-16     67975          5749           -91.54%
BenchmarkCacher_GetList-16     66776          5623           -91.58%
BenchmarkCacher_GetList-16     66774          5501           -91.76%
BenchmarkCacher_GetList-16     63987          5273           -91.76%
BenchmarkCacher_GetList-16     63252          5166           -91.83%

benchmark                      old bytes     new bytes     delta
BenchmarkCacher_GetList-16     129016510     2528573       -98.04%
BenchmarkCacher_GetList-16     151072125     2490390       -98.35%
BenchmarkCacher_GetList-16     151072186     2453680       -98.38%
BenchmarkCacher_GetList-16     126228029     2384704       -98.11%
BenchmarkCacher_GetList-16     149816737     2352476       -98.43%

```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Kube-apiserver: Improved memory use when performing GetList on the cache.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
