### PR TITLE
Add missing period

### DIFF
--- a/pkg/apis/rbac/types.go
+++ b/pkg/apis/rbac/types.go
@@ -55,7 +55,7 @@ type PolicyRule struct {
 	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 	ResourceNames []string
 
-	// NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+	// NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path.
 	// If an action is not a resource API request, then the URL is split on '/' and is checked against the NonResourceURLs to look for a match.
 	// Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
 	// Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Missing period is visible in the output of `kubectl explain`, for example:

```
❯ kubectl explain Role.rules
...
FIELDS:
   ...
   nonResourceURLs      <[]string>
     NonResourceURLs is a set of partial urls that a user should have access to.
     *s are allowed, but only as the full, final step in the path Since
     non-resource URLs are not namespaced, this field is only applicable for
     ...
...
```


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: