### PR TITLE
[CEL] Clean up reference to deleted denied function

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/library/authz.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/authz.go
@@ -156,7 +156,7 @@ import (
 // allowed
 //
 // Returns true if the authorizer's decision for the check is "allow".  Note that if the authorizer's decision is
-// "no opinion", that both the 'allowed' and 'denied' functions will return false.
+// "no opinion", that the 'allowed' function will return false.
 //
 //	<Decision>.allowed() <bool>
 //


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/kind cleanup

#### What this PR does / why we need it:

Looks like the `denied` CEL authz function got dropped somewhere in PR review, but a reference to it in the docs comment was missed.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig api-machinery
/assign @jpbetz 