### PR TITLE
pkg/printers/internalversion: Improve performance of 'formatHosts'

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -1270,8 +1270,8 @@ func printServiceList(list *api.ServiceList, options printers.GenerateOptions) (
 }
 
 func formatHosts(rules []networking.IngressRule) string {
-	list := []string{}
 	max := 3
+	list := make([]string, 0, max)
 	more := false
 	for _, rule := range rules {
 		if len(list) == max {

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -6560,5 +6560,29 @@ func TestPrintIPAddressList(t *testing.T) {
 	if !reflect.DeepEqual(expected, rows) {
 		t.Errorf("mismatch: %s", cmp.Diff(expected, rows))
 	}
+}
 
+func BenchmarkFormatHosts(b *testing.B) {
+	var s string
+	rules := []networking.IngressRule{
+		{
+			Host: "foo.com",
+		},
+		{
+			Host: "foo.bar.com",
+		},
+		{
+			Host: "foo.bar.baz.com",
+		},
+		{
+			Host: "foo.bar.baz.qux.com",
+		},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s = formatHosts(rules)
+	}
+	// Avoid compiler optimizations
+	_ = s
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If applied this commit will slightly improve the performance of the function `formatHosts`

- before

<img width="775" alt="Screenshot 2023-04-14 at 16 08 24" src="https://user-images.githubusercontent.com/9576370/232067992-284d878f-a292-4484-acc2-5671eb1705a0.png">

- after

<img width="771" alt="Screenshot 2023-04-14 at 16 08 31" src="https://user-images.githubusercontent.com/9576370/232068059-b54d5774-0a0e-4c86-b777-d549c4e38612.png">

- benchstat

<img width="553" alt="Screenshot 2023-04-14 at 16 01 47" src="https://user-images.githubusercontent.com/9576370/232068129-0230d757-fd61-41c2-8ebe-b11b81439a69.png">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
