### PR TITLE
Add `--concurrent-job-syncs` flag to kube-controller-manager

### DIFF
--- a/cmd/kube-controller-manager/app/options/jobcontroller.go
+++ b/cmd/kube-controller-manager/app/options/jobcontroller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	jobconfig "k8s.io/kubernetes/pkg/controller/job/config"
@@ -32,6 +34,8 @@ func (o *JobControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	if o == nil {
 		return
 	}
+
+	fs.Int32Var(&o.ConcurrentJobSyncs, "concurrent-job-syncs", o.ConcurrentJobSyncs, "The number of job objects that are allowed to sync concurrently. Larger number = more responsive jobs, but more CPU (and network) load")
 }
 
 // ApplyTo fills up JobController config with options.
@@ -52,5 +56,8 @@ func (o *JobControllerOptions) Validate() []error {
 	}
 
 	errs := []error{}
+	if o.ConcurrentJobSyncs < 1 {
+		errs = append(errs, fmt.Errorf("concurrent-job-syncs must be greater than 0, but got %d", o.ConcurrentJobSyncs))
+	}
 	return errs
 }

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -94,6 +94,7 @@ var args = []string{
 	"--concurrent-service-endpoint-syncs=10",
 	"--concurrent-gc-syncs=30",
 	"--concurrent-namespace-syncs=20",
+	"--concurrent-job-syncs=10",
 	"--concurrent-replicaset-syncs=10",
 	"--concurrent-resource-quota-syncs=10",
 	"--concurrent-service-syncs=2",
@@ -319,7 +320,7 @@ func TestAddFlags(t *testing.T) {
 		},
 		JobController: &JobControllerOptions{
 			&jobconfig.JobControllerConfiguration{
-				ConcurrentJobSyncs: 5,
+				ConcurrentJobSyncs: 10,
 			},
 		},
 		CronJobController: &CronJobControllerOptions{
@@ -570,7 +571,7 @@ func TestApplyTo(t *testing.T) {
 				HorizontalPodAutoscalerTolerance:                    0.1,
 			},
 			JobController: jobconfig.JobControllerConfiguration{
-				ConcurrentJobSyncs: 5,
+				ConcurrentJobSyncs: 10,
 			},
 			CronJobController: cronjobconfig.CronJobControllerConfiguration{
 				ConcurrentCronJobSyncs: 5,
@@ -1076,6 +1077,16 @@ func TestValidateControllersOptions(t *testing.T) {
 				},
 			}).Validate,
 		},
+		{
+			name:                   "JobControllerOptions ConcurrentJobSyncs equal 0",
+			expectErrors:           true,
+			expectedErrorSubString: "concurrent-job-syncs must be greater than 0",
+			validate: (&JobControllerOptions{
+				&jobconfig.JobControllerConfiguration{
+					ConcurrentJobSyncs: 0,
+				},
+			}).Validate,
+		},
 		/* empty errs */
 		{
 			name:         "CronJobControllerOptions",
@@ -1139,7 +1150,7 @@ func TestValidateControllersOptions(t *testing.T) {
 			expectErrors: false,
 			validate: (&JobControllerOptions{
 				&jobconfig.JobControllerConfiguration{
-					ConcurrentJobSyncs: 5,
+					ConcurrentJobSyncs: 10,
 				},
 			}).Validate,
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Number of job controller workers now [defaults to 5](https://github.com/kubernetes/kubernetes/blob/54348233b589a022e042b0cb7a81a2e97db9faa8/pkg/controller/job/config/v1alpha1/defaults.go#L32-L36) but cannot be overridden through CLI flags like one can already do for many other controllers in KCM.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/80397.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add '--concurrent-job-syncs' flag for kube-controller-manager to set the number of job controller workers
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
