### PR TITLE
Add flag to prune PASSED subtests in junit xml and have top level tests

### DIFF
--- a/cmd/prune-junit-xml/prunexml.go
+++ b/cmd/prune-junit-xml/prunexml.go
@@ -22,12 +22,15 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 
 	"k8s.io/kubernetes/third_party/forked/gotestsum/junitxml"
 )
 
 func main() {
 	maxTextSize := flag.Int("max-text-size", 1, "maximum size of attribute or text (in MB)")
+	pruneTests := flag.Bool("prune-tests", true,
+		"prune's xml files to display only top level tests and failed sub-tests")
 	flag.Parse()
 	for _, path := range flag.Args() {
 		fmt.Printf("processing junit xml file : %s\n", path)
@@ -42,6 +45,9 @@ func main() {
 		}
 
 		pruneXML(suites, *maxTextSize*1e6) // convert MB into bytes (roughly!)
+		if *pruneTests {
+			pruneTESTS(suites)
+		}
 
 		xmlWriter, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 		if err != nil {
@@ -77,6 +83,40 @@ func pruneXML(suites *junitxml.JUnitTestSuites, maxBytes int) {
 			}
 		}
 	}
+}
+
+// This function condenses the junit xml to have package name as top level identifier
+// and nesting under that.
+func pruneTESTS(suites *junitxml.JUnitTestSuites) {
+	var updatedTestsuites []junitxml.JUnitTestSuite
+
+	for _, suite := range suites.Suites {
+		var updatedTestcases []junitxml.JUnitTestCase
+		var updatedTestcase junitxml.JUnitTestCase
+		var updatedTestcaseFailure junitxml.JUnitFailure
+		failflag := false
+		name := suite.Name
+		regex := regexp.MustCompile(`^(.*?)/([^/]+)/?$`)
+		match := regex.FindStringSubmatch(name)
+		updatedTestcase.Classname = match[1]
+		updatedTestcase.Name = match[2]
+		updatedTestcase.Time = suite.Time
+		for _, testcase := range suite.TestCases {
+			// The top level testcase element in a JUnit xml file does not have the / character.
+			if testcase.Failure != nil {
+				failflag = true
+				updatedTestcaseFailure.Message = updatedTestcaseFailure.Message + testcase.Failure.Message + ";"
+				updatedTestcaseFailure.Contents = updatedTestcaseFailure.Contents + testcase.Failure.Contents + ";"
+				updatedTestcaseFailure.Type = updatedTestcaseFailure.Type + testcase.Failure.Type
+			}
+		}
+		if failflag {
+			updatedTestcase.Failure = &updatedTestcaseFailure
+		}
+		suite.TestCases = append(updatedTestcases, updatedTestcase)
+		updatedTestsuites = append(updatedTestsuites, suite)
+	}
+	suites.Suites = updatedTestsuites
 }
 
 func fetchXML(xmlReader io.Reader) (*junitxml.JUnitTestSuites, error) {

--- a/cmd/prune-junit-xml/prunexml_test.go
+++ b/cmd/prune-junit-xml/prunexml_test.go
@@ -65,3 +65,54 @@ func TestPruneXML(t *testing.T) {
 	_ = writer.Flush()
 	assert.Equal(t, outputXML, string(output.Bytes()), "xml was not pruned correctly")
 }
+
+func TestPruneTESTS(t *testing.T) {
+	sourceXML := `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="6" failures="0" time="5.50000" name="k8s.io/kubernetes/cluster/gce/cos" timestamp="">
+		<properties>
+			<property name="go.version" value="go1.18 linux/amd64"></property>
+		</properties>
+		<testcase classname="k8s.io/kubernetes/cluster/gce/cos" name="TestServerOverride/ETCD-SERVERS_is_not_set_-_default_override" time="0.950000"></testcase>
+		<testcase classname="k8s.io/kubernetes/cluster/gce/cos" name="TestServerOverride/ETCD-SERVERS_and_ETCD_SERVERS_OVERRIDES_are_set" time="0.660000"></testcase>
+		<testcase classname="k8s.io/kubernetes/cluster/gce/cos" name="TestServerOverride" time="1.610000"></testcase>
+		<testcase classname="k8s.io/kubernetes/cluster/gce/cos" name="TestStorageOptions/storage_options_are_supplied" time="0.860000"></testcase>
+		<testcase classname="k8s.io/kubernetes/cluster/gce/cos" name="TestStorageOptions/storage_options_are_not_supplied" time="0.280000"></testcase>
+		<testcase classname="k8s.io/kubernetes/cluster/gce/cos" name="TestStorageOptions" time="1.140000"></testcase>
+	</testsuite>
+	<testsuite tests="2" failures="1" time="30.050000" name="k8s.io/kubernetes/test/integration/apimachinery" timestamp="">
+		<properties>
+			<property name="go.version" value="go1.18 linux/amd64"></property>
+		</properties>
+		<testcase classname="k8s.io/kubernetes/test/integration/apimachinery" name="TestWatchRestartsIfTimeoutNotReached/group/InformerWatcher_survives_closed_watches" time="30.050000"></testcase>
+		<testcase classname="k8s.io/kubernetes/test/integration/apimachinery" name="TestSchedulerInformers" time="-0.000000">
+			<failure message="Failed" type="">FailureContent</failure>
+		</testcase>
+	</testsuite>
+</testsuites>`
+
+	outputXML := `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="6" failures="0" time="5.50000" name="k8s.io/kubernetes/cluster/gce/cos" timestamp="">
+		<properties>
+			<property name="go.version" value="go1.18 linux/amd64"></property>
+		</properties>
+		<testcase classname="k8s.io/kubernetes/cluster/gce" name="cos" time="5.50000"></testcase>
+	</testsuite>
+	<testsuite tests="2" failures="1" time="30.050000" name="k8s.io/kubernetes/test/integration/apimachinery" timestamp="">
+		<properties>
+			<property name="go.version" value="go1.18 linux/amd64"></property>
+		</properties>
+		<testcase classname="k8s.io/kubernetes/test/integration" name="apimachinery" time="30.050000">
+			<failure message="Failed;" type="">FailureContent;</failure>
+		</testcase>
+	</testsuite>
+</testsuites>`
+	suites, _ := fetchXML(strings.NewReader(sourceXML))
+	pruneTESTS(suites)
+	var output bytes.Buffer
+	writer := bufio.NewWriter(&output)
+	_ = streamXML(writer, suites)
+	_ = writer.Flush()
+	assert.Equal(t, outputXML, string(output.Bytes()), "tests in xml was not pruned correctly")
+}


### PR DESCRIPTION
The CI which runs k8s unit tests has a huge no.of rows while it uses https://github.com/kubernetes/kubernetes/blob/master/hack/make-rules/test.sh and generates junit xml file in artifacts.

This large no. of rows hinders the display of complete data in test grids

Ref: https://github.com/kubernetes/test-infra/issues/24779
https://github.com/kubernetes/test-infra/issues/23425

As the purpose of the test grid in certain cases would be to analyze the failing/flaking tests, it shall be useful to have an option in `prune-junit-xml` to prune PASSED test cases and display only failed test cases.