### PR TITLE
mount-utils: fix flaky test 'TestFormat'

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_linux_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux_test.go
@@ -649,41 +649,28 @@ func TestCheckUmountError(t *testing.T) {
 	}
 }
 
-func TestFormat(t *testing.T) {
+// TODO https://github.com/kubernetes/kubernetes/pull/117539#discussion_r1181873355
+func TestFormatConcurrency(t *testing.T) {
 	const (
 		formatCount    = 5
 		fstype         = "ext4"
 		output         = "complete"
-		cmdDuration    = 1 * time.Millisecond
 		defaultTimeout = 1 * time.Minute
 	)
 
 	tests := []struct {
-		desc           string
-		max            int
-		timeout        time.Duration
-		wantConcurrent int
+		desc    string
+		max     int
+		timeout time.Duration
 	}{
 		{
-			max:            0,
-			wantConcurrent: formatCount,
+			max: 2,
 		},
 		{
-			max:            -1,
-			wantConcurrent: formatCount,
+			max: 3,
 		},
 		{
-			max:            1,
-			wantConcurrent: 1,
-		},
-		{
-			max:            3,
-			wantConcurrent: 3,
-		},
-		{
-			max:            3,
-			timeout:        1 * time.Nanosecond,
-			wantConcurrent: formatCount,
+			max: 4,
 		},
 	}
 
@@ -693,20 +680,18 @@ func TestFormat(t *testing.T) {
 				tc.timeout = defaultTimeout
 			}
 
-			var concurrent, maxConcurrent int
+			var concurrent int
 			var mu sync.Mutex
+			witness := make(chan struct{})
 
 			exec := &testexec.FakeExec{}
 			for i := 0; i < formatCount; i++ {
 				exec.CommandScript = append(exec.CommandScript, makeFakeCommandAction(output, nil, func() {
 					mu.Lock()
 					concurrent++
-					if concurrent > maxConcurrent {
-						maxConcurrent = concurrent
-					}
 					mu.Unlock()
 
-					time.Sleep(cmdDuration)
+					<-witness
 
 					mu.Lock()
 					concurrent--
@@ -715,21 +700,109 @@ func TestFormat(t *testing.T) {
 			}
 			mounter := NewSafeFormatAndMount(nil, exec, WithMaxConcurrentFormat(tc.max, tc.timeout))
 
-			var wg sync.WaitGroup
-			for i := 0; i < formatCount; i++ {
-				wg.Add(1)
+			// we run max+1 goroutines and block the command execution
+			// only max goroutine should be running and the additional one should wait
+			// for one to be released
+			for i := 0; i < tc.max+1; i++ {
 				go func() {
-					defer wg.Done()
 					mounter.format(fstype, nil)
 				}()
 			}
-			wg.Wait()
 
-			if maxConcurrent != tc.wantConcurrent {
-				t.Errorf("SafeFormatAndMount.format() got concurrency: %d, want: %d", maxConcurrent, tc.wantConcurrent)
+			// wait for all goorutines to be scheduled
+			time.Sleep(100 * time.Millisecond)
+
+			mu.Lock()
+			if concurrent != tc.max {
+				t.Errorf("SafeFormatAndMount.format() got concurrency: %d, want: %d", concurrent, tc.max)
 			}
+			mu.Unlock()
+
+			// signal the commands to finish the goroutines, this will allow the command
+			// that is pending to be executed
+			for i := 0; i < tc.max; i++ {
+				witness <- struct{}{}
+			}
+
+			// wait for all goroutines to acquire the lock and decrement the counter
+			time.Sleep(100 * time.Millisecond)
+
+			mu.Lock()
+			if concurrent != 1 {
+				t.Errorf("SafeFormatAndMount.format() got concurrency: %d, want: 1", concurrent)
+			}
+			mu.Unlock()
+
+			// signal the pending command to finish, no more command should be running
+			close(witness)
+
+			// wait a few for the last goroutine to acquire the lock and decrements the counter down to zero
+			time.Sleep(10 * time.Millisecond)
+
+			mu.Lock()
+			if concurrent != 0 {
+				t.Errorf("SafeFormatAndMount.format() got concurrency: %d, want: 0", concurrent)
+			}
+			mu.Unlock()
 		})
 	}
+}
+
+// TODO https://github.com/kubernetes/kubernetes/pull/117539#discussion_r1181873355
+func TestFormatTimeout(t *testing.T) {
+	const (
+		formatCount    = 5
+		fstype         = "ext4"
+		output         = "complete"
+		maxConcurrency = 4
+		timeout        = 200 * time.Millisecond
+	)
+
+	var concurrent int
+	var mu sync.Mutex
+	witness := make(chan struct{})
+
+	exec := &testexec.FakeExec{}
+	for i := 0; i < formatCount; i++ {
+		exec.CommandScript = append(exec.CommandScript, makeFakeCommandAction(output, nil, func() {
+			mu.Lock()
+			concurrent++
+			mu.Unlock()
+
+			<-witness
+
+			mu.Lock()
+			concurrent--
+			mu.Unlock()
+		}))
+	}
+	mounter := NewSafeFormatAndMount(nil, exec, WithMaxConcurrentFormat(maxConcurrency, timeout))
+
+	for i := 0; i < maxConcurrency+1; i++ {
+		go func() {
+			mounter.format(fstype, nil)
+		}()
+	}
+
+	// wait a bit more than the configured timeout
+	time.Sleep(timeout + 100*time.Millisecond)
+
+	mu.Lock()
+	if concurrent != maxConcurrency+1 {
+		t.Errorf("SafeFormatAndMount.format() got concurrency: %d, want: %d", concurrent, maxConcurrency+1)
+	}
+	mu.Unlock()
+
+	// signal the pending commands to finish
+	close(witness)
+	// wait for all goroutines to acquire the lock and decrement the counter
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	if concurrent != 0 {
+		t.Errorf("SafeFormatAndMount.format() got concurrency: %d, want: 0", concurrent)
+	}
+	mu.Unlock()
 }
 
 func makeFakeCommandAction(stdout string, err error, cmdFn func()) testexec.FakeCommandAction {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

`TestFormat` from package `mount-utils` is reported as flaky ([link](https://storage.googleapis.com/k8s-triage/index.html?pr=1&job=ci-kubernetes-unit&test=TestFormat)). 

- Before
<img width="869" alt="Screenshot 2023-04-23 at 19 31 36" src="https://user-images.githubusercontent.com/9576370/233855550-8029a6da-2382-47cd-b07a-a60398151283.png">

- After

<img width="890" alt="Screenshot 2023-04-23 at 19 30 16" src="https://user-images.githubusercontent.com/9576370/233855564-b4c09345-fac5-4b14-8945-31a8b0f70f63.png">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
