### PR TITLE
Fixed broken link

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4867,7 +4867,7 @@ type ServicePort struct {
 	// The application protocol for this port.
 	// This field follows standard Kubernetes label syntax.
 	// Un-prefixed names are reserved for IANA standard service names (as per
-	// RFC-6335 and https://www.iana.org/assignments/service-names).
+	// RFC-6335 and https://www.iana.org/assignments/service-names ).
 	// Non-standard protocols should use prefixed names such as
 	// mycompany.com/my-custom-protocol.
 	// +optional


### PR DESCRIPTION
This PR fixes the issue https://github.com/kubernetes/website/issues/40480
before the URL was included with a closed bracket `)` was showing page not found. added a space between the URL and the bracket 