### PR TITLE
Automated cherry pick of #116550: Add integration test for DefaultBinder

### DIFF
--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -162,6 +162,7 @@ func (r *BindingREST) Destroy() {
 }
 
 var _ = rest.NamedCreater(&BindingREST{})
+var _ = rest.SubresourceObjectMetaPreserver(&BindingREST{})
 
 // Create ensures a pod is bound to a specific host.
 func (r *BindingREST) Create(ctx context.Context, name string, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (out runtime.Object, err error) {
@@ -188,6 +189,13 @@ func (r *BindingREST) Create(ctx context.Context, name string, obj runtime.Objec
 	err = r.assignPod(ctx, binding.UID, binding.ResourceVersion, binding.Name, binding.Target.Name, binding.Annotations, dryrun.IsDryRun(options.DryRun))
 	out = &metav1.Status{Status: metav1.StatusSuccess}
 	return
+}
+
+// PreserveRequestObjectMetaSystemFieldsOnSubresourceCreate indicates to a
+// handler that this endpoint requires the UID and ResourceVersion to use as
+// preconditions. Other fields, such as timestamp, are ignored.
+func (r *BindingREST) PreserveRequestObjectMetaSystemFieldsOnSubresourceCreate() bool {
+	return true
 }
 
 // setPodHostAndAnnotations sets the given pod's host to 'machine' if and only if

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
@@ -162,8 +162,13 @@ func createHandler(r rest.NamedCreater, scope *RequestScope, admit admission.Int
 		userInfo, _ := request.UserFrom(ctx)
 
 		if objectMeta, err := meta.Accessor(obj); err == nil {
-			// Wipe fields which cannot take user-provided values
-			rest.WipeObjectMetaSystemFields(objectMeta)
+			preserveObjectMetaSystemFields := false
+			if c, ok := r.(rest.SubresourceObjectMetaPreserver); ok && len(scope.Subresource) > 0 {
+				preserveObjectMetaSystemFields = c.PreserveRequestObjectMetaSystemFieldsOnSubresourceCreate()
+			}
+			if !preserveObjectMetaSystemFields {
+				rest.WipeObjectMetaSystemFields(objectMeta)
+			}
 
 			// ensure namespace on the object is correct, or error if a conflicting namespace was set in the object
 			if err := rest.EnsureObjectNamespaceMatchesRequestNamespace(rest.ExpectedNamespaceForResource(namespace, scope.Resource), objectMeta); err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -203,6 +203,13 @@ type NamedCreater interface {
 	Create(ctx context.Context, name string, obj runtime.Object, createValidation ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error)
 }
 
+// SubresourceObjectMetaPreserver adds configuration options to a Creater for subresources.
+type SubresourceObjectMetaPreserver interface {
+	// PreserveRequestObjectMetaSystemFieldsOnSubresourceCreate indicates that a
+	// handler should preserve fields of ObjectMeta that are managed by the system.
+	PreserveRequestObjectMetaSystemFieldsOnSubresourceCreate() bool
+}
+
 // UpdatedObjectInfo provides information about an updated object to an Updater.
 // It requires access to the old object in order to return the newly updated object.
 type UpdatedObjectInfo interface {

--- a/test/integration/scheduler/bind/bind_test.go
+++ b/test/integration/scheduler/bind/bind_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bind
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	testutil "k8s.io/kubernetes/test/integration/util"
+)
+
+// TestDefaultBinder tests the binding process in the scheduler.
+func TestDefaultBinder(t *testing.T) {
+	testCtx := testutil.InitTestSchedulerWithOptions(t, testutil.InitTestAPIServer(t, "", nil), 0)
+	testutil.SyncInformerFactory(testCtx)
+	// Do not start scheduler routine.
+	defer testutil.CleanupTest(t, testCtx)
+
+	// Add a node.
+	node, err := testutil.CreateNode(testCtx.ClientSet, st.MakeNode().Name("testnode").Obj())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]struct {
+		anotherUID     bool
+		wantStatusCode framework.Code
+	}{
+		"same UID": {
+			wantStatusCode: framework.Success,
+		},
+		"different UID": {
+			anotherUID:     true,
+			wantStatusCode: framework.Error,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			pod, err := testutil.CreatePausePodWithResource(testCtx.ClientSet, "fixed-name", testCtx.NS.Name, nil)
+			if err != nil {
+				t.Fatalf("Failed to create pod: %v", err)
+			}
+			defer testutil.CleanupPods(testCtx.ClientSet, t, []*corev1.Pod{pod})
+
+			podCopy := pod.DeepCopy()
+			if tc.anotherUID {
+				podCopy.UID = "another"
+			}
+
+			status := testCtx.Scheduler.Profiles["default-scheduler"].RunBindPlugins(testCtx.Ctx, nil, podCopy, node.Name)
+			if code := status.Code(); code != tc.wantStatusCode {
+				t.Errorf("Bind returned code %s, want %s", code, tc.wantStatusCode)
+			}
+		})
+	}
+}

--- a/test/integration/scheduler/bind/main_test.go
+++ b/test/integration/scheduler/bind/main_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bind
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.EtcdMain(m.Run)
+}


### PR DESCRIPTION
Cherry pick of #116550 on release-1.26.

#116550: Add integration test for DefaultBinder

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.25 regression in the pod binding subresource to honor the `metadata.uid` precondition.
This allows kube-scheduler to ensure it is assigns node names to the same instances of pods it made scheduling decisions for.
```
