### PR TITLE
kubelet: TestSyncKnownPods should not race

### DIFF
--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -1637,7 +1637,8 @@ func TestSyncKnownPods(t *testing.T) {
 	// verify workers that are not terminated stay open even if config no longer
 	// sees them
 	podWorkers.SyncKnownPods(nil)
-	if len(podWorkers.podUpdates) != 2 {
+	drainAllWorkers(podWorkers)
+	if len(podWorkers.podUpdates) != 0 {
 		t.Errorf("Incorrect number of open channels %v", len(podWorkers.podUpdates))
 	}
 	if len(podWorkers.podSyncStatuses) != 2 {


### PR DESCRIPTION
SyncKnownPods began triggering UpdatePod() for pods that have been
orphaned by desired config to ensure pods run to termination. This
test reads a mutex protected value while pod workers are running
in the background and as a consequence triggers a data race.

Wait for the workers to stabilize before reading the value. Other
tests validate that the correct sync events are triggered (see
kubelet_pods_test.go#TestKubelet_HandlePodCleanups for full
verification of this behavior).

It is slightly concerning that I was unable to recreate the race
locally even under stress testing, but I cannot identify why.


Fixes #116544

/kind flake

```release-note
NONE
```