### PR TITLE
Automated cherry pick of #117453: Fix stomping os env in kubectl e2e tests

### DIFF
--- a/test/e2e/framework/kubectl/builder.go
+++ b/test/e2e/framework/kubectl/builder.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"os"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -48,9 +49,12 @@ func NewKubectlCommand(namespace string, args ...string) *KubectlBuilder {
 	return b
 }
 
-// WithEnv sets the given environment and returns itself.
-func (b *KubectlBuilder) WithEnv(env []string) *KubectlBuilder {
-	b.cmd.Env = env
+// WithEnv appends the given environment and returns itself.
+func (b *KubectlBuilder) AppendEnv(env []string) *KubectlBuilder {
+	if b.cmd.Env == nil {
+		b.cmd.Env = os.Environ()
+	}
+	b.cmd.Env = append(b.cmd.Env, env...)
 	return b
 }
 

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -487,7 +487,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 				proxyLogs.Reset()
 				ginkgo.By("Running kubectl via an HTTP proxy using " + proxyVar)
 				output := e2ekubectl.NewKubectlCommand(ns, "exec", podRunningTimeoutArg, simplePodName, "--", "echo", "running", "in", "container").
-					WithEnv(append(os.Environ(), fmt.Sprintf("%s=%s", proxyVar, proxyAddr))).
+					AppendEnv(append(os.Environ(), fmt.Sprintf("%s=%s", proxyVar, proxyAddr))).
 					ExecOrDie(ns)
 
 				// Verify we got the normal output captured by the exec server
@@ -868,7 +868,7 @@ metadata:
 
 			manifest1 = strings.ReplaceAll(manifest1, "{{ns}}", ns)
 			args := []string{"apply", "--prune", "--applyset=applyset1", "-f", "-"}
-			e2ekubectl.NewKubectlCommand(ns, args...).WithEnv([]string{"KUBECTL_APPLYSET=true"}).WithStdinData(manifest1).ExecOrDie(ns)
+			e2ekubectl.NewKubectlCommand(ns, args...).AppendEnv([]string{"KUBECTL_APPLYSET=true"}).WithStdinData(manifest1).ExecOrDie(ns)
 
 			framework.Logf("checking which objects exist")
 			objects := mustListObjectsInNamespace(ctx, c, ns)
@@ -887,7 +887,7 @@ metadata:
 `
 			manifest2 = strings.ReplaceAll(manifest2, "{{ns}}", ns)
 
-			e2ekubectl.NewKubectlCommand(ns, args...).WithEnv([]string{"KUBECTL_APPLYSET=true"}).WithStdinData(manifest2).ExecOrDie(ns)
+			e2ekubectl.NewKubectlCommand(ns, args...).AppendEnv([]string{"KUBECTL_APPLYSET=true"}).WithStdinData(manifest2).ExecOrDie(ns)
 
 			framework.Logf("checking which objects exist")
 			objects = mustListObjectsInNamespace(ctx, c, ns)
@@ -897,7 +897,7 @@ metadata:
 			}
 
 			framework.Logf("applying manifest2 (again)")
-			e2ekubectl.NewKubectlCommand(ns, args...).WithEnv([]string{"KUBECTL_APPLYSET=true"}).WithStdinData(manifest2).ExecOrDie(ns)
+			e2ekubectl.NewKubectlCommand(ns, args...).AppendEnv([]string{"KUBECTL_APPLYSET=true"}).WithStdinData(manifest2).ExecOrDie(ns)
 
 			framework.Logf("checking which objects exist")
 			objects = mustListObjectsInNamespace(ctx, c, ns)


### PR DESCRIPTION
Cherry pick of #117453 on release-1.27.

#117453: Fix stomping os env in kubectl e2e tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```