### PR TITLE
Drop development dependencies from test targets

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -261,11 +261,6 @@ readonly KUBE_CLIENT_BINARIES_WIN=("${KUBE_CLIENT_BINARIES[@]/%/.exe}")
 # The set of test targets that we are building for all platforms
 kube::golang::test_targets() {
   local targets=(
-    cmd/gendocs
-    cmd/genkubedocs
-    cmd/genman
-    cmd/genyaml
-    cmd/genswaggertypedocs
     ginkgo
     test/e2e/e2e.test
     test/conformance/image/go-runner


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Drops development-time binaries we don't distribute in releases from the test targets list

```release-note
NONE
```