### PR TITLE
kubelet: truncate the precision at a millisecond for image pull event message

### DIFF
--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -165,7 +165,8 @@ func (m *imageManager) EnsureImageExists(ctx context.Context, pod *v1.Pod, conta
 		return "", imagePullResult.err.Error(), ErrImagePull
 	}
 	m.podPullingTimeRecorder.RecordImageFinishedPulling(pod.UID)
-	m.logIt(ref, v1.EventTypeNormal, events.PulledImage, logPrefix, fmt.Sprintf("Successfully pulled image %q in %v (%v including waiting)", container.Image, imagePullResult.pullDuration, time.Since(startTime)), klog.Info)
+	m.logIt(ref, v1.EventTypeNormal, events.PulledImage, logPrefix, fmt.Sprintf("Successfully pulled image %q in %v (%v including waiting)",
+		container.Image, imagePullResult.pullDuration.Truncate(time.Millisecond), time.Since(startTime).Truncate(time.Millisecond)), klog.Info)
 	m.backOff.GC()
 	return imagePullResult.imageRef, "", nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
#### What this PR does / why we need it:
https://github.com/kubernetes/kubernetes/pull/111772#issuecomment-1502625395 @smarterclayton 

> In observing events we have pretty high precision in the message:
> 
> Successfully pulled image "nginx:latest" in 4.614356447s (4.614439819s including waiting).
> 
> I was going to suggest we truncate the precision at a millisecond or 100 microseconds to shorten the message and make it a bit easier to read. That would be time.Since(startTime).Truncate(time.Millisecond) instead of the exact length.

#### Which issue(s) this PR fixes:

Fixes None

#### Special notes for your reviewer:

Before 
```
Successfully pulled image "nginx:latest" in 4.614356447s (4.614439819s including waiting).
```
After 
```
Successfully pulled image "nginx:latest" in 4.614s (4.614s including waiting).
```


#### Does this PR introduce a user-facing change?

```release-note
None
```