### PR TITLE
feat: make user-defined plugins discoverable with e.g. kubectl help

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -469,6 +469,12 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 		filters = append(filters, alpha.Name())
 	}
 
+	// Add plugin command group to the list of command groups.
+	// The commands are only injected for the scope of showing help and completion, they are not
+	// invoked directly.
+	pluginCommandGroup := plugin.GetPluginCommandGroup(cmds)
+	groups = append(groups, pluginCommandGroup)
+
 	templates.ActsAsRootCommand(cmds, filters, groups...)
 
 	utilcomp.SetFactoryForCompletion(f)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_completion.go
@@ -110,9 +110,9 @@ func registerPluginCommands(kubectl *cobra.Command, list bool) (cmds []*cobra.Co
 		// Plugins are named "kubectl-<name>" or with more - such as
 		// "kubectl-<name>-<subcmd1>..."
 		rawPluginArgs := strings.Split(plugin, "-")[1:]
-		pluginArgs := rawPluginArgs[0:1]
+		pluginArgs := rawPluginArgs[:1]
 		if list {
-			pluginArgs = append(pluginArgs, rawPluginArgs[1:]...)
+			pluginArgs = rawPluginArgs
 		}
 
 		// Iterate through all segments, for kubectl-my_plugin-sub_cmd, we will end up with
@@ -146,8 +146,10 @@ func registerPluginCommands(kubectl *cobra.Command, list bool) (cmds []*cobra.Co
 			// Add the plugin command to the list of user defined commands
 			userDefinedCommands = append(userDefinedCommands, cmd)
 
-			parentCmd.AddCommand(cmd)
-			parentCmd = cmd
+			if list {
+				parentCmd.AddCommand(cmd)
+				parentCmd = cmd
+			}
 		}
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_completion.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,14 +28,23 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-
-	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/util/templates"
 )
