### PR TITLE
Stablize HPA e2e jobs when running on Windows nodes

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -240,12 +240,22 @@ func scaleUp(ctx context.Context, name string, kind schema.GroupVersionKind, res
 		metricTargetType: metricTargetType,
 	}
 	if resourceType == cpuResource {
-		st.initCPUTotal = 250
+		if framework.NodeOSDistroIs("windows") {
+			st.initCPUTotal = 325
+		} else {
+			st.initCPUTotal = 250
+		}
 		st.cpuBurst = 700
 	}
 	if resourceType == memResource {
-		st.initMemTotal = 250
-		st.memBurst = 700
+		if framework.NodeOSDistroIs("windows") {
+			st.initMemTotal = 275
+			st.memBurst = 750
+		} else {
+			st.initMemTotal = 250
+			st.memBurst = 700
+		}
+
 	}
 	st.run(ctx, name, kind, f)
 }
@@ -356,7 +366,13 @@ func scaleUpContainerResource(ctx context.Context, name string, kind schema.Grou
 		st.cpuBurst = 700
 	}
 	if resourceType == memResource {
-		st.initMemTotal = 250
+		if framework.NodeOSDistroIs("windows") {
+			// Windows containers consume 30-40Mb of memory idle, so we need to
+			// lover the initial mem total so we don't scale to 4 replicas on accident.
+			st.initMemTotal = 200
+		} else {
+			st.initMemTotal = 250
+		}
 		st.memBurst = 700
 	}
 	st.run(ctx, name, kind, f)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
HPA e2e test jobs on Windows have been flakey for a few releases.
- https://testgrid.k8s.io/sig-windows-master-release#capz-windows-containerd-master-serial-slow-hpa
- https://testgrid.k8s.io/sig-windows-master-release#capz-windows-2022-master-serial-slow-hpa

Most of the flakiness is a result of the memory / CPU requests used by the test deployment will cause the HPA to over or undershoot the target nodes by 1 due to the differences in idle resource consumption in Window containers.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig windows testing