### PR TITLE
RFC: apimachinery: avoid modifying object when encoding TypeMeta as JSON

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.pb.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.pb.go
@@ -3347,7 +3347,8 @@ func (m *Timestamp) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *TypeMeta) Marshal() (dAtA []byte, err error) {
+// TODO: automatate the Marshal -> marshal renaming during code generation.
+func (m *TypeMeta) marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -3357,12 +3358,12 @@ func (m *TypeMeta) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *TypeMeta) MarshalTo(dAtA []byte) (int, error) {
+func (m *TypeMeta) marshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *TypeMeta) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *TypeMeta) marshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -4228,7 +4229,7 @@ func (m *Timestamp) Size() (n int) {
 	return n
 }
 
-func (m *TypeMeta) Size() (n int) {
+func (m *TypeMeta) size() (n int) {
 	if m == nil {
 		return 0
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/helper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/helper.go
@@ -236,6 +236,10 @@ func (e WithVersionEncoder) Encode(obj Object, stream io.Writer) error {
 			gvk = preferredGVK
 		}
 	}
+	if gvk == oldGVK {
+		// gvk already set as intended, skip injecting it.
+		return e.Encoder.Encode(obj, stream)
+	}
 	kind.SetGroupVersionKind(gvk)
 	err = e.Encoder.Encode(obj, stream)
 	kind.SetGroupVersionKind(oldGVK)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It's surprising that client-go Create calls don't treat the object as read-only. Encoding temporarily sets the kind of the object, which causes data races when the same object is used in parallel (for example, creating multiple different objects with a generated name).

A general solution is hard. However, a special solution for the most common case (API types which embed TypeMeta and JSON encoding) is possible: the underlying idea is that the type is asked to create a new TypeMeta instance, the kind is set there, then the encoder inlines the original struct and that separate TypeMeta in the same JSON object.

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/issues/82497

#### Special notes for your reviewer:

In practice, the implementation is a bit tricky because of the abstraction layers. Also, the JSON encoder doesn't inline interface types (https://github.com/golang/go/issues/6213#issuecomment-1500639389), so that part has to be done manually.

Further work is needed (covering more encoder options, more tests), but first I'd like to get feedback whether this approach is viable.

#### Does this PR introduce a user-facing change?

TBD

```release-note
```
