### PR TITLE
Add structured alternatives to strings in client-go/tools/cache

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/keyfunc.go
+++ b/staging/src/k8s.io/client-go/tools/cache/keyfunc.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+// ObjectName is a reference to an object of some implicit kind
+type ObjectName struct {
+	Namespace string
+	Name      string
+}
+
+// NewObjectName constructs a new one
+func NewObjectName(namespace, name string) ObjectName {
+	return ObjectName{Namespace: namespace, Name: name}
+}
+
+// Parts is the inverse of the constructor
+func (objName ObjectName) Parts() (namespace, name string) {
+	return objName.Namespace, objName.Name
+}
+
+// String returns the standard string encoding,
+// which is designed to match the historical behavior of MetaNamespaceKeyFunc.
+func (objName ObjectName) String() string {
+	if len(objName.Namespace) > 0 {
+		return objName.Namespace + "/" + objName.Name
+	}
+	return objName.Name
+}
+
+// ParseObjectName tries to parse the standard encoding
+func ParseObjectName(str string) (ObjectName, error) {
+	var objName ObjectName
+	var err error
+	objName.Namespace, objName.Name, err = SplitMetaNamespaceKey(str)
+	return objName, err
+}

--- a/staging/src/k8s.io/client-go/tools/cache/object-names.go
+++ b/staging/src/k8s.io/client-go/tools/cache/object-names.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package cache
 
+import (
+	"k8s.io/apimachinery/pkg/types"
+)
+
 // ObjectName is a reference to an object of some implicit kind
 type ObjectName struct {
 	Namespace string
@@ -34,6 +38,7 @@ func (objName ObjectName) Parts() (namespace, name string) {
 
 // String returns the standard string encoding,
 // which is designed to match the historical behavior of MetaNamespaceKeyFunc.
+// Note this behavior is different from the String method of types.NamespacedName.
 func (objName ObjectName) String() string {
 	if len(objName.Namespace) > 0 {
 		return objName.Namespace + "/" + objName.Name
@@ -47,4 +52,14 @@ func ParseObjectName(str string) (ObjectName, error) {
 	var err error
 	objName.Namespace, objName.Name, err = SplitMetaNamespaceKey(str)
 	return objName, err
+}
+
+// NamespacedNameAsObjectName rebrands the given NamespacedName as an ObjectName
+func NamespacedNameAsObjectName(nn types.NamespacedName) ObjectName {
+	return NewObjectName(nn.Namespace, nn.Name)
+}
+
+// AsNamespacedName rebrands as a NamespacedName
+func (objName ObjectName) AsNamespacedName() types.NamespacedName {
+	return types.NamespacedName{Namespace: objName.Namespace, Name: objName.Name}
 }

--- a/staging/src/k8s.io/client-go/tools/cache/object-names_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/object-names_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func TestObjectNames(t *testing.T) {
+	chars := "abcdefghi/"
+	for count := 1; count <= 100; count++ {
+		var encodedB strings.Builder
+		for index := 0; index < 10; index++ {
+			encodedB.WriteByte(chars[rand.Intn(len(chars))])
+		}
+		encodedS := encodedB.String()
+		parts := strings.Split(encodedS, "/")
+		on, err := ParseObjectName(encodedS)
+		expectError := len(parts) > 2
+		if expectError != (err != nil) {
+			t.Errorf("Wrong error; expected=%v, got=%v", expectError, err)
+		}
+		if expectError || err != nil {
+			continue
+		}
+		var expectedObjectName ObjectName
+		if len(parts) == 2 {
+			expectedObjectName = ObjectName{Namespace: parts[0], Name: parts[1]}
+		} else {
+			expectedObjectName = ObjectName{Name: encodedS}
+		}
+		if on != expectedObjectName {
+			t.Errorf("Parse failed, expected=%+v, got=%+v", expectedObjectName, on)
+		}
+		recoded := on.String()
+		if encodedS[0] == '/' {
+			recoded = "/" + recoded
+		}
+		if encodedS != recoded {
+			t.Errorf("Parse().String() was not identity, original=%q, final=%q", encodedS, recoded)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
The functions `MetaNamespaceKeyFunc` and its inverse (`SplitMetaNamespaceKey`) in the `client-go/tools/cache` package were originally contributed to create and parse keys for Stores.  A Store's key is necessarily a `string`.  Since then, these functions have _also_ gained a lot of other usages that would benefit from using a structured alternative instead.  An example is a controller's workqueue, which can hold values of any type that is "comparable".  Using structured parsed values in a workqueue relieves the receiver from the burden to code up a call to a parsing routine and cope with the possibility of a parsing failure.  This PR introduces a structured alternative to those encoded strings, for clients that would benefit from this alternative, and factors `MetaNamespaceKeyFunc` to stay DRY.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
