### PR TITLE
Avoid using negative words in PreFilter and PreScore tests.

### DIFF
--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
@@ -42,14 +42,15 @@ func TestNodeAffinity(t *testing.T) {
 		wantPreFilterStatus *framework.Status
 		wantPreFilterResult *framework.PreFilterResult
 		args                config.NodeAffinityArgs
-		disablePreFilter    bool
+		runPreFilter        bool
 	}{
 		{
 			name: "missing labels",
 			pod: st.MakePod().NodeSelector(map[string]string{
 				"foo": "bar",
 			}).Obj(),
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			runPreFilter: true,
 		},
 		{
 			name: "same labels",
@@ -59,6 +60,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
+			runPreFilter: true,
 		},
 		{
 			name: "node labels are superset",
@@ -69,6 +71,7 @@ func TestNodeAffinity(t *testing.T) {
 				"foo": "bar",
 				"baz": "blah",
 			},
+			runPreFilter: true,
 		},
 		{
 			name: "node labels are subset",
@@ -79,7 +82,8 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			runPreFilter: true,
 		},
 		{
 			name: "Pod with matchExpressions using In operator that matches the existing node",
@@ -107,6 +111,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
+			runPreFilter: true,
 		},
 		{
 			name: "Pod with matchExpressions using Gt operator that matches the existing node",
@@ -135,6 +140,7 @@ func TestNodeAffinity(t *testing.T) {
 				// We use two digit to denote major version and two digit for minor version.
 				"kernel-version": "0206",
 			},
+			runPreFilter: true,
 		},
 		{
 			name: "Pod with matchExpressions using NotIn operator that matches the existing node",
@@ -162,6 +168,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"mem-type": "DDR3",
 			},
+			runPreFilter: true,
 		},
 		{
 			name: "Pod with matchExpressions using Exists operator that matches the existing node",
@@ -188,6 +195,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"GPU": "NVIDIA-GRID-K1",
 			},
+			runPreFilter: true,
 		},
 		{
 			name: "Pod with affinity that don't match node's labels won't schedule onto the node",
@@ -215,7 +223,8 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			runPreFilter: true,
 		},
 		{
 			name: "Pod with empty MatchExpressions is not a valid value will match no objects and won't schedule onto the node",
@@ -237,7 +246,8 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			runPreFilter: true,
 		},
 		{
 			name: "Pod with no Affinity will schedule onto a node",
@@ -246,6 +256,7 @@ func TestNodeAffinity(t *testing.T) {
 				"foo": "bar",
 			},
 			wantPreFilterStatus: framework.NewStatus(framework.Skip),
+			runPreFilter:        true,
 		},
 		{
 			name: "Pod with Affinity but nil NodeSelector will schedule onto a node",
@@ -262,6 +273,7 @@ func TestNodeAffinity(t *testing.T) {
 				"foo": "bar",
 			},
 			wantPreFilterStatus: framework.NewStatus(framework.Skip),
+			runPreFilter:        true,
 		},
 		{
 			name: "Pod with multiple matchExpressions ANDed that matches the existing node",
@@ -292,6 +304,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"GPU": "NVIDIA-GRID-K1",
 			},
+			runPreFilter: true,
 		},
 		{
 			name: "Pod with multiple matchExpressions ANDed that doesn't match the existing node",
@@ -322,7 +335,8 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"GPU": "NVIDIA-GRID-K1",
 			},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			runPreFilter: true,
 		},
 		{
 			name: "Pod with multiple NodeSelectorTerms ORed in affinity, matches the node's labels and will schedule onto the node",
@@ -359,6 +373,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
+			runPreFilter: true,
 		},
 		{
 			name: "Pod with an Affinity and a PodSpec.NodeSelector(the old thing that we are deprecating) " +
@@ -389,6 +404,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
+			runPreFilter: true,
 		},
 		{
 			name: "Pod with an Affinity matches node's labels but the PodSpec.NodeSelector(the old thing that we are deprecating) " +
@@ -419,7 +435,8 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "barrrrrr",
 			},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			runPreFilter: true,
 		},
 		{
 			name: "Pod with an invalid value in Affinity term won't be scheduled onto the node",
@@ -447,7 +464,8 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"foo": "bar",
 			},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			runPreFilter: true,
 		},
 		{
 			name: "Pod with matchFields using In operator that matches the existing node",
@@ -474,6 +492,7 @@ func TestNodeAffinity(t *testing.T) {
 			},
 			nodeName:            "node1",
 			wantPreFilterResult: &framework.PreFilterResult{NodeNames: sets.NewString("node1")},
+			runPreFilter:        true,
 		},
 		{
 			name: "Pod with matchFields using In operator that does not match the existing node",
@@ -501,6 +520,7 @@ func TestNodeAffinity(t *testing.T) {
 			nodeName:            "node2",
 			wantStatus:          framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
 			wantPreFilterResult: &framework.PreFilterResult{NodeNames: sets.NewString("node1")},
+			runPreFilter:        true,
 		},
 		{
 			name: "Pod with two terms: matchFields does not match, but matchExpressions matches",
@@ -534,8 +554,9 @@ func TestNodeAffinity(t *testing.T) {
 					},
 				},
 			},
