### PR TITLE
safe-sysctl: skip checking for windows

### DIFF
--- a/pkg/kubelet/sysctl/safe_sysctls.go
+++ b/pkg/kubelet/sysctl/safe_sysctls.go
@@ -17,11 +17,15 @@ limitations under the License.
 package sysctl
 
 import (
+	"fmt"
+	goruntime "runtime"
+
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/proxy/ipvs"
 )
 
+// refer to https://github.com/torvalds/linux/commit/122ff243f5f104194750ecbc76d5946dd1eec934.
 const ipLocalReservedPortsMinNamespacedKernelVersion = "3.16"
 
 var safeSysctls = []string{
@@ -32,33 +36,44 @@ var safeSysctls = []string{
 	"net.ipv4.ip_unprivileged_port_start",
 }
 
+var safeSysctlsIncludeReservedPorts = []string{
+	"kernel.shm_rmid_forced",
+	"net.ipv4.ip_local_port_range",
+	"net.ipv4.tcp_syncookies",
+	"net.ipv4.ping_group_range",
+	"net.ipv4.ip_unprivileged_port_start",
+	"net.ipv4.ip_local_reserved_ports",
+}
+
 // SafeSysctlAllowlist returns the allowlist of safe sysctls and safe sysctl patterns (ending in *).
 //
 // A sysctl is called safe iff
 // - it is namespaced in the container or the pod
 // - it is isolated, i.e. has no influence on any other pod on the same node.
 func SafeSysctlAllowlist() []string {
+	if goruntime.GOOS == "linux" {
+		// make sure we're on a new enough kernel that the ip_local_reserved_ports sysctl is namespaced
+		kernelVersion, err := getKernelVersion()
+		if err != nil {
+			klog.ErrorS(err, "Failed to get kernel version, dropping net.ipv4.ip_local_reserved_ports from safe sysctl list")
+			return safeSysctls
+		}
+		if kernelVersion.LessThan(version.MustParseGeneric(ipLocalReservedPortsMinNamespacedKernelVersion)) {
+			klog.ErrorS(nil, "Kernel version is too old, dropping net.ipv4.ip_local_reserved_ports from safe sysctl list", "kernelVersion", kernelVersion)
+			return safeSysctls
+		}
+	}
+	return safeSysctlsIncludeReservedPorts
+}
+
+func getKernelVersion() (*version.Version, error) {
 	kernelVersionStr, err := ipvs.NewLinuxKernelHandler().GetKernelVersion()
 	if err != nil {
-		klog.ErrorS(err, "Failed to get kernel version.")
-		return safeSysctls
+		return nil, fmt.Errorf("failed to get kernel version: %w", err)
 	}
 	kernelVersion, err := version.ParseGeneric(kernelVersionStr)
 	if err != nil {
-		klog.ErrorS(err, "Failed to parse kernel version.")
-		return safeSysctls
+		return nil, fmt.Errorf("failed to parse kernel version: %w", err)
 	}
-	// ip_local_reserved_ports has been changed to namesapced since kernel v3.16.
-	// refer to https://github.com/torvalds/linux/commit/122ff243f5f104194750ecbc76d5946dd1eec934.
-	if kernelVersion.LessThan(version.MustParseGeneric(ipLocalReservedPortsMinNamespacedKernelVersion)) {
-		return safeSysctls
-	}
-	return []string{
-		"kernel.shm_rmid_forced",
-		"net.ipv4.ip_local_port_range",
-		"net.ipv4.tcp_syncookies",
-		"net.ipv4.ping_group_range",
-		"net.ipv4.ip_unprivileged_port_start",
-		"net.ipv4.ip_local_reserved_ports",
-	}
+	return kernelVersion, nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

For windows, the kernel version does not have the same meaning as Linux.
- we add `ip_local_reserved_ports` to `safeSysctls` for Linux the kernel version is after 3.16.

I think we should skip here for windows until we can know a dedicated mapping list of windows kernel versions to linux.

#### Which issue(s) this PR fixes:

Fixes #116790

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
/sig windows