### PR TITLE
update go to 1.19.7 in publishing bot rules and drop 1.23 config

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -5,11 +5,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/code-generator
-  - name: release-1.23
-    go: 1.19.6
-    source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/code-generator
   - name: release-1.24
     go: 1.19.6
     source:
@@ -30,11 +25,6 @@ rules:
   - name: master
     source:
       branch: master
-      dir: staging/src/k8s.io/apimachinery
-  - name: release-1.23
-    go: 1.19.6
-    source:
-      branch: release-1.23
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.24
     go: 1.19.6
@@ -60,14 +50,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/api
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.23
-    source:
-      branch: release-1.23
       dir: staging/src/k8s.io/api
   - name: release-1.24
     go: 1.19.6
@@ -104,20 +86,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/client-go
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod ./...
-      go test -mod=mod ./...
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: api
-      branch: release-1.23
-    source:
-      branch: release-1.23
       dir: staging/src/k8s.io/client-go
     smoke-test: |
       # assumes GO111MODULE=on
@@ -179,18 +147,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/component-base
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: api
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/component-base
   - name: release-1.24
     go: 1.19.6
     dependencies:
@@ -240,18 +196,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/component-helpers
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: api
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    source:
-      branch: release-1.23
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.24
     go: 1.19.6
@@ -326,20 +270,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/apiserver
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: api
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    - repository: component-base
-      branch: release-1.23
-    source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/apiserver
   - name: release-1.24
     go: 1.19.6
     dependencies:
@@ -405,24 +335,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-aggregator
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: api
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    - repository: apiserver
-      branch: release-1.23
-    - repository: component-base
-      branch: release-1.23
-    - repository: code-generator
-      branch: release-1.23
-    source:
-      branch: release-1.23
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.24
     go: 1.19.6
@@ -500,29 +412,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/sample-apiserver
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: api
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    - repository: apiserver
-      branch: release-1.23
-    - repository: code-generator
-      branch: release-1.23
-    - repository: component-base
-      branch: release-1.23
-    source:
-      branch: release-1.23
       dir: staging/src/k8s.io/sample-apiserver
     required-packages:
     - k8s.io/code-generator
@@ -620,25 +509,6 @@ rules:
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: api
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    - repository: code-generator
-      branch: release-1.23
-    source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/sample-controller
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
   - name: release-1.24
     go: 1.19.6
     dependencies:
@@ -719,26 +589,6 @@ rules:
       dir: staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: api
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    - repository: apiserver
-      branch: release-1.23
-    - repository: code-generator
-      branch: release-1.23
-    - repository: component-base
-      branch: release-1.23
-    source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    required-packages:
-    - k8s.io/code-generator
   - name: release-1.24
     go: 1.19.6
     dependencies:
@@ -816,20 +666,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/metrics
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: api
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    - repository: code-generator
-      branch: release-1.23
-    source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/metrics
   - name: release-1.24
     go: 1.19.6
     dependencies:
@@ -886,18 +722,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/cli-runtime
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: api
-      branch: release-1.23
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/cli-runtime
   - name: release-1.24
     go: 1.19.6
     dependencies:
@@ -949,20 +773,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/sample-cli-plugin
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: api
-      branch: release-1.23
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: cli-runtime
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    source:
-      branch: release-1.23
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.24
     go: 1.19.6
@@ -1020,20 +830,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-proxy
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: component-base
-      branch: release-1.23
-    - repository: api
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    source:
-      branch: release-1.23
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.24
     go: 1.19.6
@@ -1093,20 +889,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/kubelet
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: api
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    - repository: component-base
-      branch: release-1.23
-    source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/kubelet
   - name: release-1.24
     go: 1.19.6
     dependencies:
@@ -1164,20 +946,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-scheduler
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: component-base
-      branch: release-1.23
-    - repository: api
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    source:
-      branch: release-1.23
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.24
     go: 1.19.6
@@ -1240,22 +1008,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/controller-manager
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: api
-      branch: release-1.23
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    - repository: component-base
-      branch: release-1.23
-    - repository: apiserver
-      branch: release-1.23
-    source:
-      branch: release-1.23
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.24
     go: 1.19.6
@@ -1330,26 +1082,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/cloud-provider
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: api
-      branch: release-1.23
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: apiserver
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    - repository: component-base
-      branch: release-1.23
-    - repository: controller-manager
-      branch: release-1.23
-    - repository: component-helpers
-      branch: release-1.23
-    source:
-      branch: release-1.23
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.24
     go: 1.19.6
@@ -1439,28 +1171,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/kube-controller-manager
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: apiserver
-      branch: release-1.23
-    - repository: component-base
-      branch: release-1.23
-    - repository: api
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    - repository: controller-manager
-      branch: release-1.23
-    - repository: cloud-provider
-      branch: release-1.23
-    - repository: component-helpers
-      branch: release-1.23
-    source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.24
     go: 1.19.6
     dependencies:
@@ -1541,16 +1251,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/cluster-bootstrap
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: api
-      branch: release-1.23
-    source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.24
     go: 1.19.6
     dependencies:
@@ -1593,16 +1293,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/csi-translation-lib
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: api
-      branch: release-1.23
-    - repository: apimachinery
-      branch: release-1.23
-    source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.24
     go: 1.19.6
     dependencies:
