### PR TITLE
OpenAPIResourcesGetter allows lazy-loading OpenAPI V2

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/factory.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/factory.go
@@ -62,8 +62,10 @@ type Factory interface {
 
 	// Returns a schema that can validate objects stored on disk.
 	Validator(validationDirective string) (validation.Schema, error)
-	// OpenAPISchema returns the parsed openapi schema definition
-	OpenAPISchema() (openapi.Resources, error)
+
+	// Used for retrieving openapi v2 resources.
+	openapi.OpenAPIResourcesGetter
+
 	// OpenAPIV3Schema returns a client for fetching parsed schemas for
 	// any group version
 	OpenAPIV3Client() (openapiclient.Client, error)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/factory_client_access.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/factory_client_access.go
@@ -154,13 +154,8 @@ func (f *factoryImpl) Validator(validationDirective string) (validation.Schema, 
 		return validation.NullSchema{}, nil
 	}
 
-	resources, err := f.OpenAPISchema()
-	if err != nil {
-		return nil, err
-	}
-
 	schema := validation.ConjunctiveSchema{
-		validation.NewSchemaValidation(resources),
+		validation.NewSchemaValidation(f),
 		validation.NoDoubleKeySchema{},
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/util/openapi/openapi.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/openapi/openapi.go
@@ -24,6 +24,13 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// OpenAPIResourcesGetter represents a function to return
+// OpenAPI V2 resource specifications. Used for lazy-loading
+// these resource specifications.
+type OpenAPIResourcesGetter interface {
+	OpenAPISchema() (Resources, error)
+}
+
 // Resources interface describe a resources provider, that can give you
 // resource based on group-version-kind.
 type Resources interface {

--- a/staging/src/k8s.io/kubectl/pkg/validation/validation_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/validation/validation_test.go
@@ -32,14 +32,22 @@ import (
 
 var fakeSchema = testing.Fake{Path: filepath.Join("..", "..", "testdata", "openapi", "swagger.json")}
 
+// fakeResourcesGetter implements the OpenAPIResourcesGetter interface, returning the
+// openapi resources from the swagger.json (above).
+type fakeResourcesGetter struct{}
+
+func (r *fakeResourcesGetter) OpenAPISchema() (openapi.Resources, error) {
+	doc, err := fakeSchema.OpenAPISchema()
+	if err != nil {
+		return nil, err
+	}
+	return openapi.NewOpenAPIData(doc)
+}
+
 var _ = Describe("resource validation using OpenAPI Schema", func() {
 	var validator Schema
 	BeforeEach(func() {
-		s, err := fakeSchema.OpenAPISchema()
-		Expect(err).ToNot(HaveOccurred())
-		resources, err := openapi.NewOpenAPIData(s)
-		Expect(err).ToNot(HaveOccurred())
-		validator = NewSchemaValidation(resources)
+		validator = NewSchemaValidation(&fakeResourcesGetter{})
 		Expect(validator).ToNot(BeNil())
 	})
 


### PR DESCRIPTION
* Creates `OpenAPIResourcesGetter` interface, and uses it within the `schemaValidation` struct to lazy-load the OpenAPI V2 specifications for validation (using the `Validator` from the factory).
* Depends on the lazy-load mechanism within the `OpenAPISchema()` implementation in `factory_client_access.go`.
* Can reduce memory consumption, since there are only some validation cases in which the OpenAPI V2 is needed.
* Helps effort to move from OpenAPI V2 -> V3.

/kind cleanup

```release-note
NONE
```
