### PR TITLE
Fix: the node APIVersion missing group info.

### DIFF
--- a/pkg/kubelet/util/nodelease.go
+++ b/pkg/kubelet/util/nodelease.go
@@ -39,7 +39,7 @@ func SetNodeOwnerFunc(c clientset.Interface, nodeName string) func(lease *coordi
 			if node, err := c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{}); err == nil {
 				lease.OwnerReferences = []metav1.OwnerReference{
 					{
-						APIVersion: corev1.SchemeGroupVersion.WithKind("Node").Version,
+						APIVersion: corev1.SchemeGroupVersion.String(),
 						Kind:       corev1.SchemeGroupVersion.WithKind("Node").Kind,
 						Name:       nodeName,
 						UID:        node.UID,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When the lease OwnerReferences are set, the node APIVersion is missing the Group information.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```
fix lease ownerreferences  missing APIGroup information.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
