### PR TITLE
feat: Add a field to improve the utilization of Pod Security Admission

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/policy/check_allowPrivilegeEscalation_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_allowPrivilegeEscalation_test.go
@@ -20,16 +20,22 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilpointer "k8s.io/utils/pointer"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestAllowPrivilegeEscalation_1_25(t *testing.T) {
 	tests := []struct {
-		name         string
-		pod          *corev1.Pod
-		expectReason string
-		expectDetail string
-		allowed      bool
+		name          string
+		pod           *corev1.Pod
+		opts          options
+		expectReason  string
+		expectDetail  string
+		allowed       bool
+		expectErrList field.ErrorList
 	}{
 		{
 			name: "multiple containers",
@@ -45,12 +51,45 @@ func TestAllowPrivilegeEscalation_1_25(t *testing.T) {
 			allowed:      false,
 		},
 		{
+			name: "multiple containers, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a"},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: nil}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: utilpointer.Bool(true)}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: utilpointer.Bool(false)}},
+				}}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `allowPrivilegeEscalation != false`,
+			expectDetail: `containers "a", "b", "c" must set securityContext.allowPrivilegeEscalation=false`,
+			allowed:      false,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeRequired, Field: "spec.containers[0].securityContext.allowPrivilegeEscalation", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[1].securityContext.allowPrivilegeEscalation", BadValue: "nil"},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[2].securityContext.allowPrivilegeEscalation", BadValue: true},
+			},
+		},
+		{
 			name: "windows pod, admit without checking privilegeEscalation",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				OS: &corev1.PodOS{Name: corev1.Windows},
 				Containers: []corev1.Container{
 					{Name: "a"},
 				}}},
+			allowed: true,
+		},
+		{
+			name: "windows pod, admit without checking privilegeEscalation, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				OS: &corev1.PodOS{Name: corev1.Windows},
+				Containers: []corev1.Container{
+					{Name: "a"},
+				}}},
+			opts: options{
+				withFieldErrors: true,
+			},
 			allowed: true,
 		},
 		{
@@ -64,11 +103,29 @@ func TestAllowPrivilegeEscalation_1_25(t *testing.T) {
 			expectDetail: `container "a" must set securityContext.allowPrivilegeEscalation=false`,
 			allowed:      false,
 		},
+		{
+			name: "linux pod, reject if security context is not set, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				OS: &corev1.PodOS{Name: corev1.Linux},
+				Containers: []corev1.Container{
+					{Name: "a"},
+				}}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `allowPrivilegeEscalation != false`,
+			expectDetail: `container "a" must set securityContext.allowPrivilegeEscalation=false`,
+			allowed:      false,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeRequired, Field: "spec.containers[0].securityContext.allowPrivilegeEscalation", BadValue: ""},
+			},
+		},
 	}
 
+	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "Detail"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := allowPrivilegeEscalation_1_25(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			result := allowPrivilegeEscalationV1Dot25(&tc.pod.ObjectMeta, &tc.pod.Spec, tc.opts)
 			if result.Allowed && !tc.allowed {
 				t.Fatal("expected disallowed")
 			}
@@ -78,16 +135,23 @@ func TestAllowPrivilegeEscalation_1_25(t *testing.T) {
 			if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
 				t.Errorf("expected\n%s\ngot\n%s", e, a)
 			}
+			if result.ErrList != nil {
+				if diff := cmp.Diff(tc.expectErrList, *result.ErrList, cmpOpts...); diff != "" {
+					t.Errorf("unexpected field errors (-want,+got):\n%s", diff)
+				}
+			}
 		})
 	}
 }
 
 func TestAllowPrivilegeEscalation_1_8(t *testing.T) {
 	tests := []struct {
-		name         string
-		pod          *corev1.Pod
-		expectReason string
-		expectDetail string
+		name          string
+		pod           *corev1.Pod
+		opts          options
+		expectReason  string
+		expectDetail  string
+		expectErrList field.ErrorList
 	}{
 		{
 			name: "multiple containers",
@@ -101,11 +165,32 @@ func TestAllowPrivilegeEscalation_1_8(t *testing.T) {
 			expectReason: `allowPrivilegeEscalation != false`,
 			expectDetail: `containers "a", "b", "c" must set securityContext.allowPrivilegeEscalation=false`,
 		},
+		{
+			name: "multiple containers enable field error List",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a"},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: nil}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: utilpointer.Bool(true)}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{AllowPrivilegeEscalation: utilpointer.Bool(false)}},
+				}}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `allowPrivilegeEscalation != false`,
+			expectDetail: `containers "a", "b", "c" must set securityContext.allowPrivilegeEscalation=false`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeRequired, Field: "spec.containers[0].securityContext.allowPrivilegeEscalation", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[1].securityContext.allowPrivilegeEscalation", BadValue: "nil"},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[2].securityContext.allowPrivilegeEscalation", BadValue: true},
+			},
+		},
 	}
 
+	ignoreDetail := cmpopts.IgnoreFields(field.Error{}, "Detail")
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := allowPrivilegeEscalation_1_8(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			result := allowPrivilegeEscalationV1Dot8(&tc.pod.ObjectMeta, &tc.pod.Spec, tc.opts)
 			if result.Allowed {
 				t.Fatal("expected disallowed")
 			}
@@ -114,6 +199,11 @@ func TestAllowPrivilegeEscalation_1_8(t *testing.T) {
 			}
 			if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
 				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+			if result.ErrList != nil {
+				if diff := cmp.Diff(tc.expectErrList, *result.ErrList, ignoreDetail); diff != "" {
+					t.Errorf("unexpected field errors (-want,+got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_baseline_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_baseline_test.go
@@ -20,14 +20,20 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestCapabilitiesBaseline(t *testing.T) {
 	tests := []struct {
-		name         string
-		pod          *corev1.Pod
-		expectReason string
-		expectDetail string
+		name          string
+		pod           *corev1.Pod
+		opts          options
+		expectReason  string
+		expectDetail  string
+		expectErrList field.ErrorList
 	}{
 		{
 			name: "multiple containers",
@@ -39,11 +45,29 @@ func TestCapabilitiesBaseline(t *testing.T) {
 			expectReason: `non-default capabilities`,
 			expectDetail: `containers "a", "b" must not include "BAR", "BAZ", "FOO" in securityContext.capabilities.add`,
 		},
+		{
+			name: "multiple containers, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"FOO", "BAR"}}}},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"BAR", "BAZ"}}}},
+				}}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `non-default capabilities`,
+			expectDetail: `containers "a", "b" must not include "BAR", "BAZ", "FOO" in securityContext.capabilities.add`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[0].securityContext.capabilities.add", BadValue: []string{"BAR", "FOO"}},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[1].securityContext.capabilities.add", BadValue: []string{"BAR", "BAZ"}},
+			},
+		},
 	}
 
+	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "Detail"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := capabilitiesBaseline_1_0(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			result := capabilitiesBaselineV1Dot0(&tc.pod.ObjectMeta, &tc.pod.Spec, tc.opts)
 			if result.Allowed {
 				t.Fatal("expected disallowed")
 			}
@@ -52,6 +76,11 @@ func TestCapabilitiesBaseline(t *testing.T) {
 			}
 			if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
 				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+			if result.ErrList != nil {
+				if diff := cmp.Diff(tc.expectErrList, *result.ErrList, cmpOpts...); diff != "" {
+					t.Errorf("unexpected field errors (-want,+got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted_test.go
@@ -20,15 +20,21 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestCapabilitiesRestricted_1_25(t *testing.T) {
 	tests := []struct {
-		name         string
-		pod          *corev1.Pod
-		expectReason string
-		expectDetail string
-		allowed      bool
+		name          string
+		pod           *corev1.Pod
+		opts          options
+		expectReason  string
+		expectDetail  string
+		allowed       bool
+		expectErrList field.ErrorList
 	}{
 		{
 			name: "multiple containers",
@@ -42,12 +48,70 @@ func TestCapabilitiesRestricted_1_25(t *testing.T) {
 			expectDetail: `containers "a", "b" must set securityContext.capabilities.drop=["ALL"]; containers "a", "b", "c" must not include "BAR", "BAZ", "CHOWN", "FOO" in securityContext.capabilities.add`,
 		},
 		{
+			name: "multiple containers, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"FOO", "BAR"}}}},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"BAR", "BAZ"}}}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"NET_BIND_SERVICE", "CHOWN"}, Drop: []corev1.Capability{"ALL", "FOO"}}}},
+				}}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `unrestricted capabilities`,
+			expectDetail: `containers "a", "b" must set securityContext.capabilities.drop=["ALL"]; containers "a", "b", "c" must not include "BAR", "BAZ", "CHOWN", "FOO" in securityContext.capabilities.add`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[0].securityContext.capabilities.add", BadValue: []string{"BAR", "FOO"}},
+				{Type: field.ErrorTypeRequired, Field: "spec.containers[0].securityContext.capabilities.drop", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[1].securityContext.capabilities.add", BadValue: []string{"BAR", "BAZ"}},
+				{Type: field.ErrorTypeRequired, Field: "spec.containers[1].securityContext.capabilities.drop", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[2].securityContext.capabilities.add", BadValue: []string{"CHOWN"}},
+			},
+		},
+		{
+			name: "container is not allowed on both Add and Drop",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"BAR", "BAZ"}, Drop: []corev1.Capability{"FOO", "BAR"}}}},
+				}}},
+			expectReason: `unrestricted capabilities`,
+			expectDetail: `container "a" must set securityContext.capabilities.drop=["ALL"]; container "a" must not include "BAR", "BAZ" in securityContext.capabilities.add`,
+		},
+		{
+			name: "container is not allowed on both Add and Drop, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"BAR", "BAZ"}, Drop: []corev1.Capability{"FOO", "BAR"}}}},
+				}}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `unrestricted capabilities`,
+			expectDetail: `container "a" must set securityContext.capabilities.drop=["ALL"]; container "a" must not include "BAR", "BAZ" in securityContext.capabilities.add`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[0].securityContext.capabilities.add", BadValue: []string{"BAR", "BAZ"}},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[0].securityContext.capabilities.drop", BadValue: []string{"BAR", "FOO"}},
+			},
+		},
+		{
 			name: "windows pod, admit without checking capabilities",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				OS: &corev1.PodOS{Name: corev1.Windows},
 				Containers: []corev1.Container{
 					{Name: "a"},
 				}}},
