### PR TITLE
Replace os.Setenv with testing.T.Setenv in tests

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
@@ -26,7 +26,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -205,7 +204,7 @@ func TestProxierWithNoProxyCIDR(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		os.Setenv("NO_PROXY", test.noProxy)
+		t.Setenv("NO_PROXY", test.noProxy)
 		actualDelegated := false
 		proxyFunc := NewProxierWithNoProxyCIDR(func(req *http.Request) (*url.URL, error) {
 			actualDelegated = true
@@ -917,40 +916,28 @@ func TestIsProbableEOF(t *testing.T) {
 	}
 }
 
-func setEnv(key, value string) func() {
-	originalValue := os.Getenv(key)
-	os.Setenv(key, value)
-	return func() {
-		os.Setenv(key, originalValue)
-	}
-}
-
 func TestReadIdleTimeoutSeconds(t *testing.T) {
-	reset := setEnv("HTTP2_READ_IDLE_TIMEOUT_SECONDS", "60")
+	t.Setenv("HTTP2_READ_IDLE_TIMEOUT_SECONDS", "60")
 	if e, a := 60, readIdleTimeoutSeconds(); e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	reset()
 
-	reset = setEnv("HTTP2_READ_IDLE_TIMEOUT_SECONDS", "illegal value")
+	t.Setenv("HTTP2_READ_IDLE_TIMEOUT_SECONDS", "illegal value")
 	if e, a := 30, readIdleTimeoutSeconds(); e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	reset()
 }
 
 func TestPingTimeoutSeconds(t *testing.T) {
-	reset := setEnv("HTTP2_PING_TIMEOUT_SECONDS", "60")
+	t.Setenv("HTTP2_PING_TIMEOUT_SECONDS", "60")
 	if e, a := 60, pingTimeoutSeconds(); e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	reset()
 
-	reset = setEnv("HTTP2_PING_TIMEOUT_SECONDS", "illegal value")
+	t.Setenv("HTTP2_PING_TIMEOUT_SECONDS", "illegal value")
 	if e, a := 15, pingTimeoutSeconds(); e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	reset()
 }
 
 func Benchmark_ParseQuotedString(b *testing.B) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This replaces `os.Setenv` with `testing.T.Setenv` for its automatic cleanup and protection against accidental use in parallel tests.

#### Special notes for your reviewer:

Broken out from #117395.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
