### PR TITLE
endpointslice: reduce visibility of vars/funcs

### DIFF
--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -522,7 +522,7 @@ func (c *Controller) updateNode(old, cur interface{}) {
 
 	// LabelTopologyZone may be added by cloud provider asynchronously after the Node is created.
 	// The topology cache should be updated in this case.
-	if topologycache.NodeReady(oldNode.Status) != topologycache.NodeReady(curNode.Status) ||
+	if isNodeReady(oldNode) != isNodeReady(curNode) ||
 		oldNode.Labels[v1.LabelTopologyZone] != curNode.Labels[v1.LabelTopologyZone] {
 		c.checkNodeTopologyDistribution()
 	}

--- a/pkg/controller/endpointslice/reconciler.go
+++ b/pkg/controller/endpointslice/reconciler.go
@@ -58,8 +58,8 @@ type reconciler struct {
 // endpointMeta includes the attributes we group slices on, this type helps with
 // that logic in reconciler
 type endpointMeta struct {
-	Ports       []discovery.EndpointPort `json:"ports" protobuf:"bytes,2,rep,name=ports"`
-	AddressType discovery.AddressType    `json:"addressType" protobuf:"bytes,3,rep,name=addressType"`
+	ports       []discovery.EndpointPort
+	addressType discovery.AddressType
 }
 
 // reconcile takes a set of pods currently matching a service selector and
@@ -166,8 +166,8 @@ func (r *reconciler) reconcileByAddressType(service *corev1.Service, pods []*cor
 
 		if _, ok := desiredMetaByPortMap[epHash]; !ok {
 			desiredMetaByPortMap[epHash] = &endpointMeta{
-				AddressType: addressType,
-				Ports:       endpointPorts,
+				addressType: addressType,
+				ports:       endpointPorts,
 			}
 		}
 
@@ -231,7 +231,7 @@ func (r *reconciler) reconcileByAddressType(service *corev1.Service, pods []*cor
 	// When no endpoint slices would usually exist, we need to add a placeholder.
 	if len(existingSlices) == len(slicesToDelete) && len(slicesToCreate) < 1 {
 		// Check for existing placeholder slice outside of the core control flow
-		placeholderSlice := newEndpointSlice(service, &endpointMeta{Ports: []discovery.EndpointPort{}, AddressType: addressType})
+		placeholderSlice := newEndpointSlice(service, &endpointMeta{ports: []discovery.EndpointPort{}, addressType: addressType})
 		if len(slicesToDelete) == 1 && placeholderSliceCompare.DeepEqual(slicesToDelete[0], placeholderSlice) {
 			// We are about to unnecessarily delete/recreate the placeholder, remove it now.
 			slicesToDelete = slicesToDelete[:0]

--- a/pkg/controller/endpointslice/reconciler_test.go
+++ b/pkg/controller/endpointslice/reconciler_test.go
@@ -495,7 +495,7 @@ func TestReconcile1EndpointSlice(t *testing.T) {
 		},
 		{
 			desc:        "Existing placeholder that's the same",
-			existing:    newEndpointSlice(&svc, &endpointMeta{Ports: []discovery.EndpointPort{}, AddressType: discovery.AddressTypeIPv4}),
+			existing:    newEndpointSlice(&svc, &endpointMeta{ports: []discovery.EndpointPort{}, addressType: discovery.AddressTypeIPv4}),
 			wantMetrics: expectedMetrics{desiredSlices: 1, actualSlices: 1, desiredEndpoints: 0, addedPerSync: 0, removedPerSync: 0, numCreated: 0, numUpdated: 0, numDeleted: 0, slicesChangedPerSync: 0},
 		},
 		{
@@ -1022,7 +1022,7 @@ func TestReconcileEndpointSlicesReplaceDeprecated(t *testing.T) {
 
 	svc, endpointMeta := newServiceAndEndpointMeta("foo", namespace)
 	// "IP" is a deprecated address type, ensuring that it is handled properly.
-	endpointMeta.AddressType = discovery.AddressType("IP")
+	endpointMeta.addressType = discovery.AddressType("IP")
 
 	existingSlices := []*discovery.EndpointSlice{}
 	pods := []*corev1.Pod{}
@@ -1367,8 +1367,8 @@ func TestReconcilerFinalizeSvcDeletionTimestamp(t *testing.T) {
 					Name:            "to-create",
 					OwnerReferences: []metav1.OwnerReference{*ownerRef},
 				},
-				AddressType: endpointMeta.AddressType,
-				Ports:       endpointMeta.Ports,
+				AddressType: endpointMeta.addressType,
+				Ports:       endpointMeta.ports,
 			}
 
 			// Add EndpointSlice that can be updated.
@@ -1377,8 +1377,8 @@ func TestReconcilerFinalizeSvcDeletionTimestamp(t *testing.T) {
 					Name:            "to-update",
 					OwnerReferences: []metav1.OwnerReference{*ownerRef},
 				},
-				AddressType: endpointMeta.AddressType,
-				Ports:       endpointMeta.Ports,
+				AddressType: endpointMeta.addressType,
+				Ports:       endpointMeta.ports,
 			}, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("Expected no error creating EndpointSlice during test setup, got %v", err)
@@ -1393,8 +1393,8 @@ func TestReconcilerFinalizeSvcDeletionTimestamp(t *testing.T) {
 					Name:            "to-delete",
 					OwnerReferences: []metav1.OwnerReference{*ownerRef},
 				},
-				AddressType: endpointMeta.AddressType,
-				Ports:       endpointMeta.Ports,
+				AddressType: endpointMeta.addressType,
+				Ports:       endpointMeta.ports,
 			}, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("Expected no error creating EndpointSlice during test setup, got %v", err)
@@ -1687,7 +1687,7 @@ func TestReconcileTopology(t *testing.T) {
 	for name, pods := range slicePods {
 		endpoints := []discovery.Endpoint{}
 		for _, pod := range pods {
-			endpoints = append(endpoints, podToEndpoint(pod, nodesByName[pod.Spec.NodeName], &svc, endpointMeta.AddressType))
+			endpoints = append(endpoints, podToEndpoint(pod, nodesByName[pod.Spec.NodeName], &svc, endpointMeta.addressType))
 		}
 
 		slicesByName[name] = &discovery.EndpointSlice{
@@ -1699,8 +1699,8 @@ func TestReconcileTopology(t *testing.T) {
 					discovery.LabelServiceName: svc.Name,
 				},
 			},
-			AddressType: endpointMeta.AddressType,
-			Ports:       endpointMeta.Ports,
+			AddressType: endpointMeta.addressType,
+			Ports:       endpointMeta.ports,
 			Endpoints:   endpoints,
 		}
 	}

--- a/pkg/controller/endpointslice/topologycache/sliceinfo.go
+++ b/pkg/controller/endpointslice/topologycache/sliceinfo.go
@@ -52,7 +52,7 @@ func (si *SliceInfo) getTotalReadyEndpoints() int {
 //   - It has endpoint hints that would make the minimum allocations necessary
 //     impossible with changes to slices that are already being updated or
 //     created.
-func (si *SliceInfo) getAllocatedHintsByZone(allocations map[string]Allocation) EndpointZoneInfo {
+func (si *SliceInfo) getAllocatedHintsByZone(allocations map[string]allocation) EndpointZoneInfo {
 	allocatedHintsByZone := EndpointZoneInfo{}
 
 	// Using filtering in place to remove any endpoints that are no longer

--- a/pkg/controller/endpointslice/topologycache/utils_test.go
+++ b/pkg/controller/endpointslice/topologycache/utils_test.go
@@ -92,92 +92,92 @@ func Test_redistributeHints(t *testing.T) {
 func Test_getGivingAndReceivingZones(t *testing.T) {
 	testCases := []struct {
 		name                   string
-		allocations            map[string]Allocation
+		allocations            map[string]allocation
 		allocatedHintsByZone   map[string]int
 		expectedGivingZones    map[string]int
 		expectedReceivingZones map[string]int
 	}{{
 		name:                   "empty",
-		allocations:            map[string]Allocation{},
+		allocations:            map[string]allocation{},
 		allocatedHintsByZone:   map[string]int{},
 		expectedGivingZones:    map[string]int{},
 		expectedReceivingZones: map[string]int{},
 	}, {
 		name: "simple allocation with no need for rebalancing",
-		allocations: map[string]Allocation{
-			"zone-a": {Desired: 1.2},
-			"zone-b": {Desired: 1.1},
-			"zone-c": {Desired: 1.0},
+		allocations: map[string]allocation{
+			"zone-a": {desired: 1.2},
+			"zone-b": {desired: 1.1},
+			"zone-c": {desired: 1.0},
 		},
 		allocatedHintsByZone:   map[string]int{"zone-a": 1, "zone-b": 1, "zone-c": 1},
 		expectedGivingZones:    map[string]int{},
 		expectedReceivingZones: map[string]int{},
 	}, {
 		name: "preference for same zone even when giving an extra endpoint would result in slightly better distribution",
-		allocations: map[string]Allocation{
-			"zone-a": {Desired: 5.1},
-			"zone-b": {Desired: 5.1},
-			"zone-c": {Desired: 5.8},
+		allocations: map[string]allocation{
+			"zone-a": {desired: 5.1},
+			"zone-b": {desired: 5.1},
+			"zone-c": {desired: 5.8},
 		},
 		allocatedHintsByZone:   map[string]int{"zone-a": 16},
 		expectedGivingZones:    map[string]int{"zone-a": 10},
 		expectedReceivingZones: map[string]int{"zone-b": 5, "zone-c": 5},
 	}, {
 		name: "when 2 zones need < 1 endpoint, give to zone that needs endpoint most",
-		allocations: map[string]Allocation{
-			"zone-a": {Desired: 5.0},
-			"zone-b": {Desired: 5.6},
-			"zone-c": {Desired: 5.4},
+		allocations: map[string]allocation{
+			"zone-a": {desired: 5.0},
+			"zone-b": {desired: 5.6},
+			"zone-c": {desired: 5.4},
 		},
 		allocatedHintsByZone:   map[string]int{"zone-a": 16},
 		expectedGivingZones:    map[string]int{"zone-a": 11},
 		expectedReceivingZones: map[string]int{"zone-b": 6, "zone-c": 5},
 	}, {
 		name: "when 2 zones have extra endpoints, give from zone with most extra",
-		allocations: map[string]Allocation{
-			"zone-a": {Desired: 5.0},
-			"zone-b": {Desired: 5.6},
-			"zone-c": {Desired: 5.4},
+		allocations: map[string]allocation{
+			"zone-a": {desired: 5.0},
+			"zone-b": {desired: 5.6},
+			"zone-c": {desired: 5.4},
 		},
 		allocatedHintsByZone:   map[string]int{"zone-b": 8, "zone-c": 8},
 		expectedGivingZones:    map[string]int{"zone-b": 2, "zone-c": 3},
 		expectedReceivingZones: map[string]int{"zone-a": 5},
 	}, {
 		name: "ensure function can handle unexpected data (more allocated than allocations)",
-		allocations: map[string]Allocation{
-			"zone-a": {Desired: 5.0},
-			"zone-b": {Desired: 5.0},
-			"zone-c": {Desired: 5.0},
+		allocations: map[string]allocation{
+			"zone-a": {desired: 5.0},
+			"zone-b": {desired: 5.0},
+			"zone-c": {desired: 5.0},
 		},
 		allocatedHintsByZone:   map[string]int{"zone-a": 6, "zone-b": 6, "zone-c": 6},
 		expectedGivingZones:    map[string]int{},
 		expectedReceivingZones: map[string]int{},
 	}, {
 		name: "ensure function can handle unexpected data (negative allocations)",
-		allocations: map[string]Allocation{
-			"zone-a": {Desired: -5.0},
-			"zone-b": {Desired: -5.0},
-			"zone-c": {Desired: -5.0},
+		allocations: map[string]allocation{
+			"zone-a": {desired: -5.0},
+			"zone-b": {desired: -5.0},
+			"zone-c": {desired: -5.0},
 		},
 		allocatedHintsByZone:   map[string]int{"zone-a": 6, "zone-b": 6, "zone-c": 6},
 		expectedGivingZones:    map[string]int{},
 		expectedReceivingZones: map[string]int{},
 	}, {
 		name: "ensure function can handle unexpected data (negative allocated)",
-		allocations: map[string]Allocation{
-			"zone-a": {Desired: 5.0},
-			"zone-b": {Desired: 5.0},
-			"zone-c": {Desired: 5.0},
+		allocations: map[string]allocation{
+			"zone-a": {desired: 5.0},
+			"zone-b": {desired: 5.0},
+			"zone-c": {desired: 5.0},
 		},
 		allocatedHintsByZone:   map[string]int{"zone-a": -4, "zone-b": -3, "zone-c": -2},
 		expectedGivingZones:    map[string]int{},
 		expectedReceivingZones: map[string]int{},
 	}, {
 		name: "ensure function can handle unexpected data (negative for 1 zone)",
-		allocations: map[string]Allocation{
-			"zone-a": {Desired: 5.0},
-			"zone-b": {Desired: 5.0},
-			"zone-c": {Desired: 5.0},
+		allocations: map[string]allocation{
+			"zone-a": {desired: 5.0},
+			"zone-b": {desired: 5.0},
+			"zone-c": {desired: 5.0},
 		},
 		allocatedHintsByZone:   map[string]int{"zone-a": -40, "zone-b": 20, "zone-c": 20},
 		expectedGivingZones:    map[string]int{"zone-b": 15, "zone-c": 15},
@@ -203,12 +203,12 @@ func Test_getHintsByZone(t *testing.T) {
 		name                 string
 		slice                discovery.EndpointSlice
 		allocatedHintsByZone EndpointZoneInfo
-		allocations          map[string]Allocation
+		allocations          map[string]allocation
 		expectedHintsByZone  map[string]int
 	}{{
 		name:                 "empty",
 		slice:                discovery.EndpointSlice{},
-		allocations:          map[string]Allocation{},
+		allocations:          map[string]allocation{},
 		allocatedHintsByZone: EndpointZoneInfo{},
 		expectedHintsByZone:  map[string]int{},
 	}, {
@@ -220,8 +220,8 @@ func Test_getHintsByZone(t *testing.T) {
 				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
 			}},
 		},
-		allocations: map[string]Allocation{
-			"zone-a": {Maximum: 3},
+		allocations: map[string]allocation{
+			"zone-a": {maximum: 3},
 		},
 		allocatedHintsByZone: EndpointZoneInfo{"zone-a": 1},
 		expectedHintsByZone: map[string]int{
@@ -243,8 +243,8 @@ func Test_getHintsByZone(t *testing.T) {
 				Hints: &discovery.EndpointHints{ForZones: []discovery.ForZone{{Name: "zone-a"}}},
 			}},
 		},
-		allocations: map[string]Allocation{
-			"zone-a": {Maximum: 3},
+		allocations: map[string]allocation{
+			"zone-a": {maximum: 3},
 		},
 		allocatedHintsByZone: EndpointZoneInfo{"zone-a": 1},
 		expectedHintsByZone: map[string]int{
@@ -271,10 +271,10 @@ func Test_getHintsByZone(t *testing.T) {
 				},
 			},
 		},
-		allocations: map[string]Allocation{
-			"zone-a": {Maximum: 3},
-			"zone-b": {Maximum: 3},
-			"zone-c": {Maximum: 3},
+		allocations: map[string]allocation{
+			"zone-a": {maximum: 3},
+			"zone-b": {maximum: 3},
+			"zone-c": {maximum: 3},
 		},
 		allocatedHintsByZone: EndpointZoneInfo{"zone-a": 1, "zone-b": 1, "zone-c": 1},
 		expectedHintsByZone: map[string]int{
@@ -292,8 +292,8 @@ func Test_getHintsByZone(t *testing.T) {
 				},
 			},
 		},
-		allocations: map[string]Allocation{
-			"zone-a": {Maximum: 3},
+		allocations: map[string]allocation{
+			"zone-a": {maximum: 3},
 		},
 		allocatedHintsByZone: EndpointZoneInfo{"zone-a": 1, "zone-b": 1, "zone-c": 1},
 		expectedHintsByZone:  nil,
@@ -308,8 +308,8 @@ func Test_getHintsByZone(t *testing.T) {
 				},
 			},
 		},
-		allocations: map[string]Allocation{
-			"zone-a": {Maximum: 3},
+		allocations: map[string]allocation{
+			"zone-a": {maximum: 3},
 		},
 		allocatedHintsByZone: EndpointZoneInfo{},
 		expectedHintsByZone:  nil,
@@ -324,8 +324,8 @@ func Test_getHintsByZone(t *testing.T) {
 				},
 			},
 		},
-		allocations: map[string]Allocation{
-			"zone-a": {Maximum: 3},
+		allocations: map[string]allocation{
+			"zone-a": {maximum: 3},
 		},
 		allocatedHintsByZone: EndpointZoneInfo{},
 		expectedHintsByZone:  nil,
@@ -345,8 +345,8 @@ func Test_getHintsByZone(t *testing.T) {
 				},
 			},
 		},
-		allocations: map[string]Allocation{
-			"zone-a": {Maximum: 2},
+		allocations: map[string]allocation{
+			"zone-a": {maximum: 2},
 		},
 		allocatedHintsByZone: EndpointZoneInfo{"zone-a": 1},
 		expectedHintsByZone:  nil,

--- a/pkg/controller/endpointslice/utils.go
+++ b/pkg/controller/endpointslice/utils.go
@@ -138,8 +138,8 @@ func newEndpointSlice(service *v1.Service, endpointMeta *endpointMeta) *discover
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			Namespace:       service.Namespace,
 		},
-		Ports:       endpointMeta.Ports,
-		AddressType: endpointMeta.AddressType,
+		Ports:       endpointMeta.ports,
+		AddressType: endpointMeta.addressType,
 		Endpoints:   []discovery.Endpoint{},
 	}
 	// add parent service labels
@@ -246,7 +246,7 @@ func setEndpointSliceLabels(epSlice *discovery.EndpointSlice, service *v1.Servic
 	// check if the endpoint slice and the service have the same labels
 	// clone current slice labels except the reserved labels
 	for key, value := range epSlice.Labels {
-		if IsReservedLabelKey(key) {
+		if isReservedLabelKey(key) {
 			continue
 		}
 		// copy endpoint slice labels
@@ -254,7 +254,7 @@ func setEndpointSliceLabels(epSlice *discovery.EndpointSlice, service *v1.Servic
 	}
 
 	for key, value := range service.Labels {
-		if IsReservedLabelKey(key) {
+		if isReservedLabelKey(key) {
 			klog.Warningf("Service %s/%s using reserved endpoint slices label, skipping label %s: %s", service.Namespace, service.Name, key, value)
 			continue
 		}
@@ -281,8 +281,8 @@ func setEndpointSliceLabels(epSlice *discovery.EndpointSlice, service *v1.Servic
 	return svcLabels, updated
 }
 
-// IsReservedLabelKey return true if the label is one of the reserved label for slices
-func IsReservedLabelKey(label string) bool {
+// isReservedLabelKey return true if the label is one of the reserved label for slices
+func isReservedLabelKey(label string) bool {
 	if label == discovery.LabelServiceName ||
 		label == discovery.LabelManagedBy ||
 		label == v1.IsHeadlessService {
@@ -404,4 +404,14 @@ func managedByChanged(endpointSlice1, endpointSlice2 *discovery.EndpointSlice) b
 func managedByController(endpointSlice *discovery.EndpointSlice) bool {
 	managedBy, _ := endpointSlice.Labels[discovery.LabelManagedBy]
 	return managedBy == controllerName
+}
+
+// isNodeReady returns true if a node is ready; false otherwise.
+func isNodeReady(node *v1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == v1.NodeReady {
+			return c.Status == v1.ConditionTrue
+		}
+	}
+	return false
 }

--- a/pkg/controller/endpointslice/utils_test.go
+++ b/pkg/controller/endpointslice/utils_test.go
@@ -41,8 +41,8 @@ func TestNewEndpointSlice(t *testing.T) {
 	portName := "foo"
 	protocol := v1.ProtocolTCP
 	endpointMeta := endpointMeta{
-		Ports:       []discovery.EndpointPort{{Name: &portName, Protocol: &protocol}},
-		AddressType: ipAddressType,
+		ports:       []discovery.EndpointPort{{Name: &portName, Protocol: &protocol}},
+		addressType: ipAddressType,
 	}
 	service := v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "test"},
@@ -76,8 +76,8 @@ func TestNewEndpointSlice(t *testing.T) {
 					OwnerReferences: []metav1.OwnerReference{*ownerRef},
 					Namespace:       service.Namespace,
 				},
-				Ports:       endpointMeta.Ports,
-				AddressType: endpointMeta.AddressType,
+				Ports:       endpointMeta.ports,
+				AddressType: endpointMeta.addressType,
 				Endpoints:   []discovery.Endpoint{},
 			},
 		},
@@ -99,8 +99,8 @@ func TestNewEndpointSlice(t *testing.T) {
 					OwnerReferences: []metav1.OwnerReference{*ownerRef},
 					Namespace:       service.Namespace,
 				},
-				Ports:       endpointMeta.Ports,
-				AddressType: endpointMeta.AddressType,
+				Ports:       endpointMeta.ports,
+				AddressType: endpointMeta.addressType,
 				Endpoints:   []discovery.Endpoint{},
 			},
 		},
@@ -124,8 +124,8 @@ func TestNewEndpointSlice(t *testing.T) {
 					OwnerReferences: []metav1.OwnerReference{*ownerRef},
 					Namespace:       service.Namespace,
 				},
-				Ports:       endpointMeta.Ports,
-				AddressType: endpointMeta.AddressType,
+				Ports:       endpointMeta.ports,
+				AddressType: endpointMeta.addressType,
 				Endpoints:   []discovery.Endpoint{},
 			},
 		},
@@ -148,8 +148,8 @@ func TestNewEndpointSlice(t *testing.T) {
 					OwnerReferences: []metav1.OwnerReference{*ownerRef},
 					Namespace:       service.Namespace,
 				},
-				Ports:       endpointMeta.Ports,
-				AddressType: endpointMeta.AddressType,
+				Ports:       endpointMeta.ports,
+				AddressType: endpointMeta.addressType,
 				Endpoints:   []discovery.Endpoint{},
 			},
 		},
@@ -175,8 +175,8 @@ func TestNewEndpointSlice(t *testing.T) {
 					OwnerReferences: []metav1.OwnerReference{*ownerRef},
 					Namespace:       service.Namespace,
 				},
-				Ports:       endpointMeta.Ports,
-				AddressType: endpointMeta.AddressType,
+				Ports:       endpointMeta.ports,
+				AddressType: endpointMeta.addressType,
 				Endpoints:   []discovery.Endpoint{},
 			},
 		},
@@ -197,8 +197,8 @@ func TestNewEndpointSlice(t *testing.T) {
 					OwnerReferences: []metav1.OwnerReference{*ownerRef},
 					Namespace:       service.Namespace,
 				},
-				Ports:       endpointMeta.Ports,
-				AddressType: endpointMeta.AddressType,
+				Ports:       endpointMeta.ports,
+				AddressType: endpointMeta.addressType,
 				Endpoints:   []discovery.Endpoint{},
 			},
 		},
@@ -981,8 +981,8 @@ func newServiceAndEndpointMeta(name, namespace string) (v1.Service, endpointMeta
 	addressType := discovery.AddressTypeIPv4
 	protocol := v1.ProtocolTCP
 	endpointMeta := endpointMeta{
-		AddressType: addressType,
-		Ports:       []discovery.EndpointPort{{Name: &name, Port: &portNum, Protocol: &protocol}},
+		addressType: addressType,
+		ports:       []discovery.EndpointPort{{Name: &name, Port: &portNum, Protocol: &protocol}},
 	}
 
 	return svc, endpointMeta
@@ -998,8 +998,8 @@ func newEmptyEndpointSlice(n int, namespace string, endpointMeta endpointMeta, s
 			Namespace:       namespace,
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 		},
-		Ports:       endpointMeta.Ports,
-		AddressType: endpointMeta.AddressType,
+		Ports:       endpointMeta.ports,
+		AddressType: endpointMeta.addressType,
 		Endpoints:   []discovery.Endpoint{},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/sig network
/kind cleanup

#### What this PR does / why we need it:

Reduces the visibility of various public identifiers that are only used within the scope of a package. This was originally motivated by [KEP-3685](https://github.com/kubernetes/enhancements/issues/3685) in order to reduce the public API surface and improve supportability.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```