### PR TITLE
Kubectl convert - warn users with NotRegisteredError and Fail on all other errors

### DIFF
--- a/pkg/kubectl/cmd/convert/convert.go
+++ b/pkg/kubectl/cmd/convert/convert.go
@@ -263,9 +263,9 @@ func asVersionedObjects(infos []*resource.Info, specifiedOutputVersion schema.Gr
 
 		converted, err := tryConvert(scheme.Scheme, info.Object, targetVersions...)
 		if err != nil {
-			//Dont fail on not registered error converting objects.
-			//Simply warn the user with the error returned from api-machinery and continue with the rest of the file
-			//fail on all other errors
+			// Dont fail on not registered error converting objects.
+			// Simply warn the user with the error returned from api-machinery and continue with the rest of the file
+			// fail on all other errors
 			if runtime.IsNotRegisteredError(err) {
 				fmt.Fprintln(iostream.ErrOut, err.Error())
 				continue

--- a/pkg/kubectl/cmd/convert/convert.go
+++ b/pkg/kubectl/cmd/convert/convert.go
@@ -18,6 +18,7 @@ package convert
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -263,7 +264,10 @@ func asVersionedObjects(infos []*resource.Info, specifiedOutputVersion schema.Gr
 
 		converted, err := tryConvert(scheme.Scheme, info.Object, targetVersions...)
 		if err != nil {
-			return nil, err
+			//Dont fail on error converting objects.
+			//Simply warn the user with the error returned from api-machinery and continue with the rest of the file
+			fmt.Fprintln(os.Stderr, err.Error())
+			continue
 		}
 		objects = append(objects, converted)
 	}

--- a/pkg/kubectl/cmd/convert/convert.go
+++ b/pkg/kubectl/cmd/convert/convert.go
@@ -18,7 +18,6 @@ package convert
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -181,7 +180,7 @@ func (o *ConvertOptions) RunConvert() error {
 
 	internalEncoder := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
 	internalVersionJSONEncoder := unstructured.NewJSONFallbackEncoder(internalEncoder)
-	objects, err := asVersionedObject(infos, !singleItemImplied, specifiedOutputVersion, internalVersionJSONEncoder)
+	objects, err := asVersionedObject(infos, !singleItemImplied, specifiedOutputVersion, internalVersionJSONEncoder, o.IOStreams)
 	if err != nil {
 		return err
 	}
@@ -193,8 +192,8 @@ func (o *ConvertOptions) RunConvert() error {
 // the objects as children, or if only a single Object is present, as that object. The provided
 // version will be preferred as the conversion target, but the Object's mapping version will be
 // used if that version is not present.
-func asVersionedObject(infos []*resource.Info, forceList bool, specifiedOutputVersion schema.GroupVersion, encoder runtime.Encoder) (runtime.Object, error) {
-	objects, err := asVersionedObjects(infos, specifiedOutputVersion, encoder)
+func asVersionedObject(infos []*resource.Info, forceList bool, specifiedOutputVersion schema.GroupVersion, encoder runtime.Encoder, iostream genericclioptions.IOStreams) (runtime.Object, error) {
+	objects, err := asVersionedObjects(infos, specifiedOutputVersion, encoder, iostream)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +230,7 @@ func asVersionedObject(infos []*resource.Info, forceList bool, specifiedOutputVe
 // asVersionedObjects converts a list of infos into versioned objects. The provided
 // version will be preferred as the conversion target, but the Object's mapping version will be
 // used if that version is not present.
-func asVersionedObjects(infos []*resource.Info, specifiedOutputVersion schema.GroupVersion, encoder runtime.Encoder) ([]runtime.Object, error) {
+func asVersionedObjects(infos []*resource.Info, specifiedOutputVersion schema.GroupVersion, encoder runtime.Encoder, iostream genericclioptions.IOStreams) ([]runtime.Object, error) {
 	objects := []runtime.Object{}
 	for _, info := range infos {
 		if info.Object == nil {
@@ -264,10 +263,15 @@ func asVersionedObjects(infos []*resource.Info, specifiedOutputVersion schema.Gr
 
 		converted, err := tryConvert(scheme.Scheme, info.Object, targetVersions...)
 		if err != nil {
-			//Dont fail on error converting objects.
+			//Dont fail on not registered error converting objects.
 			//Simply warn the user with the error returned from api-machinery and continue with the rest of the file
-			fmt.Fprintln(os.Stderr, err.Error())
-			continue
+			//fail on all other errors
+			if runtime.IsNotRegisteredError(err) {
+				fmt.Fprintln(iostream.ErrOut, err.Error())
+				continue
+			}
+
+			return nil, err
 		}
 		objects = append(objects, converted)
 	}

--- a/pkg/kubectl/cmd/convert/convert_test.go
+++ b/pkg/kubectl/cmd/convert/convert_test.go
@@ -102,7 +102,7 @@ func TestConvertObject(t *testing.T) {
 		},
 		{
 			name:          "converting multiple including service to neworking.k8s.io/v1",
-			file:          "../../../../test/fixtures/pkg/kubectl/cmd/convert/serviceandingress.yml",
+			file:          "../../../../test/fixtures/pkg/kubectl/cmd/convert/serviceandingress.yaml",
 			outputVersion: "networking.k8s.io/v1",
 			fields: []checkField{
 				{

--- a/pkg/kubectl/cmd/convert/convert_test.go
+++ b/pkg/kubectl/cmd/convert/convert_test.go
@@ -101,7 +101,7 @@ func TestConvertObject(t *testing.T) {
 			},
 		},
 		{
-			name:          "v1beta1 Ingress to extensions Ingress",
+			name:          "converting multiple including service to neworking.k8s.io/v1",
 			file:          "../../../../test/fixtures/pkg/kubectl/cmd/convert/serviceandingress.yml",
 			outputVersion: "networking.k8s.io/v1",
 			fields: []checkField{

--- a/pkg/kubectl/cmd/convert/convert_test.go
+++ b/pkg/kubectl/cmd/convert/convert_test.go
@@ -100,6 +100,16 @@ func TestConvertObject(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "v1beta1 Ingress to extensions Ingress",
+			file:          "../../../../test/fixtures/pkg/kubectl/cmd/convert/serviceandingress.yml",
+			outputVersion: "networking.k8s.io/v1",
+			fields: []checkField{
+				{
+					expected: "apiVersion: networking.k8s.io/v1",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/test/fixtures/pkg/kubectl/cmd/convert/serviceandingress.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/convert/serviceandingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: TestClusterIP
+  name: test-cluster-ip
 spec:
   ports:
   - name: port
@@ -9,13 +9,13 @@ spec:
     protocol: TCP
     targetPort: 80
   selector:
-    app: ClusterIPExample
+    app: test-cluster-ip
   type: ClusterIP
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: testIngress
+  name: test-ingress
 spec:
   rules:
   - host: test.com

--- a/test/fixtures/pkg/kubectl/cmd/convert/serviceandingress.yml
+++ b/test/fixtures/pkg/kubectl/cmd/convert/serviceandingress.yml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: TestClusterIP
+spec:
+  ports:
+  - name: port
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: ClusterIPExample
+  type: ClusterIP
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: testIngress
+spec:
+  rules:
+  - host: test.com
+    http:
+      paths:
+      - backend:
+          serviceName: test1
+          servicePort: 80
+        path: /test1
+        pathType: ImplementationSpecific
+      - backend:
+          serviceName: webapi
+          servicePort: 80
+        path: /test2
+        pathType: ImplementationSpecific
+        


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR solves issue of kubectl-convert failing when resources cannot be converted to desired output version. The solution is to warn the user and continue converting the rest of the file.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1383
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change? No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed issue where kubectl-convert would fail when encountering resources that could not be converted to the specified api version. New behavior is to warn the user of the failed conversions and continue to convert the remaining resources. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
