### PR TITLE
e2e: podresources: promote platform-independent test as NodeConformance

### DIFF
--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -821,7 +821,7 @@ var _ = SIGDescribe("POD Resources [Serial] [Feature:PodResources][NodeFeature:P
 		})
 	})
 
-	ginkgo.Context("when querying /metrics", func() {
+	ginkgo.Context("when querying /metrics [NodeConformance]", func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			// ensure APIs have been called at least once
 			endpoint, err := util.LocalEndpoint(defaultPodResourcesPath, podresources.Socket)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
Promote podresources e2e tests to conformance. Unfortunatly for reasons explained in the commit message we can just promote a single test, because we need cross-platform support. It's still a start.

#### Which issue(s) this PR fixes:
Fixes #116421

#### Special notes for your reviewer:
Enhancements of podresources e2e tests to be able to promote more is deferred to future PRs.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
