### PR TITLE
Improve the performance of the method toKubeContainerImageSpec

### DIFF
--- a/pkg/kubelet/kuberuntime/convert.go
+++ b/pkg/kubelet/kuberuntime/convert.go
@@ -30,6 +30,7 @@ func toKubeContainerImageSpec(image *runtimeapi.Image) kubecontainer.ImageSpec {
 
 	if image.Spec != nil && len(image.Spec.Annotations) > 0 {
 		annotationKeys := make([]string, 0, len(image.Spec.Annotations))
+		annotations = make([]kubecontainer.Annotation, 0, len(image.Spec.Annotations))
 		for k := range image.Spec.Annotations {
 			annotationKeys = append(annotationKeys, k)
 		}

--- a/pkg/kubelet/kuberuntime/convert.go
+++ b/pkg/kubelet/kuberuntime/convert.go
@@ -17,8 +17,6 @@ limitations under the License.
 package kuberuntime
 
 import (
-	"sort"
-
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
@@ -29,16 +27,11 @@ func toKubeContainerImageSpec(image *runtimeapi.Image) kubecontainer.ImageSpec {
 	var annotations []kubecontainer.Annotation
 
 	if image.Spec != nil && len(image.Spec.Annotations) > 0 {
-		annotationKeys := make([]string, 0, len(image.Spec.Annotations))
 		annotations = make([]kubecontainer.Annotation, 0, len(image.Spec.Annotations))
-		for k := range image.Spec.Annotations {
-			annotationKeys = append(annotationKeys, k)
-		}
-		sort.Strings(annotationKeys)
-		for _, k := range annotationKeys {
+		for k, v := range image.Spec.Annotations {
 			annotations = append(annotations, kubecontainer.Annotation{
 				Name:  k,
-				Value: image.Spec.Annotations[k],
+				Value: v,
 			})
 		}
 	}

--- a/pkg/kubelet/kuberuntime/convert_test.go
+++ b/pkg/kubelet/kuberuntime/convert_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,8 +70,8 @@ func TestConvertToKubeContainerImageSpec(t *testing.T) {
 				Id: "test",
 				Spec: &runtimeapi.ImageSpec{
 					Annotations: map[string]string{
-						"kubernetes.io/os":             "linux",
 						"kubernetes.io/runtimehandler": "handler",
+						"kubernetes.io/os":             "linux",
 					},
 				},
 			},
@@ -92,6 +93,12 @@ func TestConvertToKubeContainerImageSpec(t *testing.T) {
 
 	for _, test := range testCases {
 		actual := toKubeContainerImageSpec(test.input)
+		sort.Slice(actual.Annotations, func(i, j int) bool {
+			if actual.Annotations[i].Name < actual.Annotations[j].Name {
+				return true
+			}
+			return false
+		})
 		assert.Equal(t, test.expected, actual)
 	}
 }

--- a/pkg/kubelet/kuberuntime/convert_test.go
+++ b/pkg/kubelet/kuberuntime/convert_test.go
@@ -94,10 +94,7 @@ func TestConvertToKubeContainerImageSpec(t *testing.T) {
 	for _, test := range testCases {
 		actual := toKubeContainerImageSpec(test.input)
 		sort.Slice(actual.Annotations, func(i, j int) bool {
-			if actual.Annotations[i].Name < actual.Annotations[j].Name {
-				return true
-			}
-			return false
+			return actual.Annotations[i].Name < actual.Annotations[j].Name
 		})
 		assert.Equal(t, test.expected, actual)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig node
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In my local env, I make a benchmark like this:
```
func BenchmarkToKubeContainerImageSpec(b *testing.B) {
	input := &runtimeapi.Image{
		Id: "test",
		Spec: &runtimeapi.ImageSpec{
			Annotations: map[string]string{
				"kubernetes.io/os":             "linux",
				"kubernetes.io/runtimehandler": "handler",
				"kubernetes.io/a":              "handlera",
				"kubernetes.io/b":              "handlerb",
				"kubernetes.io/c":              "handlerc",
			},
		},
	}
	for i := 0; i < b.N; i++ {
		toKubeContainerImageSpec(input)
	}
}
```

- original:

```
goos: darwin
goarch: amd64
pkg: k8s.io/kubernetes/pkg/kubelet/kuberuntime
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkToKubeContainerImageSpec-16    	 2106012	       565.6 ns/op	     584 B/op	       6 allocs/op
BenchmarkToKubeContainerImageSpec-16    	 2115118	       567.6 ns/op	     584 B/op	       6 allocs/op
BenchmarkToKubeContainerImageSpec-16    	 2110060	       566.2 ns/op	     584 B/op	       6 allocs/op
```

- PR:
```
goos: darwin
goarch: amd64
pkg: k8s.io/kubernetes/pkg/kubelet/kuberuntime
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkToKubeContainerImageSpec-16    	 3313998	       362.1 ns/op	     264 B/op	       3 allocs/op
BenchmarkToKubeContainerImageSpec-16    	 3318955	       362.3 ns/op	     264 B/op	       3 allocs/op
BenchmarkToKubeContainerImageSpec-16    	 3302299	       369.6 ns/op	     264 B/op	       3 allocs/op
```

Execution time reduced by around 36%, and 54.8% reduction in memory usage.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
