### PR TITLE
Cache authz decisions within the scope of validating policy admission.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/caching_authorizer.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/caching_authorizer.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validatingadmissionpolicy
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+type authzResult struct {
+	authorized authorizer.Decision
+	reason     string
+	err        error
+}
+
+type cachingAuthorizer struct {
+	authorizer authorizer.Authorizer
+	decisions  map[string]authzResult
+}
+
+func newCachingAuthorizer(in authorizer.Authorizer) authorizer.Authorizer {
+	return &cachingAuthorizer{
+		authorizer: in,
+		decisions:  make(map[string]authzResult),
+	}
+}
+
+// The attribute accessors known to cache key construction. If this fails to compile, the cache
+// implementation may need to be updated.
+var _ authorizer.Attributes = (interface {
+	GetUser() user.Info
+	GetVerb() string
+	IsReadOnly() bool
+	GetNamespace() string
+	GetResource() string
+	GetSubresource() string
+	GetName() string
+	GetAPIGroup() string
+	GetAPIVersion() string
+	IsResourceRequest() bool
+	GetPath() string
+})(nil)
+
+// The user info accessors known to cache key construction. If this fails to compile, the cache
+// implementation may need to be updated.
+var _ user.Info = (interface {
+	GetName() string
+	GetUID() string
+	GetGroups() []string
+	GetExtra() map[string][]string
+})(nil)
+
+// Authorize returns an authorization decision by delegating to another Authorizer. If an equivalent
+// check has already been performed, a cached result is returned. Not safe for concurrent use.
+func (ca *cachingAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+	serializableAttributes := authorizer.AttributesRecord{
+		Verb:            a.GetVerb(),
+		Namespace:       a.GetNamespace(),
+		APIGroup:        a.GetAPIGroup(),
+		APIVersion:      a.GetAPIVersion(),
+		Resource:        a.GetResource(),
+		Subresource:     a.GetSubresource(),
+		Name:            a.GetName(),
+		ResourceRequest: a.IsResourceRequest(),
+		Path:            a.GetPath(),
+	}
+
+	if u := a.GetUser(); u != nil {
+		di := &user.DefaultInfo{
+			Name: u.GetName(),
+			UID:  u.GetUID(),
+		}
+
+		// Differently-ordered groups or extras could cause otherwise-equivalent checks to
+		// have distinct cache keys.
+		if groups := u.GetGroups(); len(groups) > 0 {
+			di.Groups = make([]string, len(groups))
+			copy(di.Groups, groups)
+			sort.Strings(di.Groups)
+		}
+
+		if extra := u.GetExtra(); len(extra) > 0 {
+			di.Extra = make(map[string][]string, len(extra))
+			for k, vs := range extra {
+				vdupe := make([]string, len(vs))
+				copy(vdupe, vs)
+				sort.Strings(vdupe)
+				di.Extra[k] = vdupe
+			}
+		}
+
+		serializableAttributes.User = di
+	}
+
+	var b strings.Builder
+	if err := json.NewEncoder(&b).Encode(serializableAttributes); err != nil {
+		return authorizer.DecisionNoOpinion, "", err
+	}
+	key := b.String()
+
+	if cached, ok := ca.decisions[key]; ok {
+		return cached.authorized, cached.reason, cached.err
+	}
+
+	authorized, reason, err := ca.authorizer.Authorize(ctx, a)
+
+	ca.decisions[key] = authzResult{
+		authorized: authorized,
+		reason:     reason,
+		err:        err,
+	}
+
+	return authorized, reason, err
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/caching_authorizer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/caching_authorizer_test.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validatingadmissionpolicy
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func TestCachingAuthorizer(t *testing.T) {
+	type result struct {
+		decision authorizer.Decision
+		reason   string
+		error    error
+	}
+
+	type invocation struct {
+		attributes authorizer.Attributes
+		expected   result
+	}
+
+	for _, tc := range []struct {
+		name    string
+		calls   []invocation
+		backend []result
+	}{
+		{
+			name: "hit",
+			calls: []invocation{
+				{
+					attributes: authorizer.AttributesRecord{Name: "test name"},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+				{
+					attributes: authorizer.AttributesRecord{Name: "test name"},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+			},
+			backend: []result{
+				{
+					decision: authorizer.DecisionAllow,
+					reason:   "test reason",
+					error:    fmt.Errorf("test error"),
+				},
+			},
+		},
+		{
+			name: "hit with differently-ordered groups",
+			calls: []invocation{
+				{
+					attributes: authorizer.AttributesRecord{
+						User: &user.DefaultInfo{
+							Groups: []string{"a", "b", "c"},
+						},
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+				{
+					attributes: authorizer.AttributesRecord{
+						User: &user.DefaultInfo{
+							Groups: []string{"c", "b", "a"},
+						},
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+			},
+			backend: []result{
+				{
+					decision: authorizer.DecisionAllow,
+					reason:   "test reason",
+					error:    fmt.Errorf("test error"),
+				},
+			},
+		},
+		{
+			name: "hit with differently-ordered extra",
+			calls: []invocation{
+				{
+					attributes: authorizer.AttributesRecord{
+						User: &user.DefaultInfo{
+							Extra: map[string][]string{
+								"k": {"a", "b", "c"},
+							},
+						},
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+				{
+					attributes: authorizer.AttributesRecord{
+						User: &user.DefaultInfo{
+							Extra: map[string][]string{
+								"k": {"c", "b", "a"},
+							},
+						},
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+			},
+			backend: []result{
+				{
+					decision: authorizer.DecisionAllow,
+					reason:   "test reason",
+					error:    fmt.Errorf("test error"),
+				},
+			},
+		},
+		{
+			name: "miss due to different name",
+			calls: []invocation{
+				{
+					attributes: authorizer.AttributesRecord{Name: "alpha"},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason alpha",
+						error:    fmt.Errorf("test error alpha"),
+					},
+				},
+				{
+					attributes: authorizer.AttributesRecord{Name: "beta"},
+					expected: result{
+						decision: authorizer.DecisionDeny,
+						reason:   "test reason beta",
+						error:    fmt.Errorf("test error beta"),
+					},
+				},
+			},
+			backend: []result{
+				{
+					decision: authorizer.DecisionAllow,
+					reason:   "test reason alpha",
+					error:    fmt.Errorf("test error alpha"),
+				},
+				{
+					decision: authorizer.DecisionDeny,
+					reason:   "test reason beta",
+					error:    fmt.Errorf("test error beta"),
+				},
+			},
+		},
+		{
+			name: "miss due to different user",
+			calls: []invocation{
+				{
+					attributes: authorizer.AttributesRecord{
+						User: &user.DefaultInfo{Name: "alpha"},
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason alpha",
+						error:    fmt.Errorf("test error alpha"),
+					},
+				},
+				{
+					attributes: authorizer.AttributesRecord{
+						User: &user.DefaultInfo{Name: "beta"},
+					},
+					expected: result{
+						decision: authorizer.DecisionDeny,
+						reason:   "test reason beta",
+						error:    fmt.Errorf("test error beta"),
+					},
+				},
+			},
+			backend: []result{
+				{
+					decision: authorizer.DecisionAllow,
+					reason:   "test reason alpha",
+					error:    fmt.Errorf("test error alpha"),
+				},
+				{
+					decision: authorizer.DecisionDeny,
+					reason:   "test reason beta",
+					error:    fmt.Errorf("test error beta"),
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var misses int
+			frontend := newCachingAuthorizer(func() authorizer.Authorizer {
+				return authorizer.AuthorizerFunc(func(_ context.Context, attributes authorizer.Attributes) (authorizer.Decision, string, error) {
+					if misses >= len(tc.backend) {
+						t.Fatalf("got more than expected %d backend invocations", len(tc.backend))
+					}
+					result := tc.backend[misses]
+					misses++
+					return result.decision, result.reason, result.error
+				})
+			}())
+
+			for i, invocation := range tc.calls {
+				decision, reason, err := frontend.Authorize(context.TODO(), invocation.attributes)
+				if decision != invocation.expected.decision {
+					t.Errorf("(call %d of %d) expected decision %v, got %v", i+1, len(tc.calls), invocation.expected.decision, decision)
+				}
+				if reason != invocation.expected.reason {
+					t.Errorf("(call %d of %d) expected reason %q, got %q", i+1, len(tc.calls), invocation.expected.reason, reason)
+				}
+				if err.Error() != invocation.expected.error.Error() {
+					t.Errorf("(call %d of %d) expected error %q, got %q", i+1, len(tc.calls), invocation.expected.error.Error(), err.Error())
+				}
+			}
+
+			if len(tc.backend) > misses {
+				t.Errorf("expected %d backend invocations, got %d", len(tc.backend), misses)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/interface.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/interface.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/plugin/cel"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
 var _ cel.ExpressionAccessor = &ValidationCondition{}
@@ -85,5 +86,5 @@ type ValidateResult struct {
 type Validator interface {
 	// Validate is used to take cel evaluations and convert into decisions
 	// runtimeCELCostBudget was added for testing purpose only. Callers should always use const RuntimeCELCostBudget from k8s.io/apiserver/pkg/apis/cel/config.go as input.
-	Validate(ctx context.Context, versionedAttr *admission.VersionedAttributes, versionedParams runtime.Object, runtimeCELCostBudget int64) ValidateResult
+	Validate(ctx context.Context, versionedAttr *admission.VersionedAttributes, versionedParams runtime.Object, runtimeCELCostBudget int64, authz authorizer.Authorizer) ValidateResult
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook.go
@@ -225,8 +225,8 @@ func (a *Webhook) ShouldCallHook(ctx context.Context, h webhook.WebhookAccessor,
 			return nil, apierrors.NewInternalError(err)
 		}
 
-		matcher := h.GetCompiledMatcher(a.filterCompiler, a.authorizer)
-		matchResult := matcher.Match(ctx, versionedAttr, nil)
+		matcher := h.GetCompiledMatcher(a.filterCompiler)
+		matchResult := matcher.Match(ctx, versionedAttr, nil, a.authorizer)
 
 		if matchResult.Error != nil {
 			klog.Warningf("Failed evaluating match conditions, failing closed %v: %v", h.GetName(), matchResult.Error)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook_test.go
@@ -54,7 +54,7 @@ type fakeMatcher struct {
 	matchResult bool
 }
 
-func (f *fakeMatcher) Match(ctx context.Context, versionedAttr *admission.VersionedAttributes, versionedParams runtime.Object) matchconditions.MatchResult {
+func (f *fakeMatcher) Match(ctx context.Context, versionedAttr *admission.VersionedAttributes, versionedParams runtime.Object, authz authorizer.Authorizer) matchconditions.MatchResult {
 	if f.throwError != nil {
 		return matchconditions.MatchResult{
 			Matches:             true,
@@ -76,7 +76,7 @@ type fakeWebhookAccessor struct {
 	matchResult bool
 }
 
-func (f *fakeWebhookAccessor) GetCompiledMatcher(compiler cel.FilterCompiler, authorizer authorizer.Authorizer) matchconditions.Matcher {
+func (f *fakeWebhookAccessor) GetCompiledMatcher(compiler cel.FilterCompiler) matchconditions.Matcher {
 	return &fakeMatcher{
 		throwError:  f.throwError,
 		matchResult: f.matchResult,

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions/interface.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions/interface.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
 type MatchResult struct {
@@ -32,5 +33,5 @@ type MatchResult struct {
 // Matcher contains logic for converting Evaluations to bool of matches or does not match
 type Matcher interface {
 	// Match is used to take cel evaluations and convert into decisions
-	Match(ctx context.Context, versionedAttr *admission.VersionedAttributes, versionedParams runtime.Object) MatchResult
+	Match(ctx context.Context, versionedAttr *admission.VersionedAttributes, versionedParams runtime.Object, authz authorizer.Authorizer) MatchResult
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions/matcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions/matcher_test.go
@@ -334,9 +334,9 @@ func TestMatch(t *testing.T) {
 			m := NewMatcher(&fakeCelFilter{
 				evaluations: tc.evaluations,
 				throwError:  tc.throwError,
-			}, nil, tc.failPolicy, "test", "testhook")
+			}, tc.failPolicy, "test", "testhook")
 			ctx := context.TODO()
-			matchResult := m.Match(ctx, fakeVersionedAttr, nil)
+			matchResult := m.Match(ctx, fakeVersionedAttr, nil, nil)
 
 			if matchResult.Error != nil {
 				if len(tc.expectError) == 0 {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Identical checks should produce identical decisions when referenced more than once in a policy expression, or by more than one expression in a policy.

https://github.com/kubernetes/kubernetes/pull/116054#discussion_r1123547542

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
In the course of admitting a single request, the ValidatingAdmissionPolicy plugin will perform no more than one authorization check per unique authorizer expression. All evaluations of identical authorizer expressions will produce the same decision.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
