### PR TITLE
Properly align synctrack.SingleFileTracker struct

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/synctrack/synctrack.go
+++ b/staging/src/k8s.io/client-go/tools/cache/synctrack/synctrack.go
@@ -78,9 +78,13 @@ func (t *AsyncTracker[T]) HasSynced() bool {
 // SingleFileTracker helps propagate HasSynced when events are processed in
 // order (i.e. via a queue).
 type SingleFileTracker struct {
-	UpstreamHasSynced func() bool
-
+	// Important: count is used with atomic operations so it must be 64-bit
+	// aligned, otherwise atomic operations will panic. Having it at the top of
+	// the struct will guarantee that, even on 32-bit arches.
+	// See https://pkg.go.dev/sync/atomic#pkg-note-BUG for more information.
 	count int64
+
+	UpstreamHasSynced func() bool
 }
 
 // Start should be called prior to processing each key which is part of the


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

count is used with atomic operations so it must be 64-bit aligned, otherwise atomic operations will panic. Having it at the top of the struct will guarantee that, even on 32-bit arches.

<details>
<summary>This fixes panics like that one observed in kube-apiserver:</summary>

    E0310 13:48:47.476124     676 runtime.go:77] Observed a panic: unaligned 64-bit atomic operation
    goroutine 141 [running]:
    k8s.io/apimachinery/pkg/util/runtime.logPanic({0x2482378, 0x2db2ff8})
    	vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x94
    k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x0})
    	vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
    panic({0x2482378, 0x2db2ff8})
    	/usr/local/go/src/runtime/panic.go:884 +0x218
    runtime/internal/atomic.panicUnaligned()
    	/usr/local/go/src/runtime/internal/atomic/unaligned.go:8 +0x24
    runtime/internal/atomic.Load64(0x685f794)
    	/usr/local/go/src/runtime/internal/atomic/atomic_arm.s:280 +0x14
    k8s.io/client-go/tools/cache/synctrack.(*SingleFileTracker).HasSynced(0x685f790)
    	vendor/k8s.io/client-go/tools/cache/synctrack/synctrack.go:115 +0x3c
    k8s.io/client-go/tools/cache.(*processorListener).HasSynced(0x6013e60)
    	vendor/k8s.io/client-go/tools/cache/shared_informer.go:907 +0x20
    k8s.io/client-go/tools/cache.WaitForCacheSync.func1()
    	vendor/k8s.io/client-go/tools/cache/shared_informer.go:332 +0x50
    k8s.io/apimachinery/pkg/util/wait.ConditionFunc.WithContext.func1({0x2dcf274, 0x607c600})
    	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:222 +0x1c
    k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtectionWithContext({0x2dcf274, 0x607c600}, 0x6382050)
    	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:262 +0x64
    k8s.io/apimachinery/pkg/util/wait.waitForWithContext({0x2dcf274, 0x607c600}, 0x64a6060, 0x6382050)
    	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:649 +0x11c
    k8s.io/apimachinery/pkg/util/wait.poll({0x2dcf274, 0x607c600}, 0x1, 0x64a6060, 0x6382050)
    	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:600 +0xc4
    k8s.io/apimachinery/pkg/util/wait.PollImmediateUntilWithContext({0x2dcf274, 0x607c600}, 0x5f5e100, 0x6382050)
    	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:551 +0x60
    k8s.io/apimachinery/pkg/util/wait.PollImmediateUntil(0x5f5e100, 0x6298020, 0x607c600)
    	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:542 +0x48
    k8s.io/client-go/tools/cache.WaitForCacheSync(0x607c600, {0x6298000, 0x3, 0x3})
    	vendor/k8s.io/client-go/tools/cache/shared_informer.go:329 +0x80
    k8s.io/client-go/tools/cache.WaitForNamedCacheSync({0x283c5e1, 0xf}, 0x607c600, {0x6298000, 0x3, 0x3})
    	vendor/k8s.io/client-go/tools/cache/shared_informer.go:316 +0xe8
    created by k8s.io/kubernetes/plugin/pkg/auth/authorizer/node.AddGraphEventHandlers
    	plugin/pkg/auth/authorizer/node/graph_populator.go:65 +0x5b0
    panic: unaligned 64-bit atomic operation [recovered]
    	panic: unaligned 64-bit atomic operation

    goroutine 141 [running]:
    k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x0})
    	vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xf4
    panic({0x2482378, 0x2db2ff8})
    	/usr/local/go/src/runtime/panic.go:884 +0x218
    runtime/internal/atomic.panicUnaligned()
    	/usr/local/go/src/runtime/internal/atomic/unaligned.go:8 +0x24
    runtime/internal/atomic.Load64(0x685f794)
    	/usr/local/go/src/runtime/internal/atomic/atomic_arm.s:280 +0x14
    k8s.io/client-go/tools/cache/synctrack.(*SingleFileTracker).HasSynced(0x685f790)
    	vendor/k8s.io/client-go/tools/cache/synctrack/synctrack.go:115 +0x3c
    k8s.io/client-go/tools/cache.(*processorListener).HasSynced(0x6013e60)
    	vendor/k8s.io/client-go/tools/cache/shared_informer.go:907 +0x20
    k8s.io/client-go/tools/cache.WaitForCacheSync.func1()
    	vendor/k8s.io/client-go/tools/cache/shared_informer.go:332 +0x50
    k8s.io/apimachinery/pkg/util/wait.ConditionFunc.WithContext.func1({0x2dcf274, 0x607c600})
    	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:222 +0x1c
    k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtectionWithContext({0x2dcf274, 0x607c600}, 0x6382050)
    	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:262 +0x64
    k8s.io/apimachinery/pkg/util/wait.waitForWithContext({0x2dcf274, 0x607c600}, 0x64a6060, 0x6382050)
    	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:649 +0x11c
    k8s.io/apimachinery/pkg/util/wait.poll({0x2dcf274, 0x607c600}, 0x1, 0x64a6060, 0x6382050)
    	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:600 +0xc4
    k8s.io/apimachinery/pkg/util/wait.PollImmediateUntilWithContext({0x2dcf274, 0x607c600}, 0x5f5e100, 0x6382050)
    	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:551 +0x60
    k8s.io/apimachinery/pkg/util/wait.PollImmediateUntil(0x5f5e100, 0x6298020, 0x607c600)
    	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:542 +0x48
    k8s.io/client-go/tools/cache.WaitForCacheSync(0x607c600, {0x6298000, 0x3, 0x3})
    	vendor/k8s.io/client-go/tools/cache/shared_informer.go:329 +0x80
    k8s.io/client-go/tools/cache.WaitForNamedCacheSync({0x283c5e1, 0xf}, 0x607c600, {0x6298000, 0x3, 0x3})
    	vendor/k8s.io/client-go/tools/cache/shared_informer.go:316 +0xe8
    created by k8s.io/kubernetes/plugin/pkg/auth/authorizer/node.AddGraphEventHandlers
    	plugin/pkg/auth/authorizer/node/graph_populator.go:65 +0x5b0
</details>

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

The alignment problem has been introduced in #113985.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
