### PR TITLE
[1.24] Drop development dependencies from test targets

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -268,12 +268,6 @@ readonly KUBE_CLIENT_BINARIES_WIN=("${KUBE_CLIENT_BINARIES[@]/%/.exe}")
 # If you update this list, please also update build/BUILD.
 kube::golang::test_targets() {
   local targets=(
-    cmd/gendocs
-    cmd/genkubedocs
-    cmd/genman
-    cmd/genyaml
-    cmd/genswaggertypedocs
-    cmd/linkcheck
     vendor/github.com/onsi/ginkgo/ginkgo
     test/e2e/e2e.test
     test/conformance/image/go-runner


### PR DESCRIPTION
/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Cherry-pick of #116860

Drops development-time binaries we don't distribute from from test targets, since they tend to cause link issues on arm-32

https://testgrid.k8s.io/sig-release-1.24-blocking#build-1.24
https://github.com/kubernetes/kubernetes/issues/115738
https://github.com/kubernetes/kubernetes/issues/116492
https://github.com/kubernetes/kubernetes/issues/115675

```release-note
NONE
```
