### PR TITLE
Remove long/golang version information making short the default

### DIFF
--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -416,14 +416,13 @@ kube::test::if_supports_resource() {
   return 1
 }
 
-
 kube::test::version::object_to_file() {
   name=$1
   flags=${2:-""}
   file=$3
   # shellcheck disable=SC2086
   # Disabling because "flags" needs to allow for expansion here
-  kubectl version ${flags} | grep "${name} Version:" | sed -e s/"${name} Version: version.Info{"/'/' -e s/'}'/'/' -e s/', '/','/g -e s/':'/'=/g' -e s/'"'/""/g | tr , '\n' > "${file}"
+  kubectl version ${flags} | grep "${name} Version:" | sed -e s/"${name} Version: "/""/g > "${file}"
 }
 
 kube::test::version::json_object_to_file() {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
@@ -54,7 +54,6 @@ var (
 // Options is a struct to support version command
 type Options struct {
 	ClientOnly bool
-	Short      bool
 	Output     string
 
 	args []string
@@ -87,8 +86,6 @@ func NewCmdVersion(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cob
 		},
 	}
 	cmd.Flags().BoolVar(&o.ClientOnly, "client", o.ClientOnly, "If true, shows client version only (no server required).")
-	cmd.Flags().BoolVar(&o.Short, "short", o.Short, "If true, print just the version number.")
-	cmd.Flags().MarkDeprecated("short", "and will be removed in the future. The --short output will become the default.")
 	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "One of 'yaml' or 'json'.")
 	return cmd
 }
