### PR TITLE
cleanup: Remove unhelpful comment in queue.go

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue.go
@@ -205,7 +205,6 @@ func (q *Type) Get() (item interface{}, shutdown bool) {
 	}
 
 	item = q.queue[0]
-	// The underlying array still exists and reference this object, so the object will not be garbage collected.
 	q.queue[0] = nil
 	q.queue = q.queue[1:]
 


### PR DESCRIPTION
The client-go work queue does not clean up the space occupied by the underlying array after it obtains the element. Therefore, the queue consumes a large amount of memory when it runs for a long time and a large number of cluster resources change.
 
/kind bug

#### Does this PR introduce a user-facing change?
`
NONE
`