### PR TITLE
generate fully qualified type references

### DIFF
--- a/staging/src/k8s.io/api/admission/v1/generated.proto
+++ b/staging/src/k8s.io/api/admission/v1/generated.proto
@@ -38,10 +38,10 @@ message AdmissionRequest {
   optional string uid = 1;
 
   // Kind is the fully-qualified type of object being submitted (for example, v1.Pod or autoscaling.v1.Scale)
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind kind = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind kind = 2;
 
   // Resource is the fully-qualified resource being requested (for example, v1.pods)
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionResource resource = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionResource resource = 3;
 
   // SubResource is the subresource being requested, if any (for example, "status" or "scale")
   // +optional
@@ -58,7 +58,7 @@ message AdmissionRequest {
   //
   // See documentation for the "matchPolicy" field in the webhook configuration type for more details.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind requestKind = 13;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind requestKind = 13;
 
   // RequestResource is the fully-qualified resource of the original API request (for example, v1.pods).
   // If this is specified and differs from the value in "resource", an equivalent match and conversion was performed.
@@ -71,7 +71,7 @@ message AdmissionRequest {
   //
   // See documentation for the "matchPolicy" field in the webhook configuration type.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionResource requestResource = 14;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionResource requestResource = 14;
 
   // RequestSubResource is the name of the subresource of the original API request, if any (for example, "status" or "scale")
   // If this is specified and differs from the value in "subResource", an equivalent match and conversion was performed.
@@ -93,15 +93,15 @@ message AdmissionRequest {
   optional string operation = 7;
 
   // UserInfo is information about the requesting user
-  optional k8s.io.api.authentication.v1.UserInfo userInfo = 8;
+  optional .k8s.io.api.authentication.v1.UserInfo userInfo = 8;
 
   // Object is the object from the incoming request.
   // +optional
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension object = 9;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension object = 9;
 
   // OldObject is the existing object. Only populated for DELETE and UPDATE requests.
   // +optional
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension oldObject = 10;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension oldObject = 10;
 
   // DryRun indicates that modifications will definitely not be persisted for this request.
   // Defaults to false.
@@ -114,7 +114,7 @@ message AdmissionRequest {
   // Operation might be a CREATE, in which case the Options will a
   // `meta.k8s.io/v1.CreateOptions` even though the caller provided `meta.k8s.io/v1.PatchOptions`.
   // +optional
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension options = 12;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension options = 12;
 }
 
 // AdmissionResponse describes an admission response.
@@ -129,7 +129,7 @@ message AdmissionResponse {
   // Result contains extra details into why an admission request was denied.
   // This field IS NOT consulted in any way if "Allowed" is "true".
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Status status = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Status status = 3;
 
   // The patch body. Currently we only support "JSONPatch" which implements RFC 6902.
   // +optional

--- a/staging/src/k8s.io/api/admission/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/admission/v1beta1/generated.proto
@@ -38,10 +38,10 @@ message AdmissionRequest {
   optional string uid = 1;
 
   // Kind is the fully-qualified type of object being submitted (for example, v1.Pod or autoscaling.v1.Scale)
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind kind = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind kind = 2;
 
   // Resource is the fully-qualified resource being requested (for example, v1.pods)
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionResource resource = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionResource resource = 3;
 
   // SubResource is the subresource being requested, if any (for example, "status" or "scale")
   // +optional
@@ -58,7 +58,7 @@ message AdmissionRequest {
   //
   // See documentation for the "matchPolicy" field in the webhook configuration type for more details.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind requestKind = 13;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind requestKind = 13;
 
   // RequestResource is the fully-qualified resource of the original API request (for example, v1.pods).
   // If this is specified and differs from the value in "resource", an equivalent match and conversion was performed.
@@ -71,7 +71,7 @@ message AdmissionRequest {
   //
   // See documentation for the "matchPolicy" field in the webhook configuration type.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionResource requestResource = 14;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionResource requestResource = 14;
 
   // RequestSubResource is the name of the subresource of the original API request, if any (for example, "status" or "scale")
   // If this is specified and differs from the value in "subResource", an equivalent match and conversion was performed.
@@ -93,15 +93,15 @@ message AdmissionRequest {
   optional string operation = 7;
 
   // UserInfo is information about the requesting user
-  optional k8s.io.api.authentication.v1.UserInfo userInfo = 8;
+  optional .k8s.io.api.authentication.v1.UserInfo userInfo = 8;
 
   // Object is the object from the incoming request.
   // +optional
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension object = 9;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension object = 9;
 
   // OldObject is the existing object. Only populated for DELETE and UPDATE requests.
   // +optional
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension oldObject = 10;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension oldObject = 10;
 
   // DryRun indicates that modifications will definitely not be persisted for this request.
   // Defaults to false.
@@ -114,7 +114,7 @@ message AdmissionRequest {
   // Operation might be a CREATE, in which case the Options will a
   // `meta.k8s.io/v1.CreateOptions` even though the caller provided `meta.k8s.io/v1.PatchOptions`.
   // +optional
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension options = 12;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension options = 12;
 }
 
 // AdmissionResponse describes an admission response.
@@ -129,7 +129,7 @@ message AdmissionResponse {
   // Result contains extra details into why an admission request was denied.
   // This field IS NOT consulted in any way if "Allowed" is "true".
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Status status = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Status status = 3;
 
   // The patch body. Currently we only support "JSONPatch" which implements RFC 6902.
   // +optional

--- a/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
@@ -156,7 +156,7 @@ message MatchResources {
   //
   // Default to the empty LabelSelector, which matches everything.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 1;
 
   // ObjectSelector decides whether to run the validation based on if the
   // object has matching labels. objectSelector is evaluated against both
@@ -170,7 +170,7 @@ message MatchResources {
   // users may skip the admission webhook by setting the labels.
   // Default to the empty LabelSelector, which matches everything.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector objectSelector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector objectSelector = 2;
 
   // ResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy matches.
   // The policy cares about an operation if it matches _any_ Rule.
@@ -290,7 +290,7 @@ message MutatingWebhook {
   //
   // Default to the empty LabelSelector, which matches everything.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 5;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 5;
 
   // ObjectSelector decides whether to run the webhook based on if the
   // object has matching labels. objectSelector is evaluated against both
@@ -304,7 +304,7 @@ message MutatingWebhook {
   // users may skip the admission webhook by setting the labels.
   // Default to the empty LabelSelector, which matches everything.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector objectSelector = 11;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector objectSelector = 11;
 
   // SideEffects states whether this webhook has side effects.
   // Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown).
@@ -374,7 +374,7 @@ message MutatingWebhook {
 message MutatingWebhookConfiguration {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Webhooks is a list of webhooks and the affected resources and operations.
   // +optional
@@ -390,7 +390,7 @@ message MutatingWebhookConfigurationList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of MutatingWebhookConfiguration.
   repeated MutatingWebhookConfiguration items = 2;
@@ -463,7 +463,7 @@ message ParamRef {
   // mutually exclusive properties. If one is set, the other must be unset.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 3;
 
   // `parameterNotFoundAction` controls the behavior of the binding when the resource
   // exists, and name or selector is valid, but there are no parameters
@@ -579,7 +579,7 @@ message TypeChecking {
 message ValidatingAdmissionPolicy {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the ValidatingAdmissionPolicy.
   optional ValidatingAdmissionPolicySpec spec = 2;
@@ -606,7 +606,7 @@ message ValidatingAdmissionPolicy {
 message ValidatingAdmissionPolicyBinding {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
   optional ValidatingAdmissionPolicyBindingSpec spec = 2;
@@ -617,7 +617,7 @@ message ValidatingAdmissionPolicyBindingList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of PolicyBinding.
   repeated ValidatingAdmissionPolicyBinding items = 2;
@@ -695,7 +695,7 @@ message ValidatingAdmissionPolicyList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of ValidatingAdmissionPolicy.
   repeated ValidatingAdmissionPolicy items = 2;
@@ -800,7 +800,7 @@ message ValidatingAdmissionPolicyStatus {
   // +optional
   // +listType=map
   // +listMapKey=type
-  repeated k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 3;
+  repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 3;
 }
 
 // ValidatingWebhook describes an admission webhook and the resources and operations it applies to.
@@ -891,7 +891,7 @@ message ValidatingWebhook {
   //
   // Default to the empty LabelSelector, which matches everything.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 5;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 5;
 
   // ObjectSelector decides whether to run the webhook based on if the
   // object has matching labels. objectSelector is evaluated against both
@@ -905,7 +905,7 @@ message ValidatingWebhook {
   // users may skip the admission webhook by setting the labels.
   // Default to the empty LabelSelector, which matches everything.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector objectSelector = 10;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector objectSelector = 10;
 
   // SideEffects states whether this webhook has side effects.
   // Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown).
@@ -957,7 +957,7 @@ message ValidatingWebhook {
 message ValidatingWebhookConfiguration {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Webhooks is a list of webhooks and the affected resources and operations.
   // +optional
@@ -973,7 +973,7 @@ message ValidatingWebhookConfigurationList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of ValidatingWebhookConfiguration.
   repeated ValidatingWebhookConfiguration items = 2;

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/generated.proto
@@ -156,7 +156,7 @@ message MatchResources {
   //
   // Default to the empty LabelSelector, which matches everything.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 1;
 
   // ObjectSelector decides whether to run the validation based on if the
   // object has matching labels. objectSelector is evaluated against both
@@ -170,7 +170,7 @@ message MatchResources {
   // users may skip the admission webhook by setting the labels.
   // Default to the empty LabelSelector, which matches everything.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector objectSelector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector objectSelector = 2;
 
   // ResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy matches.
   // The policy cares about an operation if it matches _any_ Rule.
@@ -211,7 +211,7 @@ message NamedRuleWithOperations {
   repeated string resourceNames = 1;
 
   // RuleWithOperations is a tuple of Operations and Resources.
-  optional k8s.io.api.admissionregistration.v1.RuleWithOperations ruleWithOperations = 2;
+  optional .k8s.io.api.admissionregistration.v1.RuleWithOperations ruleWithOperations = 2;
 }
 
 // ParamKind is a tuple of Group Kind and Version.
@@ -267,7 +267,7 @@ message ParamRef {
   // mutually exclusive properties. If one is set, the other must be unset.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 3;
 
   // `parameterNotFoundAction` controls the behavior of the binding when the resource
   // exists, and name or selector is valid, but there are no parameters
@@ -295,7 +295,7 @@ message TypeChecking {
 message ValidatingAdmissionPolicy {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the ValidatingAdmissionPolicy.
   optional ValidatingAdmissionPolicySpec spec = 2;
@@ -322,7 +322,7 @@ message ValidatingAdmissionPolicy {
 message ValidatingAdmissionPolicyBinding {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
   optional ValidatingAdmissionPolicyBindingSpec spec = 2;
@@ -333,7 +333,7 @@ message ValidatingAdmissionPolicyBindingList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of PolicyBinding.
   repeated ValidatingAdmissionPolicyBinding items = 2;
@@ -409,7 +409,7 @@ message ValidatingAdmissionPolicyList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of ValidatingAdmissionPolicy.
   repeated ValidatingAdmissionPolicy items = 2;
@@ -514,7 +514,7 @@ message ValidatingAdmissionPolicyStatus {
   // +optional
   // +listType=map
   // +listMapKey=type
-  repeated k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 3;
+  repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 3;
 }
 
 // Validation specifies the CEL expression which is used to apply the validation.

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
@@ -157,7 +157,7 @@ message MatchResources {
   //
   // Default to the empty LabelSelector, which matches everything.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 1;
 
   // ObjectSelector decides whether to run the validation based on if the
   // object has matching labels. objectSelector is evaluated against both
@@ -171,7 +171,7 @@ message MatchResources {
   // users may skip the admission webhook by setting the labels.
   // Default to the empty LabelSelector, which matches everything.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector objectSelector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector objectSelector = 2;
 
   // ResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy matches.
   // The policy cares about an operation if it matches _any_ Rule.
@@ -223,7 +223,7 @@ message MutatingWebhook {
   // disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called
   // on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
   // +listType=atomic
-  repeated k8s.io.api.admissionregistration.v1.RuleWithOperations rules = 3;
+  repeated .k8s.io.api.admissionregistration.v1.RuleWithOperations rules = 3;
 
   // FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
   // allowed values are Ignore or Fail. Defaults to Ignore.
@@ -291,7 +291,7 @@ message MutatingWebhook {
   //
   // Default to the empty LabelSelector, which matches everything.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 5;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 5;
 
   // ObjectSelector decides whether to run the webhook based on if the
   // object has matching labels. objectSelector is evaluated against both
@@ -305,7 +305,7 @@ message MutatingWebhook {
   // users may skip the admission webhook by setting the labels.
   // Default to the empty LabelSelector, which matches everything.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector objectSelector = 11;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector objectSelector = 11;
 
   // SideEffects states whether this webhook has side effects.
   // Acceptable values are: Unknown, None, Some, NoneOnDryRun
@@ -379,7 +379,7 @@ message MutatingWebhook {
 message MutatingWebhookConfiguration {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Webhooks is a list of webhooks and the affected resources and operations.
   // +optional
@@ -395,7 +395,7 @@ message MutatingWebhookConfigurationList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of MutatingWebhookConfiguration.
   repeated MutatingWebhookConfiguration items = 2;
@@ -410,7 +410,7 @@ message NamedRuleWithOperations {
   repeated string resourceNames = 1;
 
   // RuleWithOperations is a tuple of Operations and Resources.
-  optional k8s.io.api.admissionregistration.v1.RuleWithOperations ruleWithOperations = 2;
+  optional .k8s.io.api.admissionregistration.v1.RuleWithOperations ruleWithOperations = 2;
 }
 
 // ParamKind is a tuple of Group Kind and Version.
@@ -468,7 +468,7 @@ message ParamRef {
   // mutually exclusive properties. If one is set, the other must be unset.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 3;
 
   // `parameterNotFoundAction` controls the behavior of the binding when the resource
   // exists, and name or selector is valid, but there are no parameters
@@ -523,7 +523,7 @@ message TypeChecking {
 message ValidatingAdmissionPolicy {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the ValidatingAdmissionPolicy.
   optional ValidatingAdmissionPolicySpec spec = 2;
@@ -550,7 +550,7 @@ message ValidatingAdmissionPolicy {
 message ValidatingAdmissionPolicyBinding {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
   optional ValidatingAdmissionPolicyBindingSpec spec = 2;
@@ -561,7 +561,7 @@ message ValidatingAdmissionPolicyBindingList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of PolicyBinding.
   repeated ValidatingAdmissionPolicyBinding items = 2;
@@ -639,7 +639,7 @@ message ValidatingAdmissionPolicyList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of ValidatingAdmissionPolicy.
   repeated ValidatingAdmissionPolicy items = 2;
@@ -744,7 +744,7 @@ message ValidatingAdmissionPolicyStatus {
   // +optional
   // +listType=map
   // +listMapKey=type
-  repeated k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 3;
+  repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 3;
 }
 
 // ValidatingWebhook describes an admission webhook and the resources and operations it applies to.
@@ -767,7 +767,7 @@ message ValidatingWebhook {
   // disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called
   // on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
   // +listType=atomic
-  repeated k8s.io.api.admissionregistration.v1.RuleWithOperations rules = 3;
+  repeated .k8s.io.api.admissionregistration.v1.RuleWithOperations rules = 3;
 
   // FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
   // allowed values are Ignore or Fail. Defaults to Ignore.
@@ -835,7 +835,7 @@ message ValidatingWebhook {
   //
   // Default to the empty LabelSelector, which matches everything.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 5;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 5;
 
   // ObjectSelector decides whether to run the webhook based on if the
   // object has matching labels. objectSelector is evaluated against both
@@ -849,7 +849,7 @@ message ValidatingWebhook {
   // users may skip the admission webhook by setting the labels.
   // Default to the empty LabelSelector, which matches everything.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector objectSelector = 10;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector objectSelector = 10;
 
   // SideEffects states whether this webhook has side effects.
   // Acceptable values are: Unknown, None, Some, NoneOnDryRun
@@ -906,7 +906,7 @@ message ValidatingWebhook {
 message ValidatingWebhookConfiguration {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Webhooks is a list of webhooks and the affected resources and operations.
   // +optional
@@ -922,7 +922,7 @@ message ValidatingWebhookConfigurationList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of ValidatingWebhookConfiguration.
   repeated ValidatingWebhookConfiguration items = 2;

--- a/staging/src/k8s.io/api/apidiscovery/v2/generated.proto
+++ b/staging/src/k8s.io/api/apidiscovery/v2/generated.proto
@@ -38,7 +38,7 @@ message APIGroupDiscovery {
   // name is allowed to be "" to represent the legacy, ungroupified resources.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // versions are the versions supported in this group. They are sorted in descending order of preference,
   // with the preferred version being the first entry.
@@ -55,7 +55,7 @@ message APIGroupDiscoveryList {
   // ResourceVersion will not be set, because this does not have a replayable ordering among multiple apiservers.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of groups for discovery. The groups are listed in priority order.
   repeated APIGroupDiscovery items = 2;
@@ -72,7 +72,7 @@ message APIResourceDiscovery {
   // responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
   // APIs may return other objects types at their discretion, such as error conditions, requests for alternate representations, or other operation specific behavior.
   // This value will be null or empty if an APIService reports subresources but supports no operations on the parent resource
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind responseKind = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind responseKind = 2;
 
   // scope indicates the scope of a resource, either Cluster or Namespaced
   optional string scope = 3;
@@ -112,7 +112,7 @@ message APISubresourceDiscovery {
 
   // responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
   // Some subresources do not return normal resources, these will have null or empty return types.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind responseKind = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind responseKind = 2;
 
   // acceptedTypes describes the kinds that this endpoint accepts.
   // Subresources may accept the standard content types or define
@@ -122,7 +122,7 @@ message APISubresourceDiscovery {
   // +listMapKey=group
   // +listMapKey=version
   // +listMapKey=kind
-  repeated k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind acceptedTypes = 3;
+  repeated .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind acceptedTypes = 3;
 
   // verbs is a list of supported API operation types (this includes
   // but is not limited to get, list, watch, create, update, patch,

--- a/staging/src/k8s.io/api/apidiscovery/v2beta1/generated.proto
+++ b/staging/src/k8s.io/api/apidiscovery/v2beta1/generated.proto
@@ -38,7 +38,7 @@ message APIGroupDiscovery {
   // name is allowed to be "" to represent the legacy, ungroupified resources.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // versions are the versions supported in this group. They are sorted in descending order of preference,
   // with the preferred version being the first entry.
@@ -55,7 +55,7 @@ message APIGroupDiscoveryList {
   // ResourceVersion will not be set, because this does not have a replayable ordering among multiple apiservers.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of groups for discovery. The groups are listed in priority order.
   repeated APIGroupDiscovery items = 2;
@@ -72,7 +72,7 @@ message APIResourceDiscovery {
   // responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
   // APIs may return other objects types at their discretion, such as error conditions, requests for alternate representations, or other operation specific behavior.
   // This value will be null or empty if an APIService reports subresources but supports no operations on the parent resource
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind responseKind = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind responseKind = 2;
 
   // scope indicates the scope of a resource, either Cluster or Namespaced
   optional string scope = 3;
@@ -112,7 +112,7 @@ message APISubresourceDiscovery {
 
   // responseKind describes the group, version, and kind of the serialization schema for the object type this endpoint typically returns.
   // Some subresources do not return normal resources, these will have null or empty return types.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind responseKind = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind responseKind = 2;
 
   // acceptedTypes describes the kinds that this endpoint accepts.
   // Subresources may accept the standard content types or define
@@ -122,7 +122,7 @@ message APISubresourceDiscovery {
   // +listMapKey=group
   // +listMapKey=version
   // +listMapKey=kind
-  repeated k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind acceptedTypes = 3;
+  repeated .k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionKind acceptedTypes = 3;
 
   // verbs is a list of supported API operation types (this includes
   // but is not limited to get, list, watch, create, update, patch,

--- a/staging/src/k8s.io/api/apiserverinternal/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/apiserverinternal/v1alpha1/generated.proto
@@ -52,7 +52,7 @@ message ServerStorageVersion {
 // Storage version of a specific resource.
 message StorageVersion {
   // The name is <group>.<resource>.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec is an empty spec. It is here to comply with Kubernetes API style.
   optional StorageVersionSpec spec = 2;
@@ -77,7 +77,7 @@ message StorageVersionCondition {
   optional int64 observedGeneration = 3;
 
   // Last time the condition transitioned from one status to another.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
 
   // The reason for the condition's last transition.
   // +required
@@ -93,7 +93,7 @@ message StorageVersionList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items holds a list of StorageVersion
   repeated StorageVersion items = 2;

--- a/staging/src/k8s.io/api/apps/v1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1/generated.proto
@@ -43,10 +43,10 @@ message ControllerRevision {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Data is the serialized representation of the state.
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension data = 2;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension data = 2;
 
   // Revision indicates the revision of the state represented by Data.
   optional int64 revision = 3;
@@ -56,7 +56,7 @@ message ControllerRevision {
 message ControllerRevisionList {
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of ControllerRevisions
   repeated ControllerRevision items = 2;
@@ -67,7 +67,7 @@ message DaemonSet {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // The desired behavior of this daemon set.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -93,7 +93,7 @@ message DaemonSetCondition {
 
   // Last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // The reason for the condition's last transition.
   // +optional
@@ -109,7 +109,7 @@ message DaemonSetList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // A list of daemon sets.
   repeated DaemonSet items = 2;
@@ -121,7 +121,7 @@ message DaemonSetSpec {
   // Must match in order to be controlled.
   // It must match the pod template's labels.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 1;
 
   // An object that describes the pod that will be created.
   // The DaemonSet will create exactly one copy of this pod on every node
@@ -129,7 +129,7 @@ message DaemonSetSpec {
   // selector is specified).
   // The only allowed template.spec.restartPolicy value is "Always".
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
-  optional k8s.io.api.core.v1.PodTemplateSpec template = 2;
+  optional .k8s.io.api.core.v1.PodTemplateSpec template = 2;
 
   // An update strategy to replace existing DaemonSet pods with new pods.
   // +optional
@@ -225,7 +225,7 @@ message Deployment {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the Deployment.
   // +optional
@@ -245,10 +245,10 @@ message DeploymentCondition {
   optional string status = 2;
 
   // The last time this condition was updated.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastUpdateTime = 6;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastUpdateTime = 6;
 
   // Last time the condition transitioned from one status to another.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 7;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 7;
 
   // The reason for the condition's last transition.
   optional string reason = 4;
@@ -261,7 +261,7 @@ message DeploymentCondition {
 message DeploymentList {
   // Standard list metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of Deployments.
   repeated Deployment items = 2;
@@ -277,11 +277,11 @@ message DeploymentSpec {
   // Label selector for pods. Existing ReplicaSets whose pods are
   // selected by this will be the ones affected by this deployment.
   // It must match the pod template's labels.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // Template describes the pods that will be created.
   // The only allowed template.spec.restartPolicy value is "Always".
-  optional k8s.io.api.core.v1.PodTemplateSpec template = 3;
+  optional .k8s.io.api.core.v1.PodTemplateSpec template = 3;
 
   // The deployment strategy to use to replace existing pods with new ones.
   // +optional
@@ -376,7 +376,7 @@ message ReplicaSet {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the specification of the desired behavior of the ReplicaSet.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -402,7 +402,7 @@ message ReplicaSetCondition {
 
   // The last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // The reason for the condition's last transition.
   // +optional
@@ -418,7 +418,7 @@ message ReplicaSetList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of ReplicaSets.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
@@ -444,13 +444,13 @@ message ReplicaSetSpec {
   // Label keys and values that must match in order to be controlled by this replica set.
   // It must match the pod template's labels.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // Template is the object that describes the pod that will be created if
   // insufficient replicas are detected.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
   // +optional
-  optional k8s.io.api.core.v1.PodTemplateSpec template = 3;
+  optional .k8s.io.api.core.v1.PodTemplateSpec template = 3;
 }
 
 // ReplicaSetStatus represents the current status of a ReplicaSet.
@@ -501,7 +501,7 @@ message RollingUpdateDaemonSet {
   // 70% of original number of DaemonSet pods are available at all times during
   // the update.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
 
   // The maximum number of nodes with an existing available DaemonSet pod that
   // can have an updated DaemonSet pod during during an update.
@@ -522,7 +522,7 @@ message RollingUpdateDaemonSet {
   // so resource intensive daemonsets should take into account that they may
   // cause evictions during disruption.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
 }
 
 // Spec to control the desired behavior of rolling update.
@@ -538,7 +538,7 @@ message RollingUpdateDeployment {
   // that the total number of pods available at all times during the update is at
   // least 70% of desired pods.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
 
   // The maximum number of pods that can be scheduled above the desired number of
   // pods.
@@ -552,7 +552,7 @@ message RollingUpdateDeployment {
   // new ReplicaSet can be scaled up further, ensuring that total number of pods running
   // at any time during the update is at most 130% of desired pods.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
 }
 
 // RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.
@@ -572,7 +572,7 @@ message RollingUpdateStatefulSetStrategy {
   // Replicas-1. That means if there is any unavailable pod in the range 0 to Replicas-1, it
   // will be counted towards MaxUnavailable.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 2;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 2;
 }
 
 // StatefulSet represents a set of pods with consistent identities.
@@ -586,7 +586,7 @@ message StatefulSet {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the desired identities of pods in this set.
   // +optional
@@ -608,7 +608,7 @@ message StatefulSetCondition {
 
   // Last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // The reason for the condition's last transition.
   // +optional
@@ -624,7 +624,7 @@ message StatefulSetList {
   // Standard list's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of stateful sets.
   repeated StatefulSet items = 2;
@@ -675,7 +675,7 @@ message StatefulSetSpec {
   // selector is a label query over pods that should match the replica count.
   // It must match the pod template's labels.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // template is the object that describes the pod that will be created if
   // insufficient replicas are detected. Each pod stamped out by the StatefulSet
@@ -684,7 +684,7 @@ message StatefulSetSpec {
   // <statefulsetname>-<podindex>. For example, a pod in a StatefulSet named
   // "web" with index number "3" would be named "web-3".
   // The only allowed template.spec.restartPolicy value is "Always".
-  optional k8s.io.api.core.v1.PodTemplateSpec template = 3;
+  optional .k8s.io.api.core.v1.PodTemplateSpec template = 3;
 
   // volumeClaimTemplates is a list of claims that pods are allowed to reference.
   // The StatefulSet controller is responsible for mapping network identities to
@@ -695,7 +695,7 @@ message StatefulSetSpec {
   // TODO: Define the behavior if a claim already exists with the same name.
   // +optional
   // +listType=atomic
-  repeated k8s.io.api.core.v1.PersistentVolumeClaim volumeClaimTemplates = 4;
+  repeated .k8s.io.api.core.v1.PersistentVolumeClaim volumeClaimTemplates = 4;
 
   // serviceName is the name of the service that governs this StatefulSet.
   // This service must exist before the StatefulSet, and is responsible for

--- a/staging/src/k8s.io/api/apps/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta1/generated.proto
@@ -45,10 +45,10 @@ message ControllerRevision {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // data is the serialized representation of the state.
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension data = 2;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension data = 2;
 
   // revision indicates the revision of the state represented by Data.
   optional int64 revision = 3;
@@ -58,7 +58,7 @@ message ControllerRevision {
 message ControllerRevisionList {
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of ControllerRevisions
   repeated ControllerRevision items = 2;
@@ -70,7 +70,7 @@ message ControllerRevisionList {
 message Deployment {
   // Standard object metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the Deployment.
   // +optional
@@ -90,10 +90,10 @@ message DeploymentCondition {
   optional string status = 2;
 
   // The last time this condition was updated.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastUpdateTime = 6;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastUpdateTime = 6;
 
   // Last time the condition transitioned from one status to another.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 7;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 7;
 
   // The reason for the condition's last transition.
   optional string reason = 4;
@@ -106,7 +106,7 @@ message DeploymentCondition {
 message DeploymentList {
   // Standard list metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of Deployments.
   repeated Deployment items = 2;
@@ -136,11 +136,11 @@ message DeploymentSpec {
   // selector is the label selector for pods. Existing ReplicaSets whose pods are
   // selected by this will be the ones affected by this deployment.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // Template describes the pods that will be created.
   // The only allowed template.spec.restartPolicy value is "Always".
-  optional k8s.io.api.core.v1.PodTemplateSpec template = 3;
+  optional .k8s.io.api.core.v1.PodTemplateSpec template = 3;
 
   // The deployment strategy to use to replace existing pods with new ones.
   // +optional
@@ -254,7 +254,7 @@ message RollingUpdateDeployment {
   // that the total number of pods available at all times during the update is at
   // least 70% of desired pods.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
 
   // The maximum number of pods that can be scheduled above the desired number of
   // pods.
@@ -268,7 +268,7 @@ message RollingUpdateDeployment {
   // new ReplicaSet can be scaled up further, ensuring that total number of pods running
   // at any time during the update is at most 130% of desired pods.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
 }
 
 // RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.
@@ -287,14 +287,14 @@ message RollingUpdateStatefulSetStrategy {
   // Replicas-1. That means if there is any unavailable pod in the range 0 to Replicas-1, it
   // will be counted towards MaxUnavailable.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 2;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 2;
 }
 
 // Scale represents a scaling request for a resource.
 message Scale {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
   // +optional
@@ -342,7 +342,7 @@ message ScaleStatus {
 // map to the same storage identity.
 message StatefulSet {
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the desired identities of pods in this set.
   // +optional
@@ -364,7 +364,7 @@ message StatefulSetCondition {
 
   // Last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // The reason for the condition's last transition.
   // +optional
@@ -378,7 +378,7 @@ message StatefulSetCondition {
 // StatefulSetList is a collection of StatefulSets.
 message StatefulSetList {
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   repeated StatefulSet items = 2;
 }
@@ -429,7 +429,7 @@ message StatefulSetSpec {
   // If empty, defaulted to labels on the pod template.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // template is the object that describes the pod that will be created if
   // insufficient replicas are detected. Each pod stamped out by the StatefulSet
@@ -437,7 +437,7 @@ message StatefulSetSpec {
   // of the StatefulSet. Each pod will be named with the format
   // <statefulsetname>-<podindex>. For example, a pod in a StatefulSet named
   // "web" with index number "3" would be named "web-3".
-  optional k8s.io.api.core.v1.PodTemplateSpec template = 3;
+  optional .k8s.io.api.core.v1.PodTemplateSpec template = 3;
 
   // volumeClaimTemplates is a list of claims that pods are allowed to reference.
   // The StatefulSet controller is responsible for mapping network identities to
@@ -448,7 +448,7 @@ message StatefulSetSpec {
   // TODO: Define the behavior if a claim already exists with the same name.
   // +optional
   // +listType=atomic
-  repeated k8s.io.api.core.v1.PersistentVolumeClaim volumeClaimTemplates = 4;
+  repeated .k8s.io.api.core.v1.PersistentVolumeClaim volumeClaimTemplates = 4;
 
   // serviceName is the name of the service that governs this StatefulSet.
   // This service must exist before the StatefulSet, and is responsible for

--- a/staging/src/k8s.io/api/apps/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta2/generated.proto
@@ -45,10 +45,10 @@ message ControllerRevision {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Data is the serialized representation of the state.
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension data = 2;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension data = 2;
 
   // Revision indicates the revision of the state represented by Data.
   optional int64 revision = 3;
@@ -58,7 +58,7 @@ message ControllerRevision {
 message ControllerRevisionList {
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of ControllerRevisions
   repeated ControllerRevision items = 2;
@@ -71,7 +71,7 @@ message DaemonSet {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // The desired behavior of this daemon set.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -97,7 +97,7 @@ message DaemonSetCondition {
 
   // Last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // The reason for the condition's last transition.
   // +optional
@@ -113,7 +113,7 @@ message DaemonSetList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // A list of daemon sets.
   repeated DaemonSet items = 2;
@@ -125,7 +125,7 @@ message DaemonSetSpec {
   // Must match in order to be controlled.
   // It must match the pod template's labels.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 1;
 
   // An object that describes the pod that will be created.
   // The DaemonSet will create exactly one copy of this pod on every node
@@ -133,7 +133,7 @@ message DaemonSetSpec {
   // selector is specified).
   // The only allowed template.spec.restartPolicy value is "Always".
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
-  optional k8s.io.api.core.v1.PodTemplateSpec template = 2;
+  optional .k8s.io.api.core.v1.PodTemplateSpec template = 2;
 
   // An update strategy to replace existing DaemonSet pods with new pods.
   // +optional
@@ -230,7 +230,7 @@ message DaemonSetUpdateStrategy {
 message Deployment {
   // Standard object metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the Deployment.
   // +optional
@@ -250,10 +250,10 @@ message DeploymentCondition {
   optional string status = 2;
 
   // The last time this condition was updated.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastUpdateTime = 6;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastUpdateTime = 6;
 
   // Last time the condition transitioned from one status to another.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 7;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 7;
 
   // The reason for the condition's last transition.
   optional string reason = 4;
@@ -266,7 +266,7 @@ message DeploymentCondition {
 message DeploymentList {
   // Standard list metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of Deployments.
   repeated Deployment items = 2;
@@ -282,11 +282,11 @@ message DeploymentSpec {
   // Label selector for pods. Existing ReplicaSets whose pods are
   // selected by this will be the ones affected by this deployment.
   // It must match the pod template's labels.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // Template describes the pods that will be created.
   // The only allowed template.spec.restartPolicy value is "Always".
-  optional k8s.io.api.core.v1.PodTemplateSpec template = 3;
+  optional .k8s.io.api.core.v1.PodTemplateSpec template = 3;
 
   // The deployment strategy to use to replace existing pods with new ones.
   // +optional
@@ -382,7 +382,7 @@ message ReplicaSet {
   // be the same as the Pod(s) that the ReplicaSet manages.
   // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the specification of the desired behavior of the ReplicaSet.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -408,7 +408,7 @@ message ReplicaSetCondition {
 
   // The last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // The reason for the condition's last transition.
   // +optional
@@ -424,7 +424,7 @@ message ReplicaSetList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of ReplicaSets.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
@@ -450,13 +450,13 @@ message ReplicaSetSpec {
   // Label keys and values that must match in order to be controlled by this replica set.
   // It must match the pod template's labels.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // Template is the object that describes the pod that will be created if
   // insufficient replicas are detected.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
   // +optional
-  optional k8s.io.api.core.v1.PodTemplateSpec template = 3;
+  optional .k8s.io.api.core.v1.PodTemplateSpec template = 3;
 }
 
 // ReplicaSetStatus represents the current status of a ReplicaSet.
@@ -507,7 +507,7 @@ message RollingUpdateDaemonSet {
   // 70% of original number of DaemonSet pods are available at all times during
   // the update.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
 
   // The maximum number of nodes with an existing available DaemonSet pod that
   // can have an updated DaemonSet pod during during an update.
@@ -528,7 +528,7 @@ message RollingUpdateDaemonSet {
   // so resource intensive daemonsets should take into account that they may
   // cause evictions during disruption.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
 }
 
 // Spec to control the desired behavior of rolling update.
@@ -544,7 +544,7 @@ message RollingUpdateDeployment {
   // that the total number of pods available at all times during the update is at
   // least 70% of desired pods.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
 
   // The maximum number of pods that can be scheduled above the desired number of
   // pods.
@@ -558,7 +558,7 @@ message RollingUpdateDeployment {
   // new ReplicaSet can be scaled up further, ensuring that total number of pods running
   // at any time during the update is at most 130% of desired pods.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
 }
 
 // RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.
@@ -578,14 +578,14 @@ message RollingUpdateStatefulSetStrategy {
   // Replicas-1. That means if there is any unavailable pod in the range 0 to Replicas-1, it
   // will be counted towards MaxUnavailable.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 2;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 2;
 }
 
 // Scale represents a scaling request for a resource.
 message Scale {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
   // +optional
@@ -634,7 +634,7 @@ message ScaleStatus {
 // map to the same storage identity.
 message StatefulSet {
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the desired identities of pods in this set.
   // +optional
@@ -656,7 +656,7 @@ message StatefulSetCondition {
 
   // Last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // The reason for the condition's last transition.
   // +optional
@@ -670,7 +670,7 @@ message StatefulSetCondition {
 // StatefulSetList is a collection of StatefulSets.
 message StatefulSetList {
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   repeated StatefulSet items = 2;
 }
@@ -720,7 +720,7 @@ message StatefulSetSpec {
   // selector is a label query over pods that should match the replica count.
   // It must match the pod template's labels.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // template is the object that describes the pod that will be created if
   // insufficient replicas are detected. Each pod stamped out by the StatefulSet
@@ -729,7 +729,7 @@ message StatefulSetSpec {
   // <statefulsetname>-<podindex>. For example, a pod in a StatefulSet named
   // "web" with index number "3" would be named "web-3".
   // The only allowed template.spec.restartPolicy value is "Always".
-  optional k8s.io.api.core.v1.PodTemplateSpec template = 3;
+  optional .k8s.io.api.core.v1.PodTemplateSpec template = 3;
 
   // volumeClaimTemplates is a list of claims that pods are allowed to reference.
   // The StatefulSet controller is responsible for mapping network identities to
@@ -740,7 +740,7 @@ message StatefulSetSpec {
   // TODO: Define the behavior if a claim already exists with the same name.
   // +optional
   // +listType=atomic
-  repeated k8s.io.api.core.v1.PersistentVolumeClaim volumeClaimTemplates = 4;
+  repeated .k8s.io.api.core.v1.PersistentVolumeClaim volumeClaimTemplates = 4;
 
   // serviceName is the name of the service that governs this StatefulSet.
   // This service must exist before the StatefulSet, and is responsible for

--- a/staging/src/k8s.io/api/authentication/v1/generated.proto
+++ b/staging/src/k8s.io/api/authentication/v1/generated.proto
@@ -63,7 +63,7 @@ message SelfSubjectReview {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Status is filled in by the server with the user attributes.
   optional SelfSubjectReviewStatus status = 2;
@@ -81,7 +81,7 @@ message TokenRequest {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec holds information about the request being evaluated
   optional TokenRequestSpec spec = 2;
@@ -123,7 +123,7 @@ message TokenRequestStatus {
   optional string token = 1;
 
   // ExpirationTimestamp is the time of expiration of the returned token.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time expirationTimestamp = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time expirationTimestamp = 2;
 }
 
 // TokenReview attempts to authenticate a token to a known user.
@@ -133,7 +133,7 @@ message TokenReview {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec holds information about the request being evaluated
   optional TokenReviewSpec spec = 2;

--- a/staging/src/k8s.io/api/authentication/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/authentication/v1alpha1/generated.proto
@@ -36,7 +36,7 @@ message SelfSubjectReview {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Status is filled in by the server with the user attributes.
   optional SelfSubjectReviewStatus status = 2;
@@ -46,6 +46,6 @@ message SelfSubjectReview {
 message SelfSubjectReviewStatus {
   // User attributes of the user making this request.
   // +optional
-  optional k8s.io.api.authentication.v1.UserInfo userInfo = 1;
+  optional .k8s.io.api.authentication.v1.UserInfo userInfo = 1;
 }
 

--- a/staging/src/k8s.io/api/authentication/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/authentication/v1beta1/generated.proto
@@ -45,7 +45,7 @@ message SelfSubjectReview {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Status is filled in by the server with the user attributes.
   optional SelfSubjectReviewStatus status = 2;
@@ -55,7 +55,7 @@ message SelfSubjectReview {
 message SelfSubjectReviewStatus {
   // User attributes of the user making this request.
   // +optional
-  optional k8s.io.api.authentication.v1.UserInfo userInfo = 1;
+  optional .k8s.io.api.authentication.v1.UserInfo userInfo = 1;
 }
 
 // TokenReview attempts to authenticate a token to a known user.
@@ -65,7 +65,7 @@ message TokenReview {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec holds information about the request being evaluated
   optional TokenReviewSpec spec = 2;

--- a/staging/src/k8s.io/api/authorization/v1/generated.proto
+++ b/staging/src/k8s.io/api/authorization/v1/generated.proto
@@ -44,7 +44,7 @@ message LocalSubjectAccessReview {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace
   // you made the request against.  If empty, it is defaulted.
@@ -145,7 +145,7 @@ message SelfSubjectAccessReview {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec holds information about the request being evaluated.  user and groups must be empty
   optional SelfSubjectAccessReviewSpec spec = 2;
@@ -177,7 +177,7 @@ message SelfSubjectRulesReview {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec holds information about the request being evaluated.
   optional SelfSubjectRulesReviewSpec spec = 2;
@@ -198,7 +198,7 @@ message SubjectAccessReview {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec holds information about the request being evaluated
   optional SubjectAccessReviewSpec spec = 2;

--- a/staging/src/k8s.io/api/authorization/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/authorization/v1beta1/generated.proto
@@ -44,7 +44,7 @@ message LocalSubjectAccessReview {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace
   // you made the request against.  If empty, it is defaulted.
@@ -145,7 +145,7 @@ message SelfSubjectAccessReview {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec holds information about the request being evaluated.  user and groups must be empty
   optional SelfSubjectAccessReviewSpec spec = 2;
@@ -177,7 +177,7 @@ message SelfSubjectRulesReview {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec holds information about the request being evaluated.
   optional SelfSubjectRulesReviewSpec spec = 2;
@@ -198,7 +198,7 @@ message SubjectAccessReview {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec holds information about the request being evaluated
   optional SubjectAccessReviewSpec spec = 2;

--- a/staging/src/k8s.io/api/autoscaling/v1/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v1/generated.proto
@@ -51,7 +51,7 @@ message ContainerResourceMetricSource {
   // resource metric across all relevant pods, as a raw value (instead of as
   // a percentage of the request), similar to the "pods" metric source type.
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 3;
 
   // container is the name of the container in the pods of the scaling target.
   optional string container = 5;
@@ -78,7 +78,7 @@ message ContainerResourceMetricStatus {
   // resource metric across all relevant pods, as a raw value (instead of as
   // a percentage of the request), similar to the "pods" metric source type.
   // It will always be set, regardless of the corresponding metric specification.
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 3;
 
   // container is the name of the container in the pods of the scaling taget
   optional string container = 4;
@@ -108,17 +108,17 @@ message ExternalMetricSource {
   // metricSelector is used to identify a specific time series
   // within a given metric.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector metricSelector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector metricSelector = 2;
 
   // targetValue is the target value of the metric (as a quantity).
   // Mutually exclusive with TargetAverageValue.
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity targetValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity targetValue = 3;
 
   // targetAverageValue is the target per-pod value of global metric (as a quantity).
   // Mutually exclusive with TargetValue.
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 4;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 4;
 }
 
 // ExternalMetricStatus indicates the current value of a global metric
@@ -131,21 +131,21 @@ message ExternalMetricStatus {
   // metricSelector is used to identify a specific time series
   // within a given metric.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector metricSelector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector metricSelector = 2;
 
   // currentValue is the current value of the metric (as a quantity)
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity currentValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentValue = 3;
 
   // currentAverageValue is the current value of metric averaged over autoscaled pods.
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 4;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 4;
 }
 
 // configuration of a horizontal pod autoscaler.
 message HorizontalPodAutoscaler {
   // Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
   // +optional
@@ -168,7 +168,7 @@ message HorizontalPodAutoscalerCondition {
   // lastTransitionTime is the last time the condition transitioned from
   // one status to another
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // reason is the reason for the condition's last transition.
   // +optional
@@ -184,7 +184,7 @@ message HorizontalPodAutoscalerCondition {
 message HorizontalPodAutoscalerList {
   // Standard list metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of horizontal pod autoscaler objects.
   repeated HorizontalPodAutoscaler items = 2;
@@ -222,7 +222,7 @@ message HorizontalPodAutoscalerStatus {
   // lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods;
   // used by the autoscaler to control how often the number of pods is changed.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastScaleTime = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastScaleTime = 2;
 
   // currentReplicas is the current number of replicas of pods managed by this autoscaler.
   optional int32 currentReplicas = 3;
@@ -336,18 +336,18 @@ message ObjectMetricSource {
   optional string metricName = 2;
 
   // targetValue is the target value of the metric (as a quantity).
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity targetValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity targetValue = 3;
 
   // selector is the string-encoded form of a standard kubernetes label selector for the given metric.
   // When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping
   // When unset, just the metricName will be used to gather metrics.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 4;
 
   // averageValue is the target value of the average of the
   // metric across all relevant pods (as a quantity)
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 5;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 5;
 }
 
 // ObjectMetricStatus indicates the current value of a metric describing a
@@ -360,18 +360,18 @@ message ObjectMetricStatus {
   optional string metricName = 2;
 
   // currentValue is the current value of the metric (as a quantity).
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity currentValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentValue = 3;
 
   // selector is the string-encoded form of a standard kubernetes label selector for the given metric
   // When set in the ObjectMetricSource, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
   // When unset, just the metricName will be used to gather metrics.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 4;
 
   // averageValue is the current value of the average of the
   // metric across all relevant pods (as a quantity)
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 5;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 5;
 }
 
 // PodsMetricSource indicates how to scale on a metric describing each pod in
@@ -384,13 +384,13 @@ message PodsMetricSource {
 
   // targetAverageValue is the target value of the average of the
   // metric across all relevant pods (as a quantity)
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 2;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 2;
 
   // selector is the string-encoded form of a standard kubernetes label selector for the given metric
   // When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping
   // When unset, just the metricName will be used to gather metrics.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 3;
 }
 
 // PodsMetricStatus indicates the current value of a metric describing each pod in
@@ -401,13 +401,13 @@ message PodsMetricStatus {
 
   // currentAverageValue is the current value of the average of the
   // metric across all relevant pods (as a quantity)
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 2;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 2;
 
   // selector is the string-encoded form of a standard kubernetes label selector for the given metric
   // When set in the PodsMetricSource, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
   // When unset, just the metricName will be used to gather metrics.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 3;
 }
 
 // ResourceMetricSource indicates how to scale on a resource metric known to
@@ -431,7 +431,7 @@ message ResourceMetricSource {
   // resource metric across all relevant pods, as a raw value (instead of as
   // a percentage of the request), similar to the "pods" metric source type.
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 3;
 }
 
 // ResourceMetricStatus indicates the current value of a resource metric known to
@@ -455,14 +455,14 @@ message ResourceMetricStatus {
   // resource metric across all relevant pods, as a raw value (instead of as
   // a percentage of the request), similar to the "pods" metric source type.
   // It will always be set, regardless of the corresponding metric specification.
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 3;
 }
 
 // Scale represents a scaling request for a resource.
 message Scale {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
   // +optional

--- a/staging/src/k8s.io/api/autoscaling/v2/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2/generated.proto
@@ -147,7 +147,7 @@ message HorizontalPodAutoscaler {
   // metadata is the standard object metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec is the specification for the behaviour of the autoscaler.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
@@ -190,7 +190,7 @@ message HorizontalPodAutoscalerCondition {
   // lastTransitionTime is the last time the condition transitioned from
   // one status to another
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // reason is the reason for the condition's last transition.
   // +optional
@@ -206,7 +206,7 @@ message HorizontalPodAutoscalerCondition {
 message HorizontalPodAutoscalerList {
   // metadata is the standard list metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of horizontal pod autoscaler objects.
   repeated HorizontalPodAutoscaler items = 2;
@@ -258,7 +258,7 @@ message HorizontalPodAutoscalerStatus {
   // lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods,
   // used by the autoscaler to control how often the number of pods is changed.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastScaleTime = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastScaleTime = 2;
 
   // currentReplicas is current number of replicas of pods managed by this autoscaler,
   // as last seen by the autoscaler.
@@ -293,7 +293,7 @@ message MetricIdentifier {
   // When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
   // When unset, just the metricName will be used to gather metrics.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 }
 
 // MetricSpec specifies how to scale based on a single metric
@@ -393,12 +393,12 @@ message MetricTarget {
 
   // value is the target value of the metric (as a quantity).
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity value = 2;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity value = 2;
 
   // averageValue is the target value of the average of the
   // metric across all relevant pods (as a quantity)
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 3;
 
   // averageUtilization is the target value of the average of the
   // resource metric across all relevant pods, represented as a percentage of
@@ -412,12 +412,12 @@ message MetricTarget {
 message MetricValueStatus {
   // value is the current value of the metric (as a quantity).
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity value = 1;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity value = 1;
 
   // averageValue is the current value of the average of the
   // metric across all relevant pods (as a quantity)
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 2;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 2;
 
   // currentAverageUtilization is the current value of the average of the
   // resource metric across all relevant pods, represented as a percentage of

--- a/staging/src/k8s.io/api/autoscaling/v2beta1/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2beta1/generated.proto
@@ -51,7 +51,7 @@ message ContainerResourceMetricSource {
   // resource metric across all relevant pods, as a raw value (instead of as
   // a percentage of the request), similar to the "pods" metric source type.
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 3;
 
   // container is the name of the container in the pods of the scaling target
   optional string container = 4;
@@ -78,7 +78,7 @@ message ContainerResourceMetricStatus {
   // resource metric across all relevant pods, as a raw value (instead of as
   // a percentage of the request), similar to the "pods" metric source type.
   // It will always be set, regardless of the corresponding metric specification.
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 3;
 
   // container is the name of the container in the pods of the scaling target
   optional string container = 4;
@@ -108,17 +108,17 @@ message ExternalMetricSource {
   // metricSelector is used to identify a specific time series
   // within a given metric.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector metricSelector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector metricSelector = 2;
 
   // targetValue is the target value of the metric (as a quantity).
   // Mutually exclusive with TargetAverageValue.
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity targetValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity targetValue = 3;
 
   // targetAverageValue is the target per-pod value of global metric (as a quantity).
   // Mutually exclusive with TargetValue.
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 4;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 4;
 }
 
 // ExternalMetricStatus indicates the current value of a global metric
@@ -131,14 +131,14 @@ message ExternalMetricStatus {
   // metricSelector is used to identify a specific time series
   // within a given metric.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector metricSelector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector metricSelector = 2;
 
   // currentValue is the current value of the metric (as a quantity)
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity currentValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentValue = 3;
 
   // currentAverageValue is the current value of metric averaged over autoscaled pods.
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 4;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 4;
 }
 
 // HorizontalPodAutoscaler is the configuration for a horizontal pod
@@ -148,7 +148,7 @@ message HorizontalPodAutoscaler {
   // metadata is the standard object metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec is the specification for the behaviour of the autoscaler.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
@@ -172,7 +172,7 @@ message HorizontalPodAutoscalerCondition {
   // lastTransitionTime is the last time the condition transitioned from
   // one status to another
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // reason is the reason for the condition's last transition.
   // +optional
@@ -188,7 +188,7 @@ message HorizontalPodAutoscalerCondition {
 message HorizontalPodAutoscalerList {
   // metadata is the standard list metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of horizontal pod autoscaler objects.
   repeated HorizontalPodAutoscaler items = 2;
@@ -233,7 +233,7 @@ message HorizontalPodAutoscalerStatus {
   // lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods,
   // used by the autoscaler to control how often the number of pods is changed.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastScaleTime = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastScaleTime = 2;
 
   // currentReplicas is current number of replicas of pods managed by this autoscaler,
   // as last seen by the autoscaler.
@@ -355,18 +355,18 @@ message ObjectMetricSource {
   optional string metricName = 2;
 
   // targetValue is the target value of the metric (as a quantity).
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity targetValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity targetValue = 3;
 
   // selector is the string-encoded form of a standard kubernetes label selector for the given metric
   // When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping
   // When unset, just the metricName will be used to gather metrics.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 4;
 
   // averageValue is the target value of the average of the
   // metric across all relevant pods (as a quantity)
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 5;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 5;
 }
 
 // ObjectMetricStatus indicates the current value of a metric describing a
@@ -379,18 +379,18 @@ message ObjectMetricStatus {
   optional string metricName = 2;
 
   // currentValue is the current value of the metric (as a quantity).
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity currentValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentValue = 3;
 
   // selector is the string-encoded form of a standard kubernetes label selector for the given metric
   // When set in the ObjectMetricSource, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
   // When unset, just the metricName will be used to gather metrics.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 4;
 
   // averageValue is the current value of the average of the
   // metric across all relevant pods (as a quantity)
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 5;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 5;
 }
 
 // PodsMetricSource indicates how to scale on a metric describing each pod in
@@ -403,13 +403,13 @@ message PodsMetricSource {
 
   // targetAverageValue is the target value of the average of the
   // metric across all relevant pods (as a quantity)
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 2;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 2;
 
   // selector is the string-encoded form of a standard kubernetes label selector for the given metric
   // When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping
   // When unset, just the metricName will be used to gather metrics.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 3;
 }
 
 // PodsMetricStatus indicates the current value of a metric describing each pod in
@@ -420,13 +420,13 @@ message PodsMetricStatus {
 
   // currentAverageValue is the current value of the average of the
   // metric across all relevant pods (as a quantity)
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 2;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 2;
 
   // selector is the string-encoded form of a standard kubernetes label selector for the given metric
   // When set in the PodsMetricSource, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
   // When unset, just the metricName will be used to gather metrics.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 3;
 }
 
 // ResourceMetricSource indicates how to scale on a resource metric known to
@@ -450,7 +450,7 @@ message ResourceMetricSource {
   // resource metric across all relevant pods, as a raw value (instead of as
   // a percentage of the request), similar to the "pods" metric source type.
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity targetAverageValue = 3;
 }
 
 // ResourceMetricStatus indicates the current value of a resource metric known to
@@ -474,6 +474,6 @@ message ResourceMetricStatus {
   // resource metric across all relevant pods, as a raw value (instead of as
   // a percentage of the request), similar to the "pods" metric source type.
   // It will always be set, regardless of the corresponding metric specification.
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity currentAverageValue = 3;
 }
 

--- a/staging/src/k8s.io/api/autoscaling/v2beta2/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2beta2/generated.proto
@@ -147,7 +147,7 @@ message HorizontalPodAutoscaler {
   // metadata is the standard object metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec is the specification for the behaviour of the autoscaler.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
@@ -190,7 +190,7 @@ message HorizontalPodAutoscalerCondition {
   // lastTransitionTime is the last time the condition transitioned from
   // one status to another
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // reason is the reason for the condition's last transition.
   // +optional
@@ -206,7 +206,7 @@ message HorizontalPodAutoscalerCondition {
 message HorizontalPodAutoscalerList {
   // metadata is the standard list metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of horizontal pod autoscaler objects.
   repeated HorizontalPodAutoscaler items = 2;
@@ -258,7 +258,7 @@ message HorizontalPodAutoscalerStatus {
   // lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods,
   // used by the autoscaler to control how often the number of pods is changed.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastScaleTime = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastScaleTime = 2;
 
   // currentReplicas is current number of replicas of pods managed by this autoscaler,
   // as last seen by the autoscaler.
@@ -289,7 +289,7 @@ message MetricIdentifier {
   // When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
   // When unset, just the metricName will be used to gather metrics.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 }
 
 // MetricSpec specifies how to scale based on a single metric
@@ -389,12 +389,12 @@ message MetricTarget {
 
   // value is the target value of the metric (as a quantity).
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity value = 2;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity value = 2;
 
   // averageValue is the target value of the average of the
   // metric across all relevant pods (as a quantity)
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 3;
 
   // averageUtilization is the target value of the average of the
   // resource metric across all relevant pods, represented as a percentage of
@@ -408,12 +408,12 @@ message MetricTarget {
 message MetricValueStatus {
   // value is the current value of the metric (as a quantity).
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity value = 1;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity value = 1;
 
   // averageValue is the current value of the average of the
   // metric across all relevant pods (as a quantity)
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 2;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 2;
 
   // averageUtilization is the current value of the average of the
   // resource metric across all relevant pods, represented as a percentage of

--- a/staging/src/k8s.io/api/batch/v1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1/generated.proto
@@ -34,7 +34,7 @@ message CronJob {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of a cron job, including the schedule.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -52,7 +52,7 @@ message CronJobList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of CronJobs.
   repeated CronJob items = 2;
@@ -113,15 +113,15 @@ message CronJobStatus {
   // A list of pointers to currently running jobs.
   // +optional
   // +listType=atomic
-  repeated k8s.io.api.core.v1.ObjectReference active = 1;
+  repeated .k8s.io.api.core.v1.ObjectReference active = 1;
 
   // Information when was the last time the job was successfully scheduled.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastScheduleTime = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastScheduleTime = 4;
 
   // Information when was the last time the job successfully completed.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastSuccessfulTime = 5;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastSuccessfulTime = 5;
 }
 
 // Job represents the configuration of a single job.
@@ -129,7 +129,7 @@ message Job {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of a job.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -152,11 +152,11 @@ message JobCondition {
 
   // Last time the condition was checked.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastProbeTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastProbeTime = 3;
 
   // Last time the condition transit from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
 
   // (brief) reason for the condition's last transition.
   // +optional
@@ -172,7 +172,7 @@ message JobList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of Jobs.
   repeated Job items = 2;
@@ -262,7 +262,7 @@ message JobSpec {
   // Normally, the system sets this field for you.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 4;
 
   // manualSelector controls generation of pod labels and pod selectors.
   // Leave `manualSelector` unset unless you are certain what you are doing.
@@ -280,7 +280,7 @@ message JobSpec {
   // Describes the pod that will be created when executing a job.
   // The only allowed template.spec.restartPolicy values are "Never" or "OnFailure".
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
-  optional k8s.io.api.core.v1.PodTemplateSpec template = 6;
+  optional .k8s.io.api.core.v1.PodTemplateSpec template = 6;
 
   // ttlSecondsAfterFinished limits the lifetime of a Job that has finished
   // execution (either Complete or Failed). If this field is set,
@@ -387,7 +387,7 @@ message JobStatus {
   // The field cannot be modified while the job is unsuspended or finished.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time startTime = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time startTime = 2;
 
   // Represents time when the job was completed. It is not guaranteed to
   // be set in happens-before order across separate operations.
@@ -396,7 +396,7 @@ message JobStatus {
   // The value cannot be updated or removed. The value indicates the same or
   // later point in time as the startTime field.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time completionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time completionTime = 3;
 
   // The number of pending and running pods which are not terminating (without
   // a deletionTimestamp).
@@ -476,7 +476,7 @@ message JobTemplateSpec {
   // Standard object's metadata of the jobs created from this template.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the job.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status

--- a/staging/src/k8s.io/api/batch/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1beta1/generated.proto
@@ -35,7 +35,7 @@ message CronJob {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of a cron job, including the schedule.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -53,7 +53,7 @@ message CronJobList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of CronJobs.
   repeated CronJob items = 2;
@@ -116,15 +116,15 @@ message CronJobStatus {
   // A list of pointers to currently running jobs.
   // +optional
   // +listType=atomic
-  repeated k8s.io.api.core.v1.ObjectReference active = 1;
+  repeated .k8s.io.api.core.v1.ObjectReference active = 1;
 
   // Information when was the last time the job was successfully scheduled.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastScheduleTime = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastScheduleTime = 4;
 
   // Information when was the last time the job successfully completed.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastSuccessfulTime = 5;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastSuccessfulTime = 5;
 }
 
 // JobTemplateSpec describes the data a Job should have when created from a template
@@ -132,11 +132,11 @@ message JobTemplateSpec {
   // Standard object's metadata of the jobs created from this template.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the job.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
   // +optional
-  optional k8s.io.api.batch.v1.JobSpec spec = 2;
+  optional .k8s.io.api.batch.v1.JobSpec spec = 2;
 }
 

--- a/staging/src/k8s.io/api/certificates/v1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1/generated.proto
@@ -41,7 +41,7 @@ option go_package = "k8s.io/api/certificates/v1";
 // or to obtain certificates from custom non-Kubernetes signers.
 message CertificateSigningRequest {
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec contains the certificate request, and is immutable after creation.
   // Only the request, signerName, expirationSeconds, and usages fields can be set on creation.
@@ -87,19 +87,19 @@ message CertificateSigningRequestCondition {
 
   // lastUpdateTime is the time of the last update to this condition
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastUpdateTime = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastUpdateTime = 4;
 
   // lastTransitionTime is the time the condition last transitioned from one status to another.
   // If unset, when a new condition type is added or an existing condition's status is changed,
   // the server defaults this to the current time.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 5;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 5;
 }
 
 // CertificateSigningRequestList is a collection of CertificateSigningRequest objects
 message CertificateSigningRequestList {
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is a collection of CertificateSigningRequest objects
   repeated CertificateSigningRequest items = 2;

--- a/staging/src/k8s.io/api/certificates/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1alpha1/generated.proto
@@ -46,7 +46,7 @@ option go_package = "k8s.io/api/certificates/v1alpha1";
 message ClusterTrustBundle {
   // metadata contains the object metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec contains the signer (if any) and trust anchors.
   optional ClusterTrustBundleSpec spec = 2;
@@ -57,7 +57,7 @@ message ClusterTrustBundleList {
   // metadata contains the list metadata.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is a collection of ClusterTrustBundle objects
   repeated ClusterTrustBundle items = 2;

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -32,7 +32,7 @@ option go_package = "k8s.io/api/certificates/v1beta1";
 // Describes a certificate signing request
 message CertificateSigningRequest {
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec contains the certificate request, and is immutable after creation.
   // Only the request, signerName, expirationSeconds, and usages fields can be set on creation.
@@ -65,18 +65,18 @@ message CertificateSigningRequestCondition {
 
   // timestamp for the last update to this condition
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastUpdateTime = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastUpdateTime = 4;
 
   // lastTransitionTime is the time the condition last transitioned from one status to another.
   // If unset, when a new condition type is added or an existing condition's status is changed,
   // the server defaults this to the current time.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 5;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 5;
 }
 
 message CertificateSigningRequestList {
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   repeated CertificateSigningRequest items = 2;
 }

--- a/staging/src/k8s.io/api/coordination/v1/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1/generated.proto
@@ -32,7 +32,7 @@ option go_package = "k8s.io/api/coordination/v1";
 message Lease {
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec contains the specification of the Lease.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -45,7 +45,7 @@ message LeaseList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is a list of schema objects.
   repeated Lease items = 2;
@@ -65,12 +65,12 @@ message LeaseSpec {
 
   // acquireTime is a time when the current lease was acquired.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime acquireTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime acquireTime = 3;
 
   // renewTime is a time when the current holder of a lease has last
   // updated the lease.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime renewTime = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime renewTime = 4;
 
   // leaseTransitions is the number of transitions of a lease between
   // holders.

--- a/staging/src/k8s.io/api/coordination/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1beta1/generated.proto
@@ -32,7 +32,7 @@ option go_package = "k8s.io/api/coordination/v1beta1";
 message Lease {
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec contains the specification of the Lease.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -45,7 +45,7 @@ message LeaseList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is a list of schema objects.
   repeated Lease items = 2;
@@ -65,12 +65,12 @@ message LeaseSpec {
 
   // acquireTime is a time when the current lease was acquired.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime acquireTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime acquireTime = 3;
 
   // renewTime is a time when the current holder of a lease has last
   // updated the lease.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime renewTime = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime renewTime = 4;
 
   // leaseTransitions is the number of transitions of a lease between
   // holders.

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -182,7 +182,7 @@ message Binding {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // The target object that you want to bind to the standard object.
   optional ObjectReference target = 2;
@@ -475,7 +475,7 @@ message ClusterTrustBundleProjection {
   // interpreted as "match nothing".  If set but empty, interpreted as "match
   // everything".
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector labelSelector = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector labelSelector = 3;
 
   // If true, don't block pod startup if the referenced ClusterTrustBundle(s)
   // aren't available.  If using name, then the named ClusterTrustBundle is
@@ -516,7 +516,7 @@ message ComponentStatus {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // List of component conditions observed
   // +optional
@@ -533,7 +533,7 @@ message ComponentStatusList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of ComponentStatus objects.
   repeated ComponentStatus items = 2;
@@ -544,7 +544,7 @@ message ConfigMap {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Immutable, if set to true, ensures that data stored in the ConfigMap cannot
   // be updated (only object metadata can be modified).
@@ -604,7 +604,7 @@ message ConfigMapKeySelector {
 message ConfigMapList {
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of ConfigMaps.
   repeated ConfigMap items = 2;
@@ -984,7 +984,7 @@ message ContainerState {
 message ContainerStateRunning {
   // Time at which the container was last (re-)started
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time startedAt = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time startedAt = 1;
 }
 
 // ContainerStateTerminated is a terminated state of a container.
@@ -1006,11 +1006,11 @@ message ContainerStateTerminated {
 
   // Time at which previous execution of the container started
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time startedAt = 5;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time startedAt = 5;
 
   // Time at which the container last terminated
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time finishedAt = 6;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time finishedAt = 6;
 
   // Container's ID in the format '<type>://<container_id>'
   // +optional
@@ -1093,7 +1093,7 @@ message ContainerStatus {
   // and after successfully admitting desired pod resize.
   // +featureGate=InPlacePodVerticalScaling
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> allocatedResources = 10;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> allocatedResources = 10;
 
   // Resources represents the compute resource requests and limits that have been successfully
   // enacted on the running container after it has been started or has been successfully resized.
@@ -1188,7 +1188,7 @@ message EmptyDirVolumeSource {
   // The default is nil which means that the limit is undefined.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity sizeLimit = 2;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity sizeLimit = 2;
 }
 
 // EndpointAddress is a tuple that describes single IP address.
@@ -1300,7 +1300,7 @@ message Endpoints {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // The set of all endpoints is the union of all subsets. Addresses are placed into
   // subsets according to the IPs they share. A single address with multiple ports,
@@ -1319,7 +1319,7 @@ message EndpointsList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of endpoints.
   repeated Endpoints items = 2;
@@ -1622,7 +1622,7 @@ message EphemeralVolumeSource {
 message Event {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // The object that this event is about.
   optional ObjectReference involvedObject = 2;
@@ -1644,11 +1644,11 @@ message Event {
 
   // The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time firstTimestamp = 6;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time firstTimestamp = 6;
 
   // The time at which the most recent occurrence of this event was recorded.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTimestamp = 7;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTimestamp = 7;
 
   // The number of times this event has occurred.
   // +optional
@@ -1660,7 +1660,7 @@ message Event {
 
   // Time when this Event was first observed.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime eventTime = 10;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime eventTime = 10;
 
   // Data about the Event series this event represents or nil if it's a singleton Event.
   // +optional
@@ -1688,7 +1688,7 @@ message EventList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of events
   repeated Event items = 2;
@@ -1701,7 +1701,7 @@ message EventSeries {
   optional int32 count = 1;
 
   // Time of the last occurrence observed
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime lastObservedTime = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime lastObservedTime = 2;
 }
 
 // EventSource contains information for an event.
@@ -1954,7 +1954,7 @@ message HTTPGetAction {
   // Name or number of the port to access on the container.
   // Number must be in the range 1 to 65535.
   // Name must be an IANA_SVC_NAME.
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString port = 2;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString port = 2;
 
   // Host name to connect to, defaults to the pod IP. You probably want to set
   // "Host" in httpHeaders instead.
@@ -2201,7 +2201,7 @@ message LimitRange {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the limits enforced.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -2216,23 +2216,23 @@ message LimitRangeItem {
 
   // Max usage constraints on this kind by resource name.
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> max = 2;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> max = 2;
 
   // Min usage constraints on this kind by resource name.
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> min = 3;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> min = 3;
 
   // Default resource requirement limit value by resource name if resource limit is omitted.
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> default = 4;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> default = 4;
 
   // DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> defaultRequest = 5;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> defaultRequest = 5;
 
   // MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> maxLimitRequestRatio = 6;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> maxLimitRequestRatio = 6;
 }
 
 // LimitRangeList is a list of LimitRange items.
@@ -2240,7 +2240,7 @@ message LimitRangeList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of LimitRange objects.
   // More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -2259,10 +2259,10 @@ message List {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of objects
-  repeated k8s.io.apimachinery.pkg.runtime.RawExtension items = 2;
+  repeated .k8s.io.apimachinery.pkg.runtime.RawExtension items = 2;
 }
 
 // LoadBalancerIngress represents the status of a load-balancer ingress point:
@@ -2370,7 +2370,7 @@ message Namespace {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the behavior of the Namespace.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -2392,7 +2392,7 @@ message NamespaceCondition {
   optional string status = 2;
 
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
 
   // +optional
   optional string reason = 5;
@@ -2406,7 +2406,7 @@ message NamespaceList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of Namespace objects in the list.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
@@ -2444,7 +2444,7 @@ message Node {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the behavior of a node.
   // https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -2502,11 +2502,11 @@ message NodeCondition {
 
   // Last time we got an update on a given condition.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastHeartbeatTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastHeartbeatTime = 3;
 
   // Last time the condition transit from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
 
   // (brief) reason for the condition's last transition.
   // +optional
@@ -2586,7 +2586,7 @@ message NodeList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of nodes
   repeated Node items = 2;
@@ -2708,12 +2708,12 @@ message NodeStatus {
   // Capacity represents the total resources of a node.
   // More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> capacity = 1;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> capacity = 1;
 
   // Allocatable represents the resources of a node that are available for scheduling.
   // Defaults to Capacity.
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> allocatable = 2;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> allocatable = 2;
 
   // NodePhase is the recently observed lifecycle phase of the node.
   // More info: https://kubernetes.io/docs/concepts/nodes/node/#phase
@@ -2897,7 +2897,7 @@ message PersistentVolume {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines a specification of a persistent volume owned by the cluster.
   // Provisioned by an administrator.
@@ -2918,7 +2918,7 @@ message PersistentVolumeClaim {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec defines the desired characteristics of a volume requested by a pod author.
   // More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
@@ -2940,11 +2940,11 @@ message PersistentVolumeClaimCondition {
 
   // lastProbeTime is the time we probed the condition.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastProbeTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastProbeTime = 3;
 
   // lastTransitionTime is the time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
 
   // reason is a unique, this should be a short, machine understandable string that gives the reason
   // for condition's last transition. If it reports "Resizing" that means the underlying
@@ -2962,7 +2962,7 @@ message PersistentVolumeClaimList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is a list of persistent volume claims.
   // More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
@@ -2980,7 +2980,7 @@ message PersistentVolumeClaimSpec {
 
   // selector is a label query over volumes to consider for binding.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 4;
 
   // resources represents the minimum resources the volume should have.
   // If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
@@ -3072,7 +3072,7 @@ message PersistentVolumeClaimStatus {
 
   // capacity represents the actual resources of the underlying volume.
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> capacity = 3;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> capacity = 3;
 
   // conditions is the current Condition of persistent volume claim. If underlying persistent volume is being
   // resized then the Condition will be set to 'Resizing'.
@@ -3107,7 +3107,7 @@ message PersistentVolumeClaimStatus {
   // This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.
   // +featureGate=RecoverVolumeExpansionFailure
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> allocatedResources = 5;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> allocatedResources = 5;
 
   // allocatedResourceStatuses stores status of resource being resized for the given PVC.
   // Key names follow standard Kubernetes label syntax. Valid values are either:
@@ -3172,7 +3172,7 @@ message PersistentVolumeClaimTemplate {
   // validation.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // The specification for the PersistentVolumeClaim. The entire content is
   // copied unchanged into the PVC that gets created from this
@@ -3201,7 +3201,7 @@ message PersistentVolumeList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is a list of persistent volumes.
   // More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
@@ -3320,7 +3320,7 @@ message PersistentVolumeSpec {
   // capacity is the description of the persistent volume's resources and capacity.
   // More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> capacity = 1;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> capacity = 1;
 
   // persistentVolumeSource is the actual volume backing the persistent volume.
   optional PersistentVolumeSource persistentVolumeSource = 2;
@@ -3402,7 +3402,7 @@ message PersistentVolumeStatus {
   // This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default).
   // +featureGate=PersistentVolumeLastPhaseTransitionTime
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastPhaseTransitionTime = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastPhaseTransitionTime = 4;
 }
 
 // Represents a Photon Controller persistent disk resource.
@@ -3422,7 +3422,7 @@ message Pod {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the pod.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -3475,7 +3475,7 @@ message PodAffinityTerm {
   // A label query over a set of resources, in this case pods.
   // If it's null, this PodAffinityTerm matches with no Pods.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector labelSelector = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector labelSelector = 1;
 
   // namespaces specifies a static list of namespace names that the term applies to.
   // The term is applied to the union of the namespaces listed in this field
@@ -3498,7 +3498,7 @@ message PodAffinityTerm {
   // null selector and null or empty namespaces list means "this pod's namespace".
   // An empty selector ({}) matches all namespaces.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 4;
 
   // MatchLabelKeys is a set of pod label keys to select which pods will
   // be taken into consideration. The keys are used to lookup values from the
@@ -3600,11 +3600,11 @@ message PodCondition {
 
   // Last time we probed the condition.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastProbeTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastProbeTime = 3;
 
   // Last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
 
   // Unique, one-word, CamelCase reason for the condition's last transition.
   // +optional
@@ -3694,7 +3694,7 @@ message PodList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of pods.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
@@ -3727,7 +3727,7 @@ message PodLogOptions {
   // If this value is in the future, no logs will be returned.
   // Only one of sinceSeconds or sinceTime may be specified.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time sinceTime = 5;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time sinceTime = 5;
 
   // If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line
   // of log output. Defaults to false.
@@ -3932,7 +3932,7 @@ message PodSecurityContext {
 message PodSignature {
   // Reference to controller whose pods should avoid this node.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.OwnerReference podController = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.OwnerReference podController = 1;
 }
 
 // PodSpec is a description of a pod.
@@ -4182,7 +4182,7 @@ message PodSpec {
   // defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
   // More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> overhead = 32;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> overhead = 32;
 
   // TopologySpreadConstraints describes how a group of pods ought to spread across topology
   // domains. Scheduler will schedule pods in a way which abides by the constraints.
@@ -4368,7 +4368,7 @@ message PodStatus {
   // RFC 3339 date and time at which the object was acknowledged by the Kubelet.
   // This is before the Kubelet pulled the container image(s) for the pod.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time startTime = 7;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time startTime = 7;
 
   // The list has one entry per init container in the manifest. The most recent successful
   // init container will have ready = true, the most recently started container will have
@@ -4416,7 +4416,7 @@ message PodStatusResult {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Most recently observed status of the pod.
   // This data may not be up to date.
@@ -4432,7 +4432,7 @@ message PodTemplate {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Template defines the pods that will be created from this pod template.
   // https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -4445,7 +4445,7 @@ message PodTemplateList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of pod templates
   repeated PodTemplate items = 2;
@@ -4456,7 +4456,7 @@ message PodTemplateSpec {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the pod.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -4518,7 +4518,7 @@ message PreferAvoidPodsEntry {
 
   // Time at which this entry was added to the list.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time evictionTime = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time evictionTime = 2;
 
   // (brief) reason why this entry was added to the list.
   // +optional
@@ -4763,7 +4763,7 @@ message RangeAllocation {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Range is string that identifies the range represented by 'data'.
   optional string range = 2;
@@ -4778,7 +4778,7 @@ message ReplicationController {
   // be the same as the Pod(s) that the replication controller manages.
   // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the specification of the desired behavior of the replication controller.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -4804,7 +4804,7 @@ message ReplicationControllerCondition {
 
   // The last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // The reason for the condition's last transition.
   // +optional
@@ -4820,7 +4820,7 @@ message ReplicationControllerList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of replication controllers.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
@@ -4911,7 +4911,7 @@ message ResourceFieldSelector {
 
   // Specifies the output format of the exposed resources, defaults to "1"
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity divisor = 3;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity divisor = 3;
 }
 
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
@@ -4919,7 +4919,7 @@ message ResourceQuota {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the desired quota.
   // https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -4937,7 +4937,7 @@ message ResourceQuotaList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of ResourceQuota objects.
   // More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
@@ -4949,7 +4949,7 @@ message ResourceQuotaSpec {
   // hard is the set of desired hard limits for each named resource.
   // More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> hard = 1;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> hard = 1;
 
   // A collection of filters that must match each object tracked by a quota.
   // If not specified, the quota matches all objects.
@@ -4969,11 +4969,11 @@ message ResourceQuotaStatus {
   // Hard is the set of enforced hard limits for each named resource.
   // More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> hard = 1;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> hard = 1;
 
   // Used is the current observed total usage of the resource in the namespace.
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> used = 2;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> used = 2;
 }
 
 // ResourceRequirements describes the compute resource requirements.
@@ -4981,14 +4981,14 @@ message ResourceRequirements {
   // Limits describes the maximum amount of compute resources allowed.
   // More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> limits = 1;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> limits = 1;
 
   // Requests describes the minimum amount of compute resources required.
   // If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
   // otherwise to an implementation-defined value. Requests cannot exceed Limits.
   // More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> requests = 2;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> requests = 2;
 
   // Claims lists the names of resources, defined in spec.resourceClaims,
   // that are used by this container.
@@ -5172,7 +5172,7 @@ message Secret {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Immutable, if set to true, ensures that data stored in the Secret cannot
   // be updated (only object metadata can be modified).
@@ -5235,7 +5235,7 @@ message SecretList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of secret objects.
   // More info: https://kubernetes.io/docs/concepts/configuration/secret
@@ -5426,7 +5426,7 @@ message Service {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the behavior of a service.
   // https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -5449,7 +5449,7 @@ message ServiceAccount {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use.
   // Pods are only limited to this list if this service account has a "kubernetes.io/enforce-mountable-secrets" annotation set to "true".
@@ -5482,7 +5482,7 @@ message ServiceAccountList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of ServiceAccounts.
   // More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -5520,7 +5520,7 @@ message ServiceList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of services
   repeated Service items = 2;
@@ -5572,7 +5572,7 @@ message ServicePort {
   // omitted or set equal to the 'port' field.
   // More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString targetPort = 4;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString targetPort = 4;
 
   // The port on each node on which this service is exposed when type is
   // NodePort or LoadBalancer.  Usually assigned by the system. If a value is
@@ -5855,7 +5855,7 @@ message ServiceStatus {
   // +patchStrategy=merge
   // +listType=map
   // +listMapKey=type
-  repeated k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 2;
+  repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 2;
 }
 
 // SessionAffinityConfig represents the configurations of session affinity.
@@ -5949,7 +5949,7 @@ message TCPSocketAction {
   // Number or name of the port to access on the container.
   // Number must be in the range 1 to 65535.
   // Name must be an IANA_SVC_NAME.
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString port = 1;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString port = 1;
 
   // Optional: Host name to connect to, defaults to the pod IP.
   // +optional
@@ -5974,7 +5974,7 @@ message Taint {
   // TimeAdded represents the time at which the taint was added.
   // It is only written for NoExecute taints.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time timeAdded = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time timeAdded = 4;
 }
 
 // The pod this Toleration is attached to tolerates any taint that matches
@@ -6098,7 +6098,7 @@ message TopologySpreadConstraint {
   // Pods that match this label selector are counted to determine the number of pods
   // in their corresponding topology domain.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector labelSelector = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector labelSelector = 4;
 
   // MinDomains indicates a minimum number of eligible domains.
   // When the number of eligible domains with matching topology keys is less than minDomains,
@@ -6346,14 +6346,14 @@ message VolumeResourceRequirements {
   // Limits describes the maximum amount of compute resources allowed.
   // More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> limits = 1;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> limits = 1;
 
   // Requests describes the minimum amount of compute resources required.
   // If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
   // otherwise to an implementation-defined value. Requests cannot exceed Limits.
   // More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> requests = 2;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> requests = 2;
 }
 
 // Represents the source of a volume to mount.

--- a/staging/src/k8s.io/api/discovery/v1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1/generated.proto
@@ -54,7 +54,7 @@ message Endpoint {
   // targetRef is a reference to a Kubernetes object that represents this
   // endpoint.
   // +optional
-  optional k8s.io.api.core.v1.ObjectReference targetRef = 4;
+  optional .k8s.io.api.core.v1.ObjectReference targetRef = 4;
 
   // deprecatedTopology contains topology information part of the v1beta1
   // API. This field is deprecated, and will be removed when the v1beta1
@@ -161,7 +161,7 @@ message EndpointPort {
 message EndpointSlice {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // addressType specifies the type of address carried by this EndpointSlice.
   // All addresses in this slice must be the same type. This field is
@@ -191,7 +191,7 @@ message EndpointSlice {
 message EndpointSliceList {
   // Standard list metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of endpoint slices
   repeated EndpointSlice items = 2;

--- a/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
@@ -54,7 +54,7 @@ message Endpoint {
   // targetRef is a reference to a Kubernetes object that represents this
   // endpoint.
   // +optional
-  optional k8s.io.api.core.v1.ObjectReference targetRef = 4;
+  optional .k8s.io.api.core.v1.ObjectReference targetRef = 4;
 
   // topology contains arbitrary topology information associated with the
   // endpoint. These key/value pairs must conform with the label format.
@@ -153,7 +153,7 @@ message EndpointPort {
 message EndpointSlice {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // addressType specifies the type of address carried by this EndpointSlice.
   // All addresses in this slice must be the same type. This field is
@@ -183,7 +183,7 @@ message EndpointSlice {
 message EndpointSliceList {
   // Standard list metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of endpoint slices
   repeated EndpointSlice items = 2;

--- a/staging/src/k8s.io/api/events/v1/generated.proto
+++ b/staging/src/k8s.io/api/events/v1/generated.proto
@@ -39,10 +39,10 @@ message Event {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // eventTime is the time when this Event was first observed. It is required.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime eventTime = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime eventTime = 2;
 
   // series is data about the Event series this event represents or nil if it's a singleton Event.
   // +optional
@@ -68,12 +68,12 @@ message Event {
   // implements, e.g. ReplicaSetController implements ReplicaSets and this event is emitted because
   // it acts on some changes in a ReplicaSet object.
   // +optional
-  optional k8s.io.api.core.v1.ObjectReference regarding = 8;
+  optional .k8s.io.api.core.v1.ObjectReference regarding = 8;
 
   // related is the optional secondary object for more complex actions. E.g. when regarding object triggers
   // a creation or deletion of related object.
   // +optional
-  optional k8s.io.api.core.v1.ObjectReference related = 9;
+  optional .k8s.io.api.core.v1.ObjectReference related = 9;
 
   // note is a human-readable description of the status of this operation.
   // Maximal length of the note is 1kB, but libraries should be prepared to
@@ -88,15 +88,15 @@ message Event {
 
   // deprecatedSource is the deprecated field assuring backward compatibility with core.v1 Event type.
   // +optional
-  optional k8s.io.api.core.v1.EventSource deprecatedSource = 12;
+  optional .k8s.io.api.core.v1.EventSource deprecatedSource = 12;
 
   // deprecatedFirstTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time deprecatedFirstTimestamp = 13;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time deprecatedFirstTimestamp = 13;
 
   // deprecatedLastTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time deprecatedLastTimestamp = 14;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time deprecatedLastTimestamp = 14;
 
   // deprecatedCount is the deprecated field assuring backward compatibility with core.v1 Event type.
   // +optional
@@ -108,7 +108,7 @@ message EventList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is a list of schema objects.
   repeated Event items = 2;
@@ -123,6 +123,6 @@ message EventSeries {
   optional int32 count = 1;
 
   // lastObservedTime is the time when last Event from the series was seen before last heartbeat.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime lastObservedTime = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime lastObservedTime = 2;
 }
 

--- a/staging/src/k8s.io/api/events/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/events/v1beta1/generated.proto
@@ -39,10 +39,10 @@ message Event {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // eventTime is the time when this Event was first observed. It is required.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime eventTime = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime eventTime = 2;
 
   // series is data about the Event series this event represents or nil if it's a singleton Event.
   // +optional
@@ -72,12 +72,12 @@ message Event {
   // implements, e.g. ReplicaSetController implements ReplicaSets and this event is emitted because
   // it acts on some changes in a ReplicaSet object.
   // +optional
-  optional k8s.io.api.core.v1.ObjectReference regarding = 8;
+  optional .k8s.io.api.core.v1.ObjectReference regarding = 8;
 
   // related is the optional secondary object for more complex actions. E.g. when regarding object triggers
   // a creation or deletion of related object.
   // +optional
-  optional k8s.io.api.core.v1.ObjectReference related = 9;
+  optional .k8s.io.api.core.v1.ObjectReference related = 9;
 
   // note is a human-readable description of the status of this operation.
   // Maximal length of the note is 1kB, but libraries should be prepared to
@@ -92,15 +92,15 @@ message Event {
 
   // deprecatedSource is the deprecated field assuring backward compatibility with core.v1 Event type.
   // +optional
-  optional k8s.io.api.core.v1.EventSource deprecatedSource = 12;
+  optional .k8s.io.api.core.v1.EventSource deprecatedSource = 12;
 
   // deprecatedFirstTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time deprecatedFirstTimestamp = 13;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time deprecatedFirstTimestamp = 13;
 
   // deprecatedLastTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time deprecatedLastTimestamp = 14;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time deprecatedLastTimestamp = 14;
 
   // deprecatedCount is the deprecated field assuring backward compatibility with core.v1 Event type.
   // +optional
@@ -112,7 +112,7 @@ message EventList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is a list of schema objects.
   repeated Event items = 2;
@@ -125,6 +125,6 @@ message EventSeries {
   optional int32 count = 1;
 
   // lastObservedTime is the time when last Event from the series was seen before last heartbeat.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime lastObservedTime = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime lastObservedTime = 2;
 }
 

--- a/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
@@ -37,7 +37,7 @@ message DaemonSet {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // The desired behavior of this daemon set.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -63,7 +63,7 @@ message DaemonSetCondition {
 
   // Last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // The reason for the condition's last transition.
   // +optional
@@ -79,7 +79,7 @@ message DaemonSetList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // A list of daemon sets.
   repeated DaemonSet items = 2;
@@ -92,14 +92,14 @@ message DaemonSetSpec {
   // If empty, defaulted to labels on Pod template.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 1;
 
   // An object that describes the pod that will be created.
   // The DaemonSet will create exactly one copy of this pod on every node
   // that matches the template's node selector (or on every node if no node
   // selector is specified).
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
-  optional k8s.io.api.core.v1.PodTemplateSpec template = 2;
+  optional .k8s.io.api.core.v1.PodTemplateSpec template = 2;
 
   // An update strategy to replace existing DaemonSet pods with new pods.
   // +optional
@@ -205,7 +205,7 @@ message DaemonSetUpdateStrategy {
 message Deployment {
   // Standard object metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the Deployment.
   // +optional
@@ -225,10 +225,10 @@ message DeploymentCondition {
   optional string status = 2;
 
   // The last time this condition was updated.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastUpdateTime = 6;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastUpdateTime = 6;
 
   // Last time the condition transitioned from one status to another.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 7;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 7;
 
   // The reason for the condition's last transition.
   optional string reason = 4;
@@ -241,7 +241,7 @@ message DeploymentCondition {
 message DeploymentList {
   // Standard list metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of Deployments.
   repeated Deployment items = 2;
@@ -271,10 +271,10 @@ message DeploymentSpec {
   // Label selector for pods. Existing ReplicaSets whose pods are
   // selected by this will be the ones affected by this deployment.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // Template describes the pods that will be created.
-  optional k8s.io.api.core.v1.PodTemplateSpec template = 3;
+  optional .k8s.io.api.core.v1.PodTemplateSpec template = 3;
 
   // The deployment strategy to use to replace existing pods with new ones.
   // +optional
@@ -440,7 +440,7 @@ message Ingress {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec is the desired state of the Ingress.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -461,13 +461,13 @@ message IngressBackend {
 
   // Specifies the port of the referenced service.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString servicePort = 2;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString servicePort = 2;
 
   // Resource is an ObjectRef to another Kubernetes resource in the namespace
   // of the Ingress object. If resource is specified, serviceName and servicePort
   // must not be specified.
   // +optional
-  optional k8s.io.api.core.v1.TypedLocalObjectReference resource = 3;
+  optional .k8s.io.api.core.v1.TypedLocalObjectReference resource = 3;
 }
 
 // IngressList is a collection of Ingress.
@@ -475,7 +475,7 @@ message IngressList {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of Ingress.
   repeated Ingress items = 2;
@@ -651,7 +651,7 @@ message NetworkPolicy {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior for this NetworkPolicy.
   // +optional
@@ -710,7 +710,7 @@ message NetworkPolicyList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of schema objects.
   repeated NetworkPolicy items = 2;
@@ -725,7 +725,7 @@ message NetworkPolicyPeer {
   // the Pods matching PodSelector in the Namespaces selected by NamespaceSelector.
   // Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector podSelector = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector podSelector = 1;
 
   // Selects Namespaces using cluster-scoped labels. This field follows standard label
   // selector semantics; if present but empty, it selects all namespaces.
@@ -734,7 +734,7 @@ message NetworkPolicyPeer {
   // the Pods matching PodSelector in the Namespaces selected by NamespaceSelector.
   // Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 2;
 
   // IPBlock defines policy on a particular IPBlock. If this field is set then
   // neither of the other fields can be.
@@ -754,7 +754,7 @@ message NetworkPolicyPort {
   // numbers.
   // If present, only traffic on the specified protocol AND port will be matched.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString port = 2;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString port = 2;
 
   // If set, indicates that the range of ports from port to endPort, inclusive,
   // should be allowed by the policy. This field cannot be defined if the port field
@@ -771,7 +771,7 @@ message NetworkPolicySpec {
   // same set of pods.  In this case, the ingress rules for each are combined additively.
   // This field is NOT optional and follows standard label selector semantics.
   // An empty podSelector matches all pods in this namespace.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector podSelector = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector podSelector = 1;
 
   // List of ingress rules to be applied to the selected pods.
   // Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod
@@ -818,7 +818,7 @@ message ReplicaSet {
   // be the same as the Pod(s) that the ReplicaSet manages.
   // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the specification of the desired behavior of the ReplicaSet.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -844,7 +844,7 @@ message ReplicaSetCondition {
 
   // The last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // The reason for the condition's last transition.
   // +optional
@@ -860,7 +860,7 @@ message ReplicaSetList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of ReplicaSets.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
@@ -887,13 +887,13 @@ message ReplicaSetSpec {
   // Label keys and values that must match in order to be controlled by this replica set.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // Template is the object that describes the pod that will be created if
   // insufficient replicas are detected.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
   // +optional
-  optional k8s.io.api.core.v1.PodTemplateSpec template = 3;
+  optional .k8s.io.api.core.v1.PodTemplateSpec template = 3;
 }
 
 // ReplicaSetStatus represents the current status of a ReplicaSet.
@@ -951,7 +951,7 @@ message RollingUpdateDaemonSet {
   // 70% of original number of DaemonSet pods are available at all times during
   // the update.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
 
   // The maximum number of nodes with an existing available DaemonSet pod that
   // can have an updated DaemonSet pod during during an update.
@@ -973,7 +973,7 @@ message RollingUpdateDaemonSet {
   // cause evictions during disruption.
   // This is an alpha field and requires enabling DaemonSetUpdateSurge feature gate.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
 }
 
 // Spec to control the desired behavior of rolling update.
@@ -989,7 +989,7 @@ message RollingUpdateDeployment {
   // that the total number of pods available at all times during the update is at
   // least 70% of desired pods.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
 
   // The maximum number of pods that can be scheduled above the desired number of
   // pods.
@@ -1003,14 +1003,14 @@ message RollingUpdateDeployment {
   // new RC can be scaled up further, ensuring that total number of pods running
   // at any time during the update is at most 130% of desired pods.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
 }
 
 // represents a scaling request for a resource.
 message Scale {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
   // +optional

--- a/staging/src/k8s.io/api/flowcontrol/v1/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1/generated.proto
@@ -76,7 +76,7 @@ message FlowSchema {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // `spec` is the specification of the desired behavior of a FlowSchema.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -101,7 +101,7 @@ message FlowSchemaCondition {
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
   optional string reason = 4;
@@ -115,7 +115,7 @@ message FlowSchemaList {
   // `metadata` is the standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // `items` is a list of FlowSchemas.
   repeated FlowSchema items = 2;
@@ -302,7 +302,7 @@ message PriorityLevelConfiguration {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // `spec` is the specification of the desired behavior of a "request-priority".
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -327,7 +327,7 @@ message PriorityLevelConfigurationCondition {
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
   optional string reason = 4;
@@ -341,7 +341,7 @@ message PriorityLevelConfigurationList {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // `items` is a list of request-priorities.
   repeated PriorityLevelConfiguration items = 2;

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/generated.proto
@@ -76,7 +76,7 @@ message FlowSchema {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // `spec` is the specification of the desired behavior of a FlowSchema.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -101,7 +101,7 @@ message FlowSchemaCondition {
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
   optional string reason = 4;
@@ -115,7 +115,7 @@ message FlowSchemaList {
   // `metadata` is the standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // `items` is a list of FlowSchemas.
   repeated FlowSchema items = 2;
@@ -295,7 +295,7 @@ message PriorityLevelConfiguration {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // `spec` is the specification of the desired behavior of a "request-priority".
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -320,7 +320,7 @@ message PriorityLevelConfigurationCondition {
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
   optional string reason = 4;
@@ -334,7 +334,7 @@ message PriorityLevelConfigurationList {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // `items` is a list of request-priorities.
   repeated PriorityLevelConfiguration items = 2;

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/generated.proto
@@ -76,7 +76,7 @@ message FlowSchema {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // `spec` is the specification of the desired behavior of a FlowSchema.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -101,7 +101,7 @@ message FlowSchemaCondition {
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
   optional string reason = 4;
@@ -115,7 +115,7 @@ message FlowSchemaList {
   // `metadata` is the standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // `items` is a list of FlowSchemas.
   repeated FlowSchema items = 2;
@@ -295,7 +295,7 @@ message PriorityLevelConfiguration {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // `spec` is the specification of the desired behavior of a "request-priority".
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -320,7 +320,7 @@ message PriorityLevelConfigurationCondition {
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
   optional string reason = 4;
@@ -334,7 +334,7 @@ message PriorityLevelConfigurationList {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // `items` is a list of request-priorities.
   repeated PriorityLevelConfiguration items = 2;

--- a/staging/src/k8s.io/api/flowcontrol/v1beta3/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta3/generated.proto
@@ -76,7 +76,7 @@ message FlowSchema {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // `spec` is the specification of the desired behavior of a FlowSchema.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -101,7 +101,7 @@ message FlowSchemaCondition {
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
   optional string reason = 4;
@@ -115,7 +115,7 @@ message FlowSchemaList {
   // `metadata` is the standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // `items` is a list of FlowSchemas.
   repeated FlowSchema items = 2;
@@ -297,7 +297,7 @@ message PriorityLevelConfiguration {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // `spec` is the specification of the desired behavior of a "request-priority".
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -322,7 +322,7 @@ message PriorityLevelConfigurationCondition {
   optional string status = 2;
 
   // `lastTransitionTime` is the last time the condition transitioned from one status to another.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
   optional string reason = 4;
@@ -336,7 +336,7 @@ message PriorityLevelConfigurationList {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // `items` is a list of request-priorities.
   repeated PriorityLevelConfiguration items = 2;

--- a/staging/src/k8s.io/api/imagepolicy/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/imagepolicy/v1alpha1/generated.proto
@@ -33,7 +33,7 @@ message ImageReview {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec holds information about the pod being evaluated
   optional ImageReviewSpec spec = 2;

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -96,7 +96,7 @@ message Ingress {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec is the desired state of the Ingress.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -121,7 +121,7 @@ message IngressBackend {
   // service.Port must not be specified.
   // This is a mutually exclusive setting with "Service".
   // +optional
-  optional k8s.io.api.core.v1.TypedLocalObjectReference resource = 3;
+  optional .k8s.io.api.core.v1.TypedLocalObjectReference resource = 3;
 }
 
 // IngressClass represents the class of the Ingress, referenced by the Ingress
@@ -133,7 +133,7 @@ message IngressClass {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec is the desired state of the IngressClass.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -145,7 +145,7 @@ message IngressClass {
 message IngressClassList {
   // Standard list metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of IngressClasses.
   repeated IngressClass items = 2;
@@ -200,7 +200,7 @@ message IngressList {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of Ingress.
   repeated Ingress items = 2;
@@ -381,7 +381,7 @@ message NetworkPolicy {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec represents the specification of the desired behavior for this NetworkPolicy.
   // +optional
@@ -438,7 +438,7 @@ message NetworkPolicyList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is a list of schema objects.
   repeated NetworkPolicy items = 2;
@@ -454,7 +454,7 @@ message NetworkPolicyPeer {
   // the pods matching podSelector in the Namespaces selected by NamespaceSelector.
   // Otherwise it selects the pods matching podSelector in the policy's own namespace.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector podSelector = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector podSelector = 1;
 
   // namespaceSelector selects namespaces using cluster-scoped labels. This field follows
   // standard label selector semantics; if present but empty, it selects all namespaces.
@@ -463,7 +463,7 @@ message NetworkPolicyPeer {
   // the pods matching podSelector in the namespaces selected by namespaceSelector.
   // Otherwise it selects all pods in the namespaces selected by namespaceSelector.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 2;
 
   // ipBlock defines policy on a particular IPBlock. If this field is set then
   // neither of the other fields can be.
@@ -483,7 +483,7 @@ message NetworkPolicyPort {
   // numbers.
   // If present, only traffic on the specified protocol AND port will be matched.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString port = 2;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString port = 2;
 
   // endPort indicates that the range of ports from port to endPort if set, inclusive,
   // should be allowed by the policy. This field cannot be defined if the port field
@@ -501,7 +501,7 @@ message NetworkPolicySpec {
   // the ingress rules for each are combined additively.
   // This field is NOT optional and follows standard label selector semantics.
   // An empty podSelector matches all pods in this namespace.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector podSelector = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector podSelector = 1;
 
   // ingress is a list of ingress rules to be applied to the selected pods.
   // Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod

--- a/staging/src/k8s.io/api/networking/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1alpha1/generated.proto
@@ -39,7 +39,7 @@ message IPAddress {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec is the desired state of the IPAddress.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -52,7 +52,7 @@ message IPAddressList {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of IPAddresses.
   repeated IPAddress items = 2;
@@ -91,7 +91,7 @@ message ServiceCIDR {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec is the desired state of the ServiceCIDR.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -109,7 +109,7 @@ message ServiceCIDRList {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of ServiceCIDRs.
   repeated ServiceCIDR items = 2;
@@ -134,6 +134,6 @@ message ServiceCIDRStatus {
   // +patchStrategy=merge
   // +listType=map
   // +listMapKey=type
-  repeated k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 1;
+  repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 1;
 }
 

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -81,7 +81,7 @@ message Ingress {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec is the desired state of the Ingress.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -102,13 +102,13 @@ message IngressBackend {
 
   // servicePort Specifies the port of the referenced service.
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString servicePort = 2;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString servicePort = 2;
 
   // resource is an ObjectRef to another Kubernetes resource in the namespace
   // of the Ingress object. If resource is specified, serviceName and servicePort
   // must not be specified.
   // +optional
-  optional k8s.io.api.core.v1.TypedLocalObjectReference resource = 3;
+  optional .k8s.io.api.core.v1.TypedLocalObjectReference resource = 3;
 }
 
 // IngressClass represents the class of the Ingress, referenced by the Ingress
@@ -120,7 +120,7 @@ message IngressClass {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec is the desired state of the IngressClass.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -132,7 +132,7 @@ message IngressClass {
 message IngressClassList {
   // Standard list metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of IngressClasses.
   repeated IngressClass items = 2;
@@ -186,7 +186,7 @@ message IngressList {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of Ingress.
   repeated Ingress items = 2;

--- a/staging/src/k8s.io/api/node/v1/generated.proto
+++ b/staging/src/k8s.io/api/node/v1/generated.proto
@@ -34,7 +34,7 @@ option go_package = "k8s.io/api/node/v1";
 message Overhead {
   // podFixed represents the fixed resource overhead associated with running a pod.
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> podFixed = 1;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> podFixed = 1;
 }
 
 // RuntimeClass defines a class of container runtime supported in the cluster.
@@ -47,7 +47,7 @@ message Overhead {
 message RuntimeClass {
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // handler specifies the underlying runtime and configuration that the CRI
   // implementation will use to handle pods of this class. The possible values
@@ -80,7 +80,7 @@ message RuntimeClassList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is a list of schema objects.
   repeated RuntimeClass items = 2;
@@ -103,6 +103,6 @@ message Scheduling {
   // tolerated by the pod and the RuntimeClass.
   // +optional
   // +listType=atomic
-  repeated k8s.io.api.core.v1.Toleration tolerations = 2;
+  repeated .k8s.io.api.core.v1.Toleration tolerations = 2;
 }
 

--- a/staging/src/k8s.io/api/node/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/node/v1alpha1/generated.proto
@@ -34,7 +34,7 @@ option go_package = "k8s.io/api/node/v1alpha1";
 message Overhead {
   // podFixed represents the fixed resource overhead associated with running a pod.
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> podFixed = 1;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> podFixed = 1;
 }
 
 // RuntimeClass defines a class of container runtime supported in the cluster.
@@ -47,7 +47,7 @@ message Overhead {
 message RuntimeClass {
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec represents specification of the RuntimeClass
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -59,7 +59,7 @@ message RuntimeClassList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is a list of schema objects.
   repeated RuntimeClass items = 2;
@@ -113,6 +113,6 @@ message Scheduling {
   // tolerated by the pod and the RuntimeClass.
   // +optional
   // +listType=atomic
-  repeated k8s.io.api.core.v1.Toleration tolerations = 2;
+  repeated .k8s.io.api.core.v1.Toleration tolerations = 2;
 }
 

--- a/staging/src/k8s.io/api/node/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/node/v1beta1/generated.proto
@@ -34,7 +34,7 @@ option go_package = "k8s.io/api/node/v1beta1";
 message Overhead {
   // podFixed represents the fixed resource overhead associated with running a pod.
   // +optional
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> podFixed = 1;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> podFixed = 1;
 }
 
 // RuntimeClass defines a class of container runtime supported in the cluster.
@@ -47,7 +47,7 @@ message Overhead {
 message RuntimeClass {
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // handler specifies the underlying runtime and configuration that the CRI
   // implementation will use to handle pods of this class. The possible values
@@ -80,7 +80,7 @@ message RuntimeClassList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is a list of schema objects.
   repeated RuntimeClass items = 2;
@@ -103,6 +103,6 @@ message Scheduling {
   // tolerated by the pod and the RuntimeClass.
   // +optional
   // +listType=atomic
-  repeated k8s.io.api.core.v1.Toleration tolerations = 2;
+  repeated .k8s.io.api.core.v1.Toleration tolerations = 2;
 }
 

--- a/staging/src/k8s.io/api/policy/v1/generated.proto
+++ b/staging/src/k8s.io/api/policy/v1/generated.proto
@@ -35,11 +35,11 @@ option go_package = "k8s.io/api/policy/v1";
 message Eviction {
   // ObjectMeta describes the pod that is being evicted.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // DeleteOptions may be provided
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.DeleteOptions deleteOptions = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.DeleteOptions deleteOptions = 2;
 }
 
 // PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
@@ -47,7 +47,7 @@ message PodDisruptionBudget {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the PodDisruptionBudget.
   // +optional
@@ -63,7 +63,7 @@ message PodDisruptionBudgetList {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of PodDisruptionBudgets
   repeated PodDisruptionBudget items = 2;
@@ -76,7 +76,7 @@ message PodDisruptionBudgetSpec {
   // absence of the evicted pod.  So for example you can prevent all voluntary
   // evictions by specifying "100%".
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString minAvailable = 1;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString minAvailable = 1;
 
   // Label query over pods whose evictions are managed by the disruption
   // budget.
@@ -84,14 +84,14 @@ message PodDisruptionBudgetSpec {
   // all pods within the namespace.
   // +patchStrategy=replace
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // An eviction is allowed if at most "maxUnavailable" pods selected by
   // "selector" are unavailable after the eviction, i.e. even in absence of
   // the evicted pod. For example, one can prevent all voluntary evictions
   // by specifying 0. This is a mutually exclusive setting with "minAvailable".
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 3;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 3;
 
   // UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods
   // should be considered for eviction. Current implementation considers healthy pods,
@@ -142,7 +142,7 @@ message PodDisruptionBudgetStatus {
   // If everything goes smooth this map should be empty for the most of the time.
   // Large number of entries in the map may indicate problems with pod deletions.
   // +optional
-  map<string, k8s.io.apimachinery.pkg.apis.meta.v1.Time> disruptedPods = 2;
+  map<string, .k8s.io.apimachinery.pkg.apis.meta.v1.Time> disruptedPods = 2;
 
   // Number of pod disruptions that are currently allowed.
   optional int32 disruptionsAllowed = 3;
@@ -174,6 +174,6 @@ message PodDisruptionBudgetStatus {
   // +patchStrategy=merge
   // +listType=map
   // +listMapKey=type
-  repeated k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 7;
+  repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 7;
 }
 

--- a/staging/src/k8s.io/api/policy/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/policy/v1beta1/generated.proto
@@ -35,11 +35,11 @@ option go_package = "k8s.io/api/policy/v1beta1";
 message Eviction {
   // ObjectMeta describes the pod that is being evicted.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // DeleteOptions may be provided
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.DeleteOptions deleteOptions = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.DeleteOptions deleteOptions = 2;
 }
 
 // PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
@@ -47,7 +47,7 @@ message PodDisruptionBudget {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the PodDisruptionBudget.
   // +optional
@@ -63,7 +63,7 @@ message PodDisruptionBudgetList {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items list individual PodDisruptionBudget objects
   repeated PodDisruptionBudget items = 2;
@@ -76,7 +76,7 @@ message PodDisruptionBudgetSpec {
   // absence of the evicted pod.  So for example you can prevent all voluntary
   // evictions by specifying "100%".
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString minAvailable = 1;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString minAvailable = 1;
 
   // Label query over pods whose evictions are managed by the disruption
   // budget.
@@ -84,14 +84,14 @@ message PodDisruptionBudgetSpec {
   // An empty selector ({}) also selects no pods, which differs from standard behavior of selecting all pods.
   // In policy/v1, an empty selector will select all pods in the namespace.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // An eviction is allowed if at most "maxUnavailable" pods selected by
   // "selector" are unavailable after the eviction, i.e. even in absence of
   // the evicted pod. For example, one can prevent all voluntary evictions
   // by specifying 0. This is a mutually exclusive setting with "minAvailable".
   // +optional
-  optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 3;
+  optional .k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 3;
 
   // UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods
   // should be considered for eviction. Current implementation considers healthy pods,
@@ -142,7 +142,7 @@ message PodDisruptionBudgetStatus {
   // If everything goes smooth this map should be empty for the most of the time.
   // Large number of entries in the map may indicate problems with pod deletions.
   // +optional
-  map<string, k8s.io.apimachinery.pkg.apis.meta.v1.Time> disruptedPods = 2;
+  map<string, .k8s.io.apimachinery.pkg.apis.meta.v1.Time> disruptedPods = 2;
 
   // Number of pod disruptions that are currently allowed.
   optional int32 disruptionsAllowed = 3;
@@ -174,6 +174,6 @@ message PodDisruptionBudgetStatus {
   // +patchStrategy=merge
   // +listType=map
   // +listMapKey=type
-  repeated k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 7;
+  repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 7;
 }
 

--- a/staging/src/k8s.io/api/rbac/v1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1/generated.proto
@@ -34,14 +34,14 @@ message AggregationRule {
   // If any of the selectors match, then the ClusterRole's permissions will be added
   // +optional
   // +listType=atomic
-  repeated k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector clusterRoleSelectors = 1;
+  repeated .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector clusterRoleSelectors = 1;
 }
 
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
 message ClusterRole {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Rules holds all the PolicyRules for this ClusterRole
   // +optional
@@ -60,7 +60,7 @@ message ClusterRole {
 message ClusterRoleBinding {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Subjects holds references to the objects the role applies to.
   // +optional
@@ -77,7 +77,7 @@ message ClusterRoleBinding {
 message ClusterRoleBindingList {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of ClusterRoleBindings
   repeated ClusterRoleBinding items = 2;
@@ -87,7 +87,7 @@ message ClusterRoleBindingList {
 message ClusterRoleList {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of ClusterRoles
   repeated ClusterRole items = 2;
@@ -128,7 +128,7 @@ message PolicyRule {
 message Role {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Rules holds all the PolicyRules for this Role
   // +optional
@@ -142,7 +142,7 @@ message Role {
 message RoleBinding {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Subjects holds references to the objects the role applies to.
   // +optional
@@ -159,7 +159,7 @@ message RoleBinding {
 message RoleBindingList {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of RoleBindings
   repeated RoleBinding items = 2;
@@ -169,7 +169,7 @@ message RoleBindingList {
 message RoleList {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of Roles
   repeated Role items = 2;

--- a/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
@@ -34,7 +34,7 @@ message AggregationRule {
   // If any of the selectors match, then the ClusterRole's permissions will be added
   // +optional
   // +listType=atomic
-  repeated k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector clusterRoleSelectors = 1;
+  repeated .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector clusterRoleSelectors = 1;
 }
 
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
@@ -42,7 +42,7 @@ message AggregationRule {
 message ClusterRole {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Rules holds all the PolicyRules for this ClusterRole
   // +optional
@@ -62,7 +62,7 @@ message ClusterRole {
 message ClusterRoleBinding {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Subjects holds references to the objects the role applies to.
   // +optional
@@ -79,7 +79,7 @@ message ClusterRoleBinding {
 message ClusterRoleBindingList {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of ClusterRoleBindings
   repeated ClusterRoleBinding items = 2;
@@ -90,7 +90,7 @@ message ClusterRoleBindingList {
 message ClusterRoleList {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of ClusterRoles
   repeated ClusterRole items = 2;
@@ -132,7 +132,7 @@ message PolicyRule {
 message Role {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Rules holds all the PolicyRules for this Role
   // +optional
@@ -147,7 +147,7 @@ message Role {
 message RoleBinding {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Subjects holds references to the objects the role applies to.
   // +optional
@@ -164,7 +164,7 @@ message RoleBinding {
 message RoleBindingList {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of RoleBindings
   repeated RoleBinding items = 2;
@@ -175,7 +175,7 @@ message RoleBindingList {
 message RoleList {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of Roles
   repeated Role items = 2;

--- a/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
@@ -34,7 +34,7 @@ message AggregationRule {
   // If any of the selectors match, then the ClusterRole's permissions will be added
   // +optional
   // +listType=atomic
-  repeated k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector clusterRoleSelectors = 1;
+  repeated .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector clusterRoleSelectors = 1;
 }
 
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
@@ -42,7 +42,7 @@ message AggregationRule {
 message ClusterRole {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Rules holds all the PolicyRules for this ClusterRole
   // +optional
@@ -62,7 +62,7 @@ message ClusterRole {
 message ClusterRoleBinding {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Subjects holds references to the objects the role applies to.
   // +optional
@@ -79,7 +79,7 @@ message ClusterRoleBinding {
 message ClusterRoleBindingList {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of ClusterRoleBindings
   repeated ClusterRoleBinding items = 2;
@@ -90,7 +90,7 @@ message ClusterRoleBindingList {
 message ClusterRoleList {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of ClusterRoles
   repeated ClusterRole items = 2;
@@ -133,7 +133,7 @@ message PolicyRule {
 message Role {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Rules holds all the PolicyRules for this Role
   // +optional
@@ -148,7 +148,7 @@ message Role {
 message RoleBinding {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Subjects holds references to the objects the role applies to.
   // +optional
@@ -165,7 +165,7 @@ message RoleBinding {
 message RoleBindingList {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of RoleBindings
   repeated RoleBinding items = 2;
@@ -176,7 +176,7 @@ message RoleBindingList {
 message RoleList {
   // Standard object's metadata.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is a list of Roles
   repeated Role items = 2;

--- a/staging/src/k8s.io/api/resource/v1alpha2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1alpha2/generated.proto
@@ -56,7 +56,7 @@ message AllocationResult {
   // Setting this field is optional. If null, the resource is available
   // everywhere.
   // +optional
-  optional k8s.io.api.core.v1.NodeSelector availableOnNodes = 2;
+  optional .k8s.io.api.core.v1.NodeSelector availableOnNodes = 2;
 
   // Shareable determines whether the resource supports more
   // than one consumer at a time.
@@ -79,7 +79,7 @@ message DriverAllocationResult {
   // from the time that the claim was allocated.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension vendorRequestParameters = 1;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension vendorRequestParameters = 1;
 
   optional AllocationResultModel allocationResultModel = 2;
 }
@@ -93,7 +93,7 @@ message DriverRequests {
   // claim. They are ignored while allocating the claim.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension vendorParameters = 2;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension vendorParameters = 2;
 
   // Requests describes all resources that are needed from the driver.
   // +listType=atomic
@@ -118,7 +118,7 @@ message NamedResourcesAttribute {
 // NamedResourcesAttributeValue must have one and only one field set.
 message NamedResourcesAttributeValue {
   // QuantityValue is a quantity.
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity quantity = 6;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity quantity = 6;
 
   // BoolValue is a true/false value.
   optional bool bool = 2;
@@ -217,7 +217,7 @@ message NamedResourcesStringSlice {
 message PodSchedulingContext {
   // Standard object metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec describes where resources for the Pod are needed.
   optional PodSchedulingContextSpec spec = 2;
@@ -231,7 +231,7 @@ message PodSchedulingContext {
 message PodSchedulingContextList {
   // Standard list metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of PodSchedulingContext objects.
   repeated PodSchedulingContext items = 2;
@@ -278,7 +278,7 @@ message PodSchedulingContextStatus {
 message ResourceClaim {
   // Standard object metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec describes the desired attributes of a resource that then needs
   // to be allocated. It can only be set once when creating the
@@ -315,7 +315,7 @@ message ResourceClaimConsumerReference {
 message ResourceClaimList {
   // Standard list metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of resource claims.
   repeated ResourceClaim items = 2;
@@ -325,7 +325,7 @@ message ResourceClaimList {
 // in-tree format understood by Kubernetes.
 message ResourceClaimParameters {
   // Standard object metadata
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // If this object was created from some other resource, then this links
   // back to that resource. This field is used to find the in-tree representation
@@ -354,7 +354,7 @@ message ResourceClaimParameters {
 message ResourceClaimParametersList {
   // Standard list metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of node resource capacity objects.
   repeated ResourceClaimParameters items = 2;
@@ -462,7 +462,7 @@ message ResourceClaimStatus {
 message ResourceClaimTemplate {
   // Standard object metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Describes the ResourceClaim that is to be generated.
   //
@@ -476,7 +476,7 @@ message ResourceClaimTemplate {
 message ResourceClaimTemplateList {
   // Standard list metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of resource claim templates.
   repeated ResourceClaimTemplate items = 2;
@@ -488,7 +488,7 @@ message ResourceClaimTemplateSpec {
   // when creating it. No other fields are allowed and will be rejected during
   // validation.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec for the ResourceClaim. The entire content is copied unchanged
   // into the ResourceClaim that gets created from this template. The
@@ -504,7 +504,7 @@ message ResourceClaimTemplateSpec {
 message ResourceClass {
   // Standard object metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // DriverName defines the name of the dynamic resource driver that is
   // used for allocation of a ResourceClaim that uses this class.
@@ -527,7 +527,7 @@ message ResourceClass {
   //
   // Setting this field is optional. If null, all nodes are candidates.
   // +optional
-  optional k8s.io.api.core.v1.NodeSelector suitableNodes = 4;
+  optional .k8s.io.api.core.v1.NodeSelector suitableNodes = 4;
 
   // If and only if allocation of claims using this class is handled
   // via structured parameters, then StructuredParameters must be set to true.
@@ -539,7 +539,7 @@ message ResourceClass {
 message ResourceClassList {
   // Standard list metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of resource classes.
   repeated ResourceClass items = 2;
@@ -549,7 +549,7 @@ message ResourceClassList {
 // in-tree format understood by Kubernetes.
 message ResourceClassParameters {
   // Standard object metadata
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // If this object was created from some other resource, then this links
   // back to that resource. This field is used to find the in-tree representation
@@ -576,7 +576,7 @@ message ResourceClassParameters {
 message ResourceClassParametersList {
   // Standard list metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of node resource capacity objects.
   repeated ResourceClassParameters items = 2;
@@ -661,7 +661,7 @@ message ResourceRequest {
   // resource. They are ignored while allocating a claim.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension vendorParameters = 1;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension vendorParameters = 1;
 
   optional ResourceRequestModel resourceRequestModel = 2;
 }
@@ -679,7 +679,7 @@ message ResourceRequestModel {
 message ResourceSlice {
   // Standard object metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // NodeName identifies the node which provides the resources
   // if they are local to a node.
@@ -702,7 +702,7 @@ message ResourceSlice {
 message ResourceSliceList {
   // Standard list metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of node resource capacity objects.
   repeated ResourceSlice items = 2;
@@ -714,14 +714,14 @@ message StructuredResourceHandle {
   // from the resource class at the time that the claim was allocated.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension vendorClassParameters = 1;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension vendorClassParameters = 1;
 
   // VendorClaimParameters are the per-claim configuration parameters
   // from the resource claim parameters at the time that the claim was
   // allocated.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension vendorClaimParameters = 2;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension vendorClaimParameters = 2;
 
   // NodeName is the name of the node providing the necessary resources
   // if the resources are local to a node.
@@ -744,6 +744,6 @@ message VendorParameters {
   // allocating a claim.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension parameters = 2;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension parameters = 2;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1/generated.proto
@@ -35,7 +35,7 @@ message PriorityClass {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
@@ -66,7 +66,7 @@ message PriorityClassList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of PriorityClasses
   repeated PriorityClass items = 2;

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/generated.proto
@@ -36,7 +36,7 @@ message PriorityClass {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
@@ -67,7 +67,7 @@ message PriorityClassList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of PriorityClasses
   repeated PriorityClass items = 2;

--- a/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
@@ -36,7 +36,7 @@ message PriorityClass {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
@@ -67,7 +67,7 @@ message PriorityClassList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of PriorityClasses
   repeated PriorityClass items = 2;

--- a/staging/src/k8s.io/api/storage/v1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1/generated.proto
@@ -44,7 +44,7 @@ message CSIDriver {
   // an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and
   // alphanumerics between.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec represents the specification of the CSI Driver.
   optional CSIDriverSpec spec = 2;
@@ -55,7 +55,7 @@ message CSIDriverList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of CSIDriver
   repeated CSIDriver items = 2;
@@ -226,7 +226,7 @@ message CSIDriverSpec {
 message CSINode {
   // Standard object's metadata.
   // metadata.name must be the Kubernetes node name.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec is the specification of CSINode
   optional CSINodeSpec spec = 2;
@@ -275,7 +275,7 @@ message CSINodeList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of CSINode
   repeated CSINode items = 2;
@@ -327,7 +327,7 @@ message CSIStorageCapacity {
   //
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // nodeTopology defines which nodes have access to the storage
   // for which capacity was reported. If not set, the storage is
@@ -336,7 +336,7 @@ message CSIStorageCapacity {
   // immutable.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector nodeTopology = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector nodeTopology = 2;
 
   // storageClassName represents the name of the StorageClass that the reported capacity applies to.
   // It must meet the same requirements as the name of a StorageClass
@@ -356,7 +356,7 @@ message CSIStorageCapacity {
   // unavailable.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity capacity = 4;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity capacity = 4;
 
   // maximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse
   // for a GetCapacityRequest with topology and parameters that match the
@@ -370,7 +370,7 @@ message CSIStorageCapacity {
   // API is ResourceRequirements.Requests in a volume claim.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity maximumVolumeSize = 5;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity maximumVolumeSize = 5;
 }
 
 // CSIStorageCapacityList is a collection of CSIStorageCapacity objects.
@@ -378,7 +378,7 @@ message CSIStorageCapacityList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of CSIStorageCapacity objects.
   repeated CSIStorageCapacity items = 2;
@@ -393,7 +393,7 @@ message StorageClass {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // provisioner indicates the type of the provisioner.
   optional string provisioner = 2;
@@ -431,7 +431,7 @@ message StorageClass {
   // This field is only honored by servers that enable the VolumeScheduling feature.
   // +optional
   // +listType=atomic
-  repeated k8s.io.api.core.v1.TopologySelectorTerm allowedTopologies = 8;
+  repeated .k8s.io.api.core.v1.TopologySelectorTerm allowedTopologies = 8;
 }
 
 // StorageClassList is a collection of storage classes.
@@ -439,7 +439,7 @@ message StorageClassList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of StorageClasses
   repeated StorageClass items = 2;
@@ -466,7 +466,7 @@ message VolumeAttachment {
   // Standard object metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
@@ -484,7 +484,7 @@ message VolumeAttachmentList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of VolumeAttachments
   repeated VolumeAttachment items = 2;
@@ -506,7 +506,7 @@ message VolumeAttachmentSource {
   // PersistentVolumeSpec. This field is beta-level and is only
   // honored by servers that enabled the CSIMigration feature.
   // +optional
-  optional k8s.io.api.core.v1.PersistentVolumeSpec inlineVolumeSpec = 2;
+  optional .k8s.io.api.core.v1.PersistentVolumeSpec inlineVolumeSpec = 2;
 }
 
 // VolumeAttachmentSpec is the specification of a VolumeAttachment request.
@@ -554,7 +554,7 @@ message VolumeAttachmentStatus {
 message VolumeError {
   // time represents the time the error was encountered.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time time = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time time = 1;
 
   // message represents the error encountered during Attach or Detach operation.
   // This string may be logged, so it should not contain sensitive

--- a/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
@@ -65,7 +65,7 @@ message CSIStorageCapacity {
   //
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // nodeTopology defines which nodes have access to the storage
   // for which capacity was reported. If not set, the storage is
@@ -74,7 +74,7 @@ message CSIStorageCapacity {
   // immutable.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector nodeTopology = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector nodeTopology = 2;
 
   // storageClassName represents the name of the StorageClass that the reported capacity applies to.
   // It must meet the same requirements as the name of a StorageClass
@@ -94,7 +94,7 @@ message CSIStorageCapacity {
   // unavailable.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity capacity = 4;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity capacity = 4;
 
   // maximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse
   // for a GetCapacityRequest with topology and parameters that match the
@@ -108,7 +108,7 @@ message CSIStorageCapacity {
   // API is ResourceRequirements.Requests in a volume claim.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity maximumVolumeSize = 5;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity maximumVolumeSize = 5;
 }
 
 // CSIStorageCapacityList is a collection of CSIStorageCapacity objects.
@@ -116,7 +116,7 @@ message CSIStorageCapacityList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of CSIStorageCapacity objects.
   repeated CSIStorageCapacity items = 2;
@@ -130,7 +130,7 @@ message VolumeAttachment {
   // Standard object metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
@@ -148,7 +148,7 @@ message VolumeAttachmentList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of VolumeAttachments
   repeated VolumeAttachment items = 2;
@@ -170,7 +170,7 @@ message VolumeAttachmentSource {
   // PersistentVolumeSpec. This field is alpha-level and is only
   // honored by servers that enabled the CSIMigration feature.
   // +optional
-  optional k8s.io.api.core.v1.PersistentVolumeSpec inlineVolumeSpec = 2;
+  optional .k8s.io.api.core.v1.PersistentVolumeSpec inlineVolumeSpec = 2;
 }
 
 // VolumeAttachmentSpec is the specification of a VolumeAttachment request.
@@ -221,7 +221,7 @@ message VolumeAttributesClass {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Name of the CSI driver
   // This field is immutable.
@@ -248,7 +248,7 @@ message VolumeAttributesClassList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of VolumeAttributesClass objects.
   repeated VolumeAttributesClass items = 2;
@@ -258,7 +258,7 @@ message VolumeAttributesClassList {
 message VolumeError {
   // time represents the time the error was encountered.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time time = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time time = 1;
 
   // message represents the error encountered during Attach or Detach operation.
   // This string maybe logged, so it should not contain sensitive

--- a/staging/src/k8s.io/api/storage/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1beta1/generated.proto
@@ -47,7 +47,7 @@ message CSIDriver {
   // an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and
   // alphanumerics between.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec represents the specification of the CSI Driver.
   optional CSIDriverSpec spec = 2;
@@ -58,7 +58,7 @@ message CSIDriverList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of CSIDriver
   repeated CSIDriver items = 2;
@@ -229,7 +229,7 @@ message CSIDriverSpec {
 // CSINode has an OwnerReference that points to the corresponding node object.
 message CSINode {
   // metadata.name must be the Kubernetes node name.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec is the specification of CSINode
   optional CSINodeSpec spec = 2;
@@ -277,7 +277,7 @@ message CSINodeList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of CSINode
   repeated CSINode items = 2;
@@ -329,7 +329,7 @@ message CSIStorageCapacity {
   //
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // nodeTopology defines which nodes have access to the storage
   // for which capacity was reported. If not set, the storage is
@@ -338,7 +338,7 @@ message CSIStorageCapacity {
   // immutable.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector nodeTopology = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector nodeTopology = 2;
 
   // storageClassName represents the name of the StorageClass that the reported capacity applies to.
   // It must meet the same requirements as the name of a StorageClass
@@ -358,7 +358,7 @@ message CSIStorageCapacity {
   // unavailable.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity capacity = 4;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity capacity = 4;
 
   // maximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse
   // for a GetCapacityRequest with topology and parameters that match the
@@ -372,7 +372,7 @@ message CSIStorageCapacity {
   // API is ResourceRequirements.Requests in a volume claim.
   //
   // +optional
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity maximumVolumeSize = 5;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity maximumVolumeSize = 5;
 }
 
 // CSIStorageCapacityList is a collection of CSIStorageCapacity objects.
@@ -380,7 +380,7 @@ message CSIStorageCapacityList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of CSIStorageCapacity objects.
   repeated CSIStorageCapacity items = 2;
@@ -395,7 +395,7 @@ message StorageClass {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // provisioner indicates the type of the provisioner.
   optional string provisioner = 2;
@@ -433,7 +433,7 @@ message StorageClass {
   // This field is only honored by servers that enable the VolumeScheduling feature.
   // +optional
   // +listType=atomic
-  repeated k8s.io.api.core.v1.TopologySelectorTerm allowedTopologies = 8;
+  repeated .k8s.io.api.core.v1.TopologySelectorTerm allowedTopologies = 8;
 }
 
 // StorageClassList is a collection of storage classes.
@@ -441,7 +441,7 @@ message StorageClassList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of StorageClasses
   repeated StorageClass items = 2;
@@ -468,7 +468,7 @@ message VolumeAttachment {
   // Standard object metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec represents specification of the desired attach/detach volume behavior.
   // Populated by the Kubernetes system.
@@ -486,7 +486,7 @@ message VolumeAttachmentList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items is the list of VolumeAttachments
   repeated VolumeAttachment items = 2;
@@ -508,7 +508,7 @@ message VolumeAttachmentSource {
   // PersistentVolumeSpec. This field is beta-level and is only
   // honored by servers that enabled the CSIMigration feature.
   // +optional
-  optional k8s.io.api.core.v1.PersistentVolumeSpec inlineVolumeSpec = 2;
+  optional .k8s.io.api.core.v1.PersistentVolumeSpec inlineVolumeSpec = 2;
 }
 
 // VolumeAttachmentSpec is the specification of a VolumeAttachment request.
@@ -556,7 +556,7 @@ message VolumeAttachmentStatus {
 message VolumeError {
   // time represents the time the error was encountered.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time time = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time time = 1;
 
   // message represents the error encountered during Attach or Detach operation.
   // This string may be logged, so it should not contain sensitive

--- a/staging/src/k8s.io/api/storagemigration/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/storagemigration/v1alpha1/generated.proto
@@ -51,7 +51,7 @@ message MigrationCondition {
 
   // The last time this condition was updated.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastUpdateTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastUpdateTime = 3;
 
   // The reason for the condition's last transition.
   // +optional
@@ -68,7 +68,7 @@ message StorageVersionMigration {
   // Standard object metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the migration.
   // +optional
@@ -84,7 +84,7 @@ message StorageVersionMigrationList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of StorageVersionMigration
   // +patchMergeKey=type

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/generated.proto
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/generated.proto
@@ -41,7 +41,7 @@ message ConversionRequest {
 
   // objects is the list of custom resource objects to be converted.
   // +listType=atomic
-  repeated k8s.io.apimachinery.pkg.runtime.RawExtension objects = 3;
+  repeated .k8s.io.apimachinery.pkg.runtime.RawExtension objects = 3;
 }
 
 // ConversionResponse describes a conversion response.
@@ -55,14 +55,14 @@ message ConversionResponse {
   // must also have the same size as the input list with the same objects in the same order (equal kind, metadata.uid, metadata.name and metadata.namespace).
   // The webhook is allowed to mutate labels and annotations. Any other change to the metadata is silently ignored.
   // +listType=atomic
-  repeated k8s.io.apimachinery.pkg.runtime.RawExtension convertedObjects = 2;
+  repeated .k8s.io.apimachinery.pkg.runtime.RawExtension convertedObjects = 2;
 
   // result contains the result of conversion with extra details if the conversion failed. `result.status` determines if
   // the conversion failed or succeeded. The `result.status` field is required and represents the success or failure of the
   // conversion. A successful conversion must set `result.status` to `Success`. A failed conversion must set
   // `result.status` to `Failure` and provide more details in `result.message` and return http status 200. The `result.message`
   // will be used to construct an error message for the end user.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Status result = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Status result = 3;
 }
 
 // ConversionReview describes a conversion request/response.
@@ -125,7 +125,7 @@ message CustomResourceDefinition {
   // Standard object's metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec describes how the user wants the resources to appear
   optional CustomResourceDefinitionSpec spec = 2;
@@ -146,7 +146,7 @@ message CustomResourceDefinitionCondition {
 
   // lastTransitionTime last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // reason is a unique, one-word, CamelCase reason for the condition's last transition.
   // +optional
@@ -162,7 +162,7 @@ message CustomResourceDefinitionList {
   // Standard object's metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items list individual CustomResourceDefinition objects
   repeated CustomResourceDefinition items = 2;

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
@@ -41,7 +41,7 @@ message ConversionRequest {
 
   // objects is the list of custom resource objects to be converted.
   // +listType=atomic
-  repeated k8s.io.apimachinery.pkg.runtime.RawExtension objects = 3;
+  repeated .k8s.io.apimachinery.pkg.runtime.RawExtension objects = 3;
 }
 
 // ConversionResponse describes a conversion response.
@@ -55,14 +55,14 @@ message ConversionResponse {
   // must also have the same size as the input list with the same objects in the same order (equal kind, metadata.uid, metadata.name and metadata.namespace).
   // The webhook is allowed to mutate labels and annotations. Any other change to the metadata is silently ignored.
   // +listType=atomic
-  repeated k8s.io.apimachinery.pkg.runtime.RawExtension convertedObjects = 2;
+  repeated .k8s.io.apimachinery.pkg.runtime.RawExtension convertedObjects = 2;
 
   // result contains the result of conversion with extra details if the conversion failed. `result.status` determines if
   // the conversion failed or succeeded. The `result.status` field is required and represents the success or failure of the
   // conversion. A successful conversion must set `result.status` to `Success`. A failed conversion must set
   // `result.status` to `Failure` and provide more details in `result.message` and return http status 200. The `result.message`
   // will be used to construct an error message for the end user.
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Status result = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Status result = 3;
 }
 
 // ConversionReview describes a conversion request/response.
@@ -138,7 +138,7 @@ message CustomResourceDefinition {
   // Standard object's metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec describes how the user wants the resources to appear
   optional CustomResourceDefinitionSpec spec = 2;
@@ -159,7 +159,7 @@ message CustomResourceDefinitionCondition {
 
   // lastTransitionTime last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // reason is a unique, one-word, CamelCase reason for the condition's last transition.
   // +optional
@@ -175,7 +175,7 @@ message CustomResourceDefinitionList {
   // Standard object's metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // items list individual CustomResourceDefinition objects
   repeated CustomResourceDefinition items = 2;

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -460,7 +460,7 @@ message List {
   optional ListMeta metadata = 1;
 
   // List of objects
-  repeated k8s.io.apimachinery.pkg.runtime.RawExtension items = 2;
+  repeated .k8s.io.apimachinery.pkg.runtime.RawExtension items = 2;
 }
 
 // ListMeta describes metadata that synthetic resources must have, including lists and
@@ -1209,6 +1209,6 @@ message WatchEvent {
   //  * If Type is Deleted: the state of the object immediately before deletion.
   //  * If Type is Error: *Status is recommended; other types may make sense
   //    depending on context.
-  optional k8s.io.apimachinery.pkg.runtime.RawExtension object = 2;
+  optional .k8s.io.apimachinery.pkg.runtime.RawExtension object = 2;
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1/generated.proto
@@ -33,9 +33,9 @@ message PartialObjectMetadataList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 2;
 
   // items contains each of the included items.
-  repeated k8s.io.apimachinery.pkg.apis.meta.v1.PartialObjectMetadata items = 1;
+  repeated .k8s.io.apimachinery.pkg.apis.meta.v1.PartialObjectMetadata items = 1;
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/generated.proto
@@ -33,7 +33,7 @@ message Carp {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the carp.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -62,11 +62,11 @@ message CarpCondition {
 
   // Last time we probed the condition.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastProbeTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastProbeTime = 3;
 
   // Last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
 
   // Unique, one-word, CamelCase reason for the condition's last transition.
   // +optional
@@ -82,7 +82,7 @@ message CarpList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of carps.
   // More info: http://kubernetes.io/docs/user-guide/carps
@@ -206,6 +206,6 @@ message CarpStatus {
   // RFC 3339 date and time at which the object was acknowledged by the Kubelet.
   // This is before the Kubelet pulled the container image(s) for the carp.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time startTime = 7;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time startTime = 7;
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/generated.proto
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/generated.proto
@@ -48,11 +48,11 @@ message Event {
   optional string verb = 5;
 
   // Authenticated user information.
-  optional k8s.io.api.authentication.v1.UserInfo user = 6;
+  optional .k8s.io.api.authentication.v1.UserInfo user = 6;
 
   // Impersonated user information.
   // +optional
-  optional k8s.io.api.authentication.v1.UserInfo impersonatedUser = 7;
+  optional .k8s.io.api.authentication.v1.UserInfo impersonatedUser = 7;
 
   // Source IPs, from where the request originated and intermediate proxies.
   // The source IPs are listed from (in order):
@@ -79,28 +79,28 @@ message Event {
   // For successful responses, this will only include the Code and StatusSuccess.
   // For non-status type error responses, this will be auto-populated with the error Message.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Status responseStatus = 10;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Status responseStatus = 10;
 
   // API object from the request, in JSON format. The RequestObject is recorded as-is in the request
   // (possibly re-encoded as JSON), prior to version conversion, defaulting, admission or
   // merging. It is an external versioned object type, and may not be a valid object on its own.
   // Omitted for non-resource requests.  Only logged at Request Level and higher.
   // +optional
-  optional k8s.io.apimachinery.pkg.runtime.Unknown requestObject = 11;
+  optional .k8s.io.apimachinery.pkg.runtime.Unknown requestObject = 11;
 
   // API object returned in the response, in JSON. The ResponseObject is recorded after conversion
   // to the external type, and serialized as JSON.  Omitted for non-resource requests.  Only logged
   // at Response Level.
   // +optional
-  optional k8s.io.apimachinery.pkg.runtime.Unknown responseObject = 12;
+  optional .k8s.io.apimachinery.pkg.runtime.Unknown responseObject = 12;
 
   // Time the request reached the apiserver.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime requestReceivedTimestamp = 13;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime requestReceivedTimestamp = 13;
 
   // Time the request reached current audit stage.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime stageTimestamp = 14;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime stageTimestamp = 14;
 
   // Annotations is an unstructured key value map stored with an audit event that may be set by
   // plugins invoked in the request serving chain, including authentication, authorization and
@@ -115,7 +115,7 @@ message Event {
 // EventList is a list of audit Events.
 message EventList {
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   repeated Event items = 2;
 }
@@ -187,7 +187,7 @@ message ObjectReference {
 message Policy {
   // ObjectMeta is included for interoperability with API infrastructure.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Rules specify the audit Level a request should be recorded at.
   // A request may match multiple rules, in which case the FIRST matching rule is used.
@@ -215,7 +215,7 @@ message Policy {
 // PolicyList is a list of audit Policies.
 message PolicyList {
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   repeated Policy items = 2;
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/v1/generated.proto
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/v1/generated.proto
@@ -33,7 +33,7 @@ message Pod {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the desired behavior of the pod.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -62,11 +62,11 @@ message PodCondition {
 
   // Last time we probed the condition.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastProbeTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastProbeTime = 3;
 
   // Last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 4;
 
   // Unique, one-word, CamelCase reason for the condition's last transition.
   // +optional
@@ -82,7 +82,7 @@ message PodList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of pods.
   // More info: http://kubernetes.io/docs/user-guide/pods
@@ -206,6 +206,6 @@ message PodStatus {
   // RFC 3339 date and time at which the object was acknowledged by the Kubelet.
   // This is before the Kubelet pulled the container image(s) for the pod.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time startTime = 7;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time startTime = 7;
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/example2/v1/generated.proto
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example2/v1/generated.proto
@@ -34,7 +34,7 @@ message ReplicaSet {
   // be the same as the Pod(s) that the ReplicaSet manages.
   // Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec defines the specification of the desired behavior of the ReplicaSet.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status

--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/namer.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/namer.go
@@ -37,6 +37,11 @@ func (n localNamer) Name(t *types.Type) string {
 	if len(n.localPackage.Package) != 0 && n.localPackage.Package == t.Name.Package {
 		return t.Name.Name
 	}
+	// For non-local and non-fundamental types, use an absolute reference
+	// see https://protobuf.com/docs/language-spec#type-references
+	if strings.Contains(t.Name.Package, ".") {
+		return fmt.Sprintf(".%s", t.Name)
+	}
 	return t.Name.String()
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/generated.proto
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/generated.proto
@@ -34,7 +34,7 @@ message APIService {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec contains information for locating and communicating with a server
   optional APIServiceSpec spec = 2;
@@ -54,7 +54,7 @@ message APIServiceCondition {
 
   // Last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // Unique, one-word, CamelCase reason for the condition's last transition.
   // +optional
@@ -70,7 +70,7 @@ message APIServiceList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of APIService
   repeated APIService items = 2;

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/generated.proto
@@ -34,7 +34,7 @@ message APIService {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec contains information for locating and communicating with a server
   optional APIServiceSpec spec = 2;
@@ -54,7 +54,7 @@ message APIServiceCondition {
 
   // Last time the condition transitioned from one status to another.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastTransitionTime = 3;
 
   // Unique, one-word, CamelCase reason for the condition's last transition.
   // +optional
@@ -70,7 +70,7 @@ message APIServiceList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // Items is the list of APIService
   repeated APIService items = 2;

--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/generated.proto
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/generated.proto
@@ -45,13 +45,13 @@ message MetricListOptions {
 // MetricValue is a metric value for some object
 message MetricValue {
   // a reference to the described object
-  optional k8s.io.api.core.v1.ObjectReference describedObject = 1;
+  optional .k8s.io.api.core.v1.ObjectReference describedObject = 1;
 
   // the name of the metric
   optional string metricName = 2;
 
   // indicates the time at which the metrics were produced
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time timestamp = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time timestamp = 3;
 
   // indicates the window ([Timestamp-Window, Timestamp]) from
   // which these metrics were calculated, when returning rate
@@ -60,19 +60,19 @@ message MetricValue {
   optional int64 window = 4;
 
   // the value of the metric for this
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity value = 5;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity value = 5;
 
   // selector represents the label selector that could be used to select
   // this metric, and will generally just be the selector passed in to
   // the query used to fetch this metric.
   // When left blank, only the metric's Name will be used to gather metrics.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 6;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 6;
 }
 
 // MetricValueList is a list of values for a given metric for some set of objects
 message MetricValueList {
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // the value of the metric across the described objects
   repeated MetricValue items = 2;

--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta2/generated.proto
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta2/generated.proto
@@ -40,7 +40,7 @@ message MetricIdentifier {
   // the query used to fetch this metric.
   // When left blank, only the metric's Name will be used to gather metrics.
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 }
 
 // MetricListOptions is used to select metrics by their label selectors
@@ -58,12 +58,12 @@ message MetricListOptions {
 // MetricValue is the metric value for some object
 message MetricValue {
   // a reference to the described object
-  optional k8s.io.api.core.v1.ObjectReference describedObject = 1;
+  optional .k8s.io.api.core.v1.ObjectReference describedObject = 1;
 
   optional MetricIdentifier metric = 2;
 
   // indicates the time at which the metrics were produced
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time timestamp = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time timestamp = 3;
 
   // indicates the window ([Timestamp-Window, Timestamp]) from
   // which these metrics were calculated, when returning rate
@@ -72,12 +72,12 @@ message MetricValue {
   optional int64 windowSeconds = 4;
 
   // the value of the metric for this
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity value = 5;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity value = 5;
 }
 
 // MetricValueList is a list of values for a given metric for some set of objects
 message MetricValueList {
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // the value of the metric across the described objects
   repeated MetricValue items = 2;

--- a/staging/src/k8s.io/metrics/pkg/apis/external_metrics/v1beta1/generated.proto
+++ b/staging/src/k8s.io/metrics/pkg/apis/external_metrics/v1beta1/generated.proto
@@ -40,7 +40,7 @@ message ExternalMetricValue {
   map<string, string> metricLabels = 2;
 
   // indicates the time at which the metrics were produced
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time timestamp = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time timestamp = 3;
 
   // indicates the window ([Timestamp-Window, Timestamp]) from
   // which these metrics were calculated, when returning rate
@@ -49,12 +49,12 @@ message ExternalMetricValue {
   optional int64 window = 4;
 
   // the value of the metric
-  optional k8s.io.apimachinery.pkg.api.resource.Quantity value = 5;
+  optional .k8s.io.apimachinery.pkg.api.resource.Quantity value = 5;
 }
 
 // ExternalMetricValueList is a list of values for a given metric for some set labels
 message ExternalMetricValueList {
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // value of the metric matching a given set of labels
   repeated ExternalMetricValue items = 2;

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/generated.proto
@@ -36,7 +36,7 @@ message ContainerMetrics {
   optional string name = 1;
 
   // The memory usage is the memory working set.
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> usage = 2;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> usage = 2;
 }
 
 // NodeMetrics sets resource usage metrics of a node.
@@ -44,23 +44,23 @@ message NodeMetrics {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // The following fields define time interval from which metrics were
   // collected from the interval [Timestamp-Window, Timestamp].
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time timestamp = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time timestamp = 2;
 
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Duration window = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration window = 3;
 
   // The memory usage is the memory working set.
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> usage = 4;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> usage = 4;
 }
 
 // NodeMetricsList is a list of NodeMetrics.
 message NodeMetricsList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of node metrics.
   repeated NodeMetrics items = 2;
@@ -71,13 +71,13 @@ message PodMetrics {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // The following fields define time interval from which metrics were
   // collected from the interval [Timestamp-Window, Timestamp].
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time timestamp = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time timestamp = 2;
 
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Duration window = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration window = 3;
 
   // Metrics for all containers are collected within the same time window.
   // +listType=atomic
@@ -88,7 +88,7 @@ message PodMetrics {
 message PodMetricsList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of pod metrics.
   repeated PodMetrics items = 2;

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1/generated.proto
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1/generated.proto
@@ -36,7 +36,7 @@ message ContainerMetrics {
   optional string name = 1;
 
   // The memory usage is the memory working set.
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> usage = 2;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> usage = 2;
 }
 
 // NodeMetrics sets resource usage metrics of a node.
@@ -44,23 +44,23 @@ message NodeMetrics {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // The following fields define time interval from which metrics were
   // collected from the interval [Timestamp-Window, Timestamp].
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time timestamp = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time timestamp = 2;
 
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Duration window = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration window = 3;
 
   // The memory usage is the memory working set.
-  map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> usage = 4;
+  map<string, .k8s.io.apimachinery.pkg.api.resource.Quantity> usage = 4;
 }
 
 // NodeMetricsList is a list of NodeMetrics.
 message NodeMetricsList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of node metrics.
   repeated NodeMetrics items = 2;
@@ -71,13 +71,13 @@ message PodMetrics {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // The following fields define time interval from which metrics were
   // collected from the interval [Timestamp-Window, Timestamp].
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Time timestamp = 2;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time timestamp = 2;
 
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.Duration window = 3;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration window = 3;
 
   // Metrics for all containers are collected within the same time window.
   // +listType=atomic
@@ -88,7 +88,7 @@ message PodMetrics {
 message PodMetricsList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
   // List of pod metrics.
   repeated PodMetrics items = 2;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently type references for non-local names are output as relative types which is subject to the resolution rules as defined at https://protobuf.com/docs/language-spec#reference-resolution This works fine within the k8s.io namespace where no subpackages are named k8s, but other users of go-to-protobuf likely have k8s in their package name. This causes conflicts in the search resolution when executing `go-to-protobuf`:

```
company.example.com/k8s/custom/pkg/apis/custom.k8s.example.com/v1/generated.proto:64:12: "k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta" is resolved to "company.example.com.k8s.custom.pkg.apis.custom.k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading '.'(i.e., ".k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta") to start from the outermost scope.
```

To avoid this we can output fully qualified type references using a preceding dot (.)

This would result in a change for k8s generated.proto files, but the effect is a noop. I.e:

```
--- a/staging/src/k8s.io/api/coordination/v1/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1/generated.proto
@@ -32,7 +32,7 @@ option go_package = "k8s.io/api/coordination/v1";
 message Lease {
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
-  optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;

   // spec contains the specification of the Lease.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/code-generator#147

#### Special notes for your reviewer:
~~The code-generator changes that would result have not been applied due to the logic in `hack/update-codegen.sh` and `hack/verify-codegen.sh` as those scripts install the latest version of code-generator as a module directly from the other repo. When/if this change is synced over, then `hack/update-codegen.sh` would need to be run.~~

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