+			allowed: true,
+		},
+		{
+			name: "windows pod, admit without checking capabilities, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				OS: &corev1.PodOS{Name: corev1.Windows},
+				Containers: []corev1.Container{
+					{Name: "a"},
+				}}},
+			opts: options{
+				withFieldErrors: true,
+			},
 			allowed: true,
 		},
 		{
@@ -61,10 +125,29 @@ func TestCapabilitiesRestricted_1_25(t *testing.T) {
 			expectDetail: `container "a" must set securityContext.capabilities.drop=["ALL"]`,
 			allowed:      false,
 		},
+		{
+			name: "linux pod, reject if security context is not set, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				OS: &corev1.PodOS{Name: corev1.Linux},
+				Containers: []corev1.Container{
+					{Name: "a"},
+				}}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `unrestricted capabilities`,
+			expectDetail: `container "a" must set securityContext.capabilities.drop=["ALL"]`,
+			allowed:      false,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeRequired, Field: "spec.containers[0].securityContext.capabilities.drop", BadValue: ""},
+			},
+		},
 	}
+
+	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "Detail"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := capabilitiesRestricted_1_25(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			result := capabilitiesRestrictedV1Dot25(&tc.pod.ObjectMeta, &tc.pod.Spec, tc.opts)
 			if result.Allowed && !tc.allowed {
 				t.Fatal("expected disallowed")
 			}
@@ -74,16 +157,23 @@ func TestCapabilitiesRestricted_1_25(t *testing.T) {
 			if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
 				t.Errorf("expected\n%s\ngot\n%s", e, a)
 			}
+			if result.ErrList != nil {
+				if diff := cmp.Diff(tc.expectErrList, *result.ErrList, cmpOpts...); diff != "" {
+					t.Errorf("unexpected field errors (-want,+got):\n%s", diff)
+				}
+			}
 		})
 	}
 }
 
 func TestCapabilitiesRestricted_1_22(t *testing.T) {
 	tests := []struct {
-		name         string
-		pod          *corev1.Pod
-		expectReason string
-		expectDetail string
+		name          string
+		pod           *corev1.Pod
+		opts          options
+		expectReason  string
+		expectDetail  string
+		expectErrList field.ErrorList
 	}{
 		{
 			name: "multiple containers",
@@ -96,10 +186,58 @@ func TestCapabilitiesRestricted_1_22(t *testing.T) {
 			expectReason: `unrestricted capabilities`,
 			expectDetail: `containers "a", "b" must set securityContext.capabilities.drop=["ALL"]; containers "a", "b", "c" must not include "BAR", "BAZ", "CHOWN", "FOO" in securityContext.capabilities.add`,
 		},
+		{
+			name: "multiple containers enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"FOO", "BAR"}}}},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"BAR", "BAZ"}}}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"NET_BIND_SERVICE", "CHOWN"}, Drop: []corev1.Capability{"ALL", "FOO"}}}},
+				}}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `unrestricted capabilities`,
+			expectDetail: `containers "a", "b" must set securityContext.capabilities.drop=["ALL"]; containers "a", "b", "c" must not include "BAR", "BAZ", "CHOWN", "FOO" in securityContext.capabilities.add`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[0].securityContext.capabilities.add", BadValue: []string{"BAR", "FOO"}},
+				{Type: field.ErrorTypeRequired, Field: "spec.containers[0].securityContext.capabilities.drop", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[1].securityContext.capabilities.add", BadValue: []string{"BAR", "BAZ"}},
+				{Type: field.ErrorTypeRequired, Field: "spec.containers[1].securityContext.capabilities.drop", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[2].securityContext.capabilities.add", BadValue: []string{"CHOWN"}},
+			},
+		},
+		{
+			name: "container is not allowed on both Add and Drop",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"BAR", "BAZ"}, Drop: []corev1.Capability{"FOO", "BAR"}}}},
+				}}},
+			expectReason: `unrestricted capabilities`,
+			expectDetail: `container "a" must set securityContext.capabilities.drop=["ALL"]; container "a" must not include "BAR", "BAZ" in securityContext.capabilities.add`,
+		},
+		{
+			name: "container is not allowed on both Add and Drop, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"BAR", "BAZ"}, Drop: []corev1.Capability{"FOO", "BAR"}}}},
+				}}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `unrestricted capabilities`,
+			expectDetail: `container "a" must set securityContext.capabilities.drop=["ALL"]; container "a" must not include "BAR", "BAZ" in securityContext.capabilities.add`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[0].securityContext.capabilities.add", BadValue: []string{"BAR", "BAZ"}},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[0].securityContext.capabilities.drop", BadValue: []string{"BAR", "FOO"}},
+			},
+		},
 	}
