### PR TITLE
Replace os.Setenv with testing.T.Setenv in tests

### DIFF
--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -413,10 +413,8 @@ profiles:
 
 	// Insulate this test from picking up in-cluster config when run inside a pod
 	// We can't assume we have permissions to write to /var/run/secrets/... from a unit test to mock in-cluster config for testing
-	originalHost := os.Getenv("KUBERNETES_SERVICE_HOST")
-	if len(originalHost) > 0 {
-		os.Setenv("KUBERNETES_SERVICE_HOST", "")
-		defer os.Setenv("KUBERNETES_SERVICE_HOST", originalHost)
+	if len(os.Getenv("KUBERNETES_SERVICE_HOST")) > 0 {
+		t.Setenv("KUBERNETES_SERVICE_HOST", "")
 	}
 
 	defaultPodInitialBackoffSeconds := int64(1)

--- a/cmd/kubeadm/app/cmd/token_test.go
+++ b/cmd/kubeadm/app/cmd/token_test.go
@@ -249,18 +249,14 @@ func TestNewCmdToken(t *testing.T) {
 			if _, err = f.WriteString(tc.configToWrite); err != nil {
 				t.Errorf("Unable to write test file %q: %v", fullPath, err)
 			}
-			// store the current value of the environment variable.
-			storedEnv := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
 			if tc.kubeConfigEnv != "" {
-				os.Setenv(clientcmd.RecommendedConfigPathEnvVar, tc.kubeConfigEnv)
+				t.Setenv(clientcmd.RecommendedConfigPathEnvVar, tc.kubeConfigEnv)
 			}
 			cmd.SetArgs(tc.args)
 			err := cmd.Execute()
 			if (err != nil) != tc.expectedError {
 				t.Errorf("Test case %q: newCmdToken expected error: %v, saw: %v", tc.name, tc.expectedError, (err != nil))
 			}
-			// restore the environment variable.
-			os.Setenv(clientcmd.RecommendedConfigPathEnvVar, storedEnv)
 		})
 	}
 }

--- a/cmd/kubeadm/test/cmd/init_test.go
+++ b/cmd/kubeadm/test/cmd/init_test.go
@@ -27,11 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 )
 
