### PR TITLE
Do not look at VPC-related resources outside the cluster's network

### DIFF
--- a/cluster/gce/list-resources.sh
+++ b/cluster/gce/list-resources.sh
@@ -29,7 +29,7 @@ set -o pipefail
 ZONE=${ZONE:-}
 REGION=${ZONE%-*}
 INSTANCE_PREFIX=${KUBE_GCE_INSTANCE_PREFIX:-${CLUSTER_NAME:-}}
-NETWORK=${KUBE_GCE_NETWORK:-${KUBE_GKE_NETWORK:-}}
+NETWORK=${KUBE_GCE_NETWORK:-${KUBE_GKE_NETWORK:-default}}
 
 # In GKE the instance prefix starts with "gke-".
 if [[ "${KUBERNETES_PROVIDER:-}" == "gke" ]]; then
@@ -90,7 +90,7 @@ gcloud-list compute disks "${ZONE:+"zone:(${ZONE}) AND "}name ~ '${INSTANCE_PREF
 gcloud-list compute addresses "${REGION:+"region=(${REGION}) AND "}name ~ 'a.*|${INSTANCE_PREFIX}.*'"
 # Match either the header or a line with the specified e2e network.
 # This assumes that the network name is the second field in the output.
-GREP_REGEX="^NAME\|^[^ ]\+[ ]\+\(default\|${NETWORK}\) "
+GREP_REGEX="^NAME\|^[^ ]\+[ ]\+\(${NETWORK}\) "
 gcloud-list compute routes "name ~ 'default.*|${INSTANCE_PREFIX}.*'"
 gcloud-list compute firewall-rules "name ~ 'default.*|k8s-fw.*|${INSTANCE_PREFIX}.*'"
 GREP_REGEX=""


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

When running e2e tests of K8s in GCP using [kubetest](https://github.com/kubernetes/test-infra/tree/master/kubetest) they use `list-resources.sh` before and after the test to establish whether there's any leakage of cloud resources.

When there's a new GCP location turnup during the test, `default` VPC network receives new route(s) that would make the test fail despite the test cluster using a completely different network.

This PR would make the script look only at routes and firewall-rules that are specific to the test cluster's VPC network. I'm not sure why we always looked at the `default` network routes so far but I'm leaving looking at it as it is if the [`NETWORK`](https://github.com/kubernetes/kubernetes/blob/8f15859afc9cfaeb05d4915ffa204d84da512094/cluster/gce/list-resources.sh#L32) env var evaluates to empty string.

#### Which issue(s) this PR fixes:

No issue is opened for that.

#### Special notes for your reviewer:

/assign @mborsz

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
