### PR TITLE
kubeadm: use the phase name to unify the logs

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/addons.go
+++ b/cmd/kubeadm/app/cmd/phases/init/addons.go
@@ -104,7 +104,7 @@ func getInitData(c workflow.RunData) (*kubeadmapi.InitConfiguration, clientset.I
 }
 
 // runCoreDNSAddon installs CoreDNS addon to a Kubernetes cluster
-func runCoreDNSAddon(c workflow.RunData) error {
+func runCoreDNSAddon(c workflow.RunData, _ string) error {
 	cfg, client, out, err := getInitData(c)
 	if err != nil {
 		return err
@@ -113,7 +113,7 @@ func runCoreDNSAddon(c workflow.RunData) error {
 }
 
 // runKubeProxyAddon installs KubeProxy addon to a Kubernetes cluster
-func runKubeProxyAddon(c workflow.RunData) error {
+func runKubeProxyAddon(c workflow.RunData, _ string) error {
 	cfg, client, out, err := getInitData(c)
 	if err != nil {
 		return err

--- a/cmd/kubeadm/app/cmd/phases/init/bootstraptoken.go
+++ b/cmd/kubeadm/app/cmd/phases/init/bootstraptoken.go
@@ -62,10 +62,10 @@ func NewBootstrapTokenPhase() workflow.Phase {
 	}
 }
 
-func runBootstrapToken(c workflow.RunData) error {
+func runBootstrapToken(c workflow.RunData, phase string) error {
 	data, ok := c.(InitData)
 	if !ok {
-		return errors.New("bootstrap-token phase invoked with an invalid data struct")
+		return errors.New(fmt.Sprintf("%s phase invoked with an invalid data struct", phase))
 	}
 
 	client, err := data.Client()
@@ -76,13 +76,13 @@ func runBootstrapToken(c workflow.RunData) error {
 	if !data.SkipTokenPrint() {
 		tokens := data.Tokens()
 		if len(tokens) == 1 {
-			fmt.Printf("[bootstrap-token] Using token: %s\n", tokens[0])
+			fmt.Printf("[%s] Using token: %s\n", phase, tokens[0])
 		} else if len(tokens) > 1 {
-			fmt.Printf("[bootstrap-token] Using tokens: %v\n", tokens)
+			fmt.Printf("[%s] Using tokens: %v\n", phase, tokens)
 		}
 	}
 
-	fmt.Println("[bootstrap-token] Configuring bootstrap tokens, cluster-info ConfigMap, RBAC Roles")
+	fmt.Printf("[%s] Configuring bootstrap tokens, cluster-info ConfigMap, RBAC Roles\n", phase)
 	// Create the default node bootstrap token
 	if err := nodebootstraptokenphase.UpdateOrCreateTokens(client, false, data.Cfg().BootstrapTokens); err != nil {
 		return errors.Wrap(err, "error updating or creating token")

--- a/cmd/kubeadm/app/cmd/phases/init/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/controlplane.go
@@ -127,25 +127,25 @@ func getControlPlanePhaseFlags(name string) []string {
 	return flags
 }
 
-func runControlPlanePhase(c workflow.RunData) error {
+func runControlPlanePhase(c workflow.RunData, phase string) error {
 	data, ok := c.(InitData)
 	if !ok {
-		return errors.New("control-plane phase invoked with an invalid data struct")
+		return errors.New(fmt.Sprintf("%s phase invoked with an invalid data struct", phase))
 	}
 
-	fmt.Printf("[control-plane] Using manifest folder %q\n", data.ManifestDir())
+	fmt.Printf("[%s] Using manifest folder %q\n", phase, data.ManifestDir())
 	return nil
 }
 
-func runControlPlaneSubphase(component string) func(c workflow.RunData) error {
-	return func(c workflow.RunData) error {
+func runControlPlaneSubphase(component string) func(c workflow.RunData, phase string) error {
+	return func(c workflow.RunData, phase string) error {
 		data, ok := c.(InitData)
 		if !ok {
-			return errors.New("control-plane phase invoked with an invalid data struct")
+			return errors.New(fmt.Sprintf("%s phase invoked with an invalid data struct", phase))
 		}
 		cfg := data.Cfg()
 
-		fmt.Printf("[control-plane] Creating static Pod manifest for %q\n", component)
+		fmt.Printf("[%s] Creating static Pod manifest for %q\n", phase, component)
 		return controlplane.CreateStaticPodFiles(data.ManifestDir(), data.PatchesDir(), &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint, data.DryRun(), component)
 	}
 }

--- a/cmd/kubeadm/app/cmd/phases/init/etcd.go
+++ b/cmd/kubeadm/app/cmd/phases/init/etcd.go
@@ -77,11 +77,11 @@ func getEtcdPhaseFlags() []string {
 	return flags
 }
 
-func runEtcdPhaseLocal() func(c workflow.RunData) error {
-	return func(c workflow.RunData) error {
+func runEtcdPhaseLocal() func(c workflow.RunData, phase string) error {
+	return func(c workflow.RunData, phase string) error {
 		data, ok := c.(InitData)
 		if !ok {
-			return errors.New("etcd phase invoked with an invalid data struct")
+			return errors.New(fmt.Sprintf("%s phase invoked with an invalid data struct", phase))
 		}
 		cfg := data.Cfg()
 
@@ -94,14 +94,14 @@ func runEtcdPhaseLocal() func(c workflow.RunData) error {
 					return err
 				}
 			} else {
-				fmt.Printf("[etcd] Would ensure that %q directory is present\n", cfg.Etcd.Local.DataDir)
+				fmt.Printf("[%s] Would ensure that %q directory is present\n", phase, cfg.Etcd.Local.DataDir)
 			}
-			fmt.Printf("[etcd] Creating static Pod manifest for local etcd in %q\n", data.ManifestDir())
+			fmt.Printf("[%s] Creating static Pod manifest for local etcd in %q\n", phase, data.ManifestDir())
 			if err := etcdphase.CreateLocalEtcdStaticPodManifestFile(data.ManifestDir(), data.PatchesDir(), cfg.NodeRegistration.Name, &cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint, data.DryRun()); err != nil {
 				return errors.Wrap(err, "error creating local etcd static pod manifest file")
 			}
 		} else {
-			klog.V(1).Infoln("[etcd] External etcd mode. Skipping the creation of a manifest for local etcd")
+			klog.V(1).Infof("[%s] External etcd mode. Skipping the creation of a manifest for local etcd", phase)
 		}
 		return nil
 	}

--- a/cmd/kubeadm/app/cmd/phases/init/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubeconfig.go
@@ -115,7 +115,7 @@ func getKubeConfigPhaseFlags(name string) []string {
 	return flags
 }
 
-func runKubeConfig(c workflow.RunData) error {
+func runKubeConfig(c workflow.RunData, phase string) error {
 	data, ok := c.(InitData)
 	if !ok {
 		return errors.New("kubeconfig phase invoked with an invalid data struct")
@@ -126,16 +126,16 @@ func runKubeConfig(c workflow.RunData) error {
 }
 
 // runKubeConfigFile executes kubeconfig creation logic.
-func runKubeConfigFile(kubeConfigFileName string) func(workflow.RunData) error {
-	return func(c workflow.RunData) error {
+func runKubeConfigFile(kubeConfigFileName string) func(workflow.RunData, string) error {
+	return func(c workflow.RunData, phase string) error {
 		data, ok := c.(InitData)
 		if !ok {
-			return errors.New("kubeconfig phase invoked with an invalid data struct")
+			return errors.New(fmt.Sprintf("%s phase invoked with an invalid data struct", phase))
 		}
 
 		// if external CA mode, skip certificate authority generation
 		if data.ExternalCA() {
-			fmt.Printf("[kubeconfig] External CA mode: Using user provided %s\n", kubeConfigFileName)
+			fmt.Printf("[%s] External CA mode: Using user provided %s\n", phase, kubeConfigFileName)
 			// If using an external CA while dryrun, copy kubeconfig files to dryrun dir for later use
 			if data.DryRun() {
 				err := phases.CopyFile(filepath.Join(kubeadmconstants.KubernetesDir, kubeConfigFileName), filepath.Join(data.KubeConfigDir(), kubeConfigFileName))

--- a/cmd/kubeadm/app/cmd/phases/init/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubelet.go
@@ -55,10 +55,10 @@ func NewKubeletStartPhase() workflow.Phase {
 }
 
 // runKubeletStart executes kubelet start logic.
-func runKubeletStart(c workflow.RunData) error {
+func runKubeletStart(c workflow.RunData, phase string) error {
 	data, ok := c.(InitData)
 	if !ok {
-		return errors.New("kubelet-start phase invoked with an invalid data struct")
+		return errors.New(fmt.Sprintf("%s phase invoked with an invalid data struct", phase))
 	}
 
 	// First off, configure the kubelet. In this short timeframe, kubeadm is trying to stop/restart the kubelet
@@ -82,7 +82,7 @@ func runKubeletStart(c workflow.RunData) error {
 
 	// Try to start the kubelet service in case it's inactive
 	if !data.DryRun() {
-		fmt.Println("[kubelet-start] Starting the kubelet")
+		fmt.Printf("[%s] Starting the kubelet\n", phase)
 		kubeletphase.TryStartKubelet()
 	}
 

--- a/cmd/kubeadm/app/cmd/phases/init/markcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/markcontrolplane.go
@@ -17,6 +17,8 @@ limitations under the License.
 package phases
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
@@ -51,10 +53,10 @@ func NewMarkControlPlanePhase() workflow.Phase {
 }
 
 // runMarkControlPlane executes mark-control-plane checks logic.
-func runMarkControlPlane(c workflow.RunData) error {
+func runMarkControlPlane(c workflow.RunData, phase string) error {
 	data, ok := c.(InitData)
 	if !ok {
-		return errors.New("mark-control-plane phase invoked with an invalid data struct")
+		return errors.New(fmt.Sprintf("%s phase invoked with an invalid data struct", phase))
 	}
 
 	client, err := data.Client()

--- a/cmd/kubeadm/app/cmd/phases/init/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/init/preflight.go
@@ -54,7 +54,7 @@ func NewPreflightPhase() workflow.Phase {
 }
 
 // runPreflight executes preflight checks logic.
-func runPreflight(c workflow.RunData) error {
+func runPreflight(c workflow.RunData, _ string) error {
 	data, ok := c.(InitData)
 	if !ok {
 		return errors.New("preflight phase invoked with an invalid data struct")

--- a/cmd/kubeadm/app/cmd/phases/init/showjoincommand.go
+++ b/cmd/kubeadm/app/cmd/phases/init/showjoincommand.go
@@ -17,6 +17,7 @@ limitations under the License.
 package phases
 
 import (
+	"fmt"
 	"io"
 	"text/template"
 
@@ -78,10 +79,10 @@ func NewShowJoinCommandPhase() workflow.Phase {
 }
 
 // showJoinCommand prints the join command after all the phases in init have finished
-func showJoinCommand(c workflow.RunData) error {
+func showJoinCommand(c workflow.RunData, phase string) error {
 	data, ok := c.(InitData)
 	if !ok {
-		return errors.New("show-join-command phase invoked with an invalid data struct")
+		return errors.New(fmt.Sprintf("%s phase invoked with an invalid data struct", phase))
 	}
 
 	adminKubeConfigPath := data.KubeConfigPath()

--- a/cmd/kubeadm/app/cmd/phases/init/uploadcerts.go
+++ b/cmd/kubeadm/app/cmd/phases/init/uploadcerts.go
@@ -45,14 +45,14 @@ func NewUploadCertsPhase() workflow.Phase {
 	}
 }
 
-func runUploadCerts(c workflow.RunData) error {
+func runUploadCerts(c workflow.RunData, phase string) error {
 	data, ok := c.(InitData)
 	if !ok {
-		return errors.New("upload-certs phase invoked with an invalid data struct")
+		return errors.New(fmt.Sprintf("%s phase invoked with an invalid data struct", phase))
 	}
 
 	if !data.UploadCerts() {
-		fmt.Printf("[upload-certs] Skipping phase. Please see --%s\n", options.UploadCerts)
+		fmt.Printf("[%s] Skipping phase. Please see --%s\n", phase, options.UploadCerts)
 		return nil
 	}
 	client, err := data.Client()
@@ -72,7 +72,7 @@ func runUploadCerts(c workflow.RunData) error {
 		return errors.Wrap(err, "error uploading certs")
 	}
 	if !data.SkipCertificateKeyPrint() {
-		fmt.Printf("[upload-certs] Using certificate key:\n%s\n", data.CertificateKey())
+		fmt.Printf("[%s] Using certificate key:\n%s\n", phase, data.CertificateKey())
 	}
 	return nil
 }

--- a/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
@@ -65,10 +65,10 @@ func NewWaitControlPlanePhase() workflow.Phase {
 	return phase
 }
 
-func runWaitControlPlanePhase(c workflow.RunData) error {
+func runWaitControlPlanePhase(c workflow.RunData, phase string) error {
 	data, ok := c.(InitData)
 	if !ok {
-		return errors.New("wait-control-plane phase invoked with an invalid data struct")
+		return errors.New(fmt.Sprintf("%s phase invoked with an invalid data struct", phase))
 	}
 
 	// If we're dry-running, print the generated manifests.
@@ -80,7 +80,7 @@ func runWaitControlPlanePhase(c workflow.RunData) error {
 	}
 
 	// waiter holds the apiclient.Waiter implementation of choice, responsible for querying the API server in various ways and waiting for conditions to be fulfilled
-	klog.V(1).Infoln("[wait-control-plane] Waiting for the API server to be healthy")
+	klog.V(1).Infof("[%s] Waiting for the API server to be healthy", phase)
 
 	client, err := data.Client()
 	if err != nil {
@@ -93,7 +93,7 @@ func runWaitControlPlanePhase(c workflow.RunData) error {
 		return errors.Wrap(err, "error creating waiter")
 	}
 
-	fmt.Printf("[wait-control-plane] Waiting for the kubelet to boot up the control plane as static Pods from directory %q. This can take up to %v\n", data.ManifestDir(), timeout)
+	fmt.Printf("[%s] Waiting for the kubelet to boot up the control plane as static Pods from directory %q. This can take up to %v\n", phase, data.ManifestDir(), timeout)
 
 	if err := waiter.WaitForKubeletAndFunc(waiter.WaitForAPI); err != nil {
 		context := struct {

--- a/cmd/kubeadm/app/cmd/phases/join/checketcd.go
+++ b/cmd/kubeadm/app/cmd/phases/join/checketcd.go
@@ -35,10 +35,10 @@ func NewCheckEtcdPhase() workflow.Phase {
 	}
 }
 
-func runCheckEtcdPhase(c workflow.RunData) error {
+func runCheckEtcdPhase(c workflow.RunData, phase string) error {
 	data, ok := c.(JoinData)
 	if !ok {
-		return errors.New("check-etcd phase invoked with an invalid data struct")
+		return errors.New(fmt.Sprintf("%s phase invoked with an invalid data struct", phase))
 	}
 
 	// Skip if this is not a control plane
@@ -46,17 +46,17 @@ func runCheckEtcdPhase(c workflow.RunData) error {
 		return nil
 	}
 
-	cfg, err := data.InitCfg()
+	cfg, err := data.InitCfg(phase)
 	if err != nil {
 		return err
 	}
 
 	if cfg.Etcd.External != nil {
-		fmt.Println("[check-etcd] Skipping etcd check in external mode")
+		fmt.Printf("%s Skipping etcd check in external mode\n", phase)
 		return nil
 	}
 
-	fmt.Println("[check-etcd] Checking that the etcd cluster is healthy")
+	fmt.Printf("%s Checking that the etcd cluster is healthy\n", phase)
 
 	// Checks that the etcd cluster is healthy
 	// NB. this check cannot be implemented before because it requires the admin.conf and all the certificates

--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -108,10 +108,10 @@ func newMarkControlPlaneSubphase() workflow.Phase {
 	}
 }
 
-func runEtcdPhase(c workflow.RunData) error {
+func runEtcdPhase(c workflow.RunData, phase string) error {
 	data, ok := c.(JoinData)
 	if !ok {
-		return errors.New("control-plane-join phase invoked with an invalid data struct")
+		return errors.New(fmt.Sprintf("[%s] phase invoked with an invalid data struct", phase))
 	}
 
 	if data.Cfg().ControlPlane == nil {
@@ -123,13 +123,13 @@ func runEtcdPhase(c workflow.RunData) error {
 	if err != nil {
 		return errors.Wrap(err, "couldn't create Kubernetes client")
 	}
-	cfg, err := data.InitCfg()
+	cfg, err := data.InitCfg(phase)
 	if err != nil {
 		return err
 	}
 	// in case of local etcd
 	if cfg.Etcd.External != nil {
-		fmt.Println("[control-plane-join] Using external etcd - no local stacked instance added")
+		fmt.Printf("[%s] Using external etcd - no local stacked instance added\n", phase)
 		return nil
 	}
 
@@ -139,7 +139,7 @@ func runEtcdPhase(c workflow.RunData) error {
 			return err
 		}
 	} else {
-		fmt.Printf("[control-plane-join] Would ensure that %q directory is present\n", cfg.Etcd.Local.DataDir)
+		fmt.Printf("[%s] Would ensure that %q directory is present\n", phase, cfg.Etcd.Local.DataDir)
 	}
 
 	// Adds a new etcd instance; in order to do this the new etcd instance should be "announced" to
@@ -159,10 +159,10 @@ func runEtcdPhase(c workflow.RunData) error {
 	return nil
 }
 
-func runUpdateStatusPhase(c workflow.RunData) error {
+func runUpdateStatusPhase(c workflow.RunData, phase string) error {
 	data, ok := c.(JoinData)
 	if !ok {
-		return errors.New("control-plane-join phase invoked with an invalid data struct")
+		return errors.New(fmt.Sprintf("[%s] phase invoked with an invalid data struct", phase))
 	}
 
 	if data.Cfg().ControlPlane != nil {
@@ -172,7 +172,7 @@ func runUpdateStatusPhase(c workflow.RunData) error {
 	return nil
 }
 
-func runMarkControlPlanePhase(c workflow.RunData) error {
+func runMarkControlPlanePhase(c workflow.RunData, phase string) error {
 	data, ok := c.(JoinData)
 	if !ok {
 		return errors.New("control-plane-join phase invoked with an invalid data struct")
@@ -187,7 +187,7 @@ func runMarkControlPlanePhase(c workflow.RunData) error {
 	if err != nil {
 		return errors.Wrap(err, "couldn't create Kubernetes client")
 	}
-	cfg, err := data.InitCfg()
+	cfg, err := data.InitCfg(phase)
 	if err != nil {
 		return err
 	}
@@ -197,7 +197,7 @@ func runMarkControlPlanePhase(c workflow.RunData) error {
 			return errors.Wrap(err, "error applying control-plane label and taints")
 		}
 	} else {
-		fmt.Printf("[control-plane-join] Would mark node %s as a control-plane\n", cfg.NodeRegistration.Name)
+		fmt.Printf("[%s] Would mark node %s as a control-plane\n", phase, cfg.NodeRegistration.Name)
 	}
 
 	return nil

--- a/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplaneprepare.go
@@ -175,7 +175,7 @@ func newControlPlanePrepareControlPlaneSubphase() workflow.Phase {
 	}
 }
 
-func runControlPlanePrepareControlPlaneSubphase(c workflow.RunData) error {
+func runControlPlanePrepareControlPlaneSubphase(c workflow.RunData, phase string) error {
 	data, ok := c.(JoinData)
 	if !ok {
 		return errors.New("control-plane-prepare phase invoked with an invalid data struct")
@@ -186,12 +186,12 @@ func runControlPlanePrepareControlPlaneSubphase(c workflow.RunData) error {
 		return nil
 	}
 
-	cfg, err := data.InitCfg()
+	cfg, err := data.InitCfg(phase)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("[control-plane] Using manifest folder %q\n", data.ManifestDir())
+	fmt.Printf("%s Using manifest folder %q\n", phase, data.ManifestDir())
 
 	// If we're dry-running, set CertificatesDir to default value to get the right cert path in static pod yaml
 	if data.DryRun() {
@@ -199,7 +199,7 @@ func runControlPlanePrepareControlPlaneSubphase(c workflow.RunData) error {
 	}
 
 	for _, component := range kubeadmconstants.ControlPlaneComponents {
-		fmt.Printf("[control-plane] Creating static Pod manifest for %q\n", component)
+		fmt.Printf("%s Creating static Pod manifest for %q\n", phase, component)
 		err := controlplane.CreateStaticPodFiles(
 			data.ManifestDir(),
 			data.PatchesDir(),
@@ -215,18 +215,18 @@ func runControlPlanePrepareControlPlaneSubphase(c workflow.RunData) error {
 	return nil
 }
 
-func runControlPlanePrepareDownloadCertsPhaseLocal(c workflow.RunData) error {
+func runControlPlanePrepareDownloadCertsPhaseLocal(c workflow.RunData, phase string) error {
 	data, ok := c.(JoinData)
 	if !ok {
-		return errors.New("download-certs phase invoked with an invalid data struct")
+		return errors.New(fmt.Sprintf("%s phase invoked with an invalid data struct", phase))
 	}
 
 	if data.Cfg().ControlPlane == nil || len(data.CertificateKey()) == 0 {
-		klog.V(1).Infoln("[download-certs] Skipping certs download")
+		klog.V(1).Infof("%s Skipping certs download", phase)
 		return nil
 	}
 
-	cfg, err := data.InitCfg()
+	cfg, err := data.InitCfg(phase)
 	if err != nil {
 		return err
 	}
@@ -247,10 +247,10 @@ func runControlPlanePrepareDownloadCertsPhaseLocal(c workflow.RunData) error {
 	return nil
 }
 
-func runControlPlanePrepareCertsPhaseLocal(c workflow.RunData) error {
+func runControlPlanePrepareCertsPhaseLocal(c workflow.RunData, phase string) error {
 	data, ok := c.(JoinData)
 	if !ok {
-		return errors.New("control-plane-prepare phase invoked with an invalid data struct")
+		return errors.New(fmt.Sprintf("%s phase invoked with an invalid data struct", phase))
 	}
 
 	// Skip if this is not a control plane
@@ -258,7 +258,7 @@ func runControlPlanePrepareCertsPhaseLocal(c workflow.RunData) error {
 		return nil
 	}
 
-	cfg, err := data.InitCfg()
+	cfg, err := data.InitCfg(phase)
 	if err != nil {
 		return err
 	}
@@ -273,7 +273,7 @@ func runControlPlanePrepareCertsPhaseLocal(c workflow.RunData) error {
 	return certsphase.CreatePKIAssets(cfg)
 }
 
-func runControlPlanePrepareKubeconfigPhaseLocal(c workflow.RunData) error {
+func runControlPlanePrepareKubeconfigPhaseLocal(c workflow.RunData, phase string) error {
 	data, ok := c.(JoinData)
 	if !ok {
 		return errors.New("control-plane-prepare phase invoked with an invalid data struct")
@@ -284,7 +284,7 @@ func runControlPlanePrepareKubeconfigPhaseLocal(c workflow.RunData) error {
 		return nil
 	}
 
-	cfg, err := data.InitCfg()
+	cfg, err := data.InitCfg(phase)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/cmd/phases/join/data.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data.go
@@ -32,7 +32,7 @@ type JoinData interface {
 	CertificateKey() string
 	Cfg() *kubeadmapi.JoinConfiguration
 	TLSBootstrapCfg() (*clientcmdapi.Config, error)
-	InitCfg() (*kubeadmapi.InitConfiguration, error)
+	InitCfg(phase string) (*kubeadmapi.InitConfiguration, error)
 	Client() (clientset.Interface, error)
 	IgnorePreflightErrors() sets.Set[string]
 	OutputWriter() io.Writer

--- a/cmd/kubeadm/app/cmd/phases/join/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data_test.go
@@ -32,16 +32,16 @@ type testJoinData struct{}
 // testJoinData must satisfy JoinData.
 var _ JoinData = &testJoinData{}
 
-func (j *testJoinData) CertificateKey() string                          { return "" }
-func (j *testJoinData) Cfg() *kubeadmapi.JoinConfiguration              { return nil }
-func (j *testJoinData) TLSBootstrapCfg() (*clientcmdapi.Config, error)  { return nil, nil }
-func (j *testJoinData) InitCfg() (*kubeadmapi.InitConfiguration, error) { return nil, nil }
-func (j *testJoinData) Client() (clientset.Interface, error)            { return nil, nil }
-func (j *testJoinData) IgnorePreflightErrors() sets.Set[string]         { return nil }
-func (j *testJoinData) OutputWriter() io.Writer                         { return nil }
-func (j *testJoinData) PatchesDir() string                              { return "" }
-func (t *testJoinData) DryRun() bool                                    { return false }
-func (t *testJoinData) KubeConfigDir() string                           { return "" }
-func (t *testJoinData) KubeletDir() string                              { return "" }
-func (t *testJoinData) ManifestDir() string                             { return "" }
-func (t *testJoinData) CertificateWriteDir() string                     { return "" }
+func (j *testJoinData) CertificateKey() string                                      { return "" }
+func (j *testJoinData) Cfg() *kubeadmapi.JoinConfiguration                          { return nil }
+func (j *testJoinData) TLSBootstrapCfg() (*clientcmdapi.Config, error)              { return nil, nil }
+func (j *testJoinData) InitCfg(phase string) (*kubeadmapi.InitConfiguration, error) { return nil, nil }
+func (j *testJoinData) Client() (clientset.Interface, error)                        { return nil, nil }
+func (j *testJoinData) IgnorePreflightErrors() sets.Set[string]                     { return nil }
+func (j *testJoinData) OutputWriter() io.Writer                                     { return nil }
+func (j *testJoinData) PatchesDir() string                                          { return "" }
+func (t *testJoinData) DryRun() bool                                                { return false }
+func (t *testJoinData) KubeConfigDir() string                                       { return "" }
+func (t *testJoinData) KubeletDir() string                                          { return "" }
+func (t *testJoinData) ManifestDir() string                                         { return "" }
+func (t *testJoinData) CertificateWriteDir() string                                 { return "" }

--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -82,13 +82,13 @@ func NewKubeletStartPhase() workflow.Phase {
 	}
 }
 
-func getKubeletStartJoinData(c workflow.RunData) (*kubeadmapi.JoinConfiguration, *kubeadmapi.InitConfiguration, *clientcmdapi.Config, error) {
+func getKubeletStartJoinData(c workflow.RunData, phase string) (*kubeadmapi.JoinConfiguration, *kubeadmapi.InitConfiguration, *clientcmdapi.Config, error) {
 	data, ok := c.(JoinData)
 	if !ok {
 		return nil, nil, nil, errors.New("kubelet-start phase invoked with an invalid data struct")
 	}
 	cfg := data.Cfg()
-	initCfg, err := data.InitCfg()
+	initCfg, err := data.InitCfg(phase)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -102,8 +102,8 @@ func getKubeletStartJoinData(c workflow.RunData) (*kubeadmapi.JoinConfiguration,
 // runKubeletStartJoinPhase executes the kubelet TLS bootstrap process.
 // This process is executed by the kubelet and completes with the node joining the cluster
 // with a dedicates set of credentials as required by the node authorizer
-func runKubeletStartJoinPhase(c workflow.RunData) (returnErr error) {
-	cfg, initCfg, tlsBootstrapCfg, err := getKubeletStartJoinData(c)
+func runKubeletStartJoinPhase(c workflow.RunData, phase string) (returnErr error) {
+	cfg, initCfg, tlsBootstrapCfg, err := getKubeletStartJoinData(c, phase)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/cmd/phases/join/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/join/preflight.go
@@ -82,7 +82,7 @@ func NewPreflightPhase() workflow.Phase {
 }
 
 // runPreflight executes preflight checks logic.
-func runPreflight(c workflow.RunData) error {
+func runPreflight(c workflow.RunData, phase string) error {
 	j, ok := c.(JoinData)
 	if !ok {
 		return errors.New("preflight phase invoked with an invalid data struct")
@@ -95,7 +95,7 @@ func runPreflight(c workflow.RunData) error {
 		return err
 	}
 
-	initCfg, err := j.InitCfg()
+	initCfg, err := j.InitCfg(phase)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/cmd/phases/reset/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/preflight.go
@@ -46,7 +46,7 @@ func NewPreflightPhase() workflow.Phase {
 }
 
 // runPreflight executes preflight checks logic.
-func runPreflight(c workflow.RunData) error {
+func runPreflight(c workflow.RunData, phase string) error {
 	r, ok := c.(resetData)
 	if !ok {
 		return errors.New("preflight phase invoked with an invalid data struct")

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
@@ -45,16 +45,16 @@ func NewControlPlane() workflow.Phase {
 	return phase
 }
 
-func runControlPlane() func(c workflow.RunData) error {
-	return func(c workflow.RunData) error {
+func runControlPlane() func(c workflow.RunData, phase string) error {
+	return func(c workflow.RunData, phase string) error {
 		data, ok := c.(Data)
 		if !ok {
-			return errors.New("control-plane phase invoked with an invalid data struct")
+			return errors.New(fmt.Sprintf("%s phase invoked with an invalid data struct", phase))
 		}
 
 		// if this is not a control-plane node, this phase should not be executed
 		if !data.IsControlPlaneNode() {
-			fmt.Println("[upgrade] Skipping phase. Not a control plane node.")
+			fmt.Printf("[%s] Skipping phase. Not a control plane node.", phase)
 			return nil
 		}
 
@@ -78,7 +78,7 @@ func runControlPlane() func(c workflow.RunData) error {
 			return errors.Wrap(err, "couldn't complete the static pod upgrade")
 		}
 
-		fmt.Println("[upgrade] The control plane instance for this node was successfully updated!")
+		fmt.Printf("[%s] The control plane instance for this node was successfully updated!\n", phase)
 
 		return nil
 	}

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeletconfig.go
@@ -49,8 +49,8 @@ func NewKubeletConfigPhase() workflow.Phase {
 	return phase
 }
 
-func runKubeletConfigPhase() func(c workflow.RunData) error {
-	return func(c workflow.RunData) error {
+func runKubeletConfigPhase() func(c workflow.RunData, phase string) error {
+	return func(c workflow.RunData, phase string) error {
 		data, ok := c.(Data)
 		if !ok {
 			return errors.New("kubelet-config phase invoked with an invalid data struct")
@@ -68,8 +68,8 @@ func runKubeletConfigPhase() func(c workflow.RunData) error {
 			return err
 		}
 
-		fmt.Println("[upgrade] The configuration for this node was successfully updated!")
-		fmt.Println("[upgrade] Now you should go ahead and upgrade the kubelet package using your package manager.")
+		fmt.Printf("[%s] The configuration for this node was successfully updated!\n", phase)
+		fmt.Printf("[%s] Now you should go ahead and upgrade the kubelet package using your package manager.\n", phase)
 		return nil
 	}
 }

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/preflight.go
@@ -42,7 +42,7 @@ func NewPreflightPhase() workflow.Phase {
 }
 
 // runPreflight executes preflight checks logic.
-func runPreflight(c workflow.RunData) error {
+func runPreflight(c workflow.RunData, _ string) error {
 	data, ok := c.(Data)
 	if !ok {
 		return errors.New("preflight phase invoked with an invalid data struct")

--- a/cmd/kubeadm/app/cmd/phases/workflow/doc_test.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/doc_test.go
@@ -42,7 +42,7 @@ func ExamplePhase() {
 	var myPhase1 = Phase{
 		Name:  "myPhase1",
 		Short: "A phase of a kubeadm composable workflow...",
-		Run: func(data RunData) error {
+		Run: func(data RunData, _ string) error {
 			// transform data into a typed data struct
 			d, ok := data.(myPhaseData)
 			if !ok {
@@ -59,7 +59,7 @@ func ExamplePhase() {
 	var myPhase2 = Phase{
 		Name:  "myPhase2",
 		Short: "Another phase of a kubeadm composable workflow...",
-		Run: func(data RunData) error {
+		Run: func(data RunData, _ string) error {
 			// transform data into a typed data struct
 			d, ok := data.(myPhaseData)
 			if !ok {
@@ -83,7 +83,7 @@ func ExampleRunner_Run() {
 	var myPhase = Phase{
 		Name:  "myPhase",
 		Short: "A phase of a kubeadm composable workflow...",
-		Run: func(data RunData) error {
+		Run: func(data RunData, _ string) error {
 			// transform data into a typed data struct
 			d, ok := data.(myPhaseData)
 			if !ok {

--- a/cmd/kubeadm/app/cmd/phases/workflow/phase.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/phase.go
@@ -56,7 +56,7 @@ type Phase struct {
 	// Run defines a function implementing the phase action.
 	// It is recommended to implent type assertion, e.g. using golang type switch,
 	// for validating the RunData type.
-	Run func(data RunData) error
+	Run func(data RunData, name string) error
 
 	// RunIf define a function that implements a condition that should be checked
 	// before executing the phase action.

--- a/cmd/kubeadm/app/cmd/phases/workflow/phase.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/phase.go
@@ -54,7 +54,7 @@ type Phase struct {
 	RunAllSiblings bool
 
 	// Run defines a function implementing the phase action.
-	// It is recommended to implent type assertion, e.g. using golang type switch,
+	// It is recommended to implement type assertion, e.g. using golang type switch,
 	// for validating the RunData type.
 	Run func(data RunData, name string) error
 

--- a/cmd/kubeadm/app/cmd/phases/workflow/runner.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/runner.go
@@ -256,7 +256,7 @@ func (e *Runner) Run(args []string) error {
 
 		// Runs the phase action (if defined)
 		if p.Run != nil {
-			if err := p.Run(data); err != nil {
+			if err := p.Run(data, p.Phase.Name); err != nil {
 				return errors.Wrapf(err, "error execution phase %s", p.generatedName)
 			}
 		}

--- a/cmd/kubeadm/app/cmd/phases/workflow/runner_test.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/runner_test.go
@@ -127,8 +127,8 @@ func phaseBuilder1(name string, runIf func(data RunData) (bool, error), phases .
 
 var callstack []string
 
-func runBuilder(name string) func(data RunData) error {
-	return func(data RunData) error {
+func runBuilder(name string) func(data RunData, _ string) error {
+	return func(data RunData, phase string) error {
 		callstack = append(callstack, name)
 		return nil
 	}
@@ -183,7 +183,7 @@ func TestRunOrderAndConditions(t *testing.T) {
 	}
 }
 
-func phaseBuilder2(name string, runIf func(data RunData) (bool, error), run func(data RunData) error, phases ...Phase) Phase {
+func phaseBuilder2(name string, runIf func(data RunData) (bool, error), run func(data RunData, _ string) error, phases ...Phase) Phase {
 	return Phase{
 		Name:   name,
 		Short:  fmt.Sprintf("long description for %s ...", name),
@@ -193,11 +193,11 @@ func phaseBuilder2(name string, runIf func(data RunData) (bool, error), run func
 	}
 }
 
-func runPass(data RunData) error {
+func runPass(data RunData, _ string) error {
 	return nil
 }
 
-func runFails(data RunData) error {
+func runFails(data RunData, _ string) error {
 	return errors.New("run fails")
 }
 


### PR DESCRIPTION
- The method like `InitCfg()` could be called by phases other that the `preflight`, it's confusing to say it is `preflight` while it's actually try to join a control node.

e.g.
```
kubeadm join phase control-plane-join mark-control-plane --control-plane -v 5
...
I0322 10:21:20.981886  556656 join.go:539] [preflight] Fetching init configuration
I0322 10:21:20.981915  556656 join.go:585] [preflight] Retrieving KubeConfig objects
...
```

- It is better to say the current phase name instead of it's parent phase name, that could be easier to indentify where we are.

e.g. If it's the `update-status` sub-phase, it would be better to say `update-status` instead of `control-plane-join` in the log.


/kind cleanup

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig cluster-lifecycle