### PR TITLE
intstr: add constructor from int32, deprecate int constructor

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
@@ -54,12 +54,17 @@ const (
 // FromInt creates an IntOrString object with an int32 value. It is
 // your responsibility not to call this method with a value greater
 // than int32.
-// TODO: convert to (val int32)
+// Deprecated: use FromInt32 instead.
 func FromInt(val int) IntOrString {
 	if val > math.MaxInt32 || val < math.MinInt32 {
 		klog.Errorf("value: %d overflows int32\n%s\n", val, debug.Stack())
 	}
 	return IntOrString{Type: Int, IntVal: int32(val)}
+}
+
+// FromInt32 creates an IntOrString object with an int32 value.
+func FromInt32(val int32) IntOrString {
+	return IntOrString{Type: Int, IntVal: val}
 }
 
 // FromString creates an IntOrString object with a string value.

--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr_test.go
@@ -31,6 +31,13 @@ func TestFromInt(t *testing.T) {
 	}
 }
 
+func TestFromInt32(t *testing.T) {
+	i := FromInt32(93)
+	if i.Type != Int || i.IntVal != 93 {
+		t.Errorf("Expected IntVal=93, got %+v", i)
+	}
+}
+
 func TestFromString(t *testing.T) {
 	i := FromString("76")
 	if i.Type != String || i.StrVal != "76" {
@@ -47,7 +54,7 @@ func TestIntOrStringUnmarshalJSON(t *testing.T) {
 		input  string
 		result IntOrString
 	}{
-		{"{\"val\": 123}", FromInt(123)},
+		{"{\"val\": 123}", FromInt32(123)},
 		{"{\"val\": \"123\"}", FromString("123")},
 	}
 
@@ -67,7 +74,7 @@ func TestIntOrStringMarshalJSON(t *testing.T) {
 		input  IntOrString
 		result string
 	}{
-		{FromInt(123), "{\"val\":123}"},
+		{FromInt32(123), "{\"val\":123}"},
 		{FromString("123"), "{\"val\":\"123\"}"},
 	}
 
@@ -87,7 +94,7 @@ func TestIntOrStringMarshalJSONUnmarshalYAML(t *testing.T) {
 	cases := []struct {
 		input IntOrString
 	}{
-		{FromInt(123)},
+		{FromInt32(123)},
 		{FromString("123")},
 	}
 
@@ -118,7 +125,7 @@ func TestGetIntFromIntOrString(t *testing.T) {
 		expectPerc bool
 	}{
 		{
-			input:      FromInt(200),
+			input:      FromInt32(200),
 			expectErr:  false,
 			expectVal:  200,
 			expectPerc: false,
@@ -191,7 +198,7 @@ func TestGetIntFromIntOrPercent(t *testing.T) {
 		expectVal int
 	}{
 		{
-			input:     FromInt(123),
+			input:     FromInt32(123),
 			expectErr: false,
 			expectVal: 123,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

`intstr` wraps an `int32` but exposes an `int`-based API. This PR adds a `FromInt32` constructor, deprecates the `FromInt` one, migrates simple uses to the new constructor.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
