### PR TITLE
feat:add-objectTrackerOption-fix-channelFull-panic

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/clientset_generated.go
@@ -59,6 +59,33 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientsetWithObjectTrackerOption returns a clientset that will respond with the provided objects.
+// its function is consistent with NewSimpleClientset, the difference is that NewSimpleClientsetWithObjectTrackerOption
+// will customize clientSet.ObjectTracker, the current optional is custom watcher
+func NewSimpleClientsetWithObjectTrackerOption(objectTrackerOption testing.ObjectTrackerOptions, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder(), objectTrackerOption)
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &Clientset{tracker: o}
+	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.

--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
@@ -37,6 +37,20 @@ type Interface interface {
 	ResultChan() <-chan Event
 }
 
+// Watcher lets you test anything that consumes a watch.Interface; threadsafe.
+type Watcher interface {
+	Interface
+
+	// Modify sends a modify event.
+	Modify(obj runtime.Object)
+
+	// Add sends an add event.
+	Add(obj runtime.Object)
+
+	// Delete sends a delete event.
+	Delete(lastValue runtime.Object)
+}
+
 // EventType defines the possible types of events.
 type EventType string
 

--- a/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
@@ -155,6 +155,33 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientsetWithObjectTrackerOption returns a clientset that will respond with the provided objects.
+// its function is consistent with NewSimpleClientset, the difference is that NewSimpleClientsetWithObjectTrackerOption
+// will customize clientSet.ObjectTracker, the current optional is custom watcher
+func NewSimpleClientsetWithObjectTrackerOption(objectTrackerOption testing.ObjectTrackerOptions, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder(), objectTrackerOption)
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &Clientset{tracker: o}
+	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.

--- a/staging/src/k8s.io/client-go/testing/fixture_test.go
+++ b/staging/src/k8s.io/client-go/testing/fixture_test.go
@@ -408,3 +408,54 @@ func Test_resourceCovers(t *testing.T) {
 		})
 	}
 }
+
+func Test_WithFakeWatchers(t *testing.T) {
+	testResource := schema.GroupVersionResource{Group: "", Version: "test_version", Resource: "test_kind"}
+	testObj := getArbitraryResource(testResource, "test_name", "test_namespace")
+	accessor, err := meta.Accessor(testObj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ns := accessor.GetNamespace()
+	scheme := runtime.NewScheme()
+	codecs := serializer.NewCodecFactory(scheme)
+	o := NewObjectTracker(scheme, codecs.UniversalDecoder(), WithFakeWatchers(watch.NewFakeWithChanSize(1000, false)))
+	w, err := o.Watch(testResource, "test_namespace")
+	if err != nil {
+		t.Fatalf("test resource watch failed in test_namespace: %v", err)
+	}
+	wAll, err := o.Watch(testResource, "")
+	if err != nil {
+		t.Fatalf("test resource watch failed in all namespaces: %v", err)
+	}
+	go func() {
+		err := o.Create(testResource, testObj, ns)
+		assert.NoError(t, err, "test resource creation failed")
+	}()
+	out := <-w.ResultChan()
+	outAll := <-wAll.ResultChan()
+	assert.Equal(t, watch.Added, out.Type, "watch event mismatch")
+	assert.Equal(t, watch.Added, outAll.Type, "watch event mismatch")
+	assert.Equal(t, testObj, out.Object, "watched created object mismatch")
+	assert.Equal(t, testObj, outAll.Object, "watched created object mismatch")
+	go func() {
+		err := o.Update(testResource, testObj, ns)
+		assert.NoError(t, err, "test resource updating failed")
+	}()
+	out = <-w.ResultChan()
+	outAll = <-wAll.ResultChan()
+	assert.Equal(t, watch.Modified, out.Type, "watch event mismatch")
+	assert.Equal(t, watch.Modified, outAll.Type, "watch event mismatch")
+	assert.Equal(t, testObj, out.Object, "watched updated object mismatch")
+	assert.Equal(t, testObj, outAll.Object, "watched updated object mismatch")
+	go func() {
+		err := o.Delete(testResource, "test_namespace", "test_name")
+		assert.NoError(t, err, "test resource deletion failed")
+	}()
+	out = <-w.ResultChan()
+	outAll = <-wAll.ResultChan()
+	assert.Equal(t, watch.Deleted, out.Type, "watch event mismatch")
+	assert.Equal(t, watch.Deleted, outAll.Type, "watch event mismatch")
+	assert.Equal(t, testObj, out.Object, "watched deleted object mismatch")
+	assert.Equal(t, testObj, outAll.Object, "watched deleted object mismatch")
+}

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
@@ -22,10 +22,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
+
+	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 )
 
 // genClientset generates a package for a clientset.
