### PR TITLE
e2e framework: remove last dependency to k/k/pkg/kubelet

### DIFF
--- a/test/e2e/common/node/ephemeral_containers.go
+++ b/test/e2e/common/node/ephemeral_containers.go
@@ -22,7 +22,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -71,14 +70,14 @@ var _ = SIGDescribe("Ephemeral Containers [NodeConformance]", func() {
 			},
 		}
 		err := podClient.AddEphemeralContainerSync(ctx, pod, ec, time.Minute)
-		framework.ExpectNoError(err, "Failed to patch ephemeral containers in pod %q", format.Pod(pod))
+		framework.ExpectNoError(err, "Failed to patch ephemeral containers in pod %q", e2epod.FormatPod(pod))
 
 		ginkgo.By("checking pod container endpoints")
 		// Can't use anything depending on kubectl here because it's not available in the node test environment
 		output := e2epod.ExecCommandInContainer(f, pod.Name, ecName, "/bin/echo", "marco")
 		gomega.Expect(output).To(gomega.ContainSubstring("marco"))
 		log, err := e2epod.GetPodLogs(ctx, f.ClientSet, pod.Namespace, pod.Name, ecName)
-		framework.ExpectNoError(err, "Failed to get logs for pod %q ephemeral container %q", format.Pod(pod), ecName)
+		framework.ExpectNoError(err, "Failed to get logs for pod %q ephemeral container %q", e2epod.FormatPod(pod), ecName)
 		gomega.Expect(log).To(gomega.ContainSubstring("polo"))
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Copied and modified pod format function from
k/k/pkg/kubelet/util/format/pod.go to e2e/framework/pod/pod_client.go

This is the last dependency from e2e framework to k/k/pkg/kubelet:
```
$ git grep 'k8s.io/kubernetes/pkg/kubelet' ./test/e2e/framework
test/e2e/framework/kubelet/stats.go:    // copied from k8s.io/kubernetes/pkg/kubelet/dockershim/metrics
test/e2e/framework/kubelet/stats.go:    // copied from k8s.io/kubernetes/pkg/kubelet/dockershim/metrics
test/e2e/framework/kubelet/stats.go:    // copied from k8s.io/kubernetes/pkg/kubelet/dockershim/metrics
test/e2e/framework/metrics/kubelet_metrics.go:  // Taken from k8s.io/kubernetes/pkg/kubelet/dockershim/metrics
test/e2e/framework/metrics/kubelet_metrics.go:  // Taken from k8s.io/kubernetes/pkg/kubelet/metrics
test/e2e/framework/metrics/kubelet_metrics.go:  // Taken from k8s.io/kubernetes/pkg/kubelet/metrics
test/e2e/framework/metrics/kubelet_metrics.go:  // Taken from k8s.io/kubernetes/pkg/kubelet/metrics
test/e2e/framework/metrics/kubelet_metrics.go:  // Taken from k8s.io/kubernetes/pkg/kubelet/metrics
test/e2e/framework/metrics/kubelet_metrics.go:  // Taken from k8s.io/kubernetes/pkg/kubelet/metrics
test/e2e/framework/metrics/kubelet_metrics.go:  // Taken from k8s.io/kubernetes/pkg/kubelet/metrics
test/e2e/framework/metrics/kubelet_metrics.go:  // Taken from k8s.io/kubernetes/pkg/kubelet/metrics
test/e2e/framework/pod/pod_client.go:   // the status of container event, copied from k8s.io/kubernetes/pkg/kubelet/events
test/e2e/framework/pod/pod_client.go:   // the status of container event, copied from k8s.io/kubernetes/pkg/kubelet/events
test/e2e/framework/pod/pod_client.go:   // the status of container event, copied from k8s.io/kubernetes/pkg/kubelet/events
test/e2e/framework/pod/pod_client.go:   // it is copied from k8s.io/kubernetes/pkg/kubelet/sysctl
```


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/triage accepted
/priority important-longterm
/assing @pohly @dims 