### PR TITLE
RFC: ktesting: add object formatter

### DIFF
--- a/test/utils/ktesting/format.go
+++ b/test/utils/ktesting/format.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ktesting
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/yaml"
+)
+
+func Format[T any](obj T) formatAny[T] {
+	return formatAny[T]{Object: obj}
+}
+
+type formatAny[T any] struct {
+	Object T
+}
+
+func (f formatAny[T]) String() string {
+	yamlBytes, err := yaml.Marshal(&f.Object)
+	if err != nil {
+		return fmt.Sprintf("error marshaling %T to YAML: %v", f, err)
+	}
+	return string(yamlBytes)
+}
+
+func (f formatAny[T]) MarshalLog() interface{} {
+	// Strip implementation of String.
+	type noStringer *T
+	return noStringer(&f.Object)
+}
+
+var _ fmt.Stringer = formatAny[int]{}
+var _ logr.Marshaler = formatAny[int]{}

--- a/test/utils/ktesting/format_test.go
+++ b/test/utils/ktesting/format_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ktesting
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFormat(t *testing.T) {
+	obj := config{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "config",
+			APIVersion: "v1",
+		},
+		RealField: 42,
+	}
+
+	assert.Equal(t, "&TypeMeta{Kind:config,APIVersion:v1,}", obj.String(), "config.String()")
+	assert.Equal(t, `RealField: 42
+apiVersion: v1
+kind: config
+`, Format(obj).String(), "Format(config).String()")
+	// fmt.Sprintf would call String if it was available.
+	assert.Equal(t, "&{{config v1} %!s(int=42)}", fmt.Sprintf("%s", Format(obj).MarshalLog()), "fmt.Sprintf")
+}
+
+type config struct {
+	metav1.TypeMeta // implements fmt.Stringer
+
+	RealField int
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is useful for logging types which implement String incorrectly, for example by inheriting it from metav1.TypeMeta. If implementing fmt.Stringer and logr.Marshaler for the type is not possible or not desirable, then log calls can wrap an instance of the type or a pointer to it with Format. That then returns a wrapper which implements both.

YAML formatting is used for pretty-printing to a multi-line string.

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/pull/115950

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @SataQiu @liggitt 