### PR TITLE
apiserver: avoid data race during timeout handling

### DIFF
--- a/test/integration/apiserver/admissionwebhook/timeout_test.go
+++ b/test/integration/apiserver/admissionwebhook/timeout_test.go
@@ -138,6 +138,7 @@ func testWebhookTimeout(t *testing.T, watchCache bool) {
 				// for the reason for triggering this scenario
 				"stream error",
 				"the server was unable to return a response in the time allotted",
+				"request did not complete within requested timeout",
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

When wrapping ServeHTTP with otelhttp, there is a data race: while the actual handler is still reading the body or processing it, timeoutHandler.ServeHTTP reacts to the timeout and returns immediately. Then otelhttp retrieves the number of bytes read from the body while the goroutine doing that reading still runs.

To make the race less likely to occur, two different changes are made: first, the body gets wrapped so that reading starts to fail once the request context is canceled. This causes handlers to abort which (for whatever reason) ignore the request context and prevents updating the otelhttp read counter after a timeout.

Second, timeoutHandler.ServeHTTP gives the handler a short while to react to the cancellation before taking over.

The new unit test triggered the race occasionally, but not all the time.

#### Which issue(s) this PR fixes:

Fixes: https://github.com/kubernetes/kubernetes/issues/117052

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
