### PR TITLE
supported version of etcd 3.5.7-0 for Kubernetes v1.27.0-rc.0

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -481,6 +481,7 @@ var (
 		24: "3.5.7-0",
 		25: "3.5.7-0",
 		26: "3.5.7-0",
+		27: "3.5.7-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows


### PR DESCRIPTION
What this PR does / why we need it:

/kind cleanup

Which issue(s) this PR fixes:

Fixes #

<img width="677" alt="image" src="https://user-images.githubusercontent.com/13757056/230715257-03a83fa0-b826-4f3e-9198-1fae4fb49f35.png">

W0407 17:22:16.780619 1038742 images.go:80] could not find officially supported version of etcd for Kubernetes v1.27.0-rc.0, falling back to the nearest etcd version (3.5.7-0)

Special notes for your reviewer:

To fix etc version support for Kubernetes v1.27.0-rc.0