### PR TITLE
enhancemanet: reduce calculation calls

### DIFF
--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -67,12 +67,12 @@ func GetEarliestPodStartTime(victims *extenderv1.Victims) *metav1.Time {
 	maxPriority := corev1helpers.PodPriority(victims.Pods[0])
 
 	for _, pod := range victims.Pods {
-		if corev1helpers.PodPriority(pod) == maxPriority {
-			if GetPodStartTime(pod).Before(earliestPodStartTime) {
-				earliestPodStartTime = GetPodStartTime(pod)
+		if podPriority := corev1helpers.PodPriority(pod); podPriority == maxPriority {
+			if podStartTime := GetPodStartTime(pod); podStartTime.Before(earliestPodStartTime) {
+				earliestPodStartTime = podStartTime
 			}
-		} else if corev1helpers.PodPriority(pod) > maxPriority {
-			maxPriority = corev1helpers.PodPriority(pod)
+		} else if podPriority > maxPriority {
+			maxPriority = podPriority
 			earliestPodStartTime = GetPodStartTime(pod)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

1.  function is called when need,  reduce calling times of function `GetPodStartTime()` or `PodPriority()`;
2. reuse the result of former function calling;

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

benchmark test result
```
go version go1.20.1
goos: darwin
goarch: arm64
pkg: k8s.io/kubernetes/pkg/scheduler/util

before:

Benchmark10kPods-8   	   67680	     16837 ns/op	       0 B/op	       0 allocs/op
Benchmark10kPods-8   	   69393	     16928 ns/op	       0 B/op	       0 allocs/op
Benchmark10kPods-8   	   68298	     16942 ns/op	       0 B/op	       0 allocs/op
Benchmark10kPods-8   	   70198	     16125 ns/op	       0 B/op	       0 allocs/op

Benchmark100kPods-8   	    2661	    444173 ns/op	       0 B/op	       0 allocs/op
Benchmark100kPods-8   	    2674	    446439 ns/op	       0 B/op	       0 allocs/op
Benchmark100kPods-8   	    2715	    454089 ns/op	       0 B/op	       0 allocs/op
Benchmark100kPods-8   	    2665	    440868 ns/op	       0 B/op	       0 allocs/op
Benchmark100kPods-8   	    2646	    452669 ns/op	       0 B/op	       0 allocs/op

after:

Benchmark10kPods-8   	   80383	     14392 ns/op	       0 B/op	       0 allocs/op
Benchmark10kPods-8   	   81895	     14073 ns/op	       0 B/op	       0 allocs/op
Benchmark10kPods-8   	   78211	     14602 ns/op	       0 B/op	       0 allocs/op
Benchmark10kPods-8   	   76614	     15110 ns/op	       0 B/op	       0 allocs/op

Benchmark100kPods-8   	    2736	    409138 ns/op	       0 B/op	       0 allocs/op
Benchmark100kPods-8   	    2932	    414789 ns/op	       0 B/op	       0 allocs/op
Benchmark100kPods-8   	    2908	    403114 ns/op	       0 B/op	       0 allocs/op
Benchmark100kPods-8   	    2925	    394417 ns/op	       0 B/op	       0 allocs/op
Benchmark100kPods-8   	    2958	    410171 ns/op	       0 B/op	       0 allocs/op
```
benchmark code 
```go
func Benchmark10kPods(b *testing.B) {
	num := 10000
	now := time.Now()
	pods := make([]*v1.Pod, 0, num)
	for i := 0; i < num; i++ {
		prio := rand.Int31n(int32(num))
		rndTime := now.Add(time.Second * time.Duration(rand.Int63n(int64(num))))
		pods = append(pods, newPriorityPodWithStartTime("pod"+strconv.Itoa(i), prio, rndTime))
	}

	victims := &extenderv1.Victims{Pods: pods}
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		GetEarliestPodStartTime(victims)
	}
	b.StopTimer()
}
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
None
