### PR TITLE
Update publishing-bot rules for release branches to Go 1.19.8

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -6,17 +6,17 @@ rules:
       branch: master
       dir: staging/src/k8s.io/code-generator
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/code-generator
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/code-generator
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/code-generator
@@ -32,17 +32,17 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/apimachinery
@@ -62,7 +62,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/api
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -70,7 +70,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/api
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -78,7 +78,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/api
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -110,7 +110,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -124,7 +124,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -138,7 +138,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -180,7 +180,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/component-base
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -192,7 +192,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-base
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -204,7 +204,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-base
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -242,7 +242,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -254,7 +254,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -266,7 +266,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -304,7 +304,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kms
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/kms
@@ -339,7 +339,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apiserver
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -353,7 +353,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/apiserver
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -367,7 +367,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/apiserver
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -421,7 +421,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -439,7 +439,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -457,7 +457,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -523,7 +523,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -546,7 +546,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -569,7 +569,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -639,7 +639,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -658,7 +658,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -677,7 +677,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -738,7 +738,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -758,7 +758,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -778,7 +778,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -837,7 +837,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/metrics
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -851,7 +851,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/metrics
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -865,7 +865,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/metrics
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -907,7 +907,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.24
@@ -919,7 +919,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -931,7 +931,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -971,7 +971,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.24
@@ -985,7 +985,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -999,7 +999,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1042,7 +1042,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1056,7 +1056,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1070,7 +1070,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1114,7 +1114,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kubelet
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1128,7 +1128,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubelet
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1142,7 +1142,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubelet
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1186,7 +1186,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1200,7 +1200,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1214,7 +1214,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1262,7 +1262,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1278,7 +1278,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1294,7 +1294,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1354,7 +1354,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1374,7 +1374,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1394,7 +1394,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1464,7 +1464,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1486,7 +1486,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1508,7 +1508,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1568,7 +1568,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1578,7 +1578,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1588,7 +1588,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1620,7 +1620,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1630,7 +1630,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1640,7 +1640,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1667,17 +1667,17 @@ rules:
       branch: master
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/mount-utils
@@ -1713,7 +1713,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1739,7 +1739,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1765,7 +1765,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1824,17 +1824,17 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cri-api
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/cri-api
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/cri-api
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/cri-api
@@ -1868,7 +1868,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kubectl
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1890,7 +1890,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubectl
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1912,7 +1912,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubectl
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1976,7 +1976,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.24
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1992,7 +1992,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.25
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -2008,7 +2008,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2062,7 +2062,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
-    go: 1.19.7
+    go: 1.19.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area dependency
#### What this PR does / why we need it:

* Update publishing-bot rules for release branches to Go 1.19.8

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/2991

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

/assign @dims @nikhita @sttts 
cc @kubernetes/release-engineering 
/hold
for cherry-picks to get merged