### PR TITLE
proto: protect field access with lock to avoid possible data race [11…

### DIFF
--- a/vendor/github.com/gogo/protobuf/proto/table_unmarshal.go
+++ b/vendor/github.com/gogo/protobuf/proto/table_unmarshal.go
@@ -134,8 +134,6 @@ func getUnmarshalInfo(t reflect.Type) *unmarshalInfo {
 // b is a byte stream to unmarshal into m.
 // This is top routine used when recursively unmarshaling submessages.
 func (u *unmarshalInfo) unmarshal(m pointer, b []byte) error {
-	u.lock.RLock()
-	defer u.lock.RUnlock()
 	if atomic.LoadInt32(&u.initialized) == 0 {
 		u.computeUnmarshalInfo()
 	}
@@ -259,6 +257,8 @@ func (u *unmarshalInfo) unmarshal(m pointer, b []byte) error {
 	}
 	if reqMask != u.reqMask && errLater == nil {
 		// A required field of this message is missing.
+		u.lock.RLock()
+		defer u.lock.RUnlock()
 		for _, n := range u.reqFields {
 			if reqMask&1 == 0 {
 				errLater = &RequiredNotSetError{n}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/needs-sig
/needs-triage

#### What this PR does / why we need it:
This PR solves the data race issues in unmarshal function that's why we need it.

#### Which issue(s) this PR fixes:
[116497](https://github.com/kubernetes/kubernetes/issues/116497)

#### Special notes for your reviewer:
I have updated the lock type from `sync.Mutex` -> `sync.RWMutex`

#### Does this PR introduce a user-facing change?
None