### PR TITLE
Support specify the name where use EphemeralContainer with kubectl debug

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -108,6 +108,7 @@ var nameSuffixFunc = utilrand.String
 
 // DebugOptions holds the options for an invocation of kubectl debug.
 type DebugOptions struct {
+	Name            string
 	Args            []string
 	ArgsOnly        bool
 	Attach          bool
@@ -176,6 +177,7 @@ func NewCmdDebug(restClientGetter genericclioptions.RESTClientGetter, streams ge
 func (o *DebugOptions) AddFlags(cmd *cobra.Command) {
 	cmdutil.AddJsonFilenameFlag(cmd.Flags(), &o.FilenameOptions.Filenames, "identifying the resource to debug")
 
+	cmd.Flags().StringVarP(&o.Name, "name", "", o.Name, i18n.T("Debug container name, if specified debug container will use it as container name, default debug container name is debugger-< 5 bit random character >. "))
 	cmd.Flags().BoolVar(&o.ArgsOnly, "arguments-only", o.ArgsOnly, i18n.T("If specified, everything after -- will be passed to the new container as Args instead of Command."))
 	cmd.Flags().BoolVar(&o.Attach, "attach", o.Attach, i18n.T("If true, wait for the container to start running, and then attach as if 'kubectl attach ...' were called.  Default false, unless '-i/--stdin' is set, in which case the default is true."))
 	cmd.Flags().StringVarP(&o.Container, "container", "c", o.Container, i18n.T("Container name to use for debug container."))
@@ -713,7 +715,7 @@ func (o *DebugOptions) computeDebugContainerName(pod *corev1.Pod) string {
 		return o.Container
 	}
 
-	cn, containerByName := "", containerNameToRef(pod)
+	cn, containerByName := o.Name, containerNameToRef(pod)
 	for len(cn) == 0 || (containerByName[cn] != nil) {
 		cn = fmt.Sprintf("debugger-%s", nameSuffixFunc(5))
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
To enhanced EphemeralContainer feature with kubectl debug command.
Then we will use one EphemeralContainer instead of leaving many debug containers to debug as EphemeralContainer can not be removed.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
