### PR TITLE
unittests: Fixes unit tests for Windows (part 8)

### DIFF
--- a/pkg/volume/flexvolume/probe.go
+++ b/pkg/volume/flexvolume/probe.go
@@ -228,6 +228,10 @@ func (prober *flexVolumeProber) updateEventsMap(eventDirAbs string, op volume.Pr
 // Each file or directory change triggers two events: one from the watch on itself, another from the watch
 // on its parent directory.
 func (prober *flexVolumeProber) addWatchRecursive(filename string) error {
+	// this may be called with an actual absolute path on Windows (with a C:\ prefix).
+	// But the prober.fs.Walk below will execute filepath.Join(fs.root, filenameAbove), which
+	// will result in an incorrect path, you can't join C:\path and C:\another\path.
+	filename = strings.TrimPrefix(filename, `C:\`)
 	addWatch := func(path string, info os.FileInfo, err error) error {
 		if err == nil && info.IsDir() {
 			if err := prober.watcher.AddWatch(path); err != nil {

--- a/pkg/volume/flexvolume/probe_test.go
+++ b/pkg/volume/flexvolume/probe_test.go
@@ -72,11 +72,6 @@ func TestProberExistingDriverBeforeInit(t *testing.T) {
 
 // Probes newly added drivers after prober is running.
 func TestProberAddRemoveDriver(t *testing.T) {
-	// Skip tests that fail on Windows, as discussed during the SIG Testing meeting from January 10, 2023
-	if goruntime.GOOS == "windows" {
-		t.Skip("Skipping test that fails on Windows")
-	}
-
 	// Arrange
 	_, fs, watcher, prober := initTestEnvironment(t)
 	prober.Probe()
@@ -210,11 +205,6 @@ func TestEmptyPluginDir(t *testing.T) {
 
 // Issue an event to remove plugindir. New directory should still be watched.
 func TestRemovePluginDir(t *testing.T) {
-	// Skip tests that fail on Windows, as discussed during the SIG Testing meeting from January 10, 2023
-	if goruntime.GOOS == "windows" {
-		t.Skip("Skipping test that fails on Windows")
-	}
-
 	// Arrange
 	driverPath, fs, watcher, _ := initTestEnvironment(t)
 	err := fs.RemoveAll(pluginDir)
@@ -236,11 +226,6 @@ func TestRemovePluginDir(t *testing.T) {
 
 // Issue an event to remove plugindir. New directory should still be watched.
 func TestNestedDriverDir(t *testing.T) {
-	// Skip tests that fail on Windows, as discussed during the SIG Testing meeting from January 10, 2023
-	if goruntime.GOOS == "windows" {
-		t.Skip("Skipping test that fails on Windows")
-	}
-
 	// Arrange
 	_, fs, watcher, _ := initTestEnvironment(t)
 	// Assert


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/sig testing
/sig windows

/kind failing-tests
/priority important-soon

#### What this PR does / why we need it:

Currently, there are some unit tests that are failing on Windows due to various reasons:

- flexvolume coverts its paths to absolute paths, which means that on Windows the ``C:\`` prefix will be added. This becomes an issue when ``prober.fs.Walk`` is called, which will join 2 absolute paths, both containing the ``C:\`` prefix, resulting in an incorrect path.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related: https://github.com/kubernetes/kubernetes/issues/51540

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
