### PR TITLE
Automated cherry pick of #117238: api: encode NamespacedName with lower case in JSON

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/types/namespacedname.go
+++ b/staging/src/k8s.io/apimachinery/pkg/types/namespacedname.go
@@ -41,7 +41,8 @@ func (n NamespacedName) String() string {
 // MarshalLog emits a struct containing required key/value pair
 func (n NamespacedName) MarshalLog() interface{} {
 	return struct {
-		Name, Namespace string
+		Name      string `json:"name"`
+		Namespace string `json:"namespace,omitempty"`
 	}{
 		Name:      n.Name,
 		Namespace: n.Namespace,

--- a/staging/src/k8s.io/component-base/logs/json/json_test.go
+++ b/staging/src/k8s.io/component-base/logs/json/json_test.go
@@ -74,8 +74,13 @@ func TestZapLoggerInfo(t *testing.T) {
 		},
 		{
 			msg:        "test for NamespacedName argument",
-			format:     "{\"ts\":%f,\"caller\":\"json/json_test.go:%d\",\"msg\":\"test for NamespacedName argument\",\"v\":0,\"obj\":{\"Name\":\"kube-proxy\",\"Namespace\":\"kube-system\"}}\n",
+			format:     "{\"ts\":%f,\"caller\":\"json/json_test.go:%d\",\"msg\":\"test for NamespacedName argument\",\"v\":0,\"obj\":{\"name\":\"kube-proxy\",\"namespace\":\"kube-system\"}}\n",
 			keysValues: []interface{}{"obj", types.NamespacedName{Name: "kube-proxy", Namespace: "kube-system"}},
+		},
+		{
+			msg:        "test for NamespacedName argument with no namespace",
+			format:     "{\"ts\":%f,\"caller\":\"json/json_test.go:%d\",\"msg\":\"test for NamespacedName argument with no namespace\",\"v\":0,\"obj\":{\"name\":\"kube-proxy\"}}\n",
+			keysValues: []interface{}{"obj", types.NamespacedName{Name: "kube-proxy"}},
 		},
 	}
 


### PR DESCRIPTION
Cherry pick of #117238 on release-1.27.

#117238: api: encode NamespacedName with lower case in JSON

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```