### PR TITLE
Deployment names can  be too long, such that ReplicaSet creation fails

### DIFF
--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -933,3 +933,20 @@ func (o ReplicaSetsByRevision) Less(i, j int) bool {
 	}
 	return revision1 < revision2
 }
+
+const (
+	maxNameLength = 253
+	// maxNameHashLength is the pod template spec hash length(10) add '-'(1).
+	podTemplateSpecHashLength = 10 + 1
+	// maxReplicaSetBaseNameLength is the max length of replicaset basename
+	maxReplicaSetBaseNameLength = maxNameLength - podTemplateSpecHashLength
+)
+
+// GetReplicaSetName truncate deployment name, if it's length longer than 242.
+// Returns truncated deployment name add '-' and pod template spec hash.
+func GetReplicaSetName(deploymentName string, podTemplateSpecHash string) string {
+	if len(deploymentName) > maxReplicaSetBaseNameLength {
+		deploymentName = deploymentName[:maxReplicaSetBaseNameLength]
+	}
+	return fmt.Sprintf("%s-%s", deploymentName, podTemplateSpecHash)
+}

--- a/pkg/controller/deployment/util/deployment_util_test.go
+++ b/pkg/controller/deployment/util/deployment_util_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -1315,6 +1316,43 @@ func TestMinAvailable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := MinAvailable(tt.deployment); got != tt.expected {
 				t.Errorf("MinAvailable() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetReplicaSetName(t *testing.T) {
+	hash := "6b4c6ffcfc"
+	tests := []struct {
+		name           string
+		deploymentName string
+		expected       string
+	}{
+		{
+			"deploymentName length less than 242",
+			"deploy",
+			"deploy" + "-" + hash,
+		},
+		{
+			"deploymentName length equal 242",
+			strings.Repeat("a", 242),
+			strings.Repeat("a", 242) + "-" + hash,
+		},
+		{
+			"deploymentName length equal 243",
+			strings.Repeat("a", 243),
+			strings.Repeat("a", 242) + "-" + hash,
+		},
+		{
+			"deploymentName length equal 253",
+			strings.Repeat("a", 253),
+			strings.Repeat("a", 242) + "-" + hash,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetReplicaSetName(tt.deploymentName, hash); got != tt.expected {
+				t.Errorf("GetReplicaSetName() = %v, want %v", got, tt.expected)
 			}
 		})
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -948,6 +948,12 @@ const (
 	//
 	// Allows namespace indexer for namespace scope resources in apiserver cache to accelerate list operations.
 	StorageNamespaceIndex featuregate.Feature = "StorageNamespaceIndex"
+
+	// owner: @hysyeah
+	// beta: v1.29
+	//
+	// TruncateReplicaSetBaseName Enables to truncate deployment name as replicaset basename if deployment name length larger than 242 char.
+	TruncateReplicaSetBaseName featuregate.Feature = "TruncateReplicaSetBaseName"
 )
 
 func init() {
@@ -1250,4 +1256,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	HPAScaleToZero: {Default: false, PreRelease: featuregate.Alpha},
 
 	StorageNamespaceIndex: {Default: true, PreRelease: featuregate.Beta},
+
+	TruncateReplicaSetBaseName: {Default: true, PreRelease: featuregate.Beta},
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
if we create a deployment with name length longer than 242, will cause replicaset creation fails. 

#### Which issue(s) this PR fixes:

Fixes #116447


#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
