### PR TITLE
fix ImageLocality plugin score is inconsistent

### DIFF
--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -570,7 +570,7 @@ func (ev *Evaluator) DryRunPreemption(ctx context.Context, pod *v1.Pod, potentia
 	var statusesLock sync.Mutex
 	var errs []error
 	checkNode := func(i int) {
-		nodeInfoCopy := potentialNodes[(int(offset)+i)%len(potentialNodes)].Clone()
+		nodeInfoCopy := potentialNodes[(int(offset)+i)%len(potentialNodes)].Snapshot()
 		stateCopy := ev.State.Clone()
 		pods, numPDBViolations, status := ev.SelectVictimsOnNode(ctx, stateCopy, pod, nodeInfoCopy, pdbs)
 		if status.IsSuccess() && len(pods) != 0 {

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -942,7 +942,7 @@ func addNominatedPods(ctx context.Context, fh framework.Handle, pod *v1.Pod, sta
 	if len(nominatedPodInfos) == 0 {
 		return false, state, nodeInfo, nil
 	}
-	nodeInfoOut := nodeInfo.Clone()
+	nodeInfoOut := nodeInfo.Snapshot()
 	stateOut := state.Clone()
 	podsAdded := false
 	for _, pi := range nominatedPodInfos {

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -494,7 +494,7 @@ func TestNodeInfoClone(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
-			ni := test.nodeInfo.Clone()
+			ni := test.nodeInfo.Snapshot()
 			// Modify the field to check if the result is a clone of the origin one.
 			test.nodeInfo.Generation += 10
 			test.nodeInfo.UsedPorts.Remove("127.0.0.1", "TCP", 80)

--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -71,8 +71,8 @@ type cacheImpl struct {
 	// head of the linked list.
 	headNode *nodeInfoListItem
 	nodeTree *nodeTree
-	// A map from image name to its imageState.
-	imageStates map[string]*imageState
+	// A map from image name to its ImageStateSummary.
+	imageStates map[string]*framework.ImageStateSummary
 }
 
 type podState struct {
@@ -82,21 +82,6 @@ type podState struct {
 	deadline *time.Time
 	// Used to block cache from expiring assumedPod if binding still runs
 	bindingFinished bool
-}
-
-type imageState struct {
-	// Size of the image
-	size int64
-	// A set of node names for nodes having this image present
-	nodes sets.Set[string]
-}
-
-// createImageStateSummary returns a summarizing snapshot of the given image's state.
-func (cache *cacheImpl) createImageStateSummary(state *imageState) *framework.ImageStateSummary {
-	return &framework.ImageStateSummary{
-		Size:     state.size,
-		NumNodes: len(state.nodes),
-	}
 }
 
 func newCache(ctx context.Context, ttl, period time.Duration) *cacheImpl {
@@ -110,7 +95,7 @@ func newCache(ctx context.Context, ttl, period time.Duration) *cacheImpl {
 		nodeTree:    newNodeTree(logger, nil),
 		assumedPods: sets.New[string](),
 		podStates:   make(map[string]*podState),
-		imageStates: make(map[string]*imageState),
+		imageStates: make(map[string]*framework.ImageStateSummary),
 	}
 }
 
@@ -182,7 +167,7 @@ func (cache *cacheImpl) Dump() *Dump {
 
 	nodes := make(map[string]*framework.NodeInfo, len(cache.nodes))
 	for k, v := range cache.nodes {
-		nodes[k] = v.info.Clone()
+		nodes[k] = v.info.Snapshot()
 	}
 
 	return &Dump{
@@ -233,7 +218,7 @@ func (cache *cacheImpl) UpdateSnapshot(logger klog.Logger, nodeSnapshot *Snapsho
 				existing = &framework.NodeInfo{}
 				nodeSnapshot.nodeInfoMap[np.Name] = existing
 			}
-			clone := node.info.Clone()
+			clone := node.info.Snapshot()
 			// We track nodes that have pods with affinity, here we check if this node changed its
 			// status from having pods with affinity to NOT having pods with affinity or the other
 			// way around.
@@ -629,13 +614,12 @@ func (cache *cacheImpl) AddNode(logger klog.Logger, node *v1.Node) *framework.No
 	cache.nodeTree.addNode(logger, node)
 	cache.addNodeImageStates(node, n.info)
 	n.info.SetNode(node)
-	return n.info.Clone()
+	return n.info.Snapshot()
 }
 
 func (cache *cacheImpl) UpdateNode(logger klog.Logger, oldNode, newNode *v1.Node) *framework.NodeInfo {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
-
 	n, ok := cache.nodes[newNode.Name]
 	if !ok {
 		n = newNodeInfoListItem(framework.NewNodeInfo())
@@ -649,7 +633,7 @@ func (cache *cacheImpl) UpdateNode(logger klog.Logger, oldNode, newNode *v1.Node
 	cache.nodeTree.updateNode(logger, oldNode, newNode)
 	cache.addNodeImageStates(newNode, n.info)
 	n.info.SetNode(newNode)
-	return n.info.Clone()
+	return n.info.Snapshot()
 }
 
 // RemoveNode removes a node from the cache's tree.
@@ -693,17 +677,17 @@ func (cache *cacheImpl) addNodeImageStates(node *v1.Node, nodeInfo *framework.No
 			// update the entry in imageStates
 			state, ok := cache.imageStates[name]
 			if !ok {
-				state = &imageState{
-					size:  image.SizeBytes,
-					nodes: sets.New(node.Name),
+				state = &framework.ImageStateSummary{
+					Size:  image.SizeBytes,
+					Nodes: sets.New(node.Name),
 				}
 				cache.imageStates[name] = state
 			} else {
-				state.nodes.Insert(node.Name)
+				state.Nodes.Insert(node.Name)
 			}
-			// create the imageStateSummary for this image
+			// create the ImageStateSummary for this image
 			if _, ok := newSum[name]; !ok {
-				newSum[name] = cache.createImageStateSummary(state)
+				newSum[name] = state
 			}
 		}
 	}
@@ -722,8 +706,8 @@ func (cache *cacheImpl) removeNodeImageStates(node *v1.Node) {
 		for _, name := range image.Names {
 			state, ok := cache.imageStates[name]
 			if ok {
-				state.nodes.Delete(node.Name)
-				if len(state.nodes) == 0 {
+				state.Nodes.Delete(node.Name)
+				if state.Nodes.Len() == 0 {
 					// Remove the unused image to make sure the length of
 					// imageStates represents the total number of different
 					// images on all nodes

--- a/pkg/scheduler/internal/cache/snapshot.go
+++ b/pkg/scheduler/internal/cache/snapshot.go
@@ -130,7 +130,7 @@ func getNodeImageStates(node *v1.Node, imageExistenceMap map[string]sets.Set[str
 		for _, name := range image.Names {
 			imageStates[name] = &framework.ImageStateSummary{
 				Size:     image.SizeBytes,
-				NumNodes: len(imageExistenceMap[name]),
+				NumNodes: imageExistenceMap[name].Len(),
 			}
 		}
 	}

--- a/pkg/scheduler/testing/framework/fake_extender.go
+++ b/pkg/scheduler/testing/framework/fake_extender.go
@@ -232,7 +232,7 @@ func (f *FakeExtender) selectVictimsOnNodeByExtender(pod *v1.Pod, node *v1.Node)
 
 	// Otherwise, as a extender support preemption and have cached node info, we will assume cachedNodeNameToInfo is available
 	// and get cached node info by given node name.
-	nodeInfoCopy := f.CachedNodeNameToInfo[node.GetName()].Clone()
+	nodeInfoCopy := f.CachedNodeNameToInfo[node.GetName()].Snapshot()
 
 	var potentialVictims []*v1.Pod
 


### PR DESCRIPTION
#### What type of PR is this?


/kind bug

the older manner is that update the `NodeInfo.ImageStates` field when receive add/update/delete event, but doesn't update

`ImageStates` of the exist `NodeInfo` when receive node add event, this manner cause inconsistent of ImageLocality plugin.

the new manner is that  update the `cache.imageStates` field when receive add/update/delete event,  update `ImageStates` 

of the exist `NodeInfo` according to `cache.imageStates` when beginning to schedule pod(in `UpdateSnapshot` function) 

#### Which issue(s) this PR fixes:

Fixes #116673


#### Does this PR introduce a user-facing change?
```release-note
Fixed inconsistency in the calculation of number of nodes that have an image, which affect the scoring in the ImageLocality plugin
```
