### PR TITLE
Adding validation for Topology annotations

### DIFF
--- a/pkg/api/service/warnings.go
+++ b/pkg/api/service/warnings.go
@@ -31,6 +31,10 @@ func GetWarningsForService(service, oldService *api.Service) []string {
 	}
 	var warnings []string
 
+	if _, ok := service.Annotations[api.DeprecatedAnnotationTopologyAwareHints]; ok {
+		warnings = append(warnings, fmt.Sprintf("annotation %s is deprecated, please use %s instead", api.DeprecatedAnnotationTopologyAwareHints, api.AnnotationTopologyMode))
+	}
+
 	if helper.IsServiceIPSet(service) {
 		for i, clusterIP := range service.Spec.ClusterIPs {
 			warnings = append(warnings, getWarningsForIP(field.NewPath("spec").Child("clusterIPs").Index(i), clusterIP)...)

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -15961,6 +15961,14 @@ func TestValidateServiceCreate(t *testing.T) {
 			},
 			numErrs: 1,
 		},
+		{
+			name: "topology annotations are mismatched",
+			tweakSvc: func(s *core.Service) {
+				s.Annotations[core.DeprecatedAnnotationTopologyAwareHints] = "original"
+				s.Annotations[core.AnnotationTopologyMode] = "different"
+			},
+			numErrs: 1,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -18596,6 +18604,14 @@ func TestValidateServiceUpdate(t *testing.T) {
 				newSvc.Spec.InternalTrafficPolicy = &cluster
 			},
 			numErrs: 0,
+		},
+		{
+			name: "topology annotations are mismatched",
+			tweakSvc: func(oldSvc, newSvc *core.Service) {
+				newSvc.Annotations[core.DeprecatedAnnotationTopologyAwareHints] = "original"
+				newSvc.Annotations[core.AnnotationTopologyMode] = "different"
+			},
+			numErrs: 1,
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This is a follow up to https://github.com/kubernetes/kubernetes/pull/116522#discussion_r1135927526. I wasn't entirely sure if validation was what @thockin was looking for so pulling it out so it doesn't interfere with the main PR merging.

#### Does this PR introduce a user-facing change?
```release-note
- Added validation to ensure that if `service.kubernetes.io/topology-aware-hints` and `service.kubernetes.io/topology-mode` annotations are both set, they are set to the same value.
- Added deprecation warning if `service.kubernetes.io/topology-aware-hints` annotation is used.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP: https://github.com/kubernetes/enhancements/issues/2433

/sig network
/cc @aojea @bowei @danwinship @shaneutt 
/assign @thockin 