### PR TITLE
Automated cherry pick of #116482: kubelet: Do not mutate pods in the pod manager

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -176,11 +176,14 @@ func (kl *Kubelet) GetPods() []*v1.Pod {
 	pods := kl.podManager.GetPods()
 	// a kubelet running without apiserver requires an additional
 	// update of the static pod status. See #57106
-	for _, p := range pods {
+	for i, p := range pods {
 		if kubelettypes.IsStaticPod(p) {
 			if status, ok := kl.statusManager.GetPodStatus(p.UID); ok {
 				klog.V(2).InfoS("Pod status updated", "pod", klog.KObj(p), "status", status.Phase)
+				// do not mutate the cache
+				p = p.DeepCopy()
 				p.Status = status
+				pods[i] = p
 			}
 		}
 	}


### PR DESCRIPTION
Cherry pick of #116482 on release-1.25.

#116482: kubelet: Do not mutate pods in the pod manager

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```