### PR TITLE
restrict controller revision hash less than 63 character

### DIFF
--- a/pkg/controller/history/controller_history.go
+++ b/pkg/controller/history/controller_history.go
@@ -49,12 +49,12 @@ import (
 const ControllerRevisionHashLabel = "controller.kubernetes.io/hash"
 
 // ControllerRevisionName returns the Name for a ControllerRevision in the form prefix-hash. If the length
-// of prefix is greater than 50 bytes, it is truncated to allow for a name that is no larger than 50 bytes.
-// This restriction is to ensure a standard Kubernetes name does not exceed the length limit of 63 bytes.
-// The controller revision hash is a Kubernetes label that must be 63 characters or less.
+// of prefix is greater than 52 bytes, it is truncated to allow for a name that is no larger than 52 bytes.
+// This restriction is to ensure a standard Kubernetes label does not exceed the length limit of 63 bytes.
+// The hash can be an int32, that is converted to a string. This string is 10 charaters or less.
 func ControllerRevisionName(prefix string, hash string) string {
-	if len(prefix) > 50 {
-		prefix = prefix[:50]
+	if len(prefix) > 52 {
+		prefix = prefix[:52]
 	}
 
 	return fmt.Sprintf("%s-%s", prefix, hash)

--- a/pkg/controller/history/controller_history.go
+++ b/pkg/controller/history/controller_history.go
@@ -49,10 +49,12 @@ import (
 const ControllerRevisionHashLabel = "controller.kubernetes.io/hash"
 
 // ControllerRevisionName returns the Name for a ControllerRevision in the form prefix-hash. If the length
-// of prefix is greater than 223 bytes, it is truncated to allow for a name that is no larger than 253 bytes.
+// of prefix is greater than 50 bytes, it is truncated to allow for a name that is no larger than 50 bytes.
+// This restriction is to ensure a standard Kubernetes name does not exceed the length limit of 63 bytes.
+// The controller revision hash is a Kubernetes label that must be 63 characters or less.
 func ControllerRevisionName(prefix string, hash string) string {
-	if len(prefix) > 223 {
-		prefix = prefix[:223]
+	if len(prefix) > 50 {
+		prefix = prefix[:50]
 	}
 
 	return fmt.Sprintf("%s-%s", prefix, hash)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We need this PR to address pod creation failure due to the controller revision hash as a Kubernetes label is over 63 characters.

#### Which issue(s) this PR fixes:

There are multiple issues opened against this problem.

Fiexes
https://github.com/kubernetes/kubernetes/issues/64023
https://github.com/kubernetes/kubernetes/issues/79337

Also on the other projects
https://github.com/GoogleCloudPlatform/flink-on-k8s-operator/issues/402



#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None
