### PR TITLE
encode NamespacedName with lower case in JSON

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/types/namespacedname.go
+++ b/staging/src/k8s.io/apimachinery/pkg/types/namespacedname.go
@@ -41,7 +41,8 @@ func (n NamespacedName) String() string {
 // MarshalLog emits a struct containing required key/value pair
 func (n NamespacedName) MarshalLog() interface{} {
 	return struct {
-		Name, Namespace string
+		Name      string `json:"name"`
+		Namespace string `json:"namespace,omitempty"`
 	}{
 		Name:      n.Name,
 		Namespace: n.Namespace,

--- a/staging/src/k8s.io/component-base/logs/json/json_test.go
+++ b/staging/src/k8s.io/component-base/logs/json/json_test.go
@@ -74,8 +74,13 @@ func TestZapLoggerInfo(t *testing.T) {
 		},
 		{
 			msg:        "test for NamespacedName argument",
-			format:     "{\"ts\":%f,\"caller\":\"json/json_test.go:%d\",\"msg\":\"test for NamespacedName argument\",\"v\":0,\"obj\":{\"Name\":\"kube-proxy\",\"Namespace\":\"kube-system\"}}\n",
+			format:     "{\"ts\":%f,\"caller\":\"json/json_test.go:%d\",\"msg\":\"test for NamespacedName argument\",\"v\":0,\"obj\":{\"name\":\"kube-proxy\",\"namespace\":\"kube-system\"}}\n",
 			keysValues: []interface{}{"obj", types.NamespacedName{Name: "kube-proxy", Namespace: "kube-system"}},
+		},
+		{
+			msg:        "test for NamespacedName argument with no namespace",
+			format:     "{\"ts\":%f,\"caller\":\"json/json_test.go:%d\",\"msg\":\"test for NamespacedName argument with no namespace\",\"v\":0,\"obj\":{\"name\":\"kube-proxy\"}}\n",
+			keysValues: []interface{}{"obj", types.NamespacedName{Name: "kube-proxy"}},
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Lower case is how a workaround in controller-runtime has encoded NamespacedName (https://github.com/kubernetes-sigs/controller-runtime/blob/a33d038b84d0e7f615b8d803bdc47f0d1f8484b7/pkg/log/zap/kube_helpers.go#L49-L57) and it is also more consistent with Kubernetes API standards.

#### Which issue(s) this PR fixes:

Returning an anonymous struct in MarshalLog makes it impossible for controller-runtime to adapt the type and thus blocks updating controller-runtime to Kubernetes 1.27 because log content would change.

#### Special notes for your reviewer:

Once merged we need to backport.

#### Does this PR introduce a user-facing change?
```release-note
Structured logging of NamespacedName was inconsistent with klog.KObj. Now both use lower case field names and namespace is optional.
```
