### PR TITLE
node: podresources: graduate to GA

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1187,9 +1187,7 @@ func startKubelet(k kubelet.Bootstrap, podCfg *config.PodConfig, kubeCfg *kubele
 	if kubeCfg.ReadOnlyPort > 0 {
 		go k.ListenAndServeReadOnly(netutils.ParseIPSloppy(kubeCfg.Address), uint(kubeCfg.ReadOnlyPort))
 	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPodResources) {
-		go k.ListenAndServePodResources()
-	}
+	go k.ListenAndServePodResources()
 }
 
 func createAndInitKubelet(kubeServer *options.KubeletServer,

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -440,9 +440,10 @@ const (
 	// All the node components such as CRI need to be running in the same user namespace.
 	KubeletInUserNamespace featuregate.Feature = "KubeletInUserNamespace"
 
-	// owner: @dashpole
+	// owner: @dashpole, @ffromani (only for GA graduation)
 	// alpha: v1.13
 	// beta: v1.15
+	// GA: v1.28
 	//
 	// Enables the kubelet's pod resources grpc endpoint
 	KubeletPodResources featuregate.Feature = "KubeletPodResources"
@@ -991,7 +992,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	KubeletInUserNamespace: {Default: false, PreRelease: featuregate.Alpha},
 
-	KubeletPodResources: {Default: true, PreRelease: featuregate.Beta},
+	KubeletPodResources: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.28, remove in 1.30
 
 	KubeletPodResourcesDynamicResources: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -776,19 +776,16 @@ func Register(collectors ...metrics.StableCollector) {
 		legacyregistry.MustRegister(OrphanedRuntimePodTotal)
 		legacyregistry.MustRegister(RestartedPodTotal)
 		legacyregistry.MustRegister(ManagedEphemeralContainers)
-		if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPodResources) {
-			legacyregistry.MustRegister(PodResourcesEndpointRequestsTotalCount)
-
-			if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPodResourcesGetAllocatable) {
-				legacyregistry.MustRegister(PodResourcesEndpointRequestsListCount)
-				legacyregistry.MustRegister(PodResourcesEndpointRequestsGetAllocatableCount)
-				legacyregistry.MustRegister(PodResourcesEndpointErrorsListCount)
-				legacyregistry.MustRegister(PodResourcesEndpointErrorsGetAllocatableCount)
-			}
-			if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPodResourcesGet) {
-				legacyregistry.MustRegister(PodResourcesEndpointRequestsGetCount)
-				legacyregistry.MustRegister(PodResourcesEndpointErrorsGetCount)
-			}
+		legacyregistry.MustRegister(PodResourcesEndpointRequestsTotalCount)
+		if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPodResourcesGetAllocatable) {
+			legacyregistry.MustRegister(PodResourcesEndpointRequestsListCount)
+			legacyregistry.MustRegister(PodResourcesEndpointRequestsGetAllocatableCount)
+			legacyregistry.MustRegister(PodResourcesEndpointErrorsListCount)
+			legacyregistry.MustRegister(PodResourcesEndpointErrorsGetAllocatableCount)
+		}
+		if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPodResourcesGet) {
+			legacyregistry.MustRegister(PodResourcesEndpointRequestsGetCount)
+			legacyregistry.MustRegister(PodResourcesEndpointErrorsGetCount)
 		}
 		legacyregistry.MustRegister(StartedPodsTotal)
 		legacyregistry.MustRegister(StartedPodsErrorsTotal)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Complete the graduation of the podresources endpoint, by locking the FG to ON

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/enhancements/issues/3743

#### Special notes for your reviewer:
Depends on:
- https://github.com/kubernetes/kubernetes/pull/115133
- https://github.com/kubernetes/kubernetes/pull/116459

#### Does this PR introduce a user-facing change?
```release-note
The kubelet podresources endpoint is GA and always enabled
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
Please use the following format for linking documentation:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/606
```
