### PR TITLE
feature(pkg/api): warning for Pod with null labelSelector in PodAffinity and TopologySpread

### DIFF
--- a/pkg/api/pod/warnings.go
+++ b/pkg/api/pod/warnings.go
@@ -115,7 +115,7 @@ func warningsForPodSpecAndMeta(fieldPath *field.Path, podSpec *api.PodSpec, meta
 
 		// warn if labelSelector is empty which is no-match.
 		if t.LabelSelector == nil {
-			warnings = append(warnings, fmt.Sprintf("%s: LabelSelector mustn't be empty; it will result in matching with no object", fieldPath.Child("spec", "topologySpreadConstraints").Index(i).Child("labelSelector")))
+			warnings = append(warnings, fmt.Sprintf("%s: a null labelSelector results in matching no pod", fieldPath.Child("spec", "topologySpreadConstraints").Index(i).Child("labelSelector")))
 		}
 	}
 
@@ -278,7 +278,7 @@ func warningsForPodAffinityTerms(terms []api.PodAffinityTerm, fieldPath *field.P
 	var warnings []string
 	for i, t := range terms {
 		if t.LabelSelector == nil {
-			warnings = append(warnings, fmt.Sprintf("%s: LabelSelector mustn't be empty; it will result in matching with no object", fieldPath.Index(i).Child("labelSelector")))
+			warnings = append(warnings, fmt.Sprintf("%s: a null labelSelector results in matching no pod", fieldPath.Index(i).Child("labelSelector")))
 		}
 	}
 	return warnings
@@ -289,7 +289,7 @@ func warningsForWeightedPodAffinityTerms(terms []api.WeightedPodAffinityTerm, fi
 	for i, t := range terms {
 		// warn if labelSelector is empty which is no-match.
 		if t.PodAffinityTerm.LabelSelector == nil {
-			warnings = append(warnings, fmt.Sprintf("%s: LabelSelector mustn't be empty; it will result in matching with no object", fieldPath.Index(i).Child("podAffinityTerm", "labelSelector")))
+			warnings = append(warnings, fmt.Sprintf("%s: a null labelSelector results in matching no pod", fieldPath.Index(i).Child("podAffinityTerm", "labelSelector")))
 		}
 	}
 	return warnings

--- a/pkg/api/pod/warnings.go
+++ b/pkg/api/pod/warnings.go
@@ -112,6 +112,11 @@ func warningsForPodSpecAndMeta(fieldPath *field.Path, podSpec *api.PodSpec, meta
 				msg,
 			))
 		}
+
+		// warn if labelSelector is empty which is no-match.
+		if t.LabelSelector == nil {
+			warnings = append(warnings, fmt.Sprintf("%s: LabelSelector mustn't be empty; it will result in matching with no object", fieldPath.Child("spec", "topologySpreadConstraints").Index(i).Child("labelSelector")))
+		}
 	}
 
 	// use of deprecated annotations