@@ -1639,11 +1329,6 @@ rules:
   - name: master
     source:
       branch: master
-      dir: staging/src/k8s.io/mount-utils
-  - name: release-1.23
-    go: 1.19.6
-    source:
-      branch: release-1.23
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.24
     go: 1.19.6
@@ -1685,32 +1370,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/legacy-cloud-providers
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: api
-      branch: release-1.23
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    - repository: cloud-provider
-      branch: release-1.23
-    - repository: csi-translation-lib
-      branch: release-1.23
-    - repository: apiserver
-      branch: release-1.23
-    - repository: component-base
-      branch: release-1.23
-    - repository: controller-manager
-      branch: release-1.23
-    - repository: mount-utils
-      branch: release-1.23
-    - repository: component-helpers
-      branch: release-1.23
-    source:
-      branch: release-1.23
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.24
     go: 1.19.6
@@ -1799,11 +1458,6 @@ rules:
     source:
       branch: master
       dir: staging/src/k8s.io/cri-api
-  - name: release-1.23
-    go: 1.19.6
-    source:
-      branch: release-1.23
-      dir: staging/src/k8s.io/cri-api
   - name: release-1.24
     go: 1.19.6
     source:
@@ -1842,28 +1496,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kubectl
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: api
-      branch: release-1.23
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: cli-runtime
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    - repository: code-generator
-      branch: release-1.23
-    - repository: component-base
-      branch: release-1.23
-    - repository: component-helpers
-      branch: release-1.23
-    - repository: metrics
-      branch: release-1.23
-    source:
-      branch: release-1.23
       dir: staging/src/k8s.io/kubectl
   - name: release-1.24
     go: 1.19.6
@@ -1950,22 +1582,6 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/pod-security-admission
-  - name: release-1.23
-    go: 1.19.6
-    dependencies:
-    - repository: api
-      branch: release-1.23
-    - repository: apimachinery
-      branch: release-1.23
-    - repository: apiserver
-      branch: release-1.23
-    - repository: client-go
-      branch: release-1.23
-    - repository: component-base
-      branch: release-1.23
-    source:
-      branch: release-1.23
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.24
     go: 1.19.6

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -6,18 +6,18 @@ rules:
       branch: master
       dir: staging/src/k8s.io/code-generator
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/code-generator
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/code-generator
   - name: release-1.26
-    go: 1.19.6
-    source: 
+    go: 1.19.7
+    source:
       branch: release-1.26
       dir: staging/src/k8s.io/code-generator
 - destination: apimachinery
@@ -27,17 +27,17 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     source: 
       branch: release-1.26
       dir: staging/src/k8s.io/apimachinery
@@ -52,7 +52,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/api
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -60,7 +60,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/api
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -68,7 +68,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/api
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -92,7 +92,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -106,7 +106,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -120,7 +120,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -148,7 +148,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/component-base
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -160,7 +160,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-base
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -172,7 +172,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-base
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -198,7 +198,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -210,7 +210,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -222,7 +222,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -249,7 +249,7 @@ rules:
     - repository: client-go
       branch: master
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/kms
@@ -271,7 +271,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apiserver
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -285,7 +285,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/apiserver
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -299,7 +299,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/apiserver
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -337,7 +337,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -355,7 +355,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -373,7 +373,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -419,7 +419,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -442,7 +442,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -465,7 +465,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -510,7 +510,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -529,7 +529,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -548,7 +548,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -590,7 +590,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -610,7 +610,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -630,7 +630,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -667,7 +667,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/metrics
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -681,7 +681,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/metrics
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -695,7 +695,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/metrics
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -723,7 +723,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -735,7 +735,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -747,7 +747,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -775,7 +775,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -789,7 +789,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -803,7 +803,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -832,7 +832,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -846,7 +846,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -860,7 +860,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -890,7 +890,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kubelet
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -904,7 +904,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubelet
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -918,7 +918,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubelet
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -948,7 +948,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -962,7 +962,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -976,7 +976,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1010,7 +1010,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1026,7 +1026,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1042,7 +1042,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1084,7 +1084,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1104,7 +1104,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1124,7 +1124,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1172,7 +1172,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1194,7 +1194,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1216,7 +1216,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1252,7 +1252,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1262,7 +1262,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1272,7 +1272,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1294,7 +1294,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1304,7 +1304,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1314,7 +1314,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1331,17 +1331,17 @@ rules:
       branch: master
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/mount-utils
@@ -1372,7 +1372,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1398,7 +1398,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1424,7 +1424,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1459,17 +1459,17 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cri-api
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/cri-api
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/cri-api
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/cri-api
@@ -1498,7 +1498,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kubectl
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1520,7 +1520,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubectl
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1542,7 +1542,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubectl
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1584,7 +1584,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.24
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1600,7 +1600,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.25
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1616,7 +1616,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1652,7 +1652,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
-    go: 1.19.6
+    go: 1.19.7
     dependencies:
       - repository: apimachinery
         branch: release-1.26


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- drop 1.23 config due to EOL
- update go to 1.19.7 in publishing bot rules for active release branches

related to https://github.com/kubernetes/release/issues/2948

/assign @nikhita @dims @liggitt @saschagrunert 
cc @kubernetes/release-managers 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
