### PR TITLE
Run all in-place pod resize tests in serial

### DIFF
--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -1307,8 +1307,8 @@ func doPodResizeResourceQuotaTests() {
 		tStamp := strconv.Itoa(time.Now().Nanosecond())
 		initDefaultResizePolicy(containers)
 		initDefaultResizePolicy(expected)
-		testPod1 := makeTestPod(f.Namespace.Name, "testpod1", tStamp, containers)
-		testPod2 := makeTestPod(f.Namespace.Name, "testpod2", tStamp, containers)
+		testPod1 := makeTestPod(f.Namespace.Name, "rqtestpod1", tStamp, containers)
+		testPod2 := makeTestPod(f.Namespace.Name, "rqtestpod2", tStamp, containers)
 
 		ginkgo.By("creating pods")
 		newPod1 := podClient.CreateSync(ctx, testPod1)
@@ -1421,7 +1421,7 @@ func doPodResizeErrorTests() {
 			tStamp := strconv.Itoa(time.Now().Nanosecond())
 			initDefaultResizePolicy(tc.containers)
 			initDefaultResizePolicy(tc.expected)
-			testPod = makeTestPod(f.Namespace.Name, "testpod", tStamp, tc.containers)
+			testPod = makeTestPod(f.Namespace.Name, "errtestpod", tStamp, tc.containers)
 
 			ginkgo.By("creating pod")
 			newPod := podClient.CreateSync(ctx, testPod)
@@ -1548,8 +1548,8 @@ func doPodResizeSchedulerTests() {
 		tStamp := strconv.Itoa(time.Now().Nanosecond())
 		initDefaultResizePolicy(c1)
 		initDefaultResizePolicy(c2)
-		testPod1 := makeTestPod(f.Namespace.Name, "testpod1", tStamp, c1)
-		testPod2 := makeTestPod(f.Namespace.Name, "testpod2", tStamp, c2)
+		testPod1 := makeTestPod(f.Namespace.Name, "sctestpod1", tStamp, c1)
+		testPod2 := makeTestPod(f.Namespace.Name, "sctestpod2", tStamp, c2)
 		e2epod.SetNodeAffinity(&testPod1.Spec, node.Name)
 		e2epod.SetNodeAffinity(&testPod2.Spec, node.Name)
 
@@ -1603,7 +1603,7 @@ func doPodResizeSchedulerTests() {
 
 		tStamp = strconv.Itoa(time.Now().Nanosecond())
 		initDefaultResizePolicy(c3)
-		testPod3 := makeTestPod(f.Namespace.Name, "testpod3", tStamp, c3)
+		testPod3 := makeTestPod(f.Namespace.Name, "sctestpod3", tStamp, c3)
 		e2epod.SetNodeAffinity(&testPod3.Spec, node.Name)
 
 		ginkgo.By(fmt.Sprintf("TEST2: Create testPod3 '%s' that cannot fit node '%s' due to insufficient CPU.", testPod3.Name, node.Name))
@@ -1637,7 +1637,7 @@ var _ = SIGDescribe("[Serial] Pod InPlace Resize Container (scheduler-focused) [
 	doPodResizeSchedulerTests()
 })
 
-var _ = SIGDescribe("Pod InPlace Resize Container [Feature:InPlacePodVerticalScaling]", func() {
+var _ = SIGDescribe("[Serial] Pod InPlace Resize Container [Feature:InPlacePodVerticalScaling]", func() {
 	doPodResizeTests()
 	doPodResizeResourceQuotaTests()
 	doPodResizeErrorTests()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: In-place pod resize CI tests were re-enabled in PR https://github.com/kubernetes/test-infra/pull/28928 following merge of PR https://github.com/kubernetes/kubernetes/pull/102884 These tests are failing and the root cause appears to be pods timing out awaiting scheduling, Unschedulable due to Insufficient cpu.

Running these tests in serial may be a quick way to address the problem.

#### Which issue(s) this PR fixes: #116371 116371
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
