### PR TITLE
golangci-lint: synchronize configs and add verification for that

### DIFF
--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -11,18 +11,21 @@ issues:
   max-same-issues: 0
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
-    # exclude ineffassing linter for generated files for conversion
+    # exclude ineffassign linter for generated files for conversion
     - path: conversion\.go
       linters:
         - ineffassign
 
 linters:
-  enable: # please keep this alphabetized
+  disable-all: false # in contrast to golangci.yaml, the default set of linters remains enabled
+  enable: # please keep this alphabetized and in sync with golangci.yaml
+    - ginkgolinter
     - gocritic
     - govet
     - ineffassign
     - logcheck
     - staticcheck
+    - stylecheck
     - unused
 
 linters-settings: # please keep this alphabetized
@@ -32,7 +35,8 @@ linters-settings: # please keep this alphabetized
       path: ../_output/local/bin/logcheck.so
       description: structured logging checker
       original-url: k8s.io/logtools/logcheck
+  gocritic:
   staticcheck:
-    checks: [
-      "all",
-    ]
+    checks:
+      - "all"
+  stylecheck:

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -13,13 +13,13 @@ issues:
         - ineffassign
     # TODO(oscr) Remove these excluded directories and fix findings. Due to large amount of findings in different components
     # with different owners it's hard to fix everything in a single pr. This will therefore be done in multiple prs.
-    - path: (pkg/volume/*|test/*|azure/*|pkg/cmd/wait*|request/bearertoken/*|metrics/*|filters/*)
-      linters:
-        - gocritic
+    - path: (pkg/volume/*|test/*|azure/*|pkg/cmd/wait*|request/bearertoken/*|metrics/*|filters/*) # not in golangci-strict.yaml
+      linters:                                                                                    # not in golangci-strict.yaml
+        - gocritic                                                                                # not in golangci-strict.yaml
 
 linters:
-  disable-all: true
-  enable: # please keep this alphabetized
+  disable-all: true # not disabled in golangci-strict.yaml
+  enable: # please keep this alphabetized and in sync with golangci-strict.yaml
     - ginkgolinter
     - gocritic
     - govet
@@ -37,16 +37,14 @@ linters-settings: # please keep this alphabetized
       description: structured logging checker
       original-url: k8s.io/logtools/logcheck
   gocritic:
-    enabled-checks:
-      - equalFold
-      - boolExprSimplify
+    enabled-checks:             # not limited in golangci-strict.yaml
+      - equalFold               # not limited in golangci-strict.yaml
+      - boolExprSimplify        # not limited in golangci-strict.yaml
   staticcheck:
-    checks: [
-      "all",
-      "-SA1019", # TODO(fix) Using a deprecated function, variable, constant or field
-      "-SA2002"  # TODO(fix) Called testing.T.FailNow or SkipNow in a goroutine, which isn’t allowed
-    ]
+    checks:
+      - "all"
+      - "-SA1019"  # TODO(fix) Using a deprecated function, variable, constant or field - enabled in golangci-strict.yaml
+      - "-SA2002"  # TODO(fix) Called testing.T.FailNow or SkipNow in a goroutine, which isn’t allowed - enabled in golangci-strict.yaml
   stylecheck:
-    checks: [
-      "ST1019",  # Importing the same package multiple times.
-    ]
+    checks:        # golangci-strict.yaml uses the default checks.
+      - "ST1019"   # Importing the same package multiple times - enabled in golangci-strict.yaml.

--- a/hack/verify-golangci-lint-config.sh
+++ b/hack/verify-golangci-lint-config.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script checks that golangci-strict.yaml and golangci.yaml remain in
+# sync. Lines that are intentionally different must have a comment which
+# mentions golangci.yaml or golangci-lint.yaml.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+if differences=$(diff --context --ignore-blank-lines \
+                      --ignore-matching-lines='^ *#' \
+                      --ignore-matching-lines='#.*golangci\(-strict\)*.yaml' \
+                      "${KUBE_ROOT}/hack/golangci.yaml" "${KUBE_ROOT}/hack/golangci-strict.yaml" ); then
+    echo "hack/golangci.yaml and hack/golangci-strict.yaml are synchronized."
+else
+    cat >&2 <<EOF
+Unexpected differences between hack/golangci.yaml and hack/golangci-strict.yaml:
+
+${differences}
+
+If these differences are intentional, then add comments at the end of each
+different line in both files that mention golangci-strict.yaml or
+golangci.yaml.
+EOF
+    exit 1
+fi


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/109728 added a golangci-strict.yaml where gingkolinter and stylecheck (some recent additions to golangci.yaml) were missing.

To prevent such mistakes in the future, lines that are intentionally different get annotated with a comment about golangci-strict.yaml or golangci.yaml. Then a suitable diff command in the new verify-golangci-lint-config.sh checks that only such lines, comments and blank lines are different.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
