### PR TITLE
Automated cherry pick of #117216: Fix azure disk e2e after migration

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1448,7 +1448,7 @@ func (a *azureDiskDriver) CreateVolume(config *storageframework.PerTestConfig, v
 		// so pods should be also scheduled there.
 		config.ClientNodeSelection = e2epod.NodeSelection{
 			Selector: map[string]string{
-				v1.LabelFailureDomainBetaZone: zone,
+				v1.LabelTopologyZone: zone,
 			},
 		}
 	}
@@ -1814,6 +1814,10 @@ func getInlineVolumeZone(f *framework.Framework) string {
 	zone, ok := node.Labels[v1.LabelFailureDomainBetaZone]
 	if ok {
 		return zone
+	}
+	topologyZone, ok := node.Labels[v1.LabelTopologyZone]
+	if ok {
+		return topologyZone
 	}
 	return ""
 }


### PR DESCRIPTION
Cherry pick of #117216 on release-1.26.

#117216: Fix azure disk e2e after migration

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```