### PR TITLE
Use standard *.kubernetes.io instead of *.k8s.io for ApplySet

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -2401,12 +2401,12 @@ func TestApplySetParentManagement(t *testing.T) {
 kind: Secret
 metadata:
   annotations:
-    applyset.k8s.io/additional-namespaces: ""
-    applyset.k8s.io/contains-group-resources: replicationcontrollers
-    applyset.k8s.io/tooling: kubectl/v0.0.0-master+$Format:%H$
+    applyset.kubernetes.io/additional-namespaces: ""
+    applyset.kubernetes.io/contains-group-resources: replicationcontrollers
+    applyset.kubernetes.io/tooling: kubectl/v0.0.0-master+$Format:%H$
   creationTimestamp: null
   labels:
-    applyset.k8s.io/id: applyset-0eFHV8ySqp7XoShsGvyWFQD3s96yqwHmzc4e0HR1dsY-v1
+    applyset.kubernetes.io/id: applyset-0eFHV8ySqp7XoShsGvyWFQD3s96yqwHmzc4e0HR1dsY-v1
   name: my-set
   namespace: test
   uid: a-static-fake-uid
@@ -2435,12 +2435,12 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    applyset.k8s.io/additional-namespaces: ""
-    applyset.k8s.io/contains-group-resources: replicationcontrollers,services
-    applyset.k8s.io/tooling: kubectl/v0.0.0-master+$Format:%H$
+    applyset.kubernetes.io/additional-namespaces: ""
+    applyset.kubernetes.io/contains-group-resources: replicationcontrollers,services
+    applyset.kubernetes.io/tooling: kubectl/v0.0.0-master+$Format:%H$
   creationTimestamp: null
   labels:
-    applyset.k8s.io/id: applyset-0eFHV8ySqp7XoShsGvyWFQD3s96yqwHmzc4e0HR1dsY-v1
+    applyset.kubernetes.io/id: applyset-0eFHV8ySqp7XoShsGvyWFQD3s96yqwHmzc4e0HR1dsY-v1
   name: my-set
   namespace: test
   uid: a-static-fake-uid
@@ -2470,12 +2470,12 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    applyset.k8s.io/additional-namespaces: ""
-    applyset.k8s.io/contains-group-resources: replicationcontrollers,services
-    applyset.k8s.io/tooling: kubectl/v0.0.0-master+$Format:%H$
+    applyset.kubernetes.io/additional-namespaces: ""
+    applyset.kubernetes.io/contains-group-resources: replicationcontrollers,services
+    applyset.kubernetes.io/tooling: kubectl/v0.0.0-master+$Format:%H$
   creationTimestamp: null
   labels:
-    applyset.k8s.io/id: applyset-0eFHV8ySqp7XoShsGvyWFQD3s96yqwHmzc4e0HR1dsY-v1
+    applyset.kubernetes.io/id: applyset-0eFHV8ySqp7XoShsGvyWFQD3s96yqwHmzc4e0HR1dsY-v1
   name: my-set
   namespace: test
   uid: a-static-fake-uid
@@ -2505,12 +2505,12 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    applyset.k8s.io/additional-namespaces: ""
-    applyset.k8s.io/contains-group-resources: services
-    applyset.k8s.io/tooling: kubectl/v0.0.0-master+$Format:%H$
+    applyset.kubernetes.io/additional-namespaces: ""
+    applyset.kubernetes.io/contains-group-resources: services
+    applyset.kubernetes.io/tooling: kubectl/v0.0.0-master+$Format:%H$
   creationTimestamp: null
   labels:
-    applyset.k8s.io/id: applyset-0eFHV8ySqp7XoShsGvyWFQD3s96yqwHmzc4e0HR1dsY-v1
+    applyset.kubernetes.io/id: applyset-0eFHV8ySqp7XoShsGvyWFQD3s96yqwHmzc4e0HR1dsY-v1
   name: my-set
   namespace: test
   uid: a-static-fake-uid
@@ -2537,19 +2537,19 @@ func TestApplySetInvalidLiveParent(t *testing.T) {
 			grsAnnotation:     "",
 			toolingAnnotation: validToolingAnnotation,
 			idLabel:           validIDLabel,
-			expectErr:         "error: parsing ApplySet annotation on \"secrets./my-set\": kubectl requires the \"applyset.k8s.io/contains-group-resources\" annotation to be set on all ApplySet parent objects",
+			expectErr:         "error: parsing ApplySet annotation on \"secrets./my-set\": kubectl requires the \"applyset.kubernetes.io/contains-group-resources\" annotation to be set on all ApplySet parent objects",
 		},
 		"group-resources annotation should not contain invalid resources": {
 			grsAnnotation:     "does-not-exist",
 			toolingAnnotation: validToolingAnnotation,
 			idLabel:           validIDLabel,
-			expectErr:         "error: parsing ApplySet annotation on \"secrets./my-set\": invalid group resource in \"applyset.k8s.io/contains-group-resources\" annotation: no matches for /, Resource=does-not-exist",
+			expectErr:         "error: parsing ApplySet annotation on \"secrets./my-set\": invalid group resource in \"applyset.kubernetes.io/contains-group-resources\" annotation: no matches for /, Resource=does-not-exist",
 		},
 		"tooling annotation is required": {
 			grsAnnotation:     validGrsAnnotation,
 			toolingAnnotation: "",
 			idLabel:           validIDLabel,
-			expectErr:         "error: ApplySet parent object \"secrets./my-set\" already exists and is missing required annotation \"applyset.k8s.io/tooling\"",
+			expectErr:         "error: ApplySet parent object \"secrets./my-set\" already exists and is missing required annotation \"applyset.kubernetes.io/tooling\"",
 		},
 		"tooling annotation must have kubectl prefix": {
 			grsAnnotation:     validGrsAnnotation,
@@ -2573,13 +2573,13 @@ func TestApplySetInvalidLiveParent(t *testing.T) {
 			grsAnnotation:     validGrsAnnotation,
 			toolingAnnotation: validToolingAnnotation,
 			idLabel:           "",
-			expectErr:         "error: ApplySet parent object \"secrets./my-set\" exists and does not have required label applyset.k8s.io/id",
+			expectErr:         "error: ApplySet parent object \"secrets./my-set\" exists and does not have required label applyset.kubernetes.io/id",
 		},
 		"ID label must match the ApplySet's real ID": {
 			grsAnnotation:     validGrsAnnotation,
 			toolingAnnotation: validToolingAnnotation,
 			idLabel:           "somethingelse",
-			expectErr:         fmt.Sprintf("error: ApplySet parent object \"secrets./my-set\" exists and has incorrect value for label \"applyset.k8s.io/id\" (got: somethingelse, want: %s)", validIDLabel),
+			expectErr:         fmt.Sprintf("error: ApplySet parent object \"secrets./my-set\" exists and has incorrect value for label \"applyset.kubernetes.io/id\" (got: somethingelse, want: %s)", validIDLabel),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -2668,12 +2668,12 @@ func TestApplySet_ClusterScopedCustomResourceParent(t *testing.T) {
 kind: ApplySet
 metadata:
   annotations:
-    applyset.k8s.io/additional-namespaces: test
-    applyset.k8s.io/contains-group-resources: replicationcontrollers
-    applyset.k8s.io/tooling: kubectl/v0.0.0-master+$Format:%H$
+    applyset.kubernetes.io/additional-namespaces: test
+    applyset.kubernetes.io/contains-group-resources: replicationcontrollers
+    applyset.kubernetes.io/tooling: kubectl/v0.0.0-master+$Format:%H$
   creationTimestamp: null
   labels:
-    applyset.k8s.io/id: applyset-rhp1a-HVAVT_dFgyEygyA1BEB82HPp2o10UiFTpqtAs-v1
+    applyset.kubernetes.io/id: applyset-rhp1a-HVAVT_dFgyEygyA1BEB82HPp2o10UiFTpqtAs-v1
   name: my-set
 `, string(updatedCRYaml))
 }
@@ -2885,12 +2885,12 @@ func TestApplySetUpdateConflictsAreRetried(t *testing.T) {
 kind: Secret
 metadata:
   annotations:
-    applyset.k8s.io/additional-namespaces: ""
-    applyset.k8s.io/contains-group-resources: replicationcontrollers
-    applyset.k8s.io/tooling: kubectl/v0.0.0-master+$Format:%H$
+    applyset.kubernetes.io/additional-namespaces: ""
+    applyset.kubernetes.io/contains-group-resources: replicationcontrollers
+    applyset.kubernetes.io/tooling: kubectl/v0.0.0-master+$Format:%H$
   creationTimestamp: null
   labels:
-    applyset.k8s.io/id: applyset-0eFHV8ySqp7XoShsGvyWFQD3s96yqwHmzc4e0HR1dsY-v1
+    applyset.kubernetes.io/id: applyset-0eFHV8ySqp7XoShsGvyWFQD3s96yqwHmzc4e0HR1dsY-v1
   name: my-set
   namespace: test
 `
@@ -2915,7 +2915,7 @@ metadata:
 				if req.URL.Path == pathSecret {
 					if !forceConflicts {
 						applyReturnedConflict = true
-						return &http.Response{StatusCode: http.StatusConflict, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader("Apply failed with 1 conflict: conflict with \"other\": .metadata.annotations.applyset.k8s.io/contains-group-resources"))}, nil
+						return &http.Response{StatusCode: http.StatusConflict, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader("Apply failed with 1 conflict: conflict with \"other\": .metadata.annotations.applyset.kubernetes.io/contains-group-resources"))}, nil
 					}
 					appliedWithConflictsForced = true
 				}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
@@ -46,13 +46,13 @@ const (
 	// Tooling should refuse to mutate ApplySets belonging to other tools.
 	// The value must be in the format <toolname>/<semver>.
 	// Example value: "kubectl/v1.27" or "helm/v3" or "kpt/v1.0.0"
-	ApplySetToolingAnnotation = "applyset.k8s.io/tooling"
+	ApplySetToolingAnnotation = "applyset.kubernetes.io/tooling"
 
 	// ApplySetAdditionalNamespacesAnnotation annotation extends the scope of the ApplySet beyond the parent
 	// object's own namespace (if any) to include the listed namespaces. The value is a comma-separated
 	// list of the names of namespaces other than the parent's namespace in which objects are found
 	// Example value: "kube-system,ns1,ns2".
-	ApplySetAdditionalNamespacesAnnotation = "applyset.k8s.io/additional-namespaces"
+	ApplySetAdditionalNamespacesAnnotation = "applyset.kubernetes.io/additional-namespaces"
 
 	// ApplySetGRsAnnotation is a list of group-resources used to optimize listing of ApplySet member objects.
 	// It is optional in the ApplySet specification, as tools can perform discovery or use a different optimization.
@@ -60,11 +60,11 @@ const (
 	// When present, the value of this annotation must be a comma separated list of the group-kinds,
 	// in the fully-qualified name format, i.e. <resourcename>.<group>.
 	// Example value: "certificates.cert-manager.io,configmaps,deployments.apps,secrets,services"
-	ApplySetGRsAnnotation = "applyset.k8s.io/contains-group-resources"
+	ApplySetGRsAnnotation = "applyset.kubernetes.io/contains-group-resources"
 
 	// ApplySetParentIDLabel is the key of the label that makes object an ApplySet parent object.
 	// Its value MUST use the format specified in V1ApplySetIdFormat below
-	ApplySetParentIDLabel = "applyset.k8s.io/id"
+	ApplySetParentIDLabel = "applyset.kubernetes.io/id"
 
 	// V1ApplySetIdFormat is the format required for the value of ApplySetParentIDLabel (and ApplysetPartOfLabel).
 	// The %s segment is the unique ID of the object itself, which MUST be the base64 encoding
@@ -74,11 +74,11 @@ const (
 
 	// ApplysetPartOfLabel is the key of the label which indicates that the object is a member of an ApplySet.
 	// The value of the label MUST match the value of ApplySetParentIDLabel on the parent object.
-	ApplysetPartOfLabel = "applyset.k8s.io/part-of"
+	ApplysetPartOfLabel = "applyset.kubernetes.io/part-of"
 
 	// ApplysetParentCRDLabel is the key of the label that can be set on a CRD to identify
 	// the custom resource type it defines (not the CRD itself) as an allowed parent for an ApplySet.
-	ApplysetParentCRDLabel = "applyset.k8s.io/is-parent-type"
+	ApplysetParentCRDLabel = "applyset.kubernetes.io/is-parent-type"
 )
 
 var defaultApplySetParentGVR = schema.GroupVersionResource{Version: "v1", Resource: "secrets"}
@@ -88,7 +88,7 @@ type ApplySet struct {
 	// parentRef is a reference to the parent object that is used to track the applyset.
 	parentRef *ApplySetParentRef
 
-	// toolingID is the value to be used and validated in the applyset.k8s.io/tooling annotation.
+	// toolingID is the value to be used and validated in the applyset.kubernetes.io/tooling annotation.
 	toolingID ApplySetTooling
 
 	// currentResources is the set of resources that are part of the sever-side set as of when the current operation started.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/manifest1-expected-getobjects.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/manifest1-expected-getobjects.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    applyset.k8s.io/part-of: applyset-bjd1LnyQq0mtUu-riZCqjDQOmh0iNb9O2RcuT12WR0k-v1
+    applyset.kubernetes.io/part-of: applyset-bjd1LnyQq0mtUu-riZCqjDQOmh0iNb9O2RcuT12WR0k-v1
   name: foo
 
 ---
@@ -11,5 +11,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    applyset.k8s.io/part-of: applyset-bjd1LnyQq0mtUu-riZCqjDQOmh0iNb9O2RcuT12WR0k-v1
+    applyset.kubernetes.io/part-of: applyset-bjd1LnyQq0mtUu-riZCqjDQOmh0iNb9O2RcuT12WR0k-v1
   name: bar

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/manifest2-expected-getobjects.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/testdata/prune/simple/manifest2-expected-getobjects.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    applyset.k8s.io/part-of: applyset-bjd1LnyQq0mtUu-riZCqjDQOmh0iNb9O2RcuT12WR0k-v1
+    applyset.kubernetes.io/part-of: applyset-bjd1LnyQq0mtUu-riZCqjDQOmh0iNb9O2RcuT12WR0k-v1
   name: foo

--- a/staging/src/k8s.io/kubectl/testdata/apply/applyset-cr.yaml
+++ b/staging/src/k8s.io/kubectl/testdata/apply/applyset-cr.yaml
@@ -3,7 +3,7 @@ kind: ApplySet
 metadata:
   name: my-set
   annotations:
-    applyset.k8s.io/tooling: kubectl/v0.0.0
-    applyset.k8s.io/contains-group-resources: ""
+    applyset.kubernetes.io/tooling: kubectl/v0.0.0
+    applyset.kubernetes.io/contains-group-resources: ""
   labels:
-    applyset.k8s.io/id: applyset-rhp1a-HVAVT_dFgyEygyA1BEB82HPp2o10UiFTpqtAs-v1
+    applyset.kubernetes.io/id: applyset-rhp1a-HVAVT_dFgyEygyA1BEB82HPp2o10UiFTpqtAs-v1

--- a/staging/src/k8s.io/kubectl/testdata/apply/applysets-crd.yaml
+++ b/staging/src/k8s.io/kubectl/testdata/apply/applysets-crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: applysets.company.com
   labels:
-    applyset.k8s.io/is-parent-type: "true"
+    applyset.kubernetes.io/is-parent-type: "true"
 spec:
   group: company.com
   names:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
/kind cleanup

/kind api-change
For an unreleased series of alpha annotations/labels.

#### What this PR does / why we need it:

In reviewing https://github.com/kubernetes/website/pull/39818, @sftim spotted that ApplySet is not using the standard `*.kubernetes.io` prefix for its labels and annotations (it instead uses `*.k8s.io`). I propose we allow this PR into the milestone as it is trivial and low-risk to fix, and prevents both us and our future users to have to go through a name migration in a future release.

#### Does this PR introduce a user-facing change?

Yes, but instead of including one here, I think we should go back and update the notes on the earlier PRs. Do you agree?

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3659
```

```release-note
NONE
```
