### PR TITLE
managedfields: A few improvements which will make testing easier

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/fieldmanager_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/fieldmanager_test.go
@@ -183,14 +183,14 @@ func TestVersionCheck(t *testing.T) {
 		t.Fatalf("error decoding YAML: %v", err)
 	}
 
-	// patch has 'apiVersion: apps/v2' but live version is apps/v1 -> error
+	// patch has 'apiVersion: apps/v1beta1' but live version is apps/v1 -> error
 	err = f.Apply(appliedObj, "fieldmanager_test", false)
 	if err == nil {
 		t.Fatalf("expected an error from mismatched patch and live versions")
 	}
 	switch typ := err.(type) {
 	default:
-		t.Fatalf("expected error to be of type %T was %T", apierrors.StatusError{}, typ)
+		t.Fatalf("expected error to be of type %T was %T (%v)", apierrors.StatusError{}, typ, err)
 	case apierrors.APIStatus:
 		if typ.Status().Code != http.StatusBadRequest {
 			t.Fatalf("expected status code to be %d but was %d",
@@ -198,6 +198,7 @@ func TestVersionCheck(t *testing.T) {
 		}
 	}
 }
+
 func TestVersionCheckDoesNotPanic(t *testing.T) {
 	f := managedfieldstest.NewTestFieldManager(fakeTypeConverter, schema.FromAPIVersionAndKind("apps/v1", "Deployment"))
 
@@ -228,7 +229,7 @@ func TestVersionCheckDoesNotPanic(t *testing.T) {
 	}
 	switch typ := err.(type) {
 	default:
-		t.Fatalf("expected error to be of type %T was %T", apierrors.StatusError{}, typ)
+		t.Fatalf("expected error to be of type %T was %T (%v)", apierrors.StatusError{}, typ, err)
 	case apierrors.APIStatus:
 		if typ.Status().Code != http.StatusBadRequest {
 			t.Fatalf("expected status code to be %d but was %d",

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/fieldmanager.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/fieldmanager.go
@@ -66,7 +66,7 @@ func NewDefaultFieldManager(f Manager, typeConverter TypeConverter, objectConver
 									NewStripMetaManager(f),
 								), kind.GroupVersion(), subresource,
 							), DefaultMaxUpdateManagers,
-						), objectCreater, kind, DefaultTrackOnCreateProbability,
+						), objectCreater, DefaultTrackOnCreateProbability,
 					), typeConverter, objectConverter, kind.GroupVersion(),
 				),
 			), kind,

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/fieldmanager.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/fieldmanager.go
@@ -56,17 +56,20 @@ func NewFieldManager(f Manager, subresource string) *FieldManager {
 // newDefaultFieldManager is a helper function which wraps a Manager with certain default logic.
 func NewDefaultFieldManager(f Manager, typeConverter TypeConverter, objectConverter runtime.ObjectConvertor, objectCreater runtime.ObjectCreater, kind schema.GroupVersionKind, subresource string) *FieldManager {
 	return NewFieldManager(
-		NewLastAppliedUpdater(
-			NewLastAppliedManager(
-				NewProbabilisticSkipNonAppliedManager(
-					NewCapManagersManager(
-						NewBuildManagerInfoManager(
-							NewManagedFieldsUpdater(
-								NewStripMetaManager(f),
-							), kind.GroupVersion(), subresource,
-						), DefaultMaxUpdateManagers,
-					), objectCreater, kind, DefaultTrackOnCreateProbability,
-				), typeConverter, objectConverter, kind.GroupVersion()),
+		NewVersionCheckManager(
+			NewLastAppliedUpdater(
+				NewLastAppliedManager(
+					NewProbabilisticSkipNonAppliedManager(
+						NewCapManagersManager(
+							NewBuildManagerInfoManager(
+								NewManagedFieldsUpdater(
+									NewStripMetaManager(f),
+								), kind.GroupVersion(), subresource,
+							), DefaultMaxUpdateManagers,
+						), objectCreater, kind, DefaultTrackOnCreateProbability,
+					), typeConverter, objectConverter, kind.GroupVersion(),
+				),
+			), kind,
 		), subresource,
 	)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/skipnonapplied.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/skipnonapplied.go
@@ -22,13 +22,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type skipNonAppliedManager struct {
 	fieldManager           Manager
 	objectCreater          runtime.ObjectCreater
-	gvk                    schema.GroupVersionKind
 	beforeApplyManagerName string
 	probability            float32
 }
@@ -36,17 +34,16 @@ type skipNonAppliedManager struct {
 var _ Manager = &skipNonAppliedManager{}
 
 // NewSkipNonAppliedManager creates a new wrapped FieldManager that only starts tracking managers after the first apply.
-func NewSkipNonAppliedManager(fieldManager Manager, objectCreater runtime.ObjectCreater, gvk schema.GroupVersionKind) Manager {
-	return NewProbabilisticSkipNonAppliedManager(fieldManager, objectCreater, gvk, 0.0)
+func NewSkipNonAppliedManager(fieldManager Manager, objectCreater runtime.ObjectCreater) Manager {
+	return NewProbabilisticSkipNonAppliedManager(fieldManager, objectCreater, 0.0)
 }
 
 // NewProbabilisticSkipNonAppliedManager creates a new wrapped FieldManager that starts tracking managers after the first apply,
 // or starts tracking on create with p probability.
-func NewProbabilisticSkipNonAppliedManager(fieldManager Manager, objectCreater runtime.ObjectCreater, gvk schema.GroupVersionKind, p float32) Manager {
+func NewProbabilisticSkipNonAppliedManager(fieldManager Manager, objectCreater runtime.ObjectCreater, p float32) Manager {
 	return &skipNonAppliedManager{
 		fieldManager:           fieldManager,
 		objectCreater:          objectCreater,
-		gvk:                    gvk,
 		beforeApplyManagerName: "before-first-apply",
 		probability:            p,
 	}
@@ -78,9 +75,10 @@ func (f *skipNonAppliedManager) Update(liveObj, newObj runtime.Object, managed M
 // Apply implements Manager.
 func (f *skipNonAppliedManager) Apply(liveObj, appliedObj runtime.Object, managed Managed, fieldManager string, force bool) (runtime.Object, Managed, error) {
 	if len(managed.Fields()) == 0 {
-		emptyObj, err := f.objectCreater.New(f.gvk)
+		gvk := appliedObj.GetObjectKind().GroupVersionKind()
+		emptyObj, err := f.objectCreater.New(gvk)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create empty object of type %v: %v", f.gvk, err)
+			return nil, nil, fmt.Errorf("failed to create empty object of type %v: %v", gvk, err)
 		}
 		liveObj, managed, err = f.fieldManager.Update(emptyObj, liveObj, managed, f.beforeApplyManagerName)
 		if err != nil {

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/skipnonapplied_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/skipnonapplied_test.go
@@ -31,11 +31,7 @@ import (
 
 func TestNoUpdateBeforeFirstApply(t *testing.T) {
 	f := internaltesting.NewTestFieldManagerImpl(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m internal.Manager) internal.Manager {
-		return internal.NewSkipNonAppliedManager(
-			m,
-			&internaltesting.FakeObjectCreater{},
-			schema.FromAPIVersionAndKind("v1", "Pod"),
-		)
+		return internal.NewSkipNonAppliedManager(m, &internaltesting.FakeObjectCreater{})
 	})
 
 	appliedObj := &unstructured.Unstructured{Object: map[string]interface{}{}}
@@ -71,11 +67,7 @@ func TestNoUpdateBeforeFirstApply(t *testing.T) {
 
 func TestUpdateBeforeFirstApply(t *testing.T) {
 	f := internaltesting.NewTestFieldManagerImpl(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m internal.Manager) internal.Manager {
-		return internal.NewSkipNonAppliedManager(
-			m,
-			&internaltesting.FakeObjectCreater{},
-			schema.FromAPIVersionAndKind("v1", "Pod"),
-		)
+		return internal.NewSkipNonAppliedManager(m, &internaltesting.FakeObjectCreater{})
 	})
 
 	updatedObj := &unstructured.Unstructured{}

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/skipnonapplied_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/skipnonapplied_test.go
@@ -33,7 +33,7 @@ func TestNoUpdateBeforeFirstApply(t *testing.T) {
 	f := internaltesting.NewTestFieldManagerImpl(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m internal.Manager) internal.Manager {
 		return internal.NewSkipNonAppliedManager(
 			m,
-			internaltesting.NewFakeObjectCreater(),
+			&internaltesting.FakeObjectCreater{},
 			schema.FromAPIVersionAndKind("v1", "Pod"),
 		)
 	})
@@ -73,7 +73,7 @@ func TestUpdateBeforeFirstApply(t *testing.T) {
 	f := internaltesting.NewTestFieldManagerImpl(fakeTypeConverter, schema.FromAPIVersionAndKind("v1", "Pod"), "", func(m internal.Manager) internal.Manager {
 		return internal.NewSkipNonAppliedManager(
 			m,
-			internaltesting.NewFakeObjectCreater(),
+			&internaltesting.FakeObjectCreater{},
 			schema.FromAPIVersionAndKind("v1", "Pod"),
 		)
 	})

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/testing/testfieldmanager.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/testing/testfieldmanager.go
@@ -27,62 +27,42 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/util/managedfields/internal"
-	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
-	"sigs.k8s.io/structured-merge-diff/v4/merge"
-	"sigs.k8s.io/structured-merge-diff/v4/typed"
 )
 
-// NewFakeObjectCreater implements ObjectCreater, it can create empty
+// FakeObjectCreater implements ObjectCreater, it can create empty
 // objects (unstructured) of the given GVK.
-func NewFakeObjectCreater() runtime.ObjectCreater {
-	return &fakeObjectCreater{}
-}
+type FakeObjectCreater struct{}
 
-type fakeObjectCreater struct{}
-
-func (f *fakeObjectCreater) New(gvk schema.GroupVersionKind) (runtime.Object, error) {
+func (f *FakeObjectCreater) New(gvk schema.GroupVersionKind) (runtime.Object, error) {
 	u := unstructured.Unstructured{Object: map[string]interface{}{}}
 	u.SetAPIVersion(gvk.GroupVersion().String())
 	u.SetKind(gvk.Kind)
 	return &u, nil
 }
 
-type fakeObjectConvertor struct {
-	converter  merge.Converter
-	apiVersion fieldpath.APIVersion
-}
+// FakeObjectConvertor implements runtime.ObjectConvertor but it
+// actually does nothing but return its input.
+type FakeObjectConvertor struct{}
 
 //nolint:staticcheck,ineffassign // SA4009 backwards compatibility
-func (c *fakeObjectConvertor) Convert(in, out, context interface{}) error {
-	if typedValue, ok := in.(*typed.TypedValue); ok {
-		var err error
-		out, err = c.converter.Convert(typedValue, c.apiVersion)
-		return err
-	}
+func (c *FakeObjectConvertor) Convert(in, out, context interface{}) error {
+	out = in
 	return nil
 }
 
-func (c *fakeObjectConvertor) ConvertToVersion(in runtime.Object, _ runtime.GroupVersioner) (runtime.Object, error) {
+func (c *FakeObjectConvertor) ConvertToVersion(in runtime.Object, _ runtime.GroupVersioner) (runtime.Object, error) {
 	return in, nil
 }
 
-func (c *fakeObjectConvertor) ConvertFieldLabel(_ schema.GroupVersionKind, _, _ string) (string, string, error) {
+func (c *FakeObjectConvertor) ConvertFieldLabel(_ schema.GroupVersionKind, _, _ string) (string, string, error) {
 	return "", "", errors.New("not implemented")
 }
 
-type fakeObjectDefaulter struct{}
+// FakeObjectDefaulter implements runtime.Defaulter, but it actually
+// does nothing.
+type FakeObjectDefaulter struct{}
 
-func (d *fakeObjectDefaulter) Default(in runtime.Object) {}
-
-type sameVersionConverter struct{}
-
-func (sameVersionConverter) Convert(object *typed.TypedValue, version fieldpath.APIVersion) (*typed.TypedValue, error) {
-	return object, nil
-}
-
-func (sameVersionConverter) IsMissingVersionError(error) bool {
-	return false
-}
+func (d *FakeObjectDefaulter) Default(in runtime.Object) {}
 
 type TestFieldManagerImpl struct {
 	fieldManager *internal.FieldManager
@@ -139,12 +119,10 @@ func (f *TestFieldManagerImpl) ManagedFields() []metav1.ManagedFieldsEntry {
 
 // NewTestFieldManager creates a new manager for the given GVK.
 func NewTestFieldManagerImpl(typeConverter managedfields.TypeConverter, gvk schema.GroupVersionKind, subresource string, chainFieldManager func(internal.Manager) internal.Manager) *TestFieldManagerImpl {
-	apiVersion := fieldpath.APIVersion(gvk.GroupVersion().String())
-	objectConverter := &fakeObjectConvertor{sameVersionConverter{}, apiVersion}
 	f, err := internal.NewStructuredMergeManager(
 		typeConverter,
-		objectConverter,
-		&fakeObjectDefaulter{},
+		&FakeObjectConvertor{},
+		&FakeObjectDefaulter{},
 		gvk.GroupVersion(),
 		gvk.GroupVersion(),
 		nil,
@@ -166,8 +144,8 @@ func NewTestFieldManagerImpl(typeConverter managedfields.TypeConverter, gvk sche
 					internal.NewManagedFieldsUpdater(
 						internal.NewStripMetaManager(f),
 					), gvk.GroupVersion(), subresource,
-				), NewFakeObjectCreater(), gvk, internal.DefaultTrackOnCreateProbability,
-			), typeConverter, objectConverter, gvk.GroupVersion(),
+				), &FakeObjectCreater{}, gvk, internal.DefaultTrackOnCreateProbability,
+			), typeConverter, &FakeObjectConvertor{}, gvk.GroupVersion(),
 		),
 	)
 	if chainFieldManager != nil {

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/testing/testfieldmanager.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/testing/testfieldmanager.go
@@ -145,7 +145,7 @@ func NewTestFieldManagerImpl(typeConverter managedfields.TypeConverter, gvk sche
 						internal.NewManagedFieldsUpdater(
 							internal.NewStripMetaManager(f),
 						), gvk.GroupVersion(), subresource,
-					), &FakeObjectCreater{}, gvk, internal.DefaultTrackOnCreateProbability,
+					), &FakeObjectCreater{}, internal.DefaultTrackOnCreateProbability,
 				), typeConverter, &FakeObjectConvertor{}, gvk.GroupVersion(),
 			),
 		), gvk,

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/testing/testfieldmanager.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/testing/testfieldmanager.go
@@ -137,16 +137,18 @@ func NewTestFieldManagerImpl(typeConverter managedfields.TypeConverter, gvk sche
 	// 1. We don't want to create a `internal.FieldManager`
 	// 2. We don't want to use the CapManager that is tested separately with
 	// a smaller than the default cap.
-	f = internal.NewLastAppliedUpdater(
-		internal.NewLastAppliedManager(
-			internal.NewProbabilisticSkipNonAppliedManager(
-				internal.NewBuildManagerInfoManager(
-					internal.NewManagedFieldsUpdater(
-						internal.NewStripMetaManager(f),
-					), gvk.GroupVersion(), subresource,
-				), &FakeObjectCreater{}, gvk, internal.DefaultTrackOnCreateProbability,
-			), typeConverter, &FakeObjectConvertor{}, gvk.GroupVersion(),
-		),
+	f = internal.NewVersionCheckManager(
+		internal.NewLastAppliedUpdater(
+			internal.NewLastAppliedManager(
+				internal.NewProbabilisticSkipNonAppliedManager(
+					internal.NewBuildManagerInfoManager(
+						internal.NewManagedFieldsUpdater(
+							internal.NewStripMetaManager(f),
+						), gvk.GroupVersion(), subresource,
+					), &FakeObjectCreater{}, gvk, internal.DefaultTrackOnCreateProbability,
+				), typeConverter, &FakeObjectConvertor{}, gvk.GroupVersion(),
+			),
+		), gvk,
 	)
 	if chainFieldManager != nil {
 		f = chainFieldManager(f)

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/versioncheck.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/versioncheck.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type versionCheckManager struct {
+	fieldManager Manager
+	gvk          schema.GroupVersionKind
+}
+
+var _ Manager = &versionCheckManager{}
+
+// NewVersionCheckManager creates a manager that makes sure that the
+// applied object is in the proper version.
+func NewVersionCheckManager(fieldManager Manager, gvk schema.GroupVersionKind) Manager {
+	return &versionCheckManager{fieldManager: fieldManager, gvk: gvk}
+}
+
+// Update implements Manager.
+func (f *versionCheckManager) Update(liveObj, newObj runtime.Object, managed Managed, manager string) (runtime.Object, Managed, error) {
+	// Nothing to do for updates, this is checked in many other places.
+	return f.fieldManager.Update(liveObj, newObj, managed, manager)
+}
+
+// Apply implements Manager.
+func (f *versionCheckManager) Apply(liveObj, appliedObj runtime.Object, managed Managed, fieldManager string, force bool) (runtime.Object, Managed, error) {
+	if gvk := appliedObj.GetObjectKind().GroupVersionKind(); gvk != f.gvk {
+		return nil, nil, errors.NewBadRequest(fmt.Sprintf("invalid object type: %v", gvk))
+	}
+	return f.fieldManager.Apply(liveObj, appliedObj, managed, fieldManager, force)
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/managedfieldstest/testfieldmanager.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/managedfieldstest/testfieldmanager.go
@@ -63,4 +63,32 @@ func NewTestFieldManager(typeConverter managedfields.TypeConverter, gvk schema.G
 // for the given gvk, on the given sub-resource.
 func NewTestFieldManagerSubresource(typeConverter managedfields.TypeConverter, gvk schema.GroupVersionKind, subresource string) TestFieldManager {
 	return testing.NewTestFieldManagerImpl(typeConverter, gvk, subresource, nil)
+
+}
+
+// NewFakeFieldManager creates an actual FieldManager but that doesn't
+// perform any conversion. This is just a convenience for tests to
+// create an actual manager that they can use but in very restricted
+// ways.
+//
+// This is different from the TestFieldManager because it's not meant to
+// assert values, or hold the state, this acts like a normal
+// FieldManager.
+//
+// Also, this only operates on the main-resource, and sub-resource can't
+// be configured.
+func NewFakeFieldManager(typeConverter managedfields.TypeConverter, gvk schema.GroupVersionKind) *managedfields.FieldManager {
+	ffm, err := managedfields.NewDefaultFieldManager(
+		typeConverter,
+		&testing.FakeObjectConvertor{},
+		&testing.FakeObjectDefaulter{},
+		&testing.FakeObjectCreater{},
+		gvk,
+		gvk.GroupVersion(),
+		"",
+		nil)
+	if err != nil {
+		panic(err)
+	}
+	return ffm
 }

--- a/staging/src/k8s.io/cli-runtime/go.sum
+++ b/staging/src/k8s.io/cli-runtime/go.sum
@@ -67,6 +67,7 @@ github.com/go-openapi/jsonreference v0.20.1 h1:FBLnyygC4/IZZr893oiomc9XaghoveYTr
 github.com/go-openapi/jsonreference v0.20.1/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En5Ap4rVB5KVcIDZG2k=
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -125,6 +126,7 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
@@ -170,6 +172,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=
+github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -382,6 +386,7 @@ golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.8.0 h1:vSDcovVPld282ceKgDimkRSC8kpaH1dgyc9UMzlt84Y=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/staging/src/k8s.io/client-go/openapi/typeconverter.go
+++ b/staging/src/k8s.io/client-go/openapi/typeconverter.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openapi
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+func NewTypeConverter(client Client, preserveUnknownFields bool) (managedfields.TypeConverter, error) {
+	spec := map[string]*spec.Schema{}
+	paths, err := client.Paths()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list paths: %w", err)
+	}
+	for _, gv := range paths {
+		s, err := gv.Schema("application/json")
+		if err != nil {
+			return nil, fmt.Errorf("failed to download schema: %w", err)
+		}
+		var openapi spec3.OpenAPI
+		if err := json.Unmarshal(s, &openapi); err != nil {
+			return nil, fmt.Errorf("failed to parse schema: %w", err)
+		}
+		for k, v := range openapi.Components.Schemas {
+			spec[k] = v
+		}
+	}
+	return managedfields.NewTypeConverter(spec, preserveUnknownFields)
+}

--- a/staging/src/k8s.io/sample-cli-plugin/go.sum
+++ b/staging/src/k8s.io/sample-cli-plugin/go.sum
@@ -67,6 +67,7 @@ github.com/go-openapi/jsonreference v0.20.1 h1:FBLnyygC4/IZZr893oiomc9XaghoveYTr
 github.com/go-openapi/jsonreference v0.20.1/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En5Ap4rVB5KVcIDZG2k=
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -125,6 +126,7 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
@@ -170,6 +172,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=
+github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -381,6 +385,7 @@ golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.8.0 h1:vSDcovVPld282ceKgDimkRSC8kpaH1dgyc9UMzlt84Y=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Allows creating a typeconverter from a client (i.e. by taking the data of the client and formatting it so that one can create a type converter).

I'm trying to see if that's what we want, possible alternatives:
- We create that from the Root object
- We just make a function to merge the specs
- ...?

This needs tests.

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Nothing

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @alexzielenski 