### PR TITLE
test/integration: create nodes directly with kubernetes.io/hostname label

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -25,8 +25,6 @@
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
-    uniqueNodeLabelStrategy:
-      labelKey: kubernetes.io/hostname
   - opcode: createNamespaces
     prefix: sched
     count: 2
@@ -198,8 +196,6 @@
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
-    uniqueNodeLabelStrategy:
-      labelKey: kubernetes.io/hostname
   - opcode: createNamespaces
     prefix: sched
     count: 2
@@ -227,8 +223,6 @@
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
-    uniqueNodeLabelStrategy:
-      labelKey: kubernetes.io/hostname
   - opcode: createNamespaces
     prefix: sched
     count: 2
@@ -491,8 +485,6 @@
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
-    uniqueNodeLabelStrategy:
-      labelKey: kubernetes.io/hostname
   - opcode: createNamespaces
     prefix: init-ns
     countParam: $initNamespaces
@@ -524,8 +516,6 @@
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
-    uniqueNodeLabelStrategy:
-      labelKey: kubernetes.io/hostname
   - opcode: createNamespaces
     prefix: init-ns
     countParam: $initNamespaces
@@ -591,8 +581,6 @@
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
-    uniqueNodeLabelStrategy:
-      labelKey: kubernetes.io/hostname
   - opcode: createNamespaces
     prefix: init-ns
     countParam: $initNamespaces
@@ -626,13 +614,9 @@
   workloadTemplate:
   - opcode: createNodes
     countParam: $normalNodes
-    uniqueNodeLabelStrategy:
-      labelKey: kubernetes.io/hostname
   - opcode: createNodes
     nodeTemplatePath: config/node-with-taint.yaml
     countParam: $taintNodes
-    uniqueNodeLabelStrategy:
-      labelKey: kubernetes.io/hostname
   - opcode: createPods
     countParam: $measurePods
     collectMetrics: true


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

By generating the unique name in advance, the label also can be set to a matching value directly in the Create request. This makes test startup in test/integration/scheduler_perf a bit faster because the extra patching can be avoided.

It also leads to a better label because previously, the unique label value didn't match the node name. This is required for simulating dynamic resource allocation, which relies on the label to track where an allocated claim is available.

#### Special notes for your reviewer:

Originally part of https://github.com/kubernetes/kubernetes/pull/116207

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @alculquicondor @kerthcet 