### PR TITLE
Lock CSIMigrationvSphere feature gate for k8s 1.27

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -908,7 +908,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	CSIMigrationRBD: {Default: false, PreRelease: featuregate.Alpha}, // Off by default (requires RBD CSI driver)
 
-	CSIMigrationvSphere: {Default: true, PreRelease: featuregate.GA}, // LockToDefault when CSI driver with GA support for Windows, raw block and xfs features are available
+	CSIMigrationvSphere: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
 
 	CSINodeExpandSecret: {Default: true, PreRelease: featuregate.Beta},
 

--- a/pkg/volume/csimigration/plugin_manager_test.go
+++ b/pkg/volume/csimigration/plugin_manager_test.go
@@ -91,62 +91,6 @@ func TestIsMigratable(t *testing.T) {
 	}
 }
 
-func TestCheckMigrationFeatureFlags(t *testing.T) {
-	testCases := []struct {
-		name                    string
-		pluginFeature           featuregate.Feature
-		pluginFeatureEnabled    bool
-		pluginUnregsiterFeature featuregate.Feature
-		pluginUnregsiterEnabled bool
-		expectMigrationComplete bool
-		expectErr               bool
-	}{
-		{
-			name:                    "plugin specific migration feature enabled with plugin unregister disabled",
-			pluginFeature:           features.CSIMigrationvSphere,
-			pluginFeatureEnabled:    true,
-			pluginUnregsiterFeature: features.InTreePluginvSphereUnregister,
-			pluginUnregsiterEnabled: false,
-			expectMigrationComplete: false,
-			expectErr:               false,
-		},
-		{
-			name:                    "plugin specific migration feature and plugin unregister disabled",
-			pluginFeature:           features.CSIMigrationvSphere,
-			pluginFeatureEnabled:    false,
-			pluginUnregsiterFeature: features.InTreePluginvSphereUnregister,
-			pluginUnregsiterEnabled: false,
-			expectMigrationComplete: false,
-			expectErr:               false,
-		},
-		{
-			name:                    "all features enabled",
-			pluginFeature:           features.CSIMigrationvSphere,
-			pluginFeatureEnabled:    true,
-			pluginUnregsiterFeature: features.InTreePluginvSphereUnregister,
-			pluginUnregsiterEnabled: true,
-			expectMigrationComplete: true,
-			expectErr:               false,
-		},
-	}
-	for _, test := range testCases {
-		t.Run(fmt.Sprintf("Testing %v", test.name), func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, test.pluginFeature, test.pluginFeatureEnabled)()
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, test.pluginUnregsiterFeature, test.pluginUnregsiterEnabled)()
-			migrationComplete, err := CheckMigrationFeatureFlags(utilfeature.DefaultFeatureGate, test.pluginFeature, test.pluginUnregsiterFeature)
-			if err != nil && test.expectErr == false {
-				t.Errorf("Unexpected error: %v", err)
-			}
-			if err == nil && test.expectErr == true {
-				t.Errorf("Unexpected validation pass")
-			}
-			if migrationComplete != test.expectMigrationComplete {
-				t.Errorf("Unexpected migrationComplete result. Exp: %v, got %v", test.expectMigrationComplete, migrationComplete)
-			}
-		})
-	}
-}
-
 func TestMigrationFeatureFlagStatus(t *testing.T) {
 	testCases := []struct {
 		name                          string


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR is locking CSIMigrationvSphere feature gate for k8s 1.27.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Locks CSIMigrationvSphere feature gate.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
