### PR TITLE
ApplySet: allow custom resources to be parent objects

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -314,9 +314,12 @@ func (flags *ApplyFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, baseNa
 			parent.Namespace = namespace
 		}
 		tooling := ApplySetTooling{name: baseName, version: ApplySetToolVersion}
-		restClient, err := f.ClientForMapping(parent.RESTMapping)
-		if err != nil || restClient == nil {
+		restClient, err := f.UnstructuredClientForMapping(parent.RESTMapping)
+		if err != nil {
 			return nil, fmt.Errorf("failed to initialize RESTClient for ApplySet: %w", err)
+		}
+		if restClient == nil {
+			return nil, fmt.Errorf("could not build RESTClient for ApplySet")
 		}
 		applySet = NewApplySet(parent, tooling, mapper, restClient)
 	}
@@ -400,7 +403,7 @@ func (o *ApplyOptions) Validate() error {
 		if !o.Prune {
 			return fmt.Errorf("--applyset requires --prune")
 		}
-		if err := o.ApplySet.Validate(); err != nil {
+		if err := o.ApplySet.Validate(context.TODO(), o.DynamicClient); err != nil {
 			return err
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -796,6 +796,7 @@ func testDynamicResources() []*restmapper.APIGroupResources {
 			VersionedResources: map[string][]metav1.APIResource{
 				"v1": {
 					{Name: "bars", Namespaced: true, Kind: "Bar"},
+					{Name: "applysets", Namespaced: false, Kind: "ApplySet"},
 				},
 			},
 		},

--- a/staging/src/k8s.io/kubectl/testdata/apply/applyset-cr.yaml
+++ b/staging/src/k8s.io/kubectl/testdata/apply/applyset-cr.yaml
@@ -1,0 +1,9 @@
+apiVersion: company.com/v1
+kind: ApplySet
+metadata:
+  name: my-set
+  annotations:
+    applyset.k8s.io/tooling: kubectl/v0.0.0
+    applyset.k8s.io/contains-group-resources: ""
+  labels:
+    applyset.k8s.io/id: applyset-rhp1a-HVAVT_dFgyEygyA1BEB82HPp2o10UiFTpqtAs-v1

--- a/staging/src/k8s.io/kubectl/testdata/apply/applysets-crd.yaml
+++ b/staging/src/k8s.io/kubectl/testdata/apply/applysets-crd.yaml
@@ -1,0 +1,25 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applysets.company.com
+  labels:
+    applyset.k8s.io/is-parent-type: "true"
+spec:
+  group: company.com
+  names:
+    kind: ApplySet
+    listKind: ApplySetList
+    plural: applysets
+    singular: applyset
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig cli

#### What this PR does / why we need it:

This is part of a series of PRs to implement the ApplySet KEP in kubectl: http://git.k8s.io/enhancements/keps/sig-cli/3659-kubectl-apply-prune.

This one enables the last missing MVP feature we were hoping to get into the alpha: the ability to use specifically marked (via an annotation on the CRD defining them) custom resources as ApplySet parent objects.

Related PRs:

https://github.com/kubernetes/kubernetes/pull/115979
https://github.com/kubernetes/kubernetes/pull/116243
https://github.com/kubernetes/kubernetes/pull/116009 / https://github.com/kubernetes/kubernetes/pull/116205
https://github.com/kubernetes/kubernetes/pull/116265

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
[alpha: kubectl apply --prune --applyset] Enables certain custom resources (CRs) to be used as ApplySet parent objects. To enable this for a given CR, apply the label `applyset.kubernetes.io/is-parent-type: true` to the CustomResourceDefinition (CRD) that defines it .
```

**Please note** that the labels/annotations shown in this PR were updated to use the `kubernetes.io` prefix in https://github.com/kubernetes/kubernetes/pull/116780.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/42a4b1c8a18780cf1d5c2460113d59b246002548/keps/sig-cli/3659-kubectl-apply-prune

```