-			nodeName: "node2",
-			labels:   map[string]string{"foo": "bar"},
+			nodeName:     "node2",
+			labels:       map[string]string{"foo": "bar"},
+			runPreFilter: true,
 		},
 		{
 			name: "Pod with one term: matchFields does not match, but matchExpressions matches",
@@ -571,6 +592,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels:              map[string]string{"foo": "bar"},
 			wantPreFilterResult: &framework.PreFilterResult{NodeNames: sets.NewString("node1")},
 			wantStatus:          framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			runPreFilter:        true,
 		},
 		{
 			name: "Pod with one term: both matchFields and matchExpressions match",
@@ -605,6 +627,7 @@ func TestNodeAffinity(t *testing.T) {
 			nodeName:            "node1",
 			labels:              map[string]string{"foo": "bar"},
 			wantPreFilterResult: &framework.PreFilterResult{NodeNames: sets.NewString("node1")},
+			runPreFilter:        true,
 		},
 		{
 			name: "Pod with two terms: both matchFields and matchExpressions do not match",
@@ -638,9 +661,10 @@ func TestNodeAffinity(t *testing.T) {
 					},
 				},
 			},
-			nodeName:   "node2",
-			labels:     map[string]string{"foo": "bar"},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			nodeName:     "node2",
+			labels:       map[string]string{"foo": "bar"},
+			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			runPreFilter: true,
 		},
 		{
 			name: "Pod with two terms of node.Name affinity",
@@ -676,6 +700,7 @@ func TestNodeAffinity(t *testing.T) {
 			},
 			nodeName:            "node2",
 			wantPreFilterResult: &framework.PreFilterResult{NodeNames: sets.NewString("node1", "node2")},
+			runPreFilter:        true,
 		},
 		{
 			name: "Pod with two conflicting mach field requirements",
@@ -709,6 +734,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels:              map[string]string{"foo": "bar"},
 			wantPreFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, errReasonConflict),
 			wantStatus:          framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			runPreFilter:        true,
 		},
 		{
 			name: "Matches added affinity and Pod's node affinity",
@@ -748,6 +774,7 @@ func TestNodeAffinity(t *testing.T) {
 					},
 				},
 			},
+			runPreFilter: true,
 		},
 		{
 			name: "Matches added affinity but not Pod's node affinity",
@@ -787,7 +814,8 @@ func TestNodeAffinity(t *testing.T) {
 					},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonPod),
+			runPreFilter: true,
 		},
 		{
 			name:     "Doesn't match added affinity",
@@ -809,7 +837,8 @@ func TestNodeAffinity(t *testing.T) {
 					},
 				},
 			},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, errReasonEnforced),
+			wantStatus:   framework.NewStatus(framework.UnschedulableAndUnresolvable, errReasonEnforced),
+			runPreFilter: true,
 		},
 		{
 			name: "Matches node selector correctly even if PreFilter is not called",
@@ -824,7 +853,7 @@ func TestNodeAffinity(t *testing.T) {
 				"foo": "bar",
 				"baz": "blah",
 			},
-			disablePreFilter: true,
+			runPreFilter: false,
 		},
 		{
 			name: "Matches node affinity correctly even if PreFilter is not called",
@@ -855,7 +884,7 @@ func TestNodeAffinity(t *testing.T) {
 			labels: map[string]string{
 				"GPU": "NVIDIA-GRID-K1",
 			},
-			disablePreFilter: true,
+			runPreFilter: false,
 		},
 	}
 
