### PR TITLE
update-mocks.sh: Execute "go clean -modcache" on the cleanup function

### DIFF
--- a/hack/update-mocks.sh
+++ b/hack/update-mocks.sh
@@ -30,6 +30,7 @@ _tmp="${KUBE_ROOT}/_tmp_build_tag_files"
 mkdir -p "${_tmp}"
 
 function cleanup {
+    go clean -modcache
     rm -rf "$_tmp"
     rm -f "tempfile"
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
I get a permission denied error when running hack/verify-mocks.sh from my macOS Monterey (Silicon).  #116338 is basically the same problem BUT with Linux. 

"go install" is adding some files to the cache and because of the permissions I can't delete them. This is an example:

```
% ls -l /private/var/folders/g3/73rql5xd5t7cxt63gwkf04n00000gn/T/verify-mocks.sh.XXXXXX.h6yL2P2F/_output/local/go/cache/mod/golang.org/x/tools@v0.6.0/go/analysis/passes/tests/testdata/src/a
total 32
-r--r--r--  1 marthinal  staff    25 Apr 12 15:30 a.go
-r--r--r--  1 marthinal  staff  3562 Apr 12 15:30 a_test.go
-r--r--r--  1 marthinal  staff   155 Apr 12 15:30 ax_test.go
-r--r--r--  1 marthinal  staff  3794 Apr 12 15:30 go118_test.go
```

The problem can be fixed by running "go clean -modcache" from the cleanup function. 

#### Which issue(s) this PR fixes:
Fixes #117272 
