### PR TITLE
fix:api version of CSIStorageCapacity

### DIFF
--- a/pkg/controlplane/instance_test.go
+++ b/pkg/controlplane/instance_test.go
@@ -36,6 +36,7 @@ import (
 	eventsv1beta1 "k8s.io/api/events/v1beta1"
 	nodev1beta1 "k8s.io/api/node/v1beta1"
 	policyapiv1beta1 "k8s.io/api/policy/v1beta1"
+	storageapiv1 "k8s.io/api/storage/v1"
 	storageapiv1beta1 "k8s.io/api/storage/v1beta1"
 	extensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -436,6 +437,7 @@ func TestNewBetaResourcesEnabledByDefault(t *testing.T) {
 		nodev1beta1.SchemeGroupVersion.WithResource("runtimeclasses"):                     true,
 		policyapiv1beta1.SchemeGroupVersion.WithResource("poddisruptionbudgets"):          true,
 		policyapiv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies"):           true,
+		storageapiv1.SchemeGroupVersion.WithResource("csinodes"):
 		storageapiv1beta1.SchemeGroupVersion.WithResource("csinodes"):                     true,
 	}
 

--- a/pkg/registry/storage/rest/storage_storage.go
+++ b/pkg/registry/storage/rest/storage_storage.go
@@ -79,7 +79,7 @@ func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorag
 	storage := map[string]rest.Storage{}
 
 	// register csistoragecapacities
-	if resource := "csistoragecapacities"; apiResourceConfigSource.ResourceEnabled(storageapiv1beta1.SchemeGroupVersion.WithResource(resource)) {
+	if resource := "csistoragecapacities"; apiResourceConfigSource.ResourceEnabled(storageapiv1.SchemeGroupVersion.WithResource(resource)) {
 		csiStorageStorage, err := csistoragecapacitystore.NewStorage(restOptionsGetter)
 		if err != nil {
 			return storage, err


### PR DESCRIPTION
storage.k8s.io/v1beta1 change to storage.k8s.io/v1
/kind cleanup
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-27
The v1.27 release will stop serving the following deprecated API versions:
CSIStorageCapacity storage.k8s.io/v1beta1 API version of CSIStorageCapacity will no longer be served in v1.27.