### PR TITLE
Codegen: a new script for subprojects to use

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/hack/update-codegen.sh
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/hack/update-codegen.sh
@@ -21,17 +21,22 @@ set -o pipefail
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
+source "${CODEGEN_PKG}/kube_codegen.sh"
+
 # generate the code with:
 # --output-base    because this script should also be able to run inside the vendor dir of
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
-"${CODEGEN_PKG}/generate-groups.sh" "applyconfiguration,client,deepcopy,informer,lister" \
-  k8s.io/apiextensions-apiserver/examples/client-go/pkg/client \
-  k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis \
-  cr:v1 \
-  --output-base "$(dirname "${BASH_SOURCE[0]}")/../../../../.." \
-  --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
 
+kube::codegen::gen_helpers \
+    --input-pkg-root k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
 
-# To use your own boilerplate text append:
-#   --go-header-file ${SCRIPT_ROOT}/hack/custom-boilerplate.go.txt
+kube::codegen::gen_client \
+    --with-watch \
+    --with-applyconfig \
+    --input-pkg-root k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis \
+    --output-pkg-root k8s.io/apiextensions-apiserver/examples/client-go/pkg/client \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"

--- a/staging/src/k8s.io/apiextensions-apiserver/hack/update-codegen.sh
+++ b/staging/src/k8s.io/apiextensions-apiserver/hack/update-codegen.sh
@@ -21,21 +21,17 @@ set -o pipefail
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
-CLIENTSET_NAME_VERSIONED=clientset \
-CLIENTSET_PKG_NAME=clientset \
-"${CODEGEN_PKG}/generate-groups.sh" "deepcopy,defaulter,client,lister,informer" \
-  k8s.io/apiextensions-apiserver/pkg/client \
-  k8s.io/apiextensions-apiserver/pkg/apis \
-  "apiextensions:v1beta1,v1" \
-  --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
-  --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+source "${CODEGEN_PKG}/kube_codegen.sh"
 
-CLIENTSET_NAME_VERSIONED=clientset \
-CLIENTSET_PKG_NAME=clientset \
-"${CODEGEN_PKG}/generate-internal-groups.sh" "deepcopy,conversion" \
-  k8s.io/apiextensions-apiserver/pkg/client \
-  k8s.io/apiextensions-apiserver/pkg/apis \
-  k8s.io/apiextensions-apiserver/pkg/apis \
-  "apiextensions:v1beta1,v1" \
-  --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
-  --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+kube::codegen::gen_helpers \
+    --input-pkg-root k8s.io/apiextensions-apiserver/pkg \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+
+kube::codegen::gen_client \
+    --with-watch \
+    --input-pkg-root k8s.io/apiextensions-apiserver/pkg/apis \
+    --output-pkg-root k8s.io/apiextensions-apiserver/pkg/client \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
+    --versioned-name clientset \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
@@ -31,25 +31,25 @@ import (
 
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
-	ApiextensionsV1beta1() apiextensionsv1beta1.ApiextensionsV1beta1Interface
 	ApiextensionsV1() apiextensionsv1.ApiextensionsV1Interface
+	ApiextensionsV1beta1() apiextensionsv1beta1.ApiextensionsV1beta1Interface
 }
 
 // Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
-	apiextensionsV1beta1 *apiextensionsv1beta1.ApiextensionsV1beta1Client
 	apiextensionsV1      *apiextensionsv1.ApiextensionsV1Client
-}
-
-// ApiextensionsV1beta1 retrieves the ApiextensionsV1beta1Client
-func (c *Clientset) ApiextensionsV1beta1() apiextensionsv1beta1.ApiextensionsV1beta1Interface {
-	return c.apiextensionsV1beta1
+	apiextensionsV1beta1 *apiextensionsv1beta1.ApiextensionsV1beta1Client
 }
 
 // ApiextensionsV1 retrieves the ApiextensionsV1Client
 func (c *Clientset) ApiextensionsV1() apiextensionsv1.ApiextensionsV1Interface {
 	return c.apiextensionsV1
+}
+
+// ApiextensionsV1beta1 retrieves the ApiextensionsV1beta1Client
+func (c *Clientset) ApiextensionsV1beta1() apiextensionsv1beta1.ApiextensionsV1beta1Interface {
+	return c.apiextensionsV1beta1
 }
 
 // Discovery retrieves the DiscoveryClient
