### PR TITLE
fix: remove SchedulingMigratedInTreePVs feature gate in sched perf test

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -97,8 +97,6 @@
       measurePods: 1000
 
 - name: SchedulingMigratedInTreePVs
-  featureGates:
-    CSIMigrationAWS: true
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test
/kind regression
/sig scheduling

#### What this PR does / why we need it:

`SchedulingMigratedInTreePVs` feature gate is removed from source code. Scheduler perf test still specifies it and thus cause a panic when running the perf test suite.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #116359

#### Special notes for your reviewer:

Without this PR, the panic looks like:

```
⇒  make test-integration WHAT=./test/integration/scheduler_perf KUBE_TEST_VMODULE="''" KUBE_TEST_ARGS="-run=^$$ -bench=BenchmarkPerfScheduling/SchedulingMigratedInTreePVs"
...
pkg: k8s.io/kubernetes/test/integration/scheduler_perf
BenchmarkPerfScheduling/SchedulingMigratedInTreePVs/500Nodes-10         	panic: feature "CSIMigrationAWS" is not registered in FeatureGate "k8s.io/apiserver/pkg/util/feature/feature_gate.go:28"

goroutine 111 [running]:
k8s.io/kubernetes/vendor/k8s.io/component-base/featuregate.(*featureGate).Enabled(0x140001220c0, {0x14000b667f0, 0xf})
	/Users/weih/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/component-base/featuregate/feature_gate.go:317 +0x18c
k8s.io/kubernetes/vendor/k8s.io/component-base/featuregate/testing.SetFeatureGateDuringTest({0x106a179c8?, 0x14000313400}, {0x1069f46e0, 0x140001220c0}, {0x14000b667f0, 0xf}, 0x1)
	/Users/weih/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/component-base/featuregate/testing/feature_gate.go:33 +0x54
k8s.io/kubernetes/test/integration/scheduler_perf.BenchmarkPerfScheduling.func1.1(0x14000313400)
	/Users/weih/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/integration/scheduler_perf/scheduler_perf_test.go:662 +0x170
testing.(*B).runN(0x14000313400, 0x1)
	/Users/weih/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.20.1.darwin.arm64/src/testing/benchmark.go:193 +0x128
testing.(*B).run1.func1()
	/Users/weih/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.20.1.darwin.arm64/src/testing/benchmark.go:233 +0x50
created by testing.(*B).run1
	/Users/weih/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.20.1.darwin.arm64/src/testing/benchmark.go:226 +0x8c
exit status 2
FAIL	k8s.io/kubernetes/test/integration/scheduler_perf	0.815s
FAIL
make[1]: *** [test] Error 1
!!! [0308 08:27:19] Call tree:
!!! [0308 08:27:19]  1: hack/make-rules/test-integration.sh:102 runTests(...)
+++ [0308 08:27:19] Cleaning up etcd
+++ [0308 08:27:19] Integration test cleanup complete
make: *** [test-integration] Error 1
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
