### PR TITLE
Reduce sync-up time of configmap/secret volumes in watch strategy.

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -923,6 +923,10 @@ func (adc *attachDetachController) GetFilteredDialOptions() *proxyutil.FilteredD
 	return adc.filteredDialOptions
 }
 
+func (adc *attachDetachController) GetPodsNeedSyncVolumes() []types.UID {
+	return nil
+}
+
 func (adc *attachDetachController) GetCSIDriverLister() storagelistersv1.CSIDriverLister {
 	return adc.csiDriverLister
 }

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -489,3 +489,7 @@ func (expc *expandController) GetSubpather() subpath.Interface {
 func (expc *expandController) GetFilteredDialOptions() *proxyutil.FilteredDialOptions {
 	return expc.filteredDialOptions
 }
+
+func (exec *expandController) GetPodsNeedSyncVolumes() []types.UID {
+	return nil
+}

--- a/pkg/controller/volume/persistentvolume/volume_host.go
+++ b/pkg/controller/volume/persistentvolume/volume_host.go
@@ -147,3 +147,7 @@ func (ctrl *PersistentVolumeController) GetSubpather() subpath.Interface {
 func (ctrl *PersistentVolumeController) GetFilteredDialOptions() *proxyutil.FilteredDialOptions {
 	return ctrl.filteredDialOptions
 }
+
+func (ctrl *PersistentVolumeController) GetPodsNeedSyncVolumes() []types.UID {
+	return nil
+}

--- a/pkg/kubelet/configmap/configmap_manager.go
+++ b/pkg/kubelet/configmap/configmap_manager.go
@@ -29,6 +29,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/utils/clock"
@@ -48,6 +49,9 @@ type Manager interface {
 	// UnregisterPod unregisters configmaps from a given pod that are not
 	// used by any other registered pod.
 	UnregisterPod(pod *v1.Pod)
+
+	// GetPodsNeedSyncObjects gets pods that need syncing objects.
+	GetPodsNeedSyncObjects() []types.UID
 }
 
 // simpleConfigMapManager implements ConfigMap Manager interface with
@@ -69,6 +73,10 @@ func (s *simpleConfigMapManager) RegisterPod(pod *v1.Pod) {
 }
 
 func (s *simpleConfigMapManager) UnregisterPod(pod *v1.Pod) {
+}
+
+func (s *simpleConfigMapManager) GetPodsNeedSyncObjects() []types.UID {
+	return nil
 }
 
 // configMapManager keeps a cache of all configmaps necessary
@@ -96,6 +104,10 @@ func (c *configMapManager) RegisterPod(pod *v1.Pod) {
 
 func (c *configMapManager) UnregisterPod(pod *v1.Pod) {
 	c.manager.UnregisterPod(pod)
+}
+
+func (c *configMapManager) GetPodsNeedSyncObjects() []types.UID {
+	return c.manager.GetPodsNeedSyncObjects()
 }
 
 func getConfigMapNames(pod *v1.Pod) sets.String {

--- a/pkg/kubelet/configmap/fake_manager.go
+++ b/pkg/kubelet/configmap/fake_manager.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package configmap
 
-import v1 "k8s.io/api/core/v1"
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
 
 // fakeManager implements Manager interface for testing purposes.
 // simple operations to apiserver.
@@ -36,4 +39,8 @@ func (s *fakeManager) RegisterPod(pod *v1.Pod) {
 }
 
 func (s *fakeManager) UnregisterPod(pod *v1.Pod) {
+}
+
+func (s *fakeManager) GetPodsNeedSyncObjects() []types.UID {
+	return nil
 }

--- a/pkg/kubelet/secret/fake_manager.go
+++ b/pkg/kubelet/secret/fake_manager.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package secret
 
-import v1 "k8s.io/api/core/v1"
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
 
 // fakeManager implements Manager interface for testing purposes.
 // simple operations to apiserver.
@@ -39,4 +42,9 @@ func (s *fakeManager) RegisterPod(pod *v1.Pod) {
 
 // UnregisterPod implements the UnregisterPod method for testing purposes.
 func (s *fakeManager) UnregisterPod(pod *v1.Pod) {
+}
+
+// GetPodsNeedSyncObjects implements the GetPodsNeedSyncObjects method for testing purposes.
+func (s *fakeManager) GetPodsNeedSyncObjects() []types.UID {
+	return nil
 }

--- a/pkg/kubelet/secret/secret_manager.go
+++ b/pkg/kubelet/secret/secret_manager.go
@@ -29,6 +29,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/utils/clock"
@@ -49,6 +50,9 @@ type Manager interface {
 	// UnregisterPod unregisters secrets from a given pod that are not
 	// used by any other registered pod.
 	UnregisterPod(pod *v1.Pod)
+
+	// GetPodsNeedSyncObjects gets pods that need syncing objects.
+	GetPodsNeedSyncObjects() []types.UID
 }
 
 // simpleSecretManager implements SecretManager interfaces with
@@ -70,6 +74,10 @@ func (s *simpleSecretManager) RegisterPod(pod *v1.Pod) {
 }
 
 func (s *simpleSecretManager) UnregisterPod(pod *v1.Pod) {
+}
+
+func (s *simpleSecretManager) GetPodsNeedSyncObjects() []types.UID {
+	return nil
 }
 
 // secretManager keeps a store with secrets necessary
@@ -97,6 +105,10 @@ func (s *secretManager) RegisterPod(pod *v1.Pod) {
 
 func (s *secretManager) UnregisterPod(pod *v1.Pod) {
 	s.manager.UnregisterPod(pod)
+}
+
+func (s *secretManager) GetPodsNeedSyncObjects() []types.UID {
+	return s.manager.GetPodsNeedSyncObjects()
 }
 
 func getSecretNames(pod *v1.Pod) sets.String {

--- a/pkg/kubelet/util/manager/cache_based_manager.go
+++ b/pkg/kubelet/util/manager/cache_based_manager.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/kubernetes/pkg/kubelet/util"
 
@@ -92,7 +92,7 @@ func isObjectOlder(newObject, oldObject runtime.Object) bool {
 	return newVersion < oldVersion
 }
 
-func (s *objectStore) AddReference(namespace, name string) {
+func (s *objectStore) AddReference(namespace, name string, _ types.UID) {
 	key := objectKey{namespace: namespace, name: name}
 
 	// AddReference is called from RegisterPod, thus it needs to be efficient.
@@ -114,7 +114,7 @@ func (s *objectStore) AddReference(namespace, name string) {
 	item.data = nil
 }
 
-func (s *objectStore) DeleteReference(namespace, name string) {
+func (s *objectStore) DeleteReference(namespace, name string, _ types.UID) {
 	key := objectKey{namespace: namespace, name: name}
 
 	s.lock.Lock()
@@ -125,6 +125,10 @@ func (s *objectStore) DeleteReference(namespace, name string) {
 			delete(s.items, key)
 		}
 	}
+}
+
+func (s *objectStore) GetPodsNeedSyncObjects() []types.UID {
+	return nil
 }
 
 // GetObjectTTLFromNodeFunc returns a function that returns TTL value
@@ -225,7 +229,7 @@ func (c *cacheBasedManager) RegisterPod(pod *v1.Pod) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	for name := range names {
-		c.objectStore.AddReference(pod.Namespace, name)
+		c.objectStore.AddReference(pod.Namespace, name, pod.UID)
 	}
 	var prev *v1.Pod
 	key := objectKey{namespace: pod.Namespace, name: pod.Name, uid: pod.UID}
@@ -238,7 +242,7 @@ func (c *cacheBasedManager) RegisterPod(pod *v1.Pod) {
 			// names and prev need to have their ref counts decremented. Any that
 			// are only in prev need to be completely removed. This unconditional
 			// call takes care of both cases.
-			c.objectStore.DeleteReference(prev.Namespace, name)
+			c.objectStore.DeleteReference(prev.Namespace, name, prev.UID)
 		}
 	}
 }
@@ -252,9 +256,13 @@ func (c *cacheBasedManager) UnregisterPod(pod *v1.Pod) {
 	delete(c.registeredPods, key)
 	if prev != nil {
 		for name := range c.getReferencedObjects(prev) {
-			c.objectStore.DeleteReference(prev.Namespace, name)
+			c.objectStore.DeleteReference(prev.Namespace, name, prev.UID)
 		}
 	}
+}
+
+func (c *cacheBasedManager) GetPodsNeedSyncObjects() []types.UID {
+	return c.objectStore.GetPodsNeedSyncObjects()
 }
 
 // NewCacheBasedManager creates a manager that keeps a cache of all objects

--- a/pkg/kubelet/util/manager/cache_based_manager_test.go
+++ b/pkg/kubelet/util/manager/cache_based_manager_test.go
@@ -89,13 +89,13 @@ func newCacheBasedSecretManager(store Store) Manager {
 func TestSecretStore(t *testing.T) {
 	fakeClient := &fake.Clientset{}
 	store := newSecretStore(fakeClient, clock.RealClock{}, noObjectTTL, 0)
-	store.AddReference("ns1", "name1")
-	store.AddReference("ns2", "name2")
-	store.AddReference("ns1", "name1")
-	store.AddReference("ns1", "name1")
-	store.DeleteReference("ns1", "name1")
-	store.DeleteReference("ns2", "name2")
-	store.AddReference("ns3", "name3")
+	store.AddReference("ns1", "name1", "pod1")
+	store.AddReference("ns2", "name2", "pod2")
+	store.AddReference("ns1", "name1", "pod3")
+	store.AddReference("ns1", "name1", "pod4")
+	store.DeleteReference("ns1", "name1", "pod1")
+	store.DeleteReference("ns2", "name2", "pod2")
+	store.AddReference("ns3", "name3", "pod5")
 
 	// Adds don't issue Get requests.
 	actions := fakeClient.Actions()
@@ -123,7 +123,7 @@ func TestSecretStore(t *testing.T) {
 func TestSecretStoreDeletingSecret(t *testing.T) {
 	fakeClient := &fake.Clientset{}
 	store := newSecretStore(fakeClient, clock.RealClock{}, noObjectTTL, 0)
-	store.AddReference("ns", "name")
+	store.AddReference("ns", "name", "pod")
 
 	result := &v1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "name", ResourceVersion: "10"}}
 	fakeClient.AddReactor("get", "secrets", func(action core.Action) (bool, runtime.Object, error) {
@@ -155,7 +155,7 @@ func TestSecretStoreGetAlwaysRefresh(t *testing.T) {
 	store := newSecretStore(fakeClient, fakeClock, noObjectTTL, 0)
 
 	for i := 0; i < 10; i++ {
-		store.AddReference(fmt.Sprintf("ns-%d", i), fmt.Sprintf("name-%d", i))
+		store.AddReference(fmt.Sprintf("ns-%d", i), fmt.Sprintf("name-%d", i), types.UID(fmt.Sprintf("pod-%d", i)))
 	}
 	fakeClient.ClearActions()
 
@@ -182,7 +182,7 @@ func TestSecretStoreGetNeverRefresh(t *testing.T) {
 	store := newSecretStore(fakeClient, fakeClock, noObjectTTL, time.Minute)
 
 	for i := 0; i < 10; i++ {
-		store.AddReference(fmt.Sprintf("ns-%d", i), fmt.Sprintf("name-%d", i))
+		store.AddReference(fmt.Sprintf("ns-%d", i), fmt.Sprintf("name-%d", i), types.UID(fmt.Sprintf("pod-%d", i)))
 	}
 	fakeClient.ClearActions()
 
@@ -211,7 +211,7 @@ func TestCustomTTL(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Time{})
 	store := newSecretStore(fakeClient, fakeClock, customTTL, time.Minute)
 
-	store.AddReference("ns", "name")
+	store.AddReference("ns", "name", "pod")
 	store.Get("ns", "name")
 	fakeClient.ClearActions()
 

--- a/pkg/kubelet/util/manager/manager.go
+++ b/pkg/kubelet/util/manager/manager.go
@@ -17,8 +17,9 @@ limitations under the License.
 package manager
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // Manager is the interface for registering and unregistering
@@ -41,6 +42,9 @@ type Manager interface {
 	//
 	// NOTE: All implementations of UnregisterPod should be idempotent.
 	UnregisterPod(pod *v1.Pod)
+
+	// GetPodsNeedSyncObjects gets pods that need syncing objects.
+	GetPodsNeedSyncObjects() []types.UID
 }
 
 // Store is the interface for a object cache that
@@ -49,12 +53,14 @@ type Store interface {
 	// AddReference adds a reference to the object to the store.
 	// Note that multiple additions to the store has to be allowed
 	// in the implementations and effectively treated as refcounted.
-	AddReference(namespace, name string)
+	AddReference(namespace, name string, podUID types.UID)
 	// DeleteReference deletes reference to the object from the store.
 	// Note that object should be deleted only when there was a
 	// corresponding Delete call for each of Add calls (effectively
 	// when refcount was reduced to zero).
-	DeleteReference(namespace, name string)
+	DeleteReference(namespace, name string, podUID types.UID)
 	// Get an object from a store.
 	Get(namespace, name string) (runtime.Object, error)
+	// GetPodsNeedSyncObjects gets pods that need syncing objects.
+	GetPodsNeedSyncObjects() []types.UID
 }

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -171,6 +171,7 @@ func (dswp *desiredStateOfWorldPopulator) HasAddedPods() bool {
 func (dswp *desiredStateOfWorldPopulator) populatorLoop() {
 	dswp.findAndAddNewPods()
 	dswp.findAndRemoveDeletedPods()
+	dswp.findPodsNeedSyncVolumes()
 }
 
 // Iterate through all pods and add to desired state of world if they don't
@@ -261,6 +262,14 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods() {
 		if _, podExists := dswp.podManager.GetPodByUID(types.UID(podName)); !podExists {
 			dswp.desiredStateOfWorld.PopPodErrors(podName)
 		}
+	}
+}
+
+// findPodsNeedSyncVolumes get pods that needs reprocess volumes from volume host, and mark
+// them unprocessed.
+func (dswp *desiredStateOfWorldPopulator) findPodsNeedSyncVolumes() {
+	for _, podUID := range dswp.volumePluginMgr.Host.GetPodsNeedSyncVolumes() {
+		dswp.markPodProcessingFailed(volumetypes.UniquePodName(podUID))
 	}
 }
 

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -446,6 +446,9 @@ type VolumeHost interface {
 
 	// Returns options to pass for proxyutil filtered dialers.
 	GetFilteredDialOptions() *proxyutil.FilteredDialOptions
+
+	// Returns pods that need syncing volumes.
+	GetPodsNeedSyncVolumes() []types.UID
 }
 
 // VolumePluginMgr tracks registered plugins.

--- a/pkg/volume/testing/volume_host.go
+++ b/pkg/volume/testing/volume_host.go
@@ -244,6 +244,10 @@ func (f *fakeVolumeHost) GetEventRecorder() record.EventRecorder {
 	return nil
 }
 
+func (f *fakeVolumeHost) GetPodsNeedSyncVolumes() []types.UID {
+	return nil
+}
+
 func (f *fakeVolumeHost) ScriptCommands(scripts []CommandScript) {
 	ScriptCommands(f.exec, scripts)
 }

--- a/test/integration/kubelet/watch_manager_test.go
+++ b/test/integration/kubelet/watch_manager_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -107,7 +108,7 @@ func TestWatchBasedManager(t *testing.T) {
 			for j := 0; j < 100; j++ {
 				name := fmt.Sprintf("s%d", i*100+j)
 				start := time.Now()
-				store.AddReference(testNamespace, name)
+				store.AddReference(testNamespace, name, (types.UID)(name))
 				err := wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (bool, error) {
 					obj, err := store.Get(testNamespace, name)
 					if err != nil {


### PR DESCRIPTION
Changes:
  1. Add "GetPodsNeedSyncVolumes() []types.UID" in interface VolumeHost. "GetPodsNeedSyncVolumes()" returns a list of Pods that needs remounting volumes.
  2. Use undeltaCache in watch strategy, to record the refed Pods while configMap/secret changes.
  3. Add interface in Manager and Store, in order to enable kubeletVolumeHost(in 1) to access the changes(made in 2).
  4. VolumesManager will call "GetPodsNeedSyncVolumes()" every loop and get pod list, then mark the pods unprocessed.

Signed-off-by: Ruquan Zhao <ruquan.zhao@arm.com>
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds a update mode for configmaps and secrets when used as volumes, which could reduce the sync-up time when configmaps/secrets changes.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubernetes/kubernetes/issues/113746
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
