### PR TITLE
Cleanup map initialize in openapi client-go.

### DIFF
--- a/staging/src/k8s.io/client-go/openapi/cached/groupversion.go
+++ b/staging/src/k8s.io/client-go/openapi/cached/groupversion.go
@@ -44,12 +44,12 @@ func (g *groupversion) Schema(contentType string) ([]byte, error) {
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
+	if g.docs == nil {
+		g.docs = make(map[string]docInfo)
+	}
+
 	cachedInfo, ok := g.docs[contentType]
 	if !ok {
-		if g.docs == nil {
-			g.docs = make(map[string]docInfo)
-		}
-
 		cachedInfo.data, cachedInfo.err = g.delegate.Schema(contentType)
 		g.docs[contentType] = cachedInfo
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Init ```g.docs = make(map[string]docInfo)``` first , if it is nil map.
for prevent potential panic when use a not initialized map..

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
