### PR TITLE
[KMSv2] cleanup comments in v2 proto api

### DIFF
--- a/staging/src/k8s.io/kms/apis/v2/api.pb.go
+++ b/staging/src/k8s.io/kms/apis/v2/api.pb.go
@@ -288,7 +288,6 @@ type EncryptResponse struct {
 	// This can be used to inform staleness of data updated via value.Transformer.TransformFromStorage.
 	KeyId string `protobuf:"bytes,2,opt,name=key_id,json=keyId,proto3" json:"key_id,omitempty"`
 	// Additional metadata to be stored with the encrypted data.
-	// This metadata can contain the encrypted local KEK that was used to encrypt the DEK.
 	// This data is stored in plaintext in etcd. KMS plugin implementations are responsible for pre-encrypting any sensitive data.
 	Annotations          map[string][]byte `protobuf:"bytes,3,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`

--- a/staging/src/k8s.io/kms/apis/v2/api.proto
+++ b/staging/src/k8s.io/kms/apis/v2/api.proto
@@ -73,7 +73,6 @@ message EncryptResponse {
     // This can be used to inform staleness of data updated via value.Transformer.TransformFromStorage.
     string key_id = 2;
     // Additional metadata to be stored with the encrypted data.
-    // This metadata can contain the encrypted local KEK that was used to encrypt the DEK.
     // This data is stored in plaintext in etcd. KMS plugin implementations are responsible for pre-encrypting any sensitive data.
     map<string, bytes> annotations = 3;
 }


### PR DESCRIPTION
/kind cleanup

- Remove comment about local KEK in the `annotations` field for v2 API

```release-note
NONE
```