### PR TITLE
kmsv2: validate encrypt response at DEK generation time

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope.go
@@ -278,6 +278,15 @@ func GenerateTransformer(ctx context.Context, uid string, envelopeService kmsser
 		return nil, nil, nil, fmt.Errorf("failed to encrypt DEK, error: %w", err)
 	}
 
+	if err := validateEncryptedObject(&kmstypes.EncryptedObject{
+		KeyID:         resp.KeyID,
+		EncryptedDEK:  resp.Ciphertext,
+		EncryptedData: []byte{0}, // any non-empty value to pass validation
+		Annotations:   resp.Annotations,
+	}); err != nil {
+		return nil, nil, nil, err
+	}
+
 	cacheKey, err := generateCacheKey(resp.Ciphertext, resp.KeyID, resp.Annotations)
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
Prior to this change, we wait until the DEK is used to perform an encryption before validating the response.  This means that the plugin could report healthy but all `TransformToStorage` calls would fail.  Now we correctly cause the plugin to become unhealthy and do not attempt to use the newly generated DEK.

/kind bug

```release-note
The encryption response from KMS v2 plugins is now validated earlier at DEK generation time instead of waiting until an encryption is performed.
```