### PR TITLE
create --from is used to manually trigger CronJobs

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
@@ -33,6 +33,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -107,6 +108,19 @@ func NewCmdCreateJob(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *c
 	cmd.Flags().StringVar(&o.Image, "image", o.Image, "Image name to run.")
 	cmd.Flags().StringVar(&o.From, "from", o.From, "The name of the resource to create a Job from (only cronjob is supported).")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
+
+	// Completion for relevant flags
+	cmdutil.CheckErr(cmd.RegisterFlagCompletionFunc(
+		"from",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			var completions []string
+			crons := completion.CompGetResource(f, "cronjob", "")
+			for _, name := range crons {
+				completions = append(completions, fmt.Sprintf("cronjob/%s", name))
+			}
+			return completions, cobra.ShellCompDirectiveNoFileComp
+		}))
+
 	return cmd
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
create --from is used to manually trigger CronJobs, when tab completion enables a much faster flow.

#### Which issue(s) this PR fixes:

Fixes #[1399](https://github.com/kubernetes/kubectl/issues/1399)

#### Special notes for your reviewer:

`source <(./kubectl completion zsh)`

#### Does this PR introduce a user-facing change?
original:

```
>>> ./kubectl create job demo --from 
kubectl*  ncpu* 
```

updated:
```
>>> ./kubectl create job demo --from cronjob/
cronjob/hello   cronjob/my-job
>>> ./kubectl create job demo --from cronjob/hello         
job.batch/demo created
```



```release-note

```


