### PR TITLE
copy pkg/proxy OWNERS to pkg/util/conntrack

### DIFF
--- a/pkg/util/conntrack/OWNERS
+++ b/pkg/util/conntrack/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-network-approvers
+reviewers:
+  - sig-network-reviewers
+labels:
+  - sig/network


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Adds a sig-network OWNERS file to `pkg/util/conntrack` so we don't need a `pkg` owner to approve changes to it

#### Special notes for your reviewer:
There has been talk about moving `pkg/util/conntrack` into `pkg/proxy` but I didn't want to argue about that here.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig network
/priority important-soon
/triage accepted
/assign @thockin 