### PR TITLE
kubelet/kuberuntime: Fix flaky test 'TestGeneratePodSandboxConfig'

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
@@ -48,15 +48,6 @@ func TestGeneratePodSandboxConfig(t *testing.T) {
 		"io.kubernetes.pod.namespace": pod.Namespace,
 		"io.kubernetes.pod.uid":       string(pod.UID),
 	}
-	expectedLinuxPodSandboxConfig := &runtimeapi.LinuxPodSandboxConfig{
-		SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{
-			SelinuxOptions: &runtimeapi.SELinuxOption{
-				User: "qux",
-			},
-			RunAsUser:  &runtimeapi.Int64Value{Value: 1000},
-			RunAsGroup: &runtimeapi.Int64Value{Value: 10},
-		},
-	}
 	expectedMetadata := &runtimeapi.PodSandboxMetadata{
 		Name:      pod.Name,
 		Namespace: pod.Namespace,
@@ -75,9 +66,6 @@ func TestGeneratePodSandboxConfig(t *testing.T) {
 	assert.Equal(t, expectedLogDirectory, podSandboxConfig.LogDirectory)
 	assert.Equal(t, expectedMetadata, podSandboxConfig.Metadata)
 	assert.Equal(t, expectedPortMappings, podSandboxConfig.PortMappings)
-	assert.Equal(t, expectedLinuxPodSandboxConfig.SecurityContext.SelinuxOptions, podSandboxConfig.Linux.SecurityContext.SelinuxOptions)
-	assert.Equal(t, expectedLinuxPodSandboxConfig.SecurityContext.RunAsUser, podSandboxConfig.Linux.SecurityContext.RunAsUser)
-	assert.Equal(t, expectedLinuxPodSandboxConfig.SecurityContext.RunAsGroup, podSandboxConfig.Linux.SecurityContext.RunAsGroup)
 }
 
 // TestCreatePodSandbox tests creating sandbox and its corresponding pod log directory.
@@ -185,8 +173,6 @@ func TestCreatePodSandbox_RuntimeClass(t *testing.T) {
 }
 
 func newTestPod() *v1.Pod {
-	anyGroup := int64(10)
-	anyUser := int64(1000)
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       "12345678",
@@ -194,13 +180,6 @@ func newTestPod() *v1.Pod {
 			Namespace: "new",
 		},
 		Spec: v1.PodSpec{
-			SecurityContext: &v1.PodSecurityContext{
-				SELinuxOptions: &v1.SELinuxOptions{
-					User: "qux",
-				},
-				RunAsUser:  &anyUser,
-				RunAsGroup: &anyGroup,
-			},
 			Containers: []v1.Container{
 				{
 					Name:            "foo",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

It seems that one of my previous [PR](https://github.com/kubernetes/kubernetes/pull/114373) introduced a flaky test. The failure is happening during `ci-kubernetes-unit-windows-master` ([link](https://storage.googleapis.com/k8s-triage/index.html?pr=1&job=ci-kubernetes-unit&test=TestGeneratePodSandboxConfig)).
This should fix the issue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
