### PR TITLE
Automated cherry pick of #117182: use case-insensitive header keys for http probes

### DIFF
--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -2566,7 +2566,7 @@
         "properties": {
           "name": {
             "default": "",
-            "description": "The header field name",
+            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
             "type": "string"
           },
           "value": {

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -2522,7 +2522,7 @@
         "properties": {
           "name": {
             "default": "",
-            "description": "The header field name",
+            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
             "type": "string"
           },
           "value": {

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -1813,7 +1813,7 @@
         "properties": {
           "name": {
             "default": "",
-            "description": "The header field name",
+            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
             "type": "string"
           },
           "value": {

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2037,7 +2037,8 @@ type SecretEnvSource struct {
 
 // HTTPHeader describes a custom header to be used in HTTP probes
 type HTTPHeader struct {
-	// The header field name
+	// The header field name.
+	// This will be canonicalized upon output, so case-variant names will be understood as the same header.
 	Name string
 	// The header field value
 	Value string

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -19286,7 +19286,7 @@ func schema_k8sio_api_core_v1_HTTPHeader(ref common.ReferenceCallback) common.Op
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The header field name",
+							Description: "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/pkg/probe/http/request.go
+++ b/pkg/probe/http/request.go
@@ -113,7 +113,7 @@ func formatURL(scheme string, host string, port int, path string) *url.URL {
 func v1HeaderToHTTPHeader(headerList []v1.HTTPHeader) http.Header {
 	headers := make(http.Header)
 	for _, header := range headerList {
-		headers[header.Name] = append(headers[header.Name], header.Value)
+		headers.Add(header.Name, header.Value)
 	}
 	return headers
 }

--- a/pkg/probe/http/request_test.go
+++ b/pkg/probe/http/request_test.go
@@ -16,7 +16,13 @@ limitations under the License.
 
 package http
 
-import "testing"
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
 
 func TestFormatURL(t *testing.T) {
 	testCases := []struct {
@@ -36,5 +42,50 @@ func TestFormatURL(t *testing.T) {
 		if url.String() != test.result {
 			t.Errorf("Expected %s, got %s", test.result, url.String())
 		}
+	}
+}
+
+func Test_v1HeaderToHTTPHeader(t *testing.T) {
+	tests := []struct {
+		name       string
+		headerList []v1.HTTPHeader
+		want       http.Header
+	}{
+		{
+			name: "not empty input",
+			headerList: []v1.HTTPHeader{
+				{Name: "Connection", Value: "Keep-Alive"},
+				{Name: "Content-Type", Value: "text/html"},
+				{Name: "Accept-Ranges", Value: "bytes"},
+			},
+			want: http.Header{
+				"Connection":    {"Keep-Alive"},
+				"Content-Type":  {"text/html"},
+				"Accept-Ranges": {"bytes"},
+			},
+		},
+		{
+			name: "case insensitive",
+			headerList: []v1.HTTPHeader{
+				{Name: "HOST", Value: "example.com"},
+				{Name: "FOO-bAR", Value: "value"},
+			},
+			want: http.Header{
+				"Host":    {"example.com"},
+				"Foo-Bar": {"value"},
+			},
+		},
+		{
+			name:       "empty input",
+			headerList: []v1.HTTPHeader{},
+			want:       http.Header{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := v1HeaderToHTTPHeader(tt.headerList); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("v1HeaderToHTTPHeader() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -1791,7 +1791,8 @@ message HTTPGetAction {
 
 // HTTPHeader describes a custom header to be used in HTTP probes
 message HTTPHeader {
-  // The header field name
+  // The header field name.
+  // This will be canonicalized upon output, so case-variant names will be understood as the same header.
   optional string name = 1;
 
   // The header field value

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2137,7 +2137,8 @@ type SecretEnvSource struct {
 
 // HTTPHeader describes a custom header to be used in HTTP probes
 type HTTPHeader struct {
-	// The header field name
+	// The header field name.
+	// This will be canonicalized upon output, so case-variant names will be understood as the same header.
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 	// The header field value
 	Value string `json:"value" protobuf:"bytes,2,opt,name=value"`

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -818,7 +818,7 @@ func (HTTPGetAction) SwaggerDoc() map[string]string {
 
 var map_HTTPHeader = map[string]string{
 	"":      "HTTPHeader describes a custom header to be used in HTTP probes",
-	"name":  "The header field name",
+	"name":  "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
 	"value": "The header field value",
 }
 


### PR DESCRIPTION
Cherry pick of #117182 on release-1.26.

#117182: use case-insensitive header keys for http probes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed an issue where kubelet does not set case-insensitive headers for http probes. (#117182, @dddddai)
```