### PR TITLE
Use generic Sets at scheduler apis

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -247,13 +247,13 @@ func (p *Plugins) Names() []string {
 		p.Permit,
 		p.QueueSort,
 	}
-	n := sets.NewString()
+	n := sets.New[string]()
 	for _, e := range extensions {
 		for _, pg := range e.Enabled {
 			n.Insert(pg.Name)
 		}
 	}
-	return n.List()
+	return sets.List(n)
 }
 
 // Extender holds the parameters used to communicate with the extender. If a verb is unspecified/empty,

--- a/pkg/scheduler/apis/config/v1/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1/default_plugins.go
@@ -110,7 +110,7 @@ type pluginIndex struct {
 }
 
 func mergePluginSet(logger klog.Logger, defaultPluginSet, customPluginSet v1.PluginSet) v1.PluginSet {
-	disabledPlugins := sets.NewString()
+	disabledPlugins := sets.New[string]()
 	enabledCustomPlugins := make(map[string]pluginIndex)
 	// replacedPluginIndex is a set of index of plugins, which have replaced the default plugins.
 	replacedPluginIndex := sets.NewInt()

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -57,13 +57,13 @@ func pluginsNames(p *configv1.Plugins) []string {
 		p.PreEnqueue,
 		p.QueueSort,
 	}
-	n := sets.NewString()
+	n := sets.New[string]()
 	for _, e := range extensions {
 		for _, pg := range e.Enabled {
 			n.Insert(pg.Name)
 		}
 	}
-	return n.List()
+	return sets.List(n)
 }
 
 func setDefaults_KubeSchedulerProfile(logger klog.Logger, prof *configv1.KubeSchedulerProfile) {
@@ -71,7 +71,7 @@ func setDefaults_KubeSchedulerProfile(logger klog.Logger, prof *configv1.KubeSch
 	prof.Plugins = mergePlugins(logger, getDefaultPlugins(), prof.Plugins)
 	// Set default plugin configs.
 	scheme := GetPluginArgConversionScheme()
-	existingConfigs := sets.NewString()
+	existingConfigs := sets.New[string]()
 	for j := range prof.PluginConfig {
 		existingConfigs.Insert(prof.PluginConfig[j].Name)
 		args := prof.PluginConfig[j].Args.Object

--- a/pkg/scheduler/apis/config/v1beta2/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1beta2/default_plugins.go
@@ -150,7 +150,7 @@ type pluginIndex struct {
 }
 
 func mergePluginSet(defaultPluginSet, customPluginSet v1beta2.PluginSet) v1beta2.PluginSet {
-	disabledPlugins := sets.NewString()
+	disabledPlugins := sets.New[string]()
 	enabledCustomPlugins := make(map[string]pluginIndex)
 	// replacedPluginIndex is a set of index of plugins, which have replaced the default plugins.
 	replacedPluginIndex := sets.NewInt()

--- a/pkg/scheduler/apis/config/v1beta2/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta2/defaults.go
@@ -54,13 +54,13 @@ func pluginsNames(p *v1beta2.Plugins) []string {
 		p.Permit,
 		p.QueueSort,
 	}
-	n := sets.NewString()
+	n := sets.New[string]()
 	for _, e := range extensions {
 		for _, pg := range e.Enabled {
 			n.Insert(pg.Name)
 		}
 	}
-	return n.List()
+	return sets.List(n)
 }
 
 func setDefaults_KubeSchedulerProfile(prof *v1beta2.KubeSchedulerProfile) {
@@ -69,7 +69,7 @@ func setDefaults_KubeSchedulerProfile(prof *v1beta2.KubeSchedulerProfile) {
 
 	// Set default plugin configs.
 	scheme := GetPluginArgConversionScheme()
-	existingConfigs := sets.NewString()
+	existingConfigs := sets.New[string]()
 	for j := range prof.PluginConfig {
 		existingConfigs.Insert(prof.PluginConfig[j].Name)
 		args := prof.PluginConfig[j].Args.Object

--- a/pkg/scheduler/apis/config/v1beta3/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1beta3/default_plugins.go
@@ -92,7 +92,7 @@ type pluginIndex struct {
 }
 
 func mergePluginSet(defaultPluginSet, customPluginSet v1beta3.PluginSet) v1beta3.PluginSet {
-	disabledPlugins := sets.NewString()
+	disabledPlugins := sets.New[string]()
 	enabledCustomPlugins := make(map[string]pluginIndex)
 	// replacedPluginIndex is a set of index of plugins, which have replaced the default plugins.
 	replacedPluginIndex := sets.NewInt()

--- a/pkg/scheduler/apis/config/v1beta3/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta3/defaults.go
@@ -55,13 +55,13 @@ func pluginsNames(p *v1beta3.Plugins) []string {
 		p.Permit,
 		p.QueueSort,
 	}
-	n := sets.NewString()
+	n := sets.New[string]()
 	for _, e := range extensions {
 		for _, pg := range e.Enabled {
 			n.Insert(pg.Name)
 		}
 	}
-	return n.List()
+	return sets.List(n)
 }
 
 func setDefaults_KubeSchedulerProfile(prof *v1beta3.KubeSchedulerProfile) {
@@ -69,7 +69,7 @@ func setDefaults_KubeSchedulerProfile(prof *v1beta3.KubeSchedulerProfile) {
 	prof.Plugins = mergePlugins(getDefaultPlugins(), prof.Plugins)
 	// Set default plugin configs.
 	scheme := GetPluginArgConversionScheme()
-	existingConfigs := sets.NewString()
+	existingConfigs := sets.New[string]()
 	for j := range prof.PluginConfig {
 		existingConfigs.Insert(prof.PluginConfig[j].Name)
 		args := prof.PluginConfig[j].Args.Object

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -227,7 +227,7 @@ func validatePluginConfig(path *field.Path, apiVersion string, profile *config.K
 		}
 	}
 
-	seenPluginConfig := make(sets.String)
+	seenPluginConfig := sets.New[string]()
 
 	for i := range profile.PluginConfig {
 		pluginConfigPath := path.Child("pluginConfig").Index(i)
@@ -298,7 +298,7 @@ func validateCommonQueueSort(path *field.Path, profiles []config.KubeSchedulerPr
 func validateExtenders(fldPath *field.Path, extenders []config.Extender) []error {
 	var errs []error
 	binders := 0
-	extenderManagedResources := sets.NewString()
+	extenderManagedResources := sets.New[string]()
 	for i, extender := range extenders {
 		path := fldPath.Index(i)
 		if len(extender.PrioritizeVerb) > 0 && extender.Weight <= 0 {

--- a/pkg/scheduler/apis/config/validation/validation_pluginargs.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 )
 
-var supportedScoringStrategyTypes = sets.NewString(
+var supportedScoringStrategyTypes = sets.New[string](
 	string(config.LeastAllocated),
 	string(config.MostAllocated),
 	string(config.RequestedToCapacityRatio),
@@ -148,13 +148,13 @@ func validateTopologyKey(p *field.Path, v string) field.ErrorList {
 }
 
 func validateWhenUnsatisfiable(p *field.Path, v v1.UnsatisfiableConstraintAction) *field.Error {
-	supportedScheduleActions := sets.NewString(string(v1.DoNotSchedule), string(v1.ScheduleAnyway))
+	supportedScheduleActions := sets.New[string](string(v1.DoNotSchedule), string(v1.ScheduleAnyway))
 
 	if len(v) == 0 {
 		return field.Required(p, "can not be empty")
 	}
 	if !supportedScheduleActions.Has(string(v)) {
-		return field.NotSupported(p, v, supportedScheduleActions.List())
+		return field.NotSupported(p, v, sets.List(supportedScheduleActions))
 	}
 	return nil
 }
@@ -221,7 +221,7 @@ func validateResources(resources []config.ResourceSpec, p *field.Path) field.Err
 // ValidateNodeResourcesBalancedAllocationArgs validates that NodeResourcesBalancedAllocationArgs are set correctly.
 func ValidateNodeResourcesBalancedAllocationArgs(path *field.Path, args *config.NodeResourcesBalancedAllocationArgs) error {
 	var allErrs field.ErrorList
-	seenResources := sets.NewString()
+	seenResources := sets.New[string]()
 	for i, resource := range args.Resources {
 		if seenResources.Has(resource.Name) {
 			allErrs = append(allErrs, field.Duplicate(path.Child("resources").Index(i).Child("name"), resource.Name))
@@ -313,7 +313,7 @@ func ValidateNodeResourcesFitArgs(path *field.Path, args *config.NodeResourcesFi
 	strategyPath := path.Child("scoringStrategy")
 	if args.ScoringStrategy != nil {
 		if !supportedScoringStrategyTypes.Has(string(args.ScoringStrategy.Type)) {
-			allErrs = append(allErrs, field.NotSupported(strategyPath.Child("type"), args.ScoringStrategy.Type, supportedScoringStrategyTypes.List()))
+			allErrs = append(allErrs, field.NotSupported(strategyPath.Child("type"), args.ScoringStrategy.Type, sets.List(supportedScoringStrategyTypes)))
 		}
 		allErrs = append(allErrs, validateResources(args.ScoringStrategy.Resources, strategyPath.Child("resources"))...)
 		if args.ScoringStrategy.RequestedToCapacityRatio != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Replace sets.String with sets.Set.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Scheduler still depends on sets.String. I've just changed simple one first. However, If it is ok, I will make other module onboarded together.

#### Does this PR introduce a user-facing change?
None
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
