### PR TITLE
Make generateName use longer names when possible

### DIFF
--- a/pkg/controller/job/indexed_job_utils_test.go
+++ b/pkg/controller/job/indexed_job_utils_test.go
@@ -423,12 +423,12 @@ func TestPodGenerateNameWithIndex(t *testing.T) {
 		"job name exceeds MaxGeneneratedNameLength": {
 			jobname:             "hhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhhooooo",
 			index:               1,
-			wantPodGenerateName: "hhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhh-1-",
+			wantPodGenerateName: "hhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhhooooo-1-",
 		},
 		"job name with index suffix exceeds MaxGeneratedNameLength": {
 			jobname:             "hhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhhoo",
 			index:               1,
-			wantPodGenerateName: "hhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhh-1-",
+			wantPodGenerateName: "hhhhhooooohhhhhooooohhhhhooooohhhhhooooohhhhhooooo-1-",
 		},
 	}
 	for name, tc := range cases {

--- a/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go
@@ -42,7 +42,7 @@ var SimpleNameGenerator NameGenerator = simpleNameGenerator{}
 const (
 	// TODO: make this flexible for non-core resources with alternate naming rules.
 	maxNameLength          = 63
-	randomLength           = 5
+	randomLength           = 10
 	MaxGeneratedNameLength = maxNameLength - randomLength
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/names/generate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/names/generate_test.go
@@ -19,11 +19,74 @@ package names
 import (
 	"strings"
 	"testing"
+
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 )
 
 func TestSimpleNameGenerator(t *testing.T) {
-	name := SimpleNameGenerator.GenerateName("foo")
-	if !strings.HasPrefix(name, "foo") || name == "foo" {
-		t.Errorf("unexpected name: %s", name)
+	const maxPrefixLen = maxNameLength - randomLength
+	mkBase := func(n int) string {
+		return utilrand.String(n)
+	}
+
+	cases := []struct {
+		base        string
+		expectLen   int
+		expectTrunc int
+	}{{
+		// Normal use
+		base:      mkBase(3),
+		expectLen: 3 + randomLength,
+	}, {
+		// Edge case: long name, just enough for suffix
+		base:      mkBase(maxPrefixLen),
+		expectLen: maxNameLength,
+	}, {
+		// Edge case: long name trucated
+		base:        mkBase(maxPrefixLen + 1),
+		expectLen:   maxNameLength,
+		expectTrunc: 1,
+	}, {
+		// Edge case: max length name trucated
+		base:        mkBase(maxNameLength),
+		expectLen:   maxNameLength,
+		expectTrunc: randomLength,
+	}, {
+		// Edge case: very long name trucated
+		base:        mkBase(maxNameLength * 2),
+		expectLen:   maxNameLength,
+		expectTrunc: maxNameLength + randomLength,
+	}}
+	for i, tc := range cases {
+		// Set the first character to be truncated (if any) to something
+		// not in the random character set, so we can prove it was replaced by
+		// random characters.
+		setSentinel := func(base string) string {
+			if len(base) <= maxPrefixLen {
+				return base
+			}
+			baseBytes := []byte(base)
+			baseBytes[maxPrefixLen] = '!'
+			return string(baseBytes)
+		}
+
+		base := setSentinel(tc.base)
+		name := SimpleNameGenerator.GenerateName(base)
+		if len(name) != tc.expectLen {
+			t.Errorf("case[%d]: wrong result len: expected %d, got %d (%q)", i, tc.expectLen, len(name), name)
+		}
+		if name == base {
+			t.Errorf("case[%d]: didn't randomize: %q", i, name)
+		}
+		if pfx := base[0 : len(base)-tc.expectTrunc]; !strings.HasPrefix(name, pfx) {
+			t.Errorf("case[%d]: wrong result prefix: expected base %q, got result %q", i, pfx, name)
+		}
+		if tc.expectTrunc > 0 {
+			// pfx = everything we expect to keep + 1, which will not be a
+			// valid suffix character.
+			if pfx := base[0 : len(base)-(tc.expectTrunc)+1]; strings.HasPrefix(name, pfx) {
+				t.Errorf("case[%d]: didn't truncate base: result %q must not be a prefix of %q", i, pfx, name)
+			}
+		}
 	}
 }


### PR DESCRIPTION
Simple enough change, but is it worth the churn?

We have 27 characters in the set.

27^5 = 14,348,907 (14M) names

27^10 = 205,891,132,094,649 (205T) names

/kind cleanup

Fixes #115489

```release-note
API objects created with `generateName` will now use longer random suffixes.  Generated names are limited to 63 characters, and previously the suffix was fixed at 5 characters (truncating the input if needed).  Now it will be 10 characters (still truncating if needed).  This reduces the risk of collision dramatically.
```
