### PR TITLE
Update DRAManager to allow multiple plugins to process a single claim

### DIFF
--- a/pkg/kubelet/cm/dra/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/dra/state/state_checkpoint.go
@@ -51,9 +51,9 @@ type ClaimInfoState struct {
 	// PodUIDs is a set of pod UIDs that reference a resource
 	PodUIDs sets.Set[string]
 
-	// CdiDevices is a list of CDI devices returned by the
+	// CDIDevices is a list of CDI devices returned by the
 	// GRPC API call NodePrepareResource
-	CdiDevices []string
+	CDIDevices []string
 }
 
 type stateCheckpoint struct {

--- a/pkg/kubelet/cm/dra/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/dra/state/state_checkpoint.go
@@ -51,9 +51,9 @@ type ClaimInfoState struct {
 	// PodUIDs is a set of pod UIDs that reference a resource
 	PodUIDs sets.Set[string]
 
-	// CDIDevices is a list of CDI devices returned by the
+	// CDIDevices is a map of KubeletPluginName --> CDI devices returned by the
 	// GRPC API call NodePrepareResource
-	CDIDevices []string
+	CDIDevices map[string][]string
 }
 
 type stateCheckpoint struct {

--- a/pkg/kubelet/cm/dra/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/dra/state/state_checkpoint_test.go
@@ -50,7 +50,7 @@ func TestCheckpointGetOrCreate(t *testing.T) {
 		},
 		{
 			"Restore valid checkpoint",
-			`{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CdiDevices":["example.com/example=cdi-example"]}],"checksum":2939981547}`,
+			`{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CDIDevices":["example.com/example=cdi-example"]}],"checksum":2242470059}`,
 			"",
 			[]ClaimInfoState{{
 				DriverName: "test-driver.cdi.k8s.io",
@@ -58,13 +58,13 @@ func TestCheckpointGetOrCreate(t *testing.T) {
 				ClaimName:  "example",
 				Namespace:  "default",
 				PodUIDs:    sets.New("139cdb46-f989-4f17-9561-ca10cfb509a6"),
-				CdiDevices: []string{"example.com/example=cdi-example"},
+				CDIDevices: []string{"example.com/example=cdi-example"},
 			},
 			},
 		},
 		{
 			"Restore checkpoint with invalid checksum",
-			`{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CdiDevices":["example.com/example=cdi-example"]}],"checksum":2939981548}`,
+			`{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CDIDevices":["example.com/example=cdi-example"]}],"checksum":2242470060}`,
 			"checkpoint is corrupted",
 			[]ClaimInfoState{},
 		},
@@ -123,10 +123,10 @@ func TestCheckpointStateStore(t *testing.T) {
 		ClaimName:  "example",
 		Namespace:  "default",
 		PodUIDs:    sets.New("139cdb46-f989-4f17-9561-ca10cfb509a6"),
-		CdiDevices: []string{"example.com/example=cdi-example"},
+		CDIDevices: []string{"example.com/example=cdi-example"},
 	}
 
-	expectedCheckpoint := `{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CdiDevices":["example.com/example=cdi-example"]}],"checksum":2939981547}`
+	expectedCheckpoint := `{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CDIDevices":["example.com/example=cdi-example"]}],"checksum":2242470059}`
 
 	// create temp dir
 	testingDir, err := os.MkdirTemp("", "dramanager_state_test")

--- a/pkg/kubelet/cm/dra/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/dra/state/state_checkpoint_test.go
@@ -49,23 +49,69 @@ func TestCheckpointGetOrCreate(t *testing.T) {
 			[]ClaimInfoState{},
 		},
 		{
-			"Restore valid checkpoint",
+			"Restore checkpoint - single claim",
 			`{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CDIDevices":{"test-driver.cdi.k8s.io":["example.com/example=cdi-example"]}}],"checksum":1988120167}`,
 			"",
-			[]ClaimInfoState{{
-				DriverName: "test-driver.cdi.k8s.io",
-				ClaimUID:   "067798be-454e-4be4-9047-1aa06aea63f7",
-				ClaimName:  "example",
-				Namespace:  "default",
-				PodUIDs:    sets.New("139cdb46-f989-4f17-9561-ca10cfb509a6"),
-				CDIDevices: map[string][]string{
-					"test-driver.cdi.k8s.io": {"example.com/example=cdi-example"},
+			[]ClaimInfoState{
+				{
+					DriverName: "test-driver.cdi.k8s.io",
+					ClaimUID:   "067798be-454e-4be4-9047-1aa06aea63f7",
+					ClaimName:  "example",
+					Namespace:  "default",
+					PodUIDs:    sets.New("139cdb46-f989-4f17-9561-ca10cfb509a6"),
+					CDIDevices: map[string][]string{
+						"test-driver.cdi.k8s.io": {"example.com/example=cdi-example"},
+					},
 				},
-			},
 			},
 		},
 		{
-			"Restore checkpoint with invalid checksum",
+			"Restore checkpoint - single claim - multiple devices",
+			`{"version":"v1","entries":[{"DriverName":"meta-test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CDIDevices":{"test-driver-1.cdi.k8s.io":["example-1.com/example-1=cdi-example-1"],"test-driver-2.cdi.k8s.io":["example-2.com/example-2=cdi-example-2"]}}],"checksum":2113538068}`,
+			"",
+			[]ClaimInfoState{
+				{
+					DriverName: "meta-test-driver.cdi.k8s.io",
+					ClaimUID:   "067798be-454e-4be4-9047-1aa06aea63f7",
+					ClaimName:  "example",
+					Namespace:  "default",
+					PodUIDs:    sets.New("139cdb46-f989-4f17-9561-ca10cfb509a6"),
+					CDIDevices: map[string][]string{
+						"test-driver-1.cdi.k8s.io": {"example-1.com/example-1=cdi-example-1"},
+						"test-driver-2.cdi.k8s.io": {"example-2.com/example-2=cdi-example-2"},
+					},
+				},
+			},
+		},
+		{
+			"Restore checkpoint - multiple claims",
+			`{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example-1","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CDIDevices":{"test-driver.cdi.k8s.io":["example.com/example=cdi-example-1"]}},{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"4cf8db2d-06c0-7d70-1a51-e59b25b2c16c","ClaimName":"example-2","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CDIDevices":{"test-driver.cdi.k8s.io":["example.com/example=cdi-example-2"]}}],"checksum":666680545}`,
+			"",
+			[]ClaimInfoState{
+				{
+					DriverName: "test-driver.cdi.k8s.io",
+					ClaimUID:   "067798be-454e-4be4-9047-1aa06aea63f7",
+					ClaimName:  "example-1",
+					Namespace:  "default",
+					PodUIDs:    sets.New("139cdb46-f989-4f17-9561-ca10cfb509a6"),
+					CDIDevices: map[string][]string{
+						"test-driver.cdi.k8s.io": {"example.com/example=cdi-example-1"},
+					},
+				},
+				{
+					DriverName: "test-driver.cdi.k8s.io",
+					ClaimUID:   "4cf8db2d-06c0-7d70-1a51-e59b25b2c16c",
+					ClaimName:  "example-2",
+					Namespace:  "default",
+					PodUIDs:    sets.New("139cdb46-f989-4f17-9561-ca10cfb509a6"),
+					CDIDevices: map[string][]string{
+						"test-driver.cdi.k8s.io": {"example.com/example=cdi-example-2"},
+					},
+				},
+			},
+		},
+		{
+			"Restore checkpoint - invalid checksum",
 			`{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CDIDevices":{"test-driver.cdi.k8s.io":["example.com/example=cdi-example"]}}],"checksum":1988120168}`,
 			"checkpoint is corrupted",
 			[]ClaimInfoState{},

--- a/pkg/kubelet/cm/dra/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/dra/state/state_checkpoint_test.go
@@ -50,7 +50,7 @@ func TestCheckpointGetOrCreate(t *testing.T) {
 		},
 		{
 			"Restore valid checkpoint",
-			`{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CDIDevices":["example.com/example=cdi-example"]}],"checksum":2242470059}`,
+			`{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CDIDevices":{"test-driver.cdi.k8s.io":["example.com/example=cdi-example"]}}],"checksum":1988120167}`,
 			"",
 			[]ClaimInfoState{{
 				DriverName: "test-driver.cdi.k8s.io",
@@ -58,13 +58,15 @@ func TestCheckpointGetOrCreate(t *testing.T) {
 				ClaimName:  "example",
 				Namespace:  "default",
 				PodUIDs:    sets.New("139cdb46-f989-4f17-9561-ca10cfb509a6"),
-				CDIDevices: []string{"example.com/example=cdi-example"},
+				CDIDevices: map[string][]string{
+					"test-driver.cdi.k8s.io": {"example.com/example=cdi-example"},
+				},
 			},
 			},
 		},
 		{
 			"Restore checkpoint with invalid checksum",
-			`{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CDIDevices":["example.com/example=cdi-example"]}],"checksum":2242470060}`,
+			`{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CDIDevices":{"test-driver.cdi.k8s.io":["example.com/example=cdi-example"]}}],"checksum":1988120168}`,
 			"checkpoint is corrupted",
 			[]ClaimInfoState{},
 		},
@@ -123,10 +125,12 @@ func TestCheckpointStateStore(t *testing.T) {
 		ClaimName:  "example",
 		Namespace:  "default",
 		PodUIDs:    sets.New("139cdb46-f989-4f17-9561-ca10cfb509a6"),
-		CDIDevices: []string{"example.com/example=cdi-example"},
+		CDIDevices: map[string][]string{
+			"test-driver.cdi.k8s.io": {"example.com/example=cdi-example"},
+		},
 	}
 
-	expectedCheckpoint := `{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CDIDevices":["example.com/example=cdi-example"]}],"checksum":2242470059}`
+	expectedCheckpoint := `{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CDIDevices":{"test-driver.cdi.k8s.io":["example.com/example=cdi-example"]}}],"checksum":1988120167}`
 
 	// create temp dir
 	testingDir, err := os.MkdirTemp("", "dramanager_state_test")


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Right now, the v1alpha1 API only passes enough information for one plugin to
process a claim, but the v1alpha2 API will allow for multiple plugins to
process a claim. This PR prepares the code for this upcoming change.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```