@@ -253,6 +258,39 @@ func warningsForPodSpecAndMeta(fieldPath *field.Path, podSpec *api.PodSpec, meta
 	// warn if the terminationGracePeriodSeconds is negative.
 	if podSpec.TerminationGracePeriodSeconds != nil && *podSpec.TerminationGracePeriodSeconds < 0 {
 		warnings = append(warnings, fmt.Sprintf("%s: must be >= 0; negative values are invalid and will be treated as 1", fieldPath.Child("spec", "terminationGracePeriodSeconds")))
+	}
+
+	if podSpec.Affinity != nil {
+		if affinity := podSpec.Affinity.PodAffinity; affinity != nil {
+			warnings = append(warnings, warningsForPodAffinityTerms(affinity.RequiredDuringSchedulingIgnoredDuringExecution, fieldPath.Child("spec", "affinity", "podAffinity", "requiredDuringSchedulingIgnoredDuringExecution"))...)
+			warnings = append(warnings, warningsForWeightedPodAffinityTerms(affinity.PreferredDuringSchedulingIgnoredDuringExecution, fieldPath.Child("spec", "affinity", "podAffinity", "preferredDuringSchedulingIgnoredDuringExecution"))...)
+		}
+		if affinity := podSpec.Affinity.PodAntiAffinity; affinity != nil {
+			warnings = append(warnings, warningsForPodAffinityTerms(affinity.RequiredDuringSchedulingIgnoredDuringExecution, fieldPath.Child("spec", "affinity", "podAntiAffinity", "requiredDuringSchedulingIgnoredDuringExecution"))...)
+			warnings = append(warnings, warningsForWeightedPodAffinityTerms(affinity.PreferredDuringSchedulingIgnoredDuringExecution, fieldPath.Child("spec", "affinity", "podAntiAffinity", "preferredDuringSchedulingIgnoredDuringExecution"))...)
+		}
+	}
+
+	return warnings
+}
+
+func warningsForPodAffinityTerms(terms []api.PodAffinityTerm, fieldPath *field.Path) []string {
+	var warnings []string
+	for i, t := range terms {
+		if t.LabelSelector == nil {
+			warnings = append(warnings, fmt.Sprintf("%s: LabelSelector mustn't be empty; it will result in matching with no object", fieldPath.Index(i).Child("labelSelector")))
+		}
+	}
+	return warnings
+}
+
+func warningsForWeightedPodAffinityTerms(terms []api.WeightedPodAffinityTerm, fieldPath *field.Path) []string {
+	var warnings []string
+	for i, t := range terms {
+		// warn if labelSelector is empty which is no-match.
+		if t.PodAffinityTerm.LabelSelector == nil {
+			warnings = append(warnings, fmt.Sprintf("%s: LabelSelector mustn't be empty; it will result in matching with no object", fieldPath.Index(i).Child("podAffinityTerm", "labelSelector")))
+		}
 	}
 	return warnings
 }

--- a/pkg/api/pod/warnings_test.go
+++ b/pkg/api/pod/warnings_test.go
@@ -401,12 +401,30 @@ func TestWarnings(t *testing.T) {
 			template: &api.PodTemplateSpec{
 				Spec: api.PodSpec{
 					TopologySpreadConstraints: []api.TopologySpreadConstraint{
-						{TopologyKey: `foo`},
-						{TopologyKey: `beta.kubernetes.io/arch`},
-						{TopologyKey: `beta.kubernetes.io/os`},
-						{TopologyKey: `failure-domain.beta.kubernetes.io/region`},
-						{TopologyKey: `failure-domain.beta.kubernetes.io/zone`},
-						{TopologyKey: `beta.kubernetes.io/instance-type`},
+						{
+							TopologyKey:   `foo`,
+							LabelSelector: &metav1.LabelSelector{},
+						},
+						{
+							TopologyKey:   `beta.kubernetes.io/arch`,
+							LabelSelector: &metav1.LabelSelector{},
+						},
+						{
+							TopologyKey:   `beta.kubernetes.io/os`,
+							LabelSelector: &metav1.LabelSelector{},
+						},
+						{
+							TopologyKey:   `failure-domain.beta.kubernetes.io/region`,
+							LabelSelector: &metav1.LabelSelector{},
+						},
+						{
+							TopologyKey:   `failure-domain.beta.kubernetes.io/zone`,
+							LabelSelector: &metav1.LabelSelector{},
+						},
+						{
+							TopologyKey:   `beta.kubernetes.io/instance-type`,
+							LabelSelector: &metav1.LabelSelector{},
+						},
 					},
 				},
 			},
@@ -500,6 +518,85 @@ func TestWarnings(t *testing.T) {
 			},
 			expected: []string{
 				`spec.terminationGracePeriodSeconds: must be >= 0; negative values are invalid and will be treated as 1`,
+			},
+		},
+		{
+			name: "empty LabelSelector in topologySpreadConstraints",
+			template: &api.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: api.PodSpec{
+					TopologySpreadConstraints: []api.TopologySpreadConstraint{
+						{
+							LabelSelector: &metav1.LabelSelector{},
+						},
+						{
+							LabelSelector: nil,
+						},
+					},
+				},
+			},
+			expected: []string{
+				`spec.topologySpreadConstraints[1].labelSelector: LabelSelector mustn't be empty; it will result in matching with no object`,
+			},
+		},
+		{
+			name: "empty LabelSelector in PodAffinity",
+			template: &api.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: api.PodSpec{
+					Affinity: &api.Affinity{
+						PodAffinity: &api.PodAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []api.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{},
+								},
+								{
+									LabelSelector: nil,
+								},
+							},
+							PreferredDuringSchedulingIgnoredDuringExecution: []api.WeightedPodAffinityTerm{
+								{
+									PodAffinityTerm: api.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{},
+									},
+								},
+								{
+									PodAffinityTerm: api.PodAffinityTerm{
+										LabelSelector: nil,
+									},
+								},
+							},
+						},
+						PodAntiAffinity: &api.PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []api.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{},
+								},
+								{
+									LabelSelector: nil,
+								},
+							},
+							PreferredDuringSchedulingIgnoredDuringExecution: []api.WeightedPodAffinityTerm{
+								{
+									PodAffinityTerm: api.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{},
+									},
+								},
+								{
+									PodAffinityTerm: api.PodAffinityTerm{
+										LabelSelector: nil,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{
+				`spec.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[1].labelSelector: LabelSelector mustn't be empty; it will result in matching with no object`,
+				`spec.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[1].podAffinityTerm.labelSelector: LabelSelector mustn't be empty; it will result in matching with no object`,
+				`spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[1].labelSelector: LabelSelector mustn't be empty; it will result in matching with no object`,
+				`spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[1].podAffinityTerm.labelSelector: LabelSelector mustn't be empty; it will result in matching with no object`,
 			},
 		},
 	}