@@ -96,11 +96,11 @@ func NewForConfigAndClient(c *rest.Config, httpClient *http.Client) (*Clientset,
 
 	var cs Clientset
 	var err error
-	cs.apiextensionsV1beta1, err = apiextensionsv1beta1.NewForConfigAndClient(&configShallowCopy, httpClient)
+	cs.apiextensionsV1, err = apiextensionsv1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
-	cs.apiextensionsV1, err = apiextensionsv1.NewForConfigAndClient(&configShallowCopy, httpClient)
+	cs.apiextensionsV1beta1, err = apiextensionsv1beta1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -125,8 +125,8 @@ func NewForConfigOrDie(c *rest.Config) *Clientset {
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
 	var cs Clientset
-	cs.apiextensionsV1beta1 = apiextensionsv1beta1.New(c)
 	cs.apiextensionsV1 = apiextensionsv1.New(c)
+	cs.apiextensionsV1beta1 = apiextensionsv1beta1.New(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/clientset_generated.go
@@ -81,12 +81,12 @@ var (
 	_ testing.FakeClient  = &Clientset{}
 )
 
-// ApiextensionsV1beta1 retrieves the ApiextensionsV1beta1Client
-func (c *Clientset) ApiextensionsV1beta1() apiextensionsv1beta1.ApiextensionsV1beta1Interface {
-	return &fakeapiextensionsv1beta1.FakeApiextensionsV1beta1{Fake: &c.Fake}
-}
-
 // ApiextensionsV1 retrieves the ApiextensionsV1Client
 func (c *Clientset) ApiextensionsV1() apiextensionsv1.ApiextensionsV1Interface {
 	return &fakeapiextensionsv1.FakeApiextensionsV1{Fake: &c.Fake}
+}
+
+// ApiextensionsV1beta1 retrieves the ApiextensionsV1beta1Client
+func (c *Clientset) ApiextensionsV1beta1() apiextensionsv1beta1.ApiextensionsV1beta1Interface {
+	return &fakeapiextensionsv1beta1.FakeApiextensionsV1beta1{Fake: &c.Fake}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/register.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/register.go
@@ -32,8 +32,8 @@ var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 
 var localSchemeBuilder = runtime.SchemeBuilder{
-	apiextensionsv1beta1.AddToScheme,
 	apiextensionsv1.AddToScheme,
+	apiextensionsv1beta1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme/register.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme/register.go
@@ -32,8 +32,8 @@ var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
-	apiextensionsv1beta1.AddToScheme,
 	apiextensionsv1.AddToScheme,
+	apiextensionsv1beta1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/interface.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/interface.go
@@ -26,10 +26,10 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// V1beta1 provides access to shared informers for resources in V1beta1.
-	V1beta1() v1beta1.Interface
 	// V1 provides access to shared informers for resources in V1.
 	V1() v1.Interface
+	// V1beta1 provides access to shared informers for resources in V1beta1.
+	V1beta1() v1beta1.Interface
 }
 
 type group struct {
@@ -43,12 +43,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// V1beta1 returns a new v1beta1.Interface.
-func (g *group) V1beta1() v1beta1.Interface {
-	return v1beta1.New(g.factory, g.namespace, g.tweakListOptions)
-}
-
 // V1 returns a new v1.Interface.
 func (g *group) V1() v1.Interface {
 	return v1.New(g.factory, g.namespace, g.tweakListOptions)
+}
+
+// V1beta1 returns a new v1beta1.Interface.
+func (g *group) V1beta1() v1beta1.Interface {
+	return v1beta1.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/staging/src/k8s.io/code-generator/examples/hack/update-codegen.sh
+++ b/staging/src/k8s.io/code-generator/examples/hack/update-codegen.sh
@@ -22,32 +22,51 @@ SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 SCRIPT_ROOT="${SCRIPT_DIR}/.."
 CODEGEN_PKG="${CODEGEN_PKG:-"${SCRIPT_ROOT}/.."}"
 
+source "${CODEGEN_PKG}/kube_codegen.sh"
+
 # generate the code with:
 # - --output-base because this script should also be able to run inside the vendor dir of
 #   k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #   instead of the $GOPATH directly. For normal projects this can be dropped.
-"${CODEGEN_PKG}/generate-internal-groups.sh" "client,conversion,deepcopy,defaulter,informer,lister,openapi" \
-  k8s.io/code-generator/examples/apiserver \
-  k8s.io/code-generator/examples/apiserver/apis \
-  k8s.io/code-generator/examples/apiserver/apis \
-  "example:v1 example2:v1 example3.io:v1" \
-  --output-base "${SCRIPT_DIR}/../../../.." \
-  --go-header-file "${SCRIPT_DIR}/boilerplate.go.txt"
-"${CODEGEN_PKG}/generate-groups.sh" "applyconfiguration,client,deepcopy,defaulter,informer,lister" \
-  k8s.io/code-generator/examples/crd \
-  k8s.io/code-generator/examples/crd/apis \
-  "example:v1 example2:v1" \
-  --output-base "${SCRIPT_DIR}/../../../.." \
-  --go-header-file "${SCRIPT_DIR}/boilerplate.go.txt"
-"${CODEGEN_PKG}/generate-groups.sh" "applyconfiguration,client,deepcopy,defaulter,informer,lister" \
-  k8s.io/code-generator/examples/MixedCase \
-  k8s.io/code-generator/examples/MixedCase/apis \
-  "example:v1" \
-  --output-base "${SCRIPT_DIR}/../../../.." \
-  --go-header-file "${SCRIPT_DIR}/boilerplate.go.txt"
-"${CODEGEN_PKG}/generate-groups.sh" "applyconfiguration,client,deepcopy,defaulter,informer,lister" \
-  k8s.io/code-generator/examples/HyphenGroup \
-  k8s.io/code-generator/examples/HyphenGroup/apis \
-  "example:v1" \
-  --output-base "${SCRIPT_DIR}/../../../.." \
-  --go-header-file "${SCRIPT_DIR}/boilerplate.go.txt"
+
+kube::codegen::gen_helpers \
+    --input-pkg-root k8s.io/code-generator/examples \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+
+kube::codegen::gen_openapi \
+    --input-pkg-root k8s.io/code-generator/examples/apiserver/apis \
+    --output-pkg-root k8s.io/code-generator/examples/apiserver \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+
+kube::codegen::gen_client \
+    --with-watch \
+    --input-pkg-root k8s.io/code-generator/examples/apiserver/apis \
+    --output-pkg-root k8s.io/code-generator/examples/apiserver \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+
+kube::codegen::gen_client \
+    --with-watch \
+    --with-applyconfig \
+    --input-pkg-root k8s.io/code-generator/examples/crd/apis \
+    --output-pkg-root k8s.io/code-generator/examples/crd \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+
+kube::codegen::gen_client \
+    --with-watch \
+    --with-applyconfig \
+    --input-pkg-root k8s.io/code-generator/examples/MixedCase/apis \
+    --output-pkg-root k8s.io/code-generator/examples/MixedCase \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+
+kube::codegen::gen_client \
+    --with-watch \
+    --with-applyconfig \
+    --input-pkg-root k8s.io/code-generator/examples/HyphenGroup/apis \
+    --output-pkg-root k8s.io/code-generator/examples/HyphenGroup \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"

--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -1,0 +1,615 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This presents several functions for packages which want to use kubernetes
+# code-generation tools.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_CODEGEN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+function kube::codegen::internal::git_find() {
+    # Similar to find but faster and easier to understand.  We want to include
+    # modified and untracked files because this might be running against code
+    # which is not tracked by git yet.
+    git ls-files -cmo --exclude-standard "$@"
+}
+
+function kube::codegen::internal::git_grep() {
+    # We want to include modified and untracked files because this might be
+    # running against code which is not tracked by git yet.
+    git grep --untracked "$@"
+}
+
+# Generate tagged helper code: conversions, deepcopy, and defaults
+#
+# Args:
+#   --input-pkg-root <string>
+#     The root package under which to search for files which request code to be
+#     generated.  This must be Go package syntax, e.g.  "k8s.io/foo/bar".
+#
+#   --output-base <string>
+#     The root directory under which to emit code.  The concatenation of
+#     <output-base> + <input-pkg-root> must be valid.
+#
+#   --boilerplate <string = path_to_kube_codegen_boilerplate>
+#     An optional override for the header file to insert into generated files.
+#
+function kube::codegen::gen_helpers() {
+    local in_pkg_root=""
+    local out_base="" # gengo needs the output dir must be $out_base/$out_pkg_root
+    local boilerplate="${KUBE_CODEGEN_ROOT}/hack/boilerplate.go.txt"
+    local v="${KUBE_VERBOSE:-0}"
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            "--input-pkg-root")
+                in_pkg_root="$2"
+                shift 2
+                ;;
+            "--output-base")
+                out_base="$2"
+                shift 2
+                ;;
+            "--boilerplate")
+                boilerplate="$2"
+                shift 2
+                ;;
+            *)
+                echo "unknown argument: $1" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    if [ -z "${in_pkg_root}" ]; then
+        echo "--input-pkg-root is required" >&2
+        return 1
+    fi
+    if [ -z "${out_base}" ]; then
+        echo "--output-base is required" >&2
+        return 1
+    fi
+
+    (
+        # To support running this from anywhere, first cd into this directory,
+        # and then install with forced module mode on and fully qualified name.
+        cd "${KUBE_CODEGEN_ROOT}"
+        BINS=(
+            conversion-gen
+            deepcopy-gen
+            defaulter-gen
+        )
+        # shellcheck disable=2046 # printf word-splitting is intentional
+        GO111MODULE=on go install $(printf "k8s.io/code-generator/cmd/%s " "${BINS[@]}")
+    )
+    # Go installs in $GOBIN if defined, and $GOPATH/bin otherwise
+    gobin="${GOBIN:-$(go env GOPATH)/bin}"
+
+    # These tools all assume out-dir == in-dir.
+    root="${out_base}/${in_pkg_root}"
+    mkdir -p "${root}"
+    root="$(cd "${root}" && pwd -P)"
+
+    # Deepcopy
+    #
+    local input_pkgs=()
+    while read -r file; do
+        dir="$(dirname "${file}")"
+        pkg="$(cd "${dir}" && GO111MODULE=on go list -find .)"
+        input_pkgs+=("${pkg}")
+    done < <(
+        ( kube::codegen::internal::git_grep -l \
+            -e '+k8s:deepcopy-gen=' \
+            ":(glob)${root}"/'**/*.go' \
+            || true \
+        ) | LC_ALL=C sort -u
+    )
+
+    if [ "${#input_pkgs[@]}" != 0 ]; then
+        echo "Generating deepcopy code for ${#input_pkgs[@]} targets"
+
+        kube::codegen::internal::git_find -z \
+            ":(glob)${root}"/'**/zz_generated.deepcopy.go' \
+            | xargs -0 rm -f
+
+        local inputs=()
+        for arg in "${input_pkgs[@]}"; do
+            inputs+=("--input-dirs" "$arg")
+        done
+        "${gobin}/deepcopy-gen" \
+            -v "${v}" \
+            -O zz_generated.deepcopy \
+            --go-header-file "${boilerplate}" \
+            --output-base "${out_base}" \
+            "${inputs[@]}"
+    fi
+
+    # Defaults
+    #
+    local input_pkgs=()
+    while read -r file; do
+        dir="$(dirname "${file}")"
+        pkg="$(cd "${dir}" && GO111MODULE=on go list -find .)"
+        input_pkgs+=("${pkg}")
+    done < <(
+        ( kube::codegen::internal::git_grep -l \
+            -e '+k8s:defaulter-gen=' \
+            ":(glob)${root}"/'**/*.go' \
+            || true \
+        ) | LC_ALL=C sort -u
+    )
+
+    if [ "${#input_pkgs[@]}" != 0 ]; then
+        echo "Generating defaulter code for ${#input_pkgs[@]} targets"
+
+        kube::codegen::internal::git_find -z \
+            ":(glob)${root}"/'**/zz_generated.defaults.go' \
+            | xargs -0 rm -f
+
+        local inputs=()
+        for arg in "${input_pkgs[@]}"; do
+            inputs+=("--input-dirs" "$arg")
+        done
+        "${gobin}/defaulter-gen" \
+            -v "${v}" \
+            -O zz_generated.defaults \
+            --go-header-file "${boilerplate}" \
+            --output-base "${out_base}" \
+            "${inputs[@]}"
+    fi
+
+    # Conversions
+    #
+    local input_pkgs=()
+    while read -r file; do
+        dir="$(dirname "${file}")"
+        pkg="$(cd "${dir}" && GO111MODULE=on go list -find .)"
+        input_pkgs+=("${pkg}")
+    done < <(
+        ( kube::codegen::internal::git_grep -l \
+            -e '+k8s:conversion-gen=' \
+            ":(glob)${root}"/'**/*.go' \
+            || true \
+        ) | LC_ALL=C sort -u
+    )
+
+    if [ "${#input_pkgs[@]}" != 0 ]; then
+        echo "Generating conversion code for ${#input_pkgs[@]} targets"
+
+        kube::codegen::internal::git_find -z \
+            ":(glob)${root}"/'**/zz_generated.conversion.go' \
+            | xargs -0 rm -f
+
+        local inputs=()
+        for arg in "${input_pkgs[@]}"; do
+            inputs+=("--input-dirs" "$arg")
+        done
+        "${gobin}/conversion-gen" \
+            -v "${v}" \
+            -O zz_generated.conversion \
+            --go-header-file "${boilerplate}" \
+            --output-base "${out_base}" \
+            "${inputs[@]}"
+    fi
+}
+
+# Generate openapi code
+#
+# Args:
+#   --input-pkg-root <string>
+#     The root package under which to search for files which request openapi to
+#     be generated.  This must be Go package syntax, e.g.  "k8s.io/foo/bar".
+#
+#   --output-pkg-root <string>
+#     The root package under which generated directories and files
+#     will be placed.  This must be go package syntax, e.g. "k8s.io/foo/bar".
+#
+#   --output-base <string>
+#     The root directory under which to emit code.  The concatenation of
+#     <output-base> + <input-pkg-root> must be valid.
+#
+#   --openapi-name <string = "openapi">
+#     An optional override for the leaf name of the generated directory.
+#
+#   --extra-pkgs <string>
+#     An optional list of additional packages to be imported during openapi
+#     generation.  The argument must be Go package syntax, e.g.
+#     "k8s.io/foo/bar".  It may be a single value or a comma-delimited list.
+#     This flag may be repeated.
+#
+#   --report-filename <string = "/dev/null">
+#     An optional path at which to write an API violations report.  "-" means
+#     stdout.
+#
+#   --boilerplate <string = path_to_kube_codegen_boilerplate>
+#     An optional override for the header file to insert into generated files.
+#
+function kube::codegen::gen_openapi() {
+    local in_pkg_root=""
+    local out_pkg_root=""
+    local out_base="" # gengo needs the output dir must be $out_base/$out_pkg_root
+    local openapi_subdir="openapi"
+    local extra_pkgs=()
+    local report="/dev/null"
+    local boilerplate="${KUBE_CODEGEN_ROOT}/hack/boilerplate.go.txt"
+    local v="${KUBE_VERBOSE:-0}"
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            "--input-pkg-root")
+                in_pkg_root="$2"
+                shift 2
+                ;;
+            "--output-pkg-root")
+                out_pkg_root="$2"
+                shift 2
+                ;;
+            "--output-base")
+                out_base="$2"
+                shift 2
+                ;;
+            "--openapi-name")
+                openapi_subdir="$2"
+                shift 2
+                ;;
+            "--extra-pkgs")
+                extra_pkgs+=("$2")
+                shift 2
+                ;;
+            "--report-filename")
+                report="$2"
+                shift 2
+                ;;
+            "--boilerplate")
+                boilerplate="$2"
+                shift 2
+                ;;
+            *)
+                echo "unknown argument: $1" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    if [ -z "${in_pkg_root}" ]; then
+        echo "--input-pkg-root is required" >&2
+        return 1
+    fi
+    if [ -z "${out_pkg_root}" ]; then
+        echo "--output-pkg-root is required" >&2
+        return 1
+    fi
+    if [ -z "${out_base}" ]; then
+        echo "--output-base is required" >&2
+        return 1
+    fi
+
+    (
+        # To support running this from anywhere, first cd into this directory,
+        # and then install with forced module mode on and fully qualified name.
+        cd "${KUBE_CODEGEN_ROOT}"
+        BINS=(
+            openapi-gen
+        )
+        # shellcheck disable=2046 # printf word-splitting is intentional
+        GO111MODULE=on go install $(printf "k8s.io/code-generator/cmd/%s " "${BINS[@]}")
+    )
+    # Go installs in $GOBIN if defined, and $GOPATH/bin otherwise
+    gobin="${GOBIN:-$(go env GOPATH)/bin}"
+
+    # These tools all assume out-dir == in-dir.
+    root="${out_base}/${in_pkg_root}"
+    mkdir -p "${root}"
+    root="$(cd "${root}" && pwd -P)"
+
+    local input_pkgs=( "${extra_pkgs[@]:+"${extra_pkgs[@]}"}")
+    while read -r file; do
+        dir="$(dirname "${file}")"
+        pkg="$(cd "${dir}" && GO111MODULE=on go list -find .)"
+        input_pkgs+=("${pkg}")
+    done < <(
+        ( kube::codegen::internal::git_grep -l \
+            -e '+k8s:openapi-gen=' \
+            ":(glob)${root}"/'**/*.go' \
+            || true \
+        ) | LC_ALL=C sort -u
+    )
+
+    if [ "${#input_pkgs[@]}" != 0 ]; then
+        echo "Generating openapi code for ${#input_pkgs[@]} targets"
+
+        kube::codegen::internal::git_find -z \
+            ":(glob)${root}"/'**/zz_generated.openapi.go' \
+            | xargs -0 rm -f
+
+        local inputs=()
+        for arg in "${input_pkgs[@]}"; do
+            inputs+=("--input-dirs" "$arg")
+        done
+        "${gobin}/openapi-gen" \
+            -v "${v}" \
+            -O zz_generated.openapi \
+            --go-header-file "${boilerplate}" \
+            --output-base "${out_base}" \
+            --output-package "${out_pkg_root}/${openapi_subdir}" \
+            --report-filename "${report}" \
+            --input-dirs "k8s.io/apimachinery/pkg/apis/meta/v1" \
+            --input-dirs "k8s.io/apimachinery/pkg/runtime" \
+            --input-dirs "k8s.io/apimachinery/pkg/version" \
+            "${inputs[@]}"
+    fi
+}
+
+# Generate client code
+#
+# Args:
+#   --input-pkg-root <string>
+#     The root package under which to search for types.go files which request
+#     clients to be generated.  This must be Go package syntax, e.g.
+#     "k8s.io/foo/bar".
+#
+#   --output-pkg-root <string>
+#     The root package into which generated directories and files will be
+#     placed.  This must be Go package syntax, e.g. "k8s.io/foo/bar".
+#
+#   --output-base <string>
+#     The root directory under which to emit code.  The concatenation of
+#     <output-base> + <output-pkg-root> must be valid.
+#
+#   --boilerplate <string = path_to_kube_codegen_boilerplate>
+#     An optional override for the header file to insert into generated files.
+#
+#   --clientset-name <string = "clientset">
+#     An optional override for the leaf name of the generated "clientset" directory.
+#
+#   --versioned-name <string = "versioned">
+#     An optional override for the leaf name of the generated
+#     "<clientset>/versioned" directory.
+#
+#   --with-applyconfig
+#     Enables generation of applyconfiguration files.
+#
+#   --applyconfig-name <string = "applyconfiguration">
+#     An optional override for the leaf name of the generated "applyconfiguration" directory.
+#
+#   --with-watch
+#     Enables generation of listers and informers for APIs which support WATCH.
+#
+#   --listers-name <string = "listers">
+#     An optional override for the leaf name of the generated "listers" directory.
+#
+#   --informers-name <string = "informers">
+#     An optional override for the leaf name of the generated "informers" directory.
+#
+function kube::codegen::gen_client() {
+    local in_pkg_root=""
+    local out_pkg_root=""
+    local out_base="" # gengo needs the output dir must be $out_base/$out_pkg_root
+    local clientset_subdir="clientset"
+    local clientset_versioned_name="versioned"
+    local applyconfig="false"
+    local applyconfig_subdir="applyconfiguration"
+    local watchable="false"
+    local listers_subdir="listers"
+    local informers_subdir="informers"
+    local boilerplate="${KUBE_CODEGEN_ROOT}/hack/boilerplate.go.txt"
+    local v="${KUBE_VERBOSE:-0}"
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            "--input-pkg-root")
+                in_pkg_root="$2"
+                shift 2
+                ;;
+            "--output-pkg-root")
+                out_pkg_root="$2"
+                shift 2
+                ;;
+            "--output-base")
+                out_base="$2"
+                shift 2
+                ;;
+            "--boilerplate")
+                boilerplate="$2"
+                shift 2
+                ;;
+            "--clientset-name")
+                clientset_subdir="$2"
+                shift 2
+                ;;
+            "--versioned-name")
+                clientset_versioned_name="$2"
+                shift 2
+                ;;
+            "--with-applyconfig")
+                applyconfig="true"
+                shift
+                ;;
+            "--applyconfig-name")
+                applyconfig_subdir="$2"
+                shift 2
+                ;;
+            "--with-watch")
+                watchable="true"
+                shift
+                ;;
+            "--listers-name")
+                listers_subdir="$2"
+                shift 2
+                ;;
+            "--informers-name")
+                informers_subdir="$2"
+                shift 2
+                ;;
+            *)
+                echo "unknown argument: $1" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    if [ -z "${in_pkg_root}" ]; then
+        echo "--input-pkg-root is required" >&2
+        return 1
+    fi
+    if [ -z "${out_pkg_root}" ]; then
+        echo "--output-pkg-root is required" >&2
+        return 1
+    fi
+    if [ -z "${out_base}" ]; then
+        echo "--output-base is required" >&2
+        return 1
+    fi
+
+    (
+        # To support running this from anywhere, first cd into this directory,
+        # and then install with forced module mode on and fully qualified name.
+        cd "${KUBE_CODEGEN_ROOT}"
+        BINS=(
+            applyconfiguration-gen
+            client-gen
+            informer-gen
+            lister-gen
+        )
+        # shellcheck disable=2046 # printf word-splitting is intentional
+        GO111MODULE=on go install $(printf "k8s.io/code-generator/cmd/%s " "${BINS[@]}")
+    )
+    # Go installs in $GOBIN if defined, and $GOPATH/bin otherwise
+    gobin="${GOBIN:-$(go env GOPATH)/bin}"
+
+    in_root="${out_base}/${in_pkg_root}"
+    mkdir -p "${in_root}"
+    in_root="$(cd "${in_root}" && pwd -P)"
+    out_root="${out_base}/${out_pkg_root}"
+    mkdir -p "${out_root}"
+    out_root="$(cd "${out_root}" && pwd -P)"
+
+    local group_versions=()
+    local input_pkgs=()
+    while read -r file; do
+        dir="$(dirname "${file}")"
+        pkg="$(cd "${dir}" && GO111MODULE=on go list -find .)"
+        leaf="$(basename "${dir}")"
+        if grep -E -q '^v[0-9]+((alpha|beta)[0-9]+)?$' <<< "${leaf}"; then
+            input_pkgs+=("${pkg}")
+
+            dir2="$(dirname "${dir}")"
+            leaf2="$(basename "${dir2}")"
+            group_versions+=("${leaf2}/${leaf}")
+        fi
+    done < <(
+        ( kube::codegen::internal::git_grep -l \
+            -e '+genclient' \
+            ":(glob)${in_root}"/'**/types.go' \
+            || true \
+        ) | LC_ALL=C sort -u
+    )
+
+    if [ "${#group_versions[@]}" == 0 ]; then
+        return 0
+    fi
+
+    applyconfig_pkg="" # set this for later use, iff enabled
+    if [ "${applyconfig}" == "true" ]; then
+        applyconfig_pkg="${out_pkg_root}/${applyconfig_subdir}"
+
+        echo "Generating applyconfig code for ${#input_pkgs[@]} targets"
+
+        ( kube::codegen::internal::git_grep -l --null \
+            -e '^// Code generated by applyconfiguration-gen. DO NOT EDIT.$' \
+            ":(glob)${out_root}/${applyconfig_subdir}"/'**/*.go' \
+            || true \
+        ) | xargs -0 rm -f
+
+        local inputs=()
+        for arg in "${input_pkgs[@]}"; do
+            inputs+=("--input-dirs" "$arg")
+        done
+        "${gobin}/applyconfiguration-gen" \
+            -v "${v}" \
+            --go-header-file "${boilerplate}" \
+            --output-base "${out_base}" \
+            --output-package "${out_pkg_root}/${applyconfig_subdir}" \
+            "${inputs[@]}"
+    fi
+
+    echo "Generating client code for ${#group_versions[@]} targets"
+
+    ( kube::codegen::internal::git_grep -l --null \
+        -e '^// Code generated by client-gen. DO NOT EDIT.$' \
+        ":(glob)${out_root}/${clientset_subdir}"/'**/*.go' \
+        || true \
+    ) | xargs -0 rm -f
+
+    local inputs=()
+    for arg in "${group_versions[@]}"; do
+        inputs+=("--input" "$arg")
+    done
+    "${gobin}/client-gen" \
+        -v "${v}" \
+        --go-header-file "${boilerplate}" \
+        --clientset-name "${clientset_versioned_name}" \
+        --input-base "${in_pkg_root}" \
+        --output-base "${out_base}" \
+        --output-package "${out_pkg_root}/${clientset_subdir}" \
+        --apply-configuration-package "${applyconfig_pkg}" \
+        "${inputs[@]}"
+
+    if [ "${watchable}" == "true" ]; then
+        echo "Generating lister code for ${#input_pkgs[@]} targets"
+
+        ( kube::codegen::internal::git_grep -l --null \
+            -e '^// Code generated by lister-gen. DO NOT EDIT.$' \
+            ":(glob)${out_root}/${listers_subdir}"/'**/*.go' \
+            || true \
+        ) | xargs -0 rm -f
+
+        local inputs=()
+        for arg in "${input_pkgs[@]}"; do
+            inputs+=("--input-dirs" "$arg")
+        done
+        "${gobin}/lister-gen" \
+            -v "${v}" \
+            --go-header-file "${boilerplate}" \
+            --output-base "${out_base}" \
+            --output-package "${out_pkg_root}/${listers_subdir}" \
+            "${inputs[@]}"
+
+        echo "Generating informer code for ${#input_pkgs[@]} targets"
+
+        ( kube::codegen::internal::git_grep -l --null \
+            -e '^// Code generated by informer-gen. DO NOT EDIT.$' \
+            ":(glob)${out_root}/${informers_subdir}"/'**/*.go' \
+            || true \
+        ) | xargs -0 rm -f
+
+        local inputs=()
+        for arg in "${input_pkgs[@]}"; do
+            inputs+=("--input-dirs" "$arg")
+        done
+        "${gobin}/informer-gen" \
+            -v "${v}" \
+            --go-header-file "${boilerplate}" \
+            --output-base "${out_base}" \
+            --output-package "${out_pkg_root}/${informers_subdir}" \
+            --versioned-clientset-package "${out_pkg_root}/${clientset_subdir}/${clientset_versioned_name}" \
+            --listers-package "${out_pkg_root}/${listers_subdir}" \
+            "${inputs[@]}"
+    fi
+}

