### PR TITLE
cronjob: shut down integration test quickly again

### DIFF
--- a/test/integration/cronjob/cronjob_test.go
+++ b/test/integration/cronjob/cronjob_test.go
@@ -152,6 +152,10 @@ func TestCronJobLaunchesPodAndCleansUp(t *testing.T) {
 	closeFn, cjc, jc, informerSet, clientSet := setup(ctx, t)
 	defer closeFn()
 
+	// When shutting down, cancel must be called before closeFn.
+	// We simply call it multiple times.
+	defer cancel()
+
 	cronJobName := "foo"
 	namespaceName := "simple-cronjob-test"
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

6f2cd1b5bd76e336c08846281db1aacca1e7dd13 swapped the order of cancel() and closeFn() so that closeFn got called first when the test was done. This caused it to block while waiting for goroutines which themselves were waiting for the context cancellation. The test still shut down, it just took ~86s instead of ~30s.

The fix is to register the cancel twice: once as soon as the context is created (to clean up in case of an unexpected panic) and once after closeFn (because then it'll get called first, as before).

#### Which issue(s) this PR fixes:
Fixes #116378

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
