### PR TITLE
Honor impersonation flags in in-cluster configuration

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -561,7 +561,7 @@ func (config *inClusterClientConfig) ClientConfig() (*restclient.Config, error) 
 		return nil, err
 	}
 
-	// in-cluster configs only takes a host, token, or CA file
+	// in-cluster configs only takes a host, token, CA file, or impersonation configurations
 	// if any of them were individually provided, overwrite anything else
 	if config.overrides != nil {
 		if server := config.overrides.ClusterInfo.Server; len(server) > 0 {
@@ -573,6 +573,14 @@ func (config *inClusterClientConfig) ClientConfig() (*restclient.Config, error) 
 		}
 		if certificateAuthorityFile := config.overrides.ClusterInfo.CertificateAuthority; len(certificateAuthorityFile) > 0 {
 			icc.TLSClientConfig.CAFile = certificateAuthorityFile
+		}
+		if len(config.overrides.AuthInfo.Impersonate) > 0 {
+			icc.Impersonate = restclient.ImpersonationConfig{
+				UserName: config.overrides.AuthInfo.Impersonate,
+				UID:      config.overrides.AuthInfo.ImpersonateUID,
+				Groups:   config.overrides.AuthInfo.ImpersonateGroups,
+				Extra:    config.overrides.AuthInfo.ImpersonateUserExtra,
+			}
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When running kubectl commands inside pod, in-cluster config is used(unless user specifies something different).
However impersonation, via `--as`(and also other flags such as `--as-uid`, etc.), does not work when in-cluster config is selected.

The reason of this problem is because in-cluster config does not honor impersonation flags. This PR adds that.

#### Which issue(s) this PR fixes:
Fixes #

#### Does this PR introduce a user-facing change?
```release-note
impersonation will work inside containers via --as, --as-uid, --as-group flags when in-cluster config takes place
```