### PR TITLE
fix Test_nodeLogQuery_validate/boot failure in windows scenario

### DIFF
--- a/pkg/kubelet/kubelet_server_journal_test.go
+++ b/pkg/kubelet/kubelet_server_journal_test.go
@@ -189,7 +189,7 @@ func Test_nodeLogQuery_validate(t *testing.T) {
 		{name: "until", Services: []string{service1}, options: options{UntilTime: &until}},
 		{name: "since until", Services: []string{service1}, options: options{SinceTime: &until, UntilTime: &since},
 			wantErr: true},
-		{name: "boot", Services: []string{service1}, options: options{Boot: intPtr(-1)}},
+		{name: "boot", Services: []string{service1}, options: options{Boot: intPtr(-1)}, wantErr: true},
 		{name: "boot out of range", Services: []string{service1}, options: options{Boot: intPtr(1)}, wantErr: true},
 		{name: "tailLines", Services: []string{service1}, options: options{TailLines: intPtr(100)}},
 		{name: "tailLines out of range", Services: []string{service1}, options: options{TailLines: intPtr(100000)}},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Fix failing unit tests on windows:
```
=== Failed
[1111](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit-windows-master/1649936520225755136#1:build-log.txt%3A1111)
=== FAIL: pkg/kubelet Test_nodeLogQuery_validate/boot (0.00s)
[1112](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit-windows-master/1649936520225755136#1:build-log.txt%3A1112)
    kubelet_server_journal_test.go:206: nodeLogQuery.validate() error = [boot: Invalid value: -1: boot is not supported on Windows], wantErr false
[1113](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit-windows-master/1649936520225755136#1:build-log.txt%3A1113)
[1114](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit-windows-master/1649936520225755136#1:build-log.txt%3A1114)
=== FAIL: pkg/kubelet Test_nodeLogQuery_validate (0.00s)
[1115](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit-windows-master/1649936520225755136#1:build-log.txt%3A1115)

```
CI: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit-windows-master/1649936520225755136

