### PR TITLE
kubeadm: fix unit test panic for TestNewResetData

### DIFF
--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -59,6 +59,7 @@ func TestNewResetData(t *testing.T) {
 			name: "fails if preflight ignores all but has individual check",
 			flags: map[string]string{
 				options.IgnorePreflightErrors: "all,something-else",
+				options.NodeCRISocket:         "unix:///var/run/crio/crio.sock",
 			},
 			expectError: "don't specify individual checks if 'all' is used",
 		},
@@ -66,6 +67,7 @@ func TestNewResetData(t *testing.T) {
 			name: "pre-flights errors from CLI args",
 			flags: map[string]string{
 				options.IgnorePreflightErrors: "a,b",
+				options.NodeCRISocket:         "unix:///var/run/crio/crio.sock",
 			},
 			validate: expectedResetIgnorePreflightErrors(sets.New("a", "b")),
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When multiple CRI endpoints on the host:
```sh
go test -timeout 30s -run ^TestNewResetData$ k8s.io/kubernetes/cmd/kubeadm/app/cmd

--- FAIL: TestNewResetData (0.00s)
    --- FAIL: TestNewResetData/pre-flights_errors_from_CLI_args (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x101886dcd]

goroutine 51 [running]:
testing.tRunner.func1.2({0x101ae3ae0, 0x1031c3ac0})
        /Users/machine/workspace/soft/go/src/testing/testing.go:1526 +0x24e
testing.tRunner.func1()
        /Users/machine/workspace/soft/go/src/testing/testing.go:1529 +0x39f
panic({0x101ae3ae0, 0x1031c3ac0})
        /Users/machine/workspace/soft/go/src/runtime/panic.go:884 +0x213
k8s.io/kubernetes/cmd/kubeadm/app/cmd.expectedResetIgnorePreflightErrors.func1(0xc0004d46e0?, 0xc0003807e0?)
        /Users/machine/workspace/gopath/src/k8s.io/kubernetes/cmd/kubeadm/app/cmd/reset_test.go:110 +0x2d
k8s.io/kubernetes/cmd/kubeadm/app/cmd.TestNewResetData.func1(0xc0004d3ba0)
        /Users/machine/workspace/gopath/src/k8s.io/kubernetes/cmd/kubeadm/app/cmd/reset_test.go:102 +0x5e3
testing.tRunner(0xc0004d3ba0, 0xc00039cda0)
        /Users/machine/workspace/soft/go/src/testing/testing.go:1576 +0x10b
created by testing.(*T).Run
        /Users/machine/workspace/soft/go/src/testing/testing.go:1629 +0x3ea
FAIL    k8s.io/kubernetes/cmd/kubeadm/app/cmd   0.642s
FAIL
```
we need to pass a predefined CRI endpoint in CLI flag for unit tests.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref kubernetes/kubeadm#2863

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
