### PR TITLE
Allow matching podFailurePolicy against failed pods with containers with 0 exit code

### DIFF
--- a/pkg/controller/job/pod_failure_policy.go
+++ b/pkg/controller/job/pod_failure_policy.go
@@ -97,10 +97,8 @@ func getMatchingContainerFromList(containerStatuses []v1.ContainerStatus, requir
 			continue
 		}
 		if requirement.ContainerName == nil || *requirement.ContainerName == containerStatus.Name {
-			if containerStatus.State.Terminated.ExitCode != 0 {
-				if isOnExitCodesOperatorMatching(containerStatus.State.Terminated.ExitCode, requirement) {
-					return &containerStatus
-				}
+			if isOnExitCodesOperatorMatching(containerStatus.State.Terminated.ExitCode, requirement) {
+				return &containerStatus
 			}
 		}
 	}

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -467,6 +467,7 @@ func TestJobPodFailurePolicyWithFailedPodDeletedDuringControllerRestart(t *testi
 // TestJobPodFailurePolicy tests handling of pod failures with respect to the
 // configured pod failure policy rules
 func TestJobPodFailurePolicy(t *testing.T) {
+	//TODO(#115688): Add tests for pod failure policy with 0 exit code for the In operator when exit code=0/code!=0 in v1.29
 	job := batchv1.Job{
 		Spec: batchv1.JobSpec{
 			Template: v1.PodTemplateSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind api-change
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #115688

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Do not exclude failed pods with 0 exit code from matching against the pod failure policy for the In operator or the NotIn operator. Also, accept validation of job updates when pod failure policy is using 0 exit code for the In operator or the NotIn operator if the old job already uses it.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
