### PR TITLE
Don't treat client-side request cancelation as a timeout

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	restful "github.com/emicklei/go-restful/v3"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/types"
 	utilsets "k8s.io/apimachinery/pkg/util/sets"
@@ -355,6 +356,14 @@ const (
 	// The source that is recording the apiserver_request_post_timeout_total metric.
 	// The "executing" request handler returns after the timeout filter times out the request.
 	PostTimeoutSourceTimeoutHandler = "timeout-handler"
+
+	// The source that is recording the apiserver_request_post_timeout_total metric.
+	// The "executing" request handler returns after the request was canceled.
+	PostTimeoutSourceCanceledHandler = "canceled-handler"
+
+	// The source that is recording the apiserver_request_post_timeout_total metric.
+	// The "executing" request handler returns after the request was terminated for an unknown reason.
+	PostTimeoutSourceUnknownHandler = "unknown-handler"
 
 	// The source that is recording the apiserver_request_post_timeout_total metric.
 	// The "executing" request handler returns after the rest layer times out the request.

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -415,8 +416,8 @@ func TestClientSideCancel(t *testing.T) {
 		time.Sleep(time.Second)
 		cancel()
 	}()
-	if _, err := client.Do(req); err == nil {
-		t.Fatalf("expected context canceled error")
+	if _, err := client.Do(req); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled  error; got %v", err)
 	}
 
 	select {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently the apiserver doesn't distinguish between a request timing out, and a request being canceled client-side. This can be confusing if you're trying to debug from the server side why requests are timing out, when the real reason is that a client is prematurely aborting.

This PR checks the context error in the timeout handler to distinguish these cases. The cancel & unknown cases are handled similarly to timeout, but use different wording and error codes to distinguish them. The `postTimeoutFn` is not called in the non-timeout cases.

#### Special notes for your reviewer:

Should `postTimeoutFn` be generalized to `requestTerminationFn`, and called in all cases? It looks like it's only used for recording request termination metrics.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig api-machinery