### PR TITLE
Replace os.Setenv with testing.T.Setenv in tests

### DIFF
--- a/staging/src/k8s.io/client-go/rest/client_test.go
+++ b/staging/src/k8s.io/client-go/rest/client_test.go
@@ -23,7 +23,6 @@ import (
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -340,8 +339,8 @@ func TestCreateBackoffManager(t *testing.T) {
 	theUrl, _ := url.Parse("http://localhost")
 
 	// 1 second base backoff + duration of 2 seconds -> exponential backoff for requests.
-	os.Setenv(envBackoffBase, "1")
-	os.Setenv(envBackoffDuration, "2")
+	t.Setenv(envBackoffBase, "1")
+	t.Setenv(envBackoffDuration, "2")
 	backoff := readExpBackoffConfig()
 	backoff.UpdateBackoff(theUrl, nil, 500)
 	backoff.UpdateBackoff(theUrl, nil, 500)
@@ -350,8 +349,8 @@ func TestCreateBackoffManager(t *testing.T) {
 	}
 
 	// 0 duration -> no backoff.
-	os.Setenv(envBackoffBase, "1")
-	os.Setenv(envBackoffDuration, "0")
+	t.Setenv(envBackoffBase, "1")
+	t.Setenv(envBackoffDuration, "0")
 	backoff.UpdateBackoff(theUrl, nil, 500)
 	backoff.UpdateBackoff(theUrl, nil, 500)
 	backoff = readExpBackoffConfig()
@@ -360,8 +359,8 @@ func TestCreateBackoffManager(t *testing.T) {
 	}
 
 	// No env -> No backoff.
-	os.Setenv(envBackoffBase, "")
-	os.Setenv(envBackoffDuration, "")
+	t.Setenv(envBackoffBase, "")
+	t.Setenv(envBackoffDuration, "")
 	backoff = readExpBackoffConfig()
 	backoff.UpdateBackoff(theUrl, nil, 500)
 	backoff.UpdateBackoff(theUrl, nil, 500)

--- a/staging/src/k8s.io/client-go/rest/connection_test.go
+++ b/staging/src/k8s.io/client-go/rest/connection_test.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -80,23 +79,15 @@ func newLB(t *testing.T, serverURL string) *tcpLB {
 	return &lb
 }
 
-func setEnv(key, value string) func() {
-	originalValue := os.Getenv(key)
-	os.Setenv(key, value)
-	return func() {
-		os.Setenv(key, originalValue)
-	}
-}
-
 const (
 	readIdleTimeout int = 1
 	pingTimeout     int = 1
 )
 
 func TestReconnectBrokenTCP(t *testing.T) {
-	defer setEnv("HTTP2_READ_IDLE_TIMEOUT_SECONDS", strconv.Itoa(readIdleTimeout))()
-	defer setEnv("HTTP2_PING_TIMEOUT_SECONDS", strconv.Itoa(pingTimeout))()
-	defer setEnv("DISABLE_HTTP2", "")()
+	t.Setenv("HTTP2_READ_IDLE_TIMEOUT_SECONDS", strconv.Itoa(readIdleTimeout))
+	t.Setenv("HTTP2_PING_TIMEOUT_SECONDS", strconv.Itoa(pingTimeout))
+	t.Setenv("DISABLE_HTTP2", "")
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Hello, %s", r.Proto)
 	}))

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -897,12 +897,9 @@ func TestLoadingGetLoadingPrecedence(t *testing.T) {
 		},
 	}
 
-	kubeconfig := os.Getenv("KUBECONFIG")
-	defer os.Setenv("KUBECONFIG", kubeconfig)
-
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			os.Setenv("KUBECONFIG", test.env)
+			t.Setenv("KUBECONFIG", test.env)
 			rules := test.rules
 			if rules == nil {
 				rules = NewDefaultClientConfigLoadingRules()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This replaces `os.Setenv` with `testing.T.Setenv` for its automatic cleanup and protection against accidental use in parallel tests.

#### Special notes for your reviewer:

Broken out from #117395.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
