### PR TITLE
Revert "fix test to look for FIELD: not RESOURCE: when a field was lo…

### DIFF
--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -129,7 +129,7 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 		if err := verifyKubectlExplain(f.Namespace.Name, crd.Crd.Spec.Names.Plural+".spec", `(?s)DESCRIPTION:.*Specification of Foo.*FIELDS:.*bars.*<\[\]Object>.*List of Bars and their specs`); err != nil {
 			framework.Failf("%v", err)
 		}
-		if err := verifyKubectlExplain(f.Namespace.Name, crd.Crd.Spec.Names.Plural+".spec.bars", `(?s)FIELD:.*bars.*<\[\]Object>.*DESCRIPTION:.*List of Bars and their specs.*FIELDS:.*bazs.*<\[\]string>.*List of Bazs.*name.*<string>.*Name of Bar`); err != nil {
+		if err := verifyKubectlExplain(f.Namespace.Name, crd.Crd.Spec.Names.Plural+".spec.bars", `(?s)RESOURCE:.*bars.*<\[\]Object>.*DESCRIPTION:.*List of Bars and their specs.*FIELDS:.*bazs.*<\[\]string>.*List of Bazs.*name.*<string>.*Name of Bar`); err != nil {
 			framework.Failf("%v", err)
 		}
 


### PR DESCRIPTION
…oked up"

This reverts commit 4fb63851404ff1a19f17e94493909125d6602cd4.

The #116390 changed the test case in its commit. 

Fixes https://github.com/kubernetes/kubernetes/issues/116650


#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:


#### Special notes for your reviewer:
https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-latest

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

