### PR TITLE
test/e2e: Fix flaking subresource test

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1990,7 +1990,22 @@ metadata:
 			outBuiltIn := e2ekubectl.RunKubectlOrDie("", "get", "nodes", node.Name)
 			ginkgo.By(fmt.Sprintf("calling kubectl get nodes %s --subresource=status", node.Name))
 			outStatusSubresource := e2ekubectl.RunKubectlOrDie("", "get", "nodes", node.Name, "--subresource=status")
-			gomega.Expect(outBuiltIn).To(gomega.Equal(outStatusSubresource))
+			// Avoid comparing values of fields that might end up
+			// changing between the two invocations of kubectl.
+			requiredOutput := [][]string{
+				{"NAME"},
+				{"STATUS"},
+				{"ROLES"},
+				{"AGE"},
+				{"VERSION"},
+				{node.Name},                           // check for NAME
+				{""},                                  // avoid comparing STATUS
+				{""},                                  // avoid comparing ROLES
+				{""},                                  // avoid comparing AGE
+				{node.Status.NodeInfo.KubeletVersion}, // check for VERSION
+			}
+			checkOutput(outBuiltIn, requiredOutput)
+			checkOutput(outStatusSubresource, requiredOutput)
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Avoid comparing fields that might end up changing
between two invocations of kubectl.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/116614

#### Special notes for your reviewer:

I also thought of only comparing the headers, but thought this might be better. Happy to revise the approach.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2590-kubectl-subresource
```
/cc @aojea 
/assign @soltysh 