+
+func GetPluginCommandGroup(kubectl *cobra.Command) templates.CommandGroup {
+	// Find root level
+	return templates.CommandGroup{
+		Message:  "User-Installed Plugin Commands:",
+		Commands: registerPluginCommands(kubectl, 1, false),
+	}
+}
 
 // SetupPluginCompletion adds a Cobra command to the command tree for each
 // plugin.  This is only done when performing shell completion that relate
 // to plugins.
 func SetupPluginCompletion(cmd *cobra.Command, args []string) {
+	kubectl := cmd.Root()
 	if len(args) > 0 {
 		if strings.HasPrefix(args[0], "-") {
 			// Plugins are not supported if the first argument is a flag,
@@ -45,7 +55,7 @@ func SetupPluginCompletion(cmd *cobra.Command, args []string) {
 		if len(args) == 1 {
 			// We are completing a subcommand at the first level so
 			// we should include all plugins names.
-			addPluginCommands(cmd)
+			registerPluginCommands(kubectl, math.MaxInt, true)
 			return
 		}
 
@@ -54,7 +64,7 @@ func SetupPluginCompletion(cmd *cobra.Command, args []string) {
 		// If we don't it could be a plugin and we'll need to add
 		// the plugin commands for completion to work.
 		found := false
-		for _, subCmd := range cmd.Root().Commands() {
+		for _, subCmd := range kubectl.Commands() {
 			if args[0] == subCmd.Name() {
 				found = true
 				break
@@ -70,19 +80,21 @@ func SetupPluginCompletion(cmd *cobra.Command, args []string) {
 			// to avoid them being included in the completion choices.
 			// This must be done *before* adding the plugin commands so that
 			// when creating those plugin commands, the flags don't exist.
-			cmd.Root().ResetFlags()
+			kubectl.ResetFlags()
 			cobra.CompDebugln("Cleared global flags for plugin completion", true)
 
-			addPluginCommands(cmd)
+			registerPluginCommands(kubectl, math.MaxInt, true)
 		}
 	}
 }
 
-// addPluginCommand adds a Cobra command to the command tree
-// for each plugin so that the completion logic knows about the plugins
-func addPluginCommands(cmd *cobra.Command) {
-	kubectl := cmd.Root()
-	streams := genericiooptions.IOStreams{
+// registerPluginCommand allows adding Cobra command to the command tree or extracting them for usage in
+// e.g. the help function or for registering the completion function
+func registerPluginCommands(kubectl *cobra.Command, depth int, register bool) (cmds []*cobra.Command) {
+
+	userDefinedCommands := []*cobra.Command{}
+
+	streams := genericclioptions.IOStreams{
 		In:     &bytes.Buffer{},
 		Out:    io.Discard,
 		ErrOut: io.Discard,
@@ -98,7 +110,17 @@ func addPluginCommands(cmd *cobra.Command) {
 
 		// Plugins are named "kubectl-<name>" or with more - such as
 		// "kubectl-<name>-<subcmd1>..."
-		for _, arg := range strings.Split(plugin, "-")[1:] {
+		// Respect the search depth to find the plugin name
+		rawPluginArgs := strings.Split(plugin, "-")[1:]
+		actualDepth := len(rawPluginArgs)
+		if depth < actualDepth {
+			actualDepth = depth
+		}
+		pluginArgs := rawPluginArgs[0:actualDepth]
+
+		// Iterate through all segments, for kubectl-my_plugin-sub_cmd, we will end up with
+		// two iterations: one for my_plugin and one for sub_cmd.
+		for _, arg := range pluginArgs {
 			// Underscores (_) in plugin's filename are replaced with dashes(-)
 			// e.g. foo_bar -> foo-bar
 			args = append(args, strings.Replace(arg, "_", "-", -1))
@@ -124,10 +146,18 @@ func addPluginCommands(cmd *cobra.Command) {
 				// A Run is required for it to be a valid command
 				Run: func(cmd *cobra.Command, args []string) {},
 			}
-			parentCmd.AddCommand(cmd)
-			parentCmd = cmd
+			// Add the plugin command to the list of user defined commands
+			userDefinedCommands = append(userDefinedCommands, cmd)
+
+			// Add the plugin command to the command tree, when requested
+			if register {
+				parentCmd.AddCommand(cmd)
+				parentCmd = cmd
+			}
 		}
 	}
+
+	return userDefinedCommands
 }
 
 // pluginCompletion deals with shell completion beyond the plugin name, it allows to complete

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_completion.go
@@ -29,13 +29,14 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
 func GetPluginCommandGroup(kubectl *cobra.Command) templates.CommandGroup {
 	// Find root level
 	return templates.CommandGroup{
-		Message:  "User-Installed Plugin Commands:",
+		Message:  i18n.T("Subcommands provided by plugins:"),
 		Commands: registerPluginCommands(kubectl, 1, false),
 	}
 }
@@ -91,7 +92,6 @@ func SetupPluginCompletion(cmd *cobra.Command, args []string) {
 // registerPluginCommand allows adding Cobra command to the command tree or extracting them for usage in
 // e.g. the help function or for registering the completion function
 func registerPluginCommands(kubectl *cobra.Command, depth int, register bool) (cmds []*cobra.Command) {
-
 	userDefinedCommands := []*cobra.Command{}
 
 	streams := genericclioptions.IOStreams{


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Kubectl plugins are a powerful way for extending kubectl, but actually discovering available plugins is hard.
Right now, the only way is to use [krew list
](https://krew.sigs.k8s.io/), check for `kubectl-<plugin-name>` executables or use tab-complete.

This PR maps the same behavior of tab-complete to the output of `kubectl` and `kubectl help`, including the new command group `User-Installed Plugin Commands:`.


<details>
  <summary>An example output (with `krew` and `convert` as plugins):
</summary>
  
```
kubectl controls the Kubernetes cluster manager.

 Find more information at: https://kubernetes.io/docs/reference/kubectl/

Basic Commands (Beginner):
  create          Create a resource from a file or from stdin
  expose          Take a replication controller, service, deployment or pod and expose it as a new Kubernetes service
  run             Run a particular image on the cluster
  set             Set specific features on objects

Basic Commands (Intermediate):
  explain         Get documentation for a resource
  get             Display one or many resources
  edit            Edit a resource on the server
  delete          Delete resources by file names, stdin, resources and names, or by resources and label selector

Deploy Commands:
  rollout         Manage the rollout of a resource
  scale           Set a new size for a deployment, replica set, or replication controller
  autoscale       Auto-scale a deployment, replica set, stateful set, or replication controller

Cluster Management Commands:
  certificate     Modify certificate resources.
  cluster-info    Display cluster information
  top             Display resource (CPU/memory) usage
  cordon          Mark node as unschedulable
  uncordon        Mark node as schedulable
  drain           Drain node in preparation for maintenance
  taint           Update the taints on one or more nodes

Troubleshooting and Debugging Commands:
  describe        Show details of a specific resource or group of resources
  logs            Print the logs for a container in a pod
  attach          Attach to a running container
  exec            Execute a command in a container
  port-forward    Forward one or more local ports to a pod
  proxy           Run a proxy to the Kubernetes API server
  cp              Copy files and directories to and from containers
  auth            Inspect authorization
  debug           Create debugging sessions for troubleshooting workloads and nodes
  events          List events

Advanced Commands:
  diff            Diff the live version against a would-be applied version
  apply           Apply a configuration to a resource by file name or stdin
  patch           Update fields of a resource
  replace         Replace a resource by file name or stdin
  wait            Experimental: Wait for a specific condition on one or many resources
  kustomize       Build a kustomization target from a directory or URL

Settings Commands:
  label           Update the labels on a resource
  annotate        Update the annotations on a resource
  completion      Output shell completion code for the specified shell (bash, zsh, fish, or powershell)

User-Installed Plugin Commands:
  convert       The command convert is a plugin installed by the user
  krew          The command krew is a plugin installed by the user

Other Commands:
  api-resources   Print the supported API resources on the server
  api-versions    Print the supported API versions on the server, in the form of "group/version"
  config          Modify kubeconfig files
  plugin          Provides utilities for interacting with plugins
  version         Print the client and server version information

Usage:
  kubectl [flags] [options]

Use "kubectl <command> --help" for more information about a given command.
Use "kubectl options" for a list of global command-line options (applies to all commands).
```
</details>



#### Which issue(s) this PR fixes:
Fixes #116751

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Changed `kubectl help` to display basic details for subcommands from plugins 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

I did not create a KEP for **this** change as it doesn't introduce breaking behavior, just a visual change. I'm planning on extending this to improve discovery of plugins by e.g. allowing user-defined descriptions as a KEP.

```docs

```
