### PR TITLE
print node status when failed for kubemark start

### DIFF
--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -183,7 +183,7 @@ function wait-for-hollow-nodes-to-run-or-timeout {
     # Fail it if it already took more than 30 minutes.
     if [ $((now - start)) -gt 1800 ]; then
       echo ""
-      "${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG}" get node -o yaml
+      "${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG}" describe node
       # shellcheck disable=SC2154 # Color defined in sourced script
       echo -e "${color_red} Timeout waiting for all hollow-nodes to become Running. ${color_norm}"
       # Try listing nodes again - if it fails it means that API server is not responding

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -183,6 +183,7 @@ function wait-for-hollow-nodes-to-run-or-timeout {
     # Fail it if it already took more than 30 minutes.
     if [ $((now - start)) -gt 1800 ]; then
       echo ""
+      "${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG}" get node -o yaml
       # shellcheck disable=SC2154 # Color defined in sourced script
       echo -e "${color_red} Timeout waiting for all hollow-nodes to become Running. ${color_norm}"
       # Try listing nodes again - if it fails it means that API server is not responding


### PR DESCRIPTION
xref #116646

This may help in the next failure of the kubemark related CI.

```release-note
None
```

I wondered if `kubectl describe node` would be better. `describe node` will show all events of nodes