### PR TITLE
sig-network OWNERS fixups

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -247,9 +247,6 @@ aliases:
     - bobbypage
     - pacoxu
     - bart0sh
-  sig-network-driver-approvers:
-    - dcbw
-    - freehan
   sig-network-approvers:
     - andrewsykim
     - aojea

--- a/cmd/kube-proxy/OWNERS
+++ b/cmd/kube-proxy/OWNERS
@@ -6,3 +6,4 @@ approvers:
   - sig-network-approvers
 labels:
   - sig/network
+  - area/kube-proxy

--- a/pkg/kubelet/network/OWNERS
+++ b/pkg/kubelet/network/OWNERS
@@ -1,7 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - sig-network-driver-approvers
+  - sig-network-approvers
 emeritus_approvers:
   - matchstick
 reviewers:

--- a/pkg/proxy/OWNERS
+++ b/pkg/proxy/OWNERS
@@ -6,3 +6,4 @@ reviewers:
   - sig-network-reviewers
 labels:
   - sig/network
+  - area/kube-proxy

--- a/pkg/proxy/winkernel/OWNERS
+++ b/pkg/proxy/winkernel/OWNERS
@@ -10,6 +10,8 @@ reviewers:
   - daschott
 labels:
   - sig/network
+  - sig/windows
+  - area/kube-proxy
 emeritus_approvers:
   - dineshgovindasamy
   - ksubrmnn

--- a/pkg/util/iptables/OWNERS
+++ b/pkg/util/iptables/OWNERS
@@ -1,14 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - dcbw
-  - thockin
-  - danwinship
+  - sig-network-reviewers
 approvers:
-  - dcbw
-  - thockin
-  - danwinship
-emeritus_approvers:
-  - eparis
+  - sig-network-approvers
 labels:
   - sig/network

--- a/pkg/util/ipvs/OWNERS
+++ b/pkg/util/ipvs/OWNERS
@@ -1,12 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - thockin
-  - andrewsykim
+  - sig-network-reviewers
   - uablrek
 approvers:
-  - thockin
-  - andrewsykim
+  - sig-network-approvers
   - uablrek
 labels:
   - sig/network

--- a/staging/src/k8s.io/kube-proxy/OWNERS
+++ b/staging/src/k8s.io/kube-proxy/OWNERS
@@ -8,3 +8,6 @@ reviewers:
   - sig-network-reviewers
   - luxas
   - sttts
+labels:
+  - sig/network
+  - area/kube-proxy


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Fixes to sig-network OWNERS files, as discussed in #114746, plus some additional cleanup:
- replace individual approvers with `sig-network-approvers` in `pkg/util/iptables` and `pkg/util/ipvs`
- add some missing labels, especially `area/kube-proxy`, but also `sig/windows` for `pkg/proxy/winkernel`
- remove the `sig-network-driver-approvers` alias that was added in #88138 for dockershim stuff, since dockershim no longer exists

I removed the redundant elements in `pkg/util/iptables/OWNERS` and `pkg/util/ipvs/OWNERS`, but maybe I shouldn't have? I see lots of redundancy in some other OWNERS files (eg, all the ones with sig-network ownership under `pkg/controllers`)

I can squash these if you want.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig network
/assign @thockin