+
+	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "Detail"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := capabilitiesRestricted_1_22(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			result := capabilitiesRestrictedV1Dot22(&tc.pod.ObjectMeta, &tc.pod.Spec, tc.opts)
 			if result.Allowed {
 				t.Fatal("expected disallowed")
 			}
@@ -108,6 +246,11 @@ func TestCapabilitiesRestricted_1_22(t *testing.T) {
 			}
 			if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
 				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+			if result.ErrList != nil {
+				if diff := cmp.Diff(tc.expectErrList, *result.ErrList, cmpOpts...); diff != "" {
+					t.Errorf("unexpected field errors (-want,+got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_hostPathVolumes_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_hostPathVolumes_test.go
@@ -20,14 +20,20 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestHostPathVolumes(t *testing.T) {
 	tests := []struct {
-		name         string
-		pod          *corev1.Pod
-		expectReason string
-		expectDetail string
+		name          string
+		pod           *corev1.Pod
+		opts          options
+		expectReason  string
+		expectDetail  string
+		expectErrList field.ErrorList
 	}{
 		{
 			name: "host path volumes",
@@ -41,11 +47,31 @@ func TestHostPathVolumes(t *testing.T) {
 			expectReason: `hostPath volumes`,
 			expectDetail: `volumes "a", "b"`,
 		},
+		{
+			name: "host path volumes, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					{Name: "a", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{}}},
+					{Name: "b", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{}}},
+					{Name: "c", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `hostPath volumes`,
+			expectDetail: `volumes "a", "b"`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[0].hostPath", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[1].hostPath", BadValue: ""},
+			},
+		},
 	}
 
+	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "Detail"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := hostPathVolumes_1_0(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			result := hostPathVolumesV1Dot0(&tc.pod.ObjectMeta, &tc.pod.Spec, tc.opts)
 			if result.Allowed {
 				t.Fatal("expected disallowed")
 			}
@@ -54,6 +80,11 @@ func TestHostPathVolumes(t *testing.T) {
 			}
 			if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
 				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+			if result.ErrList != nil {
+				if diff := cmp.Diff(tc.expectErrList, *result.ErrList, cmpOpts...); diff != "" {
+					t.Errorf("unexpected field errors (-want,+got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_hostPorts.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_hostPorts.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/pod-security-admission/api"
 )
 
@@ -51,40 +52,49 @@ func CheckHostPorts() Check {
 		Versions: []VersionedCheck{
 			{
 				MinimumVersion: api.MajorMinorVersion(1, 0),
-				CheckPod:       hostPorts_1_0,
+				CheckPod:       withOptions(hostPortsV1Dot0),
 			},
 		},
 	}
 }
 
-func hostPorts_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
-	var badContainers []string
+func hostPortsV1Dot0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec, opts options) CheckResult {
+	badContainers := NewViolations(opts.withFieldErrors)
 	forbiddenHostPorts := sets.NewString()
-	visitContainers(podSpec, func(container *corev1.Container) {
+	visitContainers(podSpec, opts, func(container *corev1.Container, path *field.Path) {
 		valid := true
-		for _, c := range container.Ports {
+		var errs field.ErrorList
+		for i, c := range container.Ports {
 			if c.HostPort != 0 {
 				valid = false
 				forbiddenHostPorts.Insert(strconv.Itoa(int(c.HostPort)))
+				if opts.withFieldErrors {
+					errs = append(errs, withBadValue(forbidden(path.Child("ports").Index(i).Child("hostPort")), int(c.HostPort)))
+				}
 			}
 		}
 		if !valid {
-			badContainers = append(badContainers, container.Name)
+			if opts.withFieldErrors {
+				badContainers.Add(container.Name, errs...)
+			} else {
+				badContainers.Add(container.Name)
+			}
 		}
 	})
 
-	if len(badContainers) > 0 {
+	if !badContainers.Empty() {
 		return CheckResult{
 			Allowed:         false,
 			ForbiddenReason: "hostPort",
 			ForbiddenDetail: fmt.Sprintf(
 				"%s %s %s %s %s",
-				pluralize("container", "containers", len(badContainers)),
-				joinQuote(badContainers),
-				pluralize("uses", "use", len(badContainers)),
+				pluralize("container", "containers", badContainers.Len()),
+				joinQuote(badContainers.Data()),
+				pluralize("uses", "use", badContainers.Len()),
 				pluralize("hostPort", "hostPorts", len(forbiddenHostPorts)),
 				strings.Join(forbiddenHostPorts.List(), ", "),
 			),
+			ErrList: badContainers.Errs(),
 		}
 	}
 	return CheckResult{Allowed: true}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_procMount.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_procMount.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/pod-security-admission/api"
 )
 
@@ -51,16 +52,16 @@ func CheckProcMount() Check {
 		Versions: []VersionedCheck{
 			{
 				MinimumVersion: api.MajorMinorVersion(1, 0),
-				CheckPod:       procMount_1_0,
+				CheckPod:       withOptions(procMountV1Dot0),
 			},
 		},
 	}
 }
 
-func procMount_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
-	var badContainers []string
+func procMountV1Dot0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec, opts options) CheckResult {
+	badContainers := NewViolations(opts.withFieldErrors)
 	forbiddenProcMountTypes := sets.NewString()
-	visitContainers(podSpec, func(container *corev1.Container) {
+	visitContainers(podSpec, opts, func(container *corev1.Container, path *field.Path) {
 		// allow if the security context is nil.
 		if container.SecurityContext == nil {
 			return
@@ -71,20 +72,25 @@ func procMount_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) Chec
 		}
 		// check if the value of the proc mount type is valid.
 		if *container.SecurityContext.ProcMount != corev1.DefaultProcMount {
-			badContainers = append(badContainers, container.Name)
+			if opts.withFieldErrors {
+				badContainers.Add(container.Name, withBadValue(forbidden(path.Child("securityContext", "procMount")), string(*container.SecurityContext.ProcMount)))
+			} else {
+				badContainers.Add(container.Name)
+			}
 			forbiddenProcMountTypes.Insert(string(*container.SecurityContext.ProcMount))
 		}
 	})
-	if len(badContainers) > 0 {
+	if !badContainers.Empty() {
 		return CheckResult{
 			Allowed:         false,
 			ForbiddenReason: "procMount",
 			ForbiddenDetail: fmt.Sprintf(
 				"%s %s must not set securityContext.procMount to %s",
-				pluralize("container", "containers", len(badContainers)),
-				joinQuote(badContainers),
+				pluralize("container", "containers", badContainers.Len()),
+				joinQuote(badContainers.Data()),
 				joinQuote(forbiddenProcMountTypes.List()),
 			),
+			ErrList: badContainers.Errs(),
 		}
 	}
 	return CheckResult{Allowed: true}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_restrictedVolumes.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_restrictedVolumes.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/pod-security-admission/api"
 )
 
@@ -77,18 +78,18 @@ func CheckRestrictedVolumes() Check {
 		Versions: []VersionedCheck{
 			{
 				MinimumVersion:   api.MajorMinorVersion(1, 0),
-				CheckPod:         restrictedVolumes_1_0,
+				CheckPod:         withOptions(restrictedVolumesV1Dot0),
 				OverrideCheckIDs: []CheckID{checkHostPathVolumesID},
 			},
 		},
 	}
 }
 
-func restrictedVolumes_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
-	var badVolumes []string
+func restrictedVolumesV1Dot0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec, opts options) CheckResult {
+	badVolumes := NewViolations(opts.withFieldErrors)
 	badVolumeTypes := sets.NewString()
 
-	for _, volume := range podSpec.Volumes {
+	for i, volume := range podSpec.Volumes {
 		switch {
 		case volume.ConfigMap != nil,
 			volume.CSI != nil,
@@ -101,69 +102,141 @@ func restrictedVolumes_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSp
 			continue
 
 		default:
-			badVolumes = append(badVolumes, volume.Name)
+			var volumesIndexPath *field.Path
+			if opts.withFieldErrors {
+				volumesIndexPath = volumesPath.Index(i)
+			} else {
+				badVolumes.Add(volume.Name)
+			}
 
 			switch {
 			case volume.HostPath != nil:
 				badVolumeTypes.Insert("hostPath")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("hostPath")))
+				}
 			case volume.GCEPersistentDisk != nil:
 				badVolumeTypes.Insert("gcePersistentDisk")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("gcePersistentDisk")))
+				}
 			case volume.AWSElasticBlockStore != nil:
 				badVolumeTypes.Insert("awsElasticBlockStore")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("awsElasticBlockStore")))
+				}
 			case volume.GitRepo != nil:
 				badVolumeTypes.Insert("gitRepo")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("gitRepo")))
+				}
 			case volume.NFS != nil:
 				badVolumeTypes.Insert("nfs")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("nfs")))
+				}
 			case volume.ISCSI != nil:
 				badVolumeTypes.Insert("iscsi")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("iscsi")))
+				}
 			case volume.Glusterfs != nil:
 				badVolumeTypes.Insert("glusterfs")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("glusterfs")))
+				}
 			case volume.RBD != nil:
 				badVolumeTypes.Insert("rbd")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("rbd")))
+				}
 			case volume.FlexVolume != nil:
 				badVolumeTypes.Insert("flexVolume")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("flexVolume")))
+				}
 			case volume.Cinder != nil:
 				badVolumeTypes.Insert("cinder")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("cinder")))
+				}
 			case volume.CephFS != nil:
 				badVolumeTypes.Insert("cephfs")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("cephfs")))
+				}
 			case volume.Flocker != nil:
 				badVolumeTypes.Insert("flocker")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("flocker")))
+				}
 			case volume.FC != nil:
 				badVolumeTypes.Insert("fc")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("fc")))
+				}
 			case volume.AzureFile != nil:
 				badVolumeTypes.Insert("azureFile")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("azureFile")))
+				}
 			case volume.VsphereVolume != nil:
 				badVolumeTypes.Insert("vsphereVolume")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("vsphereVolume")))
+				}
 			case volume.Quobyte != nil:
 				badVolumeTypes.Insert("quobyte")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("quobyte")))
+				}
 			case volume.AzureDisk != nil:
 				badVolumeTypes.Insert("azureDisk")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("azureDisk")))
+				}
 			case volume.PhotonPersistentDisk != nil:
 				badVolumeTypes.Insert("photonPersistentDisk")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("photonPersistentDisk")))
+				}
 			case volume.PortworxVolume != nil:
 				badVolumeTypes.Insert("portworxVolume")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("portworxVolume")))
+				}
 			case volume.ScaleIO != nil:
 				badVolumeTypes.Insert("scaleIO")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("scaleIO")))
+				}
 			case volume.StorageOS != nil:
 				badVolumeTypes.Insert("storageos")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("storageos")))
+				}
 			default:
 				badVolumeTypes.Insert("unknown")
+				if opts.withFieldErrors {
+					badVolumes.Add(volume.Name, forbidden(volumesIndexPath.Child("unknown")))
+				}
 			}
 		}
 	}
 
