### PR TITLE
[POC]: Support automatically configured Limited Swap support for cgroups v1 and v2

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -47,6 +47,8 @@ CGROUP_DRIVER=${CGROUP_DRIVER:-""}
 CGROUP_ROOT=${CGROUP_ROOT:-""}
 # owner of client certs, default to current user if not specified
 USER=${USER:-$(whoami)}
+# if true, limited swap is being used instead of unlimited swap
+LIMITED_SWAP=${LIMITED_SWAP:-""}
 
 # required for cni installation
 CNI_CONFIG_DIR=${CNI_CONFIG_DIR:-/etc/cni/net.d}
@@ -767,6 +769,13 @@ EOF
 tracing:
   endpoint: localhost:4317 # the default value
   samplingRatePerMillion: 1000000 # sample always
+EOF
+    fi
+
+    if [[ "$LIMITED_SWAP" == "true" ]]; then
+        cat <<EOF >> "${TMP_DIR}"/kubelet.yaml
+memorySwap:
+  swapBehavior: LimitedSwap
 EOF
     fi
 

--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -48,8 +48,9 @@ const (
 	// MemoryMin is memory.min for cgroup v2
 	MemoryMin string = "memory.min"
 	// MemoryHigh is memory.high for cgroup v2
-	MemoryHigh         string = "memory.high"
-	Cgroup2MaxCpuLimit string = "max"
+	MemoryHigh             string = "memory.high"
+	Cgroup2MaxCpuLimit     string = "max"
+	Cgroup2MaxSwapFilename string = "memory.swap.max"
 )
 
 var RootCgroupName = CgroupName([]string{})

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -20,6 +20,9 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"fmt"
+	cadvisorv1 "github.com/google/cadvisor/info/v1"
+	kubeapiqos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	"math"
 	"os"
 	"strconv"
@@ -103,35 +106,19 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(pod *v1.Pod,
 		lcr.Unified = map[string]string{}
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.NodeSwap) {
+	if swapConfigurationHelper := newSwapConfigurationHelper(*m.machineInfo); utilfeature.DefaultFeatureGate.Enabled(kubefeatures.NodeSwap) {
 		// NOTE(ehashman): Behaviour is defined in the opencontainers runtime spec:
 		// https://github.com/opencontainers/runtime-spec/blob/1c3f411f041711bbeecf35ff7e93461ea6789220/config-linux.md#memory
 		switch m.memorySwapBehavior {
 		case kubelettypes.UnlimitedSwap:
-			// -1 = unlimited swap
-			lcr.MemorySwapLimitInBytes = -1
+			swapConfigurationHelper.configureUnlimitedSwap(lcr)
 		case kubelettypes.LimitedSwap:
-			// TODO: implement
-			fallthrough
+			swapConfigurationHelper.configureLimitedSwap(lcr, pod, container)
 		default:
-			if libcontainercgroups.IsCgroup2UnifiedMode() {
-				lcr.Unified[cm.Cgroup2MaxSwapFilename] = "0"
-			} else {
-				// memorySwapLimit = total permitted memory+swap; if equal to memory limit, => 0 swap above memory limit
-				// Some swapping is still possible.
-				// Note that if memory limit is 0, memory swap limit is ignored.
-				lcr.MemorySwapLimitInBytes = lcr.MemoryLimitInBytes
-			}
+			swapConfigurationHelper.configureNoSwap(lcr)
 		}
 	} else {
-		if libcontainercgroups.IsCgroup2UnifiedMode() {
-			lcr.Unified[cm.Cgroup2MaxSwapFilename] = "0"
-		} else {
-			// memorySwapLimit = total permitted memory+swap; if equal to memory limit, => 0 swap above memory limit
-			// Some swapping is still possible.
-			// Note that if memory limit is 0, memory swap limit is ignored.
-			lcr.MemorySwapLimitInBytes = lcr.MemoryLimitInBytes
-		}
+		swapConfigurationHelper.configureNoSwap(lcr)
 	}
 
 	// Set memory.min and memory.high to enforce MemoryQoS
@@ -306,4 +293,69 @@ func toKubeContainerResources(statusResources *runtimeapi.ContainerResources) *k
 		}
 	}
 	return cStatusResources
