### PR TITLE
update `kubectl edit` documentation

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
@@ -35,6 +35,10 @@ var (
 		The edit command allows you to directly edit any API resource you can retrieve via the
 		command-line tools. It will open the editor defined by your KUBE_EDITOR, or EDITOR
 		environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows.
+		When attempting to open the editor, it will first attempt to use the shell
+		that has been defined in the 'SHELL' environment variable. If this is not defined,
+		the default shell will be used, which is '/bin/bash' for Linux or 'cmd' for Windows.
+
 		You can edit multiple objects, although changes are applied one at a time. The command
 		accepts file names as well as command-line arguments, although the files you point to must
 		be previously saved versions of resources.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
@@ -48,9 +48,6 @@ var (
 
 		The default format is YAML. To edit in JSON, specify "-o json".
 
-		Shell defaults to /bin/bash if the SHELL environment variable is not set.
-		To override the shell location set the SHELL environment variable with the desired shell location.
-
 		The flag --windows-line-endings can be used to force Windows line endings,
 		otherwise the default for your operating system will be used.
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
@@ -44,6 +44,9 @@ var (
 
 		The default format is YAML. To edit in JSON, specify "-o json".
 
+		Shell defaults to /bin/bash if the SHELL environment variable is not set.
+		To override the shell location set the SHELL environment variable with the desired shell location.
+
 		The flag --windows-line-endings can be used to force Windows line endings,
 		otherwise the default for your operating system will be used.
 


### PR DESCRIPTION
As Mentioned in [kubernetes/kubectl/#1358](https://github.com/kubernetes/kubectl/issues/1358) kubectl defaults to /bin/bash if the SHELL environment variable isn't set. @brianpursley suggested updating the docs to mention that you can override the shell location by setting the SHELL environment variable. This PR does exactly that.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR updates the documentation to mention that you can override the shell location by setting the `SHELL` environment variable. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1358

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