--- a/staging/src/k8s.io/kube-aggregator/hack/update-codegen.sh
+++ b/staging/src/k8s.io/kube-aggregator/hack/update-codegen.sh
@@ -21,21 +21,18 @@ set -o pipefail
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
-CLIENTSET_NAME_VERSIONED=clientset \
-CLIENTSET_PKG_NAME=clientset_generated \
-"${CODEGEN_PKG}/generate-groups.sh" "deepcopy,defaulter,client,lister,informer" \
-  k8s.io/kube-aggregator/pkg/client \
-  k8s.io/kube-aggregator/pkg/apis \
-  "apiregistration:v1beta1,v1" \
-  --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
-  --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+source "${CODEGEN_PKG}/kube_codegen.sh"
 
-CLIENTSET_NAME_VERSIONED=clientset \
-CLIENTSET_PKG_NAME=clientset_generated \
-"${CODEGEN_PKG}/generate-internal-groups.sh" "deepcopy,conversion" \
-  k8s.io/kube-aggregator/pkg/client \
-  k8s.io/kube-aggregator/pkg/apis \
-  k8s.io/kube-aggregator/pkg/apis \
-  "apiregistration:v1beta1,v1" \
-  --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
-  --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+kube::codegen::gen_helpers \
+    --input-pkg-root k8s.io/kube-aggregator/pkg/apis \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+
+kube::codegen::gen_client \
+    --with-watch \
+    --input-pkg-root k8s.io/kube-aggregator/pkg/apis \
+    --output-pkg-root k8s.io/kube-aggregator/pkg/client \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
+    --clientset-name clientset_generated \
+    --versioned-name clientset \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
@@ -31,25 +31,25 @@ import (
 
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
-	ApiregistrationV1beta1() apiregistrationv1beta1.ApiregistrationV1beta1Interface
 	ApiregistrationV1() apiregistrationv1.ApiregistrationV1Interface
+	ApiregistrationV1beta1() apiregistrationv1beta1.ApiregistrationV1beta1Interface
 }
 
 // Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
