### PR TITLE
Kubectl convert (pluggin) doesn't correctly handle manifests with multiple kinds #1383

### DIFF
--- a/pkg/kubectl/cmd/convert/convert.go
+++ b/pkg/kubectl/cmd/convert/convert.go
@@ -267,6 +267,7 @@ func asVersionedObjects(infos []*resource.Info, specifiedOutputVersion schema.Gr
 			//Dont fail on error converting objects.
 			//Simply warn the user with the error returned from api-machinery and continue with the rest of the file
 			fmt.Fprintln(os.Stderr, err.Error())
+			continue
 		}
 		objects = append(objects, converted)
 	}

--- a/pkg/kubectl/cmd/convert/convert.go
+++ b/pkg/kubectl/cmd/convert/convert.go
@@ -18,6 +18,7 @@ package convert
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -263,7 +264,9 @@ func asVersionedObjects(infos []*resource.Info, specifiedOutputVersion schema.Gr
 
 		converted, err := tryConvert(scheme.Scheme, info.Object, targetVersions...)
 		if err != nil {
-			return nil, err
+			//Dont fail on error converting objects.
+			//Simply warn the user with the error returned from api-machinery and continue with the rest of the file
+			fmt.Fprintln(os.Stderr, err.Error())
 		}
 		objects = append(objects, converted)
 	}

--- a/pkg/kubectl/cmd/convert/convert_test.go
+++ b/pkg/kubectl/cmd/convert/convert_test.go
@@ -100,6 +100,16 @@ func TestConvertObject(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "v1beta1 Ingress to extensions Ingress",
+			file:          "../../../../test/fixtures/pkg/kubectl/cmd/convert/serviceandingress.yml",
+			outputVersion: "networking.k8s.io/v1",
+			fields: []checkField{
+				{
+					expected: "apiVersion: networking.k8s.io/v1",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/test/fixtures/pkg/kubectl/cmd/convert/serviceandingress.yml
+++ b/test/fixtures/pkg/kubectl/cmd/convert/serviceandingress.yml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: TestClusterIP
+spec:
+  ports:
+  - name: port
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: ClusterIPExample
+  type: ClusterIP
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: testIngress
+spec:
+  rules:
+  - host: test.com
+    http:
+      paths:
+      - backend:
+          serviceName: test1
+          servicePort: 80
+        path: /test1
+        pathType: ImplementationSpecific
+      - backend:
+          serviceName: webapi
+          servicePort: 80
+        path: /test2
+        pathType: ImplementationSpecific


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR solves the issue of kubectl-convert failing when the manifest contains resources that cannot be conferted to the desired output version. This fix warns the user of the error and then continues converting the rest of the file. 

#### Which issue(s) this PR fixes: 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes (https://github.com/kubernetes/kubectl/issues/1383)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
