### PR TITLE
e2e network test for multiple protocol services on same port

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -3618,6 +3618,114 @@ var _ = common.SIGDescribe("Services", func() {
 
 		framework.Logf("Collection of services has been deleted")
 	})
+
+	ginkgo.It("should serve endpoints on same port and different protocols", func(ctx context.Context) {
+		serviceName := "multiprotocol-test"
+		testLabels := map[string]string{"app": "multiport"}
+		ns := f.Namespace.Name
+		containerPort := 80
+
+		svcTCPport := v1.ServicePort{
+			Name:       "tcp-port",
+			Port:       80,
+			TargetPort: intstr.FromInt(containerPort),
+			Protocol:   v1.ProtocolTCP,
+		}
+		svcUDPport := v1.ServicePort{
+			Name:       "udp-port",
+			Port:       80,
+			TargetPort: intstr.FromInt(containerPort),
+			Protocol:   v1.ProtocolUDP,
+		}
+
+		ginkgo.By("creating service " + serviceName + " in namespace " + ns)
+
+		testService := v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   serviceName,
+				Labels: testLabels,
+			},
+			Spec: v1.ServiceSpec{
+				Type:     v1.ServiceTypeClusterIP,
+				Selector: testLabels,
+				Ports:    []v1.ServicePort{svcTCPport, svcUDPport},
+			},
+		}
+		service, err := cs.CoreV1().Services(ns).Create(ctx, &testService, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "failed to create Service")
+
+		containerPorts := []v1.ContainerPort{{
+			Name:          svcTCPport.Name,
+			ContainerPort: int32(containerPort),
+			Protocol:      v1.ProtocolTCP,
+		}, {
+			Name:          svcUDPport.Name,
+			ContainerPort: int32(containerPort),
+			Protocol:      v1.ProtocolUDP,
+		}}
+		podname1 := "pod1"
+		ginkgo.By("creating pod " + podname1 + " in namespace " + ns)
+		createPodOrFail(ctx, f, ns, podname1, testLabels, containerPorts, "netexec", "--http-port", strconv.Itoa(containerPort), "--udp-port", strconv.Itoa(containerPort))
+		validateEndpointsPortsWithProtocolsOrFail(cs, ns, serviceName, fullPortsByPodName{podname1: containerPorts})
+
+		ginkgo.By("Checking if the Service forwards traffic to the TCP and UDP port")
+		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
+		err = testEndpointReachability(ctx, service.Spec.ClusterIP, 80, v1.ProtocolTCP, execPod, 30*time.Second)
+		if err != nil {
+			framework.Failf("Failed to connect to Service TCP port: %v", err)
+		}
+		err = testEndpointReachability(ctx, service.Spec.ClusterIP, 80, v1.ProtocolUDP, execPod, 30*time.Second)
+		if err != nil {
+			framework.Failf("Failed to connect to Service UDP port: %v", err)
+		}
+
+		ginkgo.By("Checking if the Service forwards traffic to TCP only")
+		service, err = cs.CoreV1().Services(ns).Get(ctx, serviceName, metav1.GetOptions{})
+		if err != nil {
+			framework.Failf("failed to get Service %q: %v", serviceName, err)
+		}
+		service.Spec.Ports = []v1.ServicePort{svcTCPport}
+		_, err = cs.CoreV1().Services(ns).Update(ctx, service, metav1.UpdateOptions{})
+		if err != nil {
+			framework.Failf("failed to get Service %q: %v", serviceName, err)
+		}
+
+		// test reachability
+		err = testEndpointReachability(ctx, service.Spec.ClusterIP, 80, v1.ProtocolTCP, execPod, 30*time.Second)
+		if err != nil {
+			framework.Failf("Failed to connect to Service TCP port: %v", err)
+		}
+		// take into account the NetworkProgrammingLatency
+		// testEndpointReachability tries 3 times every 3 second
+		// we retry again during 30 seconds to check if the port stops forwarding
+		gomega.Eventually(ctx, func() error {
+			return testEndpointReachability(ctx, service.Spec.ClusterIP, 80, v1.ProtocolUDP, execPod, 6*time.Second)
+		}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).ShouldNot(gomega.BeNil())
+
+		ginkgo.By("Checking if the Service forwards traffic to UDP only")
+		service, err = cs.CoreV1().Services(ns).Get(ctx, serviceName, metav1.GetOptions{})
+		if err != nil {
+			framework.Failf("failed to get Service %q: %v", serviceName, err)
+		}
+		service.Spec.Ports = []v1.ServicePort{svcUDPport}
+		_, err = cs.CoreV1().Services(ns).Update(ctx, service, metav1.UpdateOptions{})
+		if err != nil {
+			framework.Failf("failed to update Service %q: %v", serviceName, err)
+		}
+
+		// test reachability
+		err = testEndpointReachability(ctx, service.Spec.ClusterIP, 80, v1.ProtocolUDP, execPod, 30*time.Second)
+		if err != nil {
+			framework.Failf("Failed to connect to Service UDP port: %v", err)
+		}
+		// take into account the NetworkProgrammingLatency
+		// testEndpointReachability tries 3 times every 3 second
+		// we retry again during 30 seconds to check if the port stops forwarding
+		gomega.Eventually(ctx, func() error {
+			return testEndpointReachability(ctx, service.Spec.ClusterIP, 80, v1.ProtocolTCP, execPod, 6*time.Second)
+		}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).ShouldNot(gomega.BeNil())
+	})
+
 	/*
 		Release: v1.26
 		Testname: Service, same ports with different protocols on a Load Balancer Service


### PR DESCRIPTION
The test creates a Service exposing two protocols on the same port and a backend that replies on both protocols.

1. Test that Service with works for both protocol
2. Update Service to expose only the TCP port
3. Verify that TCP works and UDP does not work
4. Update Service to expose only the UDP port
5. Verify that TCP does not work and UDP does work

```release-note
NONE
```
Fixes: #116314

/sig network
/assign @thockin

I've verified it fails "correctly" against cilium , and solves the doubts about what is exacttly broken.

I was under the assumption that DNS services will not work, but is the contrary, the thing is that any port on Services will be forwarded independently of the protocol (that is kind of a huge relieve, isn't it? :) )

```
 [FAILED] [14.761 seconds]
[sig-network] Services [It] should serve endpoints on same port and different protocols
test/e2e/network/service.go:3622

  [FAILED] Unexpected connection to Service UDP port: <nil>
  In [It] at: test/e2e/network/service.go:3698 @ 03/07/23 16:15:37.749
```
