### PR TITLE
Support the "ephemeralcontainers" subresource in edit, get, patch, and replace

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -139,7 +139,7 @@ const (
 	useServerPrintColumns = "server-print"
 )
 
-var supportedSubresources = []string{"status", "scale"}
+var supportedSubresources = []string{"status", "scale", "ephemeralcontainers"}
 
 // NewGetOptions returns a GetOptions with default chunk size 500.
 func NewGetOptions(parent string, streams genericiooptions.IOStreams) *GetOptions {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -106,7 +106,7 @@ var (
 		kubectl patch deployment nginx-deployment --subresource='scale' --type='merge' -p '{"spec":{"replicas":2}}'`))
 )
 
-var supportedSubresources = []string{"status", "scale"}
+var supportedSubresources = []string{"status", "scale", "ephemeralcontainers"}
 
 func NewPatchOptions(ioStreams genericiooptions.IOStreams) *PatchOptions {
 	return &PatchOptions{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
@@ -68,7 +68,7 @@ var (
 		kubectl replace --force -f ./pod.json`))
 )
 
-var supportedSubresources = []string{"status", "scale"}
+var supportedSubresources = []string{"status", "scale", "ephemeralcontainers"}
 
 type ReplaceOptions struct {
 	PrintFlags  *genericclioptions.PrintFlags

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
@@ -55,7 +55,7 @@ import (
 	"k8s.io/kubectl/pkg/util/slice"
 )
 
-var SupportedSubresources = []string{"status"}
+var SupportedSubresources = []string{"status", "ephemeralcontainers"}
 
 // EditOptions contains all the options for running edit cli command.
 type EditOptions struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature


#### What this PR does / why we need it:
Allows `kubectl` users to use commands with the `ephemeralcontainers` subresource.

~For example, `kubectl debug` does not allow a user to patch the ephemeral container's security context. An alternative is to use `kubectl patch`, e..g.:~ As of 1.27, `kubectl debug` allows the user to use "profiles" to set the ephemeral container's security context. But `kubectl patch` is useful for additional customization of ephemeral containers, and that's enabled by this PR.

```console
kubectl patch pod/example --subresource=ephemeralcontainers --patch '{"spec":{"ephemeralContainers":[{"image":"docker.io/busybox:1.36.0","name":"test","command":["sleep"
],"args":["infinity"],"tty":true,"stdin":true,"securityContext":{"capabilities":{"add":["SYS_PTRACE"]}},"targetContainerName":"example"}]}}'
```

The above example works with this PR, but fails in master.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

I'm not sure that the "supported subresources" constraint is necessary. If I can make a case for removing it, I'll file a separate PR.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added the `ephemeralcontainers` subresource to the kubectl `edit`, `get`, `patch`, and `replace` commands. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:


- [Other doc]: <link>
- [KEP]:  <link>
- [Usage]:  <link>
-->
```docs

```
