### PR TITLE
add shortnames for mutatingwebhookconfigurations and validatingwebhookconfigurations

### DIFF
--- a/pkg/registry/admissionregistration/mutatingwebhookconfiguration/storage/storage.go
+++ b/pkg/registry/admissionregistration/mutatingwebhookconfiguration/storage/storage.go
@@ -64,3 +64,8 @@ var _ rest.CategoriesProvider = &REST{}
 func (r *REST) Categories() []string {
 	return []string{"api-extensions"}
 }
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"mwc"}
+}

--- a/pkg/registry/admissionregistration/mutatingwebhookconfiguration/storage/storage_test.go
+++ b/pkg/registry/admissionregistration/mutatingwebhookconfiguration/storage/storage_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"testing"
+
+	"k8s.io/apiserver/pkg/registry/generic"
+	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
+	"k8s.io/kubernetes/pkg/apis/admissionregistration"
+	"k8s.io/kubernetes/pkg/registry/registrytest"
+
+	// Ensure that admissionregistration package is initialized.
+	_ "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
+)
+
+func newStorage(t *testing.T) (*REST, *etcd3testing.EtcdTestServer) {
+	etcdStorage, server := registrytest.NewEtcdStorage(t, admissionregistration.GroupName)
+	restOptions := generic.RESTOptions{
+		StorageConfig:           etcdStorage,
+		Decorator:               generic.UndecoratedStorage,
+		DeleteCollectionWorkers: 1,
+		ResourcePrefix:          "mutatingwebhookconfigurations"}
+	storage, err := NewREST(restOptions)
+	if err != nil {
+		t.Fatalf("unexpected error from REST storage: %v", err)
+	}
+	return storage, server
+}
+
+func TestShortNames(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	expected := []string{"mwc"}
+	registrytest.AssertShortNames(t, storage, expected)
+}

--- a/pkg/registry/admissionregistration/validatingwebhookconfiguration/storage/storage.go
+++ b/pkg/registry/admissionregistration/validatingwebhookconfiguration/storage/storage.go
@@ -64,3 +64,8 @@ var _ rest.CategoriesProvider = &REST{}
 func (r *REST) Categories() []string {
 	return []string{"api-extensions"}
 }
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"vwc"}
+}

--- a/pkg/registry/admissionregistration/validatingwebhookconfiguration/storage/storage_test.go
+++ b/pkg/registry/admissionregistration/validatingwebhookconfiguration/storage/storage_test.go
@@ -199,3 +199,11 @@ func TestCategories(t *testing.T) {
 	expected := []string{"api-extensions"}
 	registrytest.AssertCategories(t, storage, expected)
 }
+
+func TestShortNames(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	expected := []string{"vwc"}
+	registrytest.AssertShortNames(t, storage, expected)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
add shortnames for mutatingwebhookconfigurations and validatingwebhookconfigurations. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

original release note (dropped with revert in https://github.com/kubernetes/kubernetes/pull/117993)
```
The short names vwc and mwc were introduced for the resources validatingwebhookconfigurations and mutatingwebhookconfigurations.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```