### PR TITLE
Replace StartTestServer with StartTestServerOrDie

### DIFF
--- a/test/integration/apiserver/admissionwebhook/match_conditions_test.go
+++ b/test/integration/apiserver/admissionwebhook/match_conditions_test.go
@@ -316,12 +316,9 @@ func TestMatchConditions(t *testing.T) {
 		t.Run(testcase.name, func(t *testing.T) {
 			upCh := recorder.Reset()
 
-			server, err := apiservertesting.StartTestServer(t, nil, []string{
+			server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 				"--disable-admission-plugins=ServiceAccount",
 			}, framework.SharedEtcd())
-			if err != nil {
-				t.Fatal(err)
-			}
 			defer server.TearDownFn()
 
 			config := server.ClientConfig

--- a/test/integration/apiserver/admissionwebhook/mutating_webhook_gvk_conversion_test.go
+++ b/test/integration/apiserver/admissionwebhook/mutating_webhook_gvk_conversion_test.go
@@ -157,12 +157,9 @@ func Test_MutatingWebhookConvertsGVKWithMatchPolicyEquivalent(t *testing.T) {
 
 	upCh := typeChecker.Reset()
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AdmissionWebhookMatchConditions, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--disable-admission-plugins=ServiceAccount",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	etcd.CreateTestCRDs(t, apiextensionsclientset.NewForConfigOrDie(server.ClientConfig), false, versionedCustomResourceDefinition())

--- a/test/integration/apiserver/apply/apply_crd_beta_test.go
+++ b/test/integration/apiserver/apply/apply_crd_beta_test.go
@@ -37,10 +37,7 @@ import (
 // TestApplyCRDNoSchema tests that CRDs and CRs can both be applied to with a PATCH request with the apply content type
 // when there is no validation field provided.
 func TestApplyCRDNoSchema(t *testing.T) {
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 

--- a/test/integration/apiserver/apply/apply_crd_test.go
+++ b/test/integration/apiserver/apply/apply_crd_test.go
@@ -49,10 +49,7 @@ import (
 // TestApplyCRDStructuralSchema tests that when a CRD has a structural schema in its validation field,
 // it will be used to construct the CR schema used by apply.
 func TestApplyCRDStructuralSchema(t *testing.T) {
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 
@@ -437,10 +434,7 @@ func TestApplyCRDUnhandledSchema(t *testing.T) {
 	}
 	defer etcdclient.Close()
 
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, storageConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, storageConfig)
 	defer server.TearDownFn()
 	config := server.ClientConfig
 
@@ -602,10 +596,7 @@ func getManagedFields(rawResponse []byte) ([]metav1.ManagedFieldsEntry, error) {
 }
 
 func TestDefaultMissingKeyCRD(t *testing.T) {
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 

--- a/test/integration/apiserver/apply/reset_fields_test.go
+++ b/test/integration/apiserver/apply/reset_fields_test.go
@@ -164,10 +164,7 @@ var resetFieldsSpecData = map[schema.GroupVersionResource]string{
 func TestApplyResetFields(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, k8sfeatures.NetworkPolicyStatus, true)()
 
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), []string{"--disable-admission-plugins", "ServiceAccount,TaintNodesByCondition"}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), []string{"--disable-admission-plugins", "ServiceAccount,TaintNodesByCondition"}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	client, err := kubernetes.NewForConfig(server.ClientConfig)

--- a/test/integration/apiserver/apply/status_test.go
+++ b/test/integration/apiserver/apply/status_test.go
@@ -93,10 +93,7 @@ func createMapping(groupVersion string, resource metav1.APIResource) (*meta.REST
 
 // TestApplyStatus makes sure that applying the status works for all known types.
 func TestApplyStatus(t *testing.T) {
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), []string{"--disable-admission-plugins", "ServiceAccount,TaintNodesByCondition"}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), []string{"--disable-admission-plugins", "ServiceAccount,TaintNodesByCondition"}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	client, err := kubernetes.NewForConfig(server.ClientConfig)

--- a/test/integration/apiserver/cel/typeresolution_test.go
+++ b/test/integration/apiserver/cel/typeresolution_test.go
@@ -53,10 +53,7 @@ import (
 )
 
 func TestTypeResolver(t *testing.T) {
-	server, err := apiservertesting.StartTestServer(t, nil, nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -308,10 +305,7 @@ func TestTypeResolver(t *testing.T) {
 // resolve Kubernetes built-in types without error.
 func TestBuiltinResolution(t *testing.T) {
 	// before all, setup server and client
-	server, err := apiservertesting.StartTestServer(t, nil, nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	config := server.ClientConfig

--- a/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
+++ b/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
@@ -264,12 +264,9 @@ func Test_ValidateNamespace_NoParams(t *testing.T) {
 		t.Run(testcase.name, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
 
-			server, err := apiservertesting.StartTestServer(t, nil, []string{
+			server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 				"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 			}, framework.SharedEtcd())
-			if err != nil {
-				t.Fatal(err)
-			}
 			defer server.TearDownFn()
 
 			config := server.ClientConfig
@@ -418,16 +415,13 @@ func Test_ValidateAnnotationsAndWarnings(t *testing.T) {
 	}
 	defer os.Remove(logFile.Name())
 
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 		"--audit-policy-file", policyFile.Name(),
 		"--audit-log-version", "audit.k8s.io/v1",
 		"--audit-log-mode", "blocking",
 		"--audit-log-path", logFile.Name(),
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -532,12 +526,9 @@ func Test_ValidateNamespace_WithConfigMapParams(t *testing.T) {
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-			server, err := apiservertesting.StartTestServer(t, nil, []string{
+			server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 				"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 			}, framework.SharedEtcd())
-			if err != nil {
-				t.Fatal(err)
-			}
 			defer server.TearDownFn()
 
 			config := server.ClientConfig
@@ -569,10 +560,7 @@ func Test_ValidateNamespace_WithConfigMapParams(t *testing.T) {
 
 func TestMultiplePolicyBindings(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -696,12 +684,9 @@ func TestMultiplePolicyBindings(t *testing.T) {
 // are exempt from policy rules.
 func Test_PolicyExemption(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -783,12 +768,9 @@ func Test_PolicyExemption(t *testing.T) {
 // is allowed and when ParamKind is updated to v1/Secret, only namespaces prefixed with "secret" is allowed, etc.
 func Test_ValidatingAdmissionPolicy_UpdateParamKind(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -924,12 +906,9 @@ func Test_ValidatingAdmissionPolicy_UpdateParamKind(t *testing.T) {
 // the ParamRef set in the policy binding. The paramRef in the binding is then updated to a different object.
 func Test_ValidatingAdmissionPolicy_UpdateParamRef(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1070,12 +1049,9 @@ func Test_ValidatingAdmissionPolicy_UpdateParamRef(t *testing.T) {
 // Test_ValidatingAdmissionPolicy_UpdateParamResource validates behavior of a policy after updates to the param resource.
 func Test_ValidatingAdmissionPolicy_UpdateParamResource(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1203,12 +1179,9 @@ func Test_ValidatingAdmissionPolicy_UpdateParamResource(t *testing.T) {
 
 func Test_ValidatingAdmissionPolicy_MatchByObjectSelector(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1271,12 +1244,9 @@ func Test_ValidatingAdmissionPolicy_MatchByObjectSelector(t *testing.T) {
 
 func Test_ValidatingAdmissionPolicy_MatchByNamespaceSelector(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1363,12 +1333,9 @@ func Test_ValidatingAdmissionPolicy_MatchByNamespaceSelector(t *testing.T) {
 
 func Test_ValidatingAdmissionPolicy_MatchByResourceNames(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1422,12 +1389,9 @@ func Test_ValidatingAdmissionPolicy_MatchByResourceNames(t *testing.T) {
 
 func Test_ValidatingAdmissionPolicy_MatchWithExcludeResources(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1494,13 +1458,10 @@ func Test_ValidatingAdmissionPolicy_MatchWithExcludeResources(t *testing.T) {
 
 func Test_ValidatingAdmissionPolicy_MatchWithMatchPolicyEquivalent(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
 	etcd.CreateTestCRDs(t, apiextensionsclientset.NewForConfigOrDie(server.ClientConfig), false, versionedCustomResourceDefinition())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1586,13 +1547,10 @@ func Test_ValidatingAdmissionPolicy_MatchWithMatchPolicyEquivalent(t *testing.T)
 
 func Test_ValidatingAdmissionPolicy_MatchWithMatchPolicyExact(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
 	etcd.CreateTestCRDs(t, apiextensionsclientset.NewForConfigOrDie(server.ClientConfig), false, versionedCustomResourceDefinition())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1683,12 +1641,9 @@ func Test_ValidatingAdmissionPolicy_MatchWithMatchPolicyExact(t *testing.T) {
 // removes the policy from the apiserver admission chain and recreating it re-enables it.
 func Test_ValidatingAdmissionPolicy_PolicyDeletedThenRecreated(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1801,12 +1756,9 @@ func Test_ValidatingAdmissionPolicy_PolicyDeletedThenRecreated(t *testing.T) {
 // removes the policy from the apiserver admission chain and recreating it re-enables it.
 func Test_ValidatingAdmissionPolicy_BindingDeletedThenRecreated(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -1920,12 +1872,9 @@ func Test_ValidatingAdmissionPolicy_BindingDeletedThenRecreated(t *testing.T) {
 // by a binding renders the policy as invalid. Recreating the param resource re-enables the policy.
 func Test_ValidatingAdmissionPolicy_ParamResourceDeletedThenRecreated(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -2110,12 +2059,9 @@ func TestCRDParams(t *testing.T) {
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-			server, err := apiservertesting.StartTestServer(t, nil, []string{
+			server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 				"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 			}, framework.SharedEtcd())
-			if err != nil {
-				t.Fatal(err)
-			}
 			defer server.TearDownFn()
 
 			config := server.ClientConfig
@@ -2162,12 +2108,9 @@ func TestCRDParams(t *testing.T) {
 
 func TestBindingRemoval(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig
@@ -2317,14 +2260,11 @@ func Test_ValidateSecondaryAuthorization(t *testing.T) {
 			for clientName, clientFn := range clients {
 				t.Run(clientName, func(t *testing.T) {
 					defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-					server, err := apiservertesting.StartTestServer(t, nil, []string{
+					server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 						"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 						"--authorization-mode=RBAC",
 						"--anonymous-auth",
 					}, framework.SharedEtcd())
-					if err != nil {
-						t.Fatal(err)
-					}
 					defer server.TearDownFn()
 
 					// For test set up such as creating policies, bindings and RBAC rules.
@@ -2368,7 +2308,7 @@ func Test_ValidateSecondaryAuthorization(t *testing.T) {
 							Name: "test-authz",
 						},
 					}
-					_, err = client.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+					_, err := client.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
 
 					var expected metav1.StatusReason = ""
 					if !testcase.allowed {
@@ -2914,12 +2854,9 @@ rules:
 
 func TestValidatingAdmissionPolicyTypeChecking(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ValidatingAdmissionPolicy, true)()
-	server, err := apiservertesting.StartTestServer(t, nil, []string{
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
 		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer server.TearDownFn()
 
 	config := server.ClientConfig

--- a/test/integration/apiserver/crd_regression_test.go
+++ b/test/integration/apiserver/crd_regression_test.go
@@ -36,10 +36,7 @@ import (
 
 // Regression test for https://issues.k8s.io/109099
 func TestCRDExponentialRecursionBug(t *testing.T) {
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 

--- a/test/integration/apiserver/crd_validation_expressions_test.go
+++ b/test/integration/apiserver/crd_validation_expressions_test.go
@@ -45,10 +45,7 @@ import (
 func TestCustomResourceValidatorsWithDisabledFeatureGate(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.CustomResourceValidationExpressions, false)()
 
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 
@@ -79,10 +76,7 @@ func TestCustomResourceValidatorsWithDisabledFeatureGate(t *testing.T) {
 func TestCustomResourceValidators(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.CustomResourceValidationExpressions, true)()
 
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 
@@ -455,10 +449,7 @@ func TestCustomResourceValidators(t *testing.T) {
 func TestCustomResourceValidatorsWithBlockingErrors(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.CustomResourceValidationExpressions, true)()
 
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 

--- a/test/integration/apiserver/field_validation_test.go
+++ b/test/integration/apiserver/field_validation_test.go
@@ -514,12 +514,10 @@ spec:
 )
 
 func TestFieldValidation(t *testing.T) {
-	server, err := kubeapiservertesting.StartTestServer(t, kubeapiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
-	config := server.ClientConfig
+	server := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
+
+	config := server.ClientConfig
 
 	// don't log warnings, tests inspect them in the responses directly
 	config.WarningHandler = rest.NoWarnings{}
@@ -2930,12 +2928,10 @@ func setupCRD(t testing.TB, config *rest.Config, apiGroup string, schemaless boo
 
 func BenchmarkFieldValidation(b *testing.B) {
 	flag.Lookup("v").Value.Set("0")
-	server, err := kubeapiservertesting.StartTestServer(b, kubeapiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		b.Fatal(err)
-	}
-	config := server.ClientConfig
+	server := kubeapiservertesting.StartTestServerOrDie(b, kubeapiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
+
+	config := server.ClientConfig
 
 	// don't log warnings, tests inspect them in the responses directly
 	config.WarningHandler = rest.NoWarnings{}

--- a/test/integration/apiserver/openapi/openapi_merge_test.go
+++ b/test/integration/apiserver/openapi/openapi_merge_test.go
@@ -43,10 +43,7 @@ const objectMetaSchemaName = "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
 
 func TestOpenAPIV3MultipleCRDsSameGV(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.OpenAPIV3, true)()
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 

--- a/test/integration/apiserver/openapi/openapi_v2_merge_test.go
+++ b/test/integration/apiserver/openapi/openapi_v2_merge_test.go
@@ -36,10 +36,7 @@ import (
 )
 
 func TestOpenAPIV2CRDMergeNoDuplicateTypes(t *testing.T) {
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 

--- a/test/integration/apiserver/openapi/openapiv3_test.go
+++ b/test/integration/apiserver/openapi/openapiv3_test.go
@@ -101,10 +101,7 @@ func TestOpenAPIV3SpecRoundTrip(t *testing.T) {
 
 func TestAddRemoveGroupVersion(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.OpenAPIV3, true)()
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
+	server := apiservertesting.StartTestServerOrDie(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 	config := server.ClientConfig
 

--- a/test/integration/controlplane/transformation/transformation_test.go
+++ b/test/integration/controlplane/transformation/transformation_test.go
@@ -78,7 +78,7 @@ type transformTest struct {
 	storageConfig     *storagebackend.Config
 	configDir         string
 	transformerConfig string
-	kubeAPIServer     kubeapiservertesting.TestServer
+	kubeAPIServer     *kubeapiservertesting.TestServer
 	restClient        *kubernetes.Clientset
 	ns                *corev1.Namespace
 	secret            *corev1.Secret
@@ -102,9 +102,7 @@ func newTransformTest(l kubeapiservertesting.Logger, transformerConfigYAML strin
 		e.configDir = configDir
 	}
 
-	if e.kubeAPIServer, err = kubeapiservertesting.StartTestServer(l, nil, e.getEncryptionOptions(reload), e.storageConfig); err != nil {
-		return nil, fmt.Errorf("failed to start KubeAPI server: %v", err)
-	}
+	e.kubeAPIServer = kubeapiservertesting.StartTestServerOrDie(l, nil, e.getEncryptionOptions(reload), e.storageConfig)
 	klog.Infof("Started kube-apiserver %v", e.kubeAPIServer.ClientConfig.Host)
 
 	if e.restClient, err = kubernetes.NewForConfig(e.kubeAPIServer.ClientConfig); err != nil {

--- a/test/integration/dryrun/dryrun_test.go
+++ b/test/integration/dryrun/dryrun_test.go
@@ -214,13 +214,10 @@ func TestDryRun(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DryRun, true)()
 
 	// start API server
-	s, err := kubeapiservertesting.StartTestServer(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
+	s := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
 		"--disable-admission-plugins=ServiceAccount,StorageObjectInUseProtection",
 		"--runtime-config=api/all=true",
 	}, framework.SharedEtcd())
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer s.TearDownFn()
 
 	client, err := kubernetes.NewForConfig(s.ClientConfig)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
While reading cmd/kube-apiserver/app/testing/testserver.go, I noticed all the StartTestServer function calls can be replaced with StartTestServerOrDie functions, so I did it and made the StartTestServer function private.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to https://github.com/kubernetes/kubernetes/issues/117385

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
