### PR TITLE
[WIP][Do not merge]exclude kms from kcm health check

### DIFF
--- a/staging/src/k8s.io/controller-manager/app/helper.go
+++ b/staging/src/k8s.io/controller-manager/app/helper.go
@@ -34,7 +34,7 @@ func WaitForAPIServer(client clientset.Interface, timeout time.Duration) error {
 
 	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
 		healthStatus := 0
-		result := client.Discovery().RESTClient().Get().AbsPath("/healthz").Do(context.TODO()).StatusCode(&healthStatus)
+		result := client.Discovery().RESTClient().Get().AbsPath("/healthz").Param("exclude", "kms-provider-0").Do(context.TODO()).StatusCode(&healthStatus)
 		if result.Error() != nil {
 			lastErr = fmt.Errorf("failed to get apiserver /healthz status: %v", result.Error())
 			return false, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This CR intends to exclude the kms provider check as an extension to https://github.com/kubernetes/kubernetes/issues/108014 

The following test was done. This tries to [gather data](https://github.com/kubernetes/kubernetes/issues/108014#issuecomment-1194518195) that the controllers are mostly resilient to health check errors at bootstrap time. I'll run this in production to gather confidence.
Testing:
- Create cluster with KMS enabled.
- Disable KMS key.
- Restart APIServer to invalidate the DEK cache.
- Restart KCM.
- All controllers in KCM still work. Starting 1.21, all controllers have moved to use BoundServiceAccountTokens. Secrets are no longer used for controller authentication. GarbageCollector Controller needs all discovery objects to be synced to create the object graph. Discovery Client fails because secret informer cache fails. Other controllers are able to be synchronized.
- Enable KMS key.
- APIServer secret cache fills up. Secret informer cache in KCM resyncs. Errors in KCM logs relatd to GarbageCollector Controller disapper.

KCM stays healthy throughout the testing process.


#### Which issue(s) this PR fixes:
https://github.com/kubernetes/kubernetes/issues/108014 


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

```release-note
TBD

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE

```docs
NONE
```
