### PR TITLE
Remove deprecate sets.String from client-go

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
@@ -375,12 +375,12 @@ func TestCachedDiscoveryClientUnaggregatedServerGroups(t *testing.T) {
 		expectedGroupNames := sets.New[string](test.expectedGroupNames...)
 		actualGroupNames := sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
+			"%s: Expected groups (%s), got (%s)", test.name, sets.List[string](expectedGroupNames), sets.List[string](actualGroupNames))
 		// Test the expected group versions for the aggregated discovery is correct.
 		expectedGroupVersions := sets.New[string](test.expectedGroupVersions...)
 		actualGroupVersions := sets.New[string](groupVersionsFromGroups(apiGroupList)...)
 		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
-			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.UnsortedList(), actualGroupVersions.UnsortedList())
+			"%s: Expected group/versions (%s), got (%s)", test.name, sets.List[string](expectedGroupVersions), sets.List[string](actualGroupVersions))
 	}
 }
 
@@ -666,17 +666,17 @@ func TestCachedDiscoveryClientAggregatedServerGroups(t *testing.T) {
 		expectedGroupNames := sets.New[string](test.expectedGroupNames...)
 		actualGroupNames := sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
+			"%s: Expected groups (%s), got (%s)", test.name, sets.List[string](expectedGroupNames), sets.List[string](actualGroupNames))
 		// Test the expected group versions for the aggregated discovery is correct.
 		expectedGroupVersions := sets.New[string](test.expectedGroupVersions...)
 		actualGroupVersions := sets.New[string](groupVersionsFromGroups(apiGroupList)...)
 		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
-			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.UnsortedList(), actualGroupVersions.UnsortedList())
+			"%s: Expected group/versions (%s), got (%s)", test.name, sets.List[string](expectedGroupVersions), sets.List[string](actualGroupVersions))
 		// Test the groups preferred version is correct.
 		expectedPreferredVersions := sets.New[string](test.expectedPreferredVersions...)
 		actualPreferredVersions := sets.New[string](preferredVersionsFromList(apiGroupList)...)
 		assert.True(t, expectedPreferredVersions.Equal(actualPreferredVersions),
-			"%s: Expected preferred group/version (%s), got (%s)", test.name, expectedPreferredVersions.UnsortedList(), actualPreferredVersions.UnsortedList())
+			"%s: Expected preferred group/version (%s), got (%s)", test.name, sets.List[string](expectedPreferredVersions), sets.List[string](actualPreferredVersions))
 	}
 }
 

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
@@ -372,15 +372,15 @@ func TestCachedDiscoveryClientUnaggregatedServerGroups(t *testing.T) {
 		assert.Equal(t, 1, numFound,
 			"%s: expected 1 discovery cache file servergroups.json found, got %d", test.name, numFound)
 		// Test expected groups returned by server groups.
-		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
-		actualGroupNames := sets.NewString(groupNamesFromList(apiGroupList)...)
+		expectedGroupNames := sets.New[string](test.expectedGroupNames...)
+		actualGroupNames := sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
+			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
 		// Test the expected group versions for the aggregated discovery is correct.
-		expectedGroupVersions := sets.NewString(test.expectedGroupVersions...)
-		actualGroupVersions := sets.NewString(groupVersionsFromGroups(apiGroupList)...)
+		expectedGroupVersions := sets.New[string](test.expectedGroupVersions...)
+		actualGroupVersions := sets.New[string](groupVersionsFromGroups(apiGroupList)...)
 		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
-			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.List(), actualGroupVersions.List())
+			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.UnsortedList(), actualGroupVersions.UnsortedList())
 	}
 }
 
@@ -663,20 +663,20 @@ func TestCachedDiscoveryClientAggregatedServerGroups(t *testing.T) {
 		assert.Equal(t, 1, numFound,
 			"%s: expected 1 discovery cache file servergroups.json found, got %d", test.name, numFound)
 		// Test expected groups returned by server groups.
-		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
-		actualGroupNames := sets.NewString(groupNamesFromList(apiGroupList)...)
+		expectedGroupNames := sets.New[string](test.expectedGroupNames...)
+		actualGroupNames := sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
+			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
 		// Test the expected group versions for the aggregated discovery is correct.
-		expectedGroupVersions := sets.NewString(test.expectedGroupVersions...)
-		actualGroupVersions := sets.NewString(groupVersionsFromGroups(apiGroupList)...)
+		expectedGroupVersions := sets.New[string](test.expectedGroupVersions...)
+		actualGroupVersions := sets.New[string](groupVersionsFromGroups(apiGroupList)...)
 		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
-			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.List(), actualGroupVersions.List())
+			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.UnsortedList(), actualGroupVersions.UnsortedList())
 		// Test the groups preferred version is correct.
-		expectedPreferredVersions := sets.NewString(test.expectedPreferredVersions...)
-		actualPreferredVersions := sets.NewString(preferredVersionsFromList(apiGroupList)...)
+		expectedPreferredVersions := sets.New[string](test.expectedPreferredVersions...)
+		actualPreferredVersions := sets.New[string](preferredVersionsFromList(apiGroupList)...)
 		assert.True(t, expectedPreferredVersions.Equal(actualPreferredVersions),
-			"%s: Expected preferred group/version (%s), got (%s)", test.name, expectedPreferredVersions.List(), actualPreferredVersions.List())
+			"%s: Expected preferred group/version (%s), got (%s)", test.name, expectedPreferredVersions.UnsortedList(), actualPreferredVersions.UnsortedList())
 	}
 }
 

--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
@@ -608,15 +608,15 @@ func TestMemCacheGroupsAndMaybeResources(t *testing.T) {
 		assert.False(t, memClient.receivedAggregatedDiscovery)
 		assert.True(t, memClient.Fresh())
 		// Test the expected groups are returned for the aggregated format.
-		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
-		actualGroupNames := sets.NewString(groupNamesFromList(apiGroupList)...)
+		expectedGroupNames := sets.New[string](test.expectedGroupNames...)
+		actualGroupNames := sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
+			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
 		// Test the expected group versions for the aggregated discovery is correct.
-		expectedGroupVersions := sets.NewString(test.expectedGroupVersions...)
-		actualGroupVersions := sets.NewString(groupVersionsFromGroups(apiGroupList)...)
+		expectedGroupVersions := sets.New[string](test.expectedGroupVersions...)
+		actualGroupVersions := sets.New[string](groupVersionsFromGroups(apiGroupList)...)
 		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
-			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.List(), actualGroupVersions.List())
+			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.UnsortedList(), actualGroupVersions.UnsortedList())
 		// Invalidate the cache and retrieve the server groups and resources again.
 		memClient.Invalidate()
 		assert.False(t, memClient.Fresh())
@@ -625,9 +625,9 @@ func TestMemCacheGroupsAndMaybeResources(t *testing.T) {
 		assert.Nil(t, resourcesMap)
 		assert.False(t, memClient.receivedAggregatedDiscovery)
 		// Test the expected groups are returned for the aggregated format.
-		actualGroupNames = sets.NewString(groupNamesFromList(apiGroupList)...)
+		actualGroupNames = sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected after invalidation groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
+			"%s: Expected after invalidation groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
 	}
 }
 
