### PR TITLE
AddUserAgent should keep existing user agent if set

### DIFF
--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -591,7 +591,11 @@ func dataFromSliceOrFile(data []byte, file string) ([]byte, error) {
 }
 
 func AddUserAgent(config *Config, userAgent string) *Config {
-	fullUserAgent := DefaultKubernetesUserAgent() + "/" + userAgent
+	fullUserAgent := config.UserAgent
+	if len(fullUserAgent) == 0 {
+		fullUserAgent = DefaultKubernetesUserAgent()
+	}
+	fullUserAgent = fullUserAgent + "/" + userAgent
 	config.UserAgent = fullUserAgent
 	return config
 }

--- a/staging/src/k8s.io/client-go/rest/config_test.go
+++ b/staging/src/k8s.io/client-go/rest/config_test.go
@@ -144,6 +144,37 @@ func TestDefaultKubernetesUserAgent(t *testing.T) {
 	assert.New(t).Contains(DefaultKubernetesUserAgent(), "kubernetes")
 }
 
+func TestAddUserAgent(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *Config
+		ua     string
+		want   string
+	}{
+		{
+			name: "empty user agent should concatenate the default agent with the suffix",
+			config: &Config{
+				UserAgent: "",
+			},
+			ua:   "test",
+			want: DefaultKubernetesUserAgent() + "/test",
+		}, {
+			name: "non-empty user agent should concatenate the existing agent with the suffix",
+			config: &Config{
+				UserAgent: "existing",
+			},
+			ua:   "test",
+			want: "existing/test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			AddUserAgent(tt.config, tt.ua)
+			assert.Equal(t, tt.want, tt.config.UserAgent)
+		})
+	}
+}
+
 func TestRESTClientRequires(t *testing.T) {
 	if _, err := RESTClientFor(&Config{Host: "127.0.0.1", ContentConfig: ContentConfig{NegotiatedSerializer: scheme.Codecs}}); err == nil {
 		t.Errorf("unexpected non-error")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind api-change

#### What this PR does / why we need it:

This PR is a _proposition_ to change the behavior of AddUserAgent. 

It changes the behavior of `AddUserAgent` to reuse the `rest.ClientConfig.UserAgent` if it is already set. If not set, it keeps the current behavior of defaulting to `DefaultKubernetesUserAgent() + "/" + <suffix>`. 

We encountered an "issue" when using the `controller-runtime` for an operator, where we would set the UserAgent on the `rest.ClientConfig` and leader-election `rest.ClientConfig`. Though, we observed in the logs that the specified UserAgent was not respected. We tracked down the "root" of the "issue" to this method.

see https://github.com/kubernetes-sigs/controller-runtime/issues/2243
