### PR TITLE
k8s.io/apiserver: wire --disable-http2 flag to existing logic

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -99,6 +99,7 @@ func TestAddFlags(t *testing.T) {
 		"--cloud-provider=azure",
 		"--cors-allowed-origins=10.10.10.100,10.10.10.200",
 		"--contention-profiling=true",
+		"--disable-http2",
 		"--egress-selector-config-file=/var/run/kubernetes/egress-selector/connectivity.yaml",
 		"--enable-aggregator-routing=true",
 		"--enable-priority-and-fairness=false",
@@ -107,7 +108,7 @@ func TestAddFlags(t *testing.T) {
 		"--etcd-keyfile=/var/run/kubernetes/etcd.key",
 		"--etcd-certfile=/var/run/kubernetes/etcdce.crt",
 		"--etcd-cafile=/var/run/kubernetes/etcdca.crt",
-		"--http2-max-streams-per-connection=42",
+		"--http2-max-streams-per-connection=42", // TODO make incompatible with --disable-http2
 		"--kubelet-read-only-port=10255",
 		"--kubelet-timeout=5s",
 		"--kubelet-client-certificate=/var/run/kubernetes/ceserver.crt",
@@ -139,6 +140,7 @@ func TestAddFlags(t *testing.T) {
 			MinRequestTimeout:           1800,
 			JSONPatchMaxCopyBytes:       int64(3 * 1024 * 1024),
 			MaxRequestBodyBytes:         int64(3 * 1024 * 1024),
+			DisableHTTP2:                true,
 		},
 		Admission: &kubeoptions.AdmissionOptions{
 			GenericAdmission: &apiserveroptions.AdmissionOptions{
@@ -322,6 +324,6 @@ func TestAddFlags(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(expected, s) {
-		t.Errorf("Got different run options than expected.\nDifference detected on:\n%s", cmp.Diff(expected, s, cmpopts.IgnoreUnexported(admission.Plugins{})))
+		t.Errorf("Got different run options than expected.\nDifference detected on:\n%s", cmp.Diff(expected, s, cmpopts.IgnoreUnexported(admission.Plugins{}, apiserveroptions.EtcdOptions{})))
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -26,8 +26,6 @@ import (
 	"syscall"
 
 	"github.com/spf13/pflag"
-	"k8s.io/klog/v2"
-	netutils "k8s.io/utils/net"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/server"
@@ -35,6 +33,8 @@ import (
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
 	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 )
 
 type SecureServingOptions struct {
@@ -200,6 +200,7 @@ func (s *SecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 		"--tls-sni-cert-key multiple times. "+
 		"Examples: \"example.crt,example.key\" or \"foo.crt,foo.key:*.foo.com,foo.com\".")
 
+	// TODO may move goaway chance and disable http2 here?
 	fs.IntVar(&s.HTTP2MaxStreamsPerConnection, "http2-max-streams-per-connection", s.HTTP2MaxStreamsPerConnection, ""+
 		"The limit that the server gives to clients for "+
 		"the maximum number of streams in an HTTP/2 connection. "+


### PR DESCRIPTION
This change simply wires the existing DisableHTTP2 boolean to a CLI flag so that it can be set without code level changes (and thus makes it available to the Kubernetes API server).

/kind feature
/milestone v1.28

```release-note
The --disable-http2 flag can be set to prevent the use of HTTP/2.
```