### PR TITLE
Codegen: use openapi-gen via k8s.io/code-generator

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -546,7 +546,7 @@ function indirect_array() {
 function codegen::openapi() {
     # Build the tool.
     GO111MODULE=on GOPROXY=off go install \
-        k8s.io/kube-openapi/cmd/openapi-gen
+        k8s.io/code-generator/cmd/openapi-gen
 
     # The result file, in each pkg, of open-api generation.
     local output_base="${GENERATED_FILE_PREFIX}openapi"


### PR DESCRIPTION
Trivial - this is an odd-man-out, using kube-openapi for the binary vs code-generator

/kind cleanup

```release-note
NONE
```
