### PR TITLE
apiserver/etcd: add request and request_error metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -49,7 +49,7 @@ var (
 	)
 	etcdRequestCounts = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
-			Name:           "etcd_request_total",
+			Name:           "etcd_requests_total",
 			Help:           "Etcd request counts for each operation and object type.",
 			StabilityLevel: compbasemetrics.ALPHA,
 		},

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -47,6 +47,22 @@ var (
 		},
 		[]string{"operation", "type"},
 	)
+	etcdRequestCounts = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "etcd_request_total",
+			Help:           "Etcd request counts for each operation and object type.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"operation", "type"},
+	)
+	etcdRequestErrorCounts = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "etcd_request_errors_total",
+			Help:           "Etcd failed request counts for each operation and object type.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"operation", "type"},
+	)
 	objectCounts = compbasemetrics.NewGaugeVec(
 		&compbasemetrics.GaugeOpts{
 			Name:           "apiserver_storage_objects",
@@ -140,6 +156,8 @@ func Register() {
 	// Register the metrics.
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(etcdRequestLatency)
+		legacyregistry.MustRegister(etcdRequestCounts)
+		legacyregistry.MustRegister(etcdRequestErrorCounts)
 		legacyregistry.MustRegister(objectCounts)
 		legacyregistry.MustRegister(dbTotalSize)
 		legacyregistry.MustRegister(etcdBookmarkCounts)
@@ -157,9 +175,15 @@ func UpdateObjectCount(resourcePrefix string, count int64) {
 	objectCounts.WithLabelValues(resourcePrefix).Set(float64(count))
 }
 
-// RecordEtcdRequestLatency sets the etcd_request_duration_seconds metrics.
-func RecordEtcdRequestLatency(verb, resource string, startTime time.Time) {
-	etcdRequestLatency.WithLabelValues(verb, resource).Observe(sinceInSeconds(startTime))
+// RecordEtcdRequest updates and sets the etcd_request_duration_seconds,
+// etcd_request_total, etcd_request_errors_total metrics.
+func RecordEtcdRequest(verb, resource string, err error, startTime time.Time) {
+	v := []string{verb, resource}
+	etcdRequestLatency.WithLabelValues(v...).Observe(sinceInSeconds(startTime))
+	etcdRequestCounts.WithLabelValues(v...).Inc()
+	if err != nil {
+		etcdRequestErrorCounts.WithLabelValues(v...).Inc()
+	}
 }
 
 // RecordEtcdEvent updated the etcd_events_received_total metric.
@@ -183,7 +207,9 @@ func Reset() {
 }
 
 // sinceInSeconds gets the time since the specified start in seconds.
-func sinceInSeconds(start time.Time) float64 {
+//
+// This is a variable to facilitate testing.
+var sinceInSeconds = func(start time.Time) float64 {
 	return time.Since(start).Seconds()
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
@@ -120,9 +120,9 @@ etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="60"} 1
 etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="+Inf"} 1
 etcd_request_duration_seconds_sum{operation="foo",type="bar"} 0.3
 etcd_request_duration_seconds_count{operation="foo",type="bar"} 1
-# HELP etcd_request_total [ALPHA] Etcd request counts for each operation and object type.
-# TYPE etcd_request_total counter
-etcd_request_total{operation="foo",type="bar"} 1
+# HELP etcd_requests_total [ALPHA] Etcd request counts for each operation and object type.
+# TYPE etcd_requests_total counter
+etcd_requests_total{operation="foo",type="bar"} 1
 `,
 		},
 		{
@@ -159,9 +159,9 @@ etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="60"} 1
 etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="+Inf"} 1
 etcd_request_duration_seconds_sum{operation="foo",type="bar"} 0.3
 etcd_request_duration_seconds_count{operation="foo",type="bar"} 1
-# HELP etcd_request_total [ALPHA] Etcd request counts for each operation and object type.
-# TYPE etcd_request_total counter
-etcd_request_total{operation="foo",type="bar"} 1
+# HELP etcd_requests_total [ALPHA] Etcd request counts for each operation and object type.
+# TYPE etcd_requests_total counter
+etcd_requests_total{operation="foo",type="bar"} 1
 # HELP etcd_request_errors_total [ALPHA] Etcd failed request counts for each operation and object type.
 # TYPE etcd_request_errors_total counter
 etcd_request_errors_total{operation="foo",type="bar"} 1

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package metrics
 
 import (
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/testutil"
@@ -50,6 +52,128 @@ func TestRecordDecodeError(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			RecordDecodeError(test.resource)
 			if err := testutil.GatherAndCompare(registry, strings.NewReader(test.want), testedMetrics); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestRecordEtcdRequest(t *testing.T) {
+	registry := metrics.NewKubeRegistry()
+
+	// modify default sinceInSeconds to constant NOW
+	sinceInSeconds = func(t time.Time) float64 {
+		return time.Unix(0, 300*int64(time.Millisecond)).Sub(t).Seconds()
+	}
+
+	testedMetrics := []metrics.Registerable{
+		etcdRequestCounts,
+		etcdRequestErrorCounts,
+		etcdRequestLatency,
+	}
+
+	testedMetricsName := make([]string, 0, len(testedMetrics))
+	for _, m := range testedMetrics {
+		registry.MustRegister(m)
+		testedMetricsName = append(testedMetricsName, m.FQName())
+	}
+
+	testCases := []struct {
+		desc      string
+		operation string
+		typ       string
+		err       error
+		startTime time.Time
+		want      string
+	}{
+		{
+			desc:      "success_request",
+			operation: "foo",
+			typ:       "bar",
+			err:       nil,
+			startTime: time.Unix(0, 0), // 0.3s
+			want: `# HELP etcd_request_duration_seconds [ALPHA] Etcd request latency in seconds for each operation and object type.
+# TYPE etcd_request_duration_seconds histogram
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.005"} 0
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.025"} 0
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.05"} 0
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.1"} 0
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.2"} 0
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.4"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.6"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.8"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="1"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="1.25"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="1.5"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="2"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="3"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="4"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="5"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="6"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="8"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="10"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="15"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="20"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="30"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="45"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="60"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="+Inf"} 1
+etcd_request_duration_seconds_sum{operation="foo",type="bar"} 0.3
+etcd_request_duration_seconds_count{operation="foo",type="bar"} 1
+# HELP etcd_request_total [ALPHA] Etcd request counts for each operation and object type.
+# TYPE etcd_request_total counter
+etcd_request_total{operation="foo",type="bar"} 1
+`,
+		},
+		{
+			desc:      "failed_request",
+			operation: "foo",
+			typ:       "bar",
+			err:       errors.New("some error"),
+			startTime: time.Unix(0, 0), // 0.3s
+			want: `# HELP etcd_request_duration_seconds [ALPHA] Etcd request latency in seconds for each operation and object type.
+# TYPE etcd_request_duration_seconds histogram
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.005"} 0
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.025"} 0
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.05"} 0
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.1"} 0
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.2"} 0
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.4"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.6"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="0.8"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="1"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="1.25"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="1.5"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="2"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="3"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="4"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="5"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="6"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="8"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="10"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="15"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="20"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="30"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="45"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="60"} 1
+etcd_request_duration_seconds_bucket{operation="foo",type="bar",le="+Inf"} 1
+etcd_request_duration_seconds_sum{operation="foo",type="bar"} 0.3
+etcd_request_duration_seconds_count{operation="foo",type="bar"} 1
+# HELP etcd_request_total [ALPHA] Etcd request counts for each operation and object type.
+# TYPE etcd_request_total counter
+etcd_request_total{operation="foo",type="bar"} 1
+# HELP etcd_request_errors_total [ALPHA] Etcd failed request counts for each operation and object type.
+# TYPE etcd_request_errors_total counter
+etcd_request_errors_total{operation="foo",type="bar"} 1
+`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			defer registry.Reset()
+			RecordEtcdRequest(test.operation, test.typ, test.err, test.startTime)
+			if err := testutil.GatherAndCompare(registry, strings.NewReader(test.want), testedMetricsName...); err != nil {
 				t.Fatal(err)
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add request and request_error metrics for apiserver etcd storage.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #117167 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Apiserver adds two new metrics `etcd_requests_total` and `etcd_request_errors_total` that allow users to monitor requests to etcd storage, split by operation and resource type.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
