### PR TITLE
proxy startup-time config handling cleanup

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -79,10 +79,6 @@ func newProxyServer(
 	config *proxyconfigapi.KubeProxyConfiguration,
 	master string) (*ProxyServer, error) {
 
-	if config == nil {
-		return nil, errors.New("config is required")
-	}
-
 	if c, err := configz.New(proxyconfigapi.GroupName); err == nil {
 		c.Set(config)
 	} else {
@@ -188,10 +184,6 @@ func newProxyServer(
 
 	if proxyMode == proxyconfigapi.ProxyModeIPTables {
 		klog.InfoS("Using iptables Proxier")
-		if config.IPTables.MasqueradeBit == nil {
-			// MasqueradeBit must be specified or defaulted.
-			return nil, fmt.Errorf("unable to read IPTables MasqueradeBit from config")
-		}
 
 		if dualStack {
 			klog.InfoS("kube-proxy running in dual-stack mode", "ipFamily", iptInterface.Protocol())

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -45,6 +45,12 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/winkernel"
 )
 
+func (o *Options) platformApplyDefaults(config *proxyconfigapi.KubeProxyConfiguration) {
+	if config.Mode == "" {
+		config.Mode = proxyconfigapi.ProxyModeKernelspace
+	}
+}
+
 // NewProxyServer returns a new ProxyServer.
 func NewProxyServer(o *Options) (*ProxyServer, error) {
 	return newProxyServer(o.config, o.master)
@@ -99,7 +105,6 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, master string
 	}
 
 	var proxier proxy.Provider
-	proxyMode := proxyconfigapi.ProxyModeKernelspace
 	dualStackMode := getDualStackMode(config.Winkernel.NetworkName, winkernel.DualStackCompatTester{})
 	if dualStackMode {
 		klog.InfoS("Creating dualStackProxier for Windows kernel.")
@@ -134,18 +139,13 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, master string
 	winkernel.RegisterMetrics()
 
 	return &ProxyServer{
-		Client:              client,
-		Proxier:             proxier,
-		Broadcaster:         eventBroadcaster,
-		Recorder:            recorder,
-		ProxyMode:           proxyMode,
-		NodeRef:             nodeRef,
-		MetricsBindAddress:  config.MetricsBindAddress,
-		BindAddressHardFail: config.BindAddressHardFail,
-		EnableProfiling:     config.EnableProfiling,
-		OOMScoreAdj:         config.OOMScoreAdj,
-		ConfigSyncPeriod:    config.ConfigSyncPeriod.Duration,
-		HealthzServer:       healthzServer,
+		Config:        config,
+		Client:        client,
+		Proxier:       proxier,
+		Broadcaster:   eventBroadcaster,
+		Recorder:      recorder,
+		NodeRef:       nodeRef,
+		HealthzServer: healthzServer,
 	}, nil
 }
 

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -51,10 +51,6 @@ func NewProxyServer(o *Options) (*ProxyServer, error) {
 }
 
 func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, master string) (*ProxyServer, error) {
-	if config == nil {
-		return nil, errors.New("config is required")
-	}
-
 	if c, err := configz.New(proxyconfigapi.GroupName); err == nil {
 		c.Set(config)
 	} else {

--- a/pkg/proxy/apis/config/validation/validation.go
+++ b/pkg/proxy/apis/config/validation/validation.go
@@ -95,6 +95,8 @@ func Validate(config *kubeproxyconfig.KubeProxyConfiguration) field.ErrorList {
 
 	allErrs = append(allErrs, validateKubeProxyNodePortAddress(config.NodePortAddresses, newPath.Child("NodePortAddresses"))...)
 	allErrs = append(allErrs, validateShowHiddenMetricsVersion(config.ShowHiddenMetricsForVersion, newPath.Child("ShowHiddenMetricsForVersion"))...)
+
+	allErrs = append(allErrs, validateDetectLocalMode(config.DetectLocalMode, newPath.Child("DetectLocalMode"))...)
 	if config.DetectLocalMode == kubeproxyconfig.LocalModeBridgeInterface {
 		allErrs = append(allErrs, validateInterface(config.DetectLocal.BridgeInterface, newPath.Child("InterfaceName"))...)
 	}
@@ -203,6 +205,22 @@ func validateProxyModeWindows(mode kubeproxyconfig.ProxyMode, fldPath *field.Pat
 
 	errMsg := fmt.Sprintf("must be %s or blank (blank means the most-available proxy [currently 'kernelspace'])", strings.Join(validModes.List(), ","))
 	return field.ErrorList{field.Invalid(fldPath.Child("ProxyMode"), string(mode), errMsg)}
+}
+
+func validateDetectLocalMode(mode kubeproxyconfig.LocalMode, fldPath *field.Path) field.ErrorList {
+	validModes := []string{
+		string(kubeproxyconfig.LocalModeClusterCIDR),
+		string(kubeproxyconfig.LocalModeNodeCIDR),
+		string(kubeproxyconfig.LocalModeBridgeInterface),
+		string(kubeproxyconfig.LocalModeInterfaceNamePrefix),
+		"",
+	}
+
+	if sets.New(validModes...).Has(string(mode)) {
+		return nil
+	}
+
+	return field.ErrorList{field.NotSupported(fldPath, string(mode), validModes)}
 }
 
 func validateClientConnectionConfiguration(config componentbaseconfig.ClientConnectionConfiguration, fldPath *field.Path) field.ErrorList {

--- a/pkg/proxy/apis/config/validation/validation_test.go
+++ b/pkg/proxy/apis/config/validation/validation_test.go
@@ -424,6 +424,28 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			},
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("InterfaceName"), "", "must not be empty")},
 		},
+		"invalid DetectLocalMode": {
+			config: kubeproxyconfig.KubeProxyConfiguration{
+				BindAddress:        "10.10.12.11",
+				HealthzBindAddress: "0.0.0.0:12345",
+				MetricsBindAddress: "127.0.0.1:10249",
+				ClusterCIDR:        "192.168.59.0/24",
+				ConfigSyncPeriod:   metav1.Duration{Duration: 1 * time.Second},
+				IPTables: kubeproxyconfig.KubeProxyIPTablesConfiguration{
+					MasqueradeAll: true,
+					SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
+					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
+				},
+				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
+					MaxPerCore:            pointer.Int32(1),
+					Min:                   pointer.Int32(1),
+					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
+					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
+				},
+				DetectLocalMode: "Guess",
+			},
+			expectedErrs: field.ErrorList{field.NotSupported(newPath.Child("DetectLocalMode"), "Guess", []string{"ClusterCIDR", "NodeCIDR", "BridgeInterface", "InterfaceNamePrefix", ""})},
+		},
 	}
 
 	for name, testCase := range testCases {

--- a/pkg/proxy/kubemark/hollow_proxy.go
+++ b/pkg/proxy/kubemark/hollow_proxy.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -29,6 +30,7 @@ import (
 	utilsysctl "k8s.io/component-helpers/node/util/sysctl"
 	proxyapp "k8s.io/kubernetes/cmd/kube-proxy/app"
 	"k8s.io/kubernetes/pkg/proxy"
+	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
 	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
 	"k8s.io/kubernetes/pkg/proxy/iptables"
 	proxyutiliptables "k8s.io/kubernetes/pkg/proxy/util/iptables"
@@ -124,14 +126,17 @@ func NewHollowProxyOrDie(
 	}
 	return &HollowProxy{
 		ProxyServer: &proxyapp.ProxyServer{
-			Client:           client,
-			Proxier:          proxier,
-			Broadcaster:      broadcaster,
-			Recorder:         recorder,
-			ProxyMode:        "fake",
-			NodeRef:          nodeRef,
-			OOMScoreAdj:      utilpointer.Int32Ptr(0),
-			ConfigSyncPeriod: 30 * time.Second,
+			Config: &proxyconfigapi.KubeProxyConfiguration{
+				Mode:             proxyconfigapi.ProxyMode("fake"),
+				ConfigSyncPeriod: metav1.Duration{Duration: 30 * time.Second},
+				OOMScoreAdj:      utilpointer.Int32Ptr(0),
+			},
+
+			Client:      client,
+			Proxier:     proxier,
+			Broadcaster: broadcaster,
+			Recorder:    recorder,
+			NodeRef:     nodeRef,
 		},
 	}, nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
continuing [kube-proxy refactoring](https://docs.google.com/document/d/10_bpV_-IAOWO3DGRH-qrQBNySmqFKbTHUcw_tgvuAa8/edit)

1. fix `--detect-local-mode` validation to happen at validation time
2. rather than copying values between the `KubeProxyConfiguration` object and the `ProxyServer` object (and having to copy more values every time we add a new config flag), just embed the former in the latter

(Besides being generally clean-uppy this is about minimizing the code inside the two `newProxyServer` functions so that they will eventually _just_ be wrappers around `{iptables,ipvs,winkernel}.NewProxier`; see the doc linked above

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig network
/priority important-longterm