### PR TITLE
Graduate StatefulSetAutoDelete to beta

### DIFF
--- a/pkg/apis/apps/types.go
+++ b/pkg/apis/apps/types.go
@@ -230,7 +230,7 @@ type StatefulSetSpec struct {
 
 	// PersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from
 	// the StatefulSet VolumeClaimTemplates. This requires the
-	// StatefulSetAutoDeletePVC feature gate to be enabled, which is alpha.
+	// StatefulSetAutoDeletePVC feature gate to be enabled, which is beta and default on from 1.27.
 	// +optional
 	PersistentVolumeClaimRetentionPolicy *StatefulSetPersistentVolumeClaimRetentionPolicy
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -750,6 +750,7 @@ const (
 
 	// owner: @mattcary
 	// alpha: v1.22
+	// beta: v1.27
 	//
 	// Enables policies controlling deletion of PVCs created by a StatefulSet.
 	StatefulSetAutoDeletePVC featuregate.Feature = "StatefulSetAutoDeletePVC"
@@ -1068,7 +1069,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	StableLoadBalancerNodeSet: {Default: true, PreRelease: featuregate.Beta},
 
-	StatefulSetAutoDeletePVC: {Default: false, PreRelease: featuregate.Alpha},
+	StatefulSetAutoDeletePVC: {Default: true, PreRelease: featuregate.Beta},
 
 	StatefulSetStartOrdinal: {Default: true, PreRelease: featuregate.Beta},
 

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -1463,6 +1463,13 @@ items:
     - create
     - patch
     - update
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumeclaims
+    verbs:
+    - delete
+    - update
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -1214,7 +1214,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 		}
 	})
 
-	ginkgo.Describe("Non-retain StatefulSetPersistentVolumeClaimPolicy [Feature:StatefulSetAutoDeletePVC]", func() {
+	ginkgo.Describe("Non-retain StatefulSetPersistentVolumeClaimPolicy", func() {
 		ssName := "ss"
 		labels := map[string]string{
 			"foo": "bar",
@@ -1320,7 +1320,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			framework.ExpectNoError(err)
 		})
 
-		ginkgo.It("should delete PVCs after adopting pod (WhenScaled) [Feature:StatefulSetAutoDeletePVC]", func(ctx context.Context) {
+		ginkgo.It("should delete PVCs after adopting pod (WhenScaled)", func(ctx context.Context) {
 			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 			*(ss.Spec.Replicas) = 3


### PR DESCRIPTION

/kind feature

#### What this PR does / why we need it:

Move statefulset autodelete feature to beta.

```release-note
StatefulSetAutoDeletePVC feature gate promoted to beta.
```

- [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/1847-autoremove-statefulset-pvcs)

/sig apps

Note: we still have not resolved the default-storage-class testing issue #114955, but I've figured out how to get kind working and verified that this feature passed the mutation detector (this is what blocked graduation in 1.26).

For posterity, I did the following.

Create this file ./patches/kube-controller-manager.yaml

```
apiVersion: v1
kind: Pod
metadata:
  name: kube-controller-manager
  namespace: kube-system
spec:
  containers:
  - name: kube-controller-manager
    env:
    - name: KUBE_CACHE_MUTATION_DETECTOR
      value: "true"
```

Create the following ./kind.yaml. Kind will be run from this directory, note this is important for the container mounting of the patches directory used below.

```
apiVersion: v1
kind: Pod
metadata:
  name: kube-controller-manager
  namespace: kube-system
spec:
  containers:
  - name: kube-controller-manager
    env:
    - name: KUBE_CACHE_MUTATION_DETECTOR
      value: "true"
```

Then run the following.

```
kind create cluster --config kind.yaml 
# This will set your kubeconfig to point to the new cluster
go test -timeout=0 -v ./test/e2e -provider=skeleton -kubeconfig $HOME/.kube/config -ginkgo.v -ginkgo.focus=Feature:StatefulSetAutoDeletePVC
```

This test failed the mutation detector with 1.26.0 kubernetes, but passed with a version including #114870.