### PR TITLE
Replace os.Setenv with testing.T.Setenv in tests

### DIFF
--- a/test/conformance/image/go-runner/env_test.go
+++ b/test/conformance/image/go-runner/env_test.go
@@ -32,7 +32,7 @@ func TestEnv(t *testing.T) {
 			desc: "OS env",
 			env:  &osEnv{},
 			preHook: func() {
-				os.Setenv("key1", "1")
+				t.Setenv("key1", "1")
 			},
 			expect: map[string]string{"key1": "1"},
 		}, {

--- a/test/integration/serving/serving_test.go
+++ b/test/integration/serving/serving_test.go
@@ -83,10 +83,8 @@ func TestComponentSecureServingAndAuth(t *testing.T) {
 
 	// Insulate this test from picking up in-cluster config when run inside a pod
 	// We can't assume we have permissions to write to /var/run/secrets/... from a unit test to mock in-cluster config for testing
-	originalHost := os.Getenv("KUBERNETES_SERVICE_HOST")
-	if len(originalHost) > 0 {
-		os.Setenv("KUBERNETES_SERVICE_HOST", "")
-		defer os.Setenv("KUBERNETES_SERVICE_HOST", originalHost)
+	if len(os.Getenv("KUBERNETES_SERVICE_HOST")) > 0 {
+		t.Setenv("KUBERNETES_SERVICE_HOST", "")
 	}
 
 	// authenticate to apiserver via bearer token

--- a/test/integration/volumescheduling/volume_binding_test.go
+++ b/test/integration/volumescheduling/volume_binding_test.go
@@ -21,7 +21,6 @@ package volumescheduling
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -427,10 +426,7 @@ func testVolumeBindingStress(t *testing.T, schedulerResyncPeriod time.Duration, 
 
 	// Set max volume limit to the number of PVCs the test will create
 	// TODO: remove when max volume limit allows setting through storageclass
-	if err := os.Setenv(nodevolumelimits.KubeMaxPDVols, fmt.Sprintf("%v", podLimit*volsPerPod)); err != nil {
-		t.Fatalf("failed to set max pd limit: %v", err)
-	}
-	defer os.Unsetenv(nodevolumelimits.KubeMaxPDVols)
+	t.Setenv(nodevolumelimits.KubeMaxPDVols, fmt.Sprintf("%v", podLimit*volsPerPod))
 
 	scName := &classWait
 	if dynamic {

--- a/test/typecheck/main_test.go
+++ b/test/typecheck/main_test.go
@@ -32,7 +32,7 @@ var goBinary = flag.String("go", "", "path to a `go` binary")
 func TestVerify(t *testing.T) {
 	// x/tools/packages is going to literally exec `go`, so it needs some
 	// setup.
-	setEnvVars()
+	setEnvVars(t)
 
 	tcs := []struct {
 		path   string
@@ -57,17 +57,18 @@ func TestVerify(t *testing.T) {
 	}
 }
 
-func setEnvVars() {
+func setEnvVars(t testing.TB) {
+	t.Helper()
 	if *goBinary != "" {
 		newPath := filepath.Dir(*goBinary)
 		curPath := os.Getenv("PATH")
 		if curPath != "" {
 			newPath = newPath + ":" + curPath
 		}
-		os.Setenv("PATH", newPath)
+		t.Setenv("PATH", newPath)
 	}
 	if os.Getenv("HOME") == "" {
-		os.Setenv("HOME", "/tmp")
+		t.Setenv("HOME", "/tmp")
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This replaces `os.Setenv` with `testing.T.Setenv` for its automatic cleanup and protection against accidental use in parallel tests.

#### Special notes for your reviewer:

Broken out from #117395.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig testing