-	apiregistrationV1beta1 *apiregistrationv1beta1.ApiregistrationV1beta1Client
 	apiregistrationV1      *apiregistrationv1.ApiregistrationV1Client
-}
-
-// ApiregistrationV1beta1 retrieves the ApiregistrationV1beta1Client
-func (c *Clientset) ApiregistrationV1beta1() apiregistrationv1beta1.ApiregistrationV1beta1Interface {
-	return c.apiregistrationV1beta1
+	apiregistrationV1beta1 *apiregistrationv1beta1.ApiregistrationV1beta1Client
 }
 
 // ApiregistrationV1 retrieves the ApiregistrationV1Client
 func (c *Clientset) ApiregistrationV1() apiregistrationv1.ApiregistrationV1Interface {
 	return c.apiregistrationV1
+}
+
+// ApiregistrationV1beta1 retrieves the ApiregistrationV1beta1Client
+func (c *Clientset) ApiregistrationV1beta1() apiregistrationv1beta1.ApiregistrationV1beta1Interface {
+	return c.apiregistrationV1beta1
 }
 
 // Discovery retrieves the DiscoveryClient
@@ -96,11 +96,11 @@ func NewForConfigAndClient(c *rest.Config, httpClient *http.Client) (*Clientset,
 
 	var cs Clientset
 	var err error
-	cs.apiregistrationV1beta1, err = apiregistrationv1beta1.NewForConfigAndClient(&configShallowCopy, httpClient)
+	cs.apiregistrationV1, err = apiregistrationv1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
-	cs.apiregistrationV1, err = apiregistrationv1.NewForConfigAndClient(&configShallowCopy, httpClient)
+	cs.apiregistrationV1beta1, err = apiregistrationv1beta1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -125,8 +125,8 @@ func NewForConfigOrDie(c *rest.Config) *Clientset {
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
 	var cs Clientset
-	cs.apiregistrationV1beta1 = apiregistrationv1beta1.New(c)
 	cs.apiregistrationV1 = apiregistrationv1.New(c)
+	cs.apiregistrationV1beta1 = apiregistrationv1beta1.New(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/clientset_generated.go
@@ -81,12 +81,12 @@ var (
 	_ testing.FakeClient  = &Clientset{}
 )
 
-// ApiregistrationV1beta1 retrieves the ApiregistrationV1beta1Client
-func (c *Clientset) ApiregistrationV1beta1() apiregistrationv1beta1.ApiregistrationV1beta1Interface {
-	return &fakeapiregistrationv1beta1.FakeApiregistrationV1beta1{Fake: &c.Fake}
-}
-
 // ApiregistrationV1 retrieves the ApiregistrationV1Client
 func (c *Clientset) ApiregistrationV1() apiregistrationv1.ApiregistrationV1Interface {
 	return &fakeapiregistrationv1.FakeApiregistrationV1{Fake: &c.Fake}
+}
+
+// ApiregistrationV1beta1 retrieves the ApiregistrationV1beta1Client
+func (c *Clientset) ApiregistrationV1beta1() apiregistrationv1beta1.ApiregistrationV1beta1Interface {
+	return &fakeapiregistrationv1beta1.FakeApiregistrationV1beta1{Fake: &c.Fake}
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/register.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/register.go
@@ -32,8 +32,8 @@ var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 
 var localSchemeBuilder = runtime.SchemeBuilder{
-	apiregistrationv1beta1.AddToScheme,
 	apiregistrationv1.AddToScheme,
+	apiregistrationv1beta1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme/register.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme/register.go
@@ -32,8 +32,8 @@ var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
-	apiregistrationv1beta1.AddToScheme,
 	apiregistrationv1.AddToScheme,
+	apiregistrationv1beta1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/interface.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/interface.go
@@ -26,10 +26,10 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// V1beta1 provides access to shared informers for resources in V1beta1.
-	V1beta1() v1beta1.Interface
 	// V1 provides access to shared informers for resources in V1.
 	V1() v1.Interface
+	// V1beta1 provides access to shared informers for resources in V1beta1.
+	V1beta1() v1beta1.Interface
 }
 
 type group struct {
@@ -43,12 +43,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// V1beta1 returns a new v1beta1.Interface.
-func (g *group) V1beta1() v1beta1.Interface {
-	return v1beta1.New(g.factory, g.namespace, g.tweakListOptions)
-}
-
 // V1 returns a new v1.Interface.
 func (g *group) V1() v1.Interface {
 	return v1.New(g.factory, g.namespace, g.tweakListOptions)
+}
+
+// V1beta1 returns a new v1beta1.Interface.
+func (g *group) V1beta1() v1beta1.Interface {
+	return v1beta1.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/staging/src/k8s.io/sample-apiserver/hack/update-codegen.sh
+++ b/staging/src/k8s.io/sample-apiserver/hack/update-codegen.sh
@@ -21,24 +21,28 @@ set -o pipefail
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
+source "${CODEGEN_PKG}/kube_codegen.sh"
+
 # generate the code with:
 # --output-base    because this script should also be able to run inside the vendor dir of
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
-"${CODEGEN_PKG}/generate-groups.sh" "applyconfiguration,client,deepcopy,informer,lister" \
-  k8s.io/sample-apiserver/pkg/generated \
-  k8s.io/sample-apiserver/pkg/apis \
-  "wardle:v1alpha1,v1beta1" \
-  --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
-  --go-header-file "${SCRIPT_ROOT}"/hack/boilerplate.go.txt
 
-"${CODEGEN_PKG}/generate-internal-groups.sh" "deepcopy,defaulter,conversion,openapi" \
-  k8s.io/sample-apiserver/pkg/generated \
-  k8s.io/sample-apiserver/pkg/apis \
-  k8s.io/sample-apiserver/pkg/apis \
-  "wardle:v1alpha1,v1beta1" \
-  --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
-  --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+kube::codegen::gen_helpers \
+    --input-pkg-root k8s.io/sample-apiserver/pkg/apis \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
 
-# To use your own boilerplate text append:
-#   --go-header-file "${SCRIPT_ROOT}/hack/custom-boilerplate.go.txt"
+kube::codegen::gen_openapi \
+    --input-pkg-root k8s.io/sample-apiserver/pkg/apis \
+    --output-pkg-root k8s.io/sample-apiserver/pkg/generated \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+
+kube::codegen::gen_client \
+    --with-watch \
+    --with-applyconfig \
+    --input-pkg-root k8s.io/sample-apiserver/pkg/apis \
+    --output-pkg-root k8s.io/sample-apiserver/pkg/generated \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"

--- a/staging/src/k8s.io/sample-controller/hack/update-codegen.sh
+++ b/staging/src/k8s.io/sample-controller/hack/update-codegen.sh
@@ -21,16 +21,21 @@ set -o pipefail
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
+source "${CODEGEN_PKG}/kube_codegen.sh"
+
 # generate the code with:
 # --output-base    because this script should also be able to run inside the vendor dir of
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
-"${CODEGEN_PKG}/generate-groups.sh" "deepcopy,client,informer,lister" \
-  k8s.io/sample-controller/pkg/generated \
-  k8s.io/sample-controller/pkg/apis \
-  samplecontroller:v1alpha1 \
-  --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
-  --go-header-file "${SCRIPT_ROOT}"/hack/boilerplate.go.txt
 
-# To use your own boilerplate text append:
-#   --go-header-file "${SCRIPT_ROOT}"/hack/custom-boilerplate.go.txt
+kube::codegen::gen_helpers \
+    --input-pkg-root k8s.io/sample-controller/pkg/apis \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+
+kube::codegen::gen_client \
+    --with-watch \
+    --input-pkg-root k8s.io/sample-controller/pkg/apis \
+    --output-pkg-root k8s.io/sample-controller/pkg/generated \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"


### PR DESCRIPTION
Add a new way for subprojects to do codegen
    
This new script (k8s.io/code-generator/kube_codegen.sh) should be somewhat easier to understand and maintain.  This PR includes commits which convert all of the internal subprojects to use it.

/kind cleanup

```release-note
Projects which use k8s.io/code-generator and invoke `generate-groups` or `generate-internal-groups.sh` have a new, simpler script (`kube_codegen.sh`) they can use.  The old scripts are deprecated but remain intact.
```
