### PR TITLE
Lazy openapi v2 Aggregator

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/downloader.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/downloader.go
@@ -24,8 +24,49 @@ import (
 
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/kube-openapi/pkg/cached"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
+
+// cacheableDownloader is a downloader that will always return the data
+// and the etag.
+type cacheableDownloader struct {
+	downloader *Downloader
+	handler    http.Handler
+	etag       string
+	spec       *spec.Swagger
+}
+
+// Creates a downloader that also returns the etag, making it useful to use as a cached dependency.
+func NewCacheableDownloader(downloader *Downloader, handler http.Handler) cached.Data[*spec.Swagger] {
+	return &cacheableDownloader{
+		downloader: downloader,
+		handler:    handler,
+	}
+}
+
+func (d *cacheableDownloader) Get() cached.Result[*spec.Swagger] {
+	swagger, etag, status, err := d.downloader.Download(d.handler, d.etag)
+	if err != nil {
+		return cached.NewResultErr[*spec.Swagger](err)
+	}
+	switch status {
+	case http.StatusNotModified:
+		// Nothing has changed, do nothing.
+	case http.StatusOK:
+		if swagger != nil {
+			d.etag = etag
+			d.spec = swagger
+			break
+		}
+		fallthrough
+	case http.StatusNotFound:
+		return cached.NewResultErr[*spec.Swagger](ErrNotFound)
+	default:
+		return cached.NewResultErr[*spec.Swagger](fmt.Errorf("invalid status code: %v", status))
+	}
+	return cached.NewResultOK(d.spec, d.etag)
+}
 
 // Downloader is the OpenAPI downloader type. It will try to download spec from /openapi/v2 or /swagger.json endpoint.
 type Downloader struct {

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/priority_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/priority_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
-	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 func newAPIServiceForTest(name, group string, minGroupPriority, versionPriority int32, svc *apiregistrationv1.ServiceReference) apiregistrationv1.APIService {
@@ -48,19 +47,15 @@ func TestAPIServiceSort(t *testing.T) {
 	list := []openAPISpecInfo{
 		{
 			apiService: newAPIServiceForTest("FirstService", "Group1", 10, 5, &apiregistrationv1.ServiceReference{}),
-			spec:       &spec.Swagger{},
 		},
 		{
 			apiService: newAPIServiceForTest("SecondService", "Group2", 15, 3, &apiregistrationv1.ServiceReference{}),
-			spec:       &spec.Swagger{},
 		},
 		{
 			apiService: newAPIServiceForTest("FirstServiceInternal", "Group1", 16, 3, &apiregistrationv1.ServiceReference{}),
-			spec:       &spec.Swagger{},
 		},
 		{
 			apiService: newAPIServiceForTest("ThirdService", "Group3", 15, 3, &apiregistrationv1.ServiceReference{}),
-			spec:       &spec.Swagger{},
 		},
 		{
 			apiService: newAPIServiceForTest("local_service_1", "Group4", 15, 1, nil),

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/controller.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
-	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	v1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator"
 )
 
@@ -67,11 +67,6 @@ func NewAggregationController(downloader *aggregator.Downloader, openAPIAggregat
 
 	c.syncHandler = c.sync
 
-	// update each service at least once, also those which are not coming from APIServices, namely local services
-	for _, name := range openAPIAggregationManager.GetAPIServiceNames() {
-		c.queue.AddAfter(name, time.Second)
-	}
-
 	return c
 }
 
@@ -100,55 +95,31 @@ func (c *AggregationController) processNextWorkItem() bool {
 	if quit {
 		return false
 	}
-
-	if aggregator.IsLocalAPIService(key.(string)) {
-		// for local delegation targets that are aggregated once per second, log at
-		// higher level to avoid flooding the log
-		klog.V(6).Infof("OpenAPI AggregationController: Processing item %s", key)
-	} else {
-		klog.V(4).Infof("OpenAPI AggregationController: Processing item %s", key)
-	}
+	klog.V(4).Infof("OpenAPI AggregationController: Processing item %s", key)
 
 	action, err := c.syncHandler(key.(string))
-	if err == nil {
-		c.queue.Forget(key)
-	} else {
+	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("loading OpenAPI spec for %q failed with: %v", key, err))
 	}
 
 	switch action {
 	case syncRequeue:
-		if aggregator.IsLocalAPIService(key.(string)) {
-			klog.V(7).Infof("OpenAPI AggregationController: action for local item %s: Requeue after %s.", key, successfulUpdateDelayLocal)
-			c.queue.AddAfter(key, successfulUpdateDelayLocal)
-		} else {
-			klog.V(7).Infof("OpenAPI AggregationController: action for item %s: Requeue.", key)
-			c.queue.AddAfter(key, successfulUpdateDelay)
-		}
+		c.queue.AddAfter(key, successfulUpdateDelay)
 	case syncRequeueRateLimited:
 		klog.Infof("OpenAPI AggregationController: action for item %s: Rate Limited Requeue.", key)
 		c.queue.AddRateLimited(key)
 	case syncNothing:
-		klog.Infof("OpenAPI AggregationController: action for item %s: Nothing (removed from the queue).", key)
+		c.queue.Forget(key)
 	}
 
 	return true
 }
 
 func (c *AggregationController) sync(key string) (syncAction, error) {
-	handler, etag, exists := c.openAPIAggregationManager.GetAPIServiceInfo(key)
-	if !exists || handler == nil {
-		return syncNothing, nil
-	}
-	returnSpec, newEtag, httpStatus, err := c.downloader.Download(handler, etag)
-	switch {
-	case err != nil:
-		return syncRequeueRateLimited, err
-	case httpStatus == http.StatusNotModified:
-	case httpStatus == http.StatusNotFound || returnSpec == nil:
-		return syncRequeueRateLimited, fmt.Errorf("OpenAPI spec does not exist")
-	case httpStatus == http.StatusOK:
-		if err := c.openAPIAggregationManager.UpdateAPIServiceSpec(key, returnSpec, newEtag); err != nil {
+	if err := c.openAPIAggregationManager.UpdateAPIService(key); err != nil {
+		if err == aggregator.ErrNotFound {
+			return syncNothing, nil
+		} else {
 			return syncRequeueRateLimited, err
 		}
 	}
@@ -157,10 +128,7 @@ func (c *AggregationController) sync(key string) (syncAction, error) {
 
 // AddAPIService adds a new API Service to OpenAPI Aggregation.
 func (c *AggregationController) AddAPIService(handler http.Handler, apiService *v1.APIService) {
-	if apiService.Spec.Service == nil {
-		return
-	}
-	if err := c.openAPIAggregationManager.AddUpdateAPIService(handler, apiService); err != nil {
+	if err := c.openAPIAggregationManager.AddAPIService(apiService, handler); err != nil {
 		utilruntime.HandleError(fmt.Errorf("adding %q to AggregationController failed with: %v", apiService.Name, err))
 	}
 	c.queue.AddAfter(apiService.Name, time.Second)
@@ -168,11 +136,13 @@ func (c *AggregationController) AddAPIService(handler http.Handler, apiService *
 
 // UpdateAPIService updates API Service's info and handler.
 func (c *AggregationController) UpdateAPIService(handler http.Handler, apiService *v1.APIService) {
-	if apiService.Spec.Service == nil {
-		return
-	}
-	if err := c.openAPIAggregationManager.AddUpdateAPIService(handler, apiService); err != nil {
-		utilruntime.HandleError(fmt.Errorf("updating %q to AggregationController failed with: %v", apiService.Name, err))
+	if err := c.openAPIAggregationManager.UpdateAPIService(apiService.Name); err != nil {
+		// Item as removed, forget it.
+		if err == aggregator.ErrNotFound {
+			c.queue.Forget(apiService.Name)
+		} else {
+			utilruntime.HandleError(fmt.Errorf("updating %q to AggregationController failed with: %v", apiService.Name, err))
+		}
 	}
 	key := apiService.Name
 	if c.queue.NumRequeues(key) > 0 {
@@ -187,7 +157,7 @@ func (c *AggregationController) UpdateAPIService(handler http.Handler, apiServic
 
 // RemoveAPIService removes API Service from OpenAPI Aggregation Controller.
 func (c *AggregationController) RemoveAPIService(apiServiceName string) {
-	if err := c.openAPIAggregationManager.RemoveAPIServiceSpec(apiServiceName); err != nil {
+	if err := c.openAPIAggregationManager.RemoveAPIService(apiServiceName); err != nil {
 		utilruntime.HandleError(fmt.Errorf("removing %q from AggregationController failed with: %v", apiServiceName, err))
 	}
 	// This will only remove it if it was failing before. If it was successful, processNextWorkItem will figure it out


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Changes the aggregator to lazily compute the OpenAPI v2, using the new `cached` framework. That means:
- Downloads local dependencies only on requests (e.g. CRDs)
- Continues to pull non-local dependencies on the same interval as before, non-lazily (i.e. aggregated apiservers)
- Merging, cleaning-up the openapi (e.g. pruning default), and serializing the output is now performed entirely on-demand (and only re-computing as needed)
- Since dependencies are not pulled until requested, their cache are also uninitialized saving a lot of in-use memory until actually needed

Removes a O(n^2) merging the specs in the aggregator, giving about 23% reduction in allocations, and ~16% in memory use.

The same thing can be applied to the CRD controller too, and probably to some of the OpenAPI v3 (though since OpenAPI v3 is split by group/version, the impact would be noticeably smaller).

#### Which issue(s) this PR fixes:
Performance related.

#### Special notes for your reviewer:
First two commits are based on #116349

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: