### PR TITLE
Avoid volume copy in checkAttachableInlineVolume

### DIFF
--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -172,7 +172,7 @@ func (pl *CSILimits) filterAttachableVolumes(
 			// - If the volume is migratable and CSI migration is enabled, need to count it
 			// as well.
 			// - If the volume is not migratable, it will be count in non_csi filter.
-			if err := pl.checkAttachableInlineVolume(vol, csiNode, pod, result); err != nil {
+			if err := pl.checkAttachableInlineVolume(&vol, csiNode, pod, result); err != nil {
 				return err
 			}
 
@@ -220,15 +220,15 @@ func (pl *CSILimits) filterAttachableVolumes(
 
 // checkAttachableInlineVolume takes an inline volume and add to the result map if the
 // volume is migratable and CSI migration for this plugin has been enabled.
-func (pl *CSILimits) checkAttachableInlineVolume(vol v1.Volume, csiNode *storagev1.CSINode,
+func (pl *CSILimits) checkAttachableInlineVolume(vol *v1.Volume, csiNode *storagev1.CSINode,
 	pod *v1.Pod, result map[string]string) error {
-	if !pl.translator.IsInlineMigratable(&vol) {
+	if !pl.translator.IsInlineMigratable(vol) {
 		return nil
 	}
 	// Check if the intree provisioner CSI migration has been enabled.
-	inTreeProvisionerName, err := pl.translator.GetInTreePluginNameFromSpec(nil, &vol)
+	inTreeProvisionerName, err := pl.translator.GetInTreePluginNameFromSpec(nil, vol)
 	if err != nil {
-		return fmt.Errorf("looking up provisioner name for volume %v: %w", vol, err)
+		return fmt.Errorf("looking up provisioner name for volume %s: %w", vol.Name, err)
 	}
 	if !isCSIMigrationOn(csiNode, inTreeProvisionerName) {
 		csiNodeName := ""
@@ -240,9 +240,9 @@ func (pl *CSILimits) checkAttachableInlineVolume(vol v1.Volume, csiNode *storage
 		return nil
 	}
 	// Do translation for the in-tree volume.
-	translatedPV, err := pl.translator.TranslateInTreeInlineVolumeToCSI(&vol, pod.Namespace)
+	translatedPV, err := pl.translator.TranslateInTreeInlineVolumeToCSI(vol, pod.Namespace)
 	if err != nil || translatedPV == nil {
-		return fmt.Errorf("converting volume(%v) from inline to csi: %w", vol, err)
+		return fmt.Errorf("converting volume(%s) from inline to csi: %w", vol.Name, err)
 	}
 	driverName, err := pl.translator.GetCSINameFromInTreeName(inTreeProvisionerName)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Changes type of checkAttachableInlineVolume parameter to avoid making copy of volume.

This has popped out on some cpu pprofs, probably not significant cost, but also the fix is trivial.

/assign @alculquicondor 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
