### PR TITLE
e2e: test for node expand volume with secrets failed

### DIFF
--- a/test/e2e/storage/csi_mock/base.go
+++ b/test/e2e/storage/csi_mock/base.go
@@ -836,8 +836,8 @@ func compareCSICalls(ctx context.Context, trackedCalls []string, expectedCallSeq
 
 		// if the secret is not nil, compare it
 		if expectedCall.expectedSecret != nil {
-			if !reflect.DeepEqual(expectedCall.expectedSecret, c.Request.Secret) {
-				return allCalls, i, fmt.Errorf("Unexpected secret: expected %v, got %v", expectedCall.expectedSecret, c.Request.Secret)
+			if !reflect.DeepEqual(expectedCall.expectedSecret, c.Request.Secrets) {
+				return allCalls, i, fmt.Errorf("Unexpected secret: expected %v, got %v", expectedCall.expectedSecret, c.Request.Secrets)
 			}
 		}
 

--- a/test/e2e/storage/csi_mock/csi_volume_expansion.go
+++ b/test/e2e/storage/csi_mock/csi_volume_expansion.go
@@ -201,7 +201,7 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 			})
 		}
 	})
-	ginkgo.Context("CSI online volume expansion with secret[Feature:CSINodeExpandSecret]", func() {
+	ginkgo.Context("CSI online volume expansion with secret", func() {
 		var stringSecret = map[string]string{
 			"username": "admin",
 			"password": "t0p-Secret",
@@ -274,12 +274,19 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 				err = e2epod.WaitForPodNameRunningInNamespace(ctx, m.cs, pod.Name, pod.Namespace)
 				framework.ExpectNoError(err, "Failed to start pod1: %v", err)
 
+				pvc, err = m.cs.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+				if err != nil {
+					framework.Failf("failed to get pvc %s, %v", pvc.Name, err)
+				}
 				pv, err := m.cs.CoreV1().PersistentVolumes().Get(ctx, pvc.Spec.VolumeName, metav1.GetOptions{})
 				if err != nil {
 					framework.Failf("failed to get pv %s, %v", pvc.Spec.VolumeName, err)
 				}
 				if pv.Spec.CSI == nil || pv.Spec.CSI.NodeExpandSecretRef == nil {
 					framework.Fail("creating pv without 'NodeExpandSecretRef'")
+				}
+				if pv.Spec.CSI.NodeExpandSecretRef.Namespace != f.Namespace.Name || pv.Spec.CSI.NodeExpandSecretRef.Name != secretName {
+					framework.Failf("failed to set node expand secret ref, namespace: %s name: %s", pv.Spec.CSI.NodeExpandSecretRef.Namespace, pv.Spec.CSI.NodeExpandSecretRef.Name)
 				}
 
 				ginkgo.By("Expanding current pvc")
@@ -298,6 +305,10 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 				err = testsuites.WaitForControllerVolumeResize(ctx, pvc, m.cs, csiResizeWaitPeriod)
 				framework.ExpectNoError(err, "While waiting for PV resize to finish")
 
+				ginkgo.By("Waiting for PVC resize to finish")
+				pvc, err = testsuites.WaitForFSResize(ctx, pvc, m.cs)
+				framework.ExpectNoError(err, "while waiting for PVC to finish")
+
 				ginkgo.By("Waiting for all remaining expected CSI calls")
 				err = wait.Poll(time.Second, csiResizeWaitPeriod, func() (done bool, err error) {
 					_, index, err := compareCSICalls(ctx, trackedCalls, test.expectedCalls, m.driver.GetCalls)
@@ -315,10 +326,6 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 					return false, nil
 				})
 				framework.ExpectNoError(err, "while waiting for all CSI calls")
-
-				ginkgo.By("Waiting for PVC resize to finish")
-				pvc, err = testsuites.WaitForFSResize(ctx, pvc, m.cs)
-				framework.ExpectNoError(err, "while waiting for PVC to finish")
 
 				pvcConditions := pvc.Status.Conditions
 				framework.ExpectEqual(len(pvcConditions), 0, "pvc should not have conditions")

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -379,7 +379,7 @@ type MockCSICall struct {
 	Method  string
 	Request struct {
 		VolumeContext map[string]string `json:"volume_context"`
-		Secret        map[string]string `json:"secret"`
+		Secrets       map[string]string `json:"secrets"`
 	}
 	FullError struct {
 		Code    codes.Code `json:"code"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test
/kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #116515 

#### Special notes for your reviewer:
Following https://github.com/kubernetes/kubernetes/issues/116515#issuecomment-1467412338.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
