### PR TITLE
[disruption budget controller] implement fast ResourceEventHandler

### DIFF
--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -550,7 +550,7 @@ func (dc *DisruptionController) updatePod(oldObj, newObj interface{}) {
 	dc.enqueuePod(newPod)
 
 	oldPod := oldObj.(*v1.Pod)
-	if labels.Equals(oldPod.Labels, newPod.Labels) {
+	if !labels.Equals(oldPod.Labels, newPod.Labels) {
 		dc.enqueuePod(oldPod)
 	}
 }

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -191,6 +191,8 @@ func NewDisruptionControllerInternal(
 		stalePodDisruptionQueue:   workqueue.NewRateLimitingQueueWithDelayingInterface(workqueue.NewDelayingQueueWithCustomClock(clock, "stale_pod_disruption"), workqueue.DefaultControllerRateLimiter()),
 		broadcaster:               record.NewBroadcaster(),
 		stalePodDisruptionTimeout: stalePodDisruptionTimeout,
+		labelUpdateQueue:          workqueue.NewRateLimitingQueueWithDelayingInterface(workqueue.NewDelayingQueueWithCustomClock(clock, "pod_labels_disruption"), workqueue.DefaultControllerRateLimiter()),
+		labelCache:                make(map[string]labels.Set),
 	}
 	dc.recorder = dc.broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "controllermanager"})
 

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -617,7 +617,7 @@ func (dc *DisruptionController) getPdbForPodLabels(podNamespace string, podLabel
 	}
 
 	if len(pdbs) > 1 {
-		msg := fmt.Sprintf("Pod labels %q/%q matche multiple PodDisruptionBudgets. Chose %q arbitrarily.", podNamespace, podLabels.String(), pdbs[0].Name)
+		msg := fmt.Sprintf("Pod labels %q/%q match multiple PodDisruptionBudgets. Chose %q arbitrarily.", podNamespace, podLabels.String(), pdbs[0].Name)
 		klog.Warning(msg)
 		// FIXME(oleg): how to emit events?
 		//dc.recorder.Event(pod, v1.EventTypeWarning, "MultiplePodDisruptionBudgets", msg)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Existing implementation of ResourceEventHandlerFuncs handling pod updates in pod disruption budget controller could be relatively slow (getPdbForPod() is expensive) under certain conditions (see linked issue).
It leads to unbounded pendingNotifications buffer growth (see memory profiles in linked issue): https://sourcegraph.com/github.com/kubernetes/kubernetes@94a15929cf13354fdf3747cb266d511154f8c97b/-/blob/staging/src/k8s.io/client-go/tools/cache/shared_informer.go?L872-877).
Since it happens before the disruption budget controller takes action - we don't see elevated queue/processing times for PDB workqueues.

Updating the code to make ResourceHandlerFunctions fast and mostly non-blocking.
* extract labels and discard original pod object immediately after receiving in add/update/delete ResourceHandlerFunctions. 
* introduce new queue which processes individual pod labels. As a side-effect - we deduplicate events for the same PodDisruptionBudget (if many pods for the same PDB is updated in the queue - we recalculate PDB state only once).
* it also fixes a potential issue with old PDB not being updated if pod changes labels: https://sourcegraph.com/github.com/kubernetes/kubernetes@94a1592/-/blob/pkg/controller/disruption/disruption.go?L494-507 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/117123

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
