### PR TITLE
kubelet: Do not mutate pods in the pod manager

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -176,11 +176,14 @@ func (kl *Kubelet) GetPods() []*v1.Pod {
 	pods := kl.podManager.GetPods()
 	// a kubelet running without apiserver requires an additional
 	// update of the static pod status. See #57106
-	for _, p := range pods {
+	for i, p := range pods {
 		if kubelettypes.IsStaticPod(p) {
 			if status, ok := kl.statusManager.GetPodStatus(p.UID); ok {
 				klog.V(2).InfoS("Pod status updated", "pod", klog.KObj(p), "status", status.Phase)
+				// do not mutate the cache
+				p = p.DeepCopy()
 				p.Status = status
+				pods[i] = p
 			}
 		}
 	}


### PR DESCRIPTION
The pod manager is a cache and modifying objects returned from the pod manager can cause race conditions in the Kubelet. In this case, it causes static pod status from the mirror pod to leak back to the config source, which means a static pod whose mirror pod is set to a terminal phase (succeeded or failed) cannot restart.


/kind bug
/sig node
/priority critical-urgent

```release-note
Setting a mirror pod's phase to Succeeded or Failed can prevent the corresponding static pod from restarting due mutation of a Kubelet cache.
```

```docs
```