### PR TITLE
Refresh volumes on terminating pods

### DIFF
--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
@@ -189,7 +189,7 @@ func TestFindAndAddNewPods_WithDifferentConditions(t *testing.T) {
 			desc:          "HasAddedPods is true, ShouldPodRuntimeBeRemoved is false, ShouldPodContainerBeTerminating is true",
 			hasAddedPods:  true,
 			podState:      Terminating,
-			expectedFound: false, // Pod should not be added to DSW
+			expectedFound: true, // Pod should be added to DSW
 		},
 		{
 			desc:          "HasAddedPods is true, ShouldPodRuntimeBeRemoved and ShouldPodContainerBeTerminating are both true",
@@ -282,7 +282,6 @@ func TestFindAndAddNewPods_WithReprocessPodAndVolumeRetrievalError(t *testing.T)
 	}
 	pluginPVOmittingClient(dswp)
 
-	dswp.ReprocessPod(podName)
 	dswp.findAndAddNewPods()
 
 	if !dswp.podPreviouslyProcessed(podName) {
@@ -351,7 +350,6 @@ func TestFindAndAddNewPods_FindAndRemoveDeletedPods(t *testing.T) {
 	}
 
 	// podWorker may call volume_manager WaitForUnmount() after we processed the pod in findAndRemoveDeletedPods()
-	dswp.ReprocessPod(podName)
 	dswp.findAndRemoveDeletedPods()
 
 	// findAndRemoveDeletedPods() above must detect orphaned pod and delete it from the map
@@ -1440,7 +1438,6 @@ func clearASW(asw cache.ActualStateOfWorld, dsw cache.DesiredStateOfWorld, t *te
 
 func reprocess(dswp *desiredStateOfWorldPopulator, uniquePodName types.UniquePodName,
 	dsw cache.DesiredStateOfWorld, asw cache.ActualStateOfWorld, newSize resource.Quantity) []v1.UniqueVolumeName {
-	dswp.ReprocessPod(uniquePodName)
 	dswp.findAndAddNewPods()
 	return getResizeRequiredVolumes(dsw, asw, newSize)
 }

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -60,7 +60,7 @@ const (
 
 	// desiredStateOfWorldPopulatorLoopSleepPeriod is the amount of time the
 	// DesiredStateOfWorldPopulator loop waits between successive executions
-	desiredStateOfWorldPopulatorLoopSleepPeriod = 100 * time.Millisecond
+	desiredStateOfWorldPopulatorLoopSleepPeriod = 1 * time.Second
 
 	// podAttachAndMountTimeout is the maximum amount of time the
 	// WaitForAttachAndMount call will wait for all volumes in the specified pod
@@ -400,11 +400,6 @@ func (vm *volumeManager) WaitForAttachAndMount(ctx context.Context, pod *v1.Pod)
 	klog.V(3).InfoS("Waiting for volumes to attach and mount for pod", "pod", klog.KObj(pod))
 	uniquePodName := util.GetUniquePodName(pod)
 
-	// Some pods expect to have Setup called over and over again to update.
-	// Remount plugins for which this is true. (Atomically updating volumes,
-	// like Downward API, depend on this to update the contents of the volume).
-	vm.desiredStateOfWorldPopulator.ReprocessPod(uniquePodName)
-
 	err := wait.PollUntilContextTimeout(
 		ctx,
 		podAttachAndMountRetryInterval,
@@ -444,8 +439,6 @@ func (vm *volumeManager) WaitForUnmount(ctx context.Context, pod *v1.Pod) error 
 
 	klog.V(3).InfoS("Waiting for volumes to unmount for pod", "pod", klog.KObj(pod))
 	uniquePodName := util.GetUniquePodName(pod)
-
-	vm.desiredStateOfWorldPopulator.ReprocessPod(uniquePodName)
 
 	err := wait.PollUntilContextTimeout(
 		ctx,


### PR DESCRIPTION
#116481 describes an issue where volumes stop being refreshed once a Pod enters the "Terminating" state. This is a problem for serviceAccount tokens being supplied via projected volumes. The net effect is that if a Pod is in the terminating state for more than 20% of the expiration time of the service account token, it may go stale. This is becoming a more significant issue with the change to limit Kubernetes service account tokens to 1 hour - since a terminationGracePeriod seconds of just 12 minutes could cause the token to become invalid. It's also a challenge for other serviceAccount use cases, such as AWS IAM Roles - where the max lifetime of the token of 1 day means that grace periods greater than 4.8 hours could result in an expired token.

My understanding of the way that volume refreshes work is that:

1. Once per second, `syncLoop()` will generate a tick
2. The tick causes the Kubelet's `dispatchWork()` method to be called
3. `dispatchWork()` in turn calls `UpdatePod()`
4. `UpdatePod()` makes the update available by assigning it to `status.pendingUpdate` and signals the availability of the update by writing to the `podUpdates` channel.
5. `podWorkerLoop()` handles the pod update
  - If the Pod is running:
    - Calls `SyncPod()`
    - `SyncPod()` in turn calls the VolumeManagers's `WaitForAttachAndMount()`. (but only if the container isn't Terminating - however, I don't think `SyncPod()` is called if the container is Terminating so I don't understand this check)
    - WaitForAttachAndMount() will then call the DesiredStateOfWorldPopulator's `ReprocessPod()`
    - `ReprocessPod()` will mark Pod processing as failed
    - All this time, the VolumeManager has also been running a loop - once every 100ms it checks to see which volumes need to be reprocessed. Specifically its `findAndAddNewPods()` method will call `processPodVolumes()` - but only for Pods that aren't terminating.
    - `processPodVolumes()` will, if pod processing is not marked as complete (which it isn't, because thats the net effect of `ReprocessPod()`) finally call the volume code that will cause projected volumes to be refreshed.
  - If the Pod is Terminating:
    - `SyncTerminatingPod()` is called instead of `SyncPod()`
    - `SyncTerminatingPod()` calls `killPod()` that waits for the Pod to exit and sends signals as necessary
    - While waiting for the container to exit, it does no other work - specifically, it doesn't call `WaitForAttachAndMount()` like `SyncPod()` does.

So, looking at the problem reported in the issue, what I think is happening is that while the container is running that chain of calls results in the VolumeManager refreshing the volumes once per second. However, once the Pod enters the Terminating state, we get stuck waiting for the Pod to exit and we stop making the calls necessary for the VolumeManager to refresh the volumes for us.

One way that we could handle this would be to call WaitForAttachAndMount() once a second while `killPod()` is running. In addition to this change, we also need to update the VolumeManager to not ignore Terminating Pods. This approach works - in that volumes are refreshed. However, this feels like an unfortunate solution: normally `WaitforAttachAndMount()` is called in response in ticks from syncLoop() - but with this change, we'd also be calling it during termination from a completely different loop. Having two very different paths calling this loop during different Pod lifecycles seems both confusing and error prone.

So, instead, this commit takes a different approach:
* Instead of using `ReprocessVolume()` to signal to the VolumeManager when it's time to reprocess a Pod's volumes, we instead reprocess volumes on every loop of the VolumeManager.
* The above change means that we're going from reprocessing volumes once a second to 10 times a second. To account for this, we slow down the VolumeManager's loop to only run once a second as well.
* We remove the checks from the VolumeManger that prevent processing Terminating Pods.
* With these changes, we no longer need the `ReprocessPod()` or `markPodProcessingFailed()` methods - so we remove them.
* Tests are updated to reflect the method removals - and also to account for the fact that we now expect volumes to be reprocessed on Terminating Pods.

I think the nice thing about this approach is that handles the Running and Terminating state uniformly - as long as the Pod is registered with the VolumeManager, the volumes are updated. As I understand it, it won't cause additional work because we also down the VolumeManager loop.

One thing that concerns me about this approach is that I do not fully understand the conditions that I removed from `findAndAddNewPods()` in order to make things work. These changes do have the intended effect of making sure that Pods in the Terminating state continue to have their volume's refreshed - but without fully understanding the conditions I updated here I'm not 100% sure they don't have some other unintended effect.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR resolves #116481, which is an issue where serviceAccount tokens can expire while a Pod is terminating

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #116481
Closes #122161

#### Special notes for your reviewer:

This is my first contribution. Does the approach look right? I don't have the CLA signed - but if the approach looks correct I should be able to get that signed.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
serviceAccount tokens will continue to be refreshed in Terminating Pods
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
