### PR TITLE
Clarify kubelet/kube-proxy iptables rule skew constraints

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -922,7 +922,12 @@ func (proxier *Proxier) syncProxyRules() {
 	// Install the kubernetes-specific postrouting rules. We use a whole chain for
 	// this so that it is easier to flush and change, for example if the mark
 	// value should ever change.
-	// NB: THIS MUST MATCH the corresponding code in the kubelet
+
+	// NOTE: kubelet creates identical copies of these rules. If you want to change
+	// these rules in the future, you MUST do so in a way that will interoperate
+	// correctly with skewed versions of the rules created by kubelet. (Remove this
+	// comment once IPTablesOwnershipCleanup is GA.)
+
 	proxier.natRules.Write(
 		"-A", string(kubePostroutingChain),
 		"-m", "mark", "!", "--mark", fmt.Sprintf("%s/%s", proxier.masqueradeMark, proxier.masqueradeMark),
@@ -956,9 +961,13 @@ func (proxier *Proxier) syncProxyRules() {
 		// Kube-proxy's use of `route_localnet` to enable NodePorts on localhost
 		// creates a security hole (https://issue.k8s.io/90259) which this
 		// iptables rule mitigates.
-		// NB: THIS MUST MATCH the corresponding code in the kubelet. (Actually,
-		// kubelet uses "--dst"/"--src" rather than "-d"/"-s" but that's just a
-		// command-line thing and results in the same rule being created.)
+
+		// NOTE: kubelet creates an identical copy of this rule. If you want to
+		// change this rule in the future, you MUST do so in a way that will
+		// interoperate correctly with skewed versions of the rule created by
+		// kubelet. (Actually, kubelet uses "--dst"/"--src" rather than "-d"/"-s"
+		// but that's just a command-line thing and results in the same rule being
+		// created in the kernel.)
 		proxier.filterChains.Write(utiliptables.MakeChainLine(kubeletFirewallChain))
 		proxier.filterRules.Write(
 			"-A", string(kubeletFirewallChain),

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1734,7 +1734,12 @@ func (proxier *Proxier) writeIptablesRules() {
 	// Install the kubernetes-specific postrouting rules. We use a whole chain for
 	// this so that it is easier to flush and change, for example if the mark
 	// value should ever change.
-	// NB: THIS MUST MATCH the corresponding code in the kubelet
+
+	// NOTE: kubelet creates identical copies of these rules. If you want to change
+	// these rules in the future, you MUST do so in a way that will interoperate
+	// correctly with skewed versions of the rules created by kubelet. (Remove this
+	// comment once IPTablesOwnershipCleanup is GA.)
+
 	proxier.natRules.Write(
 		"-A", string(kubePostroutingChain),
 		"-m", "mark", "!", "--mark", fmt.Sprintf("%s/%s", proxier.masqueradeMark, proxier.masqueradeMark),


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind documentation

#### What this PR does / why we need it:
As discussed in SIG Network today, the [Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/#kube-proxy) currently claims that kubelet and kube-proxy must be the same version, because of the duplicate iptables rules. This would have been a problem around 1.16 when we added `--random-fully` and again in 1.19 when we rewrote the `-j MASQUERADE` rules to deal with the double-masquerade-vxlan-bad-checksum bug, but IIRC it has not been a problem at any point since then, and once [KEP-3178](https://github.com/kubernetes/enhancements/issues/3178) goes GA it should never be a problem again, so we want to update the docs to stop saying that kube-proxy cares about kubelet versions.

However, there are two catches:
1. Until KEP-3178 is actually GA, we need to keep the `KUBE-MARK-MASQ` rules in sync. Given that they haven't changed since 1.19, this should not be a problem.
2. Even after that, we need to keep the martian-packet-protection rules in sync (until/unless we remove kubelet's copy of that rule)

In both cases, our hands aren't completely tied: we just need to be careful that if we _do_ change the rules, we change them in a way that will continue to work correctly even with skewed kubelet/kube-proxy. (Eg, use different chain names, make the rules idempotent, etc). So this clearly documents that.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig network
/priority important-soon
/assign @thockin