-	if len(badVolumes) > 0 {
+	if !badVolumes.Empty() {
 		return CheckResult{
 			Allowed:         false,
 			ForbiddenReason: "restricted volume types",
 			ForbiddenDetail: fmt.Sprintf(
 				"%s %s %s %s %s",
-				pluralize("volume", "volumes", len(badVolumes)),
-				joinQuote(badVolumes),
-				pluralize("uses", "use", len(badVolumes)),
+				pluralize("volume", "volumes", badVolumes.Len()),
+				joinQuote(badVolumes.Data()),
+				pluralize("uses", "use", badVolumes.Len()),
 				pluralize("restricted volume type", "restricted volume types", len(badVolumeTypes)),
 				joinQuote(badVolumeTypes.List()),
 			),
+			ErrList: badVolumes.Errs(),
 		}
 	}
 

--- a/staging/src/k8s.io/pod-security-admission/policy/check_restrictedVolumes_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_restrictedVolumes_test.go
@@ -20,14 +20,20 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestRestrictedVolumes(t *testing.T) {
 	tests := []struct {
-		name         string
-		pod          *corev1.Pod
-		expectReason string
-		expectDetail string
+		name          string
+		pod           *corev1.Pod
+		opts          options
+		expectReason  string
+		expectDetail  string
+		expectErrList field.ErrorList
 	}{
 		{
 			name: "host path volumes",
@@ -77,11 +83,87 @@ func TestRestrictedVolumes(t *testing.T) {
 				`"awsElasticBlockStore", "azureDisk", "azureFile", "cephfs", "cinder", "fc", "flexVolume", "flocker", "gcePersistentDisk", "gitRepo", "glusterfs", ` +
 				`"hostPath", "iscsi", "nfs", "photonPersistentDisk", "portworxVolume", "quobyte", "rbd", "scaleIO", "storageos", "unknown", "vsphereVolume"`,
 		},
+		{
+			name: "host path volumes, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					// allowed types
+					{Name: "a1", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+					{Name: "a2", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{}}},
+					{Name: "a3", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{}}},
+					{Name: "a4", VolumeSource: corev1.VolumeSource{DownwardAPI: &corev1.DownwardAPIVolumeSource{}}},
+					{Name: "a5", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{}}},
+					{Name: "a6", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{}}},
+					{Name: "a7", VolumeSource: corev1.VolumeSource{CSI: &corev1.CSIVolumeSource{}}},
+					{Name: "a8", VolumeSource: corev1.VolumeSource{Ephemeral: &corev1.EphemeralVolumeSource{}}},
+
+					// known restricted types
+					{Name: "b1", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{}}},
+					{Name: "b2", VolumeSource: corev1.VolumeSource{GCEPersistentDisk: &corev1.GCEPersistentDiskVolumeSource{}}},
+					{Name: "b3", VolumeSource: corev1.VolumeSource{AWSElasticBlockStore: &corev1.AWSElasticBlockStoreVolumeSource{}}},
+					{Name: "b4", VolumeSource: corev1.VolumeSource{GitRepo: &corev1.GitRepoVolumeSource{}}},
+					{Name: "b5", VolumeSource: corev1.VolumeSource{NFS: &corev1.NFSVolumeSource{}}},
+					{Name: "b6", VolumeSource: corev1.VolumeSource{ISCSI: &corev1.ISCSIVolumeSource{}}},
+					{Name: "b7", VolumeSource: corev1.VolumeSource{Glusterfs: &corev1.GlusterfsVolumeSource{}}},
+					{Name: "b8", VolumeSource: corev1.VolumeSource{RBD: &corev1.RBDVolumeSource{}}},
+					{Name: "b9", VolumeSource: corev1.VolumeSource{FlexVolume: &corev1.FlexVolumeSource{}}},
+					{Name: "b10", VolumeSource: corev1.VolumeSource{Cinder: &corev1.CinderVolumeSource{}}},
+					{Name: "b11", VolumeSource: corev1.VolumeSource{CephFS: &corev1.CephFSVolumeSource{}}},
+					{Name: "b12", VolumeSource: corev1.VolumeSource{Flocker: &corev1.FlockerVolumeSource{}}},
+					{Name: "b13", VolumeSource: corev1.VolumeSource{FC: &corev1.FCVolumeSource{}}},
+					{Name: "b14", VolumeSource: corev1.VolumeSource{AzureFile: &corev1.AzureFileVolumeSource{}}},
+					{Name: "b15", VolumeSource: corev1.VolumeSource{VsphereVolume: &corev1.VsphereVirtualDiskVolumeSource{}}},
+					{Name: "b16", VolumeSource: corev1.VolumeSource{Quobyte: &corev1.QuobyteVolumeSource{}}},
+					{Name: "b17", VolumeSource: corev1.VolumeSource{AzureDisk: &corev1.AzureDiskVolumeSource{}}},
+					{Name: "b18", VolumeSource: corev1.VolumeSource{PhotonPersistentDisk: &corev1.PhotonPersistentDiskVolumeSource{}}},
+					{Name: "b19", VolumeSource: corev1.VolumeSource{PortworxVolume: &corev1.PortworxVolumeSource{}}},
+					{Name: "b20", VolumeSource: corev1.VolumeSource{ScaleIO: &corev1.ScaleIOVolumeSource{}}},
+					{Name: "b21", VolumeSource: corev1.VolumeSource{StorageOS: &corev1.StorageOSVolumeSource{}}},
+
+					// unknown type
+					{Name: "c1", VolumeSource: corev1.VolumeSource{}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `restricted volume types`,
+			expectDetail: `volumes ` +
+				`"b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9", "b10", "b11", "b12", "b13", "b14", "b15", "b16", "b17", "b18", "b19", "b20", "b21", "c1"` +
+				` use restricted volume types ` +
+				`"awsElasticBlockStore", "azureDisk", "azureFile", "cephfs", "cinder", "fc", "flexVolume", "flocker", "gcePersistentDisk", "gitRepo", "glusterfs", ` +
+				`"hostPath", "iscsi", "nfs", "photonPersistentDisk", "portworxVolume", "quobyte", "rbd", "scaleIO", "storageos", "unknown", "vsphereVolume"`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[8].hostPath", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[9].gcePersistentDisk", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[10].awsElasticBlockStore", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[11].gitRepo", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[12].nfs", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[13].iscsi", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[14].glusterfs", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[15].rbd", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[16].flexVolume", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[17].cinder", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[18].cephfs", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[19].flocker", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[20].fc", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[21].azureFile", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[22].vsphereVolume", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[23].quobyte", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[24].azureDisk", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[25].photonPersistentDisk", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[26].portworxVolume", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[27].scaleIO", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[28].storageos", BadValue: ""},
+				{Type: field.ErrorTypeForbidden, Field: "spec.volumes[29].unknown", BadValue: ""},
+			},
+		},
 	}
 
+	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "Detail"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := restrictedVolumes_1_0(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			result := restrictedVolumesV1Dot0(&tc.pod.ObjectMeta, &tc.pod.Spec, tc.opts)
 			if result.Allowed {
 				t.Fatal("expected disallowed")
 			}
@@ -90,6 +172,11 @@ func TestRestrictedVolumes(t *testing.T) {
 			}
 			if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
 				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+			if result.ErrList != nil {
+				if diff := cmp.Diff(tc.expectErrList, *result.ErrList, cmpOpts...); diff != "" {
+					t.Errorf("unexpected field errors (-want,+got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_runAsNonRoot_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_runAsNonRoot_test.go
@@ -20,15 +20,21 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilpointer "k8s.io/utils/pointer"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestRunAsNonRoot(t *testing.T) {
 	tests := []struct {
 		name                                     string
 		pod                                      *corev1.Pod
+		opts                                     options
 		expectReason                             string
 		expectDetail                             string
+		expectErrList                            field.ErrorList
 		allowed                                  bool
 		enableUserNamespacesPodSecurityStandards bool
 	}{
@@ -43,6 +49,22 @@ func TestRunAsNonRoot(t *testing.T) {
 			expectDetail: `pod or container "a" must set securityContext.runAsNonRoot=true`,
 		},
 		{
+			name: "no explicit runAsNonRoot, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a"},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `runAsNonRoot != true`,
+			expectDetail: `pod or container "a" must set securityContext.runAsNonRoot=true`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeRequired, Field: "spec.containers[0].securityContext.runAsNonRoot", BadValue: ""},
+			},
+		},
+		{
 			name: "pod runAsNonRoot=false",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: utilpointer.Bool(false)},
@@ -52,6 +74,23 @@ func TestRunAsNonRoot(t *testing.T) {
 			}},
 			expectReason: `runAsNonRoot != true`,
 			expectDetail: `pod must not set securityContext.runAsNonRoot=false`,
+		},
+		{
+			name: "pod runAsNonRoot=false, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: utilpointer.Bool(false)},
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: nil},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `runAsNonRoot != true`,
+			expectDetail: `pod must not set securityContext.runAsNonRoot=false`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.runAsNonRoot", BadValue: false},
+			},
 		},
 		{
 			name: "containers runAsNonRoot=false",
@@ -70,6 +109,29 @@ func TestRunAsNonRoot(t *testing.T) {
 			expectDetail: `containers "c", "d" must not set securityContext.runAsNonRoot=false`,
 		},
 		{
+			name: "containers runAsNonRoot=false, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{RunAsNonRoot: utilpointer.Bool(true)},
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: nil},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: utilpointer.Bool(false)}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: utilpointer.Bool(false)}},
+					{Name: "e", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: utilpointer.Bool(true)}},
+					{Name: "f", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: utilpointer.Bool(true)}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `runAsNonRoot != true`,
+			expectDetail: `containers "c", "d" must not set securityContext.runAsNonRoot=false`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[2].securityContext.runAsNonRoot", BadValue: false},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[3].securityContext.runAsNonRoot", BadValue: false},
+			},
+		},
+		{
 			name: "pod nil, container fallthrough",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
@@ -83,10 +145,41 @@ func TestRunAsNonRoot(t *testing.T) {
 			expectDetail: `pod or containers "a", "b" must set securityContext.runAsNonRoot=true`,
 		},
 		{
+			name: "pod nil, container fallthrough, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: nil},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: utilpointer.Bool(true)}},
+					{Name: "e", SecurityContext: &corev1.SecurityContext{RunAsNonRoot: utilpointer.Bool(true)}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `runAsNonRoot != true`,
+			expectDetail: `pod or containers "a", "b" must set securityContext.runAsNonRoot=true`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeRequired, Field: "spec.containers[0].securityContext.runAsNonRoot", BadValue: ""},
+				{Type: field.ErrorTypeRequired, Field: "spec.containers[1].securityContext.runAsNonRoot", BadValue: ""},
+			},
+		},
+		{
 			name: "UserNamespacesPodSecurityStandards enabled without HostUsers",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				HostUsers: utilpointer.Bool(false),
 			}},
+			allowed:                                  true,
+			enableUserNamespacesPodSecurityStandards: true,
+		},
+		{
+			name: "UserNamespacesPodSecurityStandards enabled without HostUsers, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				HostUsers: utilpointer.Bool(false),
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
 			allowed:                                  true,
 			enableUserNamespacesPodSecurityStandards: true,
 		},
@@ -103,14 +196,34 @@ func TestRunAsNonRoot(t *testing.T) {
 			allowed:                                  false,
 			enableUserNamespacesPodSecurityStandards: true,
 		},
+		{
+			name: "UserNamespacesPodSecurityStandards enabled with HostUsers, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "a"},
+				},
+				HostUsers: utilpointer.Bool(true),
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `runAsNonRoot != true`,
+			expectDetail: `pod or container "a" must set securityContext.runAsNonRoot=true`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeRequired, Field: "spec.containers[0].securityContext.runAsNonRoot", BadValue: ""},
+			},
+			allowed:                                  false,
+			enableUserNamespacesPodSecurityStandards: true,
+		},
 	}
 
+	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "Detail"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.enableUserNamespacesPodSecurityStandards {
 				RelaxPolicyForUserNamespacePods(true)
 			}
