### PR TITLE
Control e2e framework -> k/k/pkg dependencies

### DIFF
--- a/test/e2e/framework/autoscaling/.import-restrictions
+++ b/test/e2e/framework/autoscaling/.import-restrictions
@@ -1,9 +1,13 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes:
+    - k8s.io/kubernetes/pkg/api/v1/pod
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/config/.import-restrictions
+++ b/test/e2e/framework/config/.import-restrictions
@@ -1,9 +1,12 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes: []
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/debug/.import-restrictions
+++ b/test/e2e/framework/debug/.import-restrictions
@@ -1,9 +1,13 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes:
+    - k8s.io/kubernetes/pkg/api/v1/pod
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/deployment/.import-restrictions
+++ b/test/e2e/framework/deployment/.import-restrictions
@@ -1,9 +1,13 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes:
+    - k8s.io/kubernetes/pkg/api/v1/pod
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/endpoints/.import-restrictions
+++ b/test/e2e/framework/endpoints/.import-restrictions
@@ -1,9 +1,12 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes: []
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/endpointslice/.import-restrictions
+++ b/test/e2e/framework/endpointslice/.import-restrictions
@@ -1,9 +1,12 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes: []
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/events/.import-restrictions
+++ b/test/e2e/framework/events/.import-restrictions
@@ -1,9 +1,12 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes: []
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/gpu/.import-restrictions
+++ b/test/e2e/framework/gpu/.import-restrictions
@@ -1,9 +1,12 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes: []
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/ingress/.import-restrictions
+++ b/test/e2e/framework/ingress/.import-restrictions
@@ -1,9 +1,13 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes:
+    - k8s.io/kubernetes/pkg/api/v1/pod
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/internal/.import-restrictions
+++ b/test/e2e/framework/internal/.import-restrictions
@@ -1,9 +1,12 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes: []
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/job/.import-restrictions
+++ b/test/e2e/framework/job/.import-restrictions
@@ -1,9 +1,12 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes: []
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/kubectl/.import-restrictions
+++ b/test/e2e/framework/kubectl/.import-restrictions
@@ -1,9 +1,13 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes:
+    - k8s.io/kubernetes/pkg/api/v1/pod
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/kubelet/.import-restrictions
+++ b/test/e2e/framework/kubelet/.import-restrictions
@@ -1,9 +1,13 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes:
+    - k8s.io/kubernetes/pkg/api/v1/pod
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/kubesystem/.import-restrictions
+++ b/test/e2e/framework/kubesystem/.import-restrictions
@@ -1,9 +1,12 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes: []
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/manifest/.import-restrictions
+++ b/test/e2e/framework/manifest/.import-restrictions
@@ -1,9 +1,12 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes: []
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/metrics/.import-restrictions
+++ b/test/e2e/framework/metrics/.import-restrictions
@@ -1,9 +1,13 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes:
+    - k8s.io/kubernetes/pkg/api/v1/pod
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/network/.import-restrictions
+++ b/test/e2e/framework/network/.import-restrictions
@@ -1,9 +1,13 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes:
+    - k8s.io/kubernetes/pkg/api/v1/pod
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/node/.import-restrictions
+++ b/test/e2e/framework/node/.import-restrictions
@@ -1,9 +1,13 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes:
+    - k8s.io/kubernetes/pkg/api/v1/pod
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/perf/.import-restrictions
+++ b/test/e2e/framework/perf/.import-restrictions
@@ -1,9 +1,13 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes:
+    - k8s.io/kubernetes/pkg/api/v1/pod
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/pod/.import-restrictions
+++ b/test/e2e/framework/pod/.import-restrictions
@@ -1,9 +1,13 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes:
+    - k8s.io/kubernetes/pkg/api/v1/pod
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/providers/.import-restrictions
+++ b/test/e2e/framework/providers/.import-restrictions
@@ -1,9 +1,13 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes:
+    - k8s.io/kubernetes/pkg/api/v1/pod
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/providers/gce/.import-restrictions
+++ b/test/e2e/framework/providers/gce/.import-restrictions
@@ -1,12 +1,9 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies except of k/k/pkg, therefore we need to override the
-# restrictions from the parent .import-restrictions file.
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
-  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
-    allowedPrefixes: []
-
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/providers/kubemark/.import-restrictions
+++ b/test/e2e/framework/providers/kubemark/.import-restrictions
@@ -1,12 +1,9 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies except of k/k/pkg, therefore we need to override the
-# restrictions from the parent .import-restrictions file.
+# dependencies, therefore we need to override the restrictions from
+# the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
-  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
-    allowedPrefixes: []
-
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/replicaset/.import-restrictions
+++ b/test/e2e/framework/replicaset/.import-restrictions
@@ -1,9 +1,12 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes: []
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/resource/.import-restrictions
+++ b/test/e2e/framework/resource/.import-restrictions
@@ -1,9 +1,13 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes:
+    - k8s.io/kubernetes/pkg/api/v1/pod
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/security/.import-restrictions
+++ b/test/e2e/framework/security/.import-restrictions
@@ -1,9 +1,13 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes:
+    - k8s.io/kubernetes/pkg/api/v1/pod
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/service/.import-restrictions
+++ b/test/e2e/framework/service/.import-restrictions
@@ -1,9 +1,13 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes:
+    - k8s.io/kubernetes/pkg/api/v1/pod
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/ssh/.import-restrictions
+++ b/test/e2e/framework/ssh/.import-restrictions
@@ -1,9 +1,12 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes: []
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/testfiles/.import-restrictions
+++ b/test/e2e/framework/testfiles/.import-restrictions
@@ -1,9 +1,12 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes: []
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/timer/.import-restrictions
+++ b/test/e2e/framework/timer/.import-restrictions
@@ -1,9 +1,12 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes: []
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]

--- a/test/e2e/framework/websocket/.import-restrictions
+++ b/test/e2e/framework/websocket/.import-restrictions
@@ -1,9 +1,12 @@
 # This E2E framework sub-package is currently allowed to use arbitrary
-# dependencies, therefore we need to override the restrictions from
-# the parent .import-restrictions file.
+# dependencies except of k/k/pkg, therefore we need to override the
+# restrictions from the parent .import-restrictions file.
 #
 # At some point it may become useful to also check this package's
 # dependencies more careful.
 rules:
+  - selectorRegexp: "^k8s[.]io/kubernetes/pkg"
+    allowedPrefixes: []
+
   - selectorRegexp: ""
     allowedPrefixes: [ "" ]


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Got rid of the last dependency to k/k/pkg/util
- Enabled control of the k/k/pkg imports

#### Special notes for your reviewer:

After this cleanup there are just a few exceptions that we need to fix, like k8s.io/kubernetes/pkg/api/v1/pod for some submodules.
Another good thing is that all k/k/pkg imports are now under control. Adding new ones would require updating .import-restrictions.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/triage accepted
/priority important-longterm
/assign @pohly @dims 