@@ -1134,38 +1134,38 @@ func TestAggregatedMemCacheGroupsAndMaybeResources(t *testing.T) {
 		assert.True(t, memClient.receivedAggregatedDiscovery)
 		assert.True(t, memClient.Fresh())
 		// Test the expected groups are returned for the aggregated format.
-		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
-		actualGroupNames := sets.NewString(groupNamesFromList(apiGroupList)...)
+		expectedGroupNames := sets.New[string](test.expectedGroupNames...)
+		actualGroupNames := sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
+			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
 		// Test the expected group versions for the aggregated discovery is correct.
-		expectedGroupVersions := sets.NewString(test.expectedGroupVersions...)
-		actualGroupVersions := sets.NewString(groupVersionsFromGroups(apiGroupList)...)
+		expectedGroupVersions := sets.New[string](test.expectedGroupVersions...)
+		actualGroupVersions := sets.New[string](groupVersionsFromGroups(apiGroupList)...)
 		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
-			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.List(), actualGroupVersions.List())
+			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.UnsortedList(), actualGroupVersions.UnsortedList())
 		// Test the resources are correct.
-		expectedGVKs := sets.NewString(test.expectedGVKs...)
+		expectedGVKs := sets.New[string](test.expectedGVKs...)
 		resources := []*metav1.APIResourceList{}
 		for _, resourceList := range resourcesMap {
 			resources = append(resources, resourceList)
 		}
-		actualGVKs := sets.NewString(groupVersionKinds(resources)...)
+		actualGVKs := sets.New[string](groupVersionKinds(resources)...)
 		assert.True(t, expectedGVKs.Equal(actualGVKs),
-			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.List(), actualGVKs.List())
+			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.UnsortedList(), actualGVKs.UnsortedList())
 		// Test the returned failed GroupVersions are correct.
-		expectedFailedGVs := sets.NewString(test.expectedFailedGVs...)
-		actualFailedGVs := sets.NewString(failedGroupVersions(failedGVs)...)
+		expectedFailedGVs := sets.New[string](test.expectedFailedGVs...)
+		actualFailedGVs := sets.New[string](failedGroupVersions(failedGVs)...)
 		assert.True(t, expectedFailedGVs.Equal(actualFailedGVs),
-			"%s: Expected Failed GroupVersions (%s), got (%s)", test.name, expectedFailedGVs.List(), actualFailedGVs.List())
+			"%s: Expected Failed GroupVersions (%s), got (%s)", test.name, expectedFailedGVs.UnsortedList(), actualFailedGVs.UnsortedList())
 		// Invalidate the cache and retrieve the server groups again.
 		memClient.Invalidate()
 		assert.False(t, memClient.Fresh())
 		apiGroupList, _, _, err = memClient.GroupsAndMaybeResources()
 		require.NoError(t, err)
 		// Test the expected groups are returned for the aggregated format.
-		actualGroupNames = sets.NewString(groupNamesFromList(apiGroupList)...)
+		actualGroupNames = sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected after invalidation groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
+			"%s: Expected after invalidation groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
 	}
 }
 
@@ -1427,29 +1427,29 @@ func TestMemCacheAggregatedServerGroups(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, memCacheClient.Fresh())
 		// Test the expected groups are returned for the aggregated format.
-		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
-		actualGroupNames := sets.NewString(groupNamesFromList(apiGroupList)...)
+		expectedGroupNames := sets.New[string](test.expectedGroupNames...)
+		actualGroupNames := sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
+			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
 		// Test the expected group versions for the aggregated discovery is correct.
-		expectedGroupVersions := sets.NewString(test.expectedGroupVersions...)
-		actualGroupVersions := sets.NewString(groupVersionsFromGroups(apiGroupList)...)
+		expectedGroupVersions := sets.New[string](test.expectedGroupVersions...)
+		actualGroupVersions := sets.New[string](groupVersionsFromGroups(apiGroupList)...)
 		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
-			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.List(), actualGroupVersions.List())
+			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.UnsortedList(), actualGroupVersions.UnsortedList())
 		// Test the groups preferred version is correct.
-		expectedPreferredVersions := sets.NewString(test.expectedPreferredVersions...)
-		actualPreferredVersions := sets.NewString(preferredVersionsFromList(apiGroupList)...)
+		expectedPreferredVersions := sets.New[string](test.expectedPreferredVersions...)
+		actualPreferredVersions := sets.New[string](preferredVersionsFromList(apiGroupList)...)
 		assert.True(t, expectedPreferredVersions.Equal(actualPreferredVersions),
-			"%s: Expected preferred group/version (%s), got (%s)", test.name, expectedPreferredVersions.List(), actualPreferredVersions.List())
+			"%s: Expected preferred group/version (%s), got (%s)", test.name, expectedPreferredVersions.UnsortedList(), actualPreferredVersions.UnsortedList())
 		// Invalidate the cache and retrieve the server groups again.
 		memCacheClient.Invalidate()
 		assert.False(t, memCacheClient.Fresh())
 		apiGroupList, err = memCacheClient.ServerGroups()
 		require.NoError(t, err)
 		// Test the expected groups are returned for the aggregated format.
-		actualGroupNames = sets.NewString(groupNamesFromList(apiGroupList)...)
+		actualGroupNames = sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected after invalidation groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
+			"%s: Expected after invalidation groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
 	}
 }
 

--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
@@ -611,12 +611,12 @@ func TestMemCacheGroupsAndMaybeResources(t *testing.T) {
 		expectedGroupNames := sets.New[string](test.expectedGroupNames...)
 		actualGroupNames := sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
+			"%s: Expected groups (%s), got (%s)", test.name, sets.List[string](expectedGroupNames), sets.List[string](actualGroupNames))
 		// Test the expected group versions for the aggregated discovery is correct.
 		expectedGroupVersions := sets.New[string](test.expectedGroupVersions...)
 		actualGroupVersions := sets.New[string](groupVersionsFromGroups(apiGroupList)...)
 		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
-			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.UnsortedList(), actualGroupVersions.UnsortedList())
+			"%s: Expected group/versions (%s), got (%s)", test.name, sets.List[string](expectedGroupVersions), sets.List[string](actualGroupVersions))
 		// Invalidate the cache and retrieve the server groups and resources again.
 		memClient.Invalidate()
 		assert.False(t, memClient.Fresh())
@@ -627,7 +627,7 @@ func TestMemCacheGroupsAndMaybeResources(t *testing.T) {
 		// Test the expected groups are returned for the aggregated format.
 		actualGroupNames = sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected after invalidation groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
+			"%s: Expected after invalidation groups (%s), got (%s)", test.name, sets.List[string](expectedGroupNames), sets.List[string](actualGroupNames))
 	}
 }
 
