### PR TITLE
WIP: prunev2: use metadata client

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/util/csaupgrade"
 	"k8s.io/component-base/version"
 	"k8s.io/klog/v2"
@@ -103,6 +104,7 @@ type ApplyOptions struct {
 	Validator           validation.Schema
 	Builder             *resource.Builder
 	Mapper              meta.RESTMapper
+	MetadataClient      metadata.Interface
 	DynamicClient       dynamic.Interface
 	OpenAPISchema       openapi.Resources
 
@@ -256,6 +258,11 @@ func (flags *ApplyFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, baseNa
 		return nil, err
 	}
 
+	metadataClient, err := f.MetadataClient()
+	if err != nil {
+		return nil, err
+	}
+
 	fieldManager := GetApplyFieldManagerFlag(cmd, serverSideApply)
 
 	// allow for a success message operation to be specified at print time
@@ -359,6 +366,7 @@ func (flags *ApplyFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, baseNa
 		Builder:             builder,
 		Mapper:              mapper,
 		DynamicClient:       dynamicClient,
+		MetadataClient:      metadataClient,
 		OpenAPISchema:       openAPISchema,
 
 		IOStreams: flags.IOStreams,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
@@ -526,7 +526,7 @@ func (a *ApplySet) Prune(ctx context.Context, o *ApplyOptions) error {
 		IOStreams: o.IOStreams,
 	}
 
-	if err := a.pruneAll(ctx, o.DynamicClient, o.VisitedUids, opt); err != nil {
+	if err := a.pruneAll(ctx, o.MetadataClient, o.DynamicClient, o.VisitedUids, opt); err != nil {
 		return err
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/metadata"
 	openapiclient "k8s.io/client-go/openapi"
 	"k8s.io/client-go/openapi/openapitest"
 	restclient "k8s.io/client-go/rest"
@@ -413,6 +414,7 @@ type TestFactory struct {
 	Client             RESTClient
 	ScaleGetter        scaleclient.ScalesGetter
 	UnstructuredClient RESTClient
+	FakeMetadataClient metadata.Interface
 	ClientConfigVal    *restclient.Config
 	FakeDynamicClient  *fakedynamic.FakeDynamicClient
 
@@ -599,6 +601,14 @@ func (f *TestFactory) DynamicClient() (dynamic.Interface, error) {
 		return f.FakeDynamicClient, nil
 	}
 	return f.Factory.DynamicClient()
+}
+
+// MetadataClient returns a metadata client from TestFactory
+func (f *TestFactory) MetadataClient() (metadata.Interface, error) {
+	if f.FakeMetadataClient != nil {
+		return f.FakeMetadataClient, nil
+	}
+	return f.Factory.MetadataClient()
 }
 
 // RESTClient returns a REST client from TestFactory

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/factory.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/factory.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	openapiclient "k8s.io/client-go/openapi"
+	"k8s.io/client-go/metadata"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/util/openapi"
 	"k8s.io/kubectl/pkg/validation"
@@ -43,6 +44,9 @@ type Factory interface {
 
 	// DynamicClient returns a dynamic client ready for use
 	DynamicClient() (dynamic.Interface, error)
+
+	// MetadataClient returns an object-metadata client ready for use
+	MetadataClient() (metadata.Interface, error)
 
 	// KubernetesClientSet gives you back an external clientset
 	KubernetesClientSet() (*kubernetes.Clientset, error)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/factory_client_access.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/factory_client_access.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	openapiclient "k8s.io/client-go/openapi"
 	"k8s.io/client-go/openapi/cached"
+	"k8s.io/client-go/metadata"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubectl/pkg/util/openapi"
@@ -89,6 +90,14 @@ func (f *factoryImpl) DynamicClient() (dynamic.Interface, error) {
 		return nil, err
 	}
 	return dynamic.NewForConfig(clientConfig)
+}
+
+func (f *factoryImpl) MetadataClient() (metadata.Interface, error) {
+	clientConfig, err := f.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	return metadata.NewForConfig(clientConfig)
 }
 
 // NewBuilder returns a new resource builder for structured api objects.


### PR DESCRIPTION
An optimization for prune - use the metadata client to avoid fetching data we don't care about.

- Add metadata client to kubectl
- Use the metadata client for listing objects
- Build the pruned object for printing

WIP because the test harness would require mocking of this client also...