### PR TITLE
remove `expansionFailed` const in volume expansion and avoid var name collision

### DIFF
--- a/test/e2e/storage/csi_mock/csi_fsgroup_policy.go
+++ b/test/e2e/storage/csi_mock/csi_fsgroup_policy.go
@@ -104,8 +104,8 @@ var _ = utils.SIGDescribe("CSI Mock volume fsgroup policies", func() {
 				// Delete the created file. This step is mandatory, as the mock driver
 				// won't clean up the contents automatically.
 				defer func() {
-					delete := fmt.Sprintf("rm -fr %s", dirName)
-					_, _, err = e2evolume.PodExec(f, pod, delete)
+					deleteDir := fmt.Sprintf("rm -fr %s", dirName)
+					_, _, err = e2evolume.PodExec(f, pod, deleteDir)
 					framework.ExpectNoError(err, "failed: deleting the directory: %s", err)
 				}()
 

--- a/test/e2e/storage/csi_mock/csi_volume_expansion.go
+++ b/test/e2e/storage/csi_mock/csi_volume_expansion.go
@@ -43,7 +43,6 @@ type expansionStatus int
 
 const (
 	expansionSuccess = iota
-	expansionFailed
 	expansionFailedOnController
 	expansionFailedOnNode
 	expansionFailedMissingStagingPath


### PR DESCRIPTION
- [x] `delete` variable has been colliding with builtin one it has been renamed
- [x] the `expansionFailed` const is unused for not needed as we have more granular ones in place.

/kind cleanup

```release-note
NONE
```
