### PR TITLE
Adding more callbacks in kubedrain helper

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -85,7 +85,14 @@ type Helper struct {
 	DryRunStrategy cmdutil.DryRunStrategy
 
 	// OnPodDeletedOrEvicted is called when a pod is evicted/deleted; for printing progress output
+	// Deprecated: use OnPodDeletionOrEvictionFinished instead
 	OnPodDeletedOrEvicted func(pod *corev1.Pod, usingEviction bool)
+
+	// OnPodDeletionOrEvictionFinished is called when a pod is eviction/deletetion is failed; for printing progress output
+	OnPodDeletionOrEvictionFinished func(pod *corev1.Pod, usingEviction bool, err error)
+
+	// OnPodDeletionOrEvictionStarted is called when a pod eviction/deletion is started; for printing progress output
+	OnPodDeletionOrEvictionStarted func(pod *corev1.Pod, usingEviction bool)
 }
 
 type waitForDeleteParams struct {
@@ -96,6 +103,7 @@ type waitForDeleteParams struct {
 	usingEviction                   bool
 	getPodFn                        func(string, string) (*corev1.Pod, error)
 	onDoneFn                        func(pod *corev1.Pod, usingEviction bool)
+	onFinishFn                      func(pod *corev1.Pod, usingEviction bool, err error)
 	globalTimeout                   time.Duration
 	skipWaitForDeleteTimeoutSeconds int
 	out                             io.Writer
@@ -276,6 +284,9 @@ func (d *Helper) evictPods(pods []corev1.Pod, evictionGroupVersion schema.GroupV
 				case cmdutil.DryRunServer:
 					fmt.Fprintf(d.Out, "evicting pod %s/%s (server dry run)\n", pod.Namespace, pod.Name)
 				default:
+					if d.OnPodDeletionOrEvictionStarted != nil {
+						d.OnPodDeletionOrEvictionStarted(&pod, true)
+					}
 					fmt.Fprintf(d.Out, "evicting pod %s/%s\n", pod.Namespace, pod.Name)
 				}
 				select {
@@ -334,6 +345,7 @@ func (d *Helper) evictPods(pods []corev1.Pod, evictionGroupVersion schema.GroupV
 				usingEviction:                   true,
 				getPodFn:                        getPodFn,
 				onDoneFn:                        d.OnPodDeletedOrEvicted,
+				onFinishFn:                      d.OnPodDeletionOrEvictionFinished,
 				globalTimeout:                   globalTimeout,
 				skipWaitForDeleteTimeoutSeconds: d.SkipWaitForDeleteTimeoutSeconds,
 				out:                             d.Out,
@@ -377,6 +389,9 @@ func (d *Helper) deletePods(pods []corev1.Pod, getPodFn func(namespace, name str
 		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
+		if d.OnPodDeletionOrEvictionStarted != nil {
+			d.OnPodDeletionOrEvictionStarted(&pod, false)
+		}
 	}
 	ctx := d.getContext()
 	params := waitForDeleteParams{
@@ -387,6 +402,7 @@ func (d *Helper) deletePods(pods []corev1.Pod, getPodFn func(namespace, name str
 		usingEviction:                   false,
 		getPodFn:                        getPodFn,
 		onDoneFn:                        d.OnPodDeletedOrEvicted,
+		onFinishFn:                      d.OnPodDeletionOrEvictionFinished,
 		globalTimeout:                   globalTimeout,
 		skipWaitForDeleteTimeoutSeconds: d.SkipWaitForDeleteTimeoutSeconds,
 		out:                             d.Out,
@@ -402,11 +418,16 @@ func waitForDelete(params waitForDeleteParams) ([]corev1.Pod, error) {
 		for i, pod := range pods {
 			p, err := params.getPodFn(pod.Namespace, pod.Name)
 			if apierrors.IsNotFound(err) || (p != nil && p.ObjectMeta.UID != pod.ObjectMeta.UID) {
-				if params.onDoneFn != nil {
+				if params.onFinishFn != nil {
+					params.onFinishFn(&pod, params.usingEviction, nil)
+				} else if params.onDoneFn != nil {
 					params.onDoneFn(&pod, params.usingEviction)
 				}
 				continue
 			} else if err != nil {
+				if params.onFinishFn != nil {
+					params.onFinishFn(&pod, params.usingEviction, err)
+				}
 				return false, err
 			} else {
 				if shouldSkipPod(*p, params.skipWaitForDeleteTimeoutSeconds) {

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
@@ -331,6 +331,39 @@ func TestDeleteOrEvict(t *testing.T) {
 			h := &Helper{
 				Out:                os.Stdout,
 				GracePeriodSeconds: 10,
+				OnPodDeletionOrEvictionStarted: func(pod *corev1.Pod, usingEviction bool) {
+					if tc.evictionSupported && !tc.disableEviction {
+						if !usingEviction {
+							t.Errorf("%s: OnPodDeletionOrEvictionStarted callback failed while evicting; actual\n\t%v\nexpected\n\t%v", tc.description, usingEviction, !usingEviction)
+						}
+					} else if tc.evictionSupported && tc.disableEviction {
+						if usingEviction {
+							t.Errorf("%s: OnPodDeletionOrEvictionStarted callback failed while deleting; actual\n\t%v\nexpected\n\t%v", tc.description, !usingEviction, usingEviction)
+						}
+					}
+				},
+				OnPodDeletedOrEvicted: func(pod *corev1.Pod, usingEviction bool) {
+					if tc.evictionSupported && !tc.disableEviction {
+						if !usingEviction {
+							t.Errorf("%s: OnPodDeletedOrEvicted callback failed while evicting; actual\n\t%v\nexpected\n\t%v", tc.description, usingEviction, !usingEviction)
+						}
+					} else if tc.evictionSupported && tc.disableEviction {
+						if usingEviction {
+							t.Errorf("%s: OnPodDeletedOrEvicted callback failed while deleting; actual\n\t%v\nexpected\n\t%v", tc.description, !usingEviction, usingEviction)
+						}
+					}
+				},
+				OnPodDeletionOrEvictionFinished: func(pod *corev1.Pod, usingEviction bool, err error) {
+					if tc.evictionSupported && !tc.disableEviction {
+						if !usingEviction {
+							t.Errorf("%s: OnPodDeletionOrEvictionFinished callback failed while evicting; actual\n\t%v\nexpected\n\t%v", tc.description, usingEviction, !usingEviction)
+						}
+					} else if tc.evictionSupported && tc.disableEviction {
+						if usingEviction {
+							t.Errorf("%s: OnPodDeletionOrEvictionFinished callback failed while deleting; actual\n\t%v\nexpected\n\t%v", tc.description, !usingEviction, usingEviction)
+						}
+					}
+				},
 			}
 
 			// Create 4 pods, and try to remove the first 2


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### Which issue(s) this PR fixes:
Fixes #116210

#### Does this PR introduce a user-facing change?
```release-note
- Added kubectl node drain helper callbacks `OnPodDeletionOrEvictionStarted` and `OnPodDeletionOrEvictionFailed`; people extending `kubectl` can use these new callbacks for more granularity.
- Deprecated the `OnPodDeletedOrEvicted` node drain helper callback.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
None
```
