### PR TITLE
Automated cherry pick of #115966: make MixedProtocolNotSupported public

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -6624,6 +6624,14 @@ const (
 	PortForwardRequestIDHeader = "requestID"
 )
 
+// These are the built-in errors for PortStatus.
+const (
+	// MixedProtocolNotSupported error in PortStatus means that the cloud provider
+	// can't ensure the port on the load balancer because mixed values of protocols
+	// on the same LoadBalancer type of Service are not supported by the cloud provider.
+	MixedProtocolNotSupported = "MixedProtocolNotSupported"
+)
+
 // PortStatus represents the error condition of a service port
 
 type PortStatus struct {

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4266,6 +4266,9 @@ const (
 	// LoadBalancerPortsError represents the condition of the requested ports
 	// on the cloud load balancer instance.
 	LoadBalancerPortsError = "LoadBalancerPortsError"
+	// LoadBalancerPortsErrorReason reason in ServiceStatus condition LoadBalancerPortsError
+	// means the LoadBalancer was not able to be configured correctly.
+	LoadBalancerPortsErrorReason = "LoadBalancerMixedProtocolNotSupported"
 )
 
 // ServiceStatus represents the current status of a service.
@@ -6624,10 +6627,9 @@ const (
 	PortForwardRequestIDHeader = "requestID"
 )
 
-// These are the built-in errors for PortStatus.
 const (
 	// MixedProtocolNotSupported error in PortStatus means that the cloud provider
-	// can't ensure the port on the load balancer because mixed values of protocols
+	// can't publish the port on the load balancer because mixed values of protocols
 	// on the same LoadBalancer type of Service are not supported by the cloud provider.
 	MixedProtocolNotSupported = "MixedProtocolNotSupported"
 )

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_test.go
@@ -21,10 +21,12 @@ package gce
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -191,5 +193,258 @@ func TestProjectsBasePath(t *testing.T) {
 	require.NoError(t, err)
 	if gce.projectsBasePath != expectProjectsBasePath && gce.projectsBasePath != expectMtlsProjectsBasePath {
 		t.Errorf("Compute projectsBasePath has changed. Got %q, want %q or %q", gce.projectsBasePath, expectProjectsBasePath, expectMtlsProjectsBasePath)
+	}
+}
+
+func TestEnsureLoadBalancerMixedProtocols(t *testing.T) {
+	t.Parallel()
+
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+
+	nodeNames := []string{"test-node-1"}
+	nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+	require.NoError(t, err)
+
+	apiService := fakeLoadbalancerService("")
+	apiService.Spec.Ports = append(apiService.Spec.Ports, v1.ServicePort{
+		Protocol: v1.ProtocolUDP,
+		Port:     int32(8080),
+	})
+	apiService, err = gce.client.CoreV1().Services(apiService.Namespace).Create(context.TODO(), apiService, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = gce.EnsureLoadBalancer(context.Background(), vals.ClusterName, apiService, nodes)
+	if err == nil {
+		t.Errorf("Expected error ensuring loadbalancer for Service with multiple ports")
+	}
+	if err.Error() != "mixed protocol is not supported for LoadBalancer" {
+		t.Fatalf("unexpected error, got: %s wanted \"mixed protocol is not supported for LoadBalancer\"", err.Error())
+	}
+	apiService, err = gce.client.CoreV1().Services(apiService.Namespace).Get(context.TODO(), apiService.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !hasLoadBalancerPortsError(apiService) {
+		t.Fatalf("Expected condition %v to be True, got %v", v1.LoadBalancerPortsError, apiService.Status.Conditions)
+	}
+}
+
+func TestUpdateLoadBalancerMixedProtocols(t *testing.T) {
+	t.Parallel()
+
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+
+	nodeNames := []string{"test-node-1"}
+	nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+	require.NoError(t, err)
+
+	apiService := fakeLoadbalancerService("")
+	apiService.Spec.Ports = append(apiService.Spec.Ports, v1.ServicePort{
+		Protocol: v1.ProtocolUDP,
+		Port:     int32(8080),
+	})
+	apiService, err = gce.client.CoreV1().Services(apiService.Namespace).Create(context.TODO(), apiService, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// create an external loadbalancer to simulate an upgrade scenario where the loadbalancer exists
+	// before the new controller is running and later the Service is updated
+	_, err = createExternalLoadBalancer(gce, apiService, nodeNames, vals.ClusterName, vals.ClusterID, vals.ZoneName)
+	assert.NoError(t, err)
+
+	err = gce.UpdateLoadBalancer(context.Background(), vals.ClusterName, apiService, nodes)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	apiService, err = gce.client.CoreV1().Services(apiService.Namespace).Get(context.TODO(), apiService.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !hasLoadBalancerPortsError(apiService) {
+		t.Fatalf("Expected condition %v to be True, got %v", v1.LoadBalancerPortsError, apiService.Status.Conditions)
+	}
+}
+
+func TestCheckMixedProtocol(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		ports       []v1.ServicePort
+		wantErr     error
+	}{
+		{
+			name:        "TCP",
+			annotations: make(map[string]string),
+			ports: []v1.ServicePort{
+				{
+					Protocol: v1.ProtocolTCP,
+					Port:     int32(8080),
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "UDP",
+			annotations: map[string]string{ServiceAnnotationLoadBalancerType: "nlb"},
+			ports: []v1.ServicePort{
+				{
+					Protocol: v1.ProtocolUDP,
+					Port:     int32(8080),
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "TCP",
+			annotations: make(map[string]string),
+			ports: []v1.ServicePort{
+				{
+					Name:     "port80",
+					Protocol: v1.ProtocolTCP,
+					Port:     int32(80),
+				},
+				{
+					Name:     "port8080",
+					Protocol: v1.ProtocolTCP,
+					Port:     int32(8080),
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "UDP",
+			annotations: map[string]string{ServiceAnnotationLoadBalancerType: "nlb"},
+			ports: []v1.ServicePort{
+				{
+					Name:     "port80",
+					Protocol: v1.ProtocolUDP,
+					Port:     int32(80),
+				},
+				{
+					Name:     "port8080",
+					Protocol: v1.ProtocolUDP,
+					Port:     int32(8080),
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "TCP and UDP",
+			annotations: map[string]string{ServiceAnnotationLoadBalancerType: "nlb"},
+			ports: []v1.ServicePort{
+				{
+					Protocol: v1.ProtocolUDP,
+					Port:     int32(53),
+				},
+				{
+					Protocol: v1.ProtocolTCP,
+					Port:     int32(53),
+				},
+			},
+			wantErr: fmt.Errorf("mixed protocol is not supported for LoadBalancer"),
+		},
+	}
+	for _, test := range tests {
+		tt := test
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := checkMixedProtocol(tt.ports)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.Equal(t, err, nil)
+			}
+		})
+	}
+}
+
+func Test_hasLoadBalancerPortsError(t *testing.T) {
+	tests := []struct {
+		name    string
+		service *v1.Service
+		want    bool
+	}{
+		{
+			name:    "no status",
+			service: &v1.Service{},
+		},
+		{
+			name: "condition set to true",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "service1"},
+				Spec: v1.ServiceSpec{
+					ClusterIPs: []string{"1.2.3.4"},
+					Type:       "LoadBalancer",
+					Ports:      []v1.ServicePort{{Port: 80, Protocol: "TCP"}},
+				},
+				Status: v1.ServiceStatus{
+					LoadBalancer: v1.LoadBalancerStatus{
+						Ingress: []v1.LoadBalancerIngress{{IP: "2.3.4.5"}, {IP: "3.4.5.6"}}},
+					Conditions: []metav1.Condition{
+						{
+							Type:   v1.LoadBalancerPortsError,
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "condition set false",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "service1"},
+				Spec: v1.ServiceSpec{
+					ClusterIPs: []string{"1.2.3.4"},
+					Type:       "LoadBalancer",
+					Ports:      []v1.ServicePort{{Port: 80, Protocol: "TCP"}},
+				},
+				Status: v1.ServiceStatus{
+					LoadBalancer: v1.LoadBalancerStatus{
+						Ingress: []v1.LoadBalancerIngress{{IP: "2.3.4.5"}, {IP: "3.4.5.6"}}},
+					Conditions: []metav1.Condition{
+						{
+							Type:   v1.LoadBalancerPortsError,
+							Status: metav1.ConditionFalse,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple conditions unrelated",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "service1"},
+				Spec: v1.ServiceSpec{
+					ClusterIPs: []string{"1.2.3.4"},
+					Type:       "LoadBalancer",
+					Ports:      []v1.ServicePort{{Port: 80, Protocol: "TCP"}},
+				},
+				Status: v1.ServiceStatus{
+					LoadBalancer: v1.LoadBalancerStatus{
+						Ingress: []v1.LoadBalancerIngress{{IP: "2.3.4.5"}, {IP: "3.4.5.6"}}},
+					Conditions: []metav1.Condition{
+						{
+							Type:   "condition1",
+							Status: metav1.ConditionFalse,
+						},
+						{
+							Type:   "condition2",
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasLoadBalancerPortsError(tt.service); got != tt.want {
+				t.Errorf("hasLoadBalancerPortsError() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_util.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_util.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
 	servicehelper "k8s.io/cloud-provider/service/helpers"
 	netutils "k8s.io/utils/net"
 )
@@ -57,6 +58,7 @@ func fakeGCECloud(vals TestClusterValues) (*Cloud, error) {
 	gce.AlphaFeatureGate = NewAlphaFeatureGate([]string{})
 	gce.nodeInformerSynced = func() bool { return true }
 	gce.client = fake.NewSimpleClientset()
+	gce.eventRecorder = &record.FakeRecorder{}
 
 	mockGCE := gce.c.(*cloud.MockGCE)
 	mockGCE.MockTargetPools.AddInstanceHook = mock.AddInstanceHook


### PR DESCRIPTION
Cherry pick of #115966 on release-1.25.

#115966:  don't process unsupported loadbalancers with mixed protocols #115966


For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

/kind bug

```release-note
NONE
```