### PR TITLE
Fix azure disk e2e after migration and while using external CCM

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1443,7 +1443,7 @@ func (a *azureDiskDriver) CreateVolume(ctx context.Context, config *storageframe
 		// so pods should be also scheduled there.
 		config.ClientNodeSelection = e2epod.NodeSelection{
 			Selector: map[string]string{
-				v1.LabelFailureDomainBetaZone: zone,
+				v1.LabelTopologyZone: zone,
 			},
 		}
 	}
@@ -1744,6 +1744,10 @@ func getInlineVolumeZone(ctx context.Context, f *framework.Framework) string {
 	zone, ok := node.Labels[v1.LabelFailureDomainBetaZone]
 	if ok {
 		return zone
+	}
+	topologyZone, ok := node.Labels[v1.LabelTopologyZone]
+	if ok {
+		return topologyZone
 	}
 	return ""
 }


### PR DESCRIPTION
This PR fixes failing e2e after azure disk migration is enabled with external CCM

The newer azure CCM is not using older `failure-domain` styled labels and hence we can't pick those labels from nodes. Also if a volume is created without zone information in Azure, it is considered non-zonal and scheduling in certain zones will fail.

```release-note
Allow Azure Disk e2es to use newer topology labels if available from nodes
```