@@ -141,19 +138,10 @@ func (o *Options) Run() error {
 
 	switch o.Output {
 	case "":
-		if o.Short {
-			fmt.Fprintf(o.Out, "Client Version: %s\n", versionInfo.ClientVersion.GitVersion)
-			fmt.Fprintf(o.Out, "Kustomize Version: %s\n", versionInfo.KustomizeVersion)
-			if versionInfo.ServerVersion != nil {
-				fmt.Fprintf(o.Out, "Server Version: %s\n", versionInfo.ServerVersion.GitVersion)
-			}
-		} else {
-			fmt.Fprintf(o.ErrOut, "WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.\n")
-			fmt.Fprintf(o.Out, "Client Version: %#v\n", *versionInfo.ClientVersion)
-			fmt.Fprintf(o.Out, "Kustomize Version: %s\n", versionInfo.KustomizeVersion)
-			if versionInfo.ServerVersion != nil {
-				fmt.Fprintf(o.Out, "Server Version: %#v\n", *versionInfo.ServerVersion)
-			}
+		fmt.Fprintf(o.Out, "Client Version: %s\n", versionInfo.ClientVersion.GitVersion)
+		fmt.Fprintf(o.Out, "Kustomize Version: %s\n", versionInfo.KustomizeVersion)
+		if versionInfo.ServerVersion != nil {
+			fmt.Fprintf(o.Out, "Server Version: %s\n", versionInfo.ServerVersion.GitVersion)
 		}
 	case "yaml":
 		marshalled, err := yaml.Marshal(&versionInfo)

--- a/test/cmd/version.sh
+++ b/test/cmd/version.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 ########################################################
-# Kubectl version (--short, --client, --output) #
+# Kubectl version (--client, --output) #
 ########################################################
 run_kubectl_version_tests() {
   set -o nounset
@@ -32,7 +32,7 @@ run_kubectl_version_tests() {
 
   # create version files, one for the client, one for the server.
   # these are the files we will use to ensure that the remainder output is correct
-  kube::test::version::object_to_file "Client" "" "${TEMP}/client_version_test"
+kube::test::version::object_to_file "Client" "" "${TEMP}/client_version_test"
   kube::test::version::object_to_file "Server" "" "${TEMP}/server_version_test"
 
   kube::log::status "Testing kubectl version: check client only output matches expected output"
@@ -44,22 +44,16 @@ run_kubectl_version_tests() {
   kube::test::version::diff_assert "${TEMP}/server_version_test" "ne" "${TEMP}/server_client_only_version_test" "the flag '--client' correctly has no server version info"
 
   kube::log::status "Testing kubectl version: verify json output"
-  kube::test::version::json_client_server_object_to_file "" "clientVersion" "${TEMP}/client_json_version_test"
-  kube::test::version::json_client_server_object_to_file "" "serverVersion" "${TEMP}/server_json_version_test"
+  kube::test::version::json_client_server_object_to_file "" "clientVersion.gitVersion" "${TEMP}/client_json_version_test"
+  kube::test::version::json_client_server_object_to_file "" "serverVersion.gitVersion" "${TEMP}/server_json_version_test"
   kube::test::version::diff_assert "${TEMP}/client_version_test" "eq" "${TEMP}/client_json_version_test" "--output json has correct client info"
   kube::test::version::diff_assert "${TEMP}/server_version_test" "eq" "${TEMP}/server_json_version_test" "--output json has correct server info"
 
   kube::log::status "Testing kubectl version: verify json output using additional --client flag does not contain serverVersion"
-  kube::test::version::json_client_server_object_to_file "--client" "clientVersion" "${TEMP}/client_only_json_version_test"
-  kube::test::version::json_client_server_object_to_file "--client" "serverVersion" "${TEMP}/server_client_only_json_version_test"
+  kube::test::version::json_client_server_object_to_file "--client" "clientVersion.gitVersion" "${TEMP}/client_only_json_version_test"
+  kube::test::version::json_client_server_object_to_file "--client" "serverVersion.gitVersion" "${TEMP}/server_client_only_json_version_test"
   kube::test::version::diff_assert "${TEMP}/client_version_test" "eq" "${TEMP}/client_only_json_version_test" "--client --output json has correct client info"
   kube::test::version::diff_assert "${TEMP}/server_version_test" "ne" "${TEMP}/server_client_only_json_version_test" "--client --output json has no server info"
-
-  kube::log::status "Testing kubectl version: compare json output using additional --short flag"
-  kube::test::version::json_client_server_object_to_file "--short" "clientVersion" "${TEMP}/client_short_json_version_test"
-  kube::test::version::json_client_server_object_to_file "--short" "serverVersion" "${TEMP}/server_short_json_version_test"
-  kube::test::version::diff_assert "${TEMP}/client_version_test" "eq" "${TEMP}/client_short_json_version_test" "--short --output client json info is equal to non short result"
-  kube::test::version::diff_assert "${TEMP}/server_version_test" "eq" "${TEMP}/server_short_json_version_test" "--short --output server json info is equal to non short result"
 
   kube::log::status "Testing kubectl version: compare json output with yaml output"
   kube::test::version::json_object_to_file "" "${TEMP}/client_server_json_version_test"
@@ -74,8 +68,6 @@ run_kubectl_version_tests() {
   kube::log::status "Testing kubectl version: all output formats include kustomize version"
   output_message=$(kubectl version --client)
   kube::test::if_has_string "${output_message}" "Kustomize Version" "kustomize version should be printed when --client is specified"
-  output_message=$(kubectl version --short)
-  kube::test::if_has_string "${output_message}" "Kustomize Version" "kustomize version should be printed when --short is specified"
   output_message=$(kubectl version -o yaml)
   kube::test::if_has_string "${output_message}" "kustomizeVersion" "kustomize version should be printed when -o yaml is used"
   output_message=$(kubectl version -o json)

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1676,7 +1676,7 @@ metadata:
 			// we expect following values for: Major -> digit, Minor -> numeric followed by an optional '+',  GitCommit -> alphanumeric
 			requiredItems := []string{"Client Version: ", "Server Version: "}
 			for _, item := range requiredItems {
-				if matched, _ := regexp.MatchString(item+`version.Info\{Major:"\d", Minor:"\d+\+?", GitVersion:"v\d\.\d+\.[\d\w\-\.\+]+", GitCommit:"[0-9a-f]+"`, versionString); !matched {
+				if matched, _ := regexp.MatchString(item+`v\d\.\d+\.[\d\w\-\.\+]+`, versionString); !matched {
 					framework.Failf("Item %s value is not valid in %s\n", item, versionString)
 				}
 			}


### PR DESCRIPTION
#### What type of PR is this?
/sig cli
/kind cleanup
/kind deprecation
/milestone v1.28

#### What this PR does / why we need it:
This is followup to https://github.com/kubernetes/kubernetes/pull/108987 where we've announced deprecation of the golang-based short version information in favor of making the `--short` the new default, and structured output being available through `--output json|yaml`.

#### Special notes for your reviewer:
/assign @KnVerey @sftim 

#### Does this PR introduce a user-facing change?
```release-note
Changed `kubectl version` default output to be identical to what `kubectl version --short` printed,
and remove `--short` flag entirely.
```

