### PR TITLE
remove GAed KubeletCredentialProviders （1.28）

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -556,6 +556,6 @@ export CLOUD_PROVIDER_FLAG="${CLOUD_PROVIDER_FLAG:-gce}"
 # are presented to kubelet:
 # --image-credential-provider-config=${path-to-config}
 # --image-credential-provider-bin-dir=${path-to-auth-provider-binary}
-# Also, it is required that DisableKubeletCloudCredentialProviders and KubeletCredentialProviders
+# Also, it is required that DisableKubeletCloudCredentialProviders
 # feature gates are set to true for kubelet to use external credential provider.
 ENABLE_AUTH_PROVIDER_GCP="${ENABLE_AUTH_PROVIDER_GCP:-false}"

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -717,8 +717,8 @@ function install-kube-binary-config {
   # are presented to kubelet:
   # --image-credential-provider-config=${path-to-config}
   # --image-credential-provider-bin-dir=${path-to-auth-provider-binary}
-  # Also, it is required that DisableKubeletCloudCredentialProviders and KubeletCredentialProviders
-  # feature gates are set to true for kubelet to use external credential provider. 
+  # Also, it is required that DisableKubeletCloudCredentialProviders
+  # feature gate is set to true for kubelet to use external credential provider.
   if [[ "${ENABLE_AUTH_PROVIDER_GCP:-}" == "true" ]]; then
     # Install out-of-tree auth-provider-gcp binary to enable kubelet to dynamically
     # retrieve credentials for a container image registry.

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -436,14 +436,6 @@ const (
 	// yet.
 	JobTrackingWithFinalizers featuregate.Feature = "JobTrackingWithFinalizers"
 
-	// owner: @andrewsykim @adisky @ndixita
-	// alpha: v1.20
-	// beta: v1.24
-	// GA: v1.26
-	//
-	// Enable kubelet exec plugins for image pull credentials.
-	KubeletCredentialProviders featuregate.Feature = "KubeletCredentialProviders"
-
 	// owner: @AkihiroSuda
 	// alpha: v1.22
 	//
@@ -1035,8 +1027,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	JobReadyPods: {Default: true, PreRelease: featuregate.Beta},
 
 	JobTrackingWithFinalizers: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.28
-
-	KubeletCredentialProviders: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.28
 
 	KubeletInUserNamespace: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/test/e2e_node/image_credential_provider.go
+++ b/test/e2e_node/image_credential_provider.go
@@ -30,7 +30,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-var _ = SIGDescribe("ImageCredentialProvider [Feature:KubeletCredentialProviders]", func() {
+var _ = SIGDescribe("ImageCredentialProvider", func() {
 	f := framework.NewDefaultFramework("image-credential-provider")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var podClient *e2epod.PodClient

--- a/test/e2e_node/plugins/gcp-credential-provider/README.md
+++ b/test/e2e_node/plugins/gcp-credential-provider/README.md
@@ -29,7 +29,7 @@ providers:
 3. Configuring the following additional flags on the kubelet:
 
 ```
---feature-gates=DisableKubeletCloudCredentialProviders=true,KubeletCredentialProviders=true
+--feature-gates=DisableKubeletCloudCredentialProviders=true
 --image-credential-provider-config=/tmp/node-e2e-123456/credential-provider.yaml
 --image-credential-provider-bin-dir=/tmp/node-e2e-12345
 ```

--- a/test/e2e_node/remote/node_e2e.go
+++ b/test/e2e_node/remote/node_e2e.go
@@ -96,7 +96,7 @@ func prependMemcgNotificationFlag(args string) string {
 // a credential provider plugin.
 func prependGCPCredentialProviderFlag(args, workspace string) string {
 	credentialProviderConfig := filepath.Join(workspace, "credential-provider.yaml")
-	featureGateFlag := "--kubelet-flags=--feature-gates=DisableKubeletCloudCredentialProviders=true,KubeletCredentialProviders=true"
+	featureGateFlag := "--kubelet-flags=--feature-gates=DisableKubeletCloudCredentialProviders=true"
 	configFlag := fmt.Sprintf("--kubelet-flags=--image-credential-provider-config=%s", credentialProviderConfig)
 	binFlag := fmt.Sprintf("--kubelet-flags=--image-credential-provider-bin-dir=%s", workspace)
 	return fmt.Sprintf("%s %s %s %s", featureGateFlag, configFlag, binFlag, args)


### PR DESCRIPTION
/kind cleanup

Fixes https://github.com/kubernetes/enhancements/issues/2133

#### Special notes for your reviewer:
- [x] https://github.com/kubernetes/test-infra/pull/29126 (wait for this to be merged.)
#### Does this PR introduce a user-facing change?

```release-note
remove GAed feature gate KubeletCredentialProviders
```
