### PR TITLE
Create local copy to avoid potential race condition

### DIFF
--- a/pkg/kubelet/nodeshutdown/systemd/inhibit_linux_test.go
+++ b/pkg/kubelet/nodeshutdown/systemd/inhibit_linux_test.go
@@ -160,6 +160,7 @@ func TestMonitorShutdown(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			fakeSystemBus := &fakeSystemDBus{}
 			bus := DBusCon{


### PR DESCRIPTION
#### What type of PR is this?
Create a local copy of testcase struct.

/sig node
/kind cleanup
/kind flake

#### What this PR does / why we need it:
When running parallel code inside a loop, it's important to avoid referencing the iterator in the loop condition directly, as it can change and we might end up accessing a different thing. To fix this, the best solution is to create a local copy of the struct.

#### Which issue(s) this PR fixes:
Fixes #116505

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None, this is a test-only change.