@@ -875,7 +904,7 @@ func TestNodeAffinity(t *testing.T) {
 
 			state := framework.NewCycleState()
 			var gotStatus *framework.Status
-			if !test.disablePreFilter {
+			if test.runPreFilter {
 				gotPreFilterResult, gotStatus := p.(framework.PreFilterPlugin).PreFilter(context.Background(), state, test.pod)
 				if diff := cmp.Diff(test.wantPreFilterStatus, gotStatus); diff != "" {
 					t.Errorf("unexpected PreFilter Status (-want,+got):\n%s", diff)
@@ -968,12 +997,12 @@ func TestNodeAffinityPriority(t *testing.T) {
 	}
 
 	tests := []struct {
-		name            string
-		pod             *v1.Pod
-		nodes           []*v1.Node
-		expectedList    framework.NodeScoreList
-		args            config.NodeAffinityArgs
-		disablePreScore bool
+		name         string
+		pod          *v1.Pod
+		nodes        []*v1.Node
+		expectedList framework.NodeScoreList
+		args         config.NodeAffinityArgs
+		runPreScore  bool
 	}{
 		{
 			name: "all nodes are same priority as NodeAffinity is nil",
@@ -988,6 +1017,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "node3", Labels: label3}},
 			},
 			expectedList: []framework.NodeScore{{Name: "node1", Score: 0}, {Name: "node2", Score: 0}, {Name: "node3", Score: 0}},
+			runPreScore:  true,
 		},
 		{
 			name: "no node matches preferred scheduling requirements in NodeAffinity of pod so all nodes' priority is zero",
@@ -1002,6 +1032,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "node3", Labels: label3}},
 			},
 			expectedList: []framework.NodeScore{{Name: "node1", Score: 0}, {Name: "node2", Score: 0}, {Name: "node3", Score: 0}},
+			runPreScore:  true,
 		},
 		{
 			name: "only node1 matches the preferred scheduling requirements of pod",
@@ -1016,6 +1047,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "node3", Labels: label3}},
 			},
 			expectedList: []framework.NodeScore{{Name: "node1", Score: framework.MaxNodeScore}, {Name: "node2", Score: 0}, {Name: "node3", Score: 0}},
+			runPreScore:  true,
 		},
 		{
 			name: "all nodes matches the preferred scheduling requirements of pod but with different priorities ",
@@ -1030,6 +1062,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: label2}},
 			},
 			expectedList: []framework.NodeScore{{Name: "node1", Score: 18}, {Name: "node5", Score: framework.MaxNodeScore}, {Name: "node2", Score: 36}},
+			runPreScore:  true,
 		},
 		{
 			name: "added affinity",
@@ -1042,6 +1075,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 			args: config.NodeAffinityArgs{
 				AddedAffinity: affinity1.NodeAffinity,
 			},
+			runPreScore: true,
 		},
 		{
 			name: "added affinity and pod has default affinity",
@@ -1074,6 +1108,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 					},
 				},
 			},
+			runPreScore: true,
 		},
 		{
 			name: "calculate the priorities correctly even if PreScore is not called",
@@ -1087,8 +1122,8 @@ func TestNodeAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "node5", Labels: label5}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: label2}},
 			},
-			expectedList:    []framework.NodeScore{{Name: "node1", Score: 18}, {Name: "node5", Score: framework.MaxNodeScore}, {Name: "node2", Score: 36}},
-			disablePreScore: true,
+			expectedList: []framework.NodeScore{{Name: "node1", Score: 18}, {Name: "node5", Score: framework.MaxNodeScore}, {Name: "node2", Score: 36}},
+			runPreScore:  true,
 		},
 	}
 
@@ -1104,7 +1139,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 				t.Fatalf("Creating plugin: %v", err)
 			}
 			var status *framework.Status
-			if !test.disablePreScore {
+			if test.runPreScore {
 				status = p.(framework.PreScorePlugin).PreScore(ctx, state, test.pod, test.nodes)
 				if !status.IsSuccess() {
 					t.Errorf("unexpected error: %v", status)

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
@@ -390,7 +390,7 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 			p, _ := NewBalancedAllocation(&test.args, fh, feature.Features{})
 			state := framework.NewCycleState()
 			for i := range test.nodes {
-				if !test.runPreScore {
+				if test.runPreScore {
 					status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.pod, test.nodes)
 					if !status.IsSuccess() {
 						t.Errorf("PreScore is expected to return success, but didn't. Got status: %v", status)

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -839,7 +839,7 @@ func TestFitScore(t *testing.T) {
 
 			var gotPriorities framework.NodeScoreList
 			for _, n := range test.nodes {
-				if !test.runPreScore {
+				if test.runPreScore {
 					status := p.(framework.PreScorePlugin).PreScore(ctx, state, test.requestedPod, test.nodes)
 					if !status.IsSuccess() {
 						t.Errorf("PreScore is expected to return success, but didn't. Got status: %v", status)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Avoid using negative words in PreFilter and PreScore tests. And fix the test for PreScore in `fix_test.go` and `balanced_allocation_test.go`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes(https://github.com/kubernetes/kubernetes/pull/115655)

#### Special notes for your reviewer:

@alculquicondor 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
