### PR TITLE
CEL lib: Update authorizer with calls that do not raise errors

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cost.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cost.go
@@ -41,7 +41,7 @@ func (l *CostEstimator) CallCost(function, overloadId string, args []ref.Val, re
 		// This cost is set to allow for only two authorization checks per expression
 		cost := uint64(350000)
 		return &cost
-	case "serviceAccount", "path", "group", "resource", "subresource", "namespace", "name", "allowed", "denied", "reason":
+	case "serviceAccount", "path", "group", "resource", "subresource", "namespace", "name", "allowed", "denied", "reason", "isError":
 		// All authorization builder and accessor functions have a nominal cost
 		cost := uint64(1)
 		return &cost
@@ -91,7 +91,7 @@ func (l *CostEstimator) EstimateCallCost(function, overloadId string, target *ch
 		// An authorization check has a fixed cost
 		// This cost is set to allow for only two authorization checks per expression
 		return &checker.CallEstimate{CostEstimate: checker.CostEstimate{Min: 350000, Max: 350000}}
-	case "serviceAccount", "path", "group", "resource", "subresource", "namespace", "name", "allowed", "denied", "reason":
+	case "serviceAccount", "path", "group", "resource", "subresource", "namespace", "name", "allowed", "denied", "reason", "isError":
 		// All authorization builder and accessor functions have a nominal cost
 		return &checker.CallEstimate{CostEstimate: checker.CostEstimate{Min: 1, Max: 1}}
 	case "isSorted", "sum", "max", "min", "indexOf", "lastIndexOf":

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cost_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cost_test.go
@@ -351,6 +351,12 @@ func TestAuthzLibrary(t *testing.T) {
 			expectEstimatedCost: checker.CostEstimate{Min: 350007, Max: 350007},
 			expectRuntimeCost:   350007,
 		},
+		{
+			name:                "resource check isError",
+			expr:                "authorizer.group('apps').resource('deployments').subresource('status').namespace('test').name('backend').check('create').isError()",
+			expectEstimatedCost: checker.CostEstimate{Min: 350007, Max: 350007},
+			expectRuntimeCost:   350007,
+		},
 	}
 
 	for _, tc := range cases {

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/library_compatibility_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/library_compatibility_test.go
@@ -48,7 +48,7 @@ func TestLibraryCompatibility(t *testing.T) {
 		"isSorted", "sum", "max", "min", "indexOf", "lastIndexOf", "find", "findAll", "url", "getScheme", "getHost", "getHostname",
 		"getPort", "getEscapedPath", "getQuery", "isURL",
 		// Kubernetes <1.27>:
-		"path", "group", "serviceAccount", "resource", "subresource", "namespace", "name", "check", "allowed", "denied", "reason",
+		"path", "group", "serviceAccount", "resource", "subresource", "namespace", "name", "check", "allowed", "reason", "isError",
 		// Kubernetes <1.??>:
 	}
 	for _, fn := range knownFunctions {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

CEL authorizer library updated to not raise errors when check() is called and to offer functions that don't raise an error. This is useful since:

1. CEL cannot catch errors once raised
2. Authz errors can happen unexpectedly if, say, the authorizer is in webhook mode and the webhook request fails

Example:

```
authorizer.group('apps').resource('deployments').check('delete').allowed() // returns false if authz check returns an error
authorizer.group('apps').resource('deployments').check('delete').reason() // returns error as string
authorizer.group('apps').resource('deployments').check('delete').isError()  // check if there was an error
```

#### Which issue(s) this PR fixes:

https://github.com/kubernetes/kubernetes/pull/116261#discussion_r1132819194

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
CEL authorizer library updated to not raise errors when check() is called and include an isError() function
```

/sig api-machinery
