### PR TITLE
kubelet: Read DNS Config options from file for Windows

### DIFF
--- a/pkg/kubelet/network/dns/dns_other.go
+++ b/pkg/kubelet/network/dns/dns_other.go
@@ -19,35 +19,5 @@ limitations under the License.
 
 package dns
 
-import (
-	"fmt"
-	"os"
-
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
-	"k8s.io/klog/v2"
-)
-
-func getHostDNSConfig(resolverConfig string) (*runtimeapi.DNSConfig, error) {
-	var hostDNS, hostSearch, hostOptions []string
-	// Get host DNS settings
-	if resolverConfig != "" {
-		f, err := os.Open(resolverConfig)
-		if err != nil {
-			klog.ErrorS(err, "Could not open resolv conf file.")
-			return nil, err
-		}
-		defer f.Close()
-
-		hostDNS, hostSearch, hostOptions, err = parseResolvConf(f)
-		if err != nil {
-			err := fmt.Errorf("Encountered error while parsing resolv conf file. Error: %w", err)
-			klog.ErrorS(err, "Could not parse resolv conf file.")
-			return nil, err
-		}
-	}
-	return &runtimeapi.DNSConfig{
-		Servers:  hostDNS,
-		Searches: hostSearch,
-		Options:  hostOptions,
-	}, nil
-}
+// Read the DNS configuration from a resolv.conf file.
+var getHostDNSConfig = getDNSConfig

--- a/pkg/kubelet/network/dns/dns_other_test.go
+++ b/pkg/kubelet/network/dns/dns_other_test.go
@@ -19,39 +19,8 @@ limitations under the License.
 
 package dns
 
-import (
-	"fmt"
-	"os"
-	"testing"
-)
-
 var (
 	defaultResolvConf = "/etc/resolv.conf"
 	// configurer.getHostDNSConfig is faked on Windows, while it is not faked on Linux.
 	fakeGetHostDNSConfigCustom = getHostDNSConfig
 )
-
-// getResolvConf returns a temporary resolv.conf file containing the testHostNameserver nameserver and
-// testHostDomain search field, and a cleanup function for the temporary file.
-func getResolvConf(t *testing.T) (string, func()) {
-	resolvConfContent := []byte(fmt.Sprintf("nameserver %s\nsearch %s\n", testHostNameserver, testHostDomain))
-	tmpfile, err := os.CreateTemp("", "tmpResolvConf")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cleanup := func() {
-		os.Remove(tmpfile.Name())
-	}
-
-	if _, err := tmpfile.Write(resolvConfContent); err != nil {
-		cleanup()
-		t.Fatal(err)
-	}
-	if err := tmpfile.Close(); err != nil {
-		cleanup()
-		t.Fatal(err)
-	}
-
-	return tmpfile.Name(), cleanup
-}

--- a/pkg/kubelet/network/dns/dns_windows_test.go
+++ b/pkg/kubelet/network/dns/dns_windows_test.go
@@ -20,8 +20,6 @@ limitations under the License.
 package dns
 
 import (
-	"testing"
-
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -34,9 +32,4 @@ func fakeGetHostDNSConfigCustom(resolverConfig string) (*runtimeapi.DNSConfig, e
 		Servers:  []string{testHostNameserver},
 		Searches: []string{testHostDomain},
 	}, nil
-}
-
-// getResolvConf returns the hostResolvConf string, which will be used to get the Host's DNS configuration.
-func getResolvConf(t *testing.T) (string, func()) {
-	return hostResolvConf, func() {}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/kind failing-test

/sig windows
/milestone v1.27
/priority important-critical

#### What this PR does / why we need it:

A previous commit added the capability to read the DNS configuration options from a Windows host, while removing the capability to read from a ``resolv.conf``-like file.

This PR addresses this issue: if the given ``--resolv-conf`` option is not set to ``Host``, it will consider it as a file, preserving the previous behavior.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #116782

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
