### PR TITLE
scheduler perf: remove cleanup func

### DIFF
--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -750,8 +750,7 @@ func runWorkload(ctx context.Context, b *testing.B, tc *testCase, w *workload) [
 			b.Fatalf("validate scheduler config file failed: %v", err)
 		}
 	}
-	finalFunc, podInformer, client, dynClient := mustSetupScheduler(ctx, b, cfg)
-	b.Cleanup(finalFunc)
+	podInformer, client, dynClient := mustSetupScheduler(ctx, b, cfg)
 
 	var mu sync.Mutex
 	var dataItems []DataItem


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

b.Cleanup may as well get called inside the function instead of leaving that to the caller. Makes the code simpler.

#### Special notes for your reviewer:

Originally part of https://github.com/kubernetes/kubernetes/pull/116207

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/cc @alculquicondor @kerthcet 