### PR TITLE
Do not log misleading error when namespace is being terminated

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -601,6 +601,8 @@ func (jm *ControllerV2) syncCronJob(
 	jobResp, err := jm.jobControl.CreateJob(cronJob.Namespace, jobReq)
 	switch {
 	case errors.HasStatusCause(err, corev1.NamespaceTerminatingCause):
+		// if the namespace is being terminated, we don't have to do anything
+		return cronJob, nil, updateStatus, err
 	case errors.IsAlreadyExists(err):
 		// If the job is created by other actor, assume  it has updated the cronjob status accordingly
 		logger.Info("Job already exists", "cronjob", klog.KObj(cronJob), "job", klog.KObj(jobReq))


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig apps

#### What this PR does / why we need it:
Found this while recently reviewing a different PR, we unnecessarily combined the 2 error cases:
1. already existing job
2. terminating namespace.

For both we logged the same misleading information that a job already exists. Which makes sense
in the first case, but it's pointless in the other case. This cleanup splits it into two separate cases
where only the first creates the log.

#### Special notes for your reviewer:
/assign @atiratree 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