@@ -115,6 +116,33 @@ var common = `
 // for a real clientset and is mostly useful in simple unit tests.
 func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &Clientset{tracker: o}
+	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
+// NewSimpleClientsetWithObjectTrackerOption returns a clientset that will respond with the provided objects.
+// its function is consistent with NewSimpleClientset, the difference is that NewSimpleClientsetWithObjectTrackerOption
+// will customize clientSet.ObjectTracker, the current optional is custom watcher
+func NewSimpleClientsetWithObjectTrackerOption(objectTrackerOption testing.ObjectTrackerOptions, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder(), objectTrackerOption)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/fake/clientset_generated.go
@@ -61,6 +61,33 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientsetWithObjectTrackerOption returns a clientset that will respond with the provided objects.
+// its function is consistent with NewSimpleClientset, the difference is that NewSimpleClientsetWithObjectTrackerOption
+// will customize clientSet.ObjectTracker, the current optional is custom watcher
+func NewSimpleClientsetWithObjectTrackerOption(objectTrackerOption testing.ObjectTrackerOptions, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder(), objectTrackerOption)
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &Clientset{tracker: o}
+	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/fake/clientset_generated.go
@@ -59,6 +59,33 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientsetWithObjectTrackerOption returns a clientset that will respond with the provided objects.
+// its function is consistent with NewSimpleClientset, the difference is that NewSimpleClientsetWithObjectTrackerOption
+// will customize clientSet.ObjectTracker, the current optional is custom watcher
+func NewSimpleClientsetWithObjectTrackerOption(objectTrackerOption testing.ObjectTrackerOptions, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder(), objectTrackerOption)
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &Clientset{tracker: o}
+	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/clientset_generated.go
@@ -59,6 +59,33 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientsetWithObjectTrackerOption returns a clientset that will respond with the provided objects.
+// its function is consistent with NewSimpleClientset, the difference is that NewSimpleClientsetWithObjectTrackerOption
+// will customize clientSet.ObjectTracker, the current optional is custom watcher
+func NewSimpleClientsetWithObjectTrackerOption(objectTrackerOption testing.ObjectTrackerOptions, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder(), objectTrackerOption)
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &Clientset{tracker: o}
+	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -59,6 +59,33 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientsetWithObjectTrackerOption returns a clientset that will respond with the provided objects.
+// its function is consistent with NewSimpleClientset, the difference is that NewSimpleClientsetWithObjectTrackerOption
+// will customize clientSet.ObjectTracker, the current optional is custom watcher
+func NewSimpleClientsetWithObjectTrackerOption(objectTrackerOption testing.ObjectTrackerOptions, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder(), objectTrackerOption)
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &Clientset{tracker: o}
+	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/fake/clientset_generated.go
@@ -59,6 +59,33 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientsetWithObjectTrackerOption returns a clientset that will respond with the provided objects.
+// its function is consistent with NewSimpleClientset, the difference is that NewSimpleClientsetWithObjectTrackerOption
+// will customize clientSet.ObjectTracker, the current optional is custom watcher
+func NewSimpleClientsetWithObjectTrackerOption(objectTrackerOption testing.ObjectTrackerOptions, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder(), objectTrackerOption)
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &Clientset{tracker: o}
+	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Because of using fake client The program panics with "channel full", panic may not be the best solution, sometimes we don't want the program to panic when it have fake client.



#### Which issue(s) this PR fixes:

Fixes #116700 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

