### PR TITLE
Cleanup: use Set instead of map in endpointSlice utils

### DIFF
--- a/pkg/controller/endpointslice/reconciler.go
+++ b/pkg/controller/endpointslice/reconciler.go
@@ -80,7 +80,7 @@ func (r *reconciler) reconcile(service *corev1.Service, pods []*corev1.Pod, exis
 	// for further adjustment
 	for _, existingSlice := range existingSlices {
 		// service no longer supports that address type, add it to deleted slices
-		if _, ok := serviceSupportedAddressesTypes[existingSlice.AddressType]; !ok {
+		if !serviceSupportedAddressesTypes.Has(existingSlice.AddressType) {
 			if r.topologyCache != nil {
 				svcKey, err := serviceControllerKey(existingSlice)
 				if err != nil {
@@ -413,9 +413,9 @@ func (r *reconciler) reconcileByPortMapping(
 	endpointMeta *endpointMeta,
 ) ([]*discovery.EndpointSlice, []*discovery.EndpointSlice, []*discovery.EndpointSlice, int, int) {
 	slicesByName := map[string]*discovery.EndpointSlice{}
-	sliceNamesUnchanged := sets.String{}
-	sliceNamesToUpdate := sets.String{}
-	sliceNamesToDelete := sets.String{}
+	sliceNamesUnchanged := sets.New[string]()
+	sliceNamesToUpdate := sets.New[string]()
+	sliceNamesToDelete := sets.New[string]()
 	numRemoved := 0
 
 	// 1. Iterate through existing slices to delete endpoints no longer desired

--- a/pkg/controller/endpointslice/utils.go
+++ b/pkg/controller/endpointslice/utils.go
@@ -302,8 +302,8 @@ func (sl endpointSliceEndpointLen) Less(i, j int) bool {
 }
 
 // returns a map of address types used by a service
-func getAddressTypesForService(service *v1.Service) map[discovery.AddressType]struct{} {
-	serviceSupportedAddresses := make(map[discovery.AddressType]struct{})
+func getAddressTypesForService(service *v1.Service) sets.Set[discovery.AddressType] {
+	serviceSupportedAddresses := sets.New[discovery.AddressType]()
 	// TODO: (khenidak) when address types are removed in favor of
 	// v1.IPFamily this will need to be removed, and work directly with
 	// v1.IPFamily types
@@ -312,15 +312,15 @@ func getAddressTypesForService(service *v1.Service) map[discovery.AddressType]st
 	// as it gets deprecated
 	for _, family := range service.Spec.IPFamilies {
 		if family == v1.IPv4Protocol {
-			serviceSupportedAddresses[discovery.AddressTypeIPv4] = struct{}{}
+			serviceSupportedAddresses.Insert(discovery.AddressTypeIPv4)
 		}
 
 		if family == v1.IPv6Protocol {
-			serviceSupportedAddresses[discovery.AddressTypeIPv6] = struct{}{}
+			serviceSupportedAddresses.Insert(discovery.AddressTypeIPv6)
 		}
 	}
 
-	if len(serviceSupportedAddresses) > 0 {
+	if serviceSupportedAddresses.Len() > 0 {
 		return serviceSupportedAddresses // we have found families for this service
 	}
 
@@ -344,7 +344,7 @@ func getAddressTypesForService(service *v1.Service) map[discovery.AddressType]st
 		if utilnet.IsIPv6String(service.Spec.ClusterIP) {
 			addrType = discovery.AddressTypeIPv6
 		}
-		serviceSupportedAddresses[addrType] = struct{}{}
+		serviceSupportedAddresses.Insert(addrType)
 		klog.V(2).Infof("couldn't find ipfamilies for service: %v/%v. This could happen if controller manager is connected to an old apiserver that does not support ip families yet. EndpointSlices for this Service will use %s as the IP Family based on familyOf(ClusterIP:%v).", service.Namespace, service.Name, addrType, service.Spec.ClusterIP)
 		return serviceSupportedAddresses
 	}
@@ -354,14 +354,14 @@ func getAddressTypesForService(service *v1.Service) map[discovery.AddressType]st
 	// if the service is headless with no selector, then this will remain the case
 	// if the service is headless with selector then chances are pods are still using single family
 	// since kubelet will need to restart in order to start patching pod status with multiple ips
-	serviceSupportedAddresses[discovery.AddressTypeIPv4] = struct{}{}
-	serviceSupportedAddresses[discovery.AddressTypeIPv6] = struct{}{}
+	serviceSupportedAddresses.Insert(discovery.AddressTypeIPv4)
+	serviceSupportedAddresses.Insert(discovery.AddressTypeIPv6)
 	klog.V(2).Infof("couldn't find ipfamilies for headless service: %v/%v likely because controller manager is likely connected to an old apiserver that does not support ip families yet. The service endpoint slice will use dual stack families until api-server default it correctly", service.Namespace, service.Name)
 	return serviceSupportedAddresses
 }
 
 func unchangedSlices(existingSlices, slicesToUpdate, slicesToDelete []*discovery.EndpointSlice) []*discovery.EndpointSlice {
-	changedSliceNames := sets.String{}
+	changedSliceNames := sets.New[string]()
 	for _, slice := range slicesToUpdate {
 		changedSliceNames.Insert(slice.Name)
 	}
@@ -402,6 +402,6 @@ func managedByChanged(endpointSlice1, endpointSlice2 *discovery.EndpointSlice) b
 // managedByController returns true if the controller of the provided
 // EndpointSlices is the EndpointSlice controller.
 func managedByController(endpointSlice *discovery.EndpointSlice) bool {
-	managedBy, _ := endpointSlice.Labels[discovery.LabelManagedBy]
+	managedBy := endpointSlice.Labels[discovery.LabelManagedBy]
 	return managedBy == controllerName
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
use `sets.Set` instead of `map[discovery.AddressType]struct{}` in endpointSlice utils
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
part of  https://github.com/kubernetes/kubernetes/issues/116731

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
