### PR TITLE
Moving Kubelet Credential Provider test to common so that it can be r…

### DIFF
--- a/test/e2e/common/node/image_credential_provider.go
+++ b/test/e2e/common/node/image_credential_provider.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2enode
+package node
 
 import (
 	"context"
@@ -30,7 +30,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-var _ = SIGDescribe("ImageCredentialProvider", func() {
+var _ = SIGDescribe("ImageCredentialProvider [Feature:KubeletCredentialProviders]", func() {
 	f := framework.NewDefaultFramework("image-credential-provider")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 	var podClient *e2epod.PodClient


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR moves image_credential_provider test from test/e2e_node test to test/common/node so that it can be run both as a node and a cluster test. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```