### PR TITLE
Export WebhookHandler struct because some CCMs use Run directly

### DIFF
--- a/staging/src/k8s.io/cloud-provider/app/builder.go
+++ b/staging/src/k8s.io/cloud-provider/app/builder.go
@@ -137,7 +137,7 @@ func (cb *CommandBuilder) BuildCommand() *cobra.Command {
 			completedConfig := config.Complete()
 			cloud := cb.cloudInitializer(completedConfig)
 			controllerInitializers := ConstructControllerInitializers(cb.controllerInitFuncConstructors, completedConfig, cloud)
-			webhooks := newWebhookHandlers(cb.webhookConfigs, completedConfig, cloud)
+			webhooks := NewWebhookHandlers(cb.webhookConfigs, completedConfig, cloud)
 
 			if err := Run(completedConfig, cloud, controllerInitializers, webhooks, cb.stopCh); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/staging/src/k8s.io/cloud-provider/app/controllermanager.go
+++ b/staging/src/k8s.io/cloud-provider/app/controllermanager.go
@@ -106,7 +106,7 @@ the cloud specific control loops shipped with Kubernetes.`,
 			cloud := cloudInitializer(completedConfig)
 			controllerInitializers := ConstructControllerInitializers(controllerInitFuncConstructors, completedConfig, cloud)
 
-			if err := Run(completedConfig, cloud, controllerInitializers, make(map[string]webhookHandler), stopCh); err != nil {
+			if err := Run(completedConfig, cloud, controllerInitializers, make(map[string]WebhookHandler), stopCh); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				return err
 			}
@@ -161,7 +161,7 @@ the cloud specific control loops shipped with Kubernetes.`,
 }
 
 // Run runs the ExternalCMServer.  This should never exit.
-func Run(c *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface, controllerInitializers map[string]InitFunc, webhooks map[string]webhookHandler,
+func Run(c *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface, controllerInitializers map[string]InitFunc, webhooks map[string]WebhookHandler,
 	stopCh <-chan struct{}) error {
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v", version.Get())

--- a/staging/src/k8s.io/cloud-provider/app/webhooks_test.go
+++ b/staging/src/k8s.io/cloud-provider/app/webhooks_test.go
@@ -38,7 +38,7 @@ func TestWebhookEnableDisable(t *testing.T) {
 		desc            string
 		webhookConfigs  map[string]WebhookConfig
 		completedConfig *config.CompletedConfig
-		expected        map[string]webhookHandler
+		expected        map[string]WebhookHandler
 	}{
 		{
 			"Webhooks Enabled",
@@ -47,9 +47,9 @@ func TestWebhookEnableDisable(t *testing.T) {
 				"webhook-b": {Path: "/path/b", AdmissionHandler: noOpAdmissionHandler},
 			},
 			newConfig(cpconfig.WebhookConfiguration{Webhooks: []string{"webhook-a", "webhook-b"}}),
-			map[string]webhookHandler{
-				"webhook-a": {path: "/path/a", admissionHandler: noOpAdmissionHandler},
-				"webhook-b": {path: "/path/b", admissionHandler: noOpAdmissionHandler},
+			map[string]WebhookHandler{
+				"webhook-a": {Path: "/path/a", AdmissionHandler: noOpAdmissionHandler},
+				"webhook-b": {Path: "/path/b", AdmissionHandler: noOpAdmissionHandler},
 			},
 		},
 		{
@@ -59,8 +59,8 @@ func TestWebhookEnableDisable(t *testing.T) {
 				"webhook-b": {Path: "/path/b", AdmissionHandler: noOpAdmissionHandler},
 			},
 			newConfig(cpconfig.WebhookConfiguration{Webhooks: []string{"webhook-a"}}),
-			map[string]webhookHandler{
-				"webhook-a": {path: "/path/a", admissionHandler: noOpAdmissionHandler},
+			map[string]WebhookHandler{
+				"webhook-a": {Path: "/path/a", AdmissionHandler: noOpAdmissionHandler},
 			},
 		},
 		{
@@ -70,8 +70,8 @@ func TestWebhookEnableDisable(t *testing.T) {
 				"webhook-b": {Path: "/path/b", AdmissionHandler: noOpAdmissionHandler},
 			},
 			newConfig(cpconfig.WebhookConfiguration{Webhooks: []string{"webhook-a", "-webhook-b"}}),
-			map[string]webhookHandler{
-				"webhook-a": {path: "/path/a", admissionHandler: noOpAdmissionHandler},
+			map[string]WebhookHandler{
+				"webhook-a": {Path: "/path/a", AdmissionHandler: noOpAdmissionHandler},
 			},
 		},
 		{
@@ -81,7 +81,7 @@ func TestWebhookEnableDisable(t *testing.T) {
 				"webhook-b": {Path: "/path/b", AdmissionHandler: noOpAdmissionHandler},
 			},
 			newConfig(cpconfig.WebhookConfiguration{Webhooks: []string{"-webhook-b"}}),
-			map[string]webhookHandler{},
+			map[string]WebhookHandler{},
 		},
 		{
 			"Webhooks Enabled Glob",
@@ -90,15 +90,15 @@ func TestWebhookEnableDisable(t *testing.T) {
 				"webhook-b": {Path: "/path/b", AdmissionHandler: noOpAdmissionHandler},
 			},
 			newConfig(cpconfig.WebhookConfiguration{Webhooks: []string{"*"}}),
-			map[string]webhookHandler{
-				"webhook-a": {path: "/path/a", admissionHandler: noOpAdmissionHandler},
-				"webhook-b": {path: "/path/b", admissionHandler: noOpAdmissionHandler},
+			map[string]WebhookHandler{
+				"webhook-a": {Path: "/path/a", AdmissionHandler: noOpAdmissionHandler},
+				"webhook-b": {Path: "/path/b", AdmissionHandler: noOpAdmissionHandler},
 			},
 		},
 	}
 	for _, tc := range cases {
 		t.Logf("Running %q", tc.desc)
-		actual := newWebhookHandlers(tc.webhookConfigs, tc.completedConfig, cloud)
+		actual := NewWebhookHandlers(tc.webhookConfigs, tc.completedConfig, cloud)
 		if !webhookHandlersEqual(actual, tc.expected) {
 			t.Fatalf(
 				"FAILED: %q\n---\nActual:\n%s\nExpected:\n%s\ntc.webhookConfigs:\n%s\ntc.completedConfig:\n%s\n",
@@ -121,7 +121,7 @@ func newConfig(webhookConfig cpconfig.WebhookConfiguration) *config.CompletedCon
 	return cfg.Complete()
 }
 
-func webhookHandlersEqual(actual, expected map[string]webhookHandler) bool {
+func webhookHandlersEqual(actual, expected map[string]WebhookHandler) bool {
 	if len(actual) != len(expected) {
 		return false
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
This change allows cloud providers to use the webhook framework when they directly call `cloud-provider.app.Run()`.  Since all of the other parameters to Run are exported, so should WebhookHandler.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
