### PR TITLE
wait: fix incorrect suggested method

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/poll.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/poll.go
@@ -41,7 +41,7 @@ func PollUntilContextCancel(ctx context.Context, interval time.Duration, immedia
 //	err := PollUntilContextCancel(ctx, interval, immediate, condition)
 //
 // The deadline context will be cancelled if the Poll succeeds before the timeout, simplifying
-// inline usage. All other behavior is identical to PollWithContextTimeout.
+// inline usage. All other behavior is identical to PollUntilContextTimeout.
 func PollUntilContextTimeout(ctx context.Context, interval, timeout time.Duration, immediate bool, condition ConditionWithContextFunc) error {
 	deadlineCtx, deadlineCancel := context.WithTimeout(ctx, timeout)
 	defer deadlineCancel()
@@ -59,7 +59,7 @@ func PollUntilContextTimeout(ctx context.Context, interval, timeout time.Duratio
 //
 // If you want to Poll something forever, see PollInfinite.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextTimeout.
+// Deprecated: This method does not return errors from context, use PollUntilContextTimeout.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func Poll(interval, timeout time.Duration, condition ConditionFunc) error {
@@ -78,7 +78,7 @@ func Poll(interval, timeout time.Duration, condition ConditionFunc) error {
 //
 // If you want to Poll something forever, see PollInfinite.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextTimeout.
+// Deprecated: This method does not return errors from context, use PollUntilContextTimeout.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollWithContext(ctx context.Context, interval, timeout time.Duration, condition ConditionWithContextFunc) error {
@@ -91,7 +91,7 @@ func PollWithContext(ctx context.Context, interval, timeout time.Duration, condi
 // PollUntil always waits interval before the first run of 'condition'.
 // 'condition' will always be invoked at least once.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollUntil(interval time.Duration, condition ConditionFunc, stopCh <-chan struct{}) error {
@@ -104,7 +104,7 @@ func PollUntil(interval time.Duration, condition ConditionFunc, stopCh <-chan st
 // PollUntilWithContext always waits interval before the first run of 'condition'.
 // 'condition' will always be invoked at least once.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollUntilWithContext(ctx context.Context, interval time.Duration, condition ConditionWithContextFunc) error {
@@ -118,7 +118,7 @@ func PollUntilWithContext(ctx context.Context, interval time.Duration, condition
 // Some intervals may be missed if the condition takes too long or the time
 // window is too short.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollInfinite(interval time.Duration, condition ConditionFunc) error {
@@ -132,7 +132,7 @@ func PollInfinite(interval time.Duration, condition ConditionFunc) error {
 // Some intervals may be missed if the condition takes too long or the time
 // window is too short.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollInfiniteWithContext(ctx context.Context, interval time.Duration, condition ConditionWithContextFunc) error {
@@ -150,7 +150,7 @@ func PollInfiniteWithContext(ctx context.Context, interval time.Duration, condit
 //
 // If you want to immediately Poll something forever, see PollImmediateInfinite.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextTimeout.
+// Deprecated: This method does not return errors from context, use PollUntilContextTimeout.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollImmediate(interval, timeout time.Duration, condition ConditionFunc) error {
@@ -168,7 +168,7 @@ func PollImmediate(interval, timeout time.Duration, condition ConditionFunc) err
 //
 // If you want to immediately Poll something forever, see PollImmediateInfinite.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextTimeout.
+// Deprecated: This method does not return errors from context, use PollUntilContextTimeout.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollImmediateWithContext(ctx context.Context, interval, timeout time.Duration, condition ConditionWithContextFunc) error {
@@ -180,7 +180,7 @@ func PollImmediateWithContext(ctx context.Context, interval, timeout time.Durati
 // PollImmediateUntil runs the 'condition' before waiting for the interval.
 // 'condition' will always be invoked at least once.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollImmediateUntil(interval time.Duration, condition ConditionFunc, stopCh <-chan struct{}) error {
@@ -193,7 +193,7 @@ func PollImmediateUntil(interval time.Duration, condition ConditionFunc, stopCh 
 // PollImmediateUntilWithContext runs the 'condition' before waiting for the interval.
 // 'condition' will always be invoked at least once.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollImmediateUntilWithContext(ctx context.Context, interval time.Duration, condition ConditionWithContextFunc) error {
@@ -207,7 +207,7 @@ func PollImmediateUntilWithContext(ctx context.Context, interval time.Duration, 
 // Some intervals may be missed if the condition takes too long or the time
 // window is too short.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollImmediateInfinite(interval time.Duration, condition ConditionFunc) error {
@@ -222,7 +222,7 @@ func PollImmediateInfinite(interval time.Duration, condition ConditionFunc) erro
 // Some intervals may be missed if the condition takes too long or the time
 // window is too short.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollImmediateInfiniteWithContext(ctx context.Context, interval time.Duration, condition ConditionWithContextFunc) error {


### PR DESCRIPTION

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Followup to https://github.com/kubernetes/kubernetes/pull/107826. The referenced method doesn't exist.

This leads to confusing lint's with 1.27. I would recommend a backport to 1.27 but not sure if that aligns with the release schedule.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
