### PR TITLE
Replace os.Setenv with testing.T.Setenv in tests

### DIFF
--- a/cmd/kubeadm/app/cmd/token_test.go
+++ b/cmd/kubeadm/app/cmd/token_test.go
@@ -249,18 +249,14 @@ func TestNewCmdToken(t *testing.T) {
 			if _, err = f.WriteString(tc.configToWrite); err != nil {
 				t.Errorf("Unable to write test file %q: %v", fullPath, err)
 			}
-			// store the current value of the environment variable.
-			storedEnv := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
 			if tc.kubeConfigEnv != "" {
-				os.Setenv(clientcmd.RecommendedConfigPathEnvVar, tc.kubeConfigEnv)
+				t.Setenv(clientcmd.RecommendedConfigPathEnvVar, tc.kubeConfigEnv)
 			}
 			cmd.SetArgs(tc.args)
 			err := cmd.Execute()
 			if (err != nil) != tc.expectedError {
 				t.Errorf("Test case %q: newCmdToken expected error: %v, saw: %v", tc.name, tc.expectedError, (err != nil))
 			}
-			// restore the environment variable.
-			os.Setenv(clientcmd.RecommendedConfigPathEnvVar, storedEnv)
 		})
 	}
 }

--- a/cmd/kubeadm/test/cmd/init_test.go
+++ b/cmd/kubeadm/test/cmd/init_test.go
@@ -27,11 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 )
 
-func runKubeadmInit(args ...string) (string, string, int, error) {
-	const dryRunDir = "KUBEADM_INIT_DRYRUN_DIR"
-	if err := os.Setenv(dryRunDir, os.TempDir()); err != nil {
-		panic(fmt.Sprintf("could not set the %s environment variable", dryRunDir))
-	}
+func runKubeadmInit(t testing.TB, args ...string) (string, string, int, error) {
+	t.Helper()
+	t.Setenv("KUBEADM_INIT_DRYRUN_DIR", os.TempDir())
 	kubeadmPath := getKubeadmPath()
 	kubeadmArgs := []string{"init", "--dry-run", "--ignore-preflight-errors=all"}
 	kubeadmArgs = append(kubeadmArgs, args...)
@@ -73,7 +71,7 @@ func TestCmdInitToken(t *testing.T) {
 
 	for _, rt := range initTest {
 		t.Run(rt.name, func(t *testing.T) {
-			_, _, _, err := runKubeadmInit(rt.args)
+			_, _, _, err := runKubeadmInit(t, rt.args)
 			if (err == nil) != rt.expected {
 				t.Fatalf(dedent.Dedent(`
 					CmdInitToken test case %q failed with an error: %v
@@ -112,7 +110,7 @@ func TestCmdInitKubernetesVersion(t *testing.T) {
 
 	for _, rt := range initTest {
 		t.Run(rt.name, func(t *testing.T) {
-			_, _, _, err := runKubeadmInit(rt.args)
+			_, _, _, err := runKubeadmInit(t, rt.args)
 			if (err == nil) != rt.expected {
 				t.Fatalf(dedent.Dedent(`
 					CmdInitKubernetesVersion test case %q failed with an error: %v
@@ -176,7 +174,7 @@ func TestCmdInitConfig(t *testing.T) {
 
 	for _, rt := range initTest {
 		t.Run(rt.name, func(t *testing.T) {
-			_, _, _, err := runKubeadmInit(rt.args)
+			_, _, _, err := runKubeadmInit(t, rt.args)
 			if (err == nil) != rt.expected {
 				t.Fatalf(dedent.Dedent(`
 						CmdInitConfig test case %q failed with an error: %v
@@ -225,7 +223,7 @@ func TestCmdInitAPIPort(t *testing.T) {
 
 	for _, rt := range initTest {
 		t.Run(rt.name, func(t *testing.T) {
-			_, _, _, err := runKubeadmInit(rt.args)
+			_, _, _, err := runKubeadmInit(t, rt.args)
 			if (err == nil) != rt.expected {
 				t.Fatalf(dedent.Dedent(`
 							CmdInitAPIPort test case %q failed with an error: %v
@@ -267,7 +265,7 @@ func TestCmdInitFeatureGates(t *testing.T) {
 
 	for _, rt := range initTest {
 		t.Run(rt.name, func(t *testing.T) {
-			_, _, exitcode, err := runKubeadmInit(rt.args)
+			_, _, exitcode, err := runKubeadmInit(t, rt.args)
 			if exitcode == PanicExitcode {
 				t.Fatalf(dedent.Dedent(`
 							CmdInitFeatureGates test case %q failed with an error: %v


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This replaces `os.Setenv` with `testing.T.Setenv` for its automatic cleanup and protection against accidental use in parallel tests.

This also cleans up after `os.Unsetenv` calls in tests using `testing.T.Cleanup`. The latter correctly runs after any parallel sub-tests, while `defer` does not.

#### Special notes for your reviewer:

Broken out from #117395.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig cluster-lifecycle