### PR TITLE
Add slash ended urls for service-account-issuer-discovery to match API in swagger

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -519,7 +519,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 	}...)
 
 	// Add the cluster role for reading the ServiceAccountIssuerDiscovery endpoints
-	// Also add slash ended URLs to allow non-golang clients to access apis without error
+	// Also allow slash-ended URLs to allow clients generated from published openapi docs prior to fixing the trailing slash to work properly
 	roles = append(roles, rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: "system:service-account-issuer-discovery"},
 		Rules: []rbacv1.PolicyRule{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -519,12 +519,15 @@ func ClusterRoles() []rbacv1.ClusterRole {
 	}...)
 
 	// Add the cluster role for reading the ServiceAccountIssuerDiscovery endpoints
+	// Also add slash ended URLs to allow non-golang clients to access apis without error
 	roles = append(roles, rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: "system:service-account-issuer-discovery"},
 		Rules: []rbacv1.PolicyRule{
 			rbacv1helpers.NewRule("get").URLs(
 				"/.well-known/openid-configuration",
+				"/.well-known/openid-configuration/",
 				"/openid/v1/jwks",
+				"/openid/v1/jwks/",
 			).RuleOrDie(),
 		},
 	})

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -1280,7 +1280,9 @@ items:
   rules:
   - nonResourceURLs:
     - /.well-known/openid-configuration
+    - /.well-known/openid-configuration/
     - /openid/v1/jwks
+    - /openid/v1/jwks/
     verbs:
     - get
 - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The service-account-issuer-discovery URLs(`/.well-known/openid-configuration` and `/openid/v1/jwks`) in swagger.json are slash ended, but the `system:service-account-issuer-discovery` is only allowed to access non slash ended endpoints.

In this case, if users follow the swagger, the request will be failed and make user confused.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #117455

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
