### PR TITLE
kubectl events: Support fully qualified names for --for flag

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/events/events.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/events/events.go
@@ -386,11 +386,18 @@ func decodeResourceTypeName(mapper meta.RESTMapper, s string) (gvk schema.GroupV
 	}
 	resource, name := seg[0], seg[1]
 
-	var gvr schema.GroupVersionResource
-	gvr, err = mapper.ResourceFor(schema.GroupVersionResource{Resource: resource})
-	if err != nil {
-		return
+	fullySpecifiedGVR, groupResource := schema.ParseResourceArg(strings.ToLower(resource))
+	gvr := schema.GroupVersionResource{}
+	if fullySpecifiedGVR != nil {
+		gvr, _ = mapper.ResourceFor(*fullySpecifiedGVR)
 	}
+	if gvr.Empty() {
+		gvr, err = mapper.ResourceFor(groupResource.WithVersion(""))
+		if err != nil {
+			return
+		}
+	}
+
 	gvk, err = mapper.KindFor(gvr)
 	if err != nil {
 		return

--- a/test/cmd/events.sh
+++ b/test/cmd/events.sh
@@ -57,6 +57,14 @@ run_kubectl_events_tests() {
     output_message=$(kubectl events -n test-events --for=Cronjob/pi "${kube_flags[@]:?}" 2>&1)
     kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
 
+    # Post-Condition: events returns event for fully qualified Cronjob.v1.batch/pi when --for flag is used
+    output_message=$(kubectl events -n test-events --for Cronjob.v1.batch/pi "${kube_flags[@]:?}" 2>&1)
+    kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
+
+    # Post-Condition: events returns event for fully qualified without version Cronjob.batch/pi when --for flag is used
+    output_message=$(kubectl events -n test-events --for=Cronjob.batch/pi "${kube_flags[@]:?}" 2>&1)
+    kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
+
     # Post-Condition: events returns event for Cronjob/pi when watch is enabled
     output_message=$(kubectl events -n test-events --for=Cronjob/pi --watch --request-timeout=1 "${kube_flags[@]:?}" 2>&1)
     kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Users can pass resources into `kubectl events` command via `--for` flag, if they have desire to only get events for the resource they specify.

However, current `kubectl events` does not support passing fully qualified names(e.g. `replicasets.apps`, `cronjobs.v1.batch`, etc.). This PR adds support for this.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1402

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kubectl events --for will also support fully qualified names such as replicasets.apps, etc.
```