-			result := runAsNonRoot_1_0(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			result := runAsNonRootV1Dot0(&tc.pod.ObjectMeta, &tc.pod.Spec, tc.opts)
 			if result.Allowed && !tc.allowed {
 				t.Fatal("expected disallowed")
 			}
@@ -119,6 +232,11 @@ func TestRunAsNonRoot(t *testing.T) {
 			}
 			if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
 				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+			if result.ErrList != nil {
+				if diff := cmp.Diff(tc.expectErrList, *result.ErrList, cmpOpts...); diff != "" {
+					t.Errorf("unexpected field errors (-want,+got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_runAsUser.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_runAsUser.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/pod-security-admission/api"
 )
 
@@ -53,50 +54,59 @@ func CheckRunAsUser() Check {
 		Versions: []VersionedCheck{
 			{
 				MinimumVersion: api.MajorMinorVersion(1, 23),
-				CheckPod:       runAsUser_1_23,
+				CheckPod:       withOptions(runAsUserV1Dot23),
 			},
 		},
 	}
 }
 
-func runAsUser_1_23(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
+func runAsUserV1Dot23(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec, opts options) CheckResult {
 	// See KEP-127: https://github.com/kubernetes/enhancements/blob/308ba8d/keps/sig-node/127-user-namespaces/README.md?plain=1#L411-L447
 	if relaxPolicyForUserNamespacePod(podSpec) {
 		return CheckResult{Allowed: true}
 	}
 
 	// things that explicitly set runAsUser=0
-	var badSetters []string
+	badSetters := NewViolations(opts.withFieldErrors)
 
 	if podSpec.SecurityContext != nil && podSpec.SecurityContext.RunAsUser != nil && *podSpec.SecurityContext.RunAsUser == 0 {
-		badSetters = append(badSetters, "pod")
+		if opts.withFieldErrors {
+			badSetters.Add("pod", withBadValue(forbidden(runAsUserPath), 0))
+		} else {
+			badSetters.Add("pod")
+		}
 	}
 
 	// containers that explicitly set runAsUser=0
-	var explicitlyBadContainers []string
+	explicitlyBadContainers := NewViolations(opts.withFieldErrors)
+	var explicitlyErrs field.ErrorList
 
-	visitContainers(podSpec, func(container *corev1.Container) {
+	visitContainers(podSpec, opts, func(container *corev1.Container, path *field.Path) {
 		if container.SecurityContext != nil && container.SecurityContext.RunAsUser != nil && *container.SecurityContext.RunAsUser == 0 {
-			explicitlyBadContainers = append(explicitlyBadContainers, container.Name)
+			explicitlyBadContainers.Add(container.Name)
+			if opts.withFieldErrors {
+				explicitlyErrs = append(explicitlyErrs, withBadValue(forbidden(path.Child("securityContext", "runAsUser")), 0))
+			}
 		}
 	})
 
-	if len(explicitlyBadContainers) > 0 {
-		badSetters = append(
-			badSetters,
+	if !explicitlyBadContainers.Empty() {
+		badSetters.Add(
 			fmt.Sprintf(
 				"%s %s",
-				pluralize("container", "containers", len(explicitlyBadContainers)),
-				joinQuote(explicitlyBadContainers),
+				pluralize("container", "containers", explicitlyBadContainers.Len()),
+				joinQuote(explicitlyBadContainers.Data()),
 			),
+			explicitlyErrs...,
 		)
 	}
 	// pod or containers explicitly set runAsUser=0
-	if len(badSetters) > 0 {
+	if !badSetters.Empty() {
 		return CheckResult{
 			Allowed:         false,
 			ForbiddenReason: "runAsUser=0",
-			ForbiddenDetail: fmt.Sprintf("%s must not set runAsUser=0", strings.Join(badSetters, " and ")),
+			ForbiddenDetail: fmt.Sprintf("%s must not set runAsUser=0", strings.Join(badSetters.Data(), " and ")),
+			ErrList:         badSetters.Errs(),
 		}
 	}
 

--- a/staging/src/k8s.io/pod-security-admission/policy/check_seLinuxOptions.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_seLinuxOptions.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/pod-security-admission/api"
 )
 
@@ -64,7 +65,7 @@ func CheckSELinuxOptions() Check {
 		Versions: []VersionedCheck{
 			{
 				MinimumVersion: api.MajorMinorVersion(1, 0),
-				CheckPod:       seLinuxOptions_1_0,
+				CheckPod:       withOptions(seLinuxOptionsV1Dot0),
 			},
 		},
 	}
@@ -74,11 +75,12 @@ var (
 	selinux_allowed_types_1_0 = sets.NewString("", "container_t", "container_init_t", "container_kvm_t")
 )
 
-func seLinuxOptions_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
+func seLinuxOptionsV1Dot0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec, opts options) CheckResult {
 	var (
 		// sources that set bad seLinuxOptions
-		badSetters []string
-
+		badSetters        = NewViolations(opts.withFieldErrors)
+		badContainersErrs field.ErrorList
+		badPodErrs        field.ErrorList
 		// invalid type values set
 		badTypes = sets.NewString()
 		// was user set?
@@ -87,49 +89,65 @@ func seLinuxOptions_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec)
 		setRole = false
 	)
 
-	validSELinuxOptions := func(opts *corev1.SELinuxOptions) bool {
+	validSELinuxOptions := func(selinuxOpts *corev1.SELinuxOptions, path *field.Path, isPodLevel bool) bool {
 		valid := true
-		if !selinux_allowed_types_1_0.Has(opts.Type) {
+		if !selinux_allowed_types_1_0.Has(selinuxOpts.Type) {
 			valid = false
-			badTypes.Insert(opts.Type)
+			badTypes.Insert(selinuxOpts.Type)
+			if path != nil {
+				badContainersErrs = append(badContainersErrs, withBadValue(forbidden(path.Child("securityContext", "seLinuxOptions", "type")), selinuxOpts.Type))
+			} else if isPodLevel && opts.withFieldErrors {
+				badPodErrs = append(badPodErrs, withBadValue(forbidden(seLinuxOptionsTypePath), selinuxOpts.Type))
+			}
 		}
-		if len(opts.User) > 0 {
+		if len(selinuxOpts.User) > 0 {
 			valid = false
 			setUser = true
+			if path != nil {
+				badContainersErrs = append(badContainersErrs, withBadValue(forbidden(path.Child("securityContext", "seLinuxOptions", "user")), selinuxOpts.User))
+			} else if isPodLevel && opts.withFieldErrors {
+				badPodErrs = append(badPodErrs, withBadValue(forbidden(seLinuxOptionsUserPath), selinuxOpts.User))
+			}
 		}
-		if len(opts.Role) > 0 {
+		if len(selinuxOpts.Role) > 0 {
 			valid = false
 			setRole = true
+			if path != nil {
+				badContainersErrs = append(badContainersErrs, withBadValue(forbidden(path.Child("securityContext", "seLinuxOptions", "role")), selinuxOpts.Role))
+			} else if isPodLevel && opts.withFieldErrors {
+				badPodErrs = append(badPodErrs, withBadValue(forbidden(seLinuxOptionsRolePath), selinuxOpts.Role))
+			}
 		}
 		return valid
 	}
 
 	if podSpec.SecurityContext != nil && podSpec.SecurityContext.SELinuxOptions != nil {
-		if !validSELinuxOptions(podSpec.SecurityContext.SELinuxOptions) {
-			badSetters = append(badSetters, "pod")
+		if !validSELinuxOptions(podSpec.SecurityContext.SELinuxOptions, nil, true) {
+			badSetters.Add("pod", badPodErrs...)
 		}
 	}
 
 	var badContainers []string
-	visitContainers(podSpec, func(container *corev1.Container) {
+	visitContainers(podSpec, opts, func(container *corev1.Container, path *field.Path) {
 		if container.SecurityContext != nil && container.SecurityContext.SELinuxOptions != nil {
-			if !validSELinuxOptions(container.SecurityContext.SELinuxOptions) {
+			if !validSELinuxOptions(container.SecurityContext.SELinuxOptions, path, false) {
 				badContainers = append(badContainers, container.Name)
 			}
 		}
 	})
+
 	if len(badContainers) > 0 {
-		badSetters = append(
-			badSetters,
+		badSetters.Add(
 			fmt.Sprintf(
 				"%s %s",
 				pluralize("container", "containers", len(badContainers)),
 				joinQuote(badContainers),
 			),
+			badContainersErrs...,
 		)
 	}
 
-	if len(badSetters) > 0 {
+	if !badSetters.Empty() {
 		var badData []string
 		if len(badTypes) > 0 {
 			badData = append(badData, fmt.Sprintf(
@@ -150,9 +168,10 @@ func seLinuxOptions_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec)
 			ForbiddenReason: "seLinuxOptions",
 			ForbiddenDetail: fmt.Sprintf(
 				`%s set forbidden securityContext.seLinuxOptions: %s`,
-				strings.Join(badSetters, " and "),
+				strings.Join(badSetters.Data(), " and "),
 				strings.Join(badData, "; "),
 			),
+			ErrList: badSetters.Errs(),
 		}
 	}
 	return CheckResult{Allowed: true}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_seLinuxOptions_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_seLinuxOptions_test.go
@@ -20,14 +20,20 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestSELinuxOptions(t *testing.T) {
 	tests := []struct {
-		name         string
-		pod          *corev1.Pod
-		expectReason string
-		expectDetail string
+		name          string
+		pod           *corev1.Pod
+		opts          options
+		expectReason  string
+		expectDetail  string
+		expectErrList field.ErrorList
 	}{
 		{
 			name: "invalid pod and containers",
@@ -64,6 +70,51 @@ func TestSELinuxOptions(t *testing.T) {
 			expectDetail: `pod and containers "d", "e", "f" set forbidden securityContext.seLinuxOptions: types "bar", "foo"; user may not be set; role may not be set`,
 		},
 		{
+			name: "invalid pod and containers, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SELinuxOptions: &corev1.SELinuxOptions{
+						Type: "foo",
+						User: "bar",
+						Role: "baz",
+					},
+				},
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: &corev1.SecurityContext{SELinuxOptions: &corev1.SELinuxOptions{
+						Type: "container_t",
+					}}},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{SELinuxOptions: &corev1.SELinuxOptions{
+						Type: "container_init_t",
+					}}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{SELinuxOptions: &corev1.SELinuxOptions{
+						Type: "container_kvm_t",
+					}}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{SELinuxOptions: &corev1.SELinuxOptions{
+						Type: "bar",
+					}}},
+					{Name: "e", SecurityContext: &corev1.SecurityContext{SELinuxOptions: &corev1.SELinuxOptions{
+						User: "bar",
+					}}},
+					{Name: "f", SecurityContext: &corev1.SecurityContext{SELinuxOptions: &corev1.SELinuxOptions{
+						Role: "baz",
+					}}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `seLinuxOptions`,
+			expectDetail: `pod and containers "d", "e", "f" set forbidden securityContext.seLinuxOptions: types "bar", "foo"; user may not be set; role may not be set`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.seLinuxOptions.type", BadValue: "foo"},
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.seLinuxOptions.user", BadValue: "bar"},
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.seLinuxOptions.role", BadValue: "baz"},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[3].securityContext.seLinuxOptions.type", BadValue: "bar"},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[4].securityContext.seLinuxOptions.user", BadValue: "bar"},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[5].securityContext.seLinuxOptions.role", BadValue: "baz"},
+			},
+		},
+		{
 			name: "invalid pod",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				SecurityContext: &corev1.PodSecurityContext{
@@ -87,6 +138,39 @@ func TestSELinuxOptions(t *testing.T) {
 			}},
 			expectReason: `seLinuxOptions`,
 			expectDetail: `pod set forbidden securityContext.seLinuxOptions: type "foo"; user may not be set; role may not be set`,
+		},
+		{
+			name: "invalid pod, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SELinuxOptions: &corev1.SELinuxOptions{
+						Type: "foo",
+						User: "bar",
+						Role: "baz",
+					},
+				},
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: &corev1.SecurityContext{SELinuxOptions: &corev1.SELinuxOptions{
+						Type: "container_t",
+					}}},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{SELinuxOptions: &corev1.SELinuxOptions{
+						Type: "container_init_t",
+					}}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{SELinuxOptions: &corev1.SELinuxOptions{
+						Type: "container_kvm_t",
+					}}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `seLinuxOptions`,
+			expectDetail: `pod set forbidden securityContext.seLinuxOptions: type "foo"; user may not be set; role may not be set`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.seLinuxOptions.type", BadValue: "foo"},
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.seLinuxOptions.user", BadValue: "bar"},
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.seLinuxOptions.role", BadValue: "baz"},
+			},
 		},
 		{
 			name: "invalid containers",
@@ -119,6 +203,44 @@ func TestSELinuxOptions(t *testing.T) {
 			expectDetail: `containers "d", "e", "f" set forbidden securityContext.seLinuxOptions: type "bar"; user may not be set; role may not be set`,
 		},
 		{
+			name: "invalid containers, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SELinuxOptions: &corev1.SELinuxOptions{},
+				},
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: &corev1.SecurityContext{SELinuxOptions: &corev1.SELinuxOptions{
+						Type: "container_t",
+					}}},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{SELinuxOptions: &corev1.SELinuxOptions{
+						Type: "container_init_t",
+					}}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{SELinuxOptions: &corev1.SELinuxOptions{
+						Type: "container_kvm_t",
+					}}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{SELinuxOptions: &corev1.SELinuxOptions{
+						Type: "bar",
+					}}},
+					{Name: "e", SecurityContext: &corev1.SecurityContext{SELinuxOptions: &corev1.SELinuxOptions{
+						User: "bar",
+					}}},
+					{Name: "f", SecurityContext: &corev1.SecurityContext{SELinuxOptions: &corev1.SELinuxOptions{
+						Role: "baz",
+					}}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `seLinuxOptions`,
+			expectDetail: `containers "d", "e", "f" set forbidden securityContext.seLinuxOptions: type "bar"; user may not be set; role may not be set`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[3].securityContext.seLinuxOptions.type", BadValue: "bar"},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[4].securityContext.seLinuxOptions.user", BadValue: "bar"},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[5].securityContext.seLinuxOptions.role", BadValue: "baz"},
+			},
+		},
+		{
 			name: "bad type",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				SecurityContext: &corev1.PodSecurityContext{
@@ -129,6 +251,24 @@ func TestSELinuxOptions(t *testing.T) {
 			}},
 			expectReason: `seLinuxOptions`,
 			expectDetail: `pod set forbidden securityContext.seLinuxOptions: type "bad"`,
+		},
+		{
+			name: "bad type, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SELinuxOptions: &corev1.SELinuxOptions{
+						Type: "bad",
+					},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `seLinuxOptions`,
+			expectDetail: `pod set forbidden securityContext.seLinuxOptions: type "bad"`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.seLinuxOptions.type", BadValue: "bad"},
+			},
 		},
 		{
 			name: "bad user",
@@ -143,6 +283,24 @@ func TestSELinuxOptions(t *testing.T) {
 			expectDetail: `pod set forbidden securityContext.seLinuxOptions: user may not be set`,
 		},
 		{
+			name: "bad user, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SELinuxOptions: &corev1.SELinuxOptions{
+						User: "bad",
+					},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `seLinuxOptions`,
+			expectDetail: `pod set forbidden securityContext.seLinuxOptions: user may not be set`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.seLinuxOptions.user", BadValue: "bad"},
+			},
+		},
+		{
 			name: "bad role",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				SecurityContext: &corev1.PodSecurityContext{
@@ -154,11 +312,30 @@ func TestSELinuxOptions(t *testing.T) {
 			expectReason: `seLinuxOptions`,
 			expectDetail: `pod set forbidden securityContext.seLinuxOptions: role may not be set`,
 		},
+		{
+			name: "bad role, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					SELinuxOptions: &corev1.SELinuxOptions{
+						Role: "bad",
+					},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `seLinuxOptions`,
+			expectDetail: `pod set forbidden securityContext.seLinuxOptions: role may not be set`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.seLinuxOptions.role", BadValue: "bad"},
+			},
+		},
 	}
 
+	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "Detail"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := seLinuxOptions_1_0(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			result := seLinuxOptionsV1Dot0(&tc.pod.ObjectMeta, &tc.pod.Spec, tc.opts)
 			if result.Allowed {
 				t.Fatal("expected disallowed")
 			}
@@ -167,6 +344,11 @@ func TestSELinuxOptions(t *testing.T) {
 			}
 			if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
 				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+			if result.ErrList != nil {
+				if diff := cmp.Diff(tc.expectErrList, *result.ErrList, cmpOpts...); diff != "" {
+					t.Errorf("unexpected field errors (-want,+got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_sysctls_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_sysctls_test.go
@@ -20,15 +20,21 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestSysctls(t *testing.T) {
 	tests := []struct {
-		name         string
-		pod          *corev1.Pod
-		allowed      bool
-		expectReason string
-		expectDetail string
+		name          string
+		pod           *corev1.Pod
+		opts          options
+		allowed       bool
+		expectReason  string
+		expectDetail  string
+		expectErrList field.ErrorList
 	}{
 		{
 			name: "forbidden sysctls",
@@ -40,6 +46,24 @@ func TestSysctls(t *testing.T) {
 			allowed:      false,
 			expectReason: `forbidden sysctls`,
 			expectDetail: `a, b`,
+		},
+		{
+			name: "forbidden sysctls, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "a"}, {Name: "b"}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			allowed:      false,
+			expectReason: `forbidden sysctls`,
+			expectDetail: `a, b`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.sysctls[0].name", BadValue: "a"},
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.sysctls[1].name", BadValue: "b"},
+			},
 		},
 		{
 			name: "new supported sysctls not supported: net.ipv4.ip_local_reserved_ports",
@@ -53,6 +77,23 @@ func TestSysctls(t *testing.T) {
 			expectDetail: `net.ipv4.ip_local_reserved_ports`,
 		},
 		{
+			name: "new supported sysctls not supported: net.ipv4.ip_local_reserved_ports, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.ip_local_reserved_ports", Value: "1024-4999"}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			allowed:      false,
+			expectReason: `forbidden sysctls`,
+			expectDetail: `net.ipv4.ip_local_reserved_ports`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.sysctls[0].name", BadValue: "net.ipv4.ip_local_reserved_ports"},
+			},
+		},
+		{
 			name: "new supported sysctls not supported: net.ipv4.tcp_keepalive_time",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				SecurityContext: &corev1.PodSecurityContext{
@@ -62,6 +103,23 @@ func TestSysctls(t *testing.T) {
 			allowed:      false,
 			expectReason: `forbidden sysctls`,
 			expectDetail: `net.ipv4.tcp_keepalive_time`,
+		},
+		{
+			name: "new supported sysctls not supported: net.ipv4.tcp_keepalive_time, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_keepalive_time", Value: "7200"}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			allowed:      false,
+			expectReason: `forbidden sysctls`,
+			expectDetail: `net.ipv4.tcp_keepalive_time`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.sysctls[0].name", BadValue: "net.ipv4.tcp_keepalive_time"},
+			},
 		},
 		{
 			name: "new supported sysctls not supported: net.ipv4.tcp_fin_timeout",
@@ -75,6 +133,23 @@ func TestSysctls(t *testing.T) {
 			expectDetail: `net.ipv4.tcp_fin_timeout`,
 		},
 		{
+			name: "new supported sysctls not supported: net.ipv4.tcp_fin_timeout, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_fin_timeout", Value: "60"}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			allowed:      false,
+			expectReason: `forbidden sysctls`,
+			expectDetail: `net.ipv4.tcp_fin_timeout`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.sysctls[0].name", BadValue: "net.ipv4.tcp_fin_timeout"},
+			},
+		},
+		{
 			name: "new supported sysctls not supported: net.ipv4.tcp_keepalive_intvl",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				SecurityContext: &corev1.PodSecurityContext{
@@ -84,6 +159,23 @@ func TestSysctls(t *testing.T) {
 			allowed:      false,
 			expectReason: `forbidden sysctls`,
 			expectDetail: `net.ipv4.tcp_keepalive_intvl`,
+		},
+		{
+			name: "new supported sysctls not supported: net.ipv4.tcp_keepalive_intvl, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_keepalive_intvl", Value: "75"}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			allowed:      false,
+			expectReason: `forbidden sysctls`,
+			expectDetail: `net.ipv4.tcp_keepalive_intvl`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.sysctls[0].name", BadValue: "net.ipv4.tcp_keepalive_intvl"},
+			},
 		},
 		{
 			name: "new supported sysctls not supported: net.ipv4.tcp_keepalive_probes",
@@ -96,11 +188,29 @@ func TestSysctls(t *testing.T) {
 			expectReason: `forbidden sysctls`,
 			expectDetail: `net.ipv4.tcp_keepalive_probes`,
 		},
+		{
+			name: "new supported sysctls not supported: net.ipv4.tcp_keepalive_probes, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_keepalive_probes", Value: "9"}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			allowed:      false,
+			expectReason: `forbidden sysctls`,
+			expectDetail: `net.ipv4.tcp_keepalive_probes`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.sysctls[0].name", BadValue: "net.ipv4.tcp_keepalive_probes"},
+			},
+		},
 	}
 
+	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "Detail"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := sysctlsV1Dot0(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			result := sysctlsV1Dot0(&tc.pod.ObjectMeta, &tc.pod.Spec, tc.opts)
 			if !tc.allowed {
 				if result.Allowed {
 					t.Fatal("expected disallowed")
@@ -110,6 +220,11 @@ func TestSysctls(t *testing.T) {
 				}
 				if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
 					t.Errorf("expected\n%s\ngot\n%s", e, a)
+				}
+				if result.ErrList != nil {
+					if diff := cmp.Diff(tc.expectErrList, *result.ErrList, cmpOpts...); diff != "" {
+						t.Errorf("unexpected field errors (-want,+got):\n%s", diff)
+					}
 				}
 			} else if !result.Allowed {
 				t.Fatal("expected allowed")
@@ -120,11 +235,13 @@ func TestSysctls(t *testing.T) {
 
 func TestSysctls_1_27(t *testing.T) {
 	tests := []struct {
-		name         string
-		pod          *corev1.Pod
-		allowed      bool
-		expectReason string
-		expectDetail string
+		name          string
+		pod           *corev1.Pod
+		opts          options
+		allowed       bool
+		expectReason  string
+		expectDetail  string
+		expectErrList field.ErrorList
 	}{
 		{
 			name: "forbidden sysctls",
@@ -136,6 +253,24 @@ func TestSysctls_1_27(t *testing.T) {
 			allowed:      false,
 			expectReason: `forbidden sysctls`,
 			expectDetail: `a, b`,
+		},
+		{
+			name: "forbidden sysctls, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "a"}, {Name: "b"}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			allowed:      false,
+			expectReason: `forbidden sysctls`,
+			expectDetail: `a, b`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.sysctls[0].name", BadValue: "a"},
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.sysctls[1].name", BadValue: "b"},
+			},
 		},
 		{
 			name: "new supported sysctls",
@@ -146,11 +281,24 @@ func TestSysctls_1_27(t *testing.T) {
 			}},
 			allowed: true,
 		},
+		{
+			name: "new supported sysctls, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.ip_local_reserved_ports", Value: "1024-4999"}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			allowed: true,
+		},
 	}
 
+	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "Detail"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := sysctlsV1Dot27(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			result := sysctlsV1Dot27(&tc.pod.ObjectMeta, &tc.pod.Spec, tc.opts)
 			if !tc.allowed {
 				if result.Allowed {
 					t.Fatal("expected disallowed")
@@ -161,6 +309,11 @@ func TestSysctls_1_27(t *testing.T) {
 				if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
 					t.Errorf("expected\n%s\ngot\n%s", e, a)
 				}
+				if result.ErrList != nil {
+					if diff := cmp.Diff(tc.expectErrList, *result.ErrList, cmpOpts...); diff != "" {
+						t.Errorf("unexpected field errors (-want,+got):\n%s", diff)
+					}
+				}
 			} else if !result.Allowed {
 				t.Fatal("expected allowed")
 			}
@@ -170,11 +323,13 @@ func TestSysctls_1_27(t *testing.T) {
 
 func TestSysctls_1_29(t *testing.T) {
 	tests := []struct {
-		name         string
-		pod          *corev1.Pod
-		allowed      bool
-		expectReason string
-		expectDetail string
+		name          string
+		pod           *corev1.Pod
+		opts          options
+		allowed       bool
+		expectReason  string
+		expectDetail  string
+		expectErrList field.ErrorList
 	}{
 		{
 			name: "forbidden sysctls",
@@ -188,12 +343,42 @@ func TestSysctls_1_29(t *testing.T) {
 			expectDetail: `a, b`,
 		},
 		{
+			name: "forbidden sysctls, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "a"}, {Name: "b"}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			allowed:      false,
+			expectReason: `forbidden sysctls`,
+			expectDetail: `a, b`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.sysctls[0].name", BadValue: "a"},
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.sysctls[1].name", BadValue: "b"},
+			},
+		},
+		{
 			name: "new supported sysctls: net.ipv4.tcp_keepalive_time",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				SecurityContext: &corev1.PodSecurityContext{
 					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_keepalive_time", Value: "7200"}},
 				},
 			}},
+			allowed: true,
+		},
+		{
+			name: "new supported sysctls: net.ipv4.tcp_keepalive_time, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_keepalive_time", Value: "7200"}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
 			allowed: true,
 		},
 		{
@@ -206,12 +391,36 @@ func TestSysctls_1_29(t *testing.T) {
 			allowed: true,
 		},
 		{
+			name: "new supported sysctls: net.ipv4.tcp_fin_timeout, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_fin_timeout", Value: "60"}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			allowed: true,
+		},
+		{
 			name: "new supported sysctls: net.ipv4.tcp_keepalive_intvl",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				SecurityContext: &corev1.PodSecurityContext{
 					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_keepalive_intvl", Value: "75"}},
 				},
 			}},
+			allowed: true,
+		},
+		{
+			name: "new supported sysctls: net.ipv4.tcp_keepalive_intvl, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_keepalive_intvl", Value: "75"}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
 			allowed: true,
 		},
 		{
@@ -223,11 +432,24 @@ func TestSysctls_1_29(t *testing.T) {
 			}},
 			allowed: true,
 		},
+		{
+			name: "new supported sysctls: net.ipv4.tcp_keepalive_probes, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_keepalive_probes", Value: "9"}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			allowed: true,
+		},
 	}
 
+	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "Detail"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := sysctlsV1Dot29(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			result := sysctlsV1Dot29(&tc.pod.ObjectMeta, &tc.pod.Spec, tc.opts)
 			if !tc.allowed {
 				if result.Allowed {
 					t.Fatal("expected disallowed")
@@ -237,6 +459,11 @@ func TestSysctls_1_29(t *testing.T) {
 				}
 				if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
 					t.Errorf("expected\n%s\ngot\n%s", e, a)
+				}
+				if result.ErrList != nil {
+					if diff := cmp.Diff(tc.expectErrList, *result.ErrList, cmpOpts...); diff != "" {
+						t.Errorf("unexpected field errors (-want,+got):\n%s", diff)
+					}
 				}
 			} else if !result.Allowed {
 				t.Fatal("expected allowed")

--- a/staging/src/k8s.io/pod-security-admission/policy/check_windowsHostProcess.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_windowsHostProcess.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/pod-security-admission/api"
 )
 
@@ -50,20 +51,24 @@ func CheckWindowsHostProcess() Check {
 		Versions: []VersionedCheck{
 			{
 				MinimumVersion: api.MajorMinorVersion(1, 0),
-				CheckPod:       windowsHostProcess_1_0,
+				CheckPod:       withOptions(windowsHostProcessV1Dot0),
 			},
 		},
 	}
 }
 
-func windowsHostProcess_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
+func windowsHostProcessV1Dot0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec, opts options) CheckResult {
 	var badContainers []string
-	visitContainers(podSpec, func(container *corev1.Container) {
+	var errs field.ErrorList
+	visitContainers(podSpec, opts, func(container *corev1.Container, path *field.Path) {
 		if container.SecurityContext != nil &&
 			container.SecurityContext.WindowsOptions != nil &&
 			container.SecurityContext.WindowsOptions.HostProcess != nil &&
 			*container.SecurityContext.WindowsOptions.HostProcess {
 			badContainers = append(badContainers, container.Name)
+			if opts.withFieldErrors {
+				errs = append(errs, withBadValue(forbidden(path.Child("securityContext", "windowsOptions", "hostProcess")), true))
+			}
 		}
 	})
 
@@ -76,25 +81,31 @@ func windowsHostProcess_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodS
 	}
 
 	// pod or containers explicitly set hostProcess=true
-	var forbiddenSetters []string
+	forbiddenSetters := NewViolations(opts.withFieldErrors)
 	if podSpecForbidden {
-		forbiddenSetters = append(forbiddenSetters, "pod")
+		if opts.withFieldErrors {
+			forbiddenSetters.Add("pod", withBadValue(forbidden(hostProcessPath), true))
+		} else {
+			forbiddenSetters.Add("pod")
+		}
+
 	}
 	if len(badContainers) > 0 {
-		forbiddenSetters = append(
-			forbiddenSetters,
+		forbiddenSetters.Add(
 			fmt.Sprintf(
 				"%s %s",
 				pluralize("container", "containers", len(badContainers)),
 				joinQuote(badContainers),
 			),
+			errs...,
 		)
 	}
-	if len(forbiddenSetters) > 0 {
+	if !forbiddenSetters.Empty() {
 		return CheckResult{
 			Allowed:         false,
 			ForbiddenReason: "hostProcess",
-			ForbiddenDetail: fmt.Sprintf("%s must not set securityContext.windowsOptions.hostProcess=true", strings.Join(forbiddenSetters, " and ")),
+			ForbiddenDetail: fmt.Sprintf("%s must not set securityContext.windowsOptions.hostProcess=true", strings.Join(forbiddenSetters.Data(), " and ")),
+			ErrList:         forbiddenSetters.Errs(),
 		}
 	}
 

--- a/staging/src/k8s.io/pod-security-admission/policy/check_windowsHostProcess_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_windowsHostProcess_test.go
@@ -20,15 +20,21 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilpointer "k8s.io/utils/pointer"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestWindowsHostProcess(t *testing.T) {
 	tests := []struct {
-		name         string
-		pod          *corev1.Pod
-		expectReason string
-		expectDetail string
+		name          string
+		pod           *corev1.Pod
+		opts          options
+		expectReason  string
+		expectDetail  string
+		expectErrList field.ErrorList
 	}{
 		{
 			name: "host process",
@@ -48,11 +54,38 @@ func TestWindowsHostProcess(t *testing.T) {
 			expectReason: `hostProcess`,
 			expectDetail: `pod and containers "e", "f" must not set securityContext.windowsOptions.hostProcess=true`,
 		},
+		{
+			name: "host process, enable field error list",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: utilpointer.Bool(true)},
+				},
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: nil},
+					{Name: "b", SecurityContext: &corev1.SecurityContext{}},
+					{Name: "c", SecurityContext: &corev1.SecurityContext{WindowsOptions: &corev1.WindowsSecurityContextOptions{}}},
+					{Name: "d", SecurityContext: &corev1.SecurityContext{WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: utilpointer.Bool(false)}}},
+					{Name: "e", SecurityContext: &corev1.SecurityContext{WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: utilpointer.Bool(true)}}},
+					{Name: "f", SecurityContext: &corev1.SecurityContext{WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: utilpointer.Bool(true)}}},
+				},
+			}},
+			opts: options{
+				withFieldErrors: true,
+			},
+			expectReason: `hostProcess`,
+			expectDetail: `pod and containers "e", "f" must not set securityContext.windowsOptions.hostProcess=true`,
+			expectErrList: field.ErrorList{
+				{Type: field.ErrorTypeForbidden, Field: "spec.securityContext.windowsOptions.hostProcess", BadValue: true},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[4].securityContext.windowsOptions.hostProcess", BadValue: true},
+				{Type: field.ErrorTypeForbidden, Field: "spec.containers[5].securityContext.windowsOptions.hostProcess", BadValue: true},
+			},
+		},
 	}
 
