### PR TITLE
Allow overriding workqueue global metrics provider

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/metrics.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics.go
@@ -17,7 +17,6 @@ limitations under the License.
 package workqueue
 
 import (
-	"sync"
 	"time"
 
 	"k8s.io/utils/clock"
@@ -216,14 +215,10 @@ var globalMetricsFactory = queueMetricsFactory{
 
 type queueMetricsFactory struct {
 	metricsProvider MetricsProvider
-
-	onlyOnce sync.Once
 }
 
 func (f *queueMetricsFactory) setProvider(mp MetricsProvider) {
-	f.onlyOnce.Do(func() {
-		f.metricsProvider = mp
-	})
+	f.metricsProvider = mp
 }
 
 func (f *queueMetricsFactory) newQueueMetrics(name string, clock clock.Clock) queueMetrics {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig api-machinery

#### What this PR does / why we need it:

This allows users of libraries that mutate the global state (e.g., [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime/issues/2238)) to override the previously set global metrics factory for workqueues.

The other options are:
* Allowing per-queue metrics: https://github.com/kubernetes/kubernetes/pull/114242
  * Side-steps the global problem and additionally allows more context to be passed to providers 
* Fixing controller-runtime behavior: https://github.com/kubernetes-sigs/controller-runtime/pull/2240
  * This breaks the majority use-case (workqueue metrics just work without doing anything) in order to support a minority use-case (set custom provider) https://github.com/kubernetes-sigs/controller-runtime/pull/2240#discussion_r1136187137

#### Which issue(s) this PR fixes:

Relates to https://github.com/kubernetes-sigs/controller-runtime/issues/2238

As suggested by @alvaroaleman https://github.com/kubernetes/kubernetes/pull/114242#issuecomment-1336624730

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

