### PR TITLE
skip clear quota if FSQuotaMonitoring is disabled

### DIFF
--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -519,10 +519,12 @@ func (ed *emptyDir) TearDownAt(dir string) error {
 }
 
 func (ed *emptyDir) teardownDefault(dir string) error {
-	// Remove any quota
-	err := fsquota.ClearQuota(ed.mounter, dir)
-	if err != nil {
-		klog.Warningf("Warning: Failed to clear quota on %s: %v", dir, err)
+	if utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolationFSQuotaMonitoring) {
+		// Remove any quota
+		err := fsquota.ClearQuota(ed.mounter, dir)
+		if err != nil {
+			klog.Warningf("Warning: Failed to clear quota on %s: %v", dir, err)
+		}
 	}
 	// Renaming the directory is not required anymore because the operation executor
 	// now handles duplicate operations on the same volume


### PR DESCRIPTION
/kind cleanup
```release-note
None
```
When I look into the log of kubelet in https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial-containerd/1643048154523766784 (one job in https://testgrid.k8s.io/sig-node-release-blocking#node-kubelet-serial-containerd), there are a lot of log saying that 

> I0403 12:45:53.883081    2312 quota_linux.go:413] ClearQuota /var/lib/kubelet/pods/c7c8a0e5-bc37-4b15-9e53-679fb1299f35/volumes/kubernetes.io\~empty-dir/test-volume
> W0403 12:45:53.883094    2312 empty_dir.go:525] Warning: Failed to clear quota on /var/lib/kubelet/pods/c7c8a0e5-bc37-4b15-9e53-679fb1299f35/volumes/kubernetes.io~empty-dir/test-volume: clearQuota called, but quotas disabled

But in this test, the LocalStorageCapacityIsolationFSQuotaMonitoring is disabled and this log does not make sense here.

/cc @jsafrane  @alex-matei 

Specifically, the warning log can interfere with the kubelet log when attempting to debug actual issues.

