### PR TITLE
get rid of e2e/framework -> k/k/pkg/kubelet dependency

### DIFF
--- a/test/e2e/framework/.import-restrictions
+++ b/test/e2e/framework/.import-restrictions
@@ -1,13 +1,6 @@
 rules:
   # The core E2E framework is meant to be a normal Kubernetes client,
-  # which means that it shouldn't depend on internal
-  # code. But we are not there yet, so some exceptions
-  # have to be allowed. Over time the list of allowed
-  # packages should get shorter, not longer.
-  - selectorRegexp: ^k8s[.]io/kubernetes/pkg/
-    allowedPrefixes:
-    - k8s.io/kubernetes/pkg/kubelet/apis/
-
+  # which means that it shouldn't depend on internal code.
   # The following packages are okay to use:
   #
   # public API

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -41,7 +41,6 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 
-	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/test/e2e/framework/internal/junit"
 	"k8s.io/kubernetes/test/utils/image"
 	"k8s.io/kubernetes/test/utils/kubeconfig"
@@ -244,8 +243,6 @@ type NodeTestContextType struct {
 	NodeConformance bool
 	// PrepullImages indicates whether node e2e framework should prepull images.
 	PrepullImages bool
-	// KubeletConfig is the kubelet configuration the test is running against.
-	KubeletConfig kubeletconfig.KubeletConfiguration
 	// ImageDescription is the description of the image on which the test is running.
 	ImageDescription string
 	// RuntimeConfig is a map of API server runtime configuration values.

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -248,6 +248,13 @@ var _ = ginkgo.SynchronizedBeforeSuite(func(ctx context.Context) []byte {
 	framework.TestContext.BearerToken = string(token)
 	// update test context with node configuration.
 	gomega.Expect(updateTestContext(ctx)).To(gomega.Succeed(), "update test context with node config.")
+
+	// Store current Kubelet configuration in the package variable
+	// This assumes all tests which dynamically change kubelet configuration
+	// must: 1) run in serial; 2) restore kubelet configuration after test.
+	var err error
+	kubeletCfg, err = getCurrentKubeletConfig(ctx)
+	framework.ExpectNoError(err)
 })
 
 // Tear down the kubelet on the node
@@ -334,14 +341,6 @@ func updateTestContext(ctx context.Context) error {
 
 	framework.Logf("Node name: %s", framework.TestContext.NodeName)
 
-	// Update test context with current kubelet configuration.
-	// This assumes all tests which dynamically change kubelet configuration
-	// must: 1) run in serial; 2) restore kubelet configuration after test.
-	kubeletCfg, err := getCurrentKubeletConfig(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get kubelet configuration: %w", err)
-	}
-	framework.TestContext.KubeletConfig = *kubeletCfg // Set kubelet config
 	return nil
 }
 

--- a/test/e2e_node/hugepages_test.go
+++ b/test/e2e_node/hugepages_test.go
@@ -70,7 +70,7 @@ func makePodToVerifyHugePages(baseName string, hugePagesLimit resource.Quantity,
 	// convert the cgroup name to its literal form
 	cgroupName := cm.NewCgroupName(cm.RootCgroupName, defaultNodeAllocatableCgroup, baseName)
 	cgroupFsName := ""
-	if framework.TestContext.KubeletConfig.CgroupDriver == "systemd" {
+	if kubeletCfg.CgroupDriver == "systemd" {
 		cgroupFsName = cgroupName.ToSystemd()
 	} else {
 		cgroupFsName = cgroupName.ToCgroupfs()

--- a/test/e2e_node/mirror_pod_grace_period_test.go
+++ b/test/e2e_node/mirror_pod_grace_period_test.go
@@ -48,7 +48,7 @@ var _ = SIGDescribe("MirrorPodWithGracePeriod", func() {
 			staticPodName = "graceful-pod-" + string(uuid.NewUUID())
 			mirrorPodName = staticPodName + "-" + framework.TestContext.NodeName
 
-			podPath = framework.TestContext.KubeletConfig.StaticPodPath
+			podPath = kubeletCfg.StaticPodPath
 
 			ginkgo.By("create the static pod")
 			err := createStaticPodWithGracePeriod(podPath, staticPodName, ns)

--- a/test/e2e_node/mirror_pod_test.go
+++ b/test/e2e_node/mirror_pod_test.go
@@ -53,7 +53,7 @@ var _ = SIGDescribe("MirrorPod", func() {
 			staticPodName = "static-pod-" + string(uuid.NewUUID())
 			mirrorPodName = staticPodName + "-" + framework.TestContext.NodeName
 
-			podPath = framework.TestContext.KubeletConfig.StaticPodPath
+			podPath = kubeletCfg.StaticPodPath
 
 			ginkgo.By("create the static pod")
 			err := createStaticPod(podPath, staticPodName, ns,
@@ -157,7 +157,7 @@ var _ = SIGDescribe("MirrorPod", func() {
 			staticPodName = "static-pod-" + string(uuid.NewUUID())
 			mirrorPodName = staticPodName + "-" + framework.TestContext.NodeName
 
-			podPath = framework.TestContext.KubeletConfig.StaticPodPath
+			podPath = kubeletCfg.StaticPodPath
 			ginkgo.By("create the static pod")
 			err := createStaticPod(podPath, staticPodName, ns,
 				imageutils.GetE2EImage(imageutils.Nginx), v1.RestartPolicyAlways)
@@ -209,7 +209,7 @@ var _ = SIGDescribe("MirrorPod", func() {
 				e2evolume.TestServerCleanup(ctx, f, nfsTestConfig)
 			})
 
-			podPath = framework.TestContext.KubeletConfig.StaticPodPath
+			podPath = kubeletCfg.StaticPodPath
 			staticPodName = "static-pod-nfs-test-pod" + string(uuid.NewUUID())
 			mirrorPodName = staticPodName + "-" + framework.TestContext.NodeName
 

--- a/test/e2e_node/pids_test.go
+++ b/test/e2e_node/pids_test.go
@@ -40,7 +40,7 @@ func makePodToVerifyPids(baseName string, pidsLimit resource.Quantity) *v1.Pod {
 	// convert the cgroup name to its literal form
 	cgroupFsName := ""
 	cgroupName := cm.NewCgroupName(cm.RootCgroupName, defaultNodeAllocatableCgroup, baseName)
-	if framework.TestContext.KubeletConfig.CgroupDriver == "systemd" {
+	if kubeletCfg.CgroupDriver == "systemd" {
 		cgroupFsName = cgroupName.ToSystemd()
 	} else {
 		cgroupFsName = cgroupName.ToCgroupfs()

--- a/test/e2e_node/pods_container_manager_test.go
+++ b/test/e2e_node/pods_container_manager_test.go
@@ -171,7 +171,7 @@ var _ = SIGDescribe("Kubelet Cgroup Manager", func() {
 	ginkgo.Describe("QOS containers", func() {
 		ginkgo.Context("On enabling QOS cgroup hierarchy", func() {
 			ginkgo.It("Top level QoS containers should have been created [NodeConformance]", func(ctx context.Context) {
-				if !framework.TestContext.KubeletConfig.CgroupsPerQOS {
+				if !kubeletCfg.CgroupsPerQOS {
 					return
 				}
 				cgroupsToVerify := []string{burstableCgroup, bestEffortCgroup}
@@ -186,7 +186,7 @@ var _ = SIGDescribe("Kubelet Cgroup Manager", func() {
 	ginkgo.Describe("Pod containers [NodeConformance]", func() {
 		ginkgo.Context("On scheduling a Guaranteed Pod", func() {
 			ginkgo.It("Pod containers should have been created under the cgroup-root", func(ctx context.Context) {
-				if !framework.TestContext.KubeletConfig.CgroupsPerQOS {
+				if !kubeletCfg.CgroupsPerQOS {
 					return
 				}
 				var (
@@ -231,7 +231,7 @@ var _ = SIGDescribe("Kubelet Cgroup Manager", func() {
 		})
 		ginkgo.Context("On scheduling a BestEffort Pod", func() {
 			ginkgo.It("Pod containers should have been created under the BestEffort cgroup", func(ctx context.Context) {
-				if !framework.TestContext.KubeletConfig.CgroupsPerQOS {
+				if !kubeletCfg.CgroupsPerQOS {
 					return
 				}
 				var (
@@ -276,7 +276,7 @@ var _ = SIGDescribe("Kubelet Cgroup Manager", func() {
 		})
 		ginkgo.Context("On scheduling a Burstable Pod", func() {
 			ginkgo.It("Pod containers should have been created under the Burstable cgroup", func(ctx context.Context) {
-				if !framework.TestContext.KubeletConfig.CgroupsPerQOS {
+				if !kubeletCfg.CgroupsPerQOS {
 					return
 				}
 				var (

--- a/test/e2e_node/runtimeclass_test.go
+++ b/test/e2e_node/runtimeclass_test.go
@@ -96,7 +96,7 @@ var _ = SIGDescribe("Kubelet PodOverhead handling [LinuxOnly]", func() {
 	ginkgo.Describe("PodOverhead cgroup accounting", func() {
 		ginkgo.Context("On running pod with PodOverhead defined", func() {
 			ginkgo.It("Pod cgroup should be sum of overhead and resource limits", func(ctx context.Context) {
-				if !framework.TestContext.KubeletConfig.CgroupsPerQOS {
+				if !kubeletCfg.CgroupsPerQOS {
 					return
 				}
 

--- a/test/e2e_node/standalone_test.go
+++ b/test/e2e_node/standalone_test.go
@@ -53,7 +53,7 @@ var _ = SIGDescribe("[Feature:StandaloneMode] ", func() {
 		ginkgo.It("the pod should be running", func(ctx context.Context) {
 			ns = f.Namespace.Name
 			staticPodName = "static-pod-" + string(uuid.NewUUID())
-			podPath = framework.TestContext.KubeletConfig.StaticPodPath
+			podPath = kubeletCfg.StaticPodPath
 
 			err := createBasicStaticPod(podPath, staticPodName, ns)
 			framework.ExpectNoError(err)

--- a/test/e2e_node/system_node_critical_test.go
+++ b/test/e2e_node/system_node_critical_test.go
@@ -67,7 +67,7 @@ var _ = SIGDescribe("SystemNodeCriticalPod [Slow] [Serial] [Disruptive] [NodeFea
 				ginkgo.By("create a static system-node-critical pod")
 				staticPodName = "static-disk-hog-" + string(uuid.NewUUID())
 				mirrorPodName = staticPodName + "-" + framework.TestContext.NodeName
-				podPath = framework.TestContext.KubeletConfig.StaticPodPath
+				podPath = kubeletCfg.StaticPodPath
 				// define a static pod consuming disk gradually
 				// the upper limit is 1024 (iterations) * 10485760 bytes (10MB) = 10GB
 				err := createStaticSystemNodeCriticalPod(

--- a/test/e2e_node/unknown_pods_test.go
+++ b/test/e2e_node/unknown_pods_test.go
@@ -55,7 +55,7 @@ var _ = SIGDescribe("Unknown Pods [Serial] [Disruptive]", func() {
 			staticPodName = "unknown-test-pod-" + string(uuid.NewUUID())
 			mirrorPodName = staticPodName + "-" + framework.TestContext.NodeName
 
-			podPath = framework.TestContext.KubeletConfig.StaticPodPath
+			podPath = kubeletCfg.StaticPodPath
 
 			framework.Logf("create the static pod %v", staticPodName)
 			err := createStaticPodWithGracePeriod(podPath, staticPodName, ns)

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -87,9 +87,12 @@ const (
 	memoryManagerStateFile = "/var/lib/kubelet/memory_manager_state"
 )
 
-var kubeletHealthCheckURL = fmt.Sprintf("http://127.0.0.1:%d/healthz", ports.KubeletHealthzPort)
-
-var containerRuntimeUnitName = ""
+var (
+	kubeletHealthCheckURL    = fmt.Sprintf("http://127.0.0.1:%d/healthz", ports.KubeletHealthzPort)
+	containerRuntimeUnitName = ""
+	// KubeletConfig is the kubelet configuration the test is running against.
+	kubeletCfg *kubeletconfig.KubeletConfiguration
+)
 
 func getNodeSummary(ctx context.Context) (*stats.Summary, error) {
 	kubeletConfig, err := getCurrentKubeletConfig(ctx)
@@ -482,7 +485,7 @@ func kubeletHealthCheck(url string) bool {
 }
 
 func toCgroupFsName(cgroupName cm.CgroupName) string {
-	if framework.TestContext.KubeletConfig.CgroupDriver == "systemd" {
+	if kubeletCfg.CgroupDriver == "systemd" {
 		return cgroupName.ToSystemd()
 	}
 	return cgroupName.ToCgroupfs()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It's conceptually wrong to have dependencies to k/k/pkg in the e2e framework code. They should be moved to corresponding  packages, in this particular case to the test/e2e_node.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```