+}
+
+type swapConfigurationHelper struct {
+	isCgroup2UnifiedMode bool
+	machineInfo          cadvisorv1.MachineInfo
+}
+
+func newSwapConfigurationHelper(machineInfo cadvisorv1.MachineInfo) *swapConfigurationHelper {
+	return &swapConfigurationHelper{isCgroup2UnifiedMode: libcontainercgroups.IsCgroup2UnifiedMode(), machineInfo: machineInfo}
+}
+
+func (m swapConfigurationHelper) configureLimitedSwap(lcr *runtimeapi.LinuxContainerResources, pod *v1.Pod, container *v1.Container) {
+	podQos := kubeapiqos.GetPodQOS(pod)
+	if podQos != v1.PodQOSBurstable {
+		m.configureNoSwap(lcr)
+		return
+	}
+
+	containerMemoryRequest := container.Resources.Requests.Memory()
+	if containerMemoryRequest == nil {
+		m.configureNoSwap(lcr)
+		return
+	}
+
+	totalPodMemory := resource.Quantity{}
+
+	for _, container := range pod.Spec.Containers {
+		memoryRequest := container.Resources.Requests.Memory()
+		if memoryRequest != nil {
+			totalPodMemory.Add(*container.Resources.Requests.Memory())
+		}
+	}
+
+	requestedMemoryProportion := float64(containerMemoryRequest.Value()) / float64(totalPodMemory.Value())
+	swapMemoryProportion := float64(m.machineInfo.SwapCapacity) / float64(m.machineInfo.MemoryCapacity)
+
+	swapLimit := int64(requestedMemoryProportion * swapMemoryProportion * float64(containerMemoryRequest.Value()))
+	m.configureSwap(lcr, swapLimit)
+}
+
+func (m swapConfigurationHelper) configureUnlimitedSwap(lcr *runtimeapi.LinuxContainerResources) {
+	if m.isCgroup2UnifiedMode {
+		lcr.Unified[cm.Cgroup2MaxSwapFilename] = "max"
+	} else {
+		lcr.MemorySwapLimitInBytes = -1
+	}
+}
+
+func (m swapConfigurationHelper) configureNoSwap(lcr *runtimeapi.LinuxContainerResources) {
+	if m.isCgroup2UnifiedMode {
+		lcr.Unified[cm.Cgroup2MaxSwapFilename] = "0"
+	} else {
+		// memorySwapLimit = total permitted memory+swap; if equal to memory limit, => 0 swap above memory limit
+		// Some swapping is still possible.
+		// Note that if memory limit is 0, memory swap limit is ignored.
+		lcr.MemorySwapLimitInBytes = lcr.MemoryLimitInBytes
+	}
+}
+
+func (m swapConfigurationHelper) configureSwap(lcr *runtimeapi.LinuxContainerResources, swapMemory int64) {
+	if m.isCgroup2UnifiedMode {
+		lcr.Unified[cm.Cgroup2MaxSwapFilename] = fmt.Sprintf("%d", swapMemory)
+	} else {
+		lcr.MemorySwapLimitInBytes = lcr.MemoryLimitInBytes + swapMemory
+	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -343,6 +343,7 @@ func (m swapConfigurationHelper) configureLimitedSwap(lcr *runtimeapi.LinuxConta
 }
 
 func (m swapConfigurationHelper) configureUnlimitedSwap(lcr *runtimeapi.LinuxContainerResources) {
+	klog.Infof("configuring unlimited swap")
 	if m.isCgroup2UnifiedMode {
 		lcr.Unified[cm.Cgroup2MaxSwapFilename] = "max"
 	} else {
@@ -351,6 +352,7 @@ func (m swapConfigurationHelper) configureUnlimitedSwap(lcr *runtimeapi.LinuxCon
 }
 
 func (m swapConfigurationHelper) configureNoSwap(lcr *runtimeapi.LinuxContainerResources) {
+	klog.Infof("configuring no swap")
 	if m.isCgroup2UnifiedMode {
 		lcr.Unified[cm.Cgroup2MaxSwapFilename] = "0"
 	} else {

--- a/vendor/github.com/google/cadvisor/info/v1/machine.go
+++ b/vendor/github.com/google/cadvisor/info/v1/machine.go
@@ -263,6 +263,7 @@ func (m *MachineInfo) Clone() *MachineInfo {
 		NumSockets:       m.NumSockets,
 		CpuFrequency:     m.CpuFrequency,
 		MemoryCapacity:   m.MemoryCapacity,
+		SwapCapacity: 	  m.SwapCapacity,
 		MemoryByType:     memoryByType,
 		NVMInfo:          m.NVMInfo,
 		HugePages:        m.HugePages,


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

Note: One of this PR's [commits](https://github.com/kubernetes/kubernetes/pull/117392/commits/46b0dfbb7cb1aeeb55baa93e3e98ac0cbc8fe304) fixes a bug in cAdvisor regarding cloning MachineInfo. It is fixed in this PR for the purposes of testing the POC, but a fix is also sent to upstream cAdvisor: https://github.com/google/cadvisor/pull/3293.

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### Overview and motivation
This PR serves as a POC for supporting LimitedSwap, configured automatically on a QoS basis, which works on both cgroups v1 and v2.

This is important for two reasons:
1. According to [the docs](https://kubernetes.io/blog/2021/08/09/run-nodes-with-swap-alpha/) [1]:
```
cgroups v2: Kubernetes workloads cannot use swap memory.
```
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Not only that currently LimitedSwap is not supported at all of cgroups v2, but 
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; also in the [current implementation](https://github.com/kubernetes/kubernetes/blob/v1.27.0-alpha.3/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go#L96) [2] it's effectively being turned off also for v1.
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; This is nicely explain as an [in-code comment](https://github.com/kubernetes/kubernetes/blob/v1.27.0-alpha.3/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go#LL99) [3].

2. This is one of the main requirements in order to [graduate swap into Beta](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md?plain=1#L542) [4].

In this PR (unlike my previous [POC](https://github.com/kubernetes/kubernetes/pull/116637)[5]), avoids introducing new APIs. Instead, the swap limitation is calculated automatically based on the Pod's QoS, the swap size, and the container and pod's memory request. See section below for full details.

[1] https://kubernetes.io/blog/2021/08/09/run-nodes-with-swap-alpha/
[2] https://github.com/kubernetes/kubernetes/blob/v1.27.0-alpha.3/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go#L96
[3] https://github.com/kubernetes/kubernetes/blob/v1.27.0-alpha.3/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go#LL99
[4] https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md?plain=1#L542
[5] https://github.com/kubernetes/kubernetes/pull/116637

#### How swap memory allocation is calculated
As mentioned above, this PR does not introduce any new APIs. Instead, it is being automatically and transparently calculated.

Note: swap access is granted only for pods of Burstrable QoS. Guaranteed QoS pods are usually higher-priority pods, therefore we want to avoid swap's performance penalty for them. Best-Effort pods, on the contrary, are low-priority pods that are the first to be killed during node pressures. In addition, they're unpredictible, therefore it's hard to assess how much swap memory is a reasonable amount to allocate for them.

Let C be the container that's being configured.
Let's define the following:

`totalPodMemory`: The sum of all the pod's containers memory requests.
`CMemory`: C's memory request.
`requestedMemoryProportion`: `CMemory` divided by `totalPodMemory`.
`swapMemoryProportion`: The node's swap capacity divided by the node's memory capacity.
`swapLimit`: C's swap limitation.

Then, `swapLimit` is calculated as follows:
`swapLimit = requestedMemoryProportion * swapMemoryProportion * CMemory`

That is, a Burstable QoS pod gets swap allocation proportional to its memory request and the swap/memory capacity on the node.
Every container in that pod gets swap allocation proportionate to its memory request.

#### Test Environment
* Kubernetes: latest master branch
* CRIO: v1.26.2, built and compiled from source code
  * The following is used to bring up the local cluster: `CGROUP_DRIVER=systemd CONTAINER_RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT='unix:///var/run/crio/crio.sock' ./hack/local-up-cluster.sh`

I'm using the following pod for testing:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
spec:
  containers:
  - name: c1
    resources:
      requests:
        memory: "512M"
    image: quay.io/mabekitzur/fedora-with-stress-ng:12-3-2022
    command: ["/bin/bash"]
    args: ["-c", "sleep 9999"]
  - name: c2
    resources:
      requests:
        memory: "256M"
    image: quay.io/mabekitzur/fedora-with-stress-ng:12-3-2022
    command: ["/bin/bash"]
    args: ["-c", "sleep 9999"]
```

The container image is based on the latest fedora, but also installs stress-ng. This would be useful to test swap behavior. The container does nothing but sleep for a huge amount of time. I'm going to refer to this pod as `pod.yaml` in the sections below.

This Pod will be slightly changed w.r.t. the relevant test case. I would show only the relevant changes, and not the whole pod for simplicity.

In addition, I'm using `k` instead of `./cluster/kubectl.sh`.

I've also added a commit with debug logs in order to ease understanding the calculations behind the scenes.

### Tests
All of the following tests were done on an environment running cgroups v2.

#### Case #1 - sanity check: without swap enabled
Create the pod:
```bash
> k create -f pod.yaml
pod/test-pod created
```

Check the swap memory limit:
```bash
> k exec -it test-pod -- "cat" "/sys/fs/cgroup/memory.swap.max"
0
```

See that swap is disabled (equals to 0).
Before this PR, it used to be `max`, which means there is no limitation for swap usage. This is fixed in this PR.

Now, let's try to stress the pod in order to show swap is being used. In order to achieve that, we can run the following two in parallel.
First, continuously print the swap usage on that Pod:
```bash
> k exec -it test-pod -- bash
[root@test-pod /]> while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 7; done
```

Meanwhile, let's stress the pod to force swapping out pages:
```bash
> k exec -it test-pod -- bash
[root@test-pod /]> stress-ng --vm-bytes 525158751436b --vm-keep -m 1
```

C1:
```bash
> k exec -it test-pod -c c1 -- bash
[root@test-pod /]# while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 2; done
0
0
...
```

C1:
```bash
> k exec -it test-pod -c c2 -- bash
[root@test-pod /]# while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 2; done
0
0
...
```

As can be seen, swap is not being used.

#### Case #2 - With unlimited swap
First, before deploying the cluster, the following environment variable has to be defined:
```bash
> export FEATURE_GATES="NodeSwap=true"
```

Create the pod:
```bash
> k create -f pod.yaml
pod/test-pod created
```

Check the swap memory limit:
```bash
> k exec -it test-pod -- "cat" "/sys/fs/cgroup/memory.swap.max"
max
```

This is now set to `max` as expected.
In addition, kubelet logs show:
```
[generateLinuxContainerResources()]: configuring container: c1
configuring unlimited swap
```

Now, let's try to stress the pod in order to show swap is being used. In order to achieve that, we can run the following two in parallel.
First, continuously print the swap usage on that Pod:
```bash
> k exec -it test-pod -- bash
[root@test-pod /]> while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 7; done
```

Meanwhile, let's stress the pod to force swapping out pages:
```bash
> k exec -it test-pod -- bash
[root@test-pod /]> stress-ng --vm-bytes 525158751436b --vm-keep -m 1
```

When we look back at the previous command continuously printing the swap usage we see:
```bash
> k exec -it test-pod -- bash
[root@test-pod /]> while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 7; done
0
# ... many zeros
0
...
5034381312
9559465984
13672230912
18211680256
22897905664
27367641088
28998823936
```

As can be seen, the swap usage is getting larger and larger as time goes by.

#### Case #3 - With limited swap and a Burstable QoS Pod
First, before deploying the cluster, the following environment variable has to be defined:
```bash
> export FEATURE_GATES="NodeSwap=true"
> export LIMITED_SWAP=true
```

Note that `LIMITED_SWAP` is a new environment variable introduced for the purposes of this POC in [this commit](https://github.com/kubernetes/kubernetes/pull/117392/commits/e795671b8d9a742f404b9ae4e2040cfce1e22b31).

Create the pod:
```bash
> k create -f pod.yaml
pod/test-pod created
```

Kubelet logs show:
```
[generateLinuxContainerResources()]: configuring container: c1
configuring limited swap
[limited swap]: totalPodMemory=768000000, containerMemoryRequest=512000000, requestedMemoryProportion=0.67
[limited swap]: node memory capacity=403955572736, swap capacity=42949664768, swap proportion=0.11
[limited swap]: swap limitation: 36291496

[generateLinuxContainerResources()]: configuring container: c2
configuring limited swap
[limited swap]: totalPodMemory=768000000, containerMemoryRequest=256000000, requestedMemoryProportion=0.33
[limited swap]: node memory capacity=403955572736, swap capacity=42949664768, swap proportion=0.11 
[limited swap]: swap limitation: 9072874
```

Check the swap memory limit:
```bash
> k exec -it test-pod -c c1 -- "cat" "/sys/fs/cgroup/memory.swap.max"
36290560
> k exec -it test-pod -c c2 -- "cat" "/sys/fs/cgroup/memory.swap.max"
9072640
```

The swap limitation is configured correctly.

Now, let's repeat the previous test's procedure. This is the output:

Running stress (done for both c1 and c2 containers):
```bash
> k exec -it test-pod -c c1 -- bash
[root@test-pod /]# stress-ng --vm-bytes 525158751436b --vm-keep -m 1
```

C1:
```bash
> k exec -it test-pod -c c1 -- bash
[root@test-pod /]# while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 2; done
0
0
...
15691776
25255936
36171776
36171776
36171776
```

C1:
```bash
> k exec -it test-pod -c c2 -- bash
[root@test-pod /]# while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 2; done
0
0
...
9072640
9072640
9072640
```

As can be seen, the swap reaches near the limit but doesn't exceed it as expected.

#### Case #4 - With limited swap and a Burstable / Guaranteed QoS Pod
As explained above, in these cases we expect that the containers wouldn't have swap access whatsoever.

Best-Effort QoS pod manifest (partial):
```yaml
kind: Pod
spec:
  containers:
  - name: c1
    resources: {}
  - name: c2
    resources: {}
```

Guaranteed QoS pod manifest (partial):
```yaml
kind: Pod
spec:
  containers:
  - name: c1
    resources:
      requests:
        cpu: 1.5
        memory: "512M"
      limits:
        cpu: 1.5
        memory: "512M"
  - name: c2
    resources:
      requests:
        cpu: 1.5
        memory: "256M"
      limits:
        cpu: 1.5
        memory: "256M"
```

Create the pod:
```bash
> k create -f pod.yaml
pod/test-pod created
```

Kubelet logs show:
```
[generateLinuxContainerResources()]: configuring container: c1
configuring no swap

[generateLinuxContainerResources()]: configuring container: c2
configuring no swap
```

Check the swap memory limit:
```bash
> k exec -it test-pod -c c1 -- "cat" "/sys/fs/cgroup/memory.swap.max"
0
> k exec -it test-pod -c c2 -- "cat" "/sys/fs/cgroup/memory.swap.max"
0
```

Now, let's try to stress the pod in order to show swap is being used. In order to achieve that, we can run the following two in parallel.
First, continuously print the swap usage on that Pod:
```bash
> k exec -it test-pod -- bash
[root@test-pod /]> while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 7; done
```

Meanwhile, let's stress the pod to force swapping out pages:
```bash
> k exec -it test-pod -- bash
[root@test-pod /]> stress-ng --vm-bytes 525158751436b --vm-keep -m 1
```

C1:
```bash
> k exec -it test-pod -c c1 -- bash
[root@test-pod /]# while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 2; done
0
0
...
```

C1:
```bash
> k exec -it test-pod -c c2 -- bash
[root@test-pod /]# while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 2; done
0
0
...
```