### PR TITLE
dependencies: update {vishvananda/netns,xlab/treeprint}

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -213,7 +213,7 @@ require (
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 // indirect
-	github.com/vishvananda/netns v0.0.2 // indirect
+	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -215,7 +215,7 @@ require (
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
-	github.com/xlab/treeprint v1.1.0 // indirect
+	github.com/xlab/treeprint v1.2.0 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.etcd.io/etcd/client/v2 v2.305.7 // indirect
 	go.etcd.io/etcd/pkg/v3 v3.5.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -673,8 +673,8 @@ github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/vishvananda/netns v0.0.2 h1:Cn05BRLm+iRP/DZxyVSsfVyrzgjDbwHwkVt38qvXnNI=
-github.com/vishvananda/netns v0.0.2/go.mod h1:yitZXdAVI+yPFSb4QUe+VW3vOVl4PZPNcBgbPxAtJxw=
+github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
+github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vmware/govmomi v0.30.0 h1:Fm8ugPnnlMSTSceDKY9goGvjmqc6eQLPUSUeNXdpeXA=
 github.com/vmware/govmomi v0.30.0/go.mod h1:F7adsVewLNHsW/IIm7ziFURaXDaHEwcc+ym4r3INMdY=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
@@ -963,7 +963,6 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=

--- a/go.sum
+++ b/go.sum
@@ -679,8 +679,8 @@ github.com/vmware/govmomi v0.30.0 h1:Fm8ugPnnlMSTSceDKY9goGvjmqc6eQLPUSUeNXdpeXA
 github.com/vmware/govmomi v0.30.0/go.mod h1:F7adsVewLNHsW/IIm7ziFURaXDaHEwcc+ym4r3INMdY=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
-github.com/xlab/treeprint v1.1.0 h1:G/1DjNkPpfZCFt9CSh6b5/nY4VimlbHF3Rh4obvtzDk=
-github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
+github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
+github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/xlab/treeprint v1.1.0 // indirect
+	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect

--- a/staging/src/k8s.io/cli-runtime/go.sum
+++ b/staging/src/k8s.io/cli-runtime/go.sum
@@ -199,8 +199,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/xlab/treeprint v1.1.0 h1:G/1DjNkPpfZCFt9CSh6b5/nY4VimlbHF3Rh4obvtzDk=
-github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
+github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
+github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/xlab/treeprint v1.1.0 // indirect
+	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect

--- a/staging/src/k8s.io/kubectl/go.sum
+++ b/staging/src/k8s.io/kubectl/go.sum
@@ -247,8 +247,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/xlab/treeprint v1.1.0 h1:G/1DjNkPpfZCFt9CSh6b5/nY4VimlbHF3Rh4obvtzDk=
-github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
+github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
+github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/staging/src/k8s.io/sample-cli-plugin/go.mod
+++ b/staging/src/k8s.io/sample-cli-plugin/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/xlab/treeprint v1.1.0 // indirect
+	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect

--- a/staging/src/k8s.io/sample-cli-plugin/go.sum
+++ b/staging/src/k8s.io/sample-cli-plugin/go.sum
@@ -198,8 +198,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/xlab/treeprint v1.1.0 h1:G/1DjNkPpfZCFt9CSh6b5/nY4VimlbHF3Rh4obvtzDk=
-github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
+github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
+github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vendor/github.com/vishvananda/netns/.golangci.yml
+++ b/vendor/github.com/vishvananda/netns/.golangci.yml
@@ -1,0 +1,2 @@
+run:
+  timeout: 5m

--- a/vendor/github.com/vishvananda/netns/README.md
+++ b/vendor/github.com/vishvananda/netns/README.md
@@ -49,14 +49,3 @@ func main() {
 }
 
 ```
-
-## NOTE
-
-The library can be safely used only with Go >= 1.10 due to [golang/go#20676](https://github.com/golang/go/issues/20676).
-
-After locking a goroutine to its current OS thread with `runtime.LockOSThread()`
-and changing its network namespace, any new subsequent goroutine won't be
-scheduled on that thread while it's locked. Therefore, the new goroutine
-will run in a different namespace leading to unexpected results.
-
-See [here](https://www.weave.works/blog/linux-namespaces-golang-followup) for more details.

--- a/vendor/github.com/vishvananda/netns/netns_linux.go
+++ b/vendor/github.com/vishvananda/netns/netns_linux.go
@@ -2,7 +2,6 @@ package netns
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -136,7 +135,7 @@ func GetFromDocker(id string) (NsHandle, error) {
 
 // borrowed from docker/utils/utils.go
 func findCgroupMountpoint(cgroupType string) (int, string, error) {
-	output, err := ioutil.ReadFile("/proc/mounts")
+	output, err := os.ReadFile("/proc/mounts")
 	if err != nil {
 		return -1, "", err
 	}
@@ -166,7 +165,7 @@ func findCgroupMountpoint(cgroupType string) (int, string, error) {
 // borrowed from docker/utils/utils.go
 // modified to get the docker pid instead of using /proc/self
 func getDockerCgroup(cgroupVer int, cgroupType string) (string, error) {
-	dockerpid, err := ioutil.ReadFile("/var/run/docker.pid")
+	dockerpid, err := os.ReadFile("/var/run/docker.pid")
 	if err != nil {
 		return "", err
 	}
@@ -178,7 +177,7 @@ func getDockerCgroup(cgroupVer int, cgroupType string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	output, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	output, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
 	if err != nil {
 		return "", err
 	}
@@ -265,7 +264,7 @@ func getPidForContainer(id string) (int, error) {
 		return pid, fmt.Errorf("Unable to find container: %v", id[:len(id)-1])
 	}
 
-	output, err := ioutil.ReadFile(filename)
+	output, err := os.ReadFile(filename)
 	if err != nil {
 		return pid, err
 	}

--- a/vendor/github.com/vishvananda/netns/nshandle_linux.go
+++ b/vendor/github.com/vishvananda/netns/nshandle_linux.go
@@ -30,7 +30,7 @@ func (ns NsHandle) Equal(other NsHandle) bool {
 // String shows the file descriptor number and its dev and inode.
 func (ns NsHandle) String() string {
 	if ns == -1 {
-		return "NS(None)"
+		return "NS(none)"
 	}
 	var s unix.Stat_t
 	if err := unix.Fstat(int(ns), &s); err != nil {

--- a/vendor/github.com/vishvananda/netns/nshandle_others.go
+++ b/vendor/github.com/vishvananda/netns/nshandle_others.go
@@ -17,7 +17,7 @@ func (ns NsHandle) Equal(_ NsHandle) bool {
 // It is only implemented on Linux, and returns "NS(none)" on other
 // platforms.
 func (ns NsHandle) String() string {
-	return "NS(None)"
+	return "NS(none)"
 }
 
 // UniqueId returns a string which uniquely identifies the namespace

--- a/vendor/github.com/xlab/treeprint/.gitignore
+++ b/vendor/github.com/xlab/treeprint/.gitignore
@@ -1,0 +1,3 @@
+vendor/**
+.idea
+**/**.iml

--- a/vendor/github.com/xlab/treeprint/treeprint.go
+++ b/vendor/github.com/xlab/treeprint/treeprint.go
@@ -16,28 +16,28 @@ type Value interface{}
 type MetaValue interface{}
 
 // NodeVisitor function type for iterating over nodes
-type NodeVisitor func(item *node)
+type NodeVisitor func(item *Node)
 
 // Tree represents a tree structure with leaf-nodes and branch-nodes.
 type Tree interface {
-	// AddNode adds a new node to a branch.
+	// AddNode adds a new Node to a branch.
 	AddNode(v Value) Tree
-	// AddMetaNode adds a new node with meta value provided to a branch.
+	// AddMetaNode adds a new Node with meta value provided to a branch.
 	AddMetaNode(meta MetaValue, v Value) Tree
-	// AddBranch adds a new branch node (a level deeper).
+	// AddBranch adds a new branch Node (a level deeper).
 	AddBranch(v Value) Tree
-	// AddMetaBranch adds a new branch node (a level deeper) with meta value provided.
+	// AddMetaBranch adds a new branch Node (a level deeper) with meta value provided.
 	AddMetaBranch(meta MetaValue, v Value) Tree
-	// Branch converts a leaf-node to a branch-node,
-	// applying this on a branch-node does no effect.
+	// Branch converts a leaf-Node to a branch-Node,
+	// applying this on a branch-Node does no effect.
 	Branch() Tree
-	// FindByMeta finds a node whose meta value matches the provided one by reflect.DeepEqual,
+	// FindByMeta finds a Node whose meta value matches the provided one by reflect.DeepEqual,
 	// returns nil if not found.
 	FindByMeta(meta MetaValue) Tree
-	// FindByValue finds a node whose value matches the provided one by reflect.DeepEqual,
+	// FindByValue finds a Node whose value matches the provided one by reflect.DeepEqual,
 	// returns nil if not found.
 	FindByValue(value Value) Tree
-	//  returns the last node of a tree
+	//  returns the last Node of a tree
 	FindLastNode() Tree
 	// String renders the tree or subtree as a string.
 	String() string
@@ -48,19 +48,19 @@ type Tree interface {
 	SetMetaValue(meta MetaValue)
 
 	// VisitAll iterates over the tree, branches and nodes.
-	// If need to iterate over the whole tree, use the root node.
+	// If need to iterate over the whole tree, use the root Node.
 	// Note this method uses a breadth-first approach.
 	VisitAll(fn NodeVisitor)
 }
 
-type node struct {
-	Root  *node
+type Node struct {
+	Root  *Node
 	Meta  MetaValue
 	Value Value
-	Nodes []*node
+	Nodes []*Node
 }
 
-func (n *node) FindLastNode() Tree {
+func (n *Node) FindLastNode() Tree {
 	ns := n.Nodes
 	if len(ns) == 0 {
 		return nil
@@ -68,16 +68,16 @@ func (n *node) FindLastNode() Tree {
 	return ns[len(ns)-1]
 }
 
-func (n *node) AddNode(v Value) Tree {
-	n.Nodes = append(n.Nodes, &node{
+func (n *Node) AddNode(v Value) Tree {
+	n.Nodes = append(n.Nodes, &Node{
 		Root:  n,
 		Value: v,
 	})
 	return n
 }
 
-func (n *node) AddMetaNode(meta MetaValue, v Value) Tree {
-	n.Nodes = append(n.Nodes, &node{
+func (n *Node) AddMetaNode(meta MetaValue, v Value) Tree {
+	n.Nodes = append(n.Nodes, &Node{
 		Root:  n,
 		Meta:  meta,
 		Value: v,
@@ -85,8 +85,8 @@ func (n *node) AddMetaNode(meta MetaValue, v Value) Tree {
 	return n
 }
 
-func (n *node) AddBranch(v Value) Tree {
-	branch := &node{
+func (n *Node) AddBranch(v Value) Tree {
+	branch := &Node{
 		Root:  n,
 		Value: v,
 	}
@@ -94,8 +94,8 @@ func (n *node) AddBranch(v Value) Tree {
 	return branch
 }
 
-func (n *node) AddMetaBranch(meta MetaValue, v Value) Tree {
-	branch := &node{
+func (n *Node) AddMetaBranch(meta MetaValue, v Value) Tree {
+	branch := &Node{
 		Root:  n,
 		Meta:  meta,
 		Value: v,
@@ -104,12 +104,12 @@ func (n *node) AddMetaBranch(meta MetaValue, v Value) Tree {
 	return branch
 }
 
-func (n *node) Branch() Tree {
+func (n *Node) Branch() Tree {
 	n.Root = nil
 	return n
 }
 
-func (n *node) FindByMeta(meta MetaValue) Tree {
+func (n *Node) FindByMeta(meta MetaValue) Tree {
 	for _, node := range n.Nodes {
 		if reflect.DeepEqual(node.Meta, meta) {
 			return node
@@ -121,7 +121,7 @@ func (n *node) FindByMeta(meta MetaValue) Tree {
 	return nil
 }
 
-func (n *node) FindByValue(value Value) Tree {
+func (n *Node) FindByValue(value Value) Tree {
 	for _, node := range n.Nodes {
 		if reflect.DeepEqual(node.Value, value) {
 			return node
@@ -133,7 +133,7 @@ func (n *node) FindByValue(value Value) Tree {
 	return nil
 }
 
-func (n *node) Bytes() []byte {
+func (n *Node) Bytes() []byte {
 	buf := new(bytes.Buffer)
 	level := 0
 	var levelsEnded []int
@@ -158,19 +158,19 @@ func (n *node) Bytes() []byte {
 	return buf.Bytes()
 }
 
-func (n *node) String() string {
+func (n *Node) String() string {
 	return string(n.Bytes())
 }
 
-func (n *node) SetValue(value Value) {
+func (n *Node) SetValue(value Value) {
 	n.Value = value
 }
 
-func (n *node) SetMetaValue(meta MetaValue) {
+func (n *Node) SetMetaValue(meta MetaValue) {
 	n.Meta = meta
 }
 
-func (n *node) VisitAll(fn NodeVisitor) {
+func (n *Node) VisitAll(fn NodeVisitor) {
 	for _, node := range n.Nodes {
 		fn(node)
 
@@ -182,7 +182,7 @@ func (n *node) VisitAll(fn NodeVisitor) {
 }
 
 func printNodes(wr io.Writer,
-	level int, levelsEnded []int, nodes []*node) {
+	level int, levelsEnded []int, nodes []*Node) {
 
 	for i, node := range nodes {
 		edge := EdgeTypeMid
@@ -198,7 +198,7 @@ func printNodes(wr io.Writer,
 }
 
 func printValues(wr io.Writer,
-	level int, levelsEnded []int, edge EdgeType, node *node) {
+	level int, levelsEnded []int, edge EdgeType, node *Node) {
 
 	for i := 0; i < level; i++ {
 		if isEnded(levelsEnded, i) {
@@ -227,7 +227,7 @@ func isEnded(levelsEnded []int, level int) bool {
 	return false
 }
 
-func renderValue(level int, node *node) Value {
+func renderValue(level int, node *Node) Value {
 	lines := strings.Split(fmt.Sprintf("%v", node.Value), "\n")
 
 	// If value does not contain multiple lines, return itself.
@@ -248,10 +248,10 @@ func renderValue(level int, node *node) Value {
 
 // padding returns a padding for the multiline values with correctly placed link edges.
 // It is generated by traversing the tree upwards (from leaf to the root of the tree)
-// and, on each level, checking if the node the last one of its siblings.
-// If a node is the last one, the padding on that level should be empty (there's nothing to link to below it).
-// If a node is not the last one, the padding on that level should be the link edge so the sibling below is correctly connected.
-func padding(level int, node *node) string {
+// and, on each level, checking if the Node the last one of its siblings.
+// If a Node is the last one, the padding on that level should be empty (there's nothing to link to below it).
+// If a Node is not the last one, the padding on that level should be the link edge so the sibling below is correctly connected.
+func padding(level int, node *Node) string {
 	links := make([]string, level+1)
 
 	for node.Root != nil {
@@ -267,8 +267,8 @@ func padding(level int, node *node) string {
 	return strings.Join(links, "")
 }
 
-// isLast checks if the node is the last one in the slice of its parent children
-func isLast(n *node) bool {
+// isLast checks if the Node is the last one in the slice of its parent children
+func isLast(n *Node) bool {
 	return n == n.Root.FindLastNode()
 }
 
@@ -285,10 +285,10 @@ var IndentSize = 3
 
 // New Generates new tree
 func New() Tree {
-	return &node{Value: "."}
+	return &Node{Value: "."}
 }
 
 // NewWithRoot Generates new tree with the given root value
 func NewWithRoot(root Value) Tree {
-	return &node{Value: root}
+	return &Node{Value: root}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -664,8 +664,8 @@ github.com/tmc/grpc-websocket-proxy/wsproxy
 ## explicit; go 1.12
 github.com/vishvananda/netlink
 github.com/vishvananda/netlink/nl
-# github.com/vishvananda/netns v0.0.2
-## explicit; go 1.12
+# github.com/vishvananda/netns v0.0.4
+## explicit; go 1.17
 github.com/vishvananda/netns
 # github.com/vmware/govmomi v0.30.0
 ## explicit; go 1.17

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -719,7 +719,7 @@ github.com/vmware/govmomi/vim25/xml
 # github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
 ## explicit
 github.com/xiang90/probing
-# github.com/xlab/treeprint v1.1.0
+# github.com/xlab/treeprint v1.2.0
 ## explicit; go 1.13
 github.com/xlab/treeprint
 # go.etcd.io/bbolt v1.3.6


### PR DESCRIPTION
- [x] gh/vishvananda/netns: v0.0.4 :
https://github.com/vishvananda/netns/compare/v0.0.2...v0.0.4 ( mainly the go version bump to 1.17.0)
- [x] gh/xlab/treeprint v1.2.0 
https://github.com/xlab/treeprint/compare/v1.1.0...v1.2.0


/kind cleanup

```release-note
NONE
```
