### PR TITLE
Automated cherry pick of #117318: Update CHANGELOG-1.27 to fix typos

### DIFF
--- a/CHANGELOG/CHANGELOG-1.27.md
+++ b/CHANGELOG/CHANGELOG-1.27.md
@@ -198,13 +198,13 @@ name | architectures
 [registry.k8s.io/kube-proxy:v1.27.0](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/kube-proxy) | [amd64](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/kube-proxy-amd64), [arm64](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/kube-proxy-arm64), [ppc64le](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/kube-proxy-ppc64le), [s390x](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/kube-proxy-s390x)
 [registry.k8s.io/kube-scheduler:v1.27.0](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/kube-scheduler) | [amd64](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/kube-scheduler-amd64), [arm64](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/kube-scheduler-arm64), [ppc64le](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/kube-scheduler-ppc64le), [s390x](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/kube-scheduler-s390x)
 
-## Changelog since v1.26.0
+## Changelog since v1.27.0
 
 ## Known Issues
 
 ### The PreEnqueue extension point doesn't work for Pods going to activeQ through backoffQ
 
-In v1.27.0, we've found the bug that the PreEnqueue extension point doesn't work for Pods going to activeQ through backoffQ. 
+In v1.27.0, we've found the bug that the PreEnqueue extension point doesn't work for Pods going to activeQ through backoffQ.
 It doesn't affect any of the vanilla Kubernetes behavior, but, may break custom PreEnqueue plugins.
 
 The cause PR is [reverted](https://github.com/kubernetes/kubernetes/pull/117194) by v1.27.1.


### PR DESCRIPTION
Cherry pick of #117318 on release-1.27.

#117318: Update CHANGELOG-1.27 to fix typos

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```