@@ -1137,12 +1137,12 @@ func TestAggregatedMemCacheGroupsAndMaybeResources(t *testing.T) {
 		expectedGroupNames := sets.New[string](test.expectedGroupNames...)
 		actualGroupNames := sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
+			"%s: Expected groups (%s), got (%s)", test.name, sets.List[string](expectedGroupNames), sets.List[string](actualGroupNames))
 		// Test the expected group versions for the aggregated discovery is correct.
 		expectedGroupVersions := sets.New[string](test.expectedGroupVersions...)
 		actualGroupVersions := sets.New[string](groupVersionsFromGroups(apiGroupList)...)
 		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
-			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.UnsortedList(), actualGroupVersions.UnsortedList())
+			"%s: Expected group/versions (%s), got (%s)", test.name, sets.List[string](expectedGroupVersions), sets.List[string](actualGroupVersions))
 		// Test the resources are correct.
 		expectedGVKs := sets.New[string](test.expectedGVKs...)
 		resources := []*metav1.APIResourceList{}
@@ -1151,12 +1151,12 @@ func TestAggregatedMemCacheGroupsAndMaybeResources(t *testing.T) {
 		}
 		actualGVKs := sets.New[string](groupVersionKinds(resources)...)
 		assert.True(t, expectedGVKs.Equal(actualGVKs),
-			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.UnsortedList(), actualGVKs.UnsortedList())
+			"%s: Expected GVKs (%s), got (%s)", test.name, sets.List[string](expectedGVKs), sets.List[string](actualGVKs))
 		// Test the returned failed GroupVersions are correct.
 		expectedFailedGVs := sets.New[string](test.expectedFailedGVs...)
 		actualFailedGVs := sets.New[string](failedGroupVersions(failedGVs)...)
 		assert.True(t, expectedFailedGVs.Equal(actualFailedGVs),
-			"%s: Expected Failed GroupVersions (%s), got (%s)", test.name, expectedFailedGVs.UnsortedList(), actualFailedGVs.UnsortedList())
+			"%s: Expected Failed GroupVersions (%s), got (%s)", test.name, sets.List[string](expectedFailedGVs), sets.List[string](actualFailedGVs))
 		// Invalidate the cache and retrieve the server groups again.
 		memClient.Invalidate()
 		assert.False(t, memClient.Fresh())
@@ -1165,7 +1165,7 @@ func TestAggregatedMemCacheGroupsAndMaybeResources(t *testing.T) {
 		// Test the expected groups are returned for the aggregated format.
 		actualGroupNames = sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected after invalidation groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
+			"%s: Expected after invalidation groups (%s), got (%s)", test.name, sets.List[string](expectedGroupNames), sets.List[string](actualGroupNames))
 	}
 }
 
@@ -1430,17 +1430,17 @@ func TestMemCacheAggregatedServerGroups(t *testing.T) {
 		expectedGroupNames := sets.New[string](test.expectedGroupNames...)
 		actualGroupNames := sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
+			"%s: Expected groups (%s), got (%s)", test.name, sets.List[string](expectedGroupNames), sets.List[string](actualGroupNames))
 		// Test the expected group versions for the aggregated discovery is correct.
 		expectedGroupVersions := sets.New[string](test.expectedGroupVersions...)
 		actualGroupVersions := sets.New[string](groupVersionsFromGroups(apiGroupList)...)
 		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
-			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.UnsortedList(), actualGroupVersions.UnsortedList())
+			"%s: Expected group/versions (%s), got (%s)", test.name, sets.List[string](expectedGroupVersions), sets.List[string](actualGroupVersions))
 		// Test the groups preferred version is correct.
 		expectedPreferredVersions := sets.New[string](test.expectedPreferredVersions...)
 		actualPreferredVersions := sets.New[string](preferredVersionsFromList(apiGroupList)...)
 		assert.True(t, expectedPreferredVersions.Equal(actualPreferredVersions),
-			"%s: Expected preferred group/version (%s), got (%s)", test.name, expectedPreferredVersions.UnsortedList(), actualPreferredVersions.UnsortedList())
+			"%s: Expected preferred group/version (%s), got (%s)", test.name, sets.List[string](expectedPreferredVersions), sets.List[string](actualPreferredVersions))
 		// Invalidate the cache and retrieve the server groups again.
 		memCacheClient.Invalidate()
 		assert.False(t, memCacheClient.Fresh())
@@ -1449,7 +1449,7 @@ func TestMemCacheAggregatedServerGroups(t *testing.T) {
 		// Test the expected groups are returned for the aggregated format.
 		actualGroupNames = sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected after invalidation groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
+			"%s: Expected after invalidation groups (%s), got (%s)", test.name, sets.List[string](expectedGroupNames), sets.List[string](actualGroupNames))
 	}
 }
 

--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -1407,17 +1407,17 @@ func TestAggregatedServerGroups(t *testing.T) {
 		expectedGroupNames := sets.New[string](test.expectedGroupNames...)
 		actualGroupNames := sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
+			"%s: Expected groups (%s), got (%s)", test.name, sets.List[string](expectedGroupNames), sets.List[string](actualGroupNames))
 		// Test the expected group versions for the aggregated discovery is correct.
 		expectedGroupVersions := sets.New[string](test.expectedGroupVersions...)
 		actualGroupVersions := sets.New[string](groupVersionsFromGroups(apiGroupList)...)
 		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
-			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.UnsortedList(), actualGroupVersions.UnsortedList())
+			"%s: Expected group/versions (%s), got (%s)", test.name, sets.List[string](expectedGroupVersions), sets.List[string](actualGroupVersions))
 		// Test the groups preferred version is correct.
 		expectedPreferredVersions := sets.New[string](test.expectedPreferredVersions...)
 		actualPreferredVersions := sets.New[string](preferredVersionsFromList(apiGroupList)...)
 		assert.True(t, expectedPreferredVersions.Equal(actualPreferredVersions),
-			"%s: Expected preferred group/version (%s), got (%s)", test.name, expectedPreferredVersions.UnsortedList(), actualPreferredVersions.UnsortedList())
+			"%s: Expected preferred group/version (%s), got (%s)", test.name, sets.List[string](expectedPreferredVersions), sets.List[string](actualPreferredVersions))
 	}
 }
 
