### PR TITLE
API docs trivial typo

### DIFF
--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -4055,7 +4055,7 @@
         ]
       },
       "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
-        "description": "PersistentVolumeClaimCondition contails details about state of pvc",
+        "description": "PersistentVolumeClaimCondition contains details about state of pvc",
         "properties": {
           "lastProbeTime": {
             "allOf": [

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -2973,7 +2973,7 @@
         ]
       },
       "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
-        "description": "PersistentVolumeClaimCondition contails details about state of pvc",
+        "description": "PersistentVolumeClaimCondition contains details about state of pvc",
         "properties": {
           "lastProbeTime": {
             "allOf": [

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -21597,7 +21597,7 @@ func schema_k8sio_api_core_v1_PersistentVolumeClaimCondition(ref common.Referenc
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "PersistentVolumeClaimCondition contails details about state of pvc",
+				Description: "PersistentVolumeClaimCondition contains details about state of pvc",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -2723,7 +2723,7 @@ message PersistentVolumeClaim {
   optional PersistentVolumeClaimStatus status = 3;
 }
 
-// PersistentVolumeClaimCondition contails details about state of pvc
+// PersistentVolumeClaimCondition contains details about state of pvc
 message PersistentVolumeClaimCondition {
   optional string type = 1;
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -577,7 +577,7 @@ const (
 	PersistentVolumeClaimNodeExpansionFailed PersistentVolumeClaimResizeStatus = "NodeExpansionFailed"
 )
 
-// PersistentVolumeClaimCondition contails details about state of pvc
+// PersistentVolumeClaimCondition contains details about state of pvc
 type PersistentVolumeClaimCondition struct {
 	Type   PersistentVolumeClaimConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=PersistentVolumeClaimConditionType"`
 	Status ConditionStatus                    `json:"status" protobuf:"bytes,2,opt,name=status,casttype=ConditionStatus"`

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -1306,7 +1306,7 @@ func (PersistentVolumeClaim) SwaggerDoc() map[string]string {
 }
 
 var map_PersistentVolumeClaimCondition = map[string]string{
-	"":                   "PersistentVolumeClaimCondition contails details about state of pvc",
+	"":                   "PersistentVolumeClaimCondition contains details about state of pvc",
 	"lastProbeTime":      "lastProbeTime is the time we probed the condition.",
 	"lastTransitionTime": "lastTransitionTime is the time the condition transitioned from one status to another.",
 	"reason":             "reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports \"ResizeStarted\" that means the underlying persistent volume is being resized.",


### PR DESCRIPTION
Replaces #111942

This typo exists in other files, but it's not clear if/how to update those:

```
$ git grep contails
staging/src/k8s.io/cli-runtime/artifacts/openapi/swagger.json:      "description": "PersistentVolumeClaimCondition contails details about state of pvc",
staging/src/k8s.io/client-go/openapi/openapitest/testdata/api__v1_openapi.json:        "description": "PersistentVolumeClaimCondition contails details about state of pvc",
staging/src/k8s.io/client-go/openapi/openapitest/testdata/apis__apps__v1_openapi.json:        "description": "PersistentVolumeClaimCondition contails details about state of pvc",
staging/src/k8s.io/kubectl/testdata/openapi/swagger.json:      "description": "PersistentVolumeClaimCondition contails details about state of pvc",
staging/src/k8s.io/kubectl/testdata/openapi/v3/api/v1.json:        "description": "PersistentVolumeClaimCondition contails details about state of pvc",
vendor/sigs.k8s.io/kustomize/kyaml/openapi/kubernetesapi/v1212/swagger.pb:1io.k8s.api.core.v1.PersistentVolumeClaimCondition^R<D9>^E"BPersistentVolumeClaimCondition contails details about state of pvc<9A>^A^Dtype<9A>^A^Fstatus<B2>^A^H
```

/kind cleanup

```release-note
NONE
```