--- a/pkg/api/pod/warnings_test.go
+++ b/pkg/api/pod/warnings_test.go
@@ -521,7 +521,7 @@ func TestWarnings(t *testing.T) {
 			},
 		},
 		{
-			name: "empty LabelSelector in topologySpreadConstraints",
+			name: "null LabelSelector in topologySpreadConstraints",
 			template: &api.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: api.PodSpec{
@@ -536,11 +536,11 @@ func TestWarnings(t *testing.T) {
 				},
 			},
 			expected: []string{
-				`spec.topologySpreadConstraints[1].labelSelector: LabelSelector mustn't be empty; it will result in matching with no object`,
+				`spec.topologySpreadConstraints[1].labelSelector: a null labelSelector results in matching no pod`,
 			},
 		},
 		{
-			name: "empty LabelSelector in PodAffinity",
+			name: "null LabelSelector in PodAffinity",
 			template: &api.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec: api.PodSpec{
@@ -593,10 +593,10 @@ func TestWarnings(t *testing.T) {
 				},
 			},
 			expected: []string{
-				`spec.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[1].labelSelector: LabelSelector mustn't be empty; it will result in matching with no object`,
-				`spec.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[1].podAffinityTerm.labelSelector: LabelSelector mustn't be empty; it will result in matching with no object`,
-				`spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[1].labelSelector: LabelSelector mustn't be empty; it will result in matching with no object`,
-				`spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[1].podAffinityTerm.labelSelector: LabelSelector mustn't be empty; it will result in matching with no object`,
+				`spec.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[1].labelSelector: a null labelSelector results in matching no pod`,
+				`spec.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution[1].podAffinityTerm.labelSelector: a null labelSelector results in matching no pod`,
+				`spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[1].labelSelector: a null labelSelector results in matching no pod`,
+				`spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[1].podAffinityTerm.labelSelector: a null labelSelector results in matching no pod`,
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

warning for Pod with null labelSelector in PodAffinity and TopologySpread.
The null lebalSelector means no-match. So, it doesn't make sense to use null labelSelector in PodAffinity or TopologySpread.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115873

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The Kubernetes apiserver now emits a warning message for Pods with a null labelSelector in podAffinity or topologySpreadConstraints. The null labelSelector means "match none". Using it in podAffinity or topologySpreadConstraint could lead to unintended behavior.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