@@ -2005,7 +2005,7 @@ func TestAggregatedServerGroupsAndResources(t *testing.T) {
 		expectedGroupNames := sets.New[string](test.expectedGroupNames...)
 		actualGroupNames := sets.New[string](groupNames(apiGroups)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
+			"%s: Expected GVKs (%s), got (%s)", test.name, sets.List[string](expectedGroupNames), sets.List[string](actualGroupNames))
 		// If the core V1 group is returned from /api, it should be the first group.
 		if expectedGroupNames.Has("") {
 			assert.True(t, len(apiGroups) > 0)
@@ -2018,12 +2018,12 @@ func TestAggregatedServerGroupsAndResources(t *testing.T) {
 		expectedGroupVersions := sets.New[string](test.expectedGroupVersions...)
 		actualGroupVersions := sets.New[string](groupVersions(resources)...)
 		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
-			"%s: Expected GroupVersions(%s), got (%s)", test.name, expectedGroupVersions.UnsortedList(), actualGroupVersions.UnsortedList())
+			"%s: Expected GroupVersions(%s), got (%s)", test.name, sets.List[string](expectedGroupVersions), sets.List[string](actualGroupVersions))
 		// Test the expected GVKs are returned from the aggregated discovery.
 		expectedGVKs := sets.New[string](test.expectedGVKs...)
 		actualGVKs := sets.New[string](groupVersionKinds(resources)...)
 		assert.True(t, expectedGVKs.Equal(actualGVKs),
-			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.UnsortedList(), actualGVKs.UnsortedList())
+			"%s: Expected GVKs (%s), got (%s)", test.name, sets.List[string](expectedGVKs), sets.List[string](actualGVKs))
 	}
 }
 
@@ -2143,12 +2143,12 @@ func TestAggregatedServerGroupsAndResourcesWithErrors(t *testing.T) {
 		expectedGroups := sets.New[string](test.expectedGroups...)
 		actualGroups := sets.New[string](groupNames(apiGroups)...)
 		assert.True(t, expectedGroups.Equal(actualGroups),
-			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGroups.UnsortedList(), actualGroups.UnsortedList())
+			"%s: Expected GVKs (%s), got (%s)", test.name, sets.List[string](expectedGroups), sets.List[string](actualGroups))
 		// Next check the returned resources
 		expectedGVKs := sets.New[string](test.expectedResources...)
 		actualGVKs := sets.New[string](groupVersionKinds(resources)...)
 		assert.True(t, expectedGVKs.Equal(actualGVKs),
-			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.UnsortedList(), actualGVKs.UnsortedList())
+			"%s: Expected GVKs (%s), got (%s)", test.name, sets.List[string](expectedGVKs), sets.List[string](actualGVKs))
 	}
 }
 
@@ -2753,7 +2753,7 @@ func TestAggregatedServerPreferredResources(t *testing.T) {
 		expectedGVKs := sets.New[string](test.expectedGVKs...)
 		actualGVKs := sets.New[string](groupVersionKinds(resources)...)
 		assert.True(t, expectedGVKs.Equal(actualGVKs),
-			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.UnsortedList(), actualGVKs.UnsortedList())
+			"%s: Expected GVKs (%s), got (%s)", test.name, sets.List[string](expectedGVKs), sets.List[string](actualGVKs))
 	}
 }
 

--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -1404,20 +1404,20 @@ func TestAggregatedServerGroups(t *testing.T) {
 		apiGroupList, err := client.ServerGroups()
 		require.NoError(t, err)
 		// Test the expected groups are returned for the aggregated format.
-		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
-		actualGroupNames := sets.NewString(groupNamesFromList(apiGroupList)...)
+		expectedGroupNames := sets.New[string](test.expectedGroupNames...)
+		actualGroupNames := sets.New[string](groupNamesFromList(apiGroupList)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
+			"%s: Expected groups (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
 		// Test the expected group versions for the aggregated discovery is correct.
-		expectedGroupVersions := sets.NewString(test.expectedGroupVersions...)
-		actualGroupVersions := sets.NewString(groupVersionsFromGroups(apiGroupList)...)
+		expectedGroupVersions := sets.New[string](test.expectedGroupVersions...)
+		actualGroupVersions := sets.New[string](groupVersionsFromGroups(apiGroupList)...)
 		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
-			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.List(), actualGroupVersions.List())
+			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.UnsortedList(), actualGroupVersions.UnsortedList())
 		// Test the groups preferred version is correct.
-		expectedPreferredVersions := sets.NewString(test.expectedPreferredVersions...)
-		actualPreferredVersions := sets.NewString(preferredVersionsFromList(apiGroupList)...)
+		expectedPreferredVersions := sets.New[string](test.expectedPreferredVersions...)
+		actualPreferredVersions := sets.New[string](preferredVersionsFromList(apiGroupList)...)
 		assert.True(t, expectedPreferredVersions.Equal(actualPreferredVersions),
-			"%s: Expected preferred group/version (%s), got (%s)", test.name, expectedPreferredVersions.List(), actualPreferredVersions.List())
+			"%s: Expected preferred group/version (%s), got (%s)", test.name, expectedPreferredVersions.UnsortedList(), actualPreferredVersions.UnsortedList())
 	}
 }
 
@@ -1994,18 +1994,18 @@ func TestAggregatedServerGroupsAndResources(t *testing.T) {
 		apiGroups, resources, err := client.ServerGroupsAndResources()
 		if len(test.expectedFailedGVs) > 0 {
 			require.Error(t, err)
-			expectedFailedGVs := sets.NewString(test.expectedFailedGVs...)
-			actualFailedGVs := sets.NewString(failedGroupVersions(err)...)
+			expectedFailedGVs := sets.New[string](test.expectedFailedGVs...)
+			actualFailedGVs := sets.New[string](failedGroupVersions(err)...)
 			assert.True(t, expectedFailedGVs.Equal(actualFailedGVs),
 				"%s: Expected Failed GVs (%s), got (%s)", test.name, expectedFailedGVs, actualFailedGVs)
 		} else {
 			require.NoError(t, err)
 		}
 		// Test the expected groups are returned for the aggregated format.
-		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
-		actualGroupNames := sets.NewString(groupNames(apiGroups)...)
+		expectedGroupNames := sets.New[string](test.expectedGroupNames...)
+		actualGroupNames := sets.New[string](groupNames(apiGroups)...)
 		assert.True(t, expectedGroupNames.Equal(actualGroupNames),
-			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
+			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGroupNames.UnsortedList(), actualGroupNames.UnsortedList())
 		// If the core V1 group is returned from /api, it should be the first group.
 		if expectedGroupNames.Has("") {
 			assert.True(t, len(apiGroups) > 0)
@@ -2015,15 +2015,15 @@ func TestAggregatedServerGroupsAndResources(t *testing.T) {
 			assert.Equal(t, "v1", actualFirstGroupVersion)
 		}
 		// Test the expected group/versions are returned from the aggregated discovery.
-		expectedGroupVersions := sets.NewString(test.expectedGroupVersions...)
-		actualGroupVersions := sets.NewString(groupVersions(resources)...)
+		expectedGroupVersions := sets.New[string](test.expectedGroupVersions...)
+		actualGroupVersions := sets.New[string](groupVersions(resources)...)
 		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
-			"%s: Expected GroupVersions(%s), got (%s)", test.name, expectedGroupVersions.List(), actualGroupVersions.List())
+			"%s: Expected GroupVersions(%s), got (%s)", test.name, expectedGroupVersions.UnsortedList(), actualGroupVersions.UnsortedList())
 		// Test the expected GVKs are returned from the aggregated discovery.
