### PR TITLE
Include stderr in cred provider plugin errors

### DIFF
--- a/pkg/credentialprovider/plugin/plugin.go
+++ b/pkg/credentialprovider/plugin/plugin.go
@@ -410,7 +410,7 @@ func (e *execPlugin) ExecPlugin(ctx context.Context, image string) (*credentialp
 	cmd.Env = mergeEnvVars(e.environ(), configEnvVars)
 
 	if err = e.runPlugin(ctx, cmd, image); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", err, stderr.String())
 	}
 
 	data = stdout.Bytes()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

This is a small quality-of-life thing.

#### What this PR does / why we need it:

This PR includes stderr in the error returned after failing to invoke a credential provider exec plugin. Failure in these external plugins (due to mismatched `apiVersion`, for example) currently only results in a generic log line:
 ```
plugin.go:233] Failed getting credential from external registry credential provider: error execing credential provider plugin foo for image bar: exit status 1
```

After this PR, the message will include more details. For example:
```
plugin.go:233] Failed getting credential from external registry credential provider: error execing credential provider plugin foo for image bar: exit status 1: E0418 06:12:14.490885   14903 main.go:161] Error running credential provider plugin: group version credentialprovider.kubelet.k8s.io/v1beta1 is not supported
```

Determining why a credential provider plugin failed is otherwise somewhat obtuse. I've done this by placing a logging shim between kubelet and the provider, but this PR makes such an effort unnecessary.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

While the credential provider does return secrets via standard output, which should *never* be logged by kubelet -- secrets should not be logged to standard error. If we need to explicitly document this in the credential provider contract, we can do that.

#### Does this PR introduce a user-facing change?

```release-note
External credential provider plugins now have their standard error output logged by kubelet upon failures.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
