### PR TITLE
Servicelb controller: don't patch status for services that are being deleted

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
@@ -334,7 +334,7 @@ func TestSyncLoadBalancerIfNeeded(t *testing.T) {
 			lbExists:             true,
 			expectOp:             deleteLoadBalancer,
 			expectDeleteAttempt:  true,
-			expectPatchStatus:    true,
+			expectPatchStatus:    false,
 			expectPatchFinalizer: true,
 		},
 		{


### PR DESCRIPTION

/kind bug
```release-note
NONE
```

   If the patch fails the service will be retried. If per example, the
    service is being garbage collected because the namespace is deleted,
    then the patch operation will always fail and will keep retrying.

Since loadbalancer operations use to be slow, this has a considerable impact on large clusters