### PR TITLE
undeprecate kubelet --provider-id flag

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -344,6 +344,7 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 			"v":                   true,
 			"vmodule":             true,
 			"log-flush-frequency": true,
+			"provider-id":         true,
 		}
 		fs.VisitAll(func(f *pflag.Flag) {
 			if notDeprecated[f.Name] {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/110041

#### Special notes for your reviewer:
Provider ID is also different on different nodes. 
Some kube installers, use a custom kubelet configuration for all nodes and custom params with flags.
- in these cases, ProviderID is not that suitable to be in KubeletConfiguration. 

cc @BenTheElder who raise the issue
#### Does this PR introduce a user-facing change?

```release-note
kubelet: un-deprecate --provider-id flag
```