-		expectedGVKs := sets.NewString(test.expectedGVKs...)
-		actualGVKs := sets.NewString(groupVersionKinds(resources)...)
+		expectedGVKs := sets.New[string](test.expectedGVKs...)
+		actualGVKs := sets.New[string](groupVersionKinds(resources)...)
 		assert.True(t, expectedGVKs.Equal(actualGVKs),
-			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.List(), actualGVKs.List())
+			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.UnsortedList(), actualGVKs.UnsortedList())
 	}
 }
 
@@ -2140,15 +2140,15 @@ func TestAggregatedServerGroupsAndResourcesWithErrors(t *testing.T) {
 		}
 		require.NoError(t, err)
 		// First check the returned groups
-		expectedGroups := sets.NewString(test.expectedGroups...)
-		actualGroups := sets.NewString(groupNames(apiGroups)...)
+		expectedGroups := sets.New[string](test.expectedGroups...)
+		actualGroups := sets.New[string](groupNames(apiGroups)...)
 		assert.True(t, expectedGroups.Equal(actualGroups),
-			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGroups.List(), actualGroups.List())
+			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGroups.UnsortedList(), actualGroups.UnsortedList())
 		// Next check the returned resources
-		expectedGVKs := sets.NewString(test.expectedResources...)
-		actualGVKs := sets.NewString(groupVersionKinds(resources)...)
+		expectedGVKs := sets.New[string](test.expectedResources...)
+		actualGVKs := sets.New[string](groupVersionKinds(resources)...)
 		assert.True(t, expectedGVKs.Equal(actualGVKs),
-			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.List(), actualGVKs.List())
+			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.UnsortedList(), actualGVKs.UnsortedList())
 	}
 }
 
@@ -2742,18 +2742,18 @@ func TestAggregatedServerPreferredResources(t *testing.T) {
 		resources, err := client.ServerPreferredResources()
 		if len(test.expectedFailedGVs) > 0 {
 			require.Error(t, err)
-			expectedFailedGVs := sets.NewString(test.expectedFailedGVs...)
-			actualFailedGVs := sets.NewString(failedGroupVersions(err)...)
+			expectedFailedGVs := sets.New[string](test.expectedFailedGVs...)
+			actualFailedGVs := sets.New[string](failedGroupVersions(err)...)
 			assert.True(t, expectedFailedGVs.Equal(actualFailedGVs),
 				"%s: Expected Failed GVs (%s), got (%s)", test.name, expectedFailedGVs, actualFailedGVs)
 		} else {
 			require.NoError(t, err)
 		}
 		// Test the expected preferred GVKs are returned from the aggregated discovery.
-		expectedGVKs := sets.NewString(test.expectedGVKs...)
-		actualGVKs := sets.NewString(groupVersionKinds(resources)...)
+		expectedGVKs := sets.New[string](test.expectedGVKs...)
+		actualGVKs := sets.New[string](groupVersionKinds(resources)...)
 		assert.True(t, expectedGVKs.Equal(actualGVKs),
-			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.List(), actualGVKs.List())
+			"%s: Expected GVKs (%s), got (%s)", test.name, expectedGVKs.UnsortedList(), actualGVKs.UnsortedList())
 	}
 }
 

--- a/staging/src/k8s.io/client-go/discovery/helper.go
+++ b/staging/src/k8s.io/client-go/discovery/helper.go
@@ -71,7 +71,7 @@ func ServerSupportsVersion(client DiscoveryInterface, requiredGV schema.GroupVer
 		return err
 	}
 	versions := metav1.ExtractGroupVersions(groups)
-	serverVersions := sets.String{}
+	serverVersions := sets.Set[string]{}
 	for _, v := range versions {
 		serverVersions.Insert(v)
 	}