+	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "Detail"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := windowsHostProcess_1_0(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			result := windowsHostProcessV1Dot0(&tc.pod.ObjectMeta, &tc.pod.Spec, tc.opts)
 			if result.Allowed {
 				t.Fatal("expected disallowed")
 			}
@@ -61,6 +94,11 @@ func TestWindowsHostProcess(t *testing.T) {
 			}
 			if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
 				t.Errorf("expected\n%s\ngot\n%s", e, a)
+			}
+			if result.ErrList != nil {
+				if diff := cmp.Diff(tc.expectErrList, *result.ErrList, cmpOpts...); diff != "" {
+					t.Errorf("unexpected field errors (-want,+got):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/staging/src/k8s.io/pod-security-admission/policy/options.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/options.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type options struct {
+	withFieldErrors bool
+}
+
+type Option func(options) options
+
+func withOptions(f func(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec, opts options) CheckResult) CheckPodFn {
+	return func(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec, opts ...Option) CheckResult {
+		var opt options
+		for _, o := range opts {
+			if o != nil {
+				opt = o(opt)
+			}
+		}
+		return f(podMetadata, podSpec, opt)
+	}
+}
+
+func WithFieldErrors() Option {
+	return func(opt options) options {
+		opt.withFieldErrors = true
+		return opt
+	}
+}

--- a/staging/src/k8s.io/pod-security-admission/policy/paths.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/paths.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import "k8s.io/apimachinery/pkg/util/validation/field"
+
+var (
+	annotationsPath            = field.NewPath("metadata", "annotations")
+	specPath                   = field.NewPath("spec")
+	initContainersFldPath      = specPath.Child("initContainers")
+	containersFldPath          = specPath.Child("containers")
+	ephemeralContainersFldPath = specPath.Child("ephemeralContainers")
+	securityContextPath        = specPath.Child("securityContext")
+	hostNetworkPath            = specPath.Child("hostNetwork")
+	hostPIDPath                = specPath.Child("hostPID")
+	hostIPCPath                = specPath.Child("hostIPC")
+	volumesPath                = specPath.Child("volumes")
+	runAsNonRootPath           = securityContextPath.Child("runAsNonRoot")
+	runAsUserPath              = securityContextPath.Child("runAsUser")
+	seccompProfileTypePath     = securityContextPath.Child("seccompProfile", "type")
+	seLinuxOptionsTypePath     = securityContextPath.Child("seLinuxOptions", "type")
+	seLinuxOptionsUserPath     = securityContextPath.Child("seLinuxOptions", "user")
+	seLinuxOptionsRolePath     = securityContextPath.Child("seLinuxOptions", "role")
+	sysctlsPath                = securityContextPath.Child("sysctls")
+	hostProcessPath            = securityContextPath.Child("windowsOptions", "hostProcess")
+	appArmorProfileTypePath    = securityContextPath.Child("appArmorProfile", "type")
+)

--- a/staging/src/k8s.io/pod-security-admission/policy/registry_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/registry_test.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/pod-security-admission/api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckRegistry(t *testing.T) {
@@ -169,7 +170,7 @@ func generateCheck(id CheckID, level api.Level, versions []string) Check {
 		v := versionOrPanic(ver) // Copy ver so it can be used in the CheckPod closure.
 		c.Versions = append(c.Versions, VersionedCheck{
 			MinimumVersion: v,
-			CheckPod: func(_ *metav1.ObjectMeta, _ *corev1.PodSpec) CheckResult {
+			CheckPod: func(_ *metav1.ObjectMeta, _ *corev1.PodSpec, _ ...Option) CheckResult {
 				return CheckResult{
 					ForbiddenReason: fmt.Sprintf("%s:%s", id, v),
 				}

--- a/staging/src/k8s.io/pod-security-admission/policy/violations.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/violations.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+type ErrFn func() *field.Error
+
+type Violations struct {
+	data            []string
+	errs            *field.ErrorList
+	withFieldErrors bool
+}
+
+func NewViolations(withFieldErrors bool) Violations {
+	violations := Violations{
+		withFieldErrors: withFieldErrors,
+	}
+	if withFieldErrors {
+		violations.errs = &field.ErrorList{}
+	}
+	return violations
+}
+
+func (v *Violations) Add(data string, errs ...*field.Error) {
+	v.data = append(v.data, data)
+	if v.withFieldErrors {
+		for _, err := range errs {
+			if err != nil {
+				*v.errs = append(*v.errs, err)
+			}
+		}
+	}
+}
+
+func (v *Violations) Empty() bool {
+	return len(v.data) == 0
+}
+
+func (v *Violations) Data() []string {
+	return v.data
+}
+
+func (v *Violations) Len() int {
+	return len(v.data)
+}
+
+func (v *Violations) Errs() *field.ErrorList {
+	return v.errs
+}
+
+func withBadValue(err *field.Error, badValue interface{}) *field.Error {
+	if err == nil {
+		return nil
+	}
+	err.BadValue = badValue
+	return err
+}
+
+func forbidden(path *field.Path) *field.Error {
+	if path == nil {
+		return nil
+	}
+	return field.Forbidden(path, "")
+}
+
+func required(path *field.Path) *field.Error {
+	if path == nil {
+		return nil
+	}
+	return field.Required(path, "")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
I am the mentee of the LFX mentorship - [Kyverno: Pod Security Admission Integrations](https://mentorship.lfx.linuxfoundation.org/project/59afc794-c33e-4930-a5b8-eb3abd8d9896). In this LFX mentorship program, we want to enable fine-grained policy control, which requires detailed information returned from the upstream Pod Security library, as described in this [issue](https://github.com/kubernetes/kubernetes/issues/111958).

We think that adding this additional field would be very helpful for external tools to adapt Pod Security, and we would love to hear your thoughts and comments on this. If this makes sense, we are more than happier to take actions and contribute to Kubernetes!

We are willing to participate in community meeting to discuss more details about it, does weekly issues/PR Triage meeting work?

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #111958 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
