### PR TITLE
Add unit tests showing the effect of unlimited containers when calculating pod limits

### DIFF
--- a/pkg/api/v1/resource/helpers_test.go
+++ b/pkg/api/v1/resource/helpers_test.go
@@ -984,6 +984,67 @@ func TestPodResourceLimits(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:    "no limited containers should result in no limits for the pod",
+			expectedLimits: v1.ResourceList{},
+			initContainers: []v1.Container{},
+			containers: []v1.Container{
+				{
+					// Unlimited container
+				},
+			},
+		},
+		{
+			description: "one limited and one unlimited container should result in the limited container's limits for the pod",
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2"),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			initContainers: []v1.Container{},
+			containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("2"),
+							v1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+				{
+					// Unlimited container
+				},
+			},
+		},
+		{
+			description: "one limited and one unlimited init container should result in the limited init container's limits for the pod",
+			expectedLimits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2"),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			initContainers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("2"),
+							v1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+				{
+					// Unlimited init container
+				},
+			},
+			containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("1"),
+							v1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		p := &v1.Pod{


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Add unit tests showing the effect of unlimited containers when calculating pod limits.

This behavior is surprising to some users (see kubectl issues [#1110](https://github.com/kubernetes/kubectl/issues/1110) and [#1385](https://github.com/kubernetes/kubectl/issues/1385)), who expect that an unlimited container will result in an unlimited pod, but that is not how [`PodLimits()`](https://github.com/kubernetes/kubernetes/blob/d011cc4d870b3089526a6c24b8fecc85bae25a75/pkg/api/v1/resource/helpers.go#L128) works, as it ignores any containers that do not specify limits when calculating the pod limits.

This commit adds unit tests that confirm this behavior.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
