### PR TITLE
Automated cherry pick of #116342: Unlock CSIMigrationvSphere feature gate 

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -955,7 +955,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	CSIMigrationRBD: {Default: false, PreRelease: featuregate.Alpha}, // Off by default (requires RBD CSI driver)
 
-	CSIMigrationvSphere: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.28
+	CSIMigrationvSphere: {Default: true, PreRelease: featuregate.GA}, // LockToDefault when CSI driver with GA support for Windows, raw block and xfs features are available
 
 	CSINodeExpandSecret: {Default: false, PreRelease: featuregate.Alpha},
 


### PR DESCRIPTION
Cherry pick of #116342 on release-1.26.

#116342: Unlock CSIMigrationvSphere feature gate until there is a

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Unlocked the `CSIMigrationvSphere` feature gate. The change allow users to continue using the in-tree vSphere driver,pending a vSphere CSI driver release that has with GA support for Windows, XFS, and raw block access.
```