### PR TITLE
Add continue for shortcut

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -4072,6 +4072,7 @@ func validateTopologySelectorLabelRequirement(rq core.TopologySelectorLabelRequi
 	for i, value := range rq.Values {
 		if valueSet.Has(value) {
 			allErrs = append(allErrs, field.Duplicate(valuesPath.Index(i), value))
+			continue
 		}
 		valueSet.Insert(value)
 	}
@@ -5465,6 +5466,7 @@ func ValidateNode(node *core.Node) field.ErrorList {
 			for i, value := range node.Spec.PodCIDRs {
 				if seen.Has(value) {
 					allErrs = append(allErrs, field.Duplicate(podCIDRsField.Index(i), value))
+					continue
 				}
 				seen.Insert(value)
 			}
@@ -7068,6 +7070,7 @@ func ValidateServiceClusterIPsRelatedFields(service *core.Service) field.ErrorLi
 		// no duplicate check also ensures that ipfamilies is dualstacked, in any order
 		if seen.Has(string(ipFamily)) {
 			allErrs = append(allErrs, field.Duplicate(ipFamiliesField.Index(i), ipFamily))
+			continue
 		}
 		seen.Insert(string(ipFamily))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add continue for shortcut
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #117068

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
