### PR TITLE
ensure we can remove _output

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -367,6 +367,8 @@ function kube::build::clean() {
 
   if [[ -d "${LOCAL_OUTPUT_ROOT}" ]]; then
     kube::log::status "Removing _output directory"
+    # this ensures we can clean _output/local/go/cache which is not rw by default
+    chmod -R +w "${LOCAL_OUTPUT_ROOT}"
     rm -rf "${LOCAL_OUTPUT_ROOT}"
   fi
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Fixes `make clean`, which currently fails, if you run something like `make test GOFLAGS="-v -failfast -count=1" KUBE_COVER="y" WHAT=./pkg/kubelet/kuberuntime` (debugging https://github.com/kubernetes/kubernetes/issues/117362) then afterwards `make clean` will fail on:
```
+++ [0420 17:03:25] Removing _output directory
rm: /Users/bentheelder/go/src/k8s.io/kubernetes/_output/local/go/cache/mod/go.uber.org/automaxprocs@v1.5.2/.build/check_license.sh: Permission denied
```

AFAICT this issue does not exist on release-1.26 @ 67c667c788a or release-1.27 @ 523dd0297f7 but it does at HEAD, I think this is related to #117016 which added a `go install` to `golang::setup_env`.


https://github.com/kubernetes/kubernetes/pull/117273 may also be related or is at least a similar problem, need to follow up on that separately.



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

Since this was introduced since 1.27 and has not been released yet, no release note. I don't see this issue on release-1.27 @ 523dd0297f7, and #117016 is so far only in 1.28.

If we cherry-pick #117016 we'll need to pick this as well.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