-func runKubeadmInit(args ...string) (string, string, int, error) {
-	const dryRunDir = "KUBEADM_INIT_DRYRUN_DIR"
-	if err := os.Setenv(dryRunDir, os.TempDir()); err != nil {
-		panic(fmt.Sprintf("could not set the %s environment variable", dryRunDir))
-	}
+func runKubeadmInit(t testing.TB, args ...string) (string, string, int, error) {
+	t.Helper()
+	t.Setenv("KUBEADM_INIT_DRYRUN_DIR", os.TempDir())
 	kubeadmPath := getKubeadmPath()
 	kubeadmArgs := []string{"init", "--dry-run", "--ignore-preflight-errors=all"}
 	kubeadmArgs = append(kubeadmArgs, args...)
@@ -73,7 +71,7 @@ func TestCmdInitToken(t *testing.T) {
 
 	for _, rt := range initTest {
 		t.Run(rt.name, func(t *testing.T) {
-			_, _, _, err := runKubeadmInit(rt.args)
+			_, _, _, err := runKubeadmInit(t, rt.args)
 			if (err == nil) != rt.expected {
 				t.Fatalf(dedent.Dedent(`
 					CmdInitToken test case %q failed with an error: %v
@@ -112,7 +110,7 @@ func TestCmdInitKubernetesVersion(t *testing.T) {
 
 	for _, rt := range initTest {
 		t.Run(rt.name, func(t *testing.T) {
-			_, _, _, err := runKubeadmInit(rt.args)
+			_, _, _, err := runKubeadmInit(t, rt.args)
 			if (err == nil) != rt.expected {
 				t.Fatalf(dedent.Dedent(`
 					CmdInitKubernetesVersion test case %q failed with an error: %v
@@ -176,7 +174,7 @@ func TestCmdInitConfig(t *testing.T) {
 
 	for _, rt := range initTest {
 		t.Run(rt.name, func(t *testing.T) {
-			_, _, _, err := runKubeadmInit(rt.args)
+			_, _, _, err := runKubeadmInit(t, rt.args)
 			if (err == nil) != rt.expected {
 				t.Fatalf(dedent.Dedent(`
 						CmdInitConfig test case %q failed with an error: %v
@@ -225,7 +223,7 @@ func TestCmdInitAPIPort(t *testing.T) {
 
 	for _, rt := range initTest {
 		t.Run(rt.name, func(t *testing.T) {
-			_, _, _, err := runKubeadmInit(rt.args)
+			_, _, _, err := runKubeadmInit(t, rt.args)
 			if (err == nil) != rt.expected {
 				t.Fatalf(dedent.Dedent(`
 							CmdInitAPIPort test case %q failed with an error: %v
@@ -267,7 +265,7 @@ func TestCmdInitFeatureGates(t *testing.T) {
 
 	for _, rt := range initTest {
 		t.Run(rt.name, func(t *testing.T) {
-			_, _, exitcode, err := runKubeadmInit(rt.args)
+			_, _, exitcode, err := runKubeadmInit(t, rt.args)
 			if exitcode == PanicExitcode {
 				t.Fatalf(dedent.Dedent(`
 							CmdInitFeatureGates test case %q failed with an error: %v

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -705,8 +704,6 @@ func TestGCEPDLimits(t *testing.T) {
 }
 
 func TestGetMaxVols(t *testing.T) {
-	previousValue := os.Getenv(KubeMaxPDVols)
-
 	tests := []struct {
 		rawMaxVols string
 		expected   int
@@ -731,17 +728,12 @@ func TestGetMaxVols(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			os.Setenv(KubeMaxPDVols, test.rawMaxVols)
+			t.Setenv(KubeMaxPDVols, test.rawMaxVols)
 			result := getMaxVolLimitFromEnv()
 			if result != test.expected {
 				t.Errorf("expected %v got %v", test.expected, result)
 			}
 		})
-	}
-
-	os.Unsetenv(KubeMaxPDVols)
-	if previousValue != "" {
-		os.Setenv(KubeMaxPDVols, previousValue)
 	}
 }
 

--- a/pkg/util/env/env_test.go
+++ b/pkg/util/env/env_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package env
 
 import (
-	"os"
 	"strconv"
 	"testing"
 
@@ -30,7 +29,7 @@ func TestGetEnvAsStringOrFallback(t *testing.T) {
 	assert := assert.New(t)
 
 	key := "FLOCKER_SET_VAR"
-	os.Setenv(key, expected)
+	t.Setenv(key, expected)
 	assert.Equal(expected, GetEnvAsStringOrFallback(key, "~"+expected))
 
 	key = "FLOCKER_UNSET_VAR"
@@ -43,7 +42,7 @@ func TestGetEnvAsIntOrFallback(t *testing.T) {
 	assert := assert.New(t)
 
 	key := "FLOCKER_SET_VAR"
-	os.Setenv(key, strconv.Itoa(expected))
+	t.Setenv(key, strconv.Itoa(expected))
 	returnVal, _ := GetEnvAsIntOrFallback(key, 1)
 	assert.Equal(expected, returnVal)
 
@@ -52,7 +51,7 @@ func TestGetEnvAsIntOrFallback(t *testing.T) {
 	assert.Equal(expected, returnVal)
 
 	key = "FLOCKER_SET_VAR"
-	os.Setenv(key, "not-an-int")
+	t.Setenv(key, "not-an-int")
 	returnVal, err := GetEnvAsIntOrFallback(key, 1)
 	assert.Equal(expected, returnVal)
 	if err == nil {
@@ -66,7 +65,7 @@ func TestGetEnvAsFloat64OrFallback(t *testing.T) {
 	assert := assert.New(t)
 
 	key := "FLOCKER_SET_VAR"
-	os.Setenv(key, "1.0")
+	t.Setenv(key, "1.0")
 	returnVal, _ := GetEnvAsFloat64OrFallback(key, 2.0)
 	assert.Equal(expected, returnVal)
 
@@ -75,7 +74,7 @@ func TestGetEnvAsFloat64OrFallback(t *testing.T) {
 	assert.Equal(expected, returnVal)
 
 	key = "FLOCKER_SET_VAR"
-	os.Setenv(key, "not-a-float")
+	t.Setenv(key, "not-a-float")
 	returnVal, err := GetEnvAsFloat64OrFallback(key, 1.0)
 	assert.Equal(expected, returnVal)
 	assert.EqualError(err, "strconv.ParseFloat: parsing \"not-a-float\": invalid syntax")

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
@@ -26,7 +26,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -205,7 +204,7 @@ func TestProxierWithNoProxyCIDR(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		os.Setenv("NO_PROXY", test.noProxy)
+		t.Setenv("NO_PROXY", test.noProxy)
 		actualDelegated := false
 		proxyFunc := NewProxierWithNoProxyCIDR(func(req *http.Request) (*url.URL, error) {
 			actualDelegated = true
@@ -917,40 +916,28 @@ func TestIsProbableEOF(t *testing.T) {
 	}
 }
 
-func setEnv(key, value string) func() {
-	originalValue := os.Getenv(key)
-	os.Setenv(key, value)
-	return func() {
-		os.Setenv(key, originalValue)
-	}
-}
-
 func TestReadIdleTimeoutSeconds(t *testing.T) {
-	reset := setEnv("HTTP2_READ_IDLE_TIMEOUT_SECONDS", "60")
+	t.Setenv("HTTP2_READ_IDLE_TIMEOUT_SECONDS", "60")
 	if e, a := 60, readIdleTimeoutSeconds(); e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	reset()
 
-	reset = setEnv("HTTP2_READ_IDLE_TIMEOUT_SECONDS", "illegal value")
+	t.Setenv("HTTP2_READ_IDLE_TIMEOUT_SECONDS", "illegal value")
 	if e, a := 30, readIdleTimeoutSeconds(); e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	reset()
 }
 
 func TestPingTimeoutSeconds(t *testing.T) {
-	reset := setEnv("HTTP2_PING_TIMEOUT_SECONDS", "60")
+	t.Setenv("HTTP2_PING_TIMEOUT_SECONDS", "60")
 	if e, a := 60, pingTimeoutSeconds(); e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	reset()
 
-	reset = setEnv("HTTP2_PING_TIMEOUT_SECONDS", "illegal value")
+	t.Setenv("HTTP2_PING_TIMEOUT_SECONDS", "illegal value")
 	if e, a := 15, pingTimeoutSeconds(); e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	reset()
 }
 
 func Benchmark_ParseQuotedString(b *testing.B) {

--- a/staging/src/k8s.io/client-go/rest/client_test.go
+++ b/staging/src/k8s.io/client-go/rest/client_test.go
@@ -23,7 +23,6 @@ import (
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -340,8 +339,8 @@ func TestCreateBackoffManager(t *testing.T) {
 	theUrl, _ := url.Parse("http://localhost")
 
 	// 1 second base backoff + duration of 2 seconds -> exponential backoff for requests.
-	os.Setenv(envBackoffBase, "1")
-	os.Setenv(envBackoffDuration, "2")
+	t.Setenv(envBackoffBase, "1")
+	t.Setenv(envBackoffDuration, "2")
 	backoff := readExpBackoffConfig()
 	backoff.UpdateBackoff(theUrl, nil, 500)
 	backoff.UpdateBackoff(theUrl, nil, 500)
@@ -350,8 +349,8 @@ func TestCreateBackoffManager(t *testing.T) {
 	}
 
 	// 0 duration -> no backoff.
-	os.Setenv(envBackoffBase, "1")
-	os.Setenv(envBackoffDuration, "0")
+	t.Setenv(envBackoffBase, "1")
+	t.Setenv(envBackoffDuration, "0")
 	backoff.UpdateBackoff(theUrl, nil, 500)
 	backoff.UpdateBackoff(theUrl, nil, 500)
 	backoff = readExpBackoffConfig()
@@ -360,8 +359,8 @@ func TestCreateBackoffManager(t *testing.T) {
 	}
 
 	// No env -> No backoff.
-	os.Setenv(envBackoffBase, "")
-	os.Setenv(envBackoffDuration, "")
+	t.Setenv(envBackoffBase, "")
+	t.Setenv(envBackoffDuration, "")
 	backoff = readExpBackoffConfig()
 	backoff.UpdateBackoff(theUrl, nil, 500)
 	backoff.UpdateBackoff(theUrl, nil, 500)

--- a/staging/src/k8s.io/client-go/rest/connection_test.go
+++ b/staging/src/k8s.io/client-go/rest/connection_test.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -80,23 +79,15 @@ func newLB(t *testing.T, serverURL string) *tcpLB {
 	return &lb
 }
 
-func setEnv(key, value string) func() {
-	originalValue := os.Getenv(key)
-	os.Setenv(key, value)
-	return func() {
-		os.Setenv(key, originalValue)
-	}
-}
-
 const (
 	readIdleTimeout int = 1
 	pingTimeout     int = 1
 )
 
 func TestReconnectBrokenTCP(t *testing.T) {
-	defer setEnv("HTTP2_READ_IDLE_TIMEOUT_SECONDS", strconv.Itoa(readIdleTimeout))()
-	defer setEnv("HTTP2_PING_TIMEOUT_SECONDS", strconv.Itoa(pingTimeout))()
-	defer setEnv("DISABLE_HTTP2", "")()
+	t.Setenv("HTTP2_READ_IDLE_TIMEOUT_SECONDS", strconv.Itoa(readIdleTimeout))
+	t.Setenv("HTTP2_PING_TIMEOUT_SECONDS", strconv.Itoa(pingTimeout))
+	t.Setenv("DISABLE_HTTP2", "")
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Hello, %s", r.Proto)
 	}))

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -897,12 +897,9 @@ func TestLoadingGetLoadingPrecedence(t *testing.T) {
 		},
 	}
 
-	kubeconfig := os.Getenv("KUBECONFIG")
-	defer os.Setenv("KUBECONFIG", kubeconfig)
-
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			os.Setenv("KUBECONFIG", test.env)
+			t.Setenv("KUBECONFIG", test.env)
 			rules := test.rules
 			if rules == nil {
 				rules = NewDefaultClientConfigLoadingRules()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
@@ -342,7 +342,7 @@ func TestKubectlCommandHeadersHooks(t *testing.T) {
 			if kubeConfigFlags.WrapConfigFn != nil {
 				t.Fatal("expected initial nil WrapConfigFn")
 			}
-			os.Setenv(kubectlCmdHeaders, testCase.envVar)
+			t.Setenv(kubectlCmdHeaders, testCase.envVar)
 			addCmdHeaderHooks(cmds, kubeConfigFlags)
 			// Valdidate whether the hooks were added.
 			if testCase.addsHooks && kubeConfigFlags.WrapConfigFn == nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap_test.go
@@ -293,8 +293,8 @@ func TestCreateConfigMap(t *testing.T) {
 		"create_get_env_from_env_file_configmap": {
 			configMapName: "get_env",
 			setup: func() func(t *testing.T, configMapOptions *ConfigMapOptions) func() {
-				os.Setenv("g_key1", "1")
-				os.Setenv("g_key2", "2")
+				t.Setenv("g_key1", "1")
+				t.Setenv("g_key2", "2")
 				return setupEnvFile([][]string{{"g_key1", "g_key2="}})
 			}(),
 			fromEnvFile: []string{"file.env"},
@@ -316,8 +316,8 @@ func TestCreateConfigMap(t *testing.T) {
 		"create_get_env_from_env_file_hash_configmap": {
 			configMapName: "get_env",
 			setup: func() func(t *testing.T, configMapOptions *ConfigMapOptions) func() {
-				os.Setenv("g_key1", "1")
-				os.Setenv("g_key2", "2")
+				t.Setenv("g_key1", "1")
+				t.Setenv("g_key2", "2")
 				return setupEnvFile([][]string{{"g_key1", "g_key2="}})
 			}(),
 			fromEnvFile: []string{"file.env"},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_test.go
@@ -340,8 +340,8 @@ func TestCreateSecretGeneric(t *testing.T) {
 		"create_secret_get_env_from_env_file": {
 			secretName: "get_env",
 			setup: func() func(t *testing.T, secretGenericOptions *CreateSecretOptions) func() {
-				os.Setenv("g_key1", "1")
-				os.Setenv("g_key2", "2")
+				t.Setenv("g_key1", "1")
+				t.Setenv("g_key2", "2")
 				return setupSecretEnvFile([][]string{{"g_key1", "g_key2="}})
 			}(),
 			fromEnvFile: []string{"file.env"},
@@ -362,8 +362,8 @@ func TestCreateSecretGeneric(t *testing.T) {
 		"create_secret_get_env_from_env_file_hash": {
 			secretName: "get_env",
 			setup: func() func(t *testing.T, secretGenericOptions *CreateSecretOptions) func() {
-				os.Setenv("g_key1", "1")
-				os.Setenv("g_key2", "2")
+				t.Setenv("g_key1", "1")
+				t.Setenv("g_key2", "2")
 				return setupSecretEnvFile([][]string{{"g_key1", "g_key2="}})
 			}(),
 			fromEnvFile: []string{"file.env"},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
@@ -64,13 +64,10 @@ func (f *FakeObject) Live() runtime.Object {
 func TestDiffProgram(t *testing.T) {
 	externalDiffCommands := [3]string{"diff", "diff -ruN", "diff --report-identical-files"}
 
-	if oriLang := os.Getenv("LANG"); oriLang != "C" {
-		os.Setenv("LANG", "C")
-		defer os.Setenv("LANG", oriLang)
-	}
+	t.Setenv("LANG", "C")
 
 	for i, c := range externalDiffCommands {
-		os.Setenv("KUBECTL_EXTERNAL_DIFF", c)
+		t.Setenv("KUBECTL_EXTERNAL_DIFF", c)
 		streams, _, stdout, _ := genericiooptions.NewTestIOStreams()
 		diff := DiffProgram{
 			IOStreams: streams,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit_test.go
@@ -170,8 +170,8 @@ func TestEdit(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	os.Setenv("KUBE_EDITOR", "testdata/test_editor.sh")
-	os.Setenv("KUBE_EDITOR_CALLBACK", server.URL+"/callback")
+	t.Setenv("KUBE_EDITOR", "testdata/test_editor.sh")
+	t.Setenv("KUBE_EDITOR_CALLBACK", server.URL+"/callback")
 
 	testcases := sets.NewString()
 	filepath.Walk("testdata", func(path string, info os.FileInfo, err error) error {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/env_file_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/env_file_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"os"
 	"strings"
 	"testing"
 )
@@ -85,12 +84,7 @@ func Test_processEnvFileLine_readEnvironment(t *testing.T) {
 	const realKey = "k8s_test_env_file_key"
 	const realValue = `my_value`
 
-	// Just in case, these two lines ensure the environment is restored to
-	// its original state.
-	original := os.Getenv(realKey)
-	defer func() { os.Setenv(realKey, original) }()
-
-	os.Setenv(realKey, `my_value`)
+	t.Setenv(realKey, `my_value`)
 
 	key, value, err := processEnvFileLine([]byte(realKey), `filename`, 3)
 	if err != nil {

--- a/test/conformance/image/go-runner/env_test.go
+++ b/test/conformance/image/go-runner/env_test.go
@@ -32,7 +32,7 @@ func TestEnv(t *testing.T) {
 			desc: "OS env",
 			env:  &osEnv{},
 			preHook: func() {
-				os.Setenv("key1", "1")
+				t.Setenv("key1", "1")
 			},
 			expect: map[string]string{"key1": "1"},
 		}, {

--- a/test/integration/serving/serving_test.go
+++ b/test/integration/serving/serving_test.go
@@ -83,10 +83,8 @@ func TestComponentSecureServingAndAuth(t *testing.T) {
 
 	// Insulate this test from picking up in-cluster config when run inside a pod
 	// We can't assume we have permissions to write to /var/run/secrets/... from a unit test to mock in-cluster config for testing
-	originalHost := os.Getenv("KUBERNETES_SERVICE_HOST")
-	if len(originalHost) > 0 {
-		os.Setenv("KUBERNETES_SERVICE_HOST", "")
-		defer os.Setenv("KUBERNETES_SERVICE_HOST", originalHost)
+	if len(os.Getenv("KUBERNETES_SERVICE_HOST")) > 0 {
+		t.Setenv("KUBERNETES_SERVICE_HOST", "")
 	}
 
 	// authenticate to apiserver via bearer token

--- a/test/integration/volumescheduling/volume_binding_test.go
+++ b/test/integration/volumescheduling/volume_binding_test.go
@@ -21,7 +21,6 @@ package volumescheduling
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -427,10 +426,7 @@ func testVolumeBindingStress(t *testing.T, schedulerResyncPeriod time.Duration, 
 
 	// Set max volume limit to the number of PVCs the test will create
 	// TODO: remove when max volume limit allows setting through storageclass
-	if err := os.Setenv(nodevolumelimits.KubeMaxPDVols, fmt.Sprintf("%v", podLimit*volsPerPod)); err != nil {
-		t.Fatalf("failed to set max pd limit: %v", err)
-	}
-	defer os.Unsetenv(nodevolumelimits.KubeMaxPDVols)
+	t.Setenv(nodevolumelimits.KubeMaxPDVols, fmt.Sprintf("%v", podLimit*volsPerPod))
 
 	scName := &classWait
 	if dynamic {

--- a/test/typecheck/main_test.go
+++ b/test/typecheck/main_test.go
@@ -32,7 +32,7 @@ var goBinary = flag.String("go", "", "path to a `go` binary")
 func TestVerify(t *testing.T) {
 	// x/tools/packages is going to literally exec `go`, so it needs some
 	// setup.
-	setEnvVars()
+	setEnvVars(t)
 
 	tcs := []struct {
 		path   string
@@ -57,17 +57,18 @@ func TestVerify(t *testing.T) {
 	}
 }
 
-func setEnvVars() {
+func setEnvVars(t testing.TB) {
+	t.Helper()
 	if *goBinary != "" {
 		newPath := filepath.Dir(*goBinary)
 		curPath := os.Getenv("PATH")
 		if curPath != "" {
 			newPath = newPath + ":" + curPath
 		}
-		os.Setenv("PATH", newPath)
+		t.Setenv("PATH", newPath)
 	}
 	if os.Getenv("HOME") == "" {
-		os.Setenv("HOME", "/tmp")
+		t.Setenv("HOME", "/tmp")
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This replaces `os.Setenv` with `testing.T.Setenv` for its automatic cleanup and protection against accidental use in parallel tests.

This also cleans up after `os.Unsetenv` calls in tests using `testing.T.Cleanup`. The latter correctly runs after any parallel sub-tests, while `defer` does not.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig testing