### PR TITLE
apiserver: optionally shut down immediately

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -20,6 +20,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -132,7 +133,7 @@ cluster's shared state through which all other components interact.`,
 			}
 			// add feature enablement metrics
 			utilfeature.DefaultMutableFeatureGate.AddMetrics()
-			return Run(completedOptions, genericapiserver.SetupSignalHandler())
+			return Run(context.Background(), completedOptions, genericapiserver.SetupSignalHandler())
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
 			for _, arg := range args {
@@ -160,7 +161,7 @@ cluster's shared state through which all other components interact.`,
 }
 
 // Run runs the specified APIServer.  This should never exit.
-func Run(completeOptions completedServerRunOptions, stopCh <-chan struct{}) error {
+func Run(ctx context.Context, completeOptions completedServerRunOptions, stopCh <-chan struct{}) error {
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v", version.Get())
 
@@ -176,7 +177,7 @@ func Run(completeOptions completedServerRunOptions, stopCh <-chan struct{}) erro
 		return err
 	}
 
-	return prepared.Run(stopCh)
+	return prepared.Run(ctx, stopCh)
 }
 
 // CreateServerChain creates the apiservers connected via delegation.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/server.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -60,5 +61,5 @@ func Run(o *options.CustomResourceDefinitionsServerOptions, stopCh <-chan struct
 	if err != nil {
 		return err
 	}
