### PR TITLE
ipallocator: reduce free ips for IPv6 unittest to avoid timeout

### DIFF
--- a/pkg/registry/core/service/ipallocator/ipallocator_test.go
+++ b/pkg/registry/core/service/ipallocator/ipallocator_test.go
@@ -97,8 +97,8 @@ func TestAllocateIPAllocator(t *testing.T) {
 		},
 		{
 			name:     "IPv6",
-			cidr:     "2001:db8:1::/116",
-			free:     4095,
+			cidr:     "2001:db8:1::/120",
+			free:     255,
 			released: "2001:db8:1::5",
 			outOfRange: []string{
 				"2001:db8::1",   // not in 2001:db8:1::/48


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

This PR helped in `ci-kubernetes-unit-eks-canary`.
```
# Before
ok      k8s.io/kubernetes/pkg/registry/core/service/ipallocator 6.958s
# After
ok      k8s.io/kubernetes/pkg/registry/core/service/ipallocator 0.665s
```

https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/ci-kubernetes-unit-eks-canary
This may fix the timeout in `ci-kubernetes-unit-eks-canary`, but for TestLazyThroughput, the ci will still fail, the ci is very slow and this cannot easily be fixed in my mind. I opened https://github.com/kubernetes/kubernetes/issues/116789 for TestLazyThroughput.

```release-note
None
```
