### PR TITLE
Add 12 get * V1APIResources to file pending_eligible_endpoints.yaml

### DIFF
--- a/test/conformance/testdata/pending_eligible_endpoints.yaml
+++ b/test/conformance/testdata/pending_eligible_endpoints.yaml
@@ -63,3 +63,15 @@
 - replaceStorageV1StorageClass
 - replaceStorageV1VolumeAttachment
 - replaceStorageV1VolumeAttachmentStatus
+- getAutoscalingV2APIResources
+- getPolicyV1APIResources
+- getEventsV1APIResources
+- getCoordinationV1APIResources
+- getSchedulingV1APIResources
+- getApiregistrationV1APIResources
+- getAppsV1APIResources
+- getAuthenticationV1APIResources
+- getAuthorizationV1APIResources
+- getAutoscalingV1APIResources
+- getBatchV1APIResources
+- getCoreV1APIResources


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a following untested endpoints to the pending_eligible_endpoints.yaml
The introduction of [Add OpenAPI V3 E2E Tests #116200](https://github.com/kubernetes/kubernetes/pull/116200) caused the `get * V1APIResources` endpoint to show up as untested.

- getAutoscalingV2APIResources
- getPolicyV1APIResources
- getEventsV1APIResources
- getCoordinationV1APIResources
- getSchedulingV1APIResources
- getApiregistrationV1APIResources
- getAppsV1APIResources
- getAuthenticationV1APIResources
- getAuthorizationV1APIResources
- getAutoscalingV1APIResources
- getBatchV1APIResources
- getCoreV1APIResources


**Special notes for your reviewer:**
Test freeze 1.27 is 6 day away. There is not sufficient time to get a test submitted in the 1.27 release
Some of these endpoints [might aready have e2e tests that could be promoted](https://kubernetes.slack.com/archives/C78F00H99/p1678833101143089?thread_ts=1678819644.493499&cid=C78F00H99) in release 1.28

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance
