### PR TITLE
apiserver: fix data race in case of timeout

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -688,7 +688,12 @@ func (p *patcher) patchResource(ctx context.Context, scope *RequestScope) (runti
 		}
 		return result, err
 	})
-	return result, wasCreated, err
+	if err != nil {
+		// Don't read wasCreated when it is unsure that the request has
+		// been handled.
+		return result, false, err
+	}
+	return result, wasCreated, nil
 }
 
 // applyPatchToObject applies a strategic merge patch of <patchMap> to


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

When finishing the request times out, the callback is still being invoked in another goroutine and the value that it is setting cannot be read because that would be a data race.

#### Which issue(s) this PR fixes:

Found with `go test -race ./test/integration/scheduler/plugins`:

```
WARNING: DATA RACE
Write at 0x00c0049a70af by goroutine 142595:
  k8s.io/apiserver/pkg/endpoints/handlers.(*patcher).patchResource.func2()
      /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/handlers/patch.go:667 +0x224
  k8s.io/apiserver/pkg/endpoints/handlers.(*patcher).patchResource.func3()
      /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/handlers/patch.go:672 +0x57
  k8s.io/apiserver/pkg/endpoints/handlers/finisher.finishRequest.func1()
      /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/handlers/finisher/finisher.go:117 +0xfa

Previous read at 0x00c0049a70af by goroutine 142593:
  k8s.io/apiserver/pkg/endpoints/handlers.(*patcher).patchResource()
      /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/handlers/patch.go:691 +0x113d
  k8s.io/apiserver/pkg/endpoints/handlers.PatchResource.func1()
      /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/handlers/patch.go:228 +0x3424
  k8s.io/apiserver/pkg/endpoints.restfulPatchResource.func1()
  ...
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
