### PR TITLE
upgrade cluster-autoscaler v1.26.1 to fix ci warnings

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -19,7 +19,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.22.0",
+                "image": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.1",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.26.1
Upgrade to 1.26.1 to use v1 PDB
- https://github.com/kubernetes/autoscaler/pull/4990
- https://github.com/kubernetes/autoscaler/pull/4888

#### Which issue(s) this PR fixes:
xref https://github.com/kubernetes/kubernetes/issues/116524
When I am looking into the issue, I found there are some warnings in the cluster-autoscaler.log.

#### Special notes for your reviewer:
Warning log example: https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-autoscaling/1634972625149104128/artifacts/ca-master/cluster-autoscaler.log

> E0312 17:45:46.682775       1 reflector.go:138] k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes/listers.go:309: Failed to watch *v1beta1.PodDisruptionBudget: failed to list *v1beta1.PodDisruptionBudget: the server could not find the requested resource

#### Does this PR introduce a user-facing change?
```release-note
Updated Cluster Autosaler to version 1.26.1
```
