### PR TITLE
Call function that validates resize policy for in-place pod resize feature

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3242,6 +3242,7 @@ func validateContainerCommon(ctr *core.Container, volumes map[string]core.Volume
 	allErrs = append(allErrs, ValidateVolumeDevices(ctr.VolumeDevices, volMounts, volumes, path.Child("volumeDevices"))...)
 	allErrs = append(allErrs, validatePullPolicy(ctr.ImagePullPolicy, path.Child("imagePullPolicy"))...)
 	allErrs = append(allErrs, ValidateResourceRequirements(&ctr.Resources, podClaimNames, path.Child("resources"), opts)...)
+	allErrs = append(allErrs, validateResizePolicy(ctr.ResizePolicy, path.Child("resizePolicy"))...)
 	allErrs = append(allErrs, ValidateSecurityContext(ctr.SecurityContext, path.Child("securityContext"))...)
 	return allErrs
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: This PR fixes missing validation of resize policy for in-place pod resize feature. Without this, user can specify arbitrary resize policies that don't mean anything.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #116854 

#### Special notes for your reviewer:
Manually tested as below:
```bash
root@vbuild:~/go/src/k8s.io/kubernetes-alpha-fixes# cat ~/YML/cpu_restart_pol.yaml 
apiVersion: v1
kind: Pod
metadata:
  name: cpurestartpol
spec:
  restartPolicy: OnFailure
  terminationGracePeriodSeconds: 2
  containers:
  - name: ctr
    image: skiibum/testpod:qos
    imagePullPolicy: IfNotPresent
    command: ["tail", "-f", "/dev/null"]
    resizePolicy:
    - resourceName: "cpu"
      restartPolicy: "NotRequired"
    resources:
      limits:
        cpu: "2"
        memory: "500Mi"
      requests:
        cpu: "2"
        memory: "500Mi"

root@vbuild:~/go/src/k8s.io/kubernetes-alpha-fixes# kcf ~/YML/cpu_restart_pol.yaml 
pod/cpurestartpol created
root@vbuild:~/go/src/k8s.io/kubernetes-alpha-fixes# k get pods cpurestartpol -ojson | jq .spec.containers[0].resizePolicy
[
  {
    "resourceName": "cpu",
    "restartPolicy": "NotRequired"
  },
  {
    "resourceName": "memory",
    "restartPolicy": "NotRequired"
  }
]
root@vbuild:~/go/src/k8s.io/kubernetes-alpha-fixes# cat ~/YML/mem_restart_pol.yaml 
apiVersion: v1
kind: Pod
metadata:
  name: memrestartpol
spec:
  restartPolicy: OnFailure
  terminationGracePeriodSeconds: 2
  containers:
  - name: ctr
    image: skiibum/testpod:qos
    imagePullPolicy: IfNotPresent
    command: ["tail", "-f", "/dev/null"]
    resizePolicy:
    - resourceName: "memory"
      restartPolicy: "RestartRequired"
    resources:
      limits:
        cpu: "2"
        memory: "500Mi"
      requests:
        cpu: "2"
        memory: "500Mi"

root@vbuild:~/go/src/k8s.io/kubernetes-alpha-fixes# kcf ~/YML/mem_restart_pol.yaml 
The Pod "memrestartpol" is invalid: spec.containers[0].resizePolicy: Unsupported value: "RestartRequired": supported values: "NotRequired", "RestartContainer"
root@vbuild:~/go/src/k8s.io/kubernetes-alpha-fixes# sed -i s/RestartRequired/RestartContainer/ ~/YML/mem_restart_pol.yaml
root@vbuild:~/go/src/k8s.io/kubernetes-alpha-fixes# kcf ~/YML/mem_restart_pol.yaml 
pod/memrestartpol created
root@vbuild:~/go/src/k8s.io/kubernetes-alpha-fixes# k get pods memrestartpol -ojson | jq .spec.containers[0].resizePolicy
[
  {
    "resourceName": "memory",
    "restartPolicy": "RestartContainer"
  },
  {
    "resourceName": "cpu",
    "restartPolicy": "NotRequired"
  }
]
root@vbuild:~/go/src/k8s.io/kubernetes-alpha-fixes# kcf ~/YML/bepod.yaml 
pod/bepod created
root@vbuild:~/go/src/k8s.io/kubernetes-alpha-fixes# kcf ~/YML/Bpod.yaml 
pod/bpod created
root@vbuild:~/go/src/k8s.io/kubernetes-alpha-fixes# cat ~/YML/Bpod.yaml 
apiVersion: v1
kind: Pod
metadata:
  name: bpod
spec:
  restartPolicy: OnFailure
  terminationGracePeriodSeconds: 2
  containers:
  - name: ctr
    image: skiibum/testpod:qos
    imagePullPolicy: IfNotPresent
    command: ["tail", "-f", "/dev/null"]
    resources:
      limits:
        cpu: "500m"
        memory: "500Mi"
      requests:
        cpu: "300m"
        memory: "200Mi"
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
