### PR TITLE
scheduler perf: allow creating 0 items

### DIFF
--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -265,6 +265,14 @@ func isValidParameterizable(val string) bool {
 	return strings.HasPrefix(val, "$")
 }
 
+func isValidCount(allowParameterization bool, count int, countParam string) bool {
+	if !allowParameterization || countParam == "" {
+		// Ignore parameter. The value itself must be okay.
+		return count >= 0
+	}
+	return isValidParameterizable(countParam)
+}
+
 // createNodesOp defines an op where nodes are created as a part of a workload.
 type createNodesOp struct {
 	// Must be "createNodes".
@@ -288,9 +296,7 @@ func (cno *createNodesOp) isValid(allowParameterization bool) error {
 	if cno.Opcode != createNodesOpcode {
 		return fmt.Errorf("invalid opcode %q", cno.Opcode)
 	}
-	ok := cno.Count > 0 ||
-		(cno.CountParam != "" && allowParameterization && isValidParameterizable(cno.CountParam))
-	if !ok {
+	if !isValidCount(allowParameterization, cno.Count, cno.CountParam) {
 		return fmt.Errorf("invalid Count=%d / CountParam=%q", cno.Count, cno.CountParam)
 	}
 	return nil
@@ -331,9 +337,7 @@ func (cmo *createNamespacesOp) isValid(allowParameterization bool) error {
 	if cmo.Opcode != createNamespacesOpcode {
 		return fmt.Errorf("invalid opcode %q", cmo.Opcode)
 	}
-	ok := cmo.Count > 0 ||
-		(cmo.CountParam != "" && allowParameterization && isValidParameterizable(cmo.CountParam))
-	if !ok {
+	if !isValidCount(allowParameterization, cmo.Count, cmo.CountParam) {
 		return fmt.Errorf("invalid Count=%d / CountParam=%q", cmo.Count, cmo.CountParam)
 	}
 	return nil
@@ -390,9 +394,7 @@ func (cpo *createPodsOp) isValid(allowParameterization bool) error {
 	if cpo.Opcode != createPodsOpcode {
 		return fmt.Errorf("invalid opcode %q; expected %q", cpo.Opcode, createPodsOpcode)
 	}
-	ok := cpo.Count > 0 ||
-		(cpo.CountParam != "" && allowParameterization && isValidParameterizable(cpo.CountParam))
-	if !ok {
+	if !isValidCount(allowParameterization, cpo.Count, cpo.CountParam) {
 		return fmt.Errorf("invalid Count=%d / CountParam=%q", cpo.Count, cpo.CountParam)
 	}
 	if cpo.CollectMetrics && cpo.SkipWaitToCompletion {
@@ -438,9 +440,7 @@ func (cpso *createPodSetsOp) isValid(allowParameterization bool) error {
 	if cpso.Opcode != createPodSetsOpcode {
 		return fmt.Errorf("invalid opcode %q; expected %q", cpso.Opcode, createPodSetsOpcode)
 	}
-	ok := cpso.Count > 0 ||
-		(cpso.CountParam != "" && allowParameterization && isValidParameterizable(cpso.CountParam))
-	if !ok {
+	if !isValidCount(allowParameterization, cpso.Count, cpso.CountParam) {
 		return fmt.Errorf("invalid Count=%d / CountParam=%q", cpso.Count, cpso.CountParam)
 	}
 	return cpso.CreatePodsOp.isValid(allowParameterization)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It makes sense to define a test where, depending on the parameters, some operation creations zero pods, namespaces or nodes. The validation didn't allow that previously due to the way how it was implemented although the underlying code works fine with zero as count.

#### Special notes for your reviewer:

Originally part of https://github.com/kubernetes/kubernetes/pull/116207

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @alculquicondor @kerthcet 