-	return server.GenericAPIServer.PrepareRun().Run(stopCh)
+	return server.GenericAPIServer.PrepareRun().Run(context.Background(), stopCh)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_graceful_termination_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_graceful_termination_test.go
@@ -41,6 +41,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
 
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/net/http2"
@@ -172,6 +173,7 @@ func newSignalInterceptingTestStep() *signalInterceptingTestStep {
 //	             |
 //	         return nil
 func TestGracefulTerminationWithKeepListeningDuringGracefulTerminationDisabled(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	fakeAudit := &fakeAudit{}
 	s := newGenericAPIServer(t, fakeAudit, false)
 	connReusingClient := newClient(false)
@@ -203,7 +205,7 @@ func TestGracefulTerminationWithKeepListeningDuringGracefulTerminationDisabled(t
 	stopCh, runCompletedCh := make(chan struct{}), make(chan struct{})
 	go func() {
 		defer close(runCompletedCh)
-		s.PrepareRun().Run(stopCh)
+		s.PrepareRun().Run(ctx, stopCh)
 	}()
 	waitForAPIServerStarted(t, doer)
 
@@ -395,6 +397,7 @@ func TestGracefulTerminationWithKeepListeningDuringGracefulTerminationDisabled(t
 //     |
 //     return nil
 func TestGracefulTerminationWithKeepListeningDuringGracefulTerminationEnabled(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	fakeAudit := &fakeAudit{}
 	s := newGenericAPIServer(t, fakeAudit, true)
 	connReusingClient := newClient(false)
@@ -426,7 +429,7 @@ func TestGracefulTerminationWithKeepListeningDuringGracefulTerminationEnabled(t 
 	stopCh, runCompletedCh := make(chan struct{}), make(chan struct{})
 	go func() {
 		defer close(runCompletedCh)
-		s.PrepareRun().Run(stopCh)
+		s.PrepareRun().Run(ctx, stopCh)
 	}()
 	waitForAPIServerStarted(t, doer)
 
@@ -551,6 +554,7 @@ func TestGracefulTerminationWithKeepListeningDuringGracefulTerminationEnabled(t 
 
 func TestMuxAndDiscoveryComplete(t *testing.T) {
 	// setup
+	_, ctx := ktesting.NewTestContext(t)
 	testSignal1 := make(chan struct{})
 	testSignal2 := make(chan struct{})
 	s := newGenericAPIServer(t, &fakeAudit{}, true)
@@ -571,7 +575,7 @@ func TestMuxAndDiscoveryComplete(t *testing.T) {
 	stopCh, runCompletedCh := make(chan struct{}), make(chan struct{})
 	go func() {
 		defer close(runCompletedCh)
-		s.PrepareRun().Run(stopCh)
+		s.PrepareRun().Run(ctx, stopCh)
 	}()
 	waitForAPIServerStarted(t, doer)
 
@@ -612,6 +616,7 @@ func TestPreShutdownHooks(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
 			s := test.server()
 			doer := setupDoer(t, s.SecureServingInfo)
 
@@ -646,7 +651,7 @@ func TestPreShutdownHooks(t *testing.T) {
 			stopCh, runCompletedCh := make(chan struct{}), make(chan struct{})
 			go func() {
 				defer close(runCompletedCh)
-				s.PrepareRun().Run(stopCh)
+				s.PrepareRun().Run(ctx, stopCh)
 			}()
 			waitForAPIServerStarted(t, doer)
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/discovery"
 	restclient "k8s.io/client-go/rest"
 	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2/ktesting"
 	netutils "k8s.io/utils/net"
 )
 
@@ -215,6 +216,7 @@ func TestServerRunWithSNI(t *testing.T) {
 		test := tests[title]
 		t.Run(title, func(t *testing.T) {
 			t.Parallel()
+			_, ctx := ktesting.NewTestContext(t)
 			// create server cert
 			certDir := "testdata/" + specToName(test.Cert)
 			serverCertBundleFile := filepath.Join(certDir, "cert")
@@ -316,7 +318,7 @@ func TestServerRunWithSNI(t *testing.T) {
 			preparedServer := s.PrepareRun()
 			preparedServerErrors := make(chan error)
 			go func() {
-				if err := preparedServer.Run(stopCh); err != nil {
+				if err := preparedServer.Run(ctx, stopCh); err != nil {
 					preparedServerErrors <- err
 				}
 			}()

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -109,7 +109,7 @@ type CompletedConfig struct {
 }
 
 type runnable interface {
-	Run(stopCh <-chan struct{}) error
+	Run(ctx context.Context, stopCh <-chan struct{}) error
 }
 
 // preparedGenericAPIServer is a private wrapper that enforces a call of PrepareRun() before Run can be invoked.
@@ -441,8 +441,8 @@ func (s *APIAggregator) PrepareRun() (preparedAPIAggregator, error) {
 	return preparedAPIAggregator{APIAggregator: s, runnable: prepared}, nil
 }
 
-func (s preparedAPIAggregator) Run(stopCh <-chan struct{}) error {
-	return s.runnable.Run(stopCh)
+func (s preparedAPIAggregator) Run(ctx context.Context, stopCh <-chan struct{}) error {
+	return s.runnable.Run(ctx, stopCh)
 }
 
 // AddAPIService adds an API service.  It is not thread-safe, so only call it on one thread at a time please.

--- a/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -171,5 +172,5 @@ func (o AggregatorOptions) RunAggregator(stopCh <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	return prepared.Run(stopCh)
+	return prepared.Run(context.Background(), stopCh)
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -176,5 +177,5 @@ func (o WardleServerOptions) RunWardleServer(stopCh <-chan struct{}) error {
 		return nil
 	})
 
-	return server.GenericAPIServer.PrepareRun().Run(stopCh)
+	return server.GenericAPIServer.PrepareRun().Run(context.Background(), stopCh)
 }

--- a/test/e2e/framework/internal/unittests/cleanup/cleanup_test.go
+++ b/test/e2e/framework/internal/unittests/cleanup/cleanup_test.go
@@ -173,10 +173,15 @@ func TestCleanup(t *testing.T) {
 	//   skip its own helper functions. That's okay, normally
 	//   ktesting should not be installed as logging backend like this.
 	// - klog.Infof messages are printed with an extra newline.
-	logger, _ := ktesting.NewTestContext(t)
+	//
+	// Once all code supports contextual logging, the klog.SetLogger
+	// call can be removed.
+	logger, ctx := ktesting.NewTestContext(t)
 	klog.SetLogger(logger)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-	apiServer := testapiserver.StartAPITestServer(t)
+	apiServer := testapiserver.StartAPITestServer(ctx, t)
 
 	// This simulates how test/e2e uses the framework and how users
 	// invoke test/e2e.

--- a/test/e2e_node/services/apiserver.go
+++ b/test/e2e_node/services/apiserver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package services
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -103,7 +104,9 @@ func (a *APIServer) Start() error {
 			return
 		}
 
-		err = apiserver.Run(completedOptions, a.stopCh)
+		// TODO (?): it probably makes sense to wire this up with some context in the caller
+		// to speed up apiserver shutdown when a test is done.
+		err = apiserver.Run(context.TODO(), completedOptions, a.stopCh)
 		if err != nil {
 			errCh <- fmt.Errorf("run apiserver error: %w", err)
 			return

--- a/test/integration/apiserver/admissionwebhook/load_balance_test.go
+++ b/test/integration/apiserver/admissionwebhook/load_balance_test.go
@@ -48,7 +48,6 @@ const (
 
 // TestWebhookLoadBalance ensures that the admission webhook opens multiple connections to backends to satisfy concurrent requests
 func TestWebhookLoadBalance(t *testing.T) {
-
 	roots := x509.NewCertPool()
 	if !roots.AppendCertsFromPEM(localhostCert) {
 		t.Fatal("Failed to append Cert from PEM")

--- a/test/integration/apiserver/admissionwebhook/match_conditions_test.go
+++ b/test/integration/apiserver/admissionwebhook/match_conditions_test.go
@@ -405,12 +405,9 @@ func Test_MatchConditions(t *testing.T) {
 			upCh := recorder.Reset()
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AdmissionWebhookMatchConditions, true)()
 
-			server, err := apiservertesting.StartTestServer(t, nil, []string{
+			server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 				"--disable-admission-plugins=ServiceAccount",
 			}, framework.SharedEtcd())
-			if err != nil {
-				t.Fatal(err)
-			}
 			defer server.TearDownFn()
 
 			config := server.ClientConfig

--- a/test/integration/apiserver/admissionwebhook/mutating_webhook_gvk_conversion_test.go
+++ b/test/integration/apiserver/admissionwebhook/mutating_webhook_gvk_conversion_test.go
@@ -135,7 +135,6 @@ func newAdmissionTypeCheckerHandler(recorder *admissionTypeChecker) http.Handler
 
 // Test_MutatingWebhookConvertsGVKWithMatchPolicyEquivalent tests if a equivalent resource is properly converted between mutating webhooks
 func Test_MutatingWebhookConvertsGVKWithMatchPolicyEquivalent(t *testing.T) {
-
 	roots := x509.NewCertPool()
 	if !roots.AppendCertsFromPEM(localhostCert) {
 		t.Fatal("Failed to append Cert from PEM")
@@ -157,12 +156,9 @@ func Test_MutatingWebhookConvertsGVKWithMatchPolicyEquivalent(t *testing.T) {
 
 	upCh := typeChecker.Reset()
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AdmissionWebhookMatchConditions, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--disable-admission-plugins=ServiceAccount",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	etcd.CreateTestCRDs(t, apiextensionsclientset.NewForConfigOrDie(server.ClientConfig), false, versionedCustomResourceDefinition())

--- a/test/integration/apiserver/apply/apply_crd_beta_test.go
+++ b/test/integration/apiserver/apply/apply_crd_beta_test.go
@@ -37,10 +37,7 @@ import (
 // TestApplyCRDNoSchema tests that CRDs and CRs can both be applied to with a PATCH request with the apply content type
 // when there is no validation field provided.
 func TestApplyCRDNoSchema(t *testing.T) {
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 

--- a/test/integration/apiserver/apply/reset_fields_test.go
+++ b/test/integration/apiserver/apply/reset_fields_test.go
@@ -164,10 +164,7 @@ var resetFieldsSpecData = map[schema.GroupVersionResource]string{
 func TestApplyResetFields(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, k8sfeatures.NetworkPolicyStatus, true)()
 
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), []string{"--disable-admission-plugins", "ServiceAccount,TaintNodesByCondition"}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), []string{"--disable-admission-plugins", "ServiceAccount,TaintNodesByCondition"}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	client, err := kubernetes.NewForConfig(server.ClientConfig)

--- a/test/integration/apiserver/apply/status_test.go
+++ b/test/integration/apiserver/apply/status_test.go
@@ -93,10 +93,7 @@ func createMapping(groupVersion string, resource metav1.APIResource) (*meta.REST
 
 // TestApplyStatus makes sure that applying the status works for all known types.
 func TestApplyStatus(t *testing.T) {
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), []string{"--disable-admission-plugins", "ServiceAccount,TaintNodesByCondition"}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), []string{"--disable-admission-plugins", "ServiceAccount,TaintNodesByCondition"}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	client, err := kubernetes.NewForConfig(server.ClientConfig)

--- a/test/integration/apiserver/cel/typeresolution_test.go
+++ b/test/integration/apiserver/cel/typeresolution_test.go
@@ -53,10 +53,7 @@ import (
 )
 
 func TestTypeResolver(t *testing.T) {
-	server, err := apiservertesting.StartTestServer(t, nil, nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -308,10 +305,7 @@ func TestTypeResolver(t *testing.T) {
 // resolve Kubernetes built-in types without error.
 func TestBuiltinResolution(t *testing.T) {
 	// before all, setup server and client
-	server, err := apiservertesting.StartTestServer(t, nil, nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	config := server.ClientConfig

--- a/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
+++ b/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
@@ -264,12 +264,9 @@ func Test_ValidateNamespace_NoParams(t *testing.T) {
 		t.Run(testcase.name, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
 
-			server, err := apiservertesting.StartTestServer(t, nil, []string{
+			server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 				"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 			}, framework.SharedEtcd())
-			if err != nil {
-				t.Fatal(err)
-			}
 			defer server.TearDownFn()
 
 			config := server.ClientConfig
@@ -418,16 +415,13 @@ func Test_ValidateAnnotationsAndWarnings(t *testing.T) {
 	}
 	defer os.Remove(logFile.Name())
 
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 		"--audit-policy-file", policyFile.Name(),
 		"--audit-log-version", "audit.k8s.io/v1",
 		"--audit-log-mode", "blocking",
 		"--audit-log-path", logFile.Name(),
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -532,12 +526,9 @@ func Test_ValidateNamespace_WithConfigMapParams(t *testing.T) {
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-			server, err := apiservertesting.StartTestServer(t, nil, []string{
+			server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 				"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 			}, framework.SharedEtcd())
-			if err != nil {
-				t.Fatal(err)
-			}
 			defer server.TearDownFn()
 
 			config := server.ClientConfig
@@ -569,10 +560,7 @@ func Test_ValidateNamespace_WithConfigMapParams(t *testing.T) {
 
 func TestMultiplePolicyBindings(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -696,12 +684,9 @@ func TestMultiplePolicyBindings(t *testing.T) {
 // are exempt from policy rules.
 func Test_PolicyExemption(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -783,12 +768,9 @@ func Test_PolicyExemption(t *testing.T) {
 // is allowed and when ParamKind is updated to v1/Secret, only namespaces prefixed with "secret" is allowed, etc.
 func Test_ValidatingAdmissionPolicy_UpdateParamKind(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -924,12 +906,9 @@ func Test_ValidatingAdmissionPolicy_UpdateParamKind(t *testing.T) {
 // the ParamRef set in the policy binding. The paramRef in the binding is then updated to a different object.
 func Test_ValidatingAdmissionPolicy_UpdateParamRef(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1070,12 +1049,9 @@ func Test_ValidatingAdmissionPolicy_UpdateParamRef(t *testing.T) {
 // Test_ValidatingAdmissionPolicy_UpdateParamResource validates behavior of a policy after updates to the param resource.
 func Test_ValidatingAdmissionPolicy_UpdateParamResource(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1203,12 +1179,9 @@ func Test_ValidatingAdmissionPolicy_UpdateParamResource(t *testing.T) {
 
 func Test_ValidatingAdmissionPolicy_MatchByObjectSelector(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1271,12 +1244,9 @@ func Test_ValidatingAdmissionPolicy_MatchByObjectSelector(t *testing.T) {
 
 func Test_ValidatingAdmissionPolicy_MatchByNamespaceSelector(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1363,12 +1333,9 @@ func Test_ValidatingAdmissionPolicy_MatchByNamespaceSelector(t *testing.T) {
 
 func Test_ValidatingAdmissionPolicy_MatchByResourceNames(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1422,12 +1389,9 @@ func Test_ValidatingAdmissionPolicy_MatchByResourceNames(t *testing.T) {
 
 func Test_ValidatingAdmissionPolicy_MatchWithExcludeResources(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1494,13 +1458,10 @@ func Test_ValidatingAdmissionPolicy_MatchWithExcludeResources(t *testing.T) {
 
 func Test_ValidatingAdmissionPolicy_MatchWithMatchPolicyEquivalent(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
 	etcd.CreateTestCRDs(t, apiextensionsclientset.NewForConfigOrDie(server.ClientConfig), false, versionedCustomResourceDefinition())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1586,13 +1547,10 @@ func Test_ValidatingAdmissionPolicy_MatchWithMatchPolicyEquivalent(t *testing.T)
 
 func Test_ValidatingAdmissionPolicy_MatchWithMatchPolicyExact(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
 	etcd.CreateTestCRDs(t, apiextensionsclientset.NewForConfigOrDie(server.ClientConfig), false, versionedCustomResourceDefinition())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1683,12 +1641,9 @@ func Test_ValidatingAdmissionPolicy_MatchWithMatchPolicyExact(t *testing.T) {
 // removes the policy from the apiserver admission chain and recreating it re-enables it.
 func Test_ValidatingAdmissionPolicy_PolicyDeletedThenRecreated(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1801,12 +1756,9 @@ func Test_ValidatingAdmissionPolicy_PolicyDeletedThenRecreated(t *testing.T) {
 // removes the policy from the apiserver admission chain and recreating it re-enables it.
 func Test_ValidatingAdmissionPolicy_BindingDeletedThenRecreated(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1920,12 +1872,9 @@ func Test_ValidatingAdmissionPolicy_BindingDeletedThenRecreated(t *testing.T) {
 // by a binding renders the policy as invalid. Recreating the param resource re-enables the policy.
 func Test_ValidatingAdmissionPolicy_ParamResourceDeletedThenRecreated(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -2110,12 +2059,9 @@ func TestCRDParams(t *testing.T) {
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-			server, err := apiservertesting.StartTestServer(t, nil, []string{
+			server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 				"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 			}, framework.SharedEtcd())
-			if err != nil {
-				t.Fatal(err)
-			}
 			defer server.TearDownFn()
 
 			config := server.ClientConfig
@@ -2162,12 +2108,9 @@ func TestCRDParams(t *testing.T) {
 
 func TestBindingRemoval(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -2317,14 +2260,11 @@ func Test_ValidateSecondaryAuthorization(t *testing.T) {
 			for clientName, clientFn := range clients {
 				t.Run(clientName, func(t *testing.T) {
 					defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-					server, err := apiservertesting.StartTestServer(t, nil, []string{
+					server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 						"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 						"--authorization-mode=RBAC",
 						"--anonymous-auth",
 					}, framework.SharedEtcd())
-					if err != nil {
-						t.Fatal(err)
-					}
 					defer server.TearDownFn()
 
 					// For test set up such as creating policies, bindings and RBAC rules.
@@ -2368,7 +2308,7 @@ func Test_ValidateSecondaryAuthorization(t *testing.T) {
 							Name: "test-authz",
 						},
 					}
-					_, err = client.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+					_, err := client.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
 
 					var expected metav1.StatusReason = ""
 					if !testcase.allowed {
@@ -2914,12 +2854,9 @@ rules:
 
 func TestValidatingAdmissionPolicyTypeChecking(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig

--- a/test/integration/apiserver/crd_regression_test.go
+++ b/test/integration/apiserver/crd_regression_test.go
@@ -36,10 +36,7 @@ import (
 
 // Regression test for https://issues.k8s.io/109099
 func TestCRDExponentialRecursionBug(t *testing.T) {
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 

--- a/test/integration/apiserver/crd_validation_expressions_test.go
+++ b/test/integration/apiserver/crd_validation_expressions_test.go
@@ -45,10 +45,7 @@ import (
 func TestCustomResourceValidatorsWithDisabledFeatureGate(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.CustomResourceValidationExpressions, false)()
 
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 
@@ -79,10 +76,7 @@ func TestCustomResourceValidatorsWithDisabledFeatureGate(t *testing.T) {
 func TestCustomResourceValidators(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.CustomResourceValidationExpressions, true)()
 
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 
@@ -455,10 +449,7 @@ func TestCustomResourceValidators(t *testing.T) {
 func TestCustomResourceValidatorsWithBlockingErrors(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.CustomResourceValidationExpressions, true)()
 
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 

--- a/test/integration/apiserver/discovery/discovery_test.go
+++ b/test/integration/apiserver/discovery/discovery_test.go
@@ -50,6 +50,7 @@ import (
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 
 	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 //lint:ignore U1000 we need to alias only for the sake of embedding
@@ -126,7 +127,8 @@ func init() {
 // Spins up an api server which is cleaned up at the end up the test
 // Returns some kubernetes clients
 func setup(t *testing.T) (context.Context, testClientSet, context.CancelFunc) {
-	ctx, cancelCtx := context.WithCancel(context.Background())
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancelCtx := context.WithCancel(ctx)
 
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
 	t.Cleanup(server.TearDownFn)

--- a/test/integration/apiserver/field_validation_test.go
+++ b/test/integration/apiserver/field_validation_test.go
@@ -514,10 +514,7 @@ spec:
 )
 
 func TestFieldValidation(t *testing.T) {
-	server, err := kubeapiservertesting.StartTestServer(t, kubeapiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	config := server.ClientConfig
 	defer server.TearDownFn()
 
@@ -2930,10 +2927,7 @@ func setupCRD(t testing.TB, config *rest.Config, apiGroup string, schemaless boo
 
 func BenchmarkFieldValidation(b *testing.B) {
 	flag.Lookup("v").Value.Set("0")
-	server, err := kubeapiservertesting.StartTestServer(b, kubeapiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		b.Fatal(err)
-	}
+	server := kubeapiservertesting.StartTestServerOrDie(b, kubeapiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	config := server.ClientConfig
 	defer server.TearDownFn()
 

--- a/test/integration/apiserver/openapi/openapi_merge_test.go
+++ b/test/integration/apiserver/openapi/openapi_merge_test.go
@@ -43,10 +43,7 @@ const objectMetaSchemaName = "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
 
 func TestOpenAPIV3MultipleCRDsSameGV(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.OpenAPIV3, true)()
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 

--- a/test/integration/apiserver/openapi/openapi_v2_merge_test.go
+++ b/test/integration/apiserver/openapi/openapi_v2_merge_test.go
@@ -36,10 +36,7 @@ import (
 )
 
 func TestOpenAPIV2CRDMergeNoDuplicateTypes(t *testing.T) {
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 

--- a/test/integration/apiserver/openapi/openapiv3_test.go
+++ b/test/integration/apiserver/openapi/openapiv3_test.go
@@ -101,10 +101,7 @@ func TestOpenAPIV3SpecRoundTrip(t *testing.T) {
 
 func TestAddRemoveGroupVersion(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.OpenAPIV3, true)()
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 

--- a/test/integration/controlplane/transformation/secrets_transformation_test.go
+++ b/test/integration/controlplane/transformation/secrets_transformation_test.go
@@ -95,7 +95,7 @@ func TestSecretsShouldBeTransformed(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create test secret, error: %v", err)
 		}
-		test.runResource(test.logger, tt.unSealFunc, tt.transformerPrefix, "", "v1", "secrets", test.secret.Name, test.secret.Namespace)
+		test.runResource(t, tt.unSealFunc, tt.transformerPrefix, "", "v1", "secrets", test.secret.Name, test.secret.Namespace)
 		test.cleanUp()
 	}
 }

--- a/test/integration/dryrun/dryrun_test.go
+++ b/test/integration/dryrun/dryrun_test.go
@@ -214,13 +214,10 @@ func TestDryRun(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DryRun, true)()
 
 	// start API server
-	s, err := kubeapiservertesting.StartTestServer(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
+	s := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
 		"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection",
 		"--runtime-config=api/all=true",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer s.TearDownFn()
 
 	client, err := kubernetes.NewForConfig(s.ClientConfig)

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -173,7 +173,7 @@ func StartTestServer(t testing.TB, setup TestServerSetup) (client.Interface, *re
 	errCh = make(chan error)
 	go func() {
 		defer close(errCh)
-		if err := kubeAPIServer.GenericAPIServer.PrepareRun().Run(ctx.Done()); err != nil {
+		if err := kubeAPIServer.GenericAPIServer.PrepareRun().Run(ctx, ctx.Done()); err != nil {
 			errCh <- err
 		}
 	}()

--- a/test/utils/apiserver/testapiserver.go
+++ b/test/utils/apiserver/testapiserver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
+	"context"
 	"path"
 	"testing"
 
@@ -44,8 +45,9 @@ type TestAPIServer struct {
 
 // StartAPIServer runs etcd and apiserver in the background in the same
 // process. All resources get released automatically when the test
-// completes. If startup fails, the test gets aborted.
-func StartAPITestServer(t *testing.T) TestAPIServer {
+// completes. If startup fails, the test gets aborted. If the context
+// gets cancelled, the server stops running immediately.
+func StartAPITestServer(ctx context.Context, t *testing.T) TestAPIServer {
 	cfg := etcdserver.NewTestConfig(t)
 	etcdClient := etcdserver.RunEtcd(t, cfg)
 	storageConfig := storagebackend.NewDefaultConfig(path.Join(uuid.New().String(), "registry"), nil)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adding a context to the apiserver Run method adds the possibility to shut down the server immediately. This is useful for unit tests. The context can also be used to pass in a per-test logger instance.

A full run of all scheduler_perf test cases with one apiserver start/stop per test and the default delay of one minute for a graceful shutdown used to take 33:32 min. Now it is down to 17:46 min.

#### Special notes for your reviewer:

For some reason, apiserver shutdown during test/integration/apiserver tests already was quick, so although those tests now also use the immediate shutdown through context cancellation, they don't become faster.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @kerthcet @aojea 