### PR TITLE
Automated cherry pick of #117245: Fix TopologyAwareHint not working when zone label is added
#117249: Fix a data race in TopologyCache

### DIFF
--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -520,7 +520,10 @@ func (c *Controller) updateNode(old, cur interface{}) {
 	oldNode := old.(*v1.Node)
 	curNode := cur.(*v1.Node)
 
-	if topologycache.NodeReady(oldNode.Status) != topologycache.NodeReady(curNode.Status) {
+	// LabelTopologyZone may be added by cloud provider asynchronously after the Node is created.
+	// The topology cache should be updated in this case.
+	if topologycache.NodeReady(oldNode.Status) != topologycache.NodeReady(curNode.Status) ||
+		oldNode.Labels[v1.LabelTopologyZone] != curNode.Labels[v1.LabelTopologyZone] {
 		c.checkNodeTopologyDistribution()
 	}
 }

--- a/pkg/controller/endpointslice/topologycache/topologycache.go
+++ b/pkg/controller/endpointslice/topologycache/topologycache.go
@@ -270,6 +270,9 @@ func (t *TopologyCache) HasPopulatedHints(serviceKey string) bool {
 // it is not possible to provide allocations that are below the overload
 // threshold, a nil value will be returned.
 func (t *TopologyCache) getAllocations(numEndpoints int) (map[string]Allocation, *EventBuilder) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
 	// it is similar to checking !t.sufficientNodeInfo
 	if t.cpuRatiosByZone == nil {
 		return nil, &EventBuilder{
@@ -292,9 +295,6 @@ func (t *TopologyCache) getAllocations(numEndpoints int) (map[string]Allocation,
 			Message:   fmt.Sprintf("%s (%d endpoints, %d zones)", InsufficientNumberOfEndpoints, numEndpoints, len(t.cpuRatiosByZone)),
 		}
 	}
-
-	t.lock.Lock()
-	defer t.lock.Unlock()
 
 	remainingMinEndpoints := numEndpoints
 	minTotal := 0


### PR DESCRIPTION
Cherry pick of #117245 #117249 on release-1.26.

#117245: Fix TopologyAwareHint not working when zone label is added
#117249: Fix a data race in TopologyCache

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
- Fix Topology Aware Hints not working when the `topology.kubernetes.io/zone` label is added after Node creation
- Fix a data race in TopologyCache when `AddHints` and `SetNodes` are called concurrently
```