### PR TITLE
Move genericclioptions.IOStreams to genericiooptions.IOStreams

### DIFF
--- a/cmd/clicheck/check_cli_conventions.go
+++ b/cmd/clicheck/check_cli_conventions.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/kubectl/pkg/cmd"
 	cmdsanity "k8s.io/kubectl/pkg/cmd/util/sanity"
 )

--- a/cmd/clicheck/check_cli_conventions.go
+++ b/cmd/clicheck/check_cli_conventions.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"os"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/kubectl/pkg/cmd"
 	cmdsanity "k8s.io/kubectl/pkg/cmd/util/sanity"
 )
@@ -29,7 +28,7 @@ import (
 func main() {
 	var errorCount int
 
-	kubectl := cmd.NewKubectlCommand(cmd.KubectlOptions{IOStreams: genericclioptions.IOStreams{In: os.Stdin, Out: io.Discard, ErrOut: io.Discard}})
+	kubectl := cmd.NewKubectlCommand(cmd.KubectlOptions{IOStreams: genericiooptions.IOStreams{In: os.Stdin, Out: io.Discard, ErrOut: io.Discard}})
 	errors := cmdsanity.RunCmdChecks(kubectl, cmdsanity.AllCmdChecks, []string{})
 	for _, err := range errors {
 		errorCount++

--- a/cmd/gendocs/gen_kubectl_docs.go
+++ b/cmd/gendocs/gen_kubectl_docs.go
@@ -23,7 +23,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra/doc"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/kubectl/pkg/cmd"
 	"k8s.io/kubernetes/cmd/genutils"
 )
@@ -47,6 +46,6 @@ func main() {
 	// Set environment variables used by kubectl so the output is consistent,
 	// regardless of where we run.
 	os.Setenv("HOME", "/home/username")
-	kubectl := cmd.NewKubectlCommand(cmd.KubectlOptions{IOStreams: genericclioptions.IOStreams{In: bytes.NewReader(nil), Out: io.Discard, ErrOut: io.Discard}})
+	kubectl := cmd.NewKubectlCommand(cmd.KubectlOptions{IOStreams: genericiooptions.IOStreams{In: bytes.NewReader(nil), Out: io.Discard, ErrOut: io.Discard}})
 	doc.GenMarkdownTree(kubectl, outDir)
 }

--- a/cmd/gendocs/gen_kubectl_docs.go
+++ b/cmd/gendocs/gen_kubectl_docs.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra/doc"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/kubectl/pkg/cmd"
 	"k8s.io/kubernetes/cmd/genutils"
 )

--- a/cmd/genman/gen_kube_man.go
+++ b/cmd/genman/gen_kube_man.go
@@ -26,7 +26,7 @@ import (
 	mangen "github.com/cpuguy83/go-md2man/v2/md2man"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	kubectlcmd "k8s.io/kubectl/pkg/cmd"
 	"k8s.io/kubernetes/cmd/genutils"
 	apiservapp "k8s.io/kubernetes/cmd/kube-apiserver/app"
@@ -97,7 +97,7 @@ func main() {
 		}
 	case "kubectl":
 		// generate manpage for kubectl
-		kubectl := kubectlcmd.NewKubectlCommand(kubectlcmd.KubectlOptions{IOStreams: genericclioptions.IOStreams{In: bytes.NewReader(nil), Out: io.Discard, ErrOut: io.Discard}})
+		kubectl := kubectlcmd.NewKubectlCommand(kubectlcmd.KubectlOptions{IOStreams: genericiooptions.IOStreams{In: bytes.NewReader(nil), Out: io.Discard, ErrOut: io.Discard}})
 		genMarkdown(kubectl, "", outDir)
 		for _, c := range kubectl.Commands() {
 			genMarkdown(c, "kubectl", outDir)

--- a/cmd/genyaml/gen_kubectl_yaml.go
+++ b/cmd/genyaml/gen_kubectl_yaml.go
@@ -26,7 +26,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/kubectl/pkg/cmd"
 	"k8s.io/kubernetes/cmd/genutils"
 )
@@ -66,7 +65,7 @@ func main() {
 	// Set environment variables used by kubectl so the output is consistent,
 	// regardless of where we run.
 	os.Setenv("HOME", "/home/username")
-	kubectl := cmd.NewKubectlCommand(cmd.KubectlOptions{IOStreams: genericclioptions.IOStreams{In: bytes.NewReader(nil), Out: io.Discard, ErrOut: io.Discard}})
+	kubectl := cmd.NewKubectlCommand(cmd.KubectlOptions{IOStreams: genericiooptions.IOStreams{In: bytes.NewReader(nil), Out: io.Discard, ErrOut: io.Discard}})
 	genYaml(kubectl, "", outDir)
 	for _, c := range kubectl.Commands() {
 		genYaml(c, "kubectl", outDir)

--- a/cmd/genyaml/gen_kubectl_yaml.go
+++ b/cmd/genyaml/gen_kubectl_yaml.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/kubectl/pkg/cmd"
 	"k8s.io/kubernetes/cmd/genutils"
 )

--- a/cmd/kubectl-convert/kubectl-convert.go
+++ b/cmd/kubectl-convert/kubectl-convert.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/component-base/cli"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/convert"

--- a/cmd/kubectl-convert/kubectl-convert.go
+++ b/cmd/kubectl-convert/kubectl-convert.go
@@ -36,7 +36,7 @@ func main() {
 	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
 
 	f := cmdutil.NewFactory(matchVersionKubeConfigFlags)
-	cmd := convert.NewCmdConvert(f, genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	cmd := convert.NewCmdConvert(f, genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 	matchVersionKubeConfigFlags.AddFlags(cmd.PersistentFlags())
 	code := cli.Run(cmd)
 	os.Exit(code)

--- a/pkg/kubectl/cmd/convert/convert.go
+++ b/pkg/kubectl/cmd/convert/convert.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"

--- a/pkg/kubectl/cmd/convert/convert.go
+++ b/pkg/kubectl/cmd/convert/convert.go
@@ -73,10 +73,10 @@ type ConvertOptions struct {
 	validator func() (validation.Schema, error)
 
 	resource.FilenameOptions
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
-func NewConvertOptions(ioStreams genericclioptions.IOStreams) *ConvertOptions {
+func NewConvertOptions(ioStreams genericiooptions.IOStreams) *ConvertOptions {
 	return &ConvertOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("converted").WithTypeSetter(scheme.Scheme).WithDefaultOutput("yaml"),
 		local:      true,
@@ -86,7 +86,7 @@ func NewConvertOptions(ioStreams genericclioptions.IOStreams) *ConvertOptions {
 
 // NewCmdConvert creates a command object for the generic "convert" action, which
 // translates the config file into a given version.
-func NewCmdConvert(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdConvert(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewConvertOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/pkg/kubectl/cmd/convert/convert_test.go
+++ b/pkg/kubectl/cmd/convert/convert_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 )
@@ -116,7 +115,7 @@ func TestConvertObject(t *testing.T) {
 				}
 
 				buf := bytes.NewBuffer([]byte{})
-				cmd := NewCmdConvert(tf, genericclioptions.IOStreams{Out: buf, ErrOut: buf})
+				cmd := NewCmdConvert(tf, genericiooptions.IOStreams{Out: buf, ErrOut: buf})
 				cmd.Flags().Set("filename", tc.file)
 				cmd.Flags().Set("output-version", tc.outputVersion)
 				cmd.Flags().Set("local", "true")

--- a/pkg/kubectl/cmd/convert/convert_test.go
+++ b/pkg/kubectl/cmd/convert/convert_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 )

--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -26,6 +26,7 @@
   - k8s.io/client-go
   # TODO this one should be tightened.  We depend on it for testing, but we should instead create our own scheme
   - k8s.io/api/core/v1
+  - k8s.io/cli-runtime/pkg/genericiooptions
   - k8s.io/cli-runtime/pkg/printers
   - k8s.io/cli-runtime/pkg/resource
   - k8s.io/cli-runtime/pkg/kustomize

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/io_options.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/io_options.go
@@ -18,30 +18,19 @@ package genericclioptions
 
 import (
 	"bytes"
-	"io"
 	"io/ioutil"
-)
 
-// IOStreams provides the standard names for iostreams.  This is useful for embedding and for unit testing.
-// Inconsistent and different names make it hard to read and review code
-// DEPRECATED: use genericiooptions.IOSTREAMS
-type IOStreams struct {
-	// In think, os.Stdin
-	In io.Reader
-	// Out think, os.Stdout
-	Out io.Writer
-	// ErrOut think, os.Stderr
-	ErrOut io.Writer
-}
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+)
 
 // NewTestIOStreams returns a valid IOStreams and in, out, errout buffers for unit tests
 // DEPRECATED: use genericiooptions.NewTestIOStreams
-func NewTestIOStreams() (IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
+func NewTestIOStreams() (genericiooptions.IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
 	in := &bytes.Buffer{}
 	out := &bytes.Buffer{}
 	errOut := &bytes.Buffer{}
 
-	return IOStreams{
+	return genericiooptions.IOStreams{
 		In:     in,
 		Out:    out,
 		ErrOut: errOut,
@@ -50,9 +39,9 @@ func NewTestIOStreams() (IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer)
 
 // NewTestIOStreamsDiscard returns a valid IOStreams that just discards
 // DEPRECATED: use genericiooptions.NewTestIOStreamsDiscard
-func NewTestIOStreamsDiscard() IOStreams {
+func NewTestIOStreamsDiscard() genericiooptions.IOStreams {
 	in := &bytes.Buffer{}
-	return IOStreams{
+	return genericiooptions.IOStreams{
 		In:     in,
 		Out:    ioutil.Discard,
 		ErrOut: ioutil.Discard,

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/io_options.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/io_options.go
@@ -23,6 +23,11 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
+// IOStreams provides the standard names for iostreams.  This is useful for embedding and for unit testing.
+// Inconsistent and different names make it hard to read and review code
+// DEPRECATED: use genericiooptions.IOStreams
+type IOStreams = genericiooptions.IOStreams
+
 // NewTestIOStreams returns a valid IOStreams and in, out, errout buffers for unit tests
 // DEPRECATED: use genericiooptions.NewTestIOStreams
 func NewTestIOStreams() (genericiooptions.IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
@@ -30,7 +35,7 @@ func NewTestIOStreams() (genericiooptions.IOStreams, *bytes.Buffer, *bytes.Buffe
 	out := &bytes.Buffer{}
 	errOut := &bytes.Buffer{}
 
-	return genericiooptions.IOStreams{
+	return IOStreams{
 		In:     in,
 		Out:    out,
 		ErrOut: errOut,
@@ -41,7 +46,7 @@ func NewTestIOStreams() (genericiooptions.IOStreams, *bytes.Buffer, *bytes.Buffe
 // DEPRECATED: use genericiooptions.NewTestIOStreamsDiscard
 func NewTestIOStreamsDiscard() genericiooptions.IOStreams {
 	in := &bytes.Buffer{}
-	return genericiooptions.IOStreams{
+	return IOStreams{
 		In:     in,
 		Out:    ioutil.Discard,
 		ErrOut: ioutil.Discard,

--- a/staging/src/k8s.io/cli-runtime/pkg/genericiooptions/io_options.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericiooptions/io_options.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/cli-runtime/pkg/genericiooptions/io_options.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericiooptions/io_options.go
@@ -14,17 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package genericclioptions
+package genericiooptions
 
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 )
 
 // IOStreams provides the standard names for iostreams.  This is useful for embedding and for unit testing.
 // Inconsistent and different names make it hard to read and review code
-// DEPRECATED: use genericiooptions.IOSTREAMS
 type IOStreams struct {
 	// In think, os.Stdin
 	In io.Reader
@@ -35,7 +33,6 @@ type IOStreams struct {
 }
 
 // NewTestIOStreams returns a valid IOStreams and in, out, errout buffers for unit tests
-// DEPRECATED: use genericiooptions.NewTestIOStreams
 func NewTestIOStreams() (IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
 	in := &bytes.Buffer{}
 	out := &bytes.Buffer{}
@@ -49,12 +46,11 @@ func NewTestIOStreams() (IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer)
 }
 
 // NewTestIOStreamsDiscard returns a valid IOStreams that just discards
-// DEPRECATED: use genericiooptions.NewTestIOStreamsDiscard
 func NewTestIOStreamsDiscard() IOStreams {
 	in := &bytes.Buffer{}
 	return IOStreams{
 		In:     in,
-		Out:    ioutil.Discard,
-		ErrOut: ioutil.Discard,
+		Out:    io.Discard,
+		ErrOut: io.Discard,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/alpha.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/alpha.go
@@ -19,14 +19,15 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
 // NewCmdAlpha creates a command that acts as an alternate root command for features in alpha
-func NewCmdAlpha(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdAlpha(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "alpha",
 		Short: i18n.T("Commands for features in alpha"),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -63,11 +64,11 @@ type AnnotateFlags struct {
 	resourceVersion string
 	Selector        string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewAnnotateFlags returns a default AnnotateFlags
-func NewAnnotateFlags(streams genericclioptions.IOStreams) *AnnotateFlags {
+func NewAnnotateFlags(streams genericiooptions.IOStreams) *AnnotateFlags {
 	return &AnnotateFlags{
 		PrintFlags:  genericclioptions.NewPrintFlags("annotate").WithTypeSetter(scheme.Scheme),
 		RecordFlags: genericclioptions.NewRecordFlags(),
@@ -88,7 +89,7 @@ type AnnotateOptions struct {
 	fieldManager     string
 	resource.FilenameOptions
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 
 	list           bool
 	local          bool
@@ -143,7 +144,7 @@ var (
 )
 
 // NewCmdAnnotate creates the `annotate` command
-func NewCmdAnnotate(parent string, f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdAnnotate(parent string, f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	flags := NewAnnotateFlags(streams)
 
 	cmd := &cobra.Command{
@@ -166,7 +167,7 @@ func NewCmdAnnotate(parent string, f cmdutil.Factory, streams genericclioptions.
 }
 
 // AddFlags registers flags for a cli.
-func (flags *AnnotateFlags) AddFlags(cmd *cobra.Command, ioStreams genericclioptions.IOStreams) {
+func (flags *AnnotateFlags) AddFlags(cmd *cobra.Command, ioStreams genericiooptions.IOStreams) {
 	flags.PrintFlags.AddFlags(cmd)
 	flags.RecordFlags.AddFlags(cmd)
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -440,7 +440,7 @@ func TestAnnotateErrors(t *testing.T) {
 
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			iostreams, _, bufOut, bufErr := genericclioptions.NewTestIOStreams()
+			iostreams, _, bufOut, bufErr := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdAnnotate("kubectl", tf, iostreams)
 			cmd.SetOut(bufOut)
 			cmd.SetErr(bufOut)
@@ -498,7 +498,7 @@ func TestAnnotateObject(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
+	iostreams, _, bufOut, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
 	cmd.SetOut(bufOut)
 	cmd.SetErr(bufOut)
@@ -564,7 +564,7 @@ func TestAnnotateResourceVersion(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
+	iostreams, _, bufOut, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
 	cmd.SetOut(bufOut)
 	cmd.SetErr(bufOut)
@@ -619,7 +619,7 @@ func TestAnnotateObjectFromFile(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
+	iostreams, _, bufOut, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
 	cmd.SetOut(bufOut)
 	cmd.SetErr(bufOut)
@@ -651,7 +651,7 @@ func TestAnnotateLocal(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	iostreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	iostreams, _, _, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
 	flags := NewAnnotateFlags(iostreams)
 	flags.Local = true
@@ -707,7 +707,7 @@ func TestAnnotateMultipleObjects(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	iostreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	iostreams, _, _, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdAnnotate("kubectl", tf, iostreams)
 	cmd.SetOut(iostreams.Out)
 	cmd.SetErr(iostreams.Out)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/discovery"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -74,7 +75,7 @@ type APIResourceOptions struct {
 
 	discoveryClient discovery.CachedDiscoveryInterface
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // groupResource contains the APIGroup and APIResource
@@ -85,7 +86,7 @@ type groupResource struct {
 }
 
 // NewAPIResourceOptions creates the options for APIResource
-func NewAPIResourceOptions(ioStreams genericclioptions.IOStreams) *APIResourceOptions {
+func NewAPIResourceOptions(ioStreams genericiooptions.IOStreams) *APIResourceOptions {
 	return &APIResourceOptions{
 		IOStreams:  ioStreams,
 		Namespaced: true,
@@ -93,7 +94,7 @@ func NewAPIResourceOptions(ioStreams genericclioptions.IOStreams) *APIResourceOp
 }
 
 // NewCmdAPIResources creates the `api-resources` command
-func NewCmdAPIResources(restClientGetter genericclioptions.RESTClientGetter, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdAPIResources(restClientGetter genericclioptions.RESTClientGetter, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewAPIResourceOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources_test.go
@@ -22,17 +22,17 @@ import (
 	"github.com/spf13/cobra"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 )
 
 func TestAPIResourcesComplete(t *testing.T) {
 	tf := cmdtesting.NewTestFactory()
 	defer tf.Cleanup()
-	cmd := NewCmdAPIResources(tf, genericclioptions.NewTestIOStreamsDiscard())
+	cmd := NewCmdAPIResources(tf, genericiooptions.NewTestIOStreamsDiscard())
 	parentCmd := &cobra.Command{Use: "kubectl"}
 	parentCmd.AddCommand(cmd)
-	o := NewAPIResourceOptions(genericclioptions.NewTestIOStreamsDiscard())
+	o := NewAPIResourceOptions(genericiooptions.NewTestIOStreamsDiscard())
 
 	err := o.Complete(tf, cmd, []string{})
 	if err != nil {
@@ -79,7 +79,7 @@ func TestAPIResourcesValidate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(tt *testing.T) {
-			o := NewAPIResourceOptions(genericclioptions.NewTestIOStreamsDiscard())
+			o := NewAPIResourceOptions(genericiooptions.NewTestIOStreamsDiscard())
 			tc.optionSetupFn(o)
 			err := o.Validate()
 			if tc.expectedError == "" {
@@ -305,7 +305,7 @@ bazzes   b            somegroup/v1   true         Baz
 	for _, tc := range testCases {
 		t.Run(tc.name, func(tt *testing.T) {
 			dc.Invalidations = 0
-			ioStreams, _, out, errOut := genericclioptions.NewTestIOStreams()
+			ioStreams, _, out, errOut := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdAPIResources(tf, ioStreams)
 			tc.commandSetupFn(cmd)
 			cmd.Run(cmd, []string{})

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiversions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiversions.go
@@ -24,6 +24,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/discovery"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -40,18 +41,18 @@ var (
 type APIVersionsOptions struct {
 	discoveryClient discovery.CachedDiscoveryInterface
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewAPIVersionsOptions creates the options for APIVersions
-func NewAPIVersionsOptions(ioStreams genericclioptions.IOStreams) *APIVersionsOptions {
+func NewAPIVersionsOptions(ioStreams genericiooptions.IOStreams) *APIVersionsOptions {
 	return &APIVersionsOptions{
 		IOStreams: ioStreams,
 	}
 }
 
 // NewCmdAPIVersions creates the `api-versions` command
-func NewCmdAPIVersions(restClientGetter genericclioptions.RESTClientGetter, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdAPIVersions(restClientGetter genericclioptions.RESTClientGetter, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewAPIVersionsOptions(ioStreams)
 	cmd := &cobra.Command{
 		Use:                   "api-versions",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiversions_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiversions_test.go
@@ -17,21 +17,22 @@ limitations under the License.
 package apiresources
 
 import (
-	"github.com/spf13/cobra"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 )
 
 func TestAPIVersionsComplete(t *testing.T) {
 	tf := cmdtesting.NewTestFactory()
 	defer tf.Cleanup()
-	cmd := NewCmdAPIVersions(tf, genericclioptions.NewTestIOStreamsDiscard())
+	cmd := NewCmdAPIVersions(tf, genericiooptions.NewTestIOStreamsDiscard())
 	parentCmd := &cobra.Command{Use: "kubectl"}
 	parentCmd.AddCommand(cmd)
-	o := NewAPIVersionsOptions(genericclioptions.NewTestIOStreamsDiscard())
+	o := NewAPIVersionsOptions(genericiooptions.NewTestIOStreamsDiscard())
 
 	err := o.Complete(tf, cmd, []string{})
 	if err != nil {
@@ -76,7 +77,7 @@ func TestAPIVersionsRun(t *testing.T) {
 	tf := cmdtesting.NewTestFactory().WithDiscoveryClient(dc)
 	defer tf.Cleanup()
 
-	ioStreams, _, out, errOut := genericclioptions.NewTestIOStreams()
+	ioStreams, _, out, errOut := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdAPIVersions(tf, ioStreams)
 	cmd.Run(cmd, []string{})
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -35,6 +35,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
@@ -75,7 +76,7 @@ type ApplyFlags struct {
 	PruneWhitelist []string // TODO: Remove this in kubectl 1.28 or later
 	PruneAllowlist []string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // ApplyOptions defines flags and other configuration parameters for the `apply` command
@@ -109,7 +110,7 @@ type ApplyOptions struct {
 	Namespace        string
 	EnforceNamespace bool
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 
 	// Objects (and some denormalized data) which are to be
 	// applied. The standard way to fill in this structure
@@ -179,7 +180,7 @@ var (
 var ApplySetToolVersion = version.Get().GitVersion
 
 // NewApplyFlags returns a default ApplyFlags
-func NewApplyFlags(streams genericclioptions.IOStreams) *ApplyFlags {
+func NewApplyFlags(streams genericiooptions.IOStreams) *ApplyFlags {
 	return &ApplyFlags{
 		RecordFlags: genericclioptions.NewRecordFlags(),
 		DeleteFlags: delete.NewDeleteFlags("The files that contain the configurations to apply."),
@@ -193,7 +194,7 @@ func NewApplyFlags(streams genericclioptions.IOStreams) *ApplyFlags {
 }
 
 // NewCmdApply creates the `apply` command
-func NewCmdApply(baseName string, f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdApply(baseName string, f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	flags := NewApplyFlags(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_edit_last_applied.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_edit_last_applied.go
@@ -19,7 +19,7 @@ package apply
 import (
 	"github.com/spf13/cobra"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/cmd/util/editor"
 	"k8s.io/kubectl/pkg/util/completion"
@@ -58,7 +58,7 @@ var (
 )
 
 // NewCmdApplyEditLastApplied created the cobra CLI command for the `apply edit-last-applied` command.
-func NewCmdApplyEditLastApplied(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdApplyEditLastApplied(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := editor.NewEditOptions(editor.ApplyEditMode, ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_set_last_applied.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_set_last_applied.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -56,7 +57,7 @@ type SetLastAppliedOptions struct {
 	builder                      *resource.Builder
 	unstructuredClientForMapping func(mapping *meta.RESTMapping) (resource.RESTClient, error)
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // PatchBuffer caches changes that are to be applied.
@@ -84,7 +85,7 @@ var (
 )
 
 // NewSetLastAppliedOptions takes option arguments from a CLI stream and returns it at SetLastAppliedOptions type.
-func NewSetLastAppliedOptions(ioStreams genericclioptions.IOStreams) *SetLastAppliedOptions {
+func NewSetLastAppliedOptions(ioStreams genericiooptions.IOStreams) *SetLastAppliedOptions {
 	return &SetLastAppliedOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("configured").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
@@ -92,7 +93,7 @@ func NewSetLastAppliedOptions(ioStreams genericclioptions.IOStreams) *SetLastApp
 }
 
 // NewCmdApplySetLastApplied creates the cobra CLI `apply` subcommand `set-last-applied`.`
-func NewCmdApplySetLastApplied(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdApplySetLastApplied(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewSetLastAppliedOptions(ioStreams)
 	cmd := &cobra.Command{
 		Use:                   "set-last-applied -f FILENAME",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	sptest "k8s.io/apimachinery/pkg/util/strategicpatch/testing"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	dynamicfakeclient "k8s.io/client-go/dynamic/fake"
 	restclient "k8s.io/client-go/rest"
@@ -90,7 +91,7 @@ func TestApplyExtraArgsFail(t *testing.T) {
 	defer f.Cleanup()
 
 	cmd := &cobra.Command{}
-	flags := NewApplyFlags(genericclioptions.NewTestIOStreamsDiscard())
+	flags := NewApplyFlags(genericiooptions.NewTestIOStreamsDiscard())
 	flags.AddFlags(cmd)
 	_, err := flags.ToOptions(f, cmd, "kubectl", []string{"rc"})
 	require.EqualError(t, err, "Unexpected args: [rc]\nSee ' -h' for help and examples")
@@ -105,13 +106,13 @@ func TestAlphaEnablement(t *testing.T) {
 		defer f.Cleanup()
 
 		cmd := &cobra.Command{}
-		flags := NewApplyFlags(genericclioptions.NewTestIOStreamsDiscard())
+		flags := NewApplyFlags(genericiooptions.NewTestIOStreamsDiscard())
 		flags.AddFlags(cmd)
 		require.Nil(t, cmd.Flags().Lookup(flag), "flag %q should not be registered without the %q feature enabled", flag, feature)
 
 		cmdtesting.WithAlphaEnvs([]cmdutil.FeatureGate{feature}, t, func(t *testing.T) {
 			cmd := &cobra.Command{}
-			flags := NewApplyFlags(genericclioptions.NewTestIOStreamsDiscard())
+			flags := NewApplyFlags(genericiooptions.NewTestIOStreamsDiscard())
 			flags.AddFlags(cmd)
 			require.NotNil(t, cmd.Flags().Lookup(flag), "flag %q should be registered with the %q feature enabled", flag, feature)
 		})
@@ -239,7 +240,7 @@ func TestApplyFlagValidation(t *testing.T) {
 			f.UnstructuredClient = f.Client
 			cmdtesting.WithAlphaEnvs(test.enableAlphas, t, func(t *testing.T) {
 				cmd := &cobra.Command{}
-				flags := NewApplyFlags(genericclioptions.NewTestIOStreamsDiscard())
+				flags := NewApplyFlags(genericiooptions.NewTestIOStreamsDiscard())
 				flags.AddFlags(cmd)
 				cmd.Flags().Set("filename", "unused")
 				for _, arg := range test.args {
@@ -498,7 +499,7 @@ func TestRunApplyPrintsValidObjectList(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdApply("kubectl", tf, ioStreams)
 	cmd.Flags().Set("filename", filenameCM)
 	cmd.Flags().Set("output", "json")
@@ -638,7 +639,7 @@ func TestRunApplyViewLastApplied(t *testing.T) {
 				}
 			})
 
-			ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdApplyViewLastApplied(tf, ioStreams)
 			if test.filePath != "" {
 				cmd.Flags().Set("filename", test.filePath)
@@ -684,7 +685,7 @@ func TestApplyObjectWithoutAnnotation(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdApply("kubectl", tf, ioStreams)
 	cmd.Flags().Set("filename", filenameRC)
 	cmd.Flags().Set("output", "name")
@@ -731,7 +732,7 @@ func TestApplyObject(t *testing.T) {
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdApply("kubectl", tf, ioStreams)
 			cmd.Flags().Set("filename", filenameRC)
 			cmd.Flags().Set("output", "name")
@@ -779,7 +780,7 @@ func TestApplyPruneObjects(t *testing.T) {
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdApply("kubectl", tf, ioStreams)
 			cmd.Flags().Set("filename", filenameRC)
 			cmd.Flags().Set("prune", "true")
@@ -1021,7 +1022,7 @@ func TestApplyPruneObjectsWithAllowlist(t *testing.T) {
 					}
 				}
 
-				ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+				ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 				cmd := NewCmdApply("kubectl", tf, ioStreams)
 				cmd.Flags().Set("filename", filenameRC)
 				cmd.Flags().Set("prune", "true")
@@ -1193,7 +1194,7 @@ func TestApplyCSAMigration(t *testing.T) {
 	tf.OpenAPISchemaFunc = FakeOpenAPISchema.OpenAPISchemaFn
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdApply("kubectl", tf, ioStreams)
 	cmd.Flags().Set("filename", filenameRC)
 	cmd.Flags().Set("output", "yaml")
@@ -1222,7 +1223,7 @@ func TestApplyCSAMigration(t *testing.T) {
 
 	// Apply the upgraded object.
 	// Expect only a single PATCH call to apiserver
-	ioStreams, _, _, errBuf = genericclioptions.NewTestIOStreams()
+	ioStreams, _, _, errBuf = genericiooptions.NewTestIOStreams()
 	cmd = NewCmdApply("kubectl", tf, ioStreams)
 	cmd.Flags().Set("filename", filenameRC)
 	cmd.Flags().Set("output", "yaml")
@@ -1281,7 +1282,7 @@ func TestApplyObjectOutput(t *testing.T) {
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdApply("kubectl", tf, ioStreams)
 			cmd.Flags().Set("filename", filenameRC)
 			cmd.Flags().Set("output", "yaml")
@@ -1342,7 +1343,7 @@ func TestApplyRetry(t *testing.T) {
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdApply("kubectl", tf, ioStreams)
 			cmd.Flags().Set("filename", filenameRC)
 			cmd.Flags().Set("output", "name")
@@ -1391,7 +1392,7 @@ func TestApplyNonExistObject(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdApply("kubectl", tf, ioStreams)
 	cmd.Flags().Set("filename", filenameRC)
 	cmd.Flags().Set("output", "name")
@@ -1444,7 +1445,7 @@ func TestApplyEmptyPatch(t *testing.T) {
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
 	// 1. apply non exist object
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdApply("kubectl", tf, ioStreams)
 	cmd.Flags().Set("filename", filenameRC)
 	cmd.Flags().Set("output", "name")
@@ -1459,7 +1460,7 @@ func TestApplyEmptyPatch(t *testing.T) {
 	}
 
 	// 2. test apply already exist object, will not send empty patch request
-	ioStreams, _, buf, _ = genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ = genericiooptions.NewTestIOStreams()
 	cmd = NewCmdApply("kubectl", tf, ioStreams)
 	cmd.Flags().Set("filename", filenameRC)
 	cmd.Flags().Set("output", "name")
@@ -1517,7 +1518,7 @@ func testApplyMultipleObjects(t *testing.T, asList bool) {
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdApply("kubectl", tf, ioStreams)
 			if asList {
 				cmd.Flags().Set("filename", filenameRCSVC)
@@ -1612,7 +1613,7 @@ func TestApplyNULLPreservation(t *testing.T) {
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdApply("kubectl", tf, ioStreams)
 			cmd.Flags().Set("filename", filenameDeployObjClientside)
 			cmd.Flags().Set("output", "name")
@@ -1674,7 +1675,7 @@ func TestUnstructuredApply(t *testing.T) {
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdApply("kubectl", tf, ioStreams)
 			cmd.Flags().Set("filename", filenameWidgetClientside)
 			cmd.Flags().Set("output", "name")
@@ -1738,7 +1739,7 @@ func TestUnstructuredIdempotentApply(t *testing.T) {
 			tf.OpenAPISchemaFunc = testingOpenAPISchema.OpenAPISchemaFn
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdApply("kubectl", tf, ioStreams)
 			cmd.Flags().Set("filename", filenameWidgetClientside)
 			cmd.Flags().Set("output", "name")
@@ -1843,7 +1844,7 @@ func TestRunApplySetLastApplied(t *testing.T) {
 				}
 			})
 
-			ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdApplySetLastApplied(tf, ioStreams)
 			cmd.Flags().Set("filename", test.filePath)
 			cmd.Flags().Set("output", test.output)
@@ -1981,7 +1982,7 @@ func TestForceApply(t *testing.T) {
 			tf.Client = tf.UnstructuredClient
 			tf.ClientConfigVal = &restclient.Config{}
 
-			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdApply("kubectl", tf, ioStreams)
 			cmd.Flags().Set("filename", filenameRC)
 			cmd.Flags().Set("output", "name")
@@ -2022,7 +2023,7 @@ func TestDontAllowForceApplyWithServerDryRun(t *testing.T) {
 
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdApply("kubectl", tf, ioStreams)
 	cmd.Flags().Set("filename", filenameRC)
 	cmd.Flags().Set("dry-run", "server")
@@ -2050,7 +2051,7 @@ func TestDontAllowForceApplyWithServerSide(t *testing.T) {
 
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdApply("kubectl", tf, ioStreams)
 	cmd.Flags().Set("filename", filenameRC)
 	cmd.Flags().Set("server-side", "true")
@@ -2072,7 +2073,7 @@ func TestDontAllowApplyWithPodGeneratedName(t *testing.T) {
 	defer tf.Cleanup()
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdApply("kubectl", tf, ioStreams)
 	cmd.Flags().Set("filename", filenamePodGeneratedName)
 	cmd.Flags().Set("dry-run", "client")
@@ -2165,7 +2166,7 @@ func TestApplySetParentValidation(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			cmdtesting.WithAlphaEnvs([]cmdutil.FeatureGate{cmdutil.ApplySet}, t, func(t *testing.T) {
 				cmd := &cobra.Command{}
-				flags := NewApplyFlags(genericclioptions.NewTestIOStreamsDiscard())
+				flags := NewApplyFlags(genericiooptions.NewTestIOStreamsDiscard())
 				flags.AddFlags(cmd)
 				cmd.Flags().Set("filename", filenameRC)
 				cmd.Flags().Set("applyset", test.applysetFlag)
@@ -2311,7 +2312,7 @@ func TestLoadObjects(t *testing.T) {
 			cmdtesting.WithAlphaEnvs([]cmdutil.FeatureGate{cmdutil.ApplySet}, t, func(t *testing.T) {
 
 				cmd := &cobra.Command{}
-				flags := NewApplyFlags(genericclioptions.NewTestIOStreamsDiscard())
+				flags := NewApplyFlags(genericiooptions.NewTestIOStreamsDiscard())
 				flags.AddFlags(cmd)
 				cmd.Flags().Set("filename", testFile+".yaml")
 				cmd.Flags().Set("applyset", filepath.Base(filepath.Dir(testFile)))
@@ -2381,7 +2382,7 @@ func TestApplySetParentManagement(t *testing.T) {
 
 	// Initially, the rc 'exists' server side but the svc and applyset secret do not
 	// This should 'update' the rc and create the secret
-	ioStreams, _, outbuff, errbuff := genericclioptions.NewTestIOStreams()
+	ioStreams, _, outbuff, errbuff := genericiooptions.NewTestIOStreams()
 	cmdtesting.WithAlphaEnvs([]cmdutil.FeatureGate{cmdutil.ApplySet}, t, func(t *testing.T) {
 		cmd := NewCmdApply("kubectl", tf, ioStreams)
 		cmd.Flags().Set("filename", filenameRC)
@@ -2609,7 +2610,7 @@ func TestApplySetInvalidLiveParent(t *testing.T) {
 			setUpClientsForApplySetWithSSA(t, tf, secret)
 
 			cmdtesting.WithAlphaEnvs([]cmdutil.FeatureGate{cmdutil.ApplySet}, t, func(t *testing.T) {
-				ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+				ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 				cmd := NewCmdApply("kubectl", tf, ioStreams)
 				cmd.Flags().Set("filename", filenameSVC)
 				cmd.Flags().Set("server-side", "true")
@@ -2630,7 +2631,7 @@ func TestApplySet_ClusterScopedCustomResourceParent(t *testing.T) {
 	cr := readUnstructuredFromFile(t, filenameApplySetCR)
 	setUpClientsForApplySetWithSSA(t, tf, replicationController, crd)
 
-	ioStreams, _, outbuff, errbuff := genericclioptions.NewTestIOStreams()
+	ioStreams, _, outbuff, errbuff := genericiooptions.NewTestIOStreams()
 	cmdutil.BehaviorOnFatal(func(s string, i int) {
 		require.Equal(t, "error: custom resource ApplySet parents cannot be created automatically", s)
 	})
@@ -2836,7 +2837,7 @@ func TestApplyWithPruneV2(t *testing.T) {
 					t.Logf("applying manifest %v", manifest)
 
 					cmd := &cobra.Command{}
-					flags := NewApplyFlags(genericclioptions.NewTestIOStreamsDiscard())
+					flags := NewApplyFlags(genericiooptions.NewTestIOStreamsDiscard())
 					flags.AddFlags(cmd)
 					cmd.Flags().Set("filename", filepath.Join(testdir, manifest+".yaml"))
 					cmd.Flags().Set("applyset", filepath.Base(testdir))
@@ -2929,7 +2930,7 @@ metadata:
 	}
 	tf.UnstructuredClient = tf.Client
 
-	ioStreams, _, outbuff, errbuff := genericclioptions.NewTestIOStreams()
+	ioStreams, _, outbuff, errbuff := genericiooptions.NewTestIOStreams()
 	cmdutil.BehaviorOnFatal(fatalNoExit(t, ioStreams))
 	defer cmdutil.DefaultBehaviorOnFatal()
 
@@ -3117,7 +3118,7 @@ func TestApplyWithPruneV2Fail(t *testing.T) {
 					t.Logf("applying manifest %v", manifest)
 
 					var unifiedOutput bytes.Buffer
-					ioStreams := genericclioptions.IOStreams{
+					ioStreams := genericiooptions.IOStreams{
 						ErrOut: &unifiedOutput,
 						Out:    &unifiedOutput,
 						In:     bytes.NewBufferString(""),
@@ -3165,7 +3166,7 @@ func TestApplyWithPruneV2Fail(t *testing.T) {
 
 // fatalNoExit is a handler that replaces the default cmdutil.BehaviorOnFatal,
 // that still prints as expected, but does not call os.Exit (which terminates our tests)
-func fatalNoExit(t *testing.T, ioStreams genericclioptions.IOStreams) func(msg string, code int) {
+func fatalNoExit(t *testing.T, ioStreams genericiooptions.IOStreams) func(msg string, code int) {
 	return func(msg string, code int) {
 		if len(msg) > 0 {
 			// add newline if needed
@@ -3216,7 +3217,7 @@ func TestApplySetDryRun(t *testing.T) {
 	}
 
 	t.Run("server side dry run", func(t *testing.T) {
-		ioStreams, _, outbuff, _ := genericclioptions.NewTestIOStreams()
+		ioStreams, _, outbuff, _ := genericiooptions.NewTestIOStreams()
 		tf.Client = fakeDryRunClient(t, true)
 		tf.UnstructuredClient = tf.Client
 		cmdtesting.WithAlphaEnvs([]cmdutil.FeatureGate{cmdutil.ApplySet}, t, func(t *testing.T) {
@@ -3234,7 +3235,7 @@ func TestApplySetDryRun(t *testing.T) {
 	})
 
 	t.Run("client side dry run", func(t *testing.T) {
-		ioStreams, _, outbuff, _ := genericclioptions.NewTestIOStreams()
+		ioStreams, _, outbuff, _ := genericiooptions.NewTestIOStreams()
 		tf.Client = fakeDryRunClient(t, false)
 		tf.UnstructuredClient = tf.Client
 		cmdtesting.WithAlphaEnvs([]cmdutil.FeatureGate{cmdutil.ApplySet}, t, func(t *testing.T) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_view_last_applied.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_view_last_applied.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util"
@@ -41,7 +41,7 @@ type ViewLastAppliedOptions struct {
 	All                          bool
 	Factory                      cmdutil.Factory
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 var (
@@ -60,7 +60,7 @@ var (
 )
 
 // NewViewLastAppliedOptions takes option arguments from a CLI stream and returns it at ViewLastAppliedOptions type.
-func NewViewLastAppliedOptions(ioStreams genericclioptions.IOStreams) *ViewLastAppliedOptions {
+func NewViewLastAppliedOptions(ioStreams genericiooptions.IOStreams) *ViewLastAppliedOptions {
 	return &ViewLastAppliedOptions{
 		OutputFormat: "yaml",
 
@@ -69,7 +69,7 @@ func NewViewLastAppliedOptions(ioStreams genericclioptions.IOStreams) *ViewLastA
 }
 
 // NewCmdApplyViewLastApplied creates the cobra CLI `apply` subcommand `view-last-applied`.`
-func NewCmdApplyViewLastApplied(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdApplyViewLastApplied(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	options := NewViewLastAppliedOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset_pruner.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset_pruner.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
@@ -40,7 +40,7 @@ type ApplySetDeleteOptions struct {
 
 	Printer printers.ResourcePrinter
 
-	IOStreams genericclioptions.IOStreams
+	IOStreams genericiooptions.IOStreams
 }
 
 // PruneObject is an apiserver object that should be deleted as part of prune.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
@@ -88,7 +89,7 @@ type AttachOptions struct {
 }
 
 // NewAttachOptions creates the options for attach
-func NewAttachOptions(streams genericclioptions.IOStreams) *AttachOptions {
+func NewAttachOptions(streams genericiooptions.IOStreams) *AttachOptions {
 	return &AttachOptions{
 		StreamOptions: exec.StreamOptions{
 			IOStreams: streams,
@@ -99,7 +100,7 @@ func NewAttachOptions(streams genericclioptions.IOStreams) *AttachOptions {
 }
 
 // NewCmdAttach returns the attach Cobra command
-func NewCmdAttach(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdAttach(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewAttachOptions(streams)
 	cmd := &cobra.Command{
 		Use:                   "attach (POD | TYPE/NAME) -c CONTAINER",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/client-go/tools/remotecommand"
@@ -308,7 +309,7 @@ func TestAttach(t *testing.T) {
 			options := &AttachOptions{
 				StreamOptions: exec.StreamOptions{
 					ContainerName: test.container,
-					IOStreams:     genericclioptions.NewTestIOStreamsDiscard(),
+					IOStreams:     genericiooptions.NewTestIOStreamsDiscard(),
 				},
 				Attach:        remoteAttach,
 				GetPodTimeout: 1000,
@@ -379,7 +380,7 @@ func TestAttachWarnings(t *testing.T) {
 			tf := cmdtesting.NewTestFactory().WithNamespace("test")
 			defer tf.Cleanup()
 
-			streams, _, _, bufErr := genericclioptions.NewTestIOStreams()
+			streams, _, _, bufErr := genericiooptions.NewTestIOStreams()
 
 			codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
 			ns := scheme.Codecs.WithoutConversion()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/auth.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/auth.go
@@ -18,13 +18,13 @@ package auth
 
 import (
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 // NewCmdAuth returns an initialized Command instance for 'auth' sub command
-func NewCmdAuth(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdAuth(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   "auth",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	discovery "k8s.io/client-go/discovery"
 	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
@@ -62,7 +62,7 @@ type CanIOptions struct {
 	ResourceName   string
 	List           bool
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 	WarningPrinter *printers.WarningPrinter
 }
 
@@ -110,7 +110,7 @@ var (
 )
 
 // NewCmdCanI returns an initialized Command for 'auth can-i' sub command
-func NewCmdCanI(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCanI(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := &CanIOptions{
 		IOStreams: streams,
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani_test.go
@@ -27,7 +27,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
@@ -215,7 +215,7 @@ func TestRunAccessList(t *testing.T) {
 				}
 			}),
 		}
-		ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+		ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 		options.IOStreams = ioStreams
 		if err := options.Complete(tf, []string{}); err != nil {
 			t.Errorf("got unexpected error when do Complete(): %v", err)
@@ -291,7 +291,7 @@ func TestRunResourceFor(t *testing.T) {
 			tf := cmdtesting.NewTestFactory().WithNamespace("test")
 			defer tf.Cleanup()
 
-			ioStreams, _, _, buf := genericclioptions.NewTestIOStreams()
+			ioStreams, _, _, buf := genericiooptions.NewTestIOStreams()
 			test.o.IOStreams = ioStreams
 			test.o.WarningPrinter = printers.NewWarningPrinter(test.o.IOStreams.ErrOut, printers.WarningPrinterOptions{Color: false})
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile.go
@@ -28,6 +28,7 @@ import (
 	rbacv1alpha1 "k8s.io/api/rbac/v1alpha1"
 	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -53,7 +54,7 @@ type ReconcileOptions struct {
 
 	PrintObject printers.ResourcePrinterFunc
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 var (
@@ -76,7 +77,7 @@ var (
 )
 
 // NewReconcileOptions returns a new ReconcileOptions instance
-func NewReconcileOptions(ioStreams genericclioptions.IOStreams) *ReconcileOptions {
+func NewReconcileOptions(ioStreams genericiooptions.IOStreams) *ReconcileOptions {
 	return &ReconcileOptions{
 		FilenameOptions: &resource.FilenameOptions{},
 		PrintFlags:      genericclioptions.NewPrintFlags("reconciled").WithTypeSetter(scheme.Scheme),
@@ -85,7 +86,7 @@ func NewReconcileOptions(ioStreams genericclioptions.IOStreams) *ReconcileOption
 }
 
 // NewCmdReconcile holds the options for 'auth reconcile' sub command
-func NewCmdReconcile(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdReconcile(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewReconcileOptions(streams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/whoami.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/whoami.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	authenticationv1alpha1client "k8s.io/client-go/kubernetes/typed/authentication/v1alpha1"
 	authenticationv1beta1client "k8s.io/client-go/kubernetes/typed/authentication/v1beta1"
@@ -45,11 +46,11 @@ type WhoAmIFlags struct {
 	RESTClientGetter genericclioptions.RESTClientGetter
 	PrintFlags       *genericclioptions.PrintFlags
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewWhoAmIFlags returns a default WhoAmIFlags.
-func NewWhoAmIFlags(restClientGetter genericclioptions.RESTClientGetter, streams genericclioptions.IOStreams) *WhoAmIFlags {
+func NewWhoAmIFlags(restClientGetter genericclioptions.RESTClientGetter, streams genericiooptions.IOStreams) *WhoAmIFlags {
 	return &WhoAmIFlags{
 		RESTClientGetter: restClientGetter,
 		PrintFlags:       genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme),
@@ -107,7 +108,7 @@ type WhoAmIOptions struct {
 
 	resourcePrinterFunc printers.ResourcePrinterFunc
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 var (
@@ -129,7 +130,7 @@ var (
 )
 
 // NewCmdWhoAmI returns an initialized Command for 'auth whoami' sub command. Experimental.
-func NewCmdWhoAmI(restClientGetter genericclioptions.RESTClientGetter, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdWhoAmI(restClientGetter genericclioptions.RESTClientGetter, streams genericiooptions.IOStreams) *cobra.Command {
 	flags := NewWhoAmIFlags(restClientGetter, streams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	autoscalingv1client "k8s.io/client-go/kubernetes/typed/autoscaling/v1"
@@ -80,11 +81,11 @@ type AutoscaleOptions struct {
 	HPAClient         autoscalingv1client.HorizontalPodAutoscalersGetter
 	scaleKindResolver scale.ScaleKindResolver
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewAutoscaleOptions creates the options for autoscale
-func NewAutoscaleOptions(ioStreams genericclioptions.IOStreams) *AutoscaleOptions {
+func NewAutoscaleOptions(ioStreams genericiooptions.IOStreams) *AutoscaleOptions {
 	return &AutoscaleOptions{
 		PrintFlags:      genericclioptions.NewPrintFlags("autoscaled").WithTypeSetter(scheme.Scheme),
 		FilenameOptions: &resource.FilenameOptions{},
@@ -96,7 +97,7 @@ func NewAutoscaleOptions(ioStreams genericclioptions.IOStreams) *AutoscaleOption
 }
 
 // NewCmdAutoscale returns the autoscale Cobra command
-func NewCmdAutoscale(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdAutoscale(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewAutoscaleOptions(ioStreams)
 
 	validArgs := []string{"deployment", "replicaset", "replicationcontroller", "statefulset"}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	v1 "k8s.io/client-go/kubernetes/typed/certificates/v1"
@@ -40,7 +41,7 @@ import (
 )
 
 // NewCmdCertificate returns `certificate` Cobra command
-func NewCmdCertificate(restClientGetter genericclioptions.RESTClientGetter, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCertificate(restClientGetter genericclioptions.RESTClientGetter, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "certificate SUBCOMMAND",
 		DisableFlagsInUseLine: true,
@@ -70,11 +71,11 @@ type CertificateOptions struct {
 	certificatesV1Client v1.CertificatesV1Interface
 	builder              *resource.Builder
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewCertificateOptions creates CertificateOptions struct for `certificate` command
-func NewCertificateOptions(ioStreams genericclioptions.IOStreams, operation string) *CertificateOptions {
+func NewCertificateOptions(ioStreams genericiooptions.IOStreams, operation string) *CertificateOptions {
 	return &CertificateOptions{
 		PrintFlags: genericclioptions.NewPrintFlags(operation).WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
@@ -119,7 +120,7 @@ func (o *CertificateOptions) Validate() error {
 }
 
 // NewCmdCertificateApprove returns the `certificate approve` Cobra command
-func NewCmdCertificateApprove(restClientGetter genericclioptions.RESTClientGetter, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCertificateApprove(restClientGetter genericclioptions.RESTClientGetter, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewCertificateOptions(ioStreams, "approved")
 
 	cmd := &cobra.Command{
@@ -167,7 +168,7 @@ func (o *CertificateOptions) RunCertificateApprove(force bool) error {
 }
 
 // NewCmdCertificateDeny returns the `certificate deny` Cobra command
-func NewCmdCertificateDeny(restClientGetter genericclioptions.RESTClientGetter, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCertificateDeny(restClientGetter genericclioptions.RESTClientGetter, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewCertificateOptions(ioStreams, "denied")
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates_test.go
@@ -29,7 +29,7 @@ import (
 	certificatesv1 "k8s.io/api/certificates/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -235,7 +235,7 @@ func TestCertificates(t *testing.T) {
 				NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 				Client:               fakeClient,
 			}
-			streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
+			streams, _, buf, errbuf := genericiooptions.NewTestIOStreams()
 			tf.ClientConfigVal.Transport = fakeClient.Transport
 
 			defer func() {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	restclient "k8s.io/client-go/rest"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -47,7 +48,7 @@ var (
 )
 
 type ClusterInfoOptions struct {
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 
 	Namespace string
 
@@ -55,7 +56,7 @@ type ClusterInfoOptions struct {
 	Client  *restclient.Config
 }
 
-func NewCmdClusterInfo(restClientGetter genericclioptions.RESTClientGetter, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdClusterInfo(restClientGetter genericclioptions.RESTClientGetter, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := &ClusterInfoOptions{
 		IOStreams: ioStreams,
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -59,10 +60,10 @@ type ClusterInfoDumpOptions struct {
 	RESTClientGetter genericclioptions.RESTClientGetter
 	LogsForObject    polymorphichelpers.LogsForObjectFunc
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
-func NewCmdClusterInfoDump(restClientGetter genericclioptions.RESTClientGetter, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdClusterInfoDump(restClientGetter genericclioptions.RESTClientGetter, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := &ClusterInfoDumpOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithDefaultOutput("json"),
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump_test.go
@@ -21,7 +21,7 @@ import (
 	"path"
 	"testing"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 )
 
@@ -41,7 +41,7 @@ func TestSetupOutputWriterNoOp(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, buf, _ := genericclioptions.NewTestIOStreams()
+			_, _, buf, _ := genericiooptions.NewTestIOStreams()
 			f := cmdtesting.NewTestFactory()
 			defer f.Cleanup()
 
@@ -63,7 +63,7 @@ func TestSetupOutputWriterFile(t *testing.T) {
 	fullPath := path.Join(dir, file) + extension
 	defer os.RemoveAll(dir)
 
-	_, _, buf, _ := genericclioptions.NewTestIOStreams()
+	_, _, buf, _ := genericiooptions.NewTestIOStreams()
 	f := cmdtesting.NewTestFactory()
 	defer f.Cleanup()
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -92,7 +93,7 @@ type KubectlOptions struct {
 	Arguments     []string
 	ConfigFlags   *genericclioptions.ConfigFlags
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 var defaultConfigFlags = genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag().WithDiscoveryBurst(300).WithDiscoveryQPS(50.0)
@@ -103,7 +104,7 @@ func NewDefaultKubectlCommand() *cobra.Command {
 		PluginHandler: NewDefaultPluginHandler(plugin.ValidPluginFilenamePrefixes),
 		Arguments:     os.Args,
 		ConfigFlags:   defaultConfigFlags,
-		IOStreams:     genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
+		IOStreams:     genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
 	})
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
@@ -27,13 +27,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 func TestNormalizationFuncGlobalExistence(t *testing.T) {
 	// This test can be safely deleted when we will not support multiple flag formats
-	root := NewKubectlCommand(KubectlOptions{IOStreams: genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}})
+	root := NewKubectlCommand(KubectlOptions{IOStreams: genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}})
 
 	if root.Parent() != nil {
 		t.Fatal("We expect the root command to be returned")
@@ -132,7 +133,7 @@ func TestKubectlSubcommandShadowPlugin(t *testing.T) {
 				pluginsHandler := &testPluginHandler{
 					pluginsDirectory: "plugin/testdata",
 				}
-				ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+				ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 
 				root := NewDefaultKubectlCommandWithArgs(KubectlOptions{PluginHandler: pluginsHandler, Arguments: test.args, IOStreams: ioStreams})
 				if err := root.Execute(); err != nil {
@@ -236,7 +237,7 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 			pluginsHandler := &testPluginHandler{
 				pluginsDirectory: "plugin/testdata",
 			}
-			ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+			ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 
 			root := NewDefaultKubectlCommandWithArgs(KubectlOptions{PluginHandler: pluginsHandler, Arguments: test.args, IOStreams: ioStreams})
 			if err := root.Execute(); err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
 func TestBashCompletions(t *testing.T) {
@@ -69,7 +69,7 @@ See 'kubectl completion -h' for help and examples`,
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(tt *testing.T) {
-			_, _, out, _ := genericclioptions.NewTestIOStreams()
+			_, _, out, _ := genericiooptions.NewTestIOStreams()
 			parentCmd := &cobra.Command{
 				Use: "kubectl",
 			}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -31,7 +31,7 @@ import (
 )
 
 // NewCmdConfig creates a command object for the "config" action, and adds all child commands to it.
-func NewCmdConfig(pathOptions *clientcmd.PathOptions, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdConfig(pathOptions *clientcmd.PathOptions, streams genericiooptions.IOStreams) *cobra.Command {
 	if len(pathOptions.ExplicitFileFlag) == 0 {
 		pathOptions.ExplicitFileFlag = clientcmd.RecommendedConfigPathFlag
 	}
@@ -54,7 +54,7 @@ func NewCmdConfig(pathOptions *clientcmd.PathOptions, streams genericclioptions.
 	// file paths are common to all sub commands
 	cmd.PersistentFlags().StringVar(&pathOptions.LoadingRules.ExplicitPath, pathOptions.ExplicitFileFlag, pathOptions.LoadingRules.ExplicitPath, "use a particular kubeconfig file")
 
-	// TODO(juanvallejo): update all subcommands to work with genericclioptions.IOStreams
+	// TODO(juanvallejo): update all subcommands to work with genericiooptions.IOStreams
 	cmd.AddCommand(NewCmdConfigView(streams, pathOptions))
 	cmd.AddCommand(NewCmdConfigSetCluster(streams.Out, pathOptions))
 	cmd.AddCommand(NewCmdConfigSetCredentials(streams.Out, pathOptions))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
@@ -26,7 +26,7 @@ import (
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/diff"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -862,7 +862,7 @@ func testConfigCommand(args []string, startingConfig clientcmdapi.Config, t *tes
 	argsToUse = append(argsToUse, "--kubeconfig="+fakeKubeFile.Name())
 	argsToUse = append(argsToUse, args...)
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdConfig(clientcmd.NewDefaultPathOptions(), streams)
 	// "context" is a global flag, inherited from base kubectl command in the real world
 	cmd.PersistentFlags().String("context", "", "The name of the kubeconfig context to use")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_user.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_user.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -44,11 +44,11 @@ type DeleteUserOptions struct {
 	config       *clientcmdapi.Config
 	configFile   string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewDeleteUserOptions creates the options for the command
-func NewDeleteUserOptions(ioStreams genericclioptions.IOStreams, configAccess clientcmd.ConfigAccess) *DeleteUserOptions {
+func NewDeleteUserOptions(ioStreams genericiooptions.IOStreams, configAccess clientcmd.ConfigAccess) *DeleteUserOptions {
 	return &DeleteUserOptions{
 		configAccess: configAccess,
 		IOStreams:    ioStreams,
@@ -56,7 +56,7 @@ func NewDeleteUserOptions(ioStreams genericclioptions.IOStreams, configAccess cl
 }
 
 // NewCmdConfigDeleteUser returns a Command instance for 'config delete-user' sub command
-func NewCmdConfigDeleteUser(streams genericclioptions.IOStreams, configAccess clientcmd.ConfigAccess) *cobra.Command {
+func NewCmdConfigDeleteUser(streams genericiooptions.IOStreams, configAccess clientcmd.ConfigAccess) *cobra.Command {
 	o := NewDeleteUserOptions(streams, configAccess)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_user_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_user_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -51,7 +51,7 @@ func TestDeleteUserComplete(t *testing.T) {
 			tf := cmdtesting.NewTestFactory()
 			defer tf.Cleanup()
 
-			ioStreams, _, out, _ := genericclioptions.NewTestIOStreams()
+			ioStreams, _, out, _ := genericiooptions.NewTestIOStreams()
 			pathOptions, err := tf.PathOptionsWithConfig(clientcmdapi.Config{})
 			if err != nil {
 				t.Fatalf("unexpected error executing command: %v", err)
@@ -116,7 +116,7 @@ func TestDeleteUserValidate(t *testing.T) {
 			tf := cmdtesting.NewTestFactory()
 			defer tf.Cleanup()
 
-			ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+			ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 			pathOptions, err := tf.PathOptionsWithConfig(test.config)
 			if err != nil {
 				t.Fatalf("unexpected error executing command: %v", err)
@@ -165,7 +165,7 @@ func TestDeleteUserRun(t *testing.T) {
 			tf := cmdtesting.NewTestFactory()
 			defer tf.Cleanup()
 
-			ioStreams, _, out, _ := genericclioptions.NewTestIOStreams()
+			ioStreams, _, out, _ := genericiooptions.NewTestIOStreams()
 			pathOptions, err := tf.PathOptionsWithConfig(test.config)
 			if err != nil {
 				t.Fatalf("unexpected error executing command: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts.go
@@ -27,7 +27,7 @@ import (
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -46,7 +46,7 @@ type GetContextsOptions struct {
 	outputFormat string
 	noHeaders    bool
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 var (
@@ -62,7 +62,7 @@ var (
 
 // NewCmdConfigGetContexts creates a command object for the "get-contexts" action, which
 // retrieves one or more contexts from a kubeconfig.
-func NewCmdConfigGetContexts(streams genericclioptions.IOStreams, configAccess clientcmd.ConfigAccess) *cobra.Command {
+func NewCmdConfigGetContexts(streams genericiooptions.IOStreams, configAccess clientcmd.ConfigAccess) *cobra.Command {
 	options := &GetContextsOptions{
 		configAccess: configAccess,
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_contexts_test.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"testing"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -156,7 +156,7 @@ func (test getContextsTest) run(t *testing.T) {
 	pathOptions := clientcmd.NewDefaultPathOptions()
 	pathOptions.GlobalFile = fakeKubeFile.Name()
 	pathOptions.EnvVar = ""
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	options := GetContextsOptions{
 		configAccess: pathOptions,
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_users.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_users.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -39,11 +39,11 @@ var (
 type GetUsersOptions struct {
 	configAccess clientcmd.ConfigAccess
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewGetUsersOptions creates the options for the command
-func NewGetUsersOptions(ioStreams genericclioptions.IOStreams, configAccess clientcmd.ConfigAccess) *GetUsersOptions {
+func NewGetUsersOptions(ioStreams genericiooptions.IOStreams, configAccess clientcmd.ConfigAccess) *GetUsersOptions {
 	return &GetUsersOptions{
 		configAccess: configAccess,
 		IOStreams:    ioStreams,
@@ -52,7 +52,7 @@ func NewGetUsersOptions(ioStreams genericclioptions.IOStreams, configAccess clie
 
 // NewCmdConfigGetUsers creates a command object for the "get-users" action, which
 // lists all users defined in the kubeconfig.
-func NewCmdConfigGetUsers(streams genericclioptions.IOStreams, configAccess clientcmd.ConfigAccess) *cobra.Command {
+func NewCmdConfigGetUsers(streams genericiooptions.IOStreams, configAccess clientcmd.ConfigAccess) *cobra.Command {
 	o := NewGetUsersOptions(streams, configAccess)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/get_users_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/get_users_test.go
@@ -19,7 +19,7 @@ package config
 import (
 	"testing"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 )
@@ -56,7 +56,7 @@ minikube
 			tf := cmdtesting.NewTestFactory()
 			defer tf.Cleanup()
 
-			ioStreams, _, out, _ := genericclioptions.NewTestIOStreams()
+			ioStreams, _, out, _ := genericiooptions.NewTestIOStreams()
 			pathOptions, err := tf.PathOptionsWithConfig(test.config)
 			if err != nil {
 				t.Fatalf("unexpected error executing command: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/view.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/view.go
@@ -18,8 +18,11 @@ package config
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
+
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -45,7 +48,7 @@ type ViewOptions struct {
 	Context      string
 	OutputFormat string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 var (
@@ -66,7 +69,7 @@ var (
 )
 
 // NewCmdConfigView returns a Command instance for 'config view' sub command
-func NewCmdConfigView(streams genericclioptions.IOStreams, ConfigAccess clientcmd.ConfigAccess) *cobra.Command {
+func NewCmdConfigView(streams genericiooptions.IOStreams, ConfigAccess clientcmd.ConfigAccess) *cobra.Command {
 	o := &ViewOptions{
 		PrintFlags:   genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithDefaultOutput("yaml"),
 		ConfigAccess: ConfigAccess,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/view_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/view_test.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"testing"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -305,7 +305,7 @@ func (test viewClusterTest) run(t *testing.T) {
 	pathOptions := clientcmd.NewDefaultPathOptions()
 	pathOptions.GlobalFile = fakeKubeFile.Name()
 	pathOptions.EnvVar = ""
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdConfigView(streams, pathOptions)
 	// "context" is a global flag, inherited from base kubectl command in the real world
 	cmd.Flags().String("context", "", "The name of the kubeconfig context to use")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/cmd/exec"
@@ -78,18 +78,18 @@ type CopyOptions struct {
 
 	args []string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewCopyOptions creates the options for copy
-func NewCopyOptions(ioStreams genericclioptions.IOStreams) *CopyOptions {
+func NewCopyOptions(ioStreams genericiooptions.IOStreams) *CopyOptions {
 	return &CopyOptions{
 		IOStreams: ioStreams,
 	}
 }
 
 // NewCmdCp creates a new Copy command.
-func NewCmdCp(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCp(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewCopyOptions(ioStreams)
 
 	cmd := &cobra.Command{
@@ -266,7 +266,7 @@ func (o *CopyOptions) Run() error {
 func (o *CopyOptions) checkDestinationIsDir(dest fileSpec) error {
 	options := &exec.ExecOptions{
 		StreamOptions: exec.StreamOptions{
-			IOStreams: genericclioptions.IOStreams{
+			IOStreams: genericiooptions.IOStreams{
 				Out:    bytes.NewBuffer([]byte{}),
 				ErrOut: bytes.NewBuffer([]byte{}),
 			},
@@ -314,7 +314,7 @@ func (o *CopyOptions) copyToPod(src, dest fileSpec, options *exec.ExecOptions) e
 	}
 
 	options.StreamOptions = exec.StreamOptions{
-		IOStreams: genericclioptions.IOStreams{
+		IOStreams: genericiooptions.IOStreams{
 			In:     reader,
 			Out:    o.Out,
 			ErrOut: o.ErrOut,
@@ -361,7 +361,7 @@ func (t *TarPipe) initReadFrom(n uint64) {
 	t.reader, t.outStream = io.Pipe()
 	options := &exec.ExecOptions{
 		StreamOptions: exec.StreamOptions{
-			IOStreams: genericclioptions.IOStreams{
+			IOStreams: genericiooptions.IOStreams{
 				In:     nil,
 				Out:    t.outStream,
 				ErrOut: t.o.Out,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
@@ -31,11 +31,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	kexec "k8s.io/kubectl/pkg/cmd/exec"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -405,7 +405,7 @@ func TestTarUntar(t *testing.T) {
 		}
 	}
 
-	opts := NewCopyOptions(genericclioptions.NewTestIOStreamsDiscard())
+	opts := NewCopyOptions(genericiooptions.NewTestIOStreamsDiscard())
 
 	writer := &bytes.Buffer{}
 	if err := makeTar(newLocalPath(dir), newRemotePath(dir), writer); err != nil {
@@ -467,7 +467,7 @@ func TestTarUntarWrongPrefix(t *testing.T) {
 	}
 	createTmpFile(t, completePath, "sample data")
 
-	opts := NewCopyOptions(genericclioptions.NewTestIOStreamsDiscard())
+	opts := NewCopyOptions(genericiooptions.NewTestIOStreamsDiscard())
 
 	writer := &bytes.Buffer{}
 	if err := makeTar(newLocalPath(dir), newRemotePath(dir), writer); err != nil {
@@ -589,7 +589,7 @@ func TestBadTar(t *testing.T) {
 		t.FailNow()
 	}
 
-	opts := NewCopyOptions(genericclioptions.NewTestIOStreamsDiscard())
+	opts := NewCopyOptions(genericiooptions.NewTestIOStreamsDiscard())
 	if err := opts.untarAll("", "", "/prefix", remotePath{}, newLocalPath(dir), &buf); err != nil {
 		t.Errorf("unexpected error: %v ", err)
 		t.FailNow()
@@ -618,7 +618,7 @@ func TestCopyToPod(t *testing.T) {
 	}
 
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdCp(tf, ioStreams)
 
@@ -689,7 +689,7 @@ func TestCopyToPodNoPreserve(t *testing.T) {
 	}
 
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdCp(tf, ioStreams)
 
@@ -753,7 +753,7 @@ func TestValidate(t *testing.T) {
 			expectedErr: true,
 		},
 	}
-	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 	opts := NewCopyOptions(ioStreams)
 
 	for _, test := range tests {
@@ -908,7 +908,7 @@ func TestUntar(t *testing.T) {
 
 	// Capture warnings to stderr for debugging.
 	output := (*testWriter)(t)
-	opts := NewCopyOptions(genericclioptions.IOStreams{In: &bytes.Buffer{}, Out: output, ErrOut: output})
+	opts := NewCopyOptions(genericiooptions.IOStreams{In: &bytes.Buffer{}, Out: output, ErrOut: output})
 
 	require.NoError(t, opts.untarAll("", "", "", remotePath{}, newLocalPath(basedir), buf))
 
@@ -959,7 +959,7 @@ func TestUntar_SingleFile(t *testing.T) {
 
 	// Capture warnings to stderr for debugging.
 	output := (*testWriter)(t)
-	opts := NewCopyOptions(genericclioptions.IOStreams{In: &bytes.Buffer{}, Out: output, ErrOut: output})
+	opts := NewCopyOptions(genericiooptions.IOStreams{In: &bytes.Buffer{}, Out: output, ErrOut: output})
 
 	require.NoError(t, opts.untarAll("", "", srcName, remotePath{}, newLocalPath(dest), buf))
 	cmpFileData(t, dest, content)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -33,6 +33,7 @@ import (
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
@@ -65,7 +66,7 @@ type CreateOptions struct {
 	Recorder genericclioptions.Recorder
 	PrintObj func(obj kruntime.Object) error
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 var (
@@ -86,7 +87,7 @@ var (
 )
 
 // NewCreateOptions returns an initialized CreateOptions instance
-func NewCreateOptions(ioStreams genericclioptions.IOStreams) *CreateOptions {
+func NewCreateOptions(ioStreams genericiooptions.IOStreams) *CreateOptions {
 	return &CreateOptions{
 		PrintFlags:  genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		RecordFlags: genericclioptions.NewRecordFlags(),
@@ -98,7 +99,7 @@ func NewCreateOptions(ioStreams genericclioptions.IOStreams) *CreateOptions {
 }
 
 // NewCmdCreate returns new initialized instance of create sub command
-func NewCmdCreate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreate(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewCreateOptions(ioStreams)
 
 	cmd := &cobra.Command{
@@ -302,7 +303,7 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 }
 
 // RunEditOnCreate performs edit on creation
-func RunEditOnCreate(f cmdutil.Factory, printFlags *genericclioptions.PrintFlags, recordFlags *genericclioptions.RecordFlags, ioStreams genericclioptions.IOStreams, cmd *cobra.Command, options *resource.FilenameOptions, fieldManager string) error {
+func RunEditOnCreate(f cmdutil.Factory, printFlags *genericclioptions.PrintFlags, recordFlags *genericclioptions.RecordFlags, ioStreams genericiooptions.IOStreams, cmd *cobra.Command, options *resource.FilenameOptions, fieldManager string) error {
 	editOptions := editor.NewEditOptions(editor.EditBeforeCreateMode, ioStreams)
 	editOptions.FilenameOptions = *options
 	validationDirective, err := cmdutil.GetValidationDirective(cmd)
@@ -358,11 +359,11 @@ type CreateSubcommandOptions struct {
 
 	PrintObj printers.ResourcePrinterFunc
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewCreateSubcommandOptions returns initialized CreateSubcommandOptions
-func NewCreateSubcommandOptions(ioStreams genericclioptions.IOStreams) *CreateSubcommandOptions {
+func NewCreateSubcommandOptions(ioStreams genericiooptions.IOStreams) *CreateSubcommandOptions {
 	return &CreateSubcommandOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
@@ -25,7 +25,7 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cliflag "k8s.io/component-base/cli/flag"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -70,7 +70,7 @@ type CreateClusterRoleOptions struct {
 }
 
 // NewCmdCreateClusterRole initializes and returns new ClusterRoles command
-func NewCmdCreateClusterRole(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateClusterRole(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	c := &CreateClusterRoleOptions{
 		CreateRoleOptions: NewCreateRoleOptions(ioStreams),
 		AggregationRule:   map[string]string{},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/kubectl/pkg/scheme"
@@ -149,7 +149,7 @@ func TestCreateClusterRole(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+		ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 		cmd := NewCmdCreateClusterRole(tf, ioStreams)
 		cmd.Flags().Set("dry-run", "client")
 		cmd.Flags().Set("output", "yaml")
@@ -496,7 +496,7 @@ func TestClusterRoleValidate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			test.clusterRoleOptions.IOStreams = genericclioptions.NewTestIOStreamsDiscard()
+			test.clusterRoleOptions.IOStreams = genericiooptions.NewTestIOStreamsDiscard()
 			var err error
 			test.clusterRoleOptions.Mapper, err = tf.ToRESTMapper()
 			if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	rbacclientv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -62,11 +63,11 @@ type ClusterRoleBindingOptions struct {
 	DryRunStrategy      cmdutil.DryRunStrategy
 	ValidationDirective string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewClusterRoleBindingOptions creates a new *ClusterRoleBindingOptions with sane defaults
-func NewClusterRoleBindingOptions(ioStreams genericclioptions.IOStreams) *ClusterRoleBindingOptions {
+func NewClusterRoleBindingOptions(ioStreams genericiooptions.IOStreams) *ClusterRoleBindingOptions {
 	return &ClusterRoleBindingOptions{
 		Users:           []string{},
 		Groups:          []string{},
@@ -77,7 +78,7 @@ func NewClusterRoleBindingOptions(ioStreams genericclioptions.IOStreams) *Cluste
 }
 
 // NewCmdCreateClusterRoleBinding returns an initialized command instance of ClusterRoleBinding
-func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewClusterRoleBindingOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -98,11 +99,11 @@ type ConfigMapOptions struct {
 	DryRunStrategy      cmdutil.DryRunStrategy
 	ValidationDirective string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewConfigMapOptions creates a new *ConfigMapOptions with default value
-func NewConfigMapOptions(ioStreams genericclioptions.IOStreams) *ConfigMapOptions {
+func NewConfigMapOptions(ioStreams genericiooptions.IOStreams) *ConfigMapOptions {
 	return &ConfigMapOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
@@ -110,7 +111,7 @@ func NewConfigMapOptions(ioStreams genericclioptions.IOStreams) *ConfigMapOption
 }
 
 // NewCmdCreateConfigMap creates the `create configmap` Cobra command
-func NewCmdCreateConfigMap(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateConfigMap(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewConfigMapOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -69,11 +70,11 @@ type CreateCronJobOptions struct {
 	FieldManager        string
 	CreateAnnotation    bool
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewCreateCronJobOptions returns an initialized CreateCronJobOptions instance
-func NewCreateCronJobOptions(ioStreams genericclioptions.IOStreams) *CreateCronJobOptions {
+func NewCreateCronJobOptions(ioStreams genericiooptions.IOStreams) *CreateCronJobOptions {
 	return &CreateCronJobOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
@@ -81,7 +82,7 @@ func NewCreateCronJobOptions(ioStreams genericclioptions.IOStreams) *CreateCronJ
 }
 
 // NewCmdCreateCronJob is a command to create CronJobs.
-func NewCmdCreateCronJob(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateCronJob(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewCreateCronJobOptions(ioStreams)
 	cmd := &cobra.Command{
 		Use:                   "cronjob NAME --image=image --schedule='0/5 * * * ?' -- [COMMAND] [args...]",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -75,11 +76,11 @@ type CreateDeploymentOptions struct {
 	DryRunStrategy      cmdutil.DryRunStrategy
 	ValidationDirective string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewCreateDeploymentOptions returns an initialized CreateDeploymentOptions instance
-func NewCreateDeploymentOptions(ioStreams genericclioptions.IOStreams) *CreateDeploymentOptions {
+func NewCreateDeploymentOptions(ioStreams genericiooptions.IOStreams) *CreateDeploymentOptions {
 	return &CreateDeploymentOptions{
 		Port:       -1,
 		Replicas:   1,
@@ -90,7 +91,7 @@ func NewCreateDeploymentOptions(ioStreams genericclioptions.IOStreams) *CreateDe
 
 // NewCmdCreateDeployment is a macro command to create a new deployment.
 // This command is better known to users as `kubectl create deployment`.
-func NewCmdCreateDeployment(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateDeployment(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewCreateDeploymentOptions(ioStreams)
 	cmd := &cobra.Command{
 		Use:                   "deployment NAME --image=image -- [COMMAND] [args...]",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -51,7 +52,7 @@ func TestCreateDeployment(t *testing.T) {
 	}
 	tf.ClientConfigVal = &restclient.Config{}
 
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdCreateDeployment(tf, ioStreams)
 	cmd.Flags().Set("dry-run", "client")
 	cmd.Flags().Set("output", "name")
@@ -82,7 +83,7 @@ func TestCreateDeploymentWithPort(t *testing.T) {
 	}
 	tf.ClientConfigVal = &restclient.Config{}
 
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdCreateDeployment(tf, ioStreams)
 	cmd.Flags().Set("dry-run", "client")
 	cmd.Flags().Set("output", "yaml")
@@ -113,7 +114,7 @@ func TestCreateDeploymentWithReplicas(t *testing.T) {
 	}
 	tf.ClientConfigVal = &restclient.Config{}
 
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdCreateDeployment(tf, ioStreams)
 	cmd.Flags().Set("dry-run", "client")
 	cmd.Flags().Set("output", "jsonpath={.spec.replicas}")
@@ -143,7 +144,7 @@ func TestCreateDeploymentNoImage(t *testing.T) {
 	}
 	tf.ClientConfigVal = &restclient.Config{}
 
-	ioStreams := genericclioptions.NewTestIOStreamsDiscard()
+	ioStreams := genericiooptions.NewTestIOStreamsDiscard()
 	cmd := NewCmdCreateDeployment(tf, ioStreams)
 	cmd.Flags().Set("output", "name")
 	options := &CreateDeploymentOptions{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	networkingv1client "k8s.io/client-go/kubernetes/typed/networking/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -121,11 +122,11 @@ type CreateIngressOptions struct {
 
 	FieldManager string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewCreateIngressOptions creates the CreateIngressOptions to be used later
-func NewCreateIngressOptions(ioStreams genericclioptions.IOStreams) *CreateIngressOptions {
+func NewCreateIngressOptions(ioStreams genericiooptions.IOStreams) *CreateIngressOptions {
 	return &CreateIngressOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
@@ -134,7 +135,7 @@ func NewCreateIngressOptions(ioStreams genericclioptions.IOStreams) *CreateIngre
 
 // NewCmdCreateIngress is a macro command to create a new ingress.
 // This command is better known to users as `kubectl create ingress`.
-func NewCmdCreateIngress(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateIngress(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewCreateIngressOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -71,11 +72,11 @@ type CreateJobOptions struct {
 	FieldManager        string
 	CreateAnnotation    bool
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewCreateJobOptions initializes and returns new CreateJobOptions instance
-func NewCreateJobOptions(ioStreams genericclioptions.IOStreams) *CreateJobOptions {
+func NewCreateJobOptions(ioStreams genericiooptions.IOStreams) *CreateJobOptions {
 	return &CreateJobOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
@@ -83,7 +84,7 @@ func NewCreateJobOptions(ioStreams genericclioptions.IOStreams) *CreateJobOption
 }
 
 // NewCmdCreateJob is a command to ease creating Jobs from CronJobs.
-func NewCmdCreateJob(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateJob(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewCreateJobOptions(ioStreams)
 	cmd := &cobra.Command{
 		Use:                   "job NAME --image=image [--from=cronjob/name] -- [COMMAND] [args...]",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubectl/pkg/util"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -60,11 +61,11 @@ type NamespaceOptions struct {
 
 	PrintObj func(obj runtime.Object) error
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewNamespaceOptions creates a new *NamespaceOptions with sane defaults
-func NewNamespaceOptions(ioStreams genericclioptions.IOStreams) *NamespaceOptions {
+func NewNamespaceOptions(ioStreams genericiooptions.IOStreams) *NamespaceOptions {
 	return &NamespaceOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
@@ -72,7 +73,7 @@ func NewNamespaceOptions(ioStreams genericclioptions.IOStreams) *NamespaceOption
 }
 
 // NewCmdCreateNamespace is a macro command to create a new namespace
-func NewCmdCreateNamespace(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateNamespace(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 
 	o := NewNamespaceOptions(ioStreams)
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	policyv1client "k8s.io/client-go/kubernetes/typed/policy/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -72,11 +73,11 @@ type PodDisruptionBudgetOpts struct {
 	DryRunStrategy      cmdutil.DryRunStrategy
 	ValidationDirective string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewPodDisruptionBudgetOpts creates a new *PodDisruptionBudgetOpts with sane defaults
-func NewPodDisruptionBudgetOpts(ioStreams genericclioptions.IOStreams) *PodDisruptionBudgetOpts {
+func NewPodDisruptionBudgetOpts(ioStreams genericiooptions.IOStreams) *PodDisruptionBudgetOpts {
 	return &PodDisruptionBudgetOpts{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
@@ -84,7 +85,7 @@ func NewPodDisruptionBudgetOpts(ioStreams genericclioptions.IOStreams) *PodDisru
 }
 
 // NewCmdCreatePodDisruptionBudget is a macro command to create a new pod disruption budget.
-func NewCmdCreatePodDisruptionBudget(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreatePodDisruptionBudget(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewPodDisruptionBudgetOpts(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	schedulingv1client "k8s.io/client-go/kubernetes/typed/scheduling/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -67,11 +68,11 @@ type PriorityClassOptions struct {
 	DryRunStrategy      cmdutil.DryRunStrategy
 	ValidationDirective string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewPriorityClassOptions returns an initialized PriorityClassOptions instance
-func NewPriorityClassOptions(ioStreams genericclioptions.IOStreams) *PriorityClassOptions {
+func NewPriorityClassOptions(ioStreams genericiooptions.IOStreams) *PriorityClassOptions {
 	return &PriorityClassOptions{
 		Value:            0,
 		PreemptionPolicy: "PreemptLowerPriority",
@@ -81,7 +82,7 @@ func NewPriorityClassOptions(ioStreams genericclioptions.IOStreams) *PriorityCla
 }
 
 // NewCmdCreatePriorityClass is a macro command to create a new priorityClass.
-func NewCmdCreatePriorityClass(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreatePriorityClass(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewPriorityClassOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass_test.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -51,7 +52,7 @@ func TestCreatePriorityClass(t *testing.T) {
 
 	outputFormat := "name"
 
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdCreatePriorityClass(tf, ioStreams)
 	cmd.Flags().Set("value", "1000")
 	cmd.Flags().Set("global-default", "true")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -68,11 +69,11 @@ type QuotaOpts struct {
 	DryRunStrategy      cmdutil.DryRunStrategy
 	ValidationDirective string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewQuotaOpts creates a new *QuotaOpts with sane defaults
-func NewQuotaOpts(ioStreams genericclioptions.IOStreams) *QuotaOpts {
+func NewQuotaOpts(ioStreams genericiooptions.IOStreams) *QuotaOpts {
 	return &QuotaOpts{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
@@ -80,7 +81,7 @@ func NewQuotaOpts(ioStreams genericclioptions.IOStreams) *QuotaOpts {
 }
 
 // NewCmdCreateQuota is a macro command to create a new quota
-func NewCmdCreateQuota(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateQuota(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewQuotaOpts(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	clientgorbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -148,11 +149,11 @@ type CreateRoleOptions struct {
 	FieldManager        string
 	CreateAnnotation    bool
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewCreateRoleOptions returns an initialized CreateRoleOptions instance
-func NewCreateRoleOptions(ioStreams genericclioptions.IOStreams) *CreateRoleOptions {
+func NewCreateRoleOptions(ioStreams genericiooptions.IOStreams) *CreateRoleOptions {
 	return &CreateRoleOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 
@@ -161,7 +162,7 @@ func NewCreateRoleOptions(ioStreams genericclioptions.IOStreams) *CreateRoleOpti
 }
 
 // NewCmdCreateRole returnns an initialized Command instance for 'create role' sub command
-func NewCmdCreateRole(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateRole(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewCreateRoleOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/kubectl/pkg/scheme"
@@ -133,7 +134,7 @@ func TestCreateRole(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdCreateRole(tf, ioStreams)
 			cmd.Flags().Set("dry-run", "client")
 			cmd.Flags().Set("output", "yaml")
@@ -341,7 +342,7 @@ func TestValidate(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		test.roleOptions.IOStreams = genericclioptions.NewTestIOStreamsDiscard()
+		test.roleOptions.IOStreams = genericiooptions.NewTestIOStreamsDiscard()
 
 		var err error
 		test.roleOptions.Mapper, err = tf.ToRESTMapper()
@@ -645,7 +646,7 @@ func TestComplete(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		cmd := NewCmdCreateRole(tf, genericclioptions.NewTestIOStreamsDiscard())
+		cmd := NewCmdCreateRole(tf, genericiooptions.NewTestIOStreamsDiscard())
 		cmd.Flags().Set("resource", test.resources)
 
 		err := test.roleOptions.Complete(tf, cmd, test.params)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	rbacclientv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -67,11 +68,11 @@ type RoleBindingOptions struct {
 	DryRunStrategy      cmdutil.DryRunStrategy
 	ValidationDirective string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewRoleBindingOptions creates a new *RoleBindingOptions with sane defaults
-func NewRoleBindingOptions(ioStreams genericclioptions.IOStreams) *RoleBindingOptions {
+func NewRoleBindingOptions(ioStreams genericiooptions.IOStreams) *RoleBindingOptions {
 	return &RoleBindingOptions{
 		Users:           []string{},
 		Groups:          []string{},
@@ -82,7 +83,7 @@ func NewRoleBindingOptions(ioStreams genericclioptions.IOStreams) *RoleBindingOp
 }
 
 // NewCmdCreateRoleBinding returns an initialized Command instance for 'create rolebinding' sub command
-func NewCmdCreateRoleBinding(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateRoleBinding(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewRoleBindingOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -41,7 +42,7 @@ import (
 
 // NewCmdCreateSecret groups subcommands to create various types of secrets.
 // This is the entry point of create_secret.go which will be called by create.go
-func NewCmdCreateSecret(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateSecret(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "secret",
 		Short: i18n.T("Create a secret using specified subcommand"),
@@ -114,11 +115,11 @@ type CreateSecretOptions struct {
 	DryRunStrategy      cmdutil.DryRunStrategy
 	ValidationDirective string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewSecretOptions creates a new *CreateSecretOptions with default value
-func NewSecretOptions(ioStreams genericclioptions.IOStreams) *CreateSecretOptions {
+func NewSecretOptions(ioStreams genericiooptions.IOStreams) *CreateSecretOptions {
 	return &CreateSecretOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
@@ -126,7 +127,7 @@ func NewSecretOptions(ioStreams genericclioptions.IOStreams) *CreateSecretOption
 }
 
 // NewCmdCreateSecretGeneric is a command to create generic secrets from files, directories, or literal values
-func NewCmdCreateSecretGeneric(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateSecretGeneric(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewSecretOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -111,11 +112,11 @@ type CreateSecretDockerRegistryOptions struct {
 	DryRunStrategy      cmdutil.DryRunStrategy
 	ValidationDirective string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewSecretDockerRegistryOptions creates a new *CreateSecretDockerRegistryOptions with default value
-func NewSecretDockerRegistryOptions(ioStreams genericclioptions.IOStreams) *CreateSecretDockerRegistryOptions {
+func NewSecretDockerRegistryOptions(ioStreams genericiooptions.IOStreams) *CreateSecretDockerRegistryOptions {
 	return &CreateSecretDockerRegistryOptions{
 		Server:     "https://index.docker.io/v1/",
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
@@ -124,7 +125,7 @@ func NewSecretDockerRegistryOptions(ioStreams genericclioptions.IOStreams) *Crea
 }
 
 // NewCmdCreateSecretDockerRegistry is a macro command for creating secrets to work with Docker registries
-func NewCmdCreateSecretDockerRegistry(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateSecretDockerRegistry(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewSecretDockerRegistryOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -72,11 +73,11 @@ type CreateSecretTLSOptions struct {
 	DryRunStrategy      cmdutil.DryRunStrategy
 	ValidationDirective string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewSecretTLSOptions creates a new *CreateSecretTLSOptions with default value
-func NewSecretTLSOptions(ioStrems genericclioptions.IOStreams) *CreateSecretTLSOptions {
+func NewSecretTLSOptions(ioStrems genericiooptions.IOStreams) *CreateSecretTLSOptions {
 	return &CreateSecretTLSOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStrems,
@@ -84,7 +85,7 @@ func NewSecretTLSOptions(ioStrems genericclioptions.IOStreams) *CreateSecretTLSO
 }
 
 // NewCmdCreateSecretTLS is a macro command for creating secrets to work with TLS client or server
-func NewCmdCreateSecretTLS(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateSecretTLS(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewSecretTLSOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -40,7 +41,7 @@ import (
 )
 
 // NewCmdCreateService is a macro command to create a new service
-func NewCmdCreateService(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateService(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "service",
 		Aliases: []string{"svc"},
@@ -76,11 +77,11 @@ type ServiceOptions struct {
 	Client              corev1client.CoreV1Interface
 	DryRunStrategy      cmdutil.DryRunStrategy
 	ValidationDirective string
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewServiceOptions creates a ServiceOptions struct
-func NewServiceOptions(ioStreams genericclioptions.IOStreams, serviceType corev1.ServiceType) *ServiceOptions {
+func NewServiceOptions(ioStreams genericiooptions.IOStreams, serviceType corev1.ServiceType) *ServiceOptions {
 	return &ServiceOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
@@ -239,7 +240,7 @@ var (
 )
 
 // NewCmdCreateServiceClusterIP is a command to create a ClusterIP service
-func NewCmdCreateServiceClusterIP(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateServiceClusterIP(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewServiceOptions(ioStreams, corev1.ServiceTypeClusterIP)
 
 	cmd := &cobra.Command{
@@ -277,7 +278,7 @@ var (
 )
 
 // NewCmdCreateServiceNodePort is a macro command for creating a NodePort service
-func NewCmdCreateServiceNodePort(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateServiceNodePort(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewServiceOptions(ioStreams, corev1.ServiceTypeNodePort)
 
 	cmd := &cobra.Command{
@@ -314,7 +315,7 @@ var (
 )
 
 // NewCmdCreateServiceLoadBalancer is a macro command for creating a LoadBalancer service
-func NewCmdCreateServiceLoadBalancer(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateServiceLoadBalancer(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewServiceOptions(ioStreams, corev1.ServiceTypeLoadBalancer)
 
 	cmd := &cobra.Command{
@@ -354,7 +355,7 @@ var (
 )
 
 // NewCmdCreateServiceExternalName is a macro command for creating an ExternalName service
-func NewCmdCreateServiceExternalName(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateServiceExternalName(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewServiceOptions(ioStreams, corev1.ServiceTypeExternalName)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service_test.go
@@ -17,15 +17,16 @@ limitations under the License.
 package create
 
 import (
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"testing"
+
 	restclient "k8s.io/client-go/rest"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
-	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
 func TestCreateServices(t *testing.T) {
@@ -279,7 +280,7 @@ func TestCreateServiceWithNamespace(t *testing.T) {
 
 	tf.ClientConfigVal = &restclient.Config{}
 
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdCreateServiceClusterIP(tf, ioStreams)
 	cmd.Flags().Set("dry-run", "client")
 	cmd.Flags().Set("output", "jsonpath={.metadata.namespace}")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -62,11 +63,11 @@ type ServiceAccountOpts struct {
 	Mapper meta.RESTMapper
 	Client *coreclient.CoreV1Client
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewServiceAccountOpts creates a new *ServiceAccountOpts with sane defaults
-func NewServiceAccountOpts(ioStreams genericclioptions.IOStreams) *ServiceAccountOpts {
+func NewServiceAccountOpts(ioStreams genericiooptions.IOStreams) *ServiceAccountOpts {
 	return &ServiceAccountOpts{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
@@ -74,7 +75,7 @@ func NewServiceAccountOpts(ioStreams genericclioptions.IOStreams) *ServiceAccoun
 }
 
 // NewCmdCreateServiceAccount is a macro command to create a new service account
-func NewCmdCreateServiceAccount(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateServiceAccount(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewServiceAccountOpts(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -34,8 +34,8 @@ func TestExtraArgsFail(t *testing.T) {
 	f := cmdtesting.NewTestFactory()
 	defer f.Cleanup()
 
-	c := NewCmdCreate(f, genericclioptions.NewTestIOStreamsDiscard())
-	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	c := NewCmdCreate(f, genericiooptions.NewTestIOStreamsDiscard())
+	ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 	options := NewCreateOptions(ioStreams)
 	if options.Complete(f, c, []string{"rc"}) == nil {
 		t.Errorf("unexpected non-error")
@@ -66,7 +66,7 @@ func TestCreateObject(t *testing.T) {
 		}),
 	}
 
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdCreate(tf, ioStreams)
 	cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
 	cmd.Flags().Set("output", "name")
@@ -103,7 +103,7 @@ func TestCreateMultipleObject(t *testing.T) {
 		}),
 	}
 
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdCreate(tf, ioStreams)
 	cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
 	cmd.Flags().Set("filename", "../../../testdata/frontend-service.yaml")
@@ -140,7 +140,7 @@ func TestCreateDirectory(t *testing.T) {
 		}),
 	}
 
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdCreate(tf, ioStreams)
 	cmd.Flags().Set("filename", "../../../testdata/replace/legacy")
 	cmd.Flags().Set("output", "name")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_token.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_token.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -66,7 +67,7 @@ type TokenOptions struct {
 	CoreClient corev1client.CoreV1Interface
 
 	// IOStreams are the output streams for the operation. Required.
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 var (
@@ -98,7 +99,7 @@ var (
 	}
 )
 
-func NewTokenOpts(ioStreams genericclioptions.IOStreams) *TokenOptions {
+func NewTokenOpts(ioStreams genericiooptions.IOStreams) *TokenOptions {
 	return &TokenOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
@@ -106,7 +107,7 @@ func NewTokenOpts(ioStreams genericclioptions.IOStreams) *TokenOptions {
 }
 
 // NewCmdCreateToken returns an initialized Command for 'create token' sub command
-func NewCmdCreateToken(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCreateToken(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewTokenOpts(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_token_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_token_test.go
@@ -33,7 +33,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -299,7 +299,7 @@ status:
 			}
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			ioStreams, _, stdout, _ := genericclioptions.NewTestIOStreams()
+			ioStreams, _, stdout, _ := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdCreateToken(tf, ioStreams)
 			if test.output != "" {
 				cmd.Flags().Set("output", test.output)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/kubernetes"
@@ -135,14 +136,14 @@ type DebugOptions struct {
 	podClient corev1client.CoreV1Interface
 
 	Builder *resource.Builder
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 	WarningPrinter *printers.WarningPrinter
 
 	resource.FilenameOptions
 }
 
 // NewDebugOptions returns a DebugOptions initialized with default values.
-func NewDebugOptions(streams genericclioptions.IOStreams) *DebugOptions {
+func NewDebugOptions(streams genericiooptions.IOStreams) *DebugOptions {
 	return &DebugOptions{
 		Args:           []string{},
 		IOStreams:      streams,
@@ -152,7 +153,7 @@ func NewDebugOptions(streams genericclioptions.IOStreams) *DebugOptions {
 }
 
 // NewCmdDebug returns a cobra command that runs kubectl debug.
-func NewCmdDebug(restClientGetter genericclioptions.RESTClientGetter, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdDebug(restClientGetter genericclioptions.RESTClientGetter, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewDebugOptions(streams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -28,7 +28,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/utils/pointer"
 )
@@ -316,7 +316,7 @@ func TestGenerateDebugContainer(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.opts.IOStreams = genericclioptions.NewTestIOStreamsDiscard()
+			tc.opts.IOStreams = genericiooptions.NewTestIOStreamsDiscard()
 			suffixCounter = 0
 
 			if tc.pod == nil {
@@ -1334,7 +1334,7 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Fail to create profile applier: %s: %v", tc.opts.Profile, err)
 			}
-			tc.opts.IOStreams = genericclioptions.NewTestIOStreamsDiscard()
+			tc.opts.IOStreams = genericiooptions.NewTestIOStreamsDiscard()
 			suffixCounter = 0
 
 			if tc.havePod == nil {
@@ -1716,7 +1716,7 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Fail to create profile applier: %s: %v", tc.opts.Profile, err)
 			}
-			tc.opts.IOStreams = genericclioptions.NewTestIOStreamsDiscard()
+			tc.opts.IOStreams = genericiooptions.NewTestIOStreamsDiscard()
 			suffixCounter = 0
 
 			pod, err := tc.opts.generateNodeDebugPod(tc.node)
@@ -1732,7 +1732,7 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 
 func TestCompleteAndValidate(t *testing.T) {
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
-	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 	cmpFilter := cmp.FilterPath(func(p cmp.Path) bool {
 		switch p.String() {
 		// IOStreams contains unexported fields

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
@@ -132,11 +133,11 @@ type DeleteOptions struct {
 	Mapper        meta.RESTMapper
 	Result        *resource.Result
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 	WarningPrinter *printers.WarningPrinter
 }
 
-func NewCmdDelete(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdDelete(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	deleteFlags := NewDeleteCommandFlags("containing the resource to delete.")
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
@@ -25,6 +25,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/dynamic"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
@@ -49,7 +50,7 @@ type DeleteFlags struct {
 	Raw               *string
 }
 
-func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams genericclioptions.IOStreams) (*DeleteOptions, error) {
+func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams genericiooptions.IOStreams) (*DeleteOptions, error) {
 	options := &DeleteOptions{
 		DynamicClient: dynamicClient,
 		IOStreams:     streams,
@@ -226,7 +227,7 @@ func NewDeleteFlags(usage string) *DeleteFlags {
 	}
 }
 
-func parseCascadingFlag(streams genericclioptions.IOStreams, cascadingFlag string) (metav1.DeletionPropagation, error) {
+func parseCascadingFlag(streams genericiooptions.IOStreams, cascadingFlag string) (metav1.DeletionPropagation, error) {
 	boolValue, err := strconv.ParseBool(cascadingFlag)
 	// The flag is not a boolean
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -29,7 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -77,7 +77,7 @@ func TestDeleteObjectByTuple(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdDelete(tf, streams)
 	cmd.Flags().Set("namespace", "test")
 	cmd.Flags().Set("cascade", "false")
@@ -88,7 +88,7 @@ func TestDeleteObjectByTuple(t *testing.T) {
 	}
 
 	// Test cascading delete of object without client-side reaper doesn't make GET requests
-	streams, _, buf, _ = genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ = genericiooptions.NewTestIOStreams()
 	cmd = NewCmdDelete(tf, streams)
 	cmd.Flags().Set("namespace", "test")
 	cmd.Flags().Set("output", "name")
@@ -139,7 +139,7 @@ func TestCascadingStrategy(t *testing.T) {
 	// DeleteOptions.PropagationPolicy should be Background, when cascading strategy is empty (default).
 	backgroundPolicy := metav1.DeletePropagationBackground
 	policy = &backgroundPolicy
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdDelete(tf, streams)
 	cmd.Flags().Set("namespace", "test")
 	cmd.Flags().Set("output", "name")
@@ -151,7 +151,7 @@ func TestCascadingStrategy(t *testing.T) {
 	// DeleteOptions.PropagationPolicy should be Foreground, when cascading strategy is foreground.
 	foregroundPolicy := metav1.DeletePropagationForeground
 	policy = &foregroundPolicy
-	streams, _, buf, _ = genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ = genericiooptions.NewTestIOStreams()
 	cmd = NewCmdDelete(tf, streams)
 	cmd.Flags().Set("namespace", "test")
 	cmd.Flags().Set("cascade", "foreground")
@@ -164,7 +164,7 @@ func TestCascadingStrategy(t *testing.T) {
 	// Test that delete options should be set to orphan when cascading strategy is orphan.
 	orphanPolicy := metav1.DeletePropagationOrphan
 	policy = &orphanPolicy
-	streams, _, buf, _ = genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ = genericiooptions.NewTestIOStreams()
 	cmd = NewCmdDelete(tf, streams)
 	cmd.Flags().Set("namespace", "test")
 	cmd.Flags().Set("cascade", "orphan")
@@ -206,7 +206,7 @@ func TestDeleteNamedObject(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdDelete(tf, streams)
 	cmd.Flags().Set("namespace", "test")
 	cmd.Flags().Set("cascade", "false")
@@ -217,7 +217,7 @@ func TestDeleteNamedObject(t *testing.T) {
 	}
 
 	// Test cascading delete of object without client-side reaper doesn't make GET requests
-	streams, _, buf, _ = genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ = genericiooptions.NewTestIOStreams()
 	cmd = NewCmdDelete(tf, streams)
 	cmd.Flags().Set("namespace", "test")
 	cmd.Flags().Set("cascade", "false")
@@ -250,7 +250,7 @@ func TestDeleteObject(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdDelete(tf, streams)
 	cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
 	cmd.Flags().Set("cascade", "false")
@@ -386,7 +386,7 @@ func TestGracePeriodScenarios(t *testing.T) {
 			}
 
 			// Test the command using the flags specified in the test case
-			streams, _, out, errOut := genericclioptions.NewTestIOStreams()
+			streams, _, out, errOut := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdDelete(tf, streams)
 			cmd.Flags().Set("output", "name")
 			if test.forceFlag {
@@ -442,7 +442,7 @@ func TestDeleteObjectNotFound(t *testing.T) {
 		GracePeriod:       -1,
 		CascadingStrategy: metav1.DeletePropagationOrphan,
 		Output:            "name",
-		IOStreams:         genericclioptions.NewTestIOStreamsDiscard(),
+		IOStreams:         genericiooptions.NewTestIOStreamsDiscard(),
 	}
 	err := options.Complete(tf, []string{}, fakecmd())
 	if err != nil {
@@ -471,7 +471,7 @@ func TestDeleteObjectIgnoreNotFound(t *testing.T) {
 			}
 		}),
 	}
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdDelete(tf, streams)
 	cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
@@ -522,7 +522,7 @@ func TestDeleteAllNotFound(t *testing.T) {
 		DeleteAll:         true,
 		IgnoreNotFound:    false,
 		Output:            "name",
-		IOStreams:         genericclioptions.NewTestIOStreamsDiscard(),
+		IOStreams:         genericiooptions.NewTestIOStreamsDiscard(),
 	}
 	err := options.Complete(tf, []string{"services"}, fakecmd())
 	if err != nil {
@@ -563,7 +563,7 @@ func TestDeleteAllIgnoreNotFound(t *testing.T) {
 			}
 		}),
 	}
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdDelete(tf, streams)
 	cmd.Flags().Set("all", "true")
@@ -599,7 +599,7 @@ func TestDeleteMultipleObject(t *testing.T) {
 			}
 		}),
 	}
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdDelete(tf, streams)
 	cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
@@ -636,7 +636,7 @@ func TestDeleteMultipleObjectContinueOnMissing(t *testing.T) {
 			}
 		}),
 	}
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	options := &DeleteOptions{
 		FilenameOptions: resource.FilenameOptions{
@@ -688,7 +688,7 @@ func TestDeleteMultipleResourcesWithTheSameName(t *testing.T) {
 			}
 		}),
 	}
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdDelete(tf, streams)
 	cmd.Flags().Set("namespace", "test")
@@ -721,7 +721,7 @@ func TestDeleteDirectory(t *testing.T) {
 			}
 		}),
 	}
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdDelete(tf, streams)
 	cmd.Flags().Set("filename", "../../../testdata/replace/legacy")
@@ -767,7 +767,7 @@ func TestDeleteMultipleSelector(t *testing.T) {
 			}
 		}),
 	}
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdDelete(tf, streams)
 	cmd.Flags().Set("selector", "a=b")
@@ -811,7 +811,7 @@ func TestResourceErrors(t *testing.T) {
 
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+			streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 			options := &DeleteOptions{
 				FilenameOptions:   resource.FilenameOptions{},
 				GracePeriod:       -1,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/describe"
@@ -77,11 +77,11 @@ type DescribeFlags struct {
 	AllNamespaces     bool
 	FilenameOptions   *resource.FilenameOptions
 	DescriberSettings *describe.DescriberSettings
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewDescribeFlags returns a default DescribeFlags
-func NewDescribeFlags(f cmdutil.Factory, streams genericclioptions.IOStreams) *DescribeFlags {
+func NewDescribeFlags(f cmdutil.Factory, streams genericiooptions.IOStreams) *DescribeFlags {
 	return &DescribeFlags{
 		Factory:         f,
 		FilenameOptions: &resource.FilenameOptions{},
@@ -141,7 +141,7 @@ func (flags *DescribeFlags) ToOptions(parent string, args []string) (*DescribeOp
 	return o, nil
 }
 
-func NewCmdDescribe(parent string, f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdDescribe(parent string, f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	flags := NewDescribeFlags(f, streams)
 
 	cmd := &cobra.Command{
@@ -290,5 +290,5 @@ type DescribeOptions struct {
 	DescriberSettings *describe.DescriberSettings
 	FilenameOptions   *resource.FilenameOptions
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -49,7 +50,7 @@ func TestDescribeUnknownSchemaObject(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, cmdtesting.NewInternalType("", "", "foo"))},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdDescribe("kubectl", tf, streams)
 	cmd.Run(cmd, []string{"type", "foo"})
@@ -82,7 +83,7 @@ func TestDescribeUnknownNamespacedSchemaObject(t *testing.T) {
 	}
 	tf.WithNamespace("non-default")
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdDescribe("kubectl", tf, streams)
 	cmd.Run(cmd, []string{"namespacedtype", "foo"})
@@ -122,7 +123,7 @@ func TestDescribeObject(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdDescribe("kubectl", tf, streams)
 	cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
@@ -155,7 +156,7 @@ func TestDescribeListObjects(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdDescribe("kubectl", tf, streams)
 	cmd.Run(cmd, []string{"pods"})
@@ -182,7 +183,7 @@ func TestDescribeObjectShowEvents(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)},
 	}
 
-	cmd := NewCmdDescribe("kubectl", tf, genericclioptions.NewTestIOStreamsDiscard())
+	cmd := NewCmdDescribe("kubectl", tf, genericiooptions.NewTestIOStreamsDiscard())
 	cmd.Flags().Set("show-events", "true")
 	cmd.Run(cmd, []string{"pods"})
 	if d.Settings.ShowEvents != true {
@@ -208,7 +209,7 @@ func TestDescribeObjectSkipEvents(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)},
 	}
 
-	cmd := NewCmdDescribe("kubectl", tf, genericclioptions.NewTestIOStreamsDiscard())
+	cmd := NewCmdDescribe("kubectl", tf, genericiooptions.NewTestIOStreamsDiscard())
 	cmd.Flags().Set("show-events", "false")
 	cmd.Run(cmd, []string{"pods"})
 	if d.Settings.ShowEvents != false {
@@ -234,7 +235,7 @@ func TestDescribeObjectChunkSize(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)},
 	}
 
-	cmd := NewCmdDescribe("kubectl", tf, genericclioptions.NewTestIOStreamsDiscard())
+	cmd := NewCmdDescribe("kubectl", tf, genericiooptions.NewTestIOStreamsDiscard())
 	cmd.Flags().Set("chunk-size", "100")
 	cmd.Run(cmd, []string{"pods"})
 	if d.Settings.ChunkSize != 100 {
@@ -246,7 +247,7 @@ func TestDescribeHelpMessage(t *testing.T) {
 	tf := cmdtesting.NewTestFactory()
 	defer tf.Cleanup()
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdDescribe("kubectl", tf, streams)
 	cmd.SetArgs([]string{"-h"})
@@ -306,7 +307,7 @@ func TestDescribeNoResourcesFound(t *testing.T) {
 				Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)},
 			}
 
-			streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
+			streams, _, buf, errbuf := genericiooptions.NewTestIOStreams()
 
 			cmd := NewCmdDescribe("kubectl", tf, streams)
 			for name, value := range testCase.flags {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
@@ -119,7 +119,7 @@ type DiffOptions struct {
 	tracker *tracker
 }
 
-func NewDiffOptions(ioStreams genericclioptions.IOStreams) *DiffOptions {
+func NewDiffOptions(ioStreams genericiooptions.IOStreams) *DiffOptions {
 	return &DiffOptions{
 		Diff: &DiffProgram{
 			Exec:      exec.New(),
@@ -128,7 +128,7 @@ func NewDiffOptions(ioStreams genericclioptions.IOStreams) *DiffOptions {
 	}
 }
 
-func NewCmdDiff(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdDiff(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	options := NewDiffOptions(streams)
 	cmd := &cobra.Command{
 		Use:                   "diff -f FILENAME",
@@ -179,7 +179,7 @@ func NewCmdDiff(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 // program. By default, `diff(1)` will be used.
 type DiffProgram struct {
 	Exec exec.Interface
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 func (d *DiffProgram) getCommand(args ...string) (string, exec.Cmd) {
@@ -326,7 +326,7 @@ type InfoObject struct {
 	ServerSideApply bool
 	FieldManager    string
 	ForceConflicts  bool
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 var _ Object = &InfoObject{}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
@@ -29,7 +29,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/utils/exec"
 )
 
@@ -71,7 +71,7 @@ func TestDiffProgram(t *testing.T) {
 
 	for i, c := range externalDiffCommands {
 		os.Setenv("KUBECTL_EXTERNAL_DIFF", c)
-		streams, _, stdout, _ := genericclioptions.NewTestIOStreams()
+		streams, _, stdout, _ := genericiooptions.NewTestIOStreams()
 		diff := DiffProgram{
 			IOStreams: streams,
 			Exec:      exec.New(),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -28,6 +28,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -48,7 +49,7 @@ type DrainCmdOptions struct {
 	drainer   *drain.Helper
 	nodeInfos []*resource.Info
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 	WarningPrinter *printers.WarningPrinter
 }
 
@@ -61,7 +62,7 @@ var (
 		kubectl cordon foo`))
 )
 
-func NewCmdCordon(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdCordon(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewDrainCmdOptions(f, ioStreams)
 
 	cmd := &cobra.Command{
@@ -90,7 +91,7 @@ var (
 		kubectl uncordon foo`))
 )
 
-func NewCmdUncordon(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdUncordon(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewDrainCmdOptions(f, ioStreams)
 
 	cmd := &cobra.Command{
@@ -144,7 +145,7 @@ var (
 		kubectl drain foo --grace-period=900`))
 )
 
-func NewDrainCmdOptions(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *DrainCmdOptions {
+func NewDrainCmdOptions(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *DrainCmdOptions {
 	o := &DrainCmdOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("drained").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
@@ -176,7 +177,7 @@ func (o *DrainCmdOptions) onPodDeletedOrEvicted(pod *corev1.Pod, usingEviction b
 	}
 }
 
-func NewCmdDrain(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdDrain(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewDrainCmdOptions(f, ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain_test.go
@@ -29,8 +29,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -38,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -75,7 +74,7 @@ func TestCordon(t *testing.T) {
 		description string
 		node        *corev1.Node
 		expected    *corev1.Node
-		cmd         func(cmdutil.Factory, genericclioptions.IOStreams) *cobra.Command
+		cmd         func(cmdutil.Factory, genericiooptions.IOStreams) *cobra.Command
 		arg         string
 		expectFatal bool
 	}{
@@ -211,7 +210,7 @@ func TestCordon(t *testing.T) {
 			}
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+			ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 			cmd := test.cmd(tf, ioStreams)
 
 			var recovered interface{}
@@ -873,7 +872,7 @@ func TestDrain(t *testing.T) {
 				}
 				tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-				ioStreams, _, outBuf, errBuf := genericclioptions.NewTestIOStreams()
+				ioStreams, _, outBuf, errBuf := genericiooptions.NewTestIOStreams()
 				cmd := NewCmdDrain(tf, ioStreams)
 
 				var recovered interface{}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
@@ -19,7 +19,8 @@ package edit
 import (
 	"github.com/spf13/cobra"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/cmd/util/editor"
 	"k8s.io/kubectl/pkg/util/completion"
@@ -70,7 +71,7 @@ var (
 )
 
 // NewCmdEdit creates the `edit` command
-func NewCmdEdit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdEdit(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := editor.NewEditOptions(editor.NormalEditMode, ioStreams)
 	cmd := &cobra.Command{
 		Use:                   "edit (RESOURCE/NAME | -f FILENAME)",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit_test.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/kubectl/pkg/cmd/apply"
@@ -227,7 +227,7 @@ func TestEdit(t *testing.T) {
 			}
 			tf.WithNamespace(testcase.Namespace)
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-			ioStreams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 
 			var cmd *cobra.Command
 			switch testcase.Mode {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/events/events.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/events/events.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	runtimeresource "k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/kubernetes"
@@ -84,11 +85,11 @@ type EventsFlags struct {
 	ForObject     string
 	FilterTypes   []string
 	ChunkSize     int64
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewEventsFlags returns a default EventsFlags
-func NewEventsFlags(restClientGetter genericclioptions.RESTClientGetter, streams genericclioptions.IOStreams) *EventsFlags {
+func NewEventsFlags(restClientGetter genericclioptions.RESTClientGetter, streams genericiooptions.IOStreams) *EventsFlags {
 	return &EventsFlags{
 		RESTClientGetter: restClientGetter,
 		PrintFlags:       genericclioptions.NewPrintFlags("events").WithTypeSetter(scheme.Scheme),
@@ -112,11 +113,11 @@ type EventsOptions struct {
 
 	PrintObj printers.ResourcePrinterFunc
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewCmdEvents creates a new events command
-func NewCmdEvents(restClientGetter genericclioptions.RESTClientGetter, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdEvents(restClientGetter genericclioptions.RESTClientGetter, streams genericiooptions.IOStreams) *cobra.Command {
 	flags := NewEventsFlags(restClientGetter, streams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/events/events_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/events/events_test.go
@@ -18,17 +18,17 @@ package events
 
 import (
 	"io"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
-	restclient "k8s.io/client-go/rest"
 	"net/http"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 )
@@ -108,7 +108,7 @@ func getFakeEvents() *corev1.EventList {
 
 func TestEventIsSorted(t *testing.T) {
 	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	clientset, err := kubernetes.NewForConfig(cmdtesting.DefaultClientConfig())
 	if err != err {
 		t.Fatal(err)
@@ -146,7 +146,7 @@ otherfoo    15m (x3 over 25m)   Normal    ScalingReplicaSet   Deployment/bar   S
 
 func TestEventNoHeaders(t *testing.T) {
 	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	clientset, err := kubernetes.NewForConfig(cmdtesting.DefaultClientConfig())
 	if err != err {
 		t.Fatal(err)
@@ -183,7 +183,7 @@ otherfoo   15m (x3 over 25m)   Normal    ScalingReplicaSet   Deployment/bar   Sc
 
 func TestEventFiltered(t *testing.T) {
 	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	clientset, err := kubernetes.NewForConfig(cmdtesting.DefaultClientConfig())
 	if err != err {
 		t.Fatal(err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
@@ -76,7 +77,7 @@ const (
 	defaultPodExecTimeout = 60 * time.Second
 )
 
-func NewCmdExec(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdExec(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	options := &ExecOptions{
 		StreamOptions: StreamOptions{
 			IOStreams: streams,
@@ -143,7 +144,7 @@ type StreamOptions struct {
 	// InterruptParent, if set, is used to handle interrupts while attached
 	InterruptParent *interrupt.Handler
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 
 	// for testing
 	overrideStreams func() (io.ReadCloser, io.Writer, io.Writer)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
@@ -29,7 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/client-go/tools/remotecommand"
@@ -142,7 +142,7 @@ func TestPodAndContainer(t *testing.T) {
 			}
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			cmd := NewCmdExec(tf, genericclioptions.NewTestIOStreamsDiscard())
+			cmd := NewCmdExec(tf, genericiooptions.NewTestIOStreamsDiscard())
 			options := test.p
 			options.ErrOut = bytes.NewBuffer([]byte{})
 			options.Out = bytes.NewBuffer([]byte{})
@@ -235,11 +235,11 @@ func TestExec(t *testing.T) {
 				StreamOptions: StreamOptions{
 					PodName:       "foo",
 					ContainerName: "bar",
-					IOStreams:     genericclioptions.NewTestIOStreamsDiscard(),
+					IOStreams:     genericiooptions.NewTestIOStreamsDiscard(),
 				},
 				Executor: ex,
 			}
-			cmd := NewCmdExec(tf, genericclioptions.NewTestIOStreamsDiscard())
+			cmd := NewCmdExec(tf, genericiooptions.NewTestIOStreamsDiscard())
 			args := []string{"pod/foo", "command"}
 			if err := params.Complete(tf, cmd, args, -1); err != nil {
 				t.Fatal(err)
@@ -290,7 +290,7 @@ func execPod() *corev1.Pod {
 }
 
 func TestSetupTTY(t *testing.T) {
-	streams, _, _, stderr := genericclioptions.NewTestIOStreams()
+	streams, _, _, stderr := genericiooptions.NewTestIOStreams()
 
 	// test 1 - don't attach stdin
 	o := &StreamOptions{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
@@ -23,7 +23,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	openapiclient "k8s.io/client-go/openapi"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/explain"
@@ -57,7 +57,7 @@ var (
 )
 
 type ExplainOptions struct {
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 
 	CmdParent  string
 	APIVersion string
@@ -76,7 +76,7 @@ type ExplainOptions struct {
 	OpenAPIV3Client openapiclient.Client
 }
 
-func NewExplainOptions(parent string, streams genericclioptions.IOStreams) *ExplainOptions {
+func NewExplainOptions(parent string, streams genericiooptions.IOStreams) *ExplainOptions {
 	return &ExplainOptions{
 		IOStreams:    streams,
 		CmdParent:    parent,
@@ -85,7 +85,7 @@ func NewExplainOptions(parent string, streams genericclioptions.IOStreams) *Expl
 }
 
 // NewCmdExplain returns a cobra command for swagger docs
-func NewCmdExplain(parent string, f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdExplain(parent string, f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewExplainOptions(parent, streams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain_test.go
@@ -24,7 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	sptest "k8s.io/apimachinery/pkg/util/strategicpatch/testing"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/discovery"
 	openapiclient "k8s.io/client-go/openapi"
 	"k8s.io/client-go/rest"
@@ -57,8 +57,8 @@ func TestExplainInvalidArgs(t *testing.T) {
 	tf := cmdtesting.NewTestFactory()
 	defer tf.Cleanup()
 
-	opts := explain.NewExplainOptions("kubectl", genericclioptions.NewTestIOStreamsDiscard())
-	cmd := explain.NewCmdExplain("kubectl", tf, genericclioptions.NewTestIOStreamsDiscard())
+	opts := explain.NewExplainOptions("kubectl", genericiooptions.NewTestIOStreamsDiscard())
+	cmd := explain.NewCmdExplain("kubectl", tf, genericiooptions.NewTestIOStreamsDiscard())
 	err := opts.Complete(tf, cmd, []string{})
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -84,8 +84,8 @@ func TestExplainNotExistResource(t *testing.T) {
 	tf := cmdtesting.NewTestFactory()
 	defer tf.Cleanup()
 
-	opts := explain.NewExplainOptions("kubectl", genericclioptions.NewTestIOStreamsDiscard())
-	cmd := explain.NewCmdExplain("kubectl", tf, genericclioptions.NewTestIOStreamsDiscard())
+	opts := explain.NewExplainOptions("kubectl", genericiooptions.NewTestIOStreamsDiscard())
+	cmd := explain.NewCmdExplain("kubectl", tf, genericiooptions.NewTestIOStreamsDiscard())
 	err := opts.Complete(tf, cmd, []string{"foo"})
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -208,7 +208,7 @@ func runExplainTestCases(t *testing.T, cases []explainTestCase) {
 	tf.OpenAPISchemaFunc = FakeOpenAPISchema.OpenAPISchemaFn
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	type catchFatal error
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -131,12 +132,12 @@ type ExposeServiceOptions struct {
 	ClientForMapping func(mapping *meta.RESTMapping) (resource.RESTClient, error)
 
 	Recorder genericclioptions.Recorder
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewExposeServiceOptions creates a new ExposeServiceOptions and return a pointer to the
 // struct
-func NewExposeServiceOptions(ioStreams genericclioptions.IOStreams) *ExposeServiceOptions {
+func NewExposeServiceOptions(ioStreams genericiooptions.IOStreams) *ExposeServiceOptions {
 	return &ExposeServiceOptions{
 		RecordFlags: genericclioptions.NewRecordFlags(),
 		PrintFlags:  genericclioptions.NewPrintFlags("exposed").WithTypeSetter(scheme.Scheme),
@@ -147,7 +148,7 @@ func NewExposeServiceOptions(ioStreams genericclioptions.IOStreams) *ExposeServi
 }
 
 // NewCmdExposeService is a command to expose the service from user's input
-func NewCmdExposeService(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdExposeService(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewExposeServiceOptions(streams)
 
 	validArgs := []string{}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/kubectl/pkg/scheme"
@@ -658,7 +658,7 @@ func TestRunExposeService(t *testing.T) {
 				}),
 			}
 
-			ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdExposeService(tf, ioStreams)
 			cmd.SetOut(buf)
 			cmd.SetErr(buf)
@@ -834,7 +834,7 @@ status:
 				}),
 			}
 
-			ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdExposeService(tf, ioStreams)
 			cmd.SetOut(buf)
 			cmd.Flags().Set("protocol", "UDP")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -36,7 +36,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
@@ -82,7 +82,7 @@ type GetOptions struct {
 	NoHeaders      bool
 	IgnoreNotFound bool
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 var (
@@ -142,7 +142,7 @@ const (
 var supportedSubresources = []string{"status", "scale"}
 
 // NewGetOptions returns a GetOptions with default chunk size 500.
-func NewGetOptions(parent string, streams genericclioptions.IOStreams) *GetOptions {
+func NewGetOptions(parent string, streams genericiooptions.IOStreams) *GetOptions {
 	return &GetOptions{
 		PrintFlags: NewGetPrintFlags(),
 		CmdParent:  parent,
@@ -155,7 +155,7 @@ func NewGetOptions(parent string, streams genericclioptions.IOStreams) *GetOptio
 
 // NewCmdGet creates a command object for the generic "get" action, which
 // retrieves one or more resources from a server.
-func NewCmdGet(parent string, f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdGet(parent string, f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewGetOptions(parent, streams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
@@ -101,7 +101,7 @@ func TestGetUnknownSchemaObject(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -145,7 +145,7 @@ func TestGetSchemaObject(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.Run(cmd, []string{"replicationcontrollers", "foo"})
 
@@ -166,7 +166,7 @@ func TestGetObjects(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -192,7 +192,7 @@ func TestGetObjectSubresourceStatus(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &replicationcontrollers.Items[0])},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -220,7 +220,7 @@ func TestGetObjectSubresourceScale(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: replicationControllersScaleSubresourceTableObjBody(codec, replicationcontrollers.Items[0])},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -248,7 +248,7 @@ func TestGetTableObjects(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: podTableObjBody(codec, pods.Items[0])},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -274,7 +274,7 @@ func TestGetV1TableObjects(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: podV1TableObjBody(codec, pods.Items[0])},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -300,7 +300,7 @@ func TestGetObjectsShowKind(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -327,7 +327,7 @@ func TestGetTableObjectsShowKind(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: podTableObjBody(codec, pods.Items[0])},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -381,7 +381,7 @@ func TestGetMultipleResourceTypesShowKinds(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, bufErr := genericclioptions.NewTestIOStreams()
+	streams, _, buf, bufErr := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -443,7 +443,7 @@ func TestGetMultipleTableResourceTypesShowKinds(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, bufErr := genericclioptions.NewTestIOStreams()
+	streams, _, buf, bufErr := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -505,7 +505,7 @@ func TestNoBlankLinesForGetMultipleTableResource(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, bufErr := genericclioptions.NewTestIOStreams()
+	streams, _, buf, bufErr := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -575,7 +575,7 @@ func TestNoBlankLinesForGetAll(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
+	streams, _, buf, errbuf := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -602,7 +602,7 @@ func TestNotFoundMessageForGetNonNamespacedResources(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: emptyTableObjBody(codec)},
 	}
 
-	streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
+	streams, _, buf, errbuf := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -631,7 +631,7 @@ func TestGetObjectsShowLabels(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -658,7 +658,7 @@ func TestGetTableObjectsShowLabels(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: podTableObjBody(codec, pods.Items[0])},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -694,7 +694,7 @@ func TestGetEmptyTable(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: emptyTable},
 	}
 
-	streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
+	streams, _, buf, errbuf := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -745,7 +745,7 @@ func TestGetObjectIgnoreNotFound(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -772,7 +772,7 @@ func TestEmptyResult(t *testing.T) {
 		}),
 	}
 
-	streams, _, _, errbuf := genericclioptions.NewTestIOStreams()
+	streams, _, _, errbuf := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	// we're assuming that an empty file is being passed from stdin
 	cmd.Flags().Set("filename", "-")
@@ -797,7 +797,7 @@ func TestEmptyResultJSON(t *testing.T) {
 		}),
 	}
 
-	streams, _, outbuf, errbuf := genericclioptions.NewTestIOStreams()
+	streams, _, outbuf, errbuf := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	// we're assuming that an empty file is being passed from stdin
 	cmd.Flags().Set("filename", "-")
@@ -861,7 +861,7 @@ func TestGetSortedObjects(t *testing.T) {
 	}
 	tf.ClientConfigVal = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &corev1.SchemeGroupVersion}}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -901,7 +901,7 @@ func TestGetSortedObjectsUnstructuredTable(t *testing.T) {
 	}
 	tf.ClientConfigVal = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &corev1.SchemeGroupVersion}}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1134,7 +1134,7 @@ func TestGetObjectsIdentifiedByFile(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1161,7 +1161,7 @@ func TestGetTableObjectsIdentifiedByFile(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: podTableObjBody(codec, pods.Items[0])},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1188,7 +1188,7 @@ func TestGetListObjects(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1215,7 +1215,7 @@ func TestGetListTableObjects(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: podTableObjBody(codec, pods.Items...)},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1242,7 +1242,7 @@ func TestGetListComponentStatus(t *testing.T) {
 		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: componentStatusTableObjBody(codec, (*statuses).Items...)},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1292,7 +1292,7 @@ func TestGetMixedGenericObjects(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1342,7 +1342,7 @@ func TestGetMultipleTypeObjects(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1382,7 +1382,7 @@ func TestGetMultipleTypeTableObjects(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1423,7 +1423,7 @@ func TestGetMultipleTypeObjectsAsList(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1526,7 +1526,7 @@ func TestGetMultipleTypeObjectsWithLabelSelector(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1571,7 +1571,7 @@ func TestGetMultipleTypeTableObjectsWithLabelSelector(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1616,7 +1616,7 @@ func TestGetMultipleTypeObjectsWithFieldSelector(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1661,7 +1661,7 @@ func TestGetMultipleTypeTableObjectsWithFieldSelector(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1708,7 +1708,7 @@ func TestGetMultipleTypeObjectsWithDirectReference(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1753,7 +1753,7 @@ func TestGetMultipleTypeTableObjectsWithDirectReference(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1909,7 +1909,7 @@ func TestWatchLabelSelector(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -1961,7 +1961,7 @@ func TestWatchTableLabelSelector(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -2013,7 +2013,7 @@ func TestWatchFieldSelector(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -2065,7 +2065,7 @@ func TestWatchTableFieldSelector(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -2111,7 +2111,7 @@ func TestWatchResource(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -2156,7 +2156,7 @@ func TestWatchStatus(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -2203,7 +2203,7 @@ func TestWatchTableResource(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -2310,7 +2310,7 @@ func TestWatchResourceTable(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -2523,7 +2523,7 @@ pod/foo
 				}),
 			}
 
-			streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+			streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdGet("kubectl", tf, streams)
 			cmd.SetOut(buf)
 			cmd.SetErr(buf)
@@ -2570,7 +2570,7 @@ func TestWatchResourceIdentifiedByFile(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -2615,7 +2615,7 @@ func TestWatchOnlyResource(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -2658,7 +2658,7 @@ func TestWatchOnlyTableResource(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -2704,7 +2704,7 @@ func TestWatchOnlyList(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -2750,7 +2750,7 @@ func TestWatchOnlyTableList(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdGet("kubectl", tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kustomize/kustomize.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kustomize/kustomize.go
@@ -18,7 +18,8 @@ package kustomize
 
 import (
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 	"sigs.k8s.io/kustomize/kustomize/v5/commands/build"
@@ -26,7 +27,7 @@ import (
 )
 
 // NewCmdKustomize returns an adapted kustomize build command.
-func NewCmdKustomize(streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdKustomize(streams genericiooptions.IOStreams) *cobra.Command {
 	h := build.MakeHelp("kubectl", "kustomize")
 	return build.NewCmdBuild(
 		filesys.MakeFsOnDisk(),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -85,7 +86,7 @@ type LabelOptions struct {
 	unstructuredClientForMapping func(mapping *meta.RESTMapping) (resource.RESTClient, error)
 
 	// Common shared fields
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 var (
@@ -118,7 +119,7 @@ var (
 		kubectl label pods foo bar-`))
 )
 
-func NewLabelOptions(ioStreams genericclioptions.IOStreams) *LabelOptions {
+func NewLabelOptions(ioStreams genericiooptions.IOStreams) *LabelOptions {
 	return &LabelOptions{
 		RecordFlags: genericclioptions.NewRecordFlags(),
 		Recorder:    genericclioptions.NoopRecorder{},
@@ -129,7 +130,7 @@ func NewLabelOptions(ioStreams genericclioptions.IOStreams) *LabelOptions {
 	}
 }
 
-func NewCmdLabel(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdLabel(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewLabelOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -346,7 +346,7 @@ func TestLabelErrors(t *testing.T) {
 
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+			ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 			buf := bytes.NewBuffer([]byte{})
 			cmd := NewCmdLabel(tf, ioStreams)
 			cmd.SetOut(buf)
@@ -406,7 +406,7 @@ func TestLabelForResourceFromFile(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdLabel(tf, ioStreams)
 	opts := NewLabelOptions(ioStreams)
 	opts.Filenames = []string{"../../../testdata/controller.yaml"}
@@ -438,7 +438,7 @@ func TestLabelLocal(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdLabel(tf, ioStreams)
 	opts := NewLabelOptions(ioStreams)
 	opts.Filenames = []string{"../../../testdata/controller.yaml"}
@@ -495,7 +495,7 @@ func TestLabelMultipleObjects(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	opts := NewLabelOptions(ioStreams)
 	opts.all = true
 	cmd := NewCmdLabel(tf, ioStreams)
@@ -564,7 +564,7 @@ func TestLabelResourceVersion(t *testing.T) {
 	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-	iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
+	iostreams, _, bufOut, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdLabel(tf, iostreams)
 	cmd.SetOut(bufOut)
 	cmd.SetErr(bufOut)
@@ -689,7 +689,7 @@ pod/foo not labeled
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
+			iostreams, _, bufOut, _ := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdLabel(tf, iostreams)
 			cmd.SetOut(bufOut)
 			cmd.SetErr(bufOut)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
@@ -125,14 +126,14 @@ type LogsOptions struct {
 	RESTClientGetter genericclioptions.RESTClientGetter
 	LogsForObject    polymorphichelpers.LogsForObjectFunc
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 
 	TailSpecified bool
 
 	containerNameFromRefSpecRegexp *regexp.Regexp
 }
 
-func NewLogsOptions(streams genericclioptions.IOStreams, allContainers bool) *LogsOptions {
+func NewLogsOptions(streams genericiooptions.IOStreams, allContainers bool) *LogsOptions {
 	return &LogsOptions{
 		IOStreams:            streams,
 		AllContainers:        allContainers,
@@ -144,7 +145,7 @@ func NewLogsOptions(streams genericclioptions.IOStreams, allContainers bool) *Lo
 }
 
 // NewCmdLogs creates a new pod logs command
-func NewCmdLogs(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdLogs(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewLogsOptions(streams, false)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -42,13 +43,13 @@ import (
 func TestLog(t *testing.T) {
 	tests := []struct {
 		name                  string
-		opts                  func(genericclioptions.IOStreams) *LogsOptions
+		opts                  func(genericiooptions.IOStreams) *LogsOptions
 		expectedErr           string
 		expectedOutSubstrings []string
 	}{
 		{
 			name: "v1 - pod log",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -69,7 +70,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "pod logs with prefix",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -91,7 +92,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "pod logs with prefix: init container",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -113,7 +114,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "pod logs with prefix: ephemeral container",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -135,7 +136,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "get logs from multiple requests sequentially",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -169,7 +170,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "follow logs from multiple requests concurrently",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				wg := &sync.WaitGroup{}
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
@@ -207,7 +208,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "fail to follow logs from multiple requests when there are more logs sources then MaxFollowConcurrency allows",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				wg := &sync.WaitGroup{}
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
@@ -242,7 +243,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "fail if LogsForObject fails",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				o := NewLogsOptions(streams, false)
 				o.LogsForObject = func(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool) (map[corev1.ObjectReference]restclient.ResponseWrapper, error) {
 					return nil, errors.New("Error from the LogsForObject")
@@ -253,7 +254,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "fail to get logs, if ConsumeRequestFn fails",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -280,7 +281,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "follow logs from multiple requests concurrently with prefix",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				wg := &sync.WaitGroup{}
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
@@ -319,7 +320,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "fail to follow logs from multiple requests, if ConsumeRequestFn fails",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				wg := &sync.WaitGroup{}
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
@@ -355,7 +356,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "fail to follow logs, if ConsumeRequestFn fails",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -378,7 +379,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "get logs from multiple requests and ignores the error if the container fails",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -413,7 +414,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "get logs from multiple requests and an container fails",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -438,7 +439,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "follow logs from multiple requests and ignores the error if the container fails",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -474,7 +475,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "follow logs from multiple requests and an container fails",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -504,7 +505,7 @@ func TestLog(t *testing.T) {
 			tf := cmdtesting.NewTestFactory().WithNamespace("test")
 			defer tf.Cleanup()
 
-			streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+			streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 			opts := test.opts(streams)
 			opts.Namespace = "test"
@@ -555,12 +556,12 @@ func TestValidateLogOptions(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     []string
-		opts     func(genericclioptions.IOStreams) *LogsOptions
+		opts     func(genericiooptions.IOStreams) *LogsOptions
 		expected string
 	}{
 		{
 			name: "since & since-time",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				o := NewLogsOptions(streams, false)
 				o.SinceSeconds = time.Hour
 				o.SinceTime = "2006-01-02T15:04:05Z"
@@ -578,7 +579,7 @@ func TestValidateLogOptions(t *testing.T) {
 		},
 		{
 			name: "negative since-time",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				o := NewLogsOptions(streams, false)
 				o.SinceSeconds = -1 * time.Second
 
@@ -595,7 +596,7 @@ func TestValidateLogOptions(t *testing.T) {
 		},
 		{
 			name: "negative limit-bytes",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				o := NewLogsOptions(streams, false)
 				o.LimitBytes = -100
 
@@ -612,7 +613,7 @@ func TestValidateLogOptions(t *testing.T) {
 		},
 		{
 			name: "negative tail",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				o := NewLogsOptions(streams, false)
 				o.Tail = -100
 
@@ -629,7 +630,7 @@ func TestValidateLogOptions(t *testing.T) {
 		},
 		{
 			name: "container name combined with --all-containers",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				o := NewLogsOptions(streams, true)
 				o.Container = "my-container"
 
@@ -646,7 +647,7 @@ func TestValidateLogOptions(t *testing.T) {
 		},
 		{
 			name: "container name combined with second argument",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				o := NewLogsOptions(streams, false)
 				o.Container = "my-container"
 				o.ContainerNameSpecified = true
@@ -664,7 +665,7 @@ func TestValidateLogOptions(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		streams := genericclioptions.NewTestIOStreamsDiscard()
+		streams := genericiooptions.NewTestIOStreamsDiscard()
 
 		o := test.opts(streams)
 		o.Resources = test.args
@@ -687,13 +688,13 @@ func TestLogComplete(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     []string
-		opts     func(genericclioptions.IOStreams) *LogsOptions
+		opts     func(genericiooptions.IOStreams) *LogsOptions
 		expected string
 	}{
 		{
 			name: "One args case",
 			args: []string{"foo"},
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				o := NewLogsOptions(streams, false)
 				o.Selector = "foo"
 				return o
@@ -702,12 +703,12 @@ func TestLogComplete(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		cmd := NewCmdLogs(f, genericclioptions.NewTestIOStreamsDiscard())
+		cmd := NewCmdLogs(f, genericiooptions.NewTestIOStreamsDiscard())
 		out := ""
 
 		// checkErr breaks tests in case of errors, plus we just
 		// need to check errors returned by the command validation
-		o := test.opts(genericclioptions.NewTestIOStreamsDiscard())
+		o := test.opts(genericiooptions.NewTestIOStreamsDiscard())
 		err := o.Complete(f, cmd, test.args)
 		if err == nil {
 			t.Fatalf("expected error %q, got none", test.expected)
@@ -811,7 +812,7 @@ func TestNoResourceFoundMessage(t *testing.T) {
 		}),
 	}
 
-	streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
+	streams, _, buf, errbuf := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdLogs(tf, streams)
 	o := NewLogsOptions(streams, false)
 	o.Selector = "foo"

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -74,7 +75,7 @@ type PatchOptions struct {
 	unstructuredClientForMapping func(mapping *meta.RESTMapping) (resource.RESTClient, error)
 	fieldManager                 string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 var (
@@ -107,7 +108,7 @@ var (
 
 var supportedSubresources = []string{"status", "scale"}
 
-func NewPatchOptions(ioStreams genericclioptions.IOStreams) *PatchOptions {
+func NewPatchOptions(ioStreams genericiooptions.IOStreams) *PatchOptions {
 	return &PatchOptions{
 		RecordFlags: genericclioptions.NewRecordFlags(),
 		Recorder:    genericclioptions.NoopRecorder{},
@@ -116,7 +117,7 @@ func NewPatchOptions(ioStreams genericclioptions.IOStreams) *PatchOptions {
 	}
 }
 
-func NewCmdPatch(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdPatch(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewPatchOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
@@ -23,7 +23,7 @@ import (
 
 	jsonpath "github.com/exponent-io/jsonpath"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -57,7 +57,7 @@ func TestPatchObject(t *testing.T) {
 			}
 		}),
 	}
-	stream, _, buf, _ := genericclioptions.NewTestIOStreams()
+	stream, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdPatch(tf, stream)
 	cmd.Flags().Set("namespace", "test")
@@ -91,7 +91,7 @@ func TestPatchObjectFromFile(t *testing.T) {
 			}
 		}),
 	}
-	stream, _, buf, _ := genericclioptions.NewTestIOStreams()
+	stream, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdPatch(tf, stream)
 	cmd.Flags().Set("namespace", "test")
@@ -138,7 +138,7 @@ func TestPatchNoop(t *testing.T) {
 			patchObject.Annotations = map[string]string{}
 		}
 		patchObject.Annotations["foo"] = "bar"
-		stream, _, buf, _ := genericclioptions.NewTestIOStreams()
+		stream, _, buf, _ := genericiooptions.NewTestIOStreams()
 		cmd := NewCmdPatch(tf, stream)
 		cmd.Flags().Set("namespace", "test")
 		cmd.Flags().Set("patch", `{"metadata":{"annotations":{"foo":"bar"}}}`)
@@ -177,7 +177,7 @@ func TestPatchObjectFromFileOutput(t *testing.T) {
 			}
 		}),
 	}
-	stream, _, buf, _ := genericclioptions.NewTestIOStreams()
+	stream, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdPatch(tf, stream)
 	cmd.Flags().Set("namespace", "test")
@@ -222,7 +222,7 @@ func TestPatchSubresource(t *testing.T) {
 			}
 		}),
 	}
-	stream, _, buf, _ := genericclioptions.NewTestIOStreams()
+	stream, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdPatch(tf, stream)
 	cmd.Flags().Set("namespace", "test")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
@@ -26,7 +26,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -58,7 +59,7 @@ var (
 	ValidPluginFilenamePrefixes = []string{"kubectl"}
 )
 
-func NewCmdPlugin(streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdPlugin(streams genericiooptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "plugin [flags]",
 		DisableFlagsInUseLine: true,
@@ -79,11 +80,11 @@ type PluginListOptions struct {
 
 	PluginPaths []string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewCmdPluginList provides a way to list all plugin executables visible to kubectl
-func NewCmdPluginList(streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdPluginList(streams genericiooptions.IOStreams) *cobra.Command {
 	o := &PluginListOptions{
 		IOStreams: streams,
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_completion.go
@@ -27,7 +27,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
 // SetupPluginCompletion adds a Cobra command to the command tree for each
@@ -81,7 +82,7 @@ func SetupPluginCompletion(cmd *cobra.Command, args []string) {
 // for each plugin so that the completion logic knows about the plugins
 func addPluginCommands(cmd *cobra.Command) {
 	kubectl := cmd.Root()
-	streams := genericclioptions.IOStreams{
+	streams := genericiooptions.IOStreams{
 		In:     &bytes.Buffer{},
 		Out:    io.Discard,
 		ErrOut: io.Discard,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
 func TestPluginPathsAreUnaltered(t *testing.T) {
@@ -46,7 +46,7 @@ func TestPluginPathsAreUnaltered(t *testing.T) {
 		}
 	}()
 
-	ioStreams, _, _, errOut := genericclioptions.NewTestIOStreams()
+	ioStreams, _, _, errOut := genericiooptions.NewTestIOStreams()
 	verifier := newFakePluginPathVerifier()
 	pluginPaths := []string{tempDir, tempDir2}
 	o := &PluginListOptions{
@@ -132,7 +132,7 @@ func TestPluginPathsAreValid(t *testing.T) {
 
 	for _, test := range tc {
 		t.Run(test.name, func(t *testing.T) {
-			ioStreams, _, out, errOut := genericclioptions.NewTestIOStreams()
+			ioStreams, _, out, errOut := genericiooptions.NewTestIOStreams()
 			o := &PluginListOptions{
 				Verifier:  test.verifier,
 				IOStreams: ioStreams,
@@ -188,7 +188,7 @@ func TestListPlugins(t *testing.T) {
 	}
 
 	verifier := newFakePluginPathVerifier()
-	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 	pluginPaths := []string{pluginPath}
 
 	o := &PluginListOptions{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
@@ -32,7 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
@@ -98,7 +98,7 @@ const (
 	defaultPodPortForwardWaitTimeout = 60 * time.Second
 )
 
-func NewCmdPortForward(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdPortForward(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	opts := &PortForwardOptions{
 		PortForwarder: &defaultPortForwarder{
 			IOStreams: streams,
@@ -128,7 +128,7 @@ type portForwarder interface {
 }
 
 type defaultPortForwarder struct {
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 func (f *defaultPortForwarder) ForwardPorts(method string, url *url.URL, opts PortForwardOptions) error {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward_test.go
@@ -29,7 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/kubectl/pkg/scheme"
@@ -101,7 +101,7 @@ func testPortForward(t *testing.T, flags map[string]string, args []string) {
 			}
 
 			opts := &PortForwardOptions{}
-			cmd := NewCmdPortForward(tf, genericclioptions.NewTestIOStreamsDiscard())
+			cmd := NewCmdPortForward(tf, genericiooptions.NewTestIOStreamsDiscard())
 			cmd.Run = func(cmd *cobra.Command, args []string) {
 				if err = opts.Complete(tf, cmd, args); err != nil {
 					return

--- a/staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go
@@ -26,9 +26,11 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
+
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/proxy"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -56,7 +58,7 @@ type ProxyOptions struct {
 	clientConfig *rest.Config
 	filter       *proxy.FilterServer
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 const (
@@ -98,7 +100,7 @@ var (
 )
 
 // NewProxyOptions creates the options for proxy
-func NewProxyOptions(ioStreams genericclioptions.IOStreams) *ProxyOptions {
+func NewProxyOptions(ioStreams genericiooptions.IOStreams) *ProxyOptions {
 	return &ProxyOptions{
 		IOStreams:     ioStreams,
 		staticPrefix:  defaultStaticPrefix,
@@ -113,7 +115,7 @@ func NewProxyOptions(ioStreams genericclioptions.IOStreams) *ProxyOptions {
 }
 
 // NewCmdProxy returns the proxy Cobra command
-func NewCmdProxy(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdProxy(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewProxyOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/kubectl/pkg/cmd/delete"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -95,12 +96,12 @@ type ReplaceOptions struct {
 
 	Subresource string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 
 	fieldManager string
 }
 
-func NewReplaceOptions(streams genericclioptions.IOStreams) *ReplaceOptions {
+func NewReplaceOptions(streams genericiooptions.IOStreams) *ReplaceOptions {
 	return &ReplaceOptions{
 		PrintFlags:  genericclioptions.NewPrintFlags("replaced"),
 		DeleteFlags: delete.NewDeleteFlags("The files that contain the configurations to replace."),
@@ -109,7 +110,7 @@ func NewReplaceOptions(streams genericclioptions.IOStreams) *ReplaceOptions {
 	}
 }
 
-func NewCmdReplace(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdReplace(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewReplaceOptions(streams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -62,7 +62,7 @@ func TestReplaceObject(t *testing.T) {
 			}
 		}),
 	}
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdReplace(tf, streams)
 	cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
@@ -132,7 +132,7 @@ func TestReplaceMultipleObject(t *testing.T) {
 			}
 		}),
 	}
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdReplace(tf, streams)
 	cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
@@ -189,7 +189,7 @@ func TestReplaceDirectory(t *testing.T) {
 			}
 		}),
 	}
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdReplace(tf, streams)
 	cmd.Flags().Set("filename", "../../../testdata/replace/legacy")
@@ -235,7 +235,7 @@ func TestForceReplaceObjectNotFound(t *testing.T) {
 			}
 		}),
 	}
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdReplace(tf, streams)
 	cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout.go
@@ -20,7 +20,8 @@ import (
 	"github.com/lithammer/dedent"
 	"github.com/spf13/cobra"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -53,7 +54,7 @@ var (
 )
 
 // NewCmdRollout returns a Command instance for 'rollout' sub command
-func NewCmdRollout(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdRollout(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "rollout SUBCOMMAND",
 		DisableFlagsInUseLine: true,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -62,11 +63,11 @@ type RolloutHistoryOptions struct {
 	RESTClientGetter genericclioptions.RESTClientGetter
 
 	resource.FilenameOptions
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewRolloutHistoryOptions returns an initialized RolloutHistoryOptions instance
-func NewRolloutHistoryOptions(streams genericclioptions.IOStreams) *RolloutHistoryOptions {
+func NewRolloutHistoryOptions(streams genericiooptions.IOStreams) *RolloutHistoryOptions {
 	return &RolloutHistoryOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme),
 		IOStreams:  streams,
@@ -74,7 +75,7 @@ func NewRolloutHistoryOptions(streams genericclioptions.IOStreams) *RolloutHisto
 }
 
 // NewCmdRolloutHistory returns a Command instance for RolloutHistory sub command
-func NewCmdRolloutHistory(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdRolloutHistory(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewRolloutHistoryOptions(streams)
 
 	validArgs := []string{"deployment", "daemonset", "statefulset"}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_history_test.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
@@ -124,7 +125,7 @@ Fake ViewHistory Output
 				return "Fake ViewHistory Output\n", nil
 			}
 
-			streams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+			streams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdRolloutHistory(tf, streams)
 			for k, v := range tc.flags {
 				cmd.Flags().Set(k, v)
@@ -223,7 +224,7 @@ Fake ViewHistory Output
 				return "Fake ViewHistory Output\n", nil
 			}
 
-			streams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+			streams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdRolloutHistory(tf, streams)
 			for k, v := range tc.flags {
 				cmd.Flags().Set(k, v)
@@ -371,7 +372,7 @@ replicaset.apps/rev2
 				}, nil
 			}
 
-			streams, _, buf, errBuf := genericclioptions.NewTestIOStreams()
+			streams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdRolloutHistory(tf, streams)
 			for k, v := range tc.flags {
 				cmd.Flags().Set(k, v)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_pause.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_pause.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/kubectl/pkg/cmd/set"
@@ -49,7 +50,7 @@ type PauseOptions struct {
 	LabelSelector    string
 
 	resource.FilenameOptions
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 
 	fieldManager string
 }
@@ -70,7 +71,7 @@ var (
 )
 
 // NewCmdRolloutPause returns a Command instance for 'rollout pause' sub command
-func NewCmdRolloutPause(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdRolloutPause(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := &PauseOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("paused").WithTypeSetter(scheme.Scheme),
 		IOStreams:  streams,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_pause_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_pause_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -61,7 +61,7 @@ func TestRolloutPause(t *testing.T) {
 		},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdRolloutPause(tf, streams)
 
 	cmd.Run(cmd, []string{deploymentName})

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart.go
@@ -18,10 +18,13 @@ package rollout
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
+
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/kubectl/pkg/cmd/set"
@@ -48,7 +51,7 @@ type RestartOptions struct {
 	LabelSelector    string
 
 	resource.FilenameOptions
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 
 	fieldManager string
 }
@@ -71,7 +74,7 @@ var (
 )
 
 // NewRolloutRestartOptions returns an initialized RestartOptions instance
-func NewRolloutRestartOptions(streams genericclioptions.IOStreams) *RestartOptions {
+func NewRolloutRestartOptions(streams genericiooptions.IOStreams) *RestartOptions {
 	return &RestartOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("restarted").WithTypeSetter(scheme.Scheme),
 		IOStreams:  streams,
@@ -79,7 +82,7 @@ func NewRolloutRestartOptions(streams genericclioptions.IOStreams) *RestartOptio
 }
 
 // NewCmdRolloutRestart returns a Command instance for 'rollout restart' sub command
-func NewCmdRolloutRestart(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdRolloutRestart(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewRolloutRestartOptions(streams)
 
 	validArgs := []string{"deployment", "daemonset", "statefulset"}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart_test.go
@@ -28,7 +28,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/kubectl/pkg/scheme"
@@ -62,7 +62,7 @@ func TestRolloutRestartOne(t *testing.T) {
 		},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdRolloutRestart(tf, streams)
 
 	cmd.Run(cmd, []string{deploymentName})
@@ -98,7 +98,7 @@ func TestRolloutRestartError(t *testing.T) {
 		},
 	}
 
-	streams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
+	streams, _, bufOut, _ := genericiooptions.NewTestIOStreams()
 	opt := NewRolloutRestartOptions(streams)
 	err := opt.Complete(tf, nil, []string{deploymentName})
 	assert.NoError(t, err)
@@ -150,7 +150,7 @@ func TestRolloutRestartSelectorNone(t *testing.T) {
 		},
 	}
 
-	streams, _, outBuf, errBuf := genericclioptions.NewTestIOStreams()
+	streams, _, outBuf, errBuf := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdRolloutRestart(tf, streams)
 	cmd.Flags().Set("selector", "app=test")
 
@@ -205,7 +205,7 @@ func TestRolloutRestartSelectorMany(t *testing.T) {
 		},
 	}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdRolloutRestart(tf, streams)
 	cmd.Flags().Set("selector", labelSelector)
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_resume.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_resume.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/kubectl/pkg/cmd/set"
@@ -50,7 +51,7 @@ type ResumeOptions struct {
 	LabelSelector    string
 
 	resource.FilenameOptions
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 
 	fieldManager string
 }
@@ -69,7 +70,7 @@ var (
 )
 
 // NewRolloutResumeOptions returns an initialized ResumeOptions instance
-func NewRolloutResumeOptions(streams genericclioptions.IOStreams) *ResumeOptions {
+func NewRolloutResumeOptions(streams genericiooptions.IOStreams) *ResumeOptions {
 	return &ResumeOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("resumed").WithTypeSetter(scheme.Scheme),
 		IOStreams:  streams,
@@ -77,7 +78,7 @@ func NewRolloutResumeOptions(streams genericclioptions.IOStreams) *ResumeOptions
 }
 
 // NewCmdRolloutResume returns a Command instance for 'rollout resume' sub command
-func NewCmdRolloutResume(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdRolloutResume(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewRolloutResumeOptions(streams)
 
 	validArgs := []string{"deployment"}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
@@ -77,11 +78,11 @@ type RolloutStatusOptions struct {
 	DynamicClient  dynamic.Interface
 
 	FilenameOptions *resource.FilenameOptions
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewRolloutStatusOptions returns an initialized RolloutStatusOptions instance
-func NewRolloutStatusOptions(streams genericclioptions.IOStreams) *RolloutStatusOptions {
+func NewRolloutStatusOptions(streams genericiooptions.IOStreams) *RolloutStatusOptions {
 	return &RolloutStatusOptions{
 		PrintFlags:      genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme),
 		FilenameOptions: &resource.FilenameOptions{},
@@ -92,7 +93,7 @@ func NewRolloutStatusOptions(streams genericclioptions.IOStreams) *RolloutStatus
 }
 
 // NewCmdRolloutStatus returns a Command instance for the 'rollout status' sub command
-func NewCmdRolloutStatus(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdRolloutStatus(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewRolloutStatusOptions(streams)
 
 	validArgs := []string{"deployment", "daemonset", "statefulset"}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status_test.go
@@ -22,6 +22,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	cgtesting "k8s.io/client-go/testing"
 	"k8s.io/kubectl/pkg/scheme"
@@ -30,7 +31,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 )
 
@@ -80,7 +80,7 @@ func TestRolloutStatus(t *testing.T) {
 		return true, fw, nil
 	})
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdRolloutStatus(tf, streams)
 	cmd.Run(cmd, []string{deploymentName})
 
@@ -138,7 +138,7 @@ func TestRolloutStatusWithSelector(t *testing.T) {
 		return true, fw, nil
 	})
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdRolloutStatus(tf, streams)
 	cmd.Flags().Set("selector", "app=api")
 	cmd.Run(cmd, []string{deploymentName})
@@ -193,7 +193,7 @@ func TestRolloutStatusWatchDisabled(t *testing.T) {
 		return true, fw, nil
 	})
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdRolloutStatus(tf, streams)
 	cmd.Flags().Set("watch", "false")
 	cmd.Run(cmd, []string{deploymentName})
@@ -248,7 +248,7 @@ func TestRolloutStatusWatchDisabledUnavailable(t *testing.T) {
 		return true, fw, nil
 	})
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdRolloutStatus(tf, streams)
 	cmd.Flags().Set("watch", "false")
 	cmd.Run(cmd, []string{deploymentName})

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_undo.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_undo.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -48,7 +49,7 @@ type UndoOptions struct {
 	RESTClientGetter genericclioptions.RESTClientGetter
 
 	resource.FilenameOptions
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 var (
@@ -67,7 +68,7 @@ var (
 )
 
 // NewRolloutUndoOptions returns an initialized UndoOptions instance
-func NewRolloutUndoOptions(streams genericclioptions.IOStreams) *UndoOptions {
+func NewRolloutUndoOptions(streams genericiooptions.IOStreams) *UndoOptions {
 	return &UndoOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("rolled back").WithTypeSetter(scheme.Scheme),
 		IOStreams:  streams,
@@ -76,7 +77,7 @@ func NewRolloutUndoOptions(streams genericclioptions.IOStreams) *UndoOptions {
 }
 
 // NewCmdRolloutUndo returns a Command instance for the 'rollout undo' sub command
-func NewCmdRolloutUndo(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdRolloutUndo(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewRolloutUndoOptions(streams)
 
 	validArgs := []string{"deployment", "daemonset", "statefulset"}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -35,6 +35,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -128,10 +129,10 @@ type RunOptions struct {
 	Namespace        string
 	EnforceNamespace bool
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
-func NewRunOptions(streams genericclioptions.IOStreams) *RunOptions {
+func NewRunOptions(streams genericiooptions.IOStreams) *RunOptions {
 	return &RunOptions{
 		PrintFlags:  genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		DeleteFlags: cmddelete.NewDeleteFlags("to use to replace the resource."),
@@ -143,7 +144,7 @@ func NewRunOptions(streams genericclioptions.IOStreams) *RunOptions {
 	}
 }
 
-func NewCmdRun(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdRun(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewRunOptions(streams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/kubectl/pkg/cmd/delete"
@@ -187,7 +188,7 @@ func TestRunArgsFollowDashRules(t *testing.T) {
 
 			tf.ClientConfigVal = &restclient.Config{}
 
-			cmd := NewCmdRun(tf, genericclioptions.NewTestIOStreamsDiscard())
+			cmd := NewCmdRun(tf, genericiooptions.NewTestIOStreamsDiscard())
 			cmd.Flags().Set("image", "nginx")
 
 			printFlags := genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme)
@@ -198,7 +199,7 @@ func TestRunArgsFollowDashRules(t *testing.T) {
 			}
 
 			deleteFlags := delete.NewDeleteFlags("to use to replace the resource.")
-			deleteOptions, err := deleteFlags.ToOptions(nil, genericclioptions.NewTestIOStreamsDiscard())
+			deleteOptions, err := deleteFlags.ToOptions(nil, genericiooptions.NewTestIOStreamsDiscard())
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
@@ -207,7 +208,7 @@ func TestRunArgsFollowDashRules(t *testing.T) {
 				PrintFlags:    printFlags,
 				DeleteOptions: deleteOptions,
 
-				IOStreams: genericclioptions.NewTestIOStreamsDiscard(),
+				IOStreams: genericiooptions.NewTestIOStreamsDiscard(),
 
 				Image: "nginx",
 
@@ -368,9 +369,9 @@ func TestGenerateService(t *testing.T) {
 				return
 			}
 
-			ioStreams, _, buff, _ := genericclioptions.NewTestIOStreams()
+			ioStreams, _, buff, _ := genericiooptions.NewTestIOStreams()
 			deleteFlags := delete.NewDeleteFlags("to use to replace the resource.")
-			deleteOptions, err := deleteFlags.ToOptions(nil, genericclioptions.NewTestIOStreamsDiscard())
+			deleteOptions, err := deleteFlags.ToOptions(nil, genericiooptions.NewTestIOStreamsDiscard())
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
@@ -519,7 +520,7 @@ func TestRunValidations(t *testing.T) {
 			}
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			streams, _, _, bufErr := genericclioptions.NewTestIOStreams()
+			streams, _, _, bufErr := genericiooptions.NewTestIOStreams()
 			cmdutil.BehaviorOnFatal(func(str string, code int) {
 				bufErr.Write([]byte(str))
 			})
@@ -611,7 +612,7 @@ func TestExpose(t *testing.T) {
 				}),
 			}
 
-			streams, _, _, bufErr := genericclioptions.NewTestIOStreams()
+			streams, _, _, bufErr := genericiooptions.NewTestIOStreams()
 			cmdutil.BehaviorOnFatal(func(str string, code int) {
 				bufErr.Write([]byte(str))
 			})
@@ -751,7 +752,7 @@ status: {}
 			tf := cmdtesting.NewTestFactory().WithNamespace("ns")
 			defer tf.Cleanup()
 
-			streams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
+			streams, _, bufOut, _ := genericiooptions.NewTestIOStreams()
 
 			cmd := NewCmdRun(tf, streams)
 			cmd.Flags().Set("dry-run", "client")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/kubernetes"
@@ -88,10 +89,10 @@ type ScaleOptions struct {
 	parent                       string
 	dryRunStrategy               cmdutil.DryRunStrategy
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
-func NewScaleOptions(ioStreams genericclioptions.IOStreams) *ScaleOptions {
+func NewScaleOptions(ioStreams genericiooptions.IOStreams) *ScaleOptions {
 	return &ScaleOptions{
 		PrintFlags:      genericclioptions.NewPrintFlags("scaled"),
 		RecordFlags:     genericclioptions.NewRecordFlags(),
@@ -102,7 +103,7 @@ func NewScaleOptions(ioStreams genericclioptions.IOStreams) *ScaleOptions {
 }
 
 // NewCmdScale returns a cobra command with the appropriate configuration and flags to run scale
-func NewCmdScale(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdScale(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewScaleOptions(ioStreams)
 
 	validArgs := []string{"deployment", "replicaset", "replicationcontroller", "statefulset"}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set.go
@@ -18,7 +18,9 @@ package set
 
 import (
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -32,7 +34,7 @@ var (
 )
 
 // NewCmdSet returns an initialized Command instance for 'set' sub command
-func NewCmdSet(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdSet(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "set SUBCOMMAND",
 		DisableFlagsInUseLine: true,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/kubernetes"
@@ -129,13 +130,13 @@ type EnvOptions struct {
 	enforceNamespace       bool
 	clientset              *kubernetes.Clientset
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 	WarningPrinter *printers.WarningPrinter
 }
 
 // NewEnvOptions returns an EnvOptions indicating all containers in the selected
 // pod templates are selected by default and allowing environment to be overwritten
-func NewEnvOptions(streams genericclioptions.IOStreams) *EnvOptions {
+func NewEnvOptions(streams genericiooptions.IOStreams) *EnvOptions {
 	return &EnvOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("env updated").WithTypeSetter(scheme.Scheme),
 
@@ -146,7 +147,7 @@ func NewEnvOptions(streams genericclioptions.IOStreams) *EnvOptions {
 }
 
 // NewCmdEnv implements the OpenShift cli env command
-func NewCmdEnv(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdEnv(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewEnvOptions(streams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
@@ -56,7 +57,7 @@ func TestSetEnvLocal(t *testing.T) {
 	tf.ClientConfigVal = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Version: ""}}}
 	outputFormat := "name"
 
-	streams, _, buf, bufErr := genericclioptions.NewTestIOStreams()
+	streams, _, buf, bufErr := genericiooptions.NewTestIOStreams()
 	opts := NewEnvOptions(streams)
 	opts.PrintFlags = genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme)
 	opts.FilenameOptions = resource.FilenameOptions{
@@ -93,7 +94,7 @@ func TestSetEnvLocalNamespace(t *testing.T) {
 	tf.ClientConfigVal = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Version: ""}}}
 	outputFormat := "yaml"
 
-	streams, _, buf, bufErr := genericclioptions.NewTestIOStreams()
+	streams, _, buf, bufErr := genericiooptions.NewTestIOStreams()
 	opts := NewEnvOptions(streams)
 	opts.PrintFlags = genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme)
 	opts.FilenameOptions = resource.FilenameOptions{
@@ -130,7 +131,7 @@ func TestSetMultiResourcesEnvLocal(t *testing.T) {
 	tf.ClientConfigVal = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Version: ""}}}
 
 	outputFormat := "name"
-	streams, _, buf, bufErr := genericclioptions.NewTestIOStreams()
+	streams, _, buf, bufErr := genericiooptions.NewTestIOStreams()
 	opts := NewEnvOptions(streams)
 	opts.PrintFlags = genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme)
 	opts.FilenameOptions = resource.FilenameOptions{
@@ -512,7 +513,7 @@ func TestSetEnvRemote(t *testing.T) {
 			}
 
 			outputFormat := "yaml"
-			streams := genericclioptions.NewTestIOStreamsDiscard()
+			streams := genericiooptions.NewTestIOStreamsDiscard()
 			opts := NewEnvOptions(streams)
 			opts.PrintFlags = genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme)
 			opts.Local = false
@@ -709,7 +710,7 @@ func TestSetEnvFromResource(t *testing.T) {
 			}
 
 			outputFormat := "yaml"
-			streams, _, _, errOut := genericclioptions.NewTestIOStreams()
+			streams, _, _, errOut := genericiooptions.NewTestIOStreams()
 			opts := NewEnvOptions(streams)
 			opts.From = input.from
 			opts.Keys = input.keys
@@ -813,7 +814,7 @@ func TestSetEnvRemoteWithSpecificContainers(t *testing.T) {
 					}
 				}),
 			}
-			streams := genericclioptions.NewTestIOStreamsDiscard()
+			streams := genericiooptions.NewTestIOStreamsDiscard()
 			opts := &EnvOptions{
 				PrintFlags:        genericclioptions.NewPrintFlags("").WithDefaultOutput("yaml").WithTypeSetter(scheme.Scheme),
 				ContainerSelector: input.selector,
@@ -842,7 +843,7 @@ func TestSetEnvDoubleStdinUsage(t *testing.T) {
 	}
 	tf.ClientConfigVal = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Version: ""}}}
 
-	streams, bufIn, _, _ := genericclioptions.NewTestIOStreams()
+	streams, bufIn, _, _ := genericiooptions.NewTestIOStreams()
 	bufIn.WriteString("SOME_ENV_VAR_KEY=SOME_ENV_VAR_VAL")
 	opts := NewEnvOptions(streams)
 	opts.FilenameOptions = resource.FilenameOptions{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -60,7 +61,7 @@ type SetImageOptions struct {
 	Resources              []string
 	ContainerImages        map[string]string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // ImageResolver is a func that receives an image name, and
@@ -96,7 +97,7 @@ var (
 )
 
 // NewImageOptions returns an initialized SetImageOptions instance
-func NewImageOptions(streams genericclioptions.IOStreams) *SetImageOptions {
+func NewImageOptions(streams genericiooptions.IOStreams) *SetImageOptions {
 	return &SetImageOptions{
 		PrintFlags:  genericclioptions.NewPrintFlags("image updated").WithTypeSetter(scheme.Scheme),
 		RecordFlags: genericclioptions.NewRecordFlags(),
@@ -108,7 +109,7 @@ func NewImageOptions(streams genericclioptions.IOStreams) *SetImageOptions {
 }
 
 // NewCmdImage returns an initialized Command instance for the 'set image' sub command
-func NewCmdImage(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdImage(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewImageOptions(streams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
@@ -58,7 +59,7 @@ func TestImageLocal(t *testing.T) {
 
 	outputFormat := "name"
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdImage(tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -171,7 +172,7 @@ func TestSetMultiResourcesImageLocal(t *testing.T) {
 
 	outputFormat := "name"
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdImage(tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -651,7 +652,7 @@ func TestSetImageRemote(t *testing.T) {
 
 			outputFormat := "yaml"
 
-			streams := genericclioptions.NewTestIOStreamsDiscard()
+			streams := genericiooptions.NewTestIOStreamsDiscard()
 			cmd := NewCmdImage(tf, streams)
 			cmd.Flags().Set("output", outputFormat)
 			opts := SetImageOptions{
@@ -764,7 +765,7 @@ func TestSetImageRemoteWithSpecificContainers(t *testing.T) {
 
 			outputFormat := "yaml"
 
-			streams := genericclioptions.NewTestIOStreamsDiscard()
+			streams := genericiooptions.NewTestIOStreamsDiscard()
 			cmd := NewCmdImage(tf, streams)
 			cmd.Flags().Set("output", outputFormat)
 			opts := SetImageOptions{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -87,12 +88,12 @@ type SetResourcesOptions struct {
 	UpdatePodSpecForObject polymorphichelpers.UpdatePodSpecForObjectFunc
 	Resources              []string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewResourcesOptions returns a ResourcesOptions indicating all containers in the selected
 // pod templates are selected by default.
-func NewResourcesOptions(streams genericclioptions.IOStreams) *SetResourcesOptions {
+func NewResourcesOptions(streams genericiooptions.IOStreams) *SetResourcesOptions {
 	return &SetResourcesOptions{
 		PrintFlags:  genericclioptions.NewPrintFlags("resource requirements updated").WithTypeSetter(scheme.Scheme),
 		RecordFlags: genericclioptions.NewRecordFlags(),
@@ -106,7 +107,7 @@ func NewResourcesOptions(streams genericclioptions.IOStreams) *SetResourcesOptio
 }
 
 // NewCmdResources returns initialized Command instance for the 'set resources' sub command
-func NewCmdResources(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdResources(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewResourcesOptions(streams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
@@ -57,7 +58,7 @@ func TestResourcesLocal(t *testing.T) {
 
 	outputFormat := "name"
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdResources(tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -106,7 +107,7 @@ func TestSetMultiResourcesLimitsLocal(t *testing.T) {
 
 	outputFormat := "name"
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdResources(tf, streams)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -497,7 +498,7 @@ func TestSetResourcesRemote(t *testing.T) {
 
 			outputFormat := "yaml"
 
-			streams := genericclioptions.NewTestIOStreamsDiscard()
+			streams := genericiooptions.NewTestIOStreamsDiscard()
 			cmd := NewCmdResources(tf, streams)
 			cmd.Flags().Set("output", outputFormat)
 			opts := SetResourcesOptions{
@@ -606,7 +607,7 @@ func TestSetResourcesRemoteWithSpecificContainers(t *testing.T) {
 
 			outputFormat := "yaml"
 
-			streams := genericclioptions.NewTestIOStreamsDiscard()
+			streams := genericiooptions.NewTestIOStreamsDiscard()
 			cmd := NewCmdResources(tf, streams)
 			cmd.Flags().Set("output", outputFormat)
 			opts := SetResourcesOptions{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -59,7 +60,7 @@ type SetSelectorOptions struct {
 	ResourceFinder genericclioptions.ResourceFinder
 
 	// set at initialization
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 var (
@@ -77,7 +78,7 @@ var (
 )
 
 // NewSelectorOptions returns an initialized SelectorOptions instance
-func NewSelectorOptions(streams genericclioptions.IOStreams) *SetSelectorOptions {
+func NewSelectorOptions(streams genericiooptions.IOStreams) *SetSelectorOptions {
 	return &SetSelectorOptions{
 		ResourceBuilderFlags: genericclioptions.NewResourceBuilderFlags().
 			WithScheme(scheme.Scheme).
@@ -94,7 +95,7 @@ func NewSelectorOptions(streams genericclioptions.IOStreams) *SetSelectorOptions
 }
 
 // NewCmdSelector is the "set selector" command.
-func NewCmdSelector(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdSelector(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewSelectorOptions(streams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 )
@@ -324,7 +325,7 @@ func TestSelectorTest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	iostreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	iostreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	o := &SetSelectorOptions{
 		selector:       labelToSet,
 		ResourceFinder: genericclioptions.NewSimpleFakeResourceFinder(info),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -75,11 +76,11 @@ type SetServiceAccountOptions struct {
 	PrintObj printers.ResourcePrinterFunc
 	Recorder genericclioptions.Recorder
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewSetServiceAccountOptions returns an initialized SetServiceAccountOptions instance
-func NewSetServiceAccountOptions(streams genericclioptions.IOStreams) *SetServiceAccountOptions {
+func NewSetServiceAccountOptions(streams genericiooptions.IOStreams) *SetServiceAccountOptions {
 	return &SetServiceAccountOptions{
 		PrintFlags:  genericclioptions.NewPrintFlags("serviceaccount updated").WithTypeSetter(scheme.Scheme),
 		RecordFlags: genericclioptions.NewRecordFlags(),
@@ -91,7 +92,7 @@ func NewSetServiceAccountOptions(streams genericclioptions.IOStreams) *SetServic
 }
 
 // NewCmdServiceAccount returns the "set serviceaccount" command.
-func NewCmdServiceAccount(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdServiceAccount(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewSetServiceAccountOptions(streams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
@@ -78,7 +79,7 @@ func TestSetServiceAccountLocal(t *testing.T) {
 
 			outputFormat := "yaml"
 
-			streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+			streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 			cmd := NewCmdServiceAccount(tf, streams)
 			cmd.Flags().Set("output", outputFormat)
 			cmd.Flags().Set("local", "true")
@@ -114,7 +115,7 @@ func TestSetServiceAccountMultiLocal(t *testing.T) {
 
 	outputFormat := "name"
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdServiceAccount(tf, streams)
 	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("local", "true")
@@ -347,7 +348,7 @@ func TestSetServiceAccountRemote(t *testing.T) {
 
 			outputFormat := "yaml"
 
-			streams := genericclioptions.NewTestIOStreamsDiscard()
+			streams := genericiooptions.NewTestIOStreamsDiscard()
 			cmd := NewCmdServiceAccount(tf, streams)
 			cmd.Flags().Set("output", outputFormat)
 			saConfig := SetServiceAccountOptions{
@@ -388,7 +389,7 @@ func TestServiceAccountValidation(t *testing.T) {
 
 			outputFormat := ""
 
-			streams := genericclioptions.NewTestIOStreamsDiscard()
+			streams := genericiooptions.NewTestIOStreamsDiscard()
 			cmd := NewCmdServiceAccount(tf, streams)
 
 			saConfig := &SetServiceAccountOptions{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
@@ -28,6 +28,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -77,11 +78,11 @@ type SubjectOptions struct {
 
 	PrintObj printers.ResourcePrinterFunc
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewSubjectOptions returns an initialized SubjectOptions instance
-func NewSubjectOptions(streams genericclioptions.IOStreams) *SubjectOptions {
+func NewSubjectOptions(streams genericiooptions.IOStreams) *SubjectOptions {
 	return &SubjectOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("subjects updated").WithTypeSetter(scheme.Scheme),
 
@@ -90,7 +91,7 @@ func NewSubjectOptions(streams genericclioptions.IOStreams) *SubjectOptions {
 }
 
 // NewCmdSubject returns the "new subject" sub command
-func NewCmdSubject(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdSubject(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewSubjectOptions(streams)
 	cmd := &cobra.Command{
 		Use:                   "subject (-f FILENAME | TYPE NAME) [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run=server|client|none]",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_test.go
@@ -22,12 +22,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	clientcmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 func TestLocalAndDryRunFlags(t *testing.T) {
 	f := clientcmdutil.NewFactory(genericclioptions.NewTestConfigFlags())
-	setCmd := NewCmdSet(f, genericclioptions.NewTestIOStreamsDiscard())
+	setCmd := NewCmdSet(f, genericiooptions.NewTestIOStreamsDiscard())
 	ensureLocalAndDryRunFlagsOnChildren(t, setCmd, "")
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -61,7 +62,7 @@ type TaintOptions struct {
 
 	ClientForMapping func(*meta.RESTMapping) (resource.RESTClient, error)
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 
 	Mapper meta.RESTMapper
 }
@@ -95,7 +96,7 @@ var (
 		kubectl taint nodes foo bar:NoSchedule`))
 )
 
-func NewCmdTaint(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdTaint(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	options := &TaintOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("tainted").WithTypeSetter(scheme.Scheme),
 		IOStreams:  streams,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -309,7 +309,7 @@ func TestTaint(t *testing.T) {
 			}
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
-			cmd := NewCmdTaint(tf, genericclioptions.NewTestIOStreamsDiscard())
+			cmd := NewCmdTaint(tf, genericiooptions.NewTestIOStreamsDiscard())
 
 			sawFatal := false
 			func() {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -44,7 +44,7 @@ var (
 		This command requires Metrics Server to be correctly configured and working on the server. `))
 )
 
-func NewCmdTop(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdTop(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "top",
 		Short: i18n.T("Display resource (CPU/memory) usage"),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
@@ -21,10 +21,10 @@ import (
 	"errors"
 
 	"github.com/spf13/cobra"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/discovery"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -51,7 +51,7 @@ type TopNodeOptions struct {
 	DiscoveryClient discovery.DiscoveryInterface
 	MetricsClient   metricsclientset.Interface
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 var (
@@ -68,7 +68,7 @@ var (
 		  kubectl top node NODE_NAME`))
 )
 
-func NewCmdTopNode(f cmdutil.Factory, o *TopNodeOptions, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdTopNode(f cmdutil.Factory, o *TopNodeOptions, streams genericiooptions.IOStreams) *cobra.Command {
 	if o == nil {
 		o = &TopNodeOptions{
 			IOStreams:          streams,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node_test.go
@@ -27,7 +27,6 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest/fake"
 	core "k8s.io/client-go/testing"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -73,7 +72,7 @@ func TestTopNodeAllMetricsFrom(t *testing.T) {
 		return true, expectedMetrics, nil
 	})
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdTopNode(tf, nil, streams)
 
@@ -140,7 +139,7 @@ func TestTopNodeWithNameMetricsFrom(t *testing.T) {
 		return true, &expectedMetrics, nil
 	})
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdTopNode(tf, nil, streams)
 
@@ -218,7 +217,7 @@ func TestTopNodeWithLabelSelectorMetricsFrom(t *testing.T) {
 		return true, expectedMetrics, nil
 	})
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdTopNode(tf, nil, streams)
 	cmd.Flags().Set("selector", label)
@@ -294,7 +293,7 @@ func TestTopNodeWithSortByCpuMetricsFrom(t *testing.T) {
 		return true, expectedMetrics, nil
 	})
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdTopNode(tf, nil, streams)
 	cmd.Flags().Set("sort-by", "cpu")
@@ -380,7 +379,7 @@ func TestTopNodeWithSortByMemoryMetricsFrom(t *testing.T) {
 		return true, expectedMetrics, nil
 	})
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdTopNode(tf, nil, streams)
 	cmd.Flags().Set("sort-by", "memory")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node_test.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	core "k8s.io/client-go/testing"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/discovery"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -38,7 +39,6 @@ import (
 	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
 
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog/v2"
 )
 
@@ -59,7 +59,7 @@ type TopPodOptions struct {
 	DiscoveryClient discovery.DiscoveryInterface
 	MetricsClient   metricsclientset.Interface
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 const metricsCreationDelay = 2 * time.Minute
@@ -87,7 +87,7 @@ var (
 		kubectl top pod -l name=myLabel`))
 )
 
-func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericiooptions.IOStreams) *cobra.Command {
 	if o == nil {
 		o = &TopPodOptions{
 			IOStreams:          streams,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	core "k8s.io/client-go/testing"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -226,7 +226,7 @@ func TestTopPod(t *testing.T) {
 				}),
 			}
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-			streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+			streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 			cmd := NewCmdTopPod(tf, nil, streams)
 			var cmdOptions *TopPodOptions
@@ -367,7 +367,7 @@ func TestTopPodNoResourcesFound(t *testing.T) {
 				}),
 			}
 			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-			streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
+			streams, _, buf, errbuf := genericiooptions.NewTestIOStreams()
 
 			cmd := NewCmdTopPod(tf, nil, streams)
 			var cmdOptions *TopPodOptions

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_test.go
@@ -24,10 +24,10 @@ import (
 
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
@@ -38,7 +38,7 @@ func TestTopSubcommandsExist(t *testing.T) {
 	f := cmdtesting.NewTestFactory()
 	defer f.Cleanup()
 
-	cmd := NewCmdTop(f, genericclioptions.NewTestIOStreamsDiscard())
+	cmd := NewCmdTop(f, genericiooptions.NewTestIOStreamsDiscard())
 	if !cmd.HasSubCommands() {
 		t.Error("top command should have subcommands")
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -80,7 +81,7 @@ type EditOptions struct {
 
 	managedFields map[types.UID][]metav1.ManagedFieldsEntry
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 
 	Recorder            genericclioptions.Recorder
 	f                   cmdutil.Factory
@@ -93,7 +94,7 @@ type EditOptions struct {
 }
 
 // NewEditOptions returns an initialized EditOptions instance
-func NewEditOptions(editMode EditMode, ioStreams genericclioptions.IOStreams) *EditOptions {
+func NewEditOptions(editMode EditMode, ioStreams genericiooptions.IOStreams) *EditOptions {
 	return &EditOptions{
 		RecordFlags: genericclioptions.NewRecordFlags(),
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 )
 
@@ -243,7 +243,7 @@ func TestManagedFieldsExtractAndRestore(t *testing.T) {
 			// operate on a copy, so we can compare the original and the modified object
 			objCopy := test.object.DeepCopyObject()
 			var infos []*resource.Info
-			o := NewEditOptions(NormalEditMode, genericclioptions.NewTestIOStreamsDiscard())
+			o := NewEditOptions(NormalEditMode, genericiooptions.NewTestIOStreamsDiscard())
 			err := o.extractManagedFields(objCopy)
 			if err != nil {
 				t.Errorf("unexpected extraction error %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/component-base/version"
@@ -61,11 +61,11 @@ type Options struct {
 
 	discoveryClient discovery.CachedDiscoveryInterface
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewOptions returns initialized Options
-func NewOptions(ioStreams genericclioptions.IOStreams) *Options {
+func NewOptions(ioStreams genericiooptions.IOStreams) *Options {
 	return &Options{
 		IOStreams: ioStreams,
 	}
@@ -73,7 +73,7 @@ func NewOptions(ioStreams genericclioptions.IOStreams) *Options {
 }
 
 // NewCmdVersion returns a cobra command for fetching versions
-func NewCmdVersion(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdVersion(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	o := NewOptions(ioStreams)
 	cmd := &cobra.Command{
 		Use:     "version",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
@@ -22,14 +22,15 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 )
 
 func TestNewCmdVersionClientVersion(t *testing.T) {
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 	o := NewOptions(streams)
 	if err := o.Complete(tf, &cobra.Command{}, nil); err != nil {
 		t.Errorf("Unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
@@ -92,11 +93,11 @@ type WaitFlags struct {
 	Timeout      time.Duration
 	ForCondition string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewWaitFlags returns a default WaitFlags
-func NewWaitFlags(restClientGetter genericclioptions.RESTClientGetter, streams genericclioptions.IOStreams) *WaitFlags {
+func NewWaitFlags(restClientGetter genericclioptions.RESTClientGetter, streams genericiooptions.IOStreams) *WaitFlags {
 	return &WaitFlags{
 		RESTClientGetter: restClientGetter,
 		PrintFlags:       genericclioptions.NewPrintFlags("condition met"),
@@ -115,7 +116,7 @@ func NewWaitFlags(restClientGetter genericclioptions.RESTClientGetter, streams g
 }
 
 // NewCmdWait returns a cobra command for waiting
-func NewCmdWait(restClientGetter genericclioptions.RESTClientGetter, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdWait(restClientGetter genericclioptions.RESTClientGetter, streams genericiooptions.IOStreams) *cobra.Command {
 	flags := NewWaitFlags(restClientGetter, streams)
 
 	cmd := &cobra.Command{
@@ -276,7 +277,7 @@ type WaitOptions struct {
 
 	Printer     printers.ResourcePrinter
 	ConditionFn ConditionFunc
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // ConditionFunc is the interface for providing condition checks

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	dynamicfakeclient "k8s.io/client-go/dynamic/fake"
@@ -554,7 +555,7 @@ func TestWaitForDeletion(t *testing.T) {
 
 				Printer:     printers.NewDiscardingPrinter(),
 				ConditionFn: IsDeleted,
-				IOStreams:   genericclioptions.NewTestIOStreamsDiscard(),
+				IOStreams:   genericiooptions.NewTestIOStreamsDiscard(),
 			}
 			err := o.RunWait()
 			switch {
@@ -964,7 +965,7 @@ func TestWaitForCondition(t *testing.T) {
 
 				Printer:     printers.NewDiscardingPrinter(),
 				ConditionFn: ConditionalWait{conditionName: "the-condition", conditionStatus: "status-value", errOut: io.Discard}.IsConditionMet,
-				IOStreams:   genericclioptions.NewTestIOStreamsDiscard(),
+				IOStreams:   genericiooptions.NewTestIOStreamsDiscard(),
 			}
 			err := o.RunWait()
 			switch {
@@ -995,7 +996,7 @@ func TestWaitForDeletionIgnoreNotFound(t *testing.T) {
 		DynamicClient:  fakeClient,
 		Printer:        printers.NewDiscardingPrinter(),
 		ConditionFn:    IsDeleted,
-		IOStreams:      genericclioptions.NewTestIOStreamsDiscard(),
+		IOStreams:      genericiooptions.NewTestIOStreamsDiscard(),
 		ForCondition:   "delete",
 	}
 	err := o.RunWait()
@@ -1182,7 +1183,7 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 					jsonPathCondition: test.jsonPathCond,
 					jsonPathParser:    j,
 					errOut:            io.Discard}.IsJSONPathConditionMet,
-				IOStreams: genericclioptions.NewTestIOStreamsDiscard(),
+				IOStreams: genericiooptions.NewTestIOStreamsDiscard(),
 			}
 
 			err := o.RunWait()
@@ -1445,7 +1446,7 @@ func TestWaitForJSONPathCondition(t *testing.T) {
 				ConditionFn: JSONPathWait{
 					jsonPathCondition: test.jsonPathCond,
 					jsonPathParser:    j, errOut: io.Discard}.IsJSONPathConditionMet,
-				IOStreams: genericclioptions.NewTestIOStreamsDiscard(),
+				IOStreams: genericiooptions.NewTestIOStreamsDiscard(),
 			}
 
 			err := o.RunWait()

--- a/staging/src/k8s.io/kubectl/pkg/rawhttp/raw.go
+++ b/staging/src/k8s.io/kubectl/pkg/rawhttp/raw.go
@@ -23,32 +23,32 @@ import (
 	"io"
 	"os"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest"
 )
 
 // RawPost uses the REST client to POST content
-func RawPost(restClient *rest.RESTClient, streams genericclioptions.IOStreams, url, filename string) error {
+func RawPost(restClient *rest.RESTClient, streams genericiooptions.IOStreams, url, filename string) error {
 	return raw(restClient, streams, url, filename, "POST")
 }
 
 // RawPut uses the REST client to PUT content
-func RawPut(restClient *rest.RESTClient, streams genericclioptions.IOStreams, url, filename string) error {
+func RawPut(restClient *rest.RESTClient, streams genericiooptions.IOStreams, url, filename string) error {
 	return raw(restClient, streams, url, filename, "PUT")
 }
 
 // RawGet uses the REST client to GET content
-func RawGet(restClient *rest.RESTClient, streams genericclioptions.IOStreams, url string) error {
+func RawGet(restClient *rest.RESTClient, streams genericiooptions.IOStreams, url string) error {
 	return raw(restClient, streams, url, "", "GET")
 }
 
 // RawDelete uses the REST client to DELETE content
-func RawDelete(restClient *rest.RESTClient, streams genericclioptions.IOStreams, url, filename string) error {
+func RawDelete(restClient *rest.RESTClient, streams genericiooptions.IOStreams, url, filename string) error {
 	return raw(restClient, streams, url, filename, "DELETE")
 }
 
 // raw makes a simple HTTP request to the provided path on the server using the default credentials.
-func raw(restClient *rest.RESTClient, streams genericclioptions.IOStreams, url, filename, requestType string) error {
+func raw(restClient *rest.RESTClient, streams genericiooptions.IOStreams, url, filename, requestType string) error {
 	var data io.Reader
 	switch {
 	case len(filename) == 0:

--- a/staging/src/k8s.io/kubectl/pkg/util/completion/completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/completion/completion.go
@@ -28,6 +28,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/kubectl/pkg/cmd/apiresources"
 	"k8s.io/kubectl/pkg/cmd/get"
@@ -170,7 +171,7 @@ func CompGetContainers(f cmdutil.Factory, podName string, toComplete string) []s
 // which begin with `toComplete`.
 func CompGetFromTemplate(template *string, f cmdutil.Factory, namespace string, args []string, toComplete string) []string {
 	buf := new(bytes.Buffer)
-	streams := genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: io.Discard}
+	streams := genericiooptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: io.Discard}
 	o := get.NewGetOptions("kubectl", streams)
 
 	// Get the list of names of the specified resource
@@ -260,7 +261,7 @@ func ListUsersInConfig(toComplete string) []string {
 // compGetResourceList returns the list of api resources which begin with `toComplete`.
 func compGetResourceList(restClientGetter genericclioptions.RESTClientGetter, cmd *cobra.Command, toComplete string) []string {
 	buf := new(bytes.Buffer)
-	streams := genericclioptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: io.Discard}
+	streams := genericiooptions.IOStreams{In: os.Stdin, Out: buf, ErrOut: io.Discard}
 	o := apiresources.NewAPIResourceOptions(streams)
 
 	o.Complete(restClientGetter, cmd, nil)

--- a/staging/src/k8s.io/kubectl/pkg/util/completion/completion_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/completion/completion_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/client-go/tools/clientcmd"
@@ -364,7 +364,7 @@ func prepareCompletionTest() (*cmdtesting.TestFactory, *cobra.Command) {
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
 
-	streams, _, _, _ := genericclioptions.NewTestIOStreams()
+	streams, _, _, _ := genericiooptions.NewTestIOStreams()
 	cmd := get.NewCmdGet("kubectl", tf, streams)
 	return tf, cmd
 }

--- a/staging/src/k8s.io/sample-cli-plugin/cmd/kubectl-ns.go
+++ b/staging/src/k8s.io/sample-cli-plugin/cmd/kubectl-ns.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/sample-cli-plugin/pkg/cmd"
 )
 

--- a/staging/src/k8s.io/sample-cli-plugin/cmd/kubectl-ns.go
+++ b/staging/src/k8s.io/sample-cli-plugin/cmd/kubectl-ns.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/spf13/pflag"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/sample-cli-plugin/pkg/cmd"
 )
 
@@ -29,7 +28,7 @@ func main() {
 	flags := pflag.NewFlagSet("kubectl-ns", pflag.ExitOnError)
 	pflag.CommandLine = flags
 
-	root := cmd.NewCmdNamespace(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	root := cmd.NewCmdNamespace(genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/staging/src/k8s.io/sample-cli-plugin/pkg/cmd/ns.go
+++ b/staging/src/k8s.io/sample-cli-plugin/pkg/cmd/ns.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
 var (

--- a/staging/src/k8s.io/sample-cli-plugin/pkg/cmd/ns.go
+++ b/staging/src/k8s.io/sample-cli-plugin/pkg/cmd/ns.go
@@ -60,11 +60,11 @@ type NamespaceOptions struct {
 	listNamespaces bool
 	args           []string
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
 // NewNamespaceOptions provides an instance of NamespaceOptions with default values
-func NewNamespaceOptions(streams genericclioptions.IOStreams) *NamespaceOptions {
+func NewNamespaceOptions(streams genericiooptions.IOStreams) *NamespaceOptions {
 	return &NamespaceOptions{
 		configFlags: genericclioptions.NewConfigFlags(true),
 
@@ -73,7 +73,7 @@ func NewNamespaceOptions(streams genericclioptions.IOStreams) *NamespaceOptions 
 }
 
 // NewCmdNamespace provides a cobra command wrapping NamespaceOptions
-func NewCmdNamespace(streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdNamespace(streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewNamespaceOptions(streams)
 
 	cmd := &cobra.Command{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1558,6 +1558,7 @@ k8s.io/apiserver/plugin/pkg/authorizer/webhook
 # k8s.io/cli-runtime v0.0.0 => ./staging/src/k8s.io/cli-runtime
 ## explicit; go 1.20
 k8s.io/cli-runtime/pkg/genericclioptions
+k8s.io/cli-runtime/pkg/genericiooptions
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
 # k8s.io/client-go v0.0.0 => ./staging/src/k8s.io/client-go


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Currently, `genericclioptions` package imports `resource` package in cli-runtime
(i.e. builder_flags uses builder object in resource). Therefore, it is not allowed
that `resource` can import any package in `genericclioptions`(due to disallowed import cycles).
It is already reasonable burden except `genericclioptions.IOStreams`.

There are some cases we want to raise a warning to user in builder but
it can not be achieved due to resource package can not depend on
IOStreams. Since IOStreams solely contains go primitives, this PR
deprecates `genericclioptions.IOStreams` and introduces `genericiooptions.IOStreams`.
Thanks to this PR, every package can safely import and use `IOStreams`.

But more importantly, this PR paves the way for https://github.com/kubernetes/kubernetes/pull/110218 
which attempts to solve an issue well-known for a long time.

#### Does this PR introduce a user-facing change?
```release-note
Deprecate genericclioptions.IOStreams and use genericiooptions.IOStreams
```