### PR TITLE
Turn off P&F filter in standalone CRD server tests

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/server.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/server.go
@@ -86,6 +86,8 @@ users:
 		"--authentication-kubeconfig", fakeKubeConfig.Name(),
 		"--authorization-kubeconfig", fakeKubeConfig.Name(),
 		"--kubeconfig", fakeKubeConfig.Name(),
+		// disable admission and filters that require talking to kube-apiserver
+		"--enable-priority-and-fairness=false",
 		"--disable-admission-plugins", "NamespaceLifecycle,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"},
 		flags...,
 	), nil)


### PR DESCRIPTION
Noticed in test logs while debugging https://github.com/kubernetes/kubernetes/pull/116380

These integration tests run standalone apiextensions API servers with a dummy kubeconfig pointing at a non-existent kube-apiserver, and disable admission / filters that would need to talk to that apiserver.

Priority and fairness got added since this test was constructed, and was failing in the background polluting the test log complaining about not being able to list against the dummy kube-apiserver.

/kind cleanup
/cc @deads2k 
/sig api-machinery

```release-note
NONE
```