### PR TITLE
Updating perfCounterUpdatePeriod for Windows to 10 seconds

### DIFF
--- a/pkg/kubelet/winstats/perfcounters.go
+++ b/pkg/kubelet/winstats/perfcounters.go
@@ -32,9 +32,9 @@ const (
 	cpuQuery                  = "\\Processor(_Total)\\% Processor Time"
 	memoryPrivWorkingSetQuery = "\\Process(_Total)\\Working Set - Private"
 	memoryCommittedBytesQuery = "\\Memory\\Committed Bytes"
-	// Perf counters are updated every second. This is the same as the default cadvisor collection period
-	// see https://github.com/google/cadvisor/blob/master/docs/runtime_options.md#housekeeping
-	perfCounterUpdatePeriod = 1 * time.Second
+	// Perf counters are updated 10 seconds. This is the same as the default cadvisor housekeeping interval
+	// set at https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cadvisor/cadvisor_linux.go
+	perfCounterUpdatePeriod = 10 * time.Second
 	// defaultCachePeriod is the default cache period for each cpuUsage.
 	// This matches with the cadvisor setting and the time interval we use for containers.
 	// see https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cadvisor/cadvisor_linux.go#L63


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR sets the perCounterUpdatePerioud for Windows stat collection to 10 seconds (previously it was 1 second).
This is being done to address some performance bottlenecks discussed in the linked issue

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #114928

#### Special notes for your reviewer:
This has been discussed several times during SIG-Windows meetings (most recently on 3/7/2023) [meeting notes](https://docs.google.com/document/d/1Tjxzjjuy4SQsFSUVXZbvqVb64hjNAG5CQX8bK7Yda9w)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md.
-->
```release-note
Potentially breaking change - Updating the polling interval for Windows stats collection from 1 second to 10 seconds
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig windows node
/milestone v1.27
/assign @jsturtevant @bobbypage 