### PR TITLE
remove unused service keys from aggregated discovery

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints"
@@ -459,6 +460,36 @@ func (dm *discoveryManager) Run(stopCh <-chan struct{}) {
 	}, stopCh)
 }
 
+// Takes a snapshot of all currently used services by known APIServices and
+// purges the cache entries of those not present in the snapshot.
+func (dm *discoveryManager) removeUnusedServices() {
+	usedServiceKeys := sets.Set[serviceKey]{}
+
+	func() {
+		dm.servicesLock.Lock()
+		defer dm.servicesLock.Unlock()
+
+		// Mark all non-local APIServices as dirty
+		for _, info := range dm.apiServices {
+			usedServiceKeys.Insert(info.service)
+		}
+	}()
+
+	// Avoids double lock. It is okay if a service is added/removed between these
+	// functions. This is just a cache and that should be infrequent.
+
+	func() {
+		dm.resultsLock.Lock()
+		defer dm.resultsLock.Unlock()
+
+		for key := range dm.cachedResults {
+			if !usedServiceKeys.Has(key) {
+				delete(dm.cachedResults, key)
+			}
+		}
+	}()
+}
+
 // Adds an APIService to be tracked by the discovery manager. If the APIService
 // is already known
 func (dm *discoveryManager) AddAPIService(apiService *apiregistrationv1.APIService, handler http.Handler) {
@@ -476,12 +507,14 @@ func (dm *discoveryManager) AddAPIService(apiService *apiregistrationv1.APIServi
 		lastMarkedDirty: time.Now(),
 		service:         newServiceKey(*apiService.Spec.Service),
 	})
+	dm.removeUnusedServices()
 	dm.dirtyAPIServiceQueue.Add(apiService.Name)
 }
 
 func (dm *discoveryManager) RemoveAPIService(apiServiceName string) {
 	if dm.setInfoForAPIService(apiServiceName, nil) != nil {
 		// mark dirty if there was actually something deleted
+		dm.removeUnusedServices()
 		dm.dirtyAPIServiceQueue.Add(apiServiceName)
 	}
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery_test.go
@@ -240,6 +240,58 @@ func checkAPIGroups(t *testing.T, api apidiscoveryv2beta1.APIGroupDiscoveryList,
 	}
 }
 
+func TestServiceGC(t *testing.T) {
+	service := discoveryendpoint.NewResourceManager("apis")
+
+	aggregatedResourceManager := discoveryendpoint.NewResourceManager("apis")
+	aggregatedManager := newDiscoveryManager(aggregatedResourceManager)
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go aggregatedManager.Run(testCtx.Done())
+
+	aggregatedManager.AddAPIService(&apiregistrationv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "v1.stable.example.com",
+		},
+		Spec: apiregistrationv1.APIServiceSpec{
+			Group:   "stable.example.com",
+			Version: "v1",
+			Service: &apiregistrationv1.ServiceReference{
+				Name: "test-service",
+			},
+		},
+	}, service)
+
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
+
+	// Lookup size of cache
+	getCacheLen := func() int {
+		aggregatedManager.resultsLock.Lock()
+		defer aggregatedManager.resultsLock.Unlock()
+		return len(aggregatedManager.cachedResults)
+	}
+
+	require.Equal(t, 1, getCacheLen())
+
+	// Change the service of the same APIService a bit to create duplicate entry
+	aggregatedManager.AddAPIService(&apiregistrationv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "v1.stable.example.com",
+		},
+		Spec: apiregistrationv1.APIServiceSpec{
+			Group:   "stable.example.com",
+			Version: "v1",
+			Service: &apiregistrationv1.ServiceReference{
+				Name: "test-service-changed",
+			},
+		},
+	}, service)
+
+	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
+	require.Equal(t, 1, getCacheLen())
+}
+
 // Test that a handler associated with an APIService gets pinged after the
 // APIService has been marked as dirty
 func TestDirty(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

patches a leak of a discovery document that would occur when an Aggregated APIService changed its Spec.Service field and did not change it back.

#### Which issue(s) this PR fixes:

Fixes #115301

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
patches a leak of a discovery document that would occur when an Aggregated APIService changed its Spec.Service field and did not change it back.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig api-machinery
/cc @apelisse 