### PR TITLE
Ensure version "*" is passed instead of "" for all authz checks

### DIFF
--- a/pkg/controller/certificates/approver/sarapprove.go
+++ b/pkg/controller/certificates/approver/sarapprove.go
@@ -31,7 +31,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	capihelper "k8s.io/kubernetes/pkg/apis/certificates"
 	"k8s.io/kubernetes/pkg/controller/certificates"
-	"k8s.io/kubernetes/pkg/registry/authorization/util"
 )
 
 type csrRecognizer struct {
@@ -63,12 +62,12 @@ func recognizers() []csrRecognizer {
 	recognizers := []csrRecognizer{
 		{
 			recognize:      isSelfNodeClientCert,
-			permission:     authorization.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Verb: "create", Subresource: "selfnodeclient", Version: util.AllVersion},
+			permission:     authorization.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Verb: "create", Subresource: "selfnodeclient", Version: "*"},
 			successMessage: "Auto approving self kubelet client certificate after SubjectAccessReview.",
 		},
 		{
 			recognize:      isNodeClientCert,
-			permission:     authorization.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Verb: "create", Subresource: "nodeclient", Version: util.AllVersion},
+			permission:     authorization.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Verb: "create", Subresource: "nodeclient", Version: "*"},
 			successMessage: "Auto approving kubelet client certificate after SubjectAccessReview.",
 		},
 	}

--- a/pkg/controller/certificates/approver/sarapprove.go
+++ b/pkg/controller/certificates/approver/sarapprove.go
@@ -29,9 +29,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	certificatesinformers "k8s.io/client-go/informers/certificates/v1"
 	clientset "k8s.io/client-go/kubernetes"
-
 	capihelper "k8s.io/kubernetes/pkg/apis/certificates"
 	"k8s.io/kubernetes/pkg/controller/certificates"
+	"k8s.io/kubernetes/pkg/registry/authorization/util"
 )
 
 type csrRecognizer struct {
@@ -63,12 +63,12 @@ func recognizers() []csrRecognizer {
 	recognizers := []csrRecognizer{
 		{
 			recognize:      isSelfNodeClientCert,
-			permission:     authorization.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Verb: "create", Subresource: "selfnodeclient"},
+			permission:     authorization.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Verb: "create", Subresource: "selfnodeclient", Version: util.AllVersion},
 			successMessage: "Auto approving self kubelet client certificate after SubjectAccessReview.",
 		},
 		{
 			recognize:      isNodeClientCert,
-			permission:     authorization.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Verb: "create", Subresource: "nodeclient"},
+			permission:     authorization.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Verb: "create", Subresource: "nodeclient", Version: util.AllVersion},
 			successMessage: "Auto approving kubelet client certificate after SubjectAccessReview.",
 		},
 	}

