### PR TITLE
Remove storage.k8s.io/v1beta1 API version of CSIStorageCapacity 

### DIFF
--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -706,7 +706,6 @@ var (
 	// see https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/3136-beta-apis-off-by-default
 	// for more details.
 	legacyBetaEnabledByDefaultResources = []schema.GroupVersionResource{
-		storageapiv1beta1.SchemeGroupVersion.WithResource("csistoragecapacities"),         // remove in 1.27
 		flowcontrolv1beta2.SchemeGroupVersion.WithResource("flowschemas"),                 // remove in 1.29
 		flowcontrolv1beta2.SchemeGroupVersion.WithResource("prioritylevelconfigurations"), // remove in 1.29
 		flowcontrolv1beta3.SchemeGroupVersion.WithResource("flowschemas"),                 // deprecate in 1.29, remove in 1.32

--- a/pkg/controlplane/instance_test.go
+++ b/pkg/controlplane/instance_test.go
@@ -430,7 +430,6 @@ func TestNewBetaResourcesEnabledByDefault(t *testing.T) {
 		policyapiv1beta1.SchemeGroupVersion.WithResource("poddisruptionbudgets"):          true,
 		policyapiv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies"):           true,
 		storageapiv1beta1.SchemeGroupVersion.WithResource("csinodes"):                     true,
-		storageapiv1beta1.SchemeGroupVersion.WithResource("csistoragecapacities"):         true,
 	}
 
 	// legacyBetaResourcesWithoutStableEquivalents contains those groupresources that were enabled by default as beta
@@ -438,7 +437,6 @@ func TestNewBetaResourcesEnabledByDefault(t *testing.T) {
 	// beta versions enabled by default.  Nothing new should be added here.  There are no future exceptions because there
 	// are no more beta resources enabled by default.
 	legacyBetaResourcesWithoutStableEquivalents := map[schema.GroupResource]bool{
-		storageapiv1beta1.SchemeGroupVersion.WithResource("csistoragecapacities").GroupResource():         true,
 		flowcontrolv1beta2.SchemeGroupVersion.WithResource("flowschemas").GroupResource():                 true,
 		flowcontrolv1beta2.SchemeGroupVersion.WithResource("prioritylevelconfigurations").GroupResource(): true,
 	}

--- a/pkg/controlplane/storageversionhashdata/data.go
+++ b/pkg/controlplane/storageversionhashdata/data.go
@@ -73,7 +73,6 @@ var GVRToStorageVersionHash = map[string]string{
 	"storage.k8s.io/v1/storageclasses":                                 "K+m6uJwbjGY=",
 	"storage.k8s.io/v1/csistoragecapacities":                           "xeVl+2Ly1kE=",
 	"storage.k8s.io/v1/volumeattachments":                              "tJx/ezt6UDU=",
-	"storage.k8s.io/v1beta1/csistoragecapacities":                      "xeVl+2Ly1kE=",
 	"apps/v1/controllerrevisions":                                      "85nkx63pcBU=",
 	"apps/v1/daemonsets":                                               "dd7pWHUlMKQ=",
 	"apps/v1/deployments":                                              "8aSe+NMegvE=",


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-27

> The v1.27 release will stop serving the following deprecated API versions:
> 
> CSIStorageCapacity
> The storage.k8s.io/v1beta1 API version of CSIStorageCapacity will no longer be served in v1.27.
> 
> Migrate manifests and API clients to use the storage.k8s.io/v1 API version, available since v1.24.
> All existing persisted objects are accessible via the new API
> No notable changes


#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/website/pull/32765
xref https://github.com/kubernetes/kubernetes/issues/108451 and https://github.com/kubernetes/kubernetes/pull/109394

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
storage.k8s.io/v1beta1 API version of CSIStorageCapacity will no longer be served
```

