### PR TITLE
Replace os.Setenv with testing.T.Setenv in tests

### DIFF
--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -413,10 +413,8 @@ profiles:
 
 	// Insulate this test from picking up in-cluster config when run inside a pod
 	// We can't assume we have permissions to write to /var/run/secrets/... from a unit test to mock in-cluster config for testing
-	originalHost := os.Getenv("KUBERNETES_SERVICE_HOST")
-	if len(originalHost) > 0 {
-		os.Setenv("KUBERNETES_SERVICE_HOST", "")
-		defer os.Setenv("KUBERNETES_SERVICE_HOST", originalHost)
+	if len(os.Getenv("KUBERNETES_SERVICE_HOST")) > 0 {
+		t.Setenv("KUBERNETES_SERVICE_HOST", "")
 	}
 
 	defaultPodInitialBackoffSeconds := int64(1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This replaces `os.Setenv` with `testing.T.Setenv` for its automatic cleanup and protection against accidental use in parallel tests.

#### Special notes for your reviewer:

Broken out from #117395.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig scheduling
