### PR TITLE
Unify fsnotify usage for the apiserver.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller.go
@@ -122,7 +122,7 @@ func (d *DynamicKMSEncryptionConfigContent) handleWatchEvent(event fsnotify.Even
 	defer d.queue.Add(workqueueKey)
 
 	// return if file has not been removed or renamed.
-	if event.Op&(fsnotify.Remove|fsnotify.Rename) == 0 {
+	if !event.Has(fsnotify.Remove) && !event.Has(fsnotify.Rename) {
 		return nil
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
I read the code , found there are 3 places to reference the 'fsnotify' , but the ```staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller.go``` is not the same style for it..
cleanup it for the unify.

#### Does this PR introduce a user-facing change?
```release-note
None
```
