### PR TITLE
emit warning on deprecated annotation volume.beta.kubernetes.io/storage-class

### DIFF
--- a/pkg/api/persistentvolume/util_test.go
+++ b/pkg/api/persistentvolume/util_test.go
@@ -146,6 +146,9 @@ func TestWarnings(t *testing.T) {
 			template: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
+					Annotations: map[string]string{
+						api.BetaStorageClassAnnotation: "",
+					},
 				},
 				Spec: api.PersistentVolumeSpec{
 					NodeAffinity: &api.VolumeNodeAffinity{
@@ -169,6 +172,7 @@ func TestWarnings(t *testing.T) {
 				},
 			},
 			expected: []string{
+				`metadata.annotations[volume.beta.kubernetes.io/storage-class]: deprecated since v1.8; use "storageClassName" attribute instead`,
 				`spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[0].key: beta.kubernetes.io/os is deprecated since v1.14; use "kubernetes.io/os" instead`,
 			},
 		},

--- a/pkg/api/persistentvolumeclaim/util.go
+++ b/pkg/api/persistentvolumeclaim/util.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	pvc            string = "PersistentVolumeClaim"
-	volumeSnapshot string = "VolumeSnapshot"
+	pvc                                  string = "PersistentVolumeClaim"
+	volumeSnapshot                       string = "VolumeSnapshot"
+	deprecatedStorageClassAnnotationsMsg        = `deprecated since v1.8; use "storageClassName" attribute instead`
 )
 
 // DropDisabledFields removes disabled fields from the pvc spec.
@@ -197,11 +198,25 @@ func allocatedResourcesInUse(oldPVC *core.PersistentVolumeClaim) bool {
 }
 
 func GetWarningsForPersistentVolumeClaim(pv *core.PersistentVolumeClaim) []string {
+	var warnings []string
+
 	if pv == nil {
 		return nil
 	}
 
-	return GetWarningsForPersistentVolumeClaimSpec(field.NewPath("spec"), pv.Spec)
+	if _, ok := pv.ObjectMeta.Annotations[core.BetaStorageClassAnnotation]; ok {
+		warnings = append(warnings,
+			fmt.Sprintf(
+				"%s: %s",
+				field.NewPath("metadata", "annotations").Key(core.BetaStorageClassAnnotation),
+				deprecatedStorageClassAnnotationsMsg,
+			),
+		)
+	}
+
+	warnings = append(warnings, GetWarningsForPersistentVolumeClaimSpec(field.NewPath("spec"), pv.Spec)...)
+
+	return warnings
 }
 
 func GetWarningsForPersistentVolumeClaimSpec(fieldPath *field.Path, pvSpec core.PersistentVolumeClaimSpec) []string {

--- a/pkg/api/persistentvolumeclaim/util_test.go
+++ b/pkg/api/persistentvolumeclaim/util_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/apis/core"
@@ -555,6 +556,20 @@ func TestWarnings(t *testing.T) {
 				},
 			},
 			expected: nil,
+		},
+		{
+			name: "storageclass annotations warning",
+			template: &core.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+					Annotations: map[string]string{
+						core.BetaStorageClassAnnotation: "",
+					},
+				},
+			},
+			expected: []string{
+				`metadata.annotations[volume.beta.kubernetes.io/storage-class]: deprecated since v1.8; use "storageClassName" attribute instead`,
+			},
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The annotation `volume.beta.kubernetes.io/storage-class` is long deprecated #53580, but with no warning message.

Before we stop honoring it, a warning message should be added
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes part of #116336

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Show a warning when `volume.beta.kubernetes.io/storage-class` annotation is used in pv or pvc
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
