### PR TITLE
Added no resource found message to rollout status

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
@@ -169,6 +169,13 @@ func (o *RolloutStatusOptions) Run() error {
 		Flatten().
 		Do()
 
+	info, _ := r.Infos()
+
+	if len(info) == 0 {
+		fmt.Fprintf(o.Out, "no resources found in %s namespace.\n", o.Namespace)
+		return nil
+	}
+
 	err := r.Err()
 	if err != nil {
 		return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
@@ -169,19 +169,15 @@ func (o *RolloutStatusOptions) Run() error {
 		Flatten().
 		Do()
 
-	info, _ := r.Infos()
-
-	if len(info) == 0 {
-		fmt.Fprintf(o.ErrOut, "No resources found in %s namespace.\n", o.Namespace)
-		return nil
-	}
-
 	err := r.Err()
 	if err != nil {
 		return err
 	}
 
-	return r.Visit(func(info *resource.Info, _ error) error {
+	resourceFound := false
+
+	r.Visit(func(info *resource.Info, _ error) error {
+		resourceFound = true
 		mapping := info.ResourceMapping()
 		statusViewer, err := o.StatusViewerFn(mapping)
 		if err != nil {
@@ -235,4 +231,10 @@ func (o *RolloutStatusOptions) Run() error {
 			return err
 		})
 	})
+
+	if !resourceFound {
+		fmt.Fprintf(o.ErrOut, "No resources found in %s namespace.\n", o.Namespace)
+	}
+
+	return nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
@@ -172,7 +172,7 @@ func (o *RolloutStatusOptions) Run() error {
 	info, _ := r.Infos()
 
 	if len(info) == 0 {
-		fmt.Fprintf(o.Out, "no resources found in %s namespace.\n", o.Namespace)
+		fmt.Fprintf(o.ErrOut, "No resources found in %s namespace.\n", o.Namespace)
 		return nil
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status_test.go
@@ -110,29 +110,6 @@ func TestRolloutStatusNoResources(t *testing.T) {
 		}),
 	}
 
-	tf.FakeDynamicClient.WatchReactionChain = nil
-	tf.FakeDynamicClient.AddWatchReactor("*", func(action cgtesting.Action) (handled bool, ret watch.Interface, err error) {
-		fw := watch.NewFake()
-		dep := &appsv1.ReplicaSet{}
-		dep.Name = deploymentName
-		dep.Status = appsv1.ReplicaSetStatus{
-			Replicas:          1,
-			ReadyReplicas:     1,
-			AvailableReplicas: 1,
-			Conditions: []appsv1.ReplicaSetCondition{{
-				Type: "Available",
-			}},
-		}
-		c, err := runtime.DefaultUnstructuredConverter.ToUnstructured(dep.DeepCopyObject())
-		if err != nil {
-			t.Errorf("unexpected err %s", err)
-		}
-		u := &unstructured.Unstructured{}
-		u.SetUnstructuredContent(c)
-		go fw.Add(u)
-		return true, fw, nil
-	})
-
 	streams, _, _, buf := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdRolloutStatus(tf, streams)
 	cmd.Run(cmd, []string{"deployment"})

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status_test.go
@@ -133,11 +133,11 @@ func TestRolloutStatusNoResources(t *testing.T) {
 		return true, fw, nil
 	})
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	streams, _, _, buf := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdRolloutStatus(tf, streams)
 	cmd.Run(cmd, []string{"deployment"})
 
-	expectedMsg := "no resources found in test namespace.\n"
+	expectedMsg := "No resources found in test namespace.\n"
 	if buf.String() != expectedMsg {
 		t.Errorf("expected output: %s, but got: %s", expectedMsg, buf.String())
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status_test.go
@@ -110,7 +110,7 @@ func TestRolloutStatusNoResources(t *testing.T) {
 		}),
 	}
 
-	streams, _, _, buf := genericclioptions.NewTestIOStreams()
+	streams, _, _, buf := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdRolloutStatus(tf, streams)
 	cmd.Run(cmd, []string{"deployment"})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds no resource found message to kubectl rollout status when there are no resources of the specified kind
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1362

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed issue where there was no response or error from kubectl rollout status when there were no resources of specified kind. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
