### PR TITLE
quantity: Add multiplication methods

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
@@ -106,6 +106,9 @@ func TestInt64AmountMul(t *testing.T) {
 		{int64Amount{value: mostPositive, scale: -1}, 10, int64Amount{value: mostPositive, scale: -1}, false},
 		{int64Amount{value: mostPositive, scale: -1}, 0, int64Amount{value: 0, scale: 0}, true},
 		{int64Amount{value: mostPositive / 10, scale: 1}, 10, int64Amount{value: mostPositive / 10, scale: 1}, false},
+		{int64Amount{value: mostPositive, scale: 0}, -1, int64Amount{value: -mostPositive, scale: 0}, true},
+		{int64Amount{value: mostNegative, scale: 1}, 0, int64Amount{value: 0, scale: 0}, true},
+		{int64Amount{value: mostNegative, scale: 1}, 1, int64Amount{value: mostNegative, scale: 1}, false},
 	} {
 		c := test.a
 		ok := c.Mul(test.b)

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
@@ -91,18 +91,21 @@ func TestInt64AmountAdd(t *testing.T) {
 
 func TestInt64AmountMul(t *testing.T) {
 	for _, test := range []struct {
-		a, b, c int64Amount
-		ok      bool
+		a  int64Amount
+		b  int64
+		c  int64Amount
+		ok bool
 	}{
-		{int64Amount{value: 100, scale: 1}, int64Amount{value: 10, scale: 2}, int64Amount{value: 10000, scale: 1}, true},
-		{int64Amount{value: 100, scale: 1}, int64Amount{value: 1, scale: 2}, int64Amount{value: 1000, scale: 1}, true},
-		{int64Amount{value: 100, scale: 1}, int64Amount{value: 1, scale: 100}, int64Amount{value: 1, scale: 100}, false},
-		{int64Amount{value: -5, scale: 2}, int64Amount{value: 50, scale: 1}, int64Amount{value: -2500, scale: 1}, true},
-		{int64Amount{value: -5, scale: 2}, int64Amount{value: 5, scale: 2}, int64Amount{value: -25, scale: 2}, true},
+		{int64Amount{value: 100, scale: 1}, 1000, int64Amount{value: 100000, scale: 1}, true},
+		{int64Amount{value: 100, scale: -1}, 1000, int64Amount{value: 100000, scale: -1}, true},
+		{int64Amount{value: 1, scale: 100}, 10, int64Amount{value: 1, scale: 100}, false},
+		{int64Amount{value: 1, scale: -100}, 10, int64Amount{value: 1, scale: -100}, false},
+		{int64Amount{value: -5, scale: 2}, 500, int64Amount{value: -2500, scale: 2}, true},
+		{int64Amount{value: -5, scale: -2}, 500, int64Amount{value: -2500, scale: -2}, true},
 
-		{int64Amount{value: mostPositive, scale: -1}, int64Amount{value: 1, scale: -1}, int64Amount{value: 9223372036854775807, scale: -1}, true},
-		{int64Amount{value: mostPositive, scale: -1}, int64Amount{value: 0, scale: -1}, int64Amount{value: 0, scale: -1}, true},
-		{int64Amount{value: mostPositive / 10, scale: 1}, int64Amount{value: 10, scale: 0}, int64Amount{value: mostPositive, scale: -1}, false},
+		{int64Amount{value: mostPositive, scale: -1}, 10, int64Amount{value: mostPositive, scale: -1}, false},
+		{int64Amount{value: mostPositive, scale: -1}, 0, int64Amount{value: 0, scale: 0}, true},
+		{int64Amount{value: mostPositive / 10, scale: 1}, 10, int64Amount{value: mostPositive / 10, scale: 1}, false},
 	} {
 		c := test.a
 		ok := c.Mul(test.b)
@@ -115,21 +118,6 @@ func TestInt64AmountMul(t *testing.T) {
 			}
 		} else {
 			if c != test.a {
-				t.Errorf("%v: overflow multiplication mutated source: %d", test, c)
-			}
-		}
-
-		// multiplication is commutative
-		c = test.b
-		if ok = c.Mul(test.a); ok != test.ok {
-			t.Errorf("%v: unexpected ok: %t", test, ok)
-		}
-		if ok {
-			if c != test.c {
-				t.Errorf("%v: unexpected result: %d", test, c)
-			}
-		} else {
-			if c != test.b {
 				t.Errorf("%v: overflow multiplication mutated source: %d", test, c)
 			}
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
@@ -105,8 +105,10 @@ func TestInt64AmountMul(t *testing.T) {
 
 		{int64Amount{value: mostPositive, scale: -1}, 10, int64Amount{value: mostPositive, scale: -1}, false},
 		{int64Amount{value: mostPositive, scale: -1}, 0, int64Amount{value: 0, scale: 0}, true},
+		{int64Amount{value: mostPositive, scale: 0}, 1, int64Amount{value: mostPositive, scale: 0}, true},
 		{int64Amount{value: mostPositive / 10, scale: 1}, 10, int64Amount{value: mostPositive / 10, scale: 1}, false},
 		{int64Amount{value: mostPositive, scale: 0}, -1, int64Amount{value: -mostPositive, scale: 0}, true},
+		{int64Amount{value: mostNegative, scale: 0}, 1, int64Amount{value: mostNegative, scale: 0}, true},
 		{int64Amount{value: mostNegative, scale: 1}, 0, int64Amount{value: 0, scale: 0}, true},
 		{int64Amount{value: mostNegative, scale: 1}, 1, int64Amount{value: mostNegative, scale: 1}, false},
 	} {

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
@@ -114,10 +114,11 @@ func TestInt64AmountMul(t *testing.T) {
 	} {
 		c := test.a
 		ok := c.Mul(test.b)
-		if ok != test.ok {
-			t.Errorf("%v: unexpected ok: %t", test, ok)
-		}
-		if ok {
+		if ok && !test.ok {
+			t.Errorf("unextected success: %v", c)
+		} else if !ok && test.ok {
+			t.Errorf("unexpeted failure: %v", c)
+		} else if ok {
 			if c != test.c {
 				t.Errorf("%v: unexpected result: %d", test, c)
 			}

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
@@ -88,6 +88,54 @@ func TestInt64AmountAdd(t *testing.T) {
 		}
 	}
 }
+
+func TestInt64AmountMul(t *testing.T) {
+	for _, test := range []struct {
+		a, b, c int64Amount
+		ok      bool
+	}{
+		{int64Amount{value: 100, scale: 1}, int64Amount{value: 10, scale: 2}, int64Amount{value: 10000, scale: 1}, true},
+		{int64Amount{value: 100, scale: 1}, int64Amount{value: 1, scale: 2}, int64Amount{value: 1000, scale: 1}, true},
+		{int64Amount{value: 100, scale: 1}, int64Amount{value: 1, scale: 100}, int64Amount{value: 1, scale: 100}, false},
+		{int64Amount{value: -5, scale: 2}, int64Amount{value: 50, scale: 1}, int64Amount{value: -2500, scale: 1}, true},
+		{int64Amount{value: -5, scale: 2}, int64Amount{value: 5, scale: 2}, int64Amount{value: -25, scale: 2}, true},
+
+		{int64Amount{value: mostPositive, scale: -1}, int64Amount{value: 1, scale: -1}, int64Amount{value: 9223372036854775807, scale: -1}, true},
+		{int64Amount{value: mostPositive, scale: -1}, int64Amount{value: 0, scale: -1}, int64Amount{value: 0, scale: -1}, true},
+		{int64Amount{value: mostPositive / 10, scale: 1}, int64Amount{value: 10, scale: 0}, int64Amount{value: mostPositive, scale: -1}, false},
+	} {
+		c := test.a
+		ok := c.Mul(test.b)
+		if ok != test.ok {
+			t.Errorf("%v: unexpected ok: %t", test, ok)
+		}
+		if ok {
+			if c != test.c {
+				t.Errorf("%v: unexpected result: %d", test, c)
+			}
+		} else {
+			if c != test.a {
+				t.Errorf("%v: overflow multiplication mutated source: %d", test, c)
+			}
+		}
+
+		// multiplication is commutative
+		c = test.b
+		if ok = c.Mul(test.a); ok != test.ok {
+			t.Errorf("%v: unexpected ok: %t", test, ok)
+		}
+		if ok {
+			if c != test.c {
+				t.Errorf("%v: unexpected result: %d", test, c)
+			}
+		} else {
+			if c != test.b {
+				t.Errorf("%v: overflow multiplication mutated source: %d", test, c)
+			}
+		}
+	}
+}
+
 func TestInt64AsCanonicalString(t *testing.T) {
 	for _, test := range []struct {
 		value    int64

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
@@ -102,6 +102,7 @@ func TestInt64AmountMul(t *testing.T) {
 		{int64Amount{value: 1, scale: -100}, 10, int64Amount{value: 1, scale: -100}, false},
 		{int64Amount{value: -5, scale: 2}, 500, int64Amount{value: -2500, scale: 2}, true},
 		{int64Amount{value: -5, scale: -2}, 500, int64Amount{value: -2500, scale: -2}, true},
+		{int64Amount{value: 0, scale: 1}, 0, int64Amount{value: 0, scale: 1}, true},
 
 		{int64Amount{value: mostPositive, scale: -1}, 10, int64Amount{value: mostPositive, scale: -1}, false},
 		{int64Amount{value: mostPositive, scale: -1}, 0, int64Amount{value: 0, scale: 0}, true},

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -592,6 +592,19 @@ func (q *Quantity) Sub(y Quantity) {
 	q.ToDec().d.Dec.Sub(q.d.Dec, y.AsDec())
 }
 
+// Mul multiplies the provided y quantity to the current value. If the current value is zero,
+// the format of the quantity will be updated to the format of y.
+func (q *Quantity) Mul(y Quantity) {
+	q.s = ""
+	if q.IsZero() {
+		q.Format = y.Format
+	}
+	if q.d.Dec == nil && y.d.Dec == nil && q.i.Mul(y.i) {
+		return
+	}
+	q.ToDec().d.Dec.Mul(q.d.Dec, y.AsDec())
+}
+
 // Cmp returns 0 if the quantity is equal to y, -1 if the quantity is less than y, or 1 if the
 // quantity is greater than y.
 func (q *Quantity) Cmp(y Quantity) int {

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -592,17 +592,14 @@ func (q *Quantity) Sub(y Quantity) {
 	q.ToDec().d.Dec.Sub(q.d.Dec, y.AsDec())
 }
 
-// Mul multiplies the provided y quantity to the current value. If the current value is zero,
-// the format of the quantity will be updated to the format of y.
-func (q *Quantity) Mul(y Quantity) {
+// Mul multiplies the provided y to the current value.
+// It will return false if the result is inexact. Otherwise, it will return true.
+func (q *Quantity) Mul(y int64) bool {
 	q.s = ""
-	if q.IsZero() {
-		q.Format = y.Format
+	if q.d.Dec == nil && q.i.Mul(y) {
+		return true
 	}
-	if q.d.Dec == nil && y.d.Dec == nil && q.i.Mul(y.i) {
-		return
-	}
-	q.ToDec().d.Dec.Mul(q.d.Dec, y.AsDec())
+	return q.ToDec().d.Dec.Mul(q.d.Dec, inf.NewDec(y, inf.Scale(0))).UnscaledBig().IsInt64()
 }
 
 // Cmp returns 0 if the quantity is equal to y, -1 if the quantity is less than y, or 1 if the

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -1151,7 +1151,16 @@ func TestMul(t *testing.T) {
 		{decQuantity(50, 0, DecimalSI), 0, decQuantity(0, 0, DecimalSI), true},
 		{Quantity{Format: DecimalSI}, 0, decQuantity(0, 0, DecimalSI), true},
 
+		{decQuantity(10, 0, DecimalSI), -10, decQuantity(-100, 0, DecimalSI), true},
+		{decQuantity(-10, 0, DecimalSI), 1, decQuantity(-10, 0, DecimalSI), true},
+		{decQuantity(10, 0, BinarySI), -1, decQuantity(-10, 0, BinarySI), true},
+		{decQuantity(-50, 0, DecimalSI), 0, decQuantity(0, 0, DecimalSI), true},
+		{decQuantity(-50, 0, DecimalSI), -50, decQuantity(2500, 0, DecimalSI), true},
+		{Quantity{Format: DecimalSI}, -50, decQuantity(0, 0, DecimalSI), true},
+
 		{decQuantity(mostPositive, 0, DecimalSI), 10, decQuantity(mostPositive, 1, DecimalSI), false},
+		{decQuantity(mostNegative, 0, DecimalSI), 10, decQuantity(mostNegative, 1, DecimalSI), false},
+		{decQuantity(mostPositive, 0, DecimalSI), -10, decQuantity(-mostPositive, 1, DecimalSI), false},
 	}
 
 	for i, test := range tests {

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"math/big"
 	"math/rand"
 	"os"
 	"strings"
@@ -32,13 +33,27 @@ import (
 	inf "gopkg.in/inf.v0"
 )
 
+var (
+	bigMostPositive = big.NewInt(mostPositive)
+	bigMostNegative = big.NewInt(mostNegative)
+)
+
 func dec(i int64, exponent int) infDecAmount {
 	// See the below test-- scale is the negative of an exponent.
 	return infDecAmount{inf.NewDec(i, inf.Scale(-exponent))}
 }
 
+func bigDec(i *big.Int, exponent int) infDecAmount {
+	// See the below test-- scale is the negative of an exponent.
+	return infDecAmount{inf.NewDecBig(i, inf.Scale(-exponent))}
+}
+
 func decQuantity(i int64, exponent int, format Format) Quantity {
 	return Quantity{d: dec(i, exponent), Format: format}
+}
+
+func bigDecQuantity(i *big.Int, exponent int, format Format) Quantity {
+	return Quantity{d: bigDec(i, exponent), Format: format}
 }
 
 func intQuantity(i int64, exponent Scale, format Format) Quantity {
@@ -58,6 +73,38 @@ func TestDec(t *testing.T) {
 		{dec(1, -1), "0.1"},
 		{dec(3, -2), "0.03"},
 		{dec(4, -3), "0.004"},
+	}
+
+	for _, item := range table {
+		if e, a := item.expect, item.got.Dec.String(); e != a {
+			t.Errorf("expected %v, got %v", e, a)
+		}
+	}
+}
+
+func TestBigDec(t *testing.T) {
+	table := []struct {
+		got    infDecAmount
+		expect string
+	}{
+		{bigDec(big.NewInt(1), 0), "1"},
+		{bigDec(big.NewInt(1), 1), "10"},
+		{bigDec(big.NewInt(5), 2), "500"},
+		{bigDec(big.NewInt(8), 3), "8000"},
+		{bigDec(big.NewInt(2), 0), "2"},
+		{bigDec(big.NewInt(1), -1), "0.1"},
+		{bigDec(big.NewInt(3), -2), "0.03"},
+		{bigDec(big.NewInt(4), -3), "0.004"},
+		{bigDec(big.NewInt(0).Add(bigMostPositive, big.NewInt(1)), 0), "9223372036854775808"},
+		{bigDec(big.NewInt(0).Add(bigMostPositive, big.NewInt(1)), 1), "92233720368547758080"},
+		{bigDec(big.NewInt(0).Add(bigMostPositive, big.NewInt(1)), 2), "922337203685477580800"},
+		{bigDec(big.NewInt(0).Add(bigMostPositive, big.NewInt(1)), -1), "922337203685477580.8"},
+		{bigDec(big.NewInt(0).Add(bigMostPositive, big.NewInt(1)), -2), "92233720368547758.08"},
+		{bigDec(big.NewInt(0).Sub(bigMostNegative, big.NewInt(1)), 0), "-9223372036854775809"},
+		{bigDec(big.NewInt(0).Sub(bigMostNegative, big.NewInt(1)), 1), "-92233720368547758090"},
+		{bigDec(big.NewInt(0).Sub(bigMostNegative, big.NewInt(1)), 2), "-922337203685477580900"},
+		{bigDec(big.NewInt(0).Sub(bigMostNegative, big.NewInt(1)), -1), "-922337203685477580.9"},
+		{bigDec(big.NewInt(0).Sub(bigMostNegative, big.NewInt(1)), -2), "-92233720368547758.09"},
 	}
 
 	for _, item := range table {
@@ -1157,10 +1204,26 @@ func TestMul(t *testing.T) {
 		{decQuantity(-50, 0, DecimalSI), 0, decQuantity(0, 0, DecimalSI), true},
 		{decQuantity(-50, 0, DecimalSI), -50, decQuantity(2500, 0, DecimalSI), true},
 		{Quantity{Format: DecimalSI}, -50, decQuantity(0, 0, DecimalSI), true},
-
+		{decQuantity(mostPositive, 0, DecimalSI), 0, decQuantity(0, 1, DecimalSI), true},
+		{decQuantity(mostPositive, 0, DecimalSI), 1, decQuantity(mostPositive, 0, DecimalSI), true},
+		{decQuantity(mostPositive, 0, DecimalSI), -1, decQuantity(-mostPositive, 0, DecimalSI), true},
+		{decQuantity(mostPositive/2, 0, DecimalSI), 2, decQuantity((mostPositive/2)*2, 0, DecimalSI), true},
+		{decQuantity(mostPositive/-2, 0, DecimalSI), -2, decQuantity((mostPositive/2)*2, 0, DecimalSI), true},
+		{decQuantity(mostPositive, 0, DecimalSI), 2,
+			bigDecQuantity(big.NewInt(0).Mul(bigMostPositive, big.NewInt(2)), 0, DecimalSI), false},
 		{decQuantity(mostPositive, 0, DecimalSI), 10, decQuantity(mostPositive, 1, DecimalSI), false},
-		{decQuantity(mostNegative, 0, DecimalSI), 10, decQuantity(mostNegative, 1, DecimalSI), false},
 		{decQuantity(mostPositive, 0, DecimalSI), -10, decQuantity(-mostPositive, 1, DecimalSI), false},
+		{decQuantity(mostNegative, 0, DecimalSI), 0, decQuantity(0, 1, DecimalSI), true},
+		{decQuantity(mostNegative, 0, DecimalSI), 1, decQuantity(mostNegative, 0, DecimalSI), true},
+		{decQuantity(mostNegative, 0, DecimalSI), -1,
+			bigDecQuantity(big.NewInt(0).Add(bigMostPositive, big.NewInt(1)), 0, DecimalSI), false},
+		{decQuantity(mostNegative/2, 0, DecimalSI), 2, decQuantity(mostNegative, 0, DecimalSI), true},
+		{decQuantity(mostNegative/-2, 0, DecimalSI), -2, decQuantity(mostNegative, 0, DecimalSI), true},
+		{decQuantity(mostNegative, 0, DecimalSI), 2,
+			bigDecQuantity(big.NewInt(0).Mul(bigMostNegative, big.NewInt(2)), 0, DecimalSI), false},
+		{decQuantity(mostNegative, 0, DecimalSI), 10, decQuantity(mostNegative, 1, DecimalSI), false},
+		{decQuantity(mostNegative, 0, DecimalSI), -10,
+			bigDecQuantity(big.NewInt(0).Add(bigMostPositive, big.NewInt(1)), 1, DecimalSI), false},
 	}
 
 	for i, test := range tests {

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -1140,21 +1140,26 @@ func TestAdd(t *testing.T) {
 func TestMul(t *testing.T) {
 	tests := []struct {
 		a        Quantity
-		b        Quantity
+		b        int64
 		expected Quantity
+		ok       bool
 	}{
-		{decQuantity(10, 0, DecimalSI), decQuantity(1, 1, DecimalSI), decQuantity(100, 0, DecimalSI)},
-		{decQuantity(10, 0, DecimalSI), decQuantity(1, 0, BinarySI), decQuantity(10, 0, DecimalSI)},
-		{decQuantity(10, 0, BinarySI), decQuantity(1, 0, DecimalSI), decQuantity(10, 0, BinarySI)},
-		{Quantity{Format: DecimalSI}, decQuantity(50, 0, DecimalSI), decQuantity(0, 0, DecimalSI)},
-		{decQuantity(50, 0, DecimalSI), Quantity{Format: DecimalSI}, decQuantity(0, 0, DecimalSI)},
-		{Quantity{Format: DecimalSI}, Quantity{Format: DecimalSI}, decQuantity(0, 0, DecimalSI)},
+		{decQuantity(10, 0, DecimalSI), 10, decQuantity(100, 0, DecimalSI), true},
+		{decQuantity(10, 0, DecimalSI), 1, decQuantity(10, 0, DecimalSI), true},
+		{decQuantity(10, 0, BinarySI), 1, decQuantity(10, 0, BinarySI), true},
+		{Quantity{Format: DecimalSI}, 50, decQuantity(0, 0, DecimalSI), true},
+		{decQuantity(50, 0, DecimalSI), 0, decQuantity(0, 0, DecimalSI), true},
+		{Quantity{Format: DecimalSI}, 0, decQuantity(0, 0, DecimalSI), true},
+
+		{decQuantity(mostPositive, 0, DecimalSI), 10, decQuantity(mostPositive, 1, DecimalSI), false},
 	}
 
 	for i, test := range tests {
-		test.a.Mul(test.b)
+		if ok := test.a.Mul(test.b); test.ok != ok {
+			t.Errorf("[%d] Expected ok: %t, got ok: %t", i, test.ok, ok)
+		}
 		if test.a.Cmp(test.expected) != 0 {
-			t.Errorf("[%d] Expected %q, got %q", i, test.expected.String(), test.a.String())
+			t.Errorf("[%d] Expected %q, got %q", i, test.expected.AsDec().String(), test.a.AsDec().String())
 		}
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -1137,6 +1137,28 @@ func TestAdd(t *testing.T) {
 	}
 }
 
+func TestMul(t *testing.T) {
+	tests := []struct {
+		a        Quantity
+		b        Quantity
+		expected Quantity
+	}{
+		{decQuantity(10, 0, DecimalSI), decQuantity(1, 1, DecimalSI), decQuantity(100, 0, DecimalSI)},
+		{decQuantity(10, 0, DecimalSI), decQuantity(1, 0, BinarySI), decQuantity(10, 0, DecimalSI)},
+		{decQuantity(10, 0, BinarySI), decQuantity(1, 0, DecimalSI), decQuantity(10, 0, BinarySI)},
+		{Quantity{Format: DecimalSI}, decQuantity(50, 0, DecimalSI), decQuantity(0, 0, DecimalSI)},
+		{decQuantity(50, 0, DecimalSI), Quantity{Format: DecimalSI}, decQuantity(0, 0, DecimalSI)},
+		{Quantity{Format: DecimalSI}, Quantity{Format: DecimalSI}, decQuantity(0, 0, DecimalSI)},
+	}
+
+	for i, test := range tests {
+		test.a.Mul(test.b)
+		if test.a.Cmp(test.expected) != 0 {
+			t.Errorf("[%d] Expected %q, got %q", i, test.expected.String(), test.a.String())
+		}
+	}
+}
+
 func TestAddSubRoundTrip(t *testing.T) {
 	for k := -10; k <= 10; k++ {
 		q := Quantity{Format: DecimalSI}


### PR DESCRIPTION
Add multiplication functionality to Quantity.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
I added multiplication functionally to Quantity.
Please see #117044 about the background.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #117044 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add multiplication functionality to Quantity.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Usage:

```go
ps := kueue.PodSet{
	Name:  "test",
	Count: int32(100),
	Template: corev1.PodTemplateSpec{
		Spec: corev1.PodSpec{
			Containers: []corev1.Container{
				{
					Name: "main",
					Resources: corev1.ResourceRequirements{
						Requests: corev1.ResourceList{
							corev1.ResourceMemory: resource.MustParse("32Gi"),
						},
					},
				},
			},
		},
	},
}

requestedMemory := ps.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]
ok := requestedMemory.Mul(int64(ps.Count))

// Output:
//
//	requestedMemory: 3200Gi
fmt.Sprintf("requestedMemory: %s\n", requestedMemory.String())
```

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->