--- a/pkg/registry/authorization/subjectaccessreview/rest_test.go
+++ b/pkg/registry/authorization/subjectaccessreview/rest_test.go
@@ -19,6 +19,7 @@ package subjectaccessreview
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -181,6 +182,7 @@ func TestCreate(t *testing.T) {
 			expectedAttrs: authorizer.AttributesRecord{
 				User:            &user.DefaultInfo{Name: "bob"},
 				ResourceRequest: true,
+				APIVersion:      "*",
 			},
 			expectedStatus: authorizationapi.SubjectAccessReviewStatus{
 				Allowed: false,
@@ -209,6 +211,7 @@ func TestCreate(t *testing.T) {
 			continue
 		}
 		if !reflect.DeepEqual(auth.attrs, tc.expectedAttrs) {
+			fmt.Println(k)
 			t.Errorf("%s: expected\n%#v\ngot\n%#v", k, tc.expectedAttrs, auth.attrs)
 		}
 		status := result.(*authorizationapi.SubjectAccessReview).Status

--- a/pkg/registry/authorization/subjectaccessreview/rest_test.go
+++ b/pkg/registry/authorization/subjectaccessreview/rest_test.go
@@ -19,11 +19,9 @@ package subjectaccessreview
 import (
 	"context"
 	"errors"
-	"fmt"
+	"reflect"
 	"strings"
 	"testing"
-
-	"reflect"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -211,7 +209,6 @@ func TestCreate(t *testing.T) {
 			continue
 		}
 		if !reflect.DeepEqual(auth.attrs, tc.expectedAttrs) {
-			fmt.Println(k)
 			t.Errorf("%s: expected\n%#v\ngot\n%#v", k, tc.expectedAttrs, auth.attrs)
 		}
 		status := result.(*authorizationapi.SubjectAccessReview).Status

--- a/pkg/registry/authorization/util/helpers.go
+++ b/pkg/registry/authorization/util/helpers.go
@@ -29,7 +29,7 @@ func ResourceAttributesFrom(user user.Info, in authorizationapi.ResourceAttribut
 		Verb:            in.Verb,
 		Namespace:       in.Namespace,
 		APIGroup:        in.Group,
-		APIVersion:      MatchAllVersionIfEmpty(in.Version),
+		APIVersion:      matchAllVersionIfEmpty(in.Version),
 		Resource:        in.Resource,
 		Subresource:     in.Subresource,
 		Name:            in.Name,
@@ -80,8 +80,8 @@ func AuthorizationAttributesFrom(spec authorizationapi.SubjectAccessReviewSpec) 
 
 const AllVersion = "*"
 
-// MatchAllVersionIfEmpty returns a "*" if the version is unspecified
-func MatchAllVersionIfEmpty(version string) string {
+// matchAllVersionIfEmpty returns a "*" if the version is unspecified
+func matchAllVersionIfEmpty(version string) string {
 	if len(version) == 0 {
 		return AllVersion
 	}

--- a/pkg/registry/authorization/util/helpers.go
+++ b/pkg/registry/authorization/util/helpers.go
@@ -78,12 +78,10 @@ func AuthorizationAttributesFrom(spec authorizationapi.SubjectAccessReviewSpec) 
 	return authorizationAttributes
 }
 
-const AllVersion = "*"
-
 // matchAllVersionIfEmpty returns a "*" if the version is unspecified
 func matchAllVersionIfEmpty(version string) string {
 	if len(version) == 0 {
-		return AllVersion
+		return "*"
 	}
 	return version
 }

--- a/pkg/registry/authorization/util/helpers.go
+++ b/pkg/registry/authorization/util/helpers.go
@@ -29,7 +29,7 @@ func ResourceAttributesFrom(user user.Info, in authorizationapi.ResourceAttribut
 		Verb:            in.Verb,
 		Namespace:       in.Namespace,
 		APIGroup:        in.Group,
-		APIVersion:      in.Version,
+		APIVersion:      MatchAllVersionIfEmpty(in.Version),
 		Resource:        in.Resource,
 		Subresource:     in.Subresource,
 		Name:            in.Name,
@@ -76,4 +76,14 @@ func AuthorizationAttributesFrom(spec authorizationapi.SubjectAccessReviewSpec) 
 	}
 
 	return authorizationAttributes
+}
+
+const AllVersion = "*"
+
+// MatchAllVersionIfEmpty returns a "*" if the version is unspecified
+func MatchAllVersionIfEmpty(version string) string {
+	if len(version) == 0 {
+		return AllVersion
+	}
+	return version
 }

--- a/pkg/registry/authorization/util/helpers_test.go
+++ b/pkg/registry/authorization/util/helpers_test.go
@@ -133,6 +133,35 @@ func TestAuthorizationAttributesFrom(t *testing.T) {
 				ResourceRequest: true,
 			},
 		},
+		{
+			name: "resource with no version",
+			args: args{
+				spec: authorizationapi.SubjectAccessReviewSpec{
+					User: "bob",
+					ResourceAttributes: &authorizationapi.ResourceAttributes{
+						Namespace:   "myns",
+						Verb:        "create",
+						Group:       "extensions",
+						Resource:    "deployments",
+						Subresource: "scale",
+						Name:        "mydeployment",
+					},
+				},
+			},
+			want: authorizer.AttributesRecord{
+				User: &user.DefaultInfo{
+					Name: "bob",
+				},
+				APIGroup:        "extensions",
+				APIVersion:      "*",
+				Namespace:       "myns",
+				Verb:            "create",
+				Resource:        "deployments",
+				Subresource:     "scale",
+				Name:            "mydeployment",
+				ResourceRequest: true,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
SubjectAccessReview [expects "*"](https://github.com/kubernetes/api/blob/0478a3e95231398d8b380dc2a1905972be8ae1d5/authorization/v1/types.go#L106-L108) (not "") if the version is unspecified. 
This pr audit all authz checks to ensure that "*" is being passed everywhere.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115660 

#### Special notes for your reviewer:
I'm not familiar with the codes in auth part. So if I'm missing something, plz give me a hint and I will dig into it.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
SubjectAccessReview requests sent to webhook authorizers now default `spec.resourceAttributes.version` to `*` if unset.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
