### PR TITLE
Initialize pod resource allocation checkpoint manager to noop

### DIFF
--- a/pkg/kubelet/status/state/state_checkpoint.go
+++ b/pkg/kubelet/status/state/state_checkpoint.go
@@ -177,3 +177,50 @@ func (sc *stateCheckpoint) ClearState() error {
 	sc.cache.ClearState()
 	return sc.storeState()
 }
+
+type noopStateCheckpoint struct{}
+
+// NewNoopStateCheckpoint creates a dummy state checkpoint manager
+func NewNoopStateCheckpoint() State {
+	return &noopStateCheckpoint{}
+}
+
+func (sc *noopStateCheckpoint) GetContainerResourceAllocation(_ string, _ string) (v1.ResourceList, bool) {
+	return nil, false
+}
+
+func (sc *noopStateCheckpoint) GetPodResourceAllocation() PodResourceAllocation {
+	return nil
+}
+
+func (sc *noopStateCheckpoint) GetPodResizeStatus(_ string) (v1.PodResizeStatus, bool) {
+	return "", false
+}
+
+func (sc *noopStateCheckpoint) GetResizeStatus() PodResizeStatus {
+	return nil
+}
+
+func (sc *noopStateCheckpoint) SetContainerResourceAllocation(_ string, _ string, _ v1.ResourceList) error {
+	return nil
+}
+
+func (sc *noopStateCheckpoint) SetPodResourceAllocation(_ PodResourceAllocation) error {
+	return nil
+}
+
+func (sc *noopStateCheckpoint) SetPodResizeStatus(_ string, _ v1.PodResizeStatus) error {
+	return nil
+}
+
+func (sc *noopStateCheckpoint) SetResizeStatus(_ PodResizeStatus) error {
+	return nil
+}
+
+func (sc *noopStateCheckpoint) Delete(_ string, _ string) error {
+	return nil
+}
+
+func (sc *noopStateCheckpoint) ClearState() error {
+	return nil
+}

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -186,6 +186,9 @@ func isPodStatusByKubeletEqual(oldStatus, status *v1.PodStatus) bool {
 }
 
 func (m *manager) Start() {
+	// Initialize m.state to no-op state checkpoint manager
+	m.state = state.NewNoopStateCheckpoint()
+
 	// Create pod allocation checkpoint manager even if client is nil so as to allow local get/set of AllocatedResources & Resize
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		stateImpl, err := state.NewStateCheckpoint(m.stateFileDirectory, podStatusManagerStateFile)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: This change initializes pod resource allocation checkpoint manager to no-op in order to avoid accidentally introducing null pointer access if the manager functions were to be called outside of the InPlacePodVerticalScaling feature gate.
Ref: https://github.com/kubernetes/kubernetes/pull/116271#discussion_r1128277122

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
I tested this by commenting out the block that allocated real pod resource allocation manager and verified local-cluster in kubeletonly mode for a single static pod. Additionally, with code committed in this PR, I verified kubeletonly mode as well as pod resize tests with local cluster. Rest is for CI. 

#### Does this PR introduce a user-facing change? No.
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