@@ -142,5 +142,5 @@ type SupportsAllVerbs struct {
 
 // Match checks if a resource contains all the given verbs.
 func (p SupportsAllVerbs) Match(groupVersion string, r *metav1.APIResource) bool {
-	return sets.NewString([]string(r.Verbs)...).HasAll(p.Verbs...)
+	return sets.New[string]([]string(r.Verbs)...).HasAll(p.Verbs...)
 }

--- a/staging/src/k8s.io/client-go/discovery/helper_blackbox_test.go
+++ b/staging/src/k8s.io/client-go/discovery/helper_blackbox_test.go
@@ -166,7 +166,7 @@ func TestFilteredBy(t *testing.T) {
 	for i, test := range tests {
 		filtered := discovery.FilteredBy(test.pred, test.input)
 
-		if expected, got := sets.NewString(test.expectedResources...), sets.NewString(stringify(filtered)...); !expected.Equal(got) {
+		if expected, got := sets.New[string](test.expectedResources...), sets.New[string](stringify(filtered)...); !expected.Equal(got) {
 			t.Errorf("[%d] unexpected group versions: expected=%v, got=%v", i, test.expectedResources, stringify(filtered))
 		}
 	}

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/daemonset_expansion_test.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/daemonset_expansion_test.go
@@ -33,7 +33,7 @@ func TestDaemonSetLister(t *testing.T) {
 	testCases := []struct {
 		inDSs             []*extensions.DaemonSet
 		list              func() ([]*extensions.DaemonSet, error)
-		outDaemonSetNames sets.String
+		outDaemonSetNames sets.Set[string]
 		expectErr         bool
 	}{
 		// Basic listing
@@ -44,7 +44,7 @@ func TestDaemonSetLister(t *testing.T) {
 			list: func() ([]*extensions.DaemonSet, error) {
 				return lister.List(labels.Everything())
 			},
-			outDaemonSetNames: sets.NewString("basic"),
+			outDaemonSetNames: sets.New[string]("basic"),
 		},
 		// Listing multiple daemon sets
 		{
@@ -56,7 +56,7 @@ func TestDaemonSetLister(t *testing.T) {
 			list: func() ([]*extensions.DaemonSet, error) {
 				return lister.List(labels.Everything())
 			},
-			outDaemonSetNames: sets.NewString("basic", "complex", "complex2"),
+			outDaemonSetNames: sets.New[string]("basic", "complex", "complex2"),
 		},
 		// No pod labels
 		{
@@ -74,7 +74,7 @@ func TestDaemonSetLister(t *testing.T) {
 				}
 				return lister.GetPodDaemonSets(pod)
 			},
-			outDaemonSetNames: sets.NewString(),
+			outDaemonSetNames: sets.New[string](),
 			expectErr:         true,
 		},
 		// No DS selectors
@@ -94,7 +94,7 @@ func TestDaemonSetLister(t *testing.T) {
 				}
 				return lister.GetPodDaemonSets(pod)
 			},
-			outDaemonSetNames: sets.NewString(),
+			outDaemonSetNames: sets.New[string](),
 			expectErr:         true,
 		},
 		// Matching labels to selectors and namespace
@@ -123,7 +123,7 @@ func TestDaemonSetLister(t *testing.T) {
 				}
 				return lister.GetPodDaemonSets(pod)
 			},
-			outDaemonSetNames: sets.NewString("bar"),
+			outDaemonSetNames: sets.New[string]("bar"),
 		},
 	}
 	for _, c := range testCases {

--- a/staging/src/k8s.io/client-go/tools/auth/exec/types_test.go
+++ b/staging/src/k8s.io/client-go/tools/auth/exec/types_test.go
@@ -57,7 +57,7 @@ func testClientAuthenticationClusterTypesAreSynced(t *testing.T, cluster interfa
 		t.Parallel()
 
 		// These are fields that are specific to Cluster and shouldn't be in clientcmdv1.Cluster.
-		execSkippedFieldNames := sets.NewString(
+		execSkippedFieldNames := sets.New[string](
 			// Cluster uses Config to provide its cluster-specific configuration object.
 			"Config",
 		)
@@ -98,7 +98,7 @@ func testClientAuthenticationClusterTypesAreSynced(t *testing.T, cluster interfa
 		t.Parallel()
 
 		// These are the fields that we don't want to shadow from clientcmdv1.Cluster.
-		clientcmdSkippedFieldNames := sets.NewString(
+		clientcmdSkippedFieldNames := sets.New[string](
 			// CA data will be passed via CertificateAuthorityData, so we don't need this field.
 			"CertificateAuthority",
 			// Cluster uses Config to provide its cluster-specific configuration object.
@@ -142,7 +142,7 @@ func testClientAuthenticationClusterTypesAreSynced(t *testing.T, cluster interfa
 // TestClientAuthenticationClusterTypesAreSynced for any future ExecCredential version. It should start failing
 // when someone adds support for any other ExecCredential type to this package.
 func TestAllClusterTypesAreSynced(t *testing.T) {
-	versionsThatDontNeedTests := sets.NewString(
+	versionsThatDontNeedTests := sets.New[string](
 		// The internal Cluster type should only be used...internally...and therefore doesn't
 		// necessarily need to be synced with clientcmdv1.
 		runtime.APIVersionInternal,

--- a/staging/src/k8s.io/client-go/tools/cache/controller_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller_test.go
@@ -110,12 +110,12 @@ func Example() {
 	}
 
 	// Let's wait for the controller to process the things we just added.
-	outputSet := sets.String{}
+	outputSet := sets.Set[string]{}
 	for i := 0; i < len(testIDs); i++ {
 		outputSet.Insert(<-deletionCounter)
 	}
 
-	for _, key := range outputSet.List() {
+	for _, key := range outputSet.UnsortedList() {
 		fmt.Println(key)
 	}
 	// Output:
@@ -167,12 +167,12 @@ func ExampleNewInformer() {
 	}
 
 	// Let's wait for the controller to process the things we just added.
-	outputSet := sets.String{}
+	outputSet := sets.Set[string]{}
 	for i := 0; i < len(testIDs); i++ {
 		outputSet.Insert(<-deletionCounter)
 	}
 
-	for _, key := range outputSet.List() {
+	for _, key := range outputSet.UnsortedList() {
 		fmt.Println(key)
 	}
 	// Output:
@@ -243,7 +243,7 @@ func TestHammerController(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			// Let's add a few objects to the source.
-			currentNames := sets.String{}
+			currentNames := sets.Set[string]{}
 			rs := rand.NewSource(rand.Int63())
 			f := fuzz.New().NilChance(.5).NumElements(0, 2).RandSource(rs)
 			for i := 0; i < 100; i++ {
@@ -253,7 +253,7 @@ func TestHammerController(t *testing.T) {
 					f.Fuzz(&name)
 					isNew = true
 				} else {
-					l := currentNames.List()
+					l := currentNames.UnsortedList()
 					name = l[rand.Intn(len(l))]
 				}
 

--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -623,7 +623,7 @@ func (f *DeltaFIFO) Pop(process PopProcessFunc) (interface{}, error) {
 func (f *DeltaFIFO) Replace(list []interface{}, _ string) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
-	keys := make(sets.String, len(list))
+	keys := make(sets.Set[string], len(list))
 
 	// keep backwards compat for old clients
 	action := Sync

--- a/staging/src/k8s.io/client-go/tools/cache/expiration_cache_fakes.go
+++ b/staging/src/k8s.io/client-go/tools/cache/expiration_cache_fakes.go
@@ -35,7 +35,7 @@ func (c *fakeThreadSafeMap) Delete(key string) {
 
 // FakeExpirationPolicy keeps the list for keys which never expires.
 type FakeExpirationPolicy struct {
-	NeverExpire     sets.String
+	NeverExpire     sets.Set[string]
 	RetrieveKeyFunc KeyFunc
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/expiration_cache_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/expiration_cache_test.go
@@ -33,7 +33,7 @@ func TestTTLExpirationBasic(t *testing.T) {
 	ttlStore := NewFakeExpirationStore(
 		testStoreKeyFunc, deleteChan,
 		&FakeExpirationPolicy{
-			NeverExpire: sets.NewString(),
+			NeverExpire: sets.New[string](),
 			RetrieveKeyFunc: func(obj interface{}) (string, error) {
 				return obj.(*TimestampedEntry).Obj.(testStoreObject).id, nil
 			},
@@ -66,7 +66,7 @@ func TestTTLExpirationBasic(t *testing.T) {
 func TestReAddExpiredItem(t *testing.T) {
 	deleteChan := make(chan string, 1)
 	exp := &FakeExpirationPolicy{
-		NeverExpire: sets.NewString(),
+		NeverExpire: sets.New[string](),
 		RetrieveKeyFunc: func(obj interface{}) (string, error) {
 			return obj.(*TimestampedEntry).Obj.(testStoreObject).id, nil
 		},
@@ -105,7 +105,7 @@ func TestReAddExpiredItem(t *testing.T) {
 	case <-time.After(wait.ForeverTestTimeout):
 		t.Errorf("Unexpected timeout waiting on delete")
 	}
-	exp.NeverExpire = sets.NewString(testKey)
+	exp.NeverExpire = sets.New[string](testKey)
 	item, exists, err = ttlStore.GetByKey(testKey)
 	if err != nil {
 		t.Errorf("Failed to get from store, %v", err)
@@ -122,14 +122,14 @@ func TestTTLList(t *testing.T) {
 		{id: "foo1", val: "bar1"},
 		{id: "foo2", val: "bar2"},
 	}
-	expireKeys := sets.NewString(testObjs[0].id, testObjs[2].id)
+	expireKeys := sets.New[string](testObjs[0].id, testObjs[2].id)
 	deleteChan := make(chan string, len(testObjs))
 	defer close(deleteChan)
 
 	ttlStore := NewFakeExpirationStore(
 		testStoreKeyFunc, deleteChan,
 		&FakeExpirationPolicy{
-			NeverExpire: sets.NewString(testObjs[1].id),
+			NeverExpire: sets.New[string](testObjs[1].id),
 			RetrieveKeyFunc: func(obj interface{}) (string, error) {
 				return obj.(*TimestampedEntry).Obj.(testStoreObject).id, nil
 			},

--- a/staging/src/k8s.io/client-go/tools/cache/fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/fifo.go
@@ -354,7 +354,7 @@ func (f *FIFO) Resync() error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	inQueue := sets.NewString()
+	inQueue := sets.New[string]()
 	for _, id := range f.queue {
 		inQueue.Insert(id)
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/index.go
+++ b/staging/src/k8s.io/client-go/tools/cache/index.go
@@ -92,7 +92,7 @@ func MetaNamespaceIndexFunc(obj interface{}) ([]string, error) {
 }
 
 // Index maps the indexed value to a set of keys in the store that match on that value
-type Index map[string]sets.String
+type Index map[string]sets.Set[string]
 
 // Indexers maps a name to an IndexFunc
 type Indexers map[string]IndexFunc

--- a/staging/src/k8s.io/client-go/tools/cache/index_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/index_test.go
@@ -71,15 +71,15 @@ func TestMultiIndexKeys(t *testing.T) {
 	index.Add(pod2)
 	index.Add(pod3)
 
-	expected := map[string]sets.String{}
-	expected["ernie"] = sets.NewString("one", "tre")
-	expected["bert"] = sets.NewString("one", "two")
-	expected["elmo"] = sets.NewString("tre")
-	expected["oscar"] = sets.NewString("two")
-	expected["elmo1"] = sets.NewString()
+	expected := map[string]sets.Set[string]{}
+	expected["ernie"] = sets.New[string]("one", "tre")
+	expected["bert"] = sets.New[string]("one", "two")
+	expected["elmo"] = sets.New[string]("tre")
+	expected["oscar"] = sets.New[string]("two")
+	expected["elmo1"] = sets.New[string]()
 	{
 		for k, v := range expected {
-			found := sets.String{}
+			found := sets.Set[string]{}
 			indexResults, err := index.ByIndex("byUser", k)
 			if err != nil {
 				t.Errorf("Unexpected error %v", err)
@@ -88,7 +88,7 @@ func TestMultiIndexKeys(t *testing.T) {
 				found.Insert(item.(*v1.Pod).Name)
 			}
 			if !found.Equal(v) {
-				t.Errorf("missing items, index %s, expected %v but found %v", k, v.List(), found.List())
+				t.Errorf("missing items, index %s, expected %v but found %v", k, v.UnsortedList(), found.UnsortedList())
 			}
 		}
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/index_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/index_test.go
@@ -88,7 +88,7 @@ func TestMultiIndexKeys(t *testing.T) {
 				found.Insert(item.(*v1.Pod).Name)
 			}
 			if !found.Equal(v) {
-				t.Errorf("missing items, index %s, expected %v but found %v", k, v.UnsortedList(), found.UnsortedList())
+				t.Errorf("missing items, index %s, expected %v but found %v", k, sets.List[string](v), sets.List[string](found))
 			}
 		}
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
@@ -127,7 +127,7 @@ func (c *mutationCache) ByIndex(name string, indexKey string) ([]interface{}, er
 		return nil, err
 	}
 	var items []interface{}
-	keySet := sets.NewString()
+	keySet := sets.New[string]()
 	for _, key := range keys {
 		keySet.Insert(key)
 		obj, exists, err := c.indexer.GetByKey(key)

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -38,7 +38,7 @@ import (
 type testListener struct {
 	lock              sync.RWMutex
 	resyncPeriod      time.Duration
-	expectedItemNames sets.String
+	expectedItemNames sets.Set[string]
 	receivedItemNames []string
 	name              string
 }
@@ -46,7 +46,7 @@ type testListener struct {
 func newTestListener(name string, resyncPeriod time.Duration, expected ...string) *testListener {
 	l := &testListener{
 		resyncPeriod:      resyncPeriod,
-		expectedItemNames: sets.NewString(expected...),
+		expectedItemNames: sets.New[string](expected...),
 		name:              name,
 	}
 	return l
@@ -95,7 +95,7 @@ func (l *testListener) satisfiedExpectations() bool {
 	l.lock.RLock()
 	defer l.lock.RUnlock()
 
-	return sets.NewString(l.receivedItemNames...).Equal(l.expectedItemNames)
+	return sets.New[string](l.receivedItemNames...).Equal(l.expectedItemNames)
 }
 
 func eventHandlerCount(i SharedInformer) int {
@@ -339,8 +339,8 @@ func TestSharedInformerWatchDisruption(t *testing.T) {
 		listener.receivedItemNames = []string{}
 	}
 
-	listenerNoResync.expectedItemNames = sets.NewString("pod2", "pod3")
-	listenerResync.expectedItemNames = sets.NewString("pod1", "pod2", "pod3")
+	listenerNoResync.expectedItemNames = sets.New[string]("pod2", "pod3")
+	listenerResync.expectedItemNames = sets.New[string]("pod1", "pod2", "pod3")
 
 	// This calls shouldSync, which deletes noResync from the list of syncingListeners
 	clock.Step(1 * time.Second)

--- a/staging/src/k8s.io/client-go/tools/cache/store_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/store_test.go
@@ -55,7 +55,7 @@ func doTestStore(t *testing.T, store Store) {
 	store.Add(mkObj("c", "d"))
 	store.Add(mkObj("e", "e"))
 	{
-		found := sets.String{}
+		found := sets.Set[string]{}
 		for _, item := range store.List() {
 			found.Insert(item.(testStoreObject).val)
 		}
@@ -74,7 +74,7 @@ func doTestStore(t *testing.T, store Store) {
 	}, "0")
 
 	{
-		found := sets.String{}
+		found := sets.Set[string]{}
 		for _, item := range store.List() {
 			found.Insert(item.(testStoreObject).val)
 		}
@@ -94,17 +94,17 @@ func doTestIndex(t *testing.T, indexer Indexer) {
 	}
 
 	// Test Index
-	expected := map[string]sets.String{}
-	expected["b"] = sets.NewString("a", "c")
-	expected["f"] = sets.NewString("e")
-	expected["h"] = sets.NewString("g")
+	expected := map[string]sets.Set[string]{}
+	expected["b"] = sets.New[string]("a", "c")
+	expected["f"] = sets.New[string]("e")
+	expected["h"] = sets.New[string]("g")
 	indexer.Add(mkObj("a", "b"))
 	indexer.Add(mkObj("c", "b"))
 	indexer.Add(mkObj("e", "f"))
 	indexer.Add(mkObj("g", "h"))
 	{
 		for k, v := range expected {
-			found := sets.String{}
+			found := sets.Set[string]{}
 			indexResults, err := indexer.Index("by_val", mkObj("", k))
 			if err != nil {
 				t.Errorf("Unexpected error %v", err)
@@ -112,9 +112,9 @@ func doTestIndex(t *testing.T, indexer Indexer) {
 			for _, item := range indexResults {
 				found.Insert(item.(testStoreObject).id)
 			}
-			items := v.List()
+			items := v.UnsortedList()
 			if !found.HasAll(items...) {
-				t.Errorf("missing items, index %s, expected %v but found %v", k, items, found.List())
+				t.Errorf("missing items, index %s, expected %v but found %v", k, items, found.UnsortedList())
 			}
 		}
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/thread_safe_store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/thread_safe_store.go
@@ -71,7 +71,7 @@ func (i *storeIndex) reset() {
 	i.indices = Indices{}
 }
 
-func (i *storeIndex) getKeysFromIndex(indexName string, obj interface{}) (sets.String, error) {
+func (i *storeIndex) getKeysFromIndex(indexName string, obj interface{}) (sets.Set[string], error) {
 	indexFunc := i.indexers[indexName]
 	if indexFunc == nil {
 		return nil, fmt.Errorf("Index with name %s does not exist", indexName)
@@ -83,7 +83,7 @@ func (i *storeIndex) getKeysFromIndex(indexName string, obj interface{}) (sets.S
 	}
 	index := i.indices[indexName]
 
-	var storeKeySet sets.String
+	var storeKeySet sets.Set[string]
 	if len(indexedValues) == 1 {
 		// In majority of cases, there is exactly one value matching.
 		// Optimize the most common path - deduping is not needed here.
@@ -91,7 +91,7 @@ func (i *storeIndex) getKeysFromIndex(indexName string, obj interface{}) (sets.S
 	} else {
 		// Need to de-dupe the return list.
 		// Since multiple keys are allowed, this can happen.
-		storeKeySet = sets.String{}
+		storeKeySet = sets.Set[string]{}
 		for _, indexedValue := range indexedValues {
 			for key := range index[indexedValue] {
 				storeKeySet.Insert(key)
@@ -102,7 +102,7 @@ func (i *storeIndex) getKeysFromIndex(indexName string, obj interface{}) (sets.S
 	return storeKeySet, nil
 }
 
-func (i *storeIndex) getKeysByIndex(indexName, indexedValue string) (sets.String, error) {
+func (i *storeIndex) getKeysByIndex(indexName, indexedValue string) (sets.Set[string], error) {
 	indexFunc := i.indexers[indexName]
 	if indexFunc == nil {
 		return nil, fmt.Errorf("Index with name %s does not exist", indexName)
@@ -185,7 +185,7 @@ func (i *storeIndex) updateIndices(oldObj interface{}, newObj interface{}, key s
 func (i *storeIndex) addKeyToIndex(key, indexValue string, index Index) {
 	set := index[indexValue]
 	if set == nil {
-		set = sets.String{}
+		set = sets.Set[string]{}
 		index[indexValue] = set
 	}
 	set.Insert(key)
@@ -321,7 +321,7 @@ func (c *threadSafeMap) IndexKeys(indexName, indexedValue string) ([]string, err
 	if err != nil {
 		return nil, err
 	}
-	return set.List(), nil
+	return set.UnsortedList(), nil
 }
 
 func (c *threadSafeMap) ListIndexFuncValues(indexName string) []string {

--- a/staging/src/k8s.io/client-go/tools/cache/thread_safe_store_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/thread_safe_store_test.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"strings"
 	"testing"
 
@@ -114,7 +115,7 @@ func TestThreadSafeStoreIndexingFunctionsWithMultipleValues(t *testing.T) {
 	assert := assert.New(t)
 
 	compare := func(key string, expected []string) error {
-		values := store.index.indices[testIndexer][key].List()
+		values := sets.List[string](store.index.indices[testIndexer][key])
 		if cmp.Equal(values, expected) {
 			return nil
 		}

--- a/staging/src/k8s.io/client-go/tools/record/events_cache.go
+++ b/staging/src/k8s.io/client-go/tools/record/events_cache.go
@@ -227,7 +227,7 @@ func NewEventAggregator(lruCacheSize int, keyFunc EventAggregatorKeyFunc, messag
 type aggregateRecord struct {
 	// we track the number of unique local keys we have seen in the aggregate set to know when to actually aggregate
 	// if the size of this set exceeds the max, we know we need to aggregate
-	localKeys sets.String
+	localKeys sets.Set[string]
 	// The last time at which the aggregate was recorded
 	lastTimestamp metav1.Time
 }
@@ -261,7 +261,7 @@ func (e *EventAggregator) EventAggregate(newEvent *v1.Event) (*v1.Event, string)
 	maxInterval := time.Duration(e.maxIntervalInSeconds) * time.Second
 	interval := now.Time.Sub(record.lastTimestamp.Time)
 	if interval > maxInterval {
-		record = aggregateRecord{localKeys: sets.NewString()}
+		record = aggregateRecord{localKeys: sets.New[string]()}
 	}
 
 	// Write the new event into the aggregation record and put it on the cache

--- a/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
@@ -617,33 +617,33 @@ func (m *manager) certSatisfiesTemplateLocked() bool {
 			return false
 		}
 
-		currentDNSNames := sets.NewString(m.cert.Leaf.DNSNames...)
-		desiredDNSNames := sets.NewString(template.DNSNames...)
+		currentDNSNames := sets.New[string](m.cert.Leaf.DNSNames...)
+		desiredDNSNames := sets.New[string](template.DNSNames...)
 		missingDNSNames := desiredDNSNames.Difference(currentDNSNames)
 		if len(missingDNSNames) > 0 {
-			m.logf("%s: Current certificate is missing requested DNS names %v", m.name, missingDNSNames.List())
+			m.logf("%s: Current certificate is missing requested DNS names %v", m.name, missingDNSNames.UnsortedList())
 			return false
 		}
 
-		currentIPs := sets.NewString()
+		currentIPs := sets.New[string]()
 		for _, ip := range m.cert.Leaf.IPAddresses {
 			currentIPs.Insert(ip.String())
 		}
-		desiredIPs := sets.NewString()
+		desiredIPs := sets.New[string]()
 		for _, ip := range template.IPAddresses {
 			desiredIPs.Insert(ip.String())
 		}
 		missingIPs := desiredIPs.Difference(currentIPs)
 		if len(missingIPs) > 0 {
-			m.logf("%s: Current certificate is missing requested IP addresses %v", m.name, missingIPs.List())
+			m.logf("%s: Current certificate is missing requested IP addresses %v", m.name, missingIPs.UnsortedList())
 			return false
 		}
 
-		currentOrgs := sets.NewString(m.cert.Leaf.Subject.Organization...)
-		desiredOrgs := sets.NewString(template.Subject.Organization...)
+		currentOrgs := sets.New[string](m.cert.Leaf.Subject.Organization...)
+		desiredOrgs := sets.New[string](template.Subject.Organization...)
 		missingOrgs := desiredOrgs.Difference(currentOrgs)
 		if len(missingOrgs) > 0 {
-			m.logf("%s: Current certificate is missing requested orgs %v", m.name, missingOrgs.List())
+			m.logf("%s: Current certificate is missing requested orgs %v", m.name, missingOrgs.UnsortedList())
 			return false
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
While reading the source code of client-go, I noticed it uses deprecated `sets.String`, so I replaced them with `sets.Set`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
