### PR TITLE
Fix: Restricted profile comply with PSS

### DIFF
--- a/hack/testdata/pod-restricted-localhost.yaml
+++ b/hack/testdata/pod-restricted-localhost.yaml
@@ -12,7 +12,7 @@ spec:
   containers:
   - image: busybox
     name: target
-    command: ["/bin/sh", "-c", "while :; do sleep 10; done"]
+    command: ["/bin/sh", "-c", "sleep 100"]
     securityContext:
         runAsUser: 1000
         runAsGroup: 1000
@@ -21,6 +21,3 @@ spec:
         capabilities:
           drop: 
           - "ALL"
-          add:
-          - "NET_BIND_SERVICE"
-          

--- a/hack/testdata/pod-restricted-localhost.yaml
+++ b/hack/testdata/pod-restricted-localhost.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: target
+  name: target
+spec:
+  securityContext:
+    seccompProfile: 
+      type: Localhost
+      localhostProfile: dummy.json
+  containers:
+  - image: busybox
+    name: target
+    command: ["/bin/sh", "-c", "while :; do sleep 10; done"]
+    securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: 
+          - "ALL"
+          add:
+          - "NET_BIND_SERVICE"
+          

--- a/hack/testdata/pod-restricted-runtime-default.yaml
+++ b/hack/testdata/pod-restricted-runtime-default.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: target
+  name: target
+spec:
+  securityContext:
+    seccompProfile: 
+      type: RuntimeDefault
+  containers:
+  - image: busybox
+    name: target
+    command: ["/bin/sh", "-c", "while :; do sleep 10; done"]
+    securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: 
+          - "ALL"
+          add:
+          - "NET_BIND_SERVICE"
+          

--- a/hack/testdata/pod-restricted-runtime-default.yaml
+++ b/hack/testdata/pod-restricted-runtime-default.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - image: busybox
     name: target
-    command: ["/bin/sh", "-c", "while :; do sleep 10; done"]
+    command: ["/bin/sh", "-c", "sleep 100"]
     securityContext:
         runAsUser: 1000
         runAsGroup: 1000
@@ -20,6 +20,3 @@ spec:
         capabilities:
           drop: 
           - "ALL"
-          add:
-          - "NET_BIND_SERVICE"
-          

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -289,6 +289,8 @@ func TestGenerateDebugContainer(t *testing.T) {
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{"ALL"},
 						},
+						AllowPrivilegeEscalation: pointer.Bool(false),
+						SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
 					},
 				},
 			},
@@ -1274,10 +1276,12 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 							Image:           "busybox",
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot: pointer.Bool(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},
-								RunAsNonRoot: pointer.Bool(true),
+								AllowPrivilegeEscalation: pointer.Bool(false),
+								SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
 							},
 						},
 					},
@@ -1646,6 +1650,8 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},
+								AllowPrivilegeEscalation: pointer.Bool(false),
+								SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
 							},
 						},
 					},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles_test.go
@@ -347,6 +347,8 @@ func TestRestrictedProfile(t *testing.T) {
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},
+								AllowPrivilegeEscalation: pointer.Bool(false),
+								SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
 							},
 						},
 					},
@@ -386,6 +388,8 @@ func TestRestrictedProfile(t *testing.T) {
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},
+								AllowPrivilegeEscalation: pointer.Bool(false),
+								SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
 							},
 						},
 					},
@@ -404,6 +408,8 @@ func TestRestrictedProfile(t *testing.T) {
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{"ALL"},
 								},
+								AllowPrivilegeEscalation: pointer.Bool(false),
+								SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
 							},
 						},
 					},
@@ -423,6 +429,8 @@ func TestRestrictedProfile(t *testing.T) {
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},
+								AllowPrivilegeEscalation: pointer.Bool(false),
+								SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
 							},
 						},
 					},

--- a/test/cmd/debug.sh
+++ b/test/cmd/debug.sh
@@ -88,44 +88,6 @@ run_kubectl_debug_pod_tests() {
   # Clean up
   kubectl delete pod target target-copy "${kube_flags[@]:?}"
 
-  ### Pod Troubleshooting by ephemeral containers with debugging profile
-  
-  # Pre-Condition: Pod "nginx" is created
-  kubectl run target "--image=${IMAGE_NGINX:?}" "${kube_flags[@]:?}"
-  kube::test::get_object_assert pod "{{range.items}}{{${id_field:?}}}:{{end}}" 'target:'
-  # Restricted profile just works in not restricted namespace
-  # Command: add a new debug container with restricted profile
-  kubectl debug target -it --image=gcr.io/distroless/static-debian11:debug-nonroot --attach=false -c debug-container --profile=restricted "${kube_flags[@]:?}"
-  # Post-Conditions
-  kube::test::get_object_assert pod/target '{{range.spec.ephemeralContainers}}{{.name}}:{{end}}' 'debug-container:'
-  # Clean up
-  kubectl delete pod target "${kube_flags[@]:?}"
-
-  # Create and use a namespace with restricted policy
-  create_and_use_new_restricted_namespace
-
-  # Pre-Condition: Pod "busybox" is created that complies with the restricted policy
-  kubectl create -f hack/testdata/pod-restricted-runtime-default.yaml
-  kube::test::get_object_assert pod "{{range.items}}{{${id_field:?}}}:{{end}}" 'target:'
-  # Restricted profile works when pod's seccompProfile is RuntimeDefault
-  # Command: add a new debug container with restricted profile
-  kubectl debug target -it --image=gcr.io/distroless/static-debian11:debug-nonroot --attach=false -c debug-container --profile=restricted "${kube_flags[@]:?}"
-  # Post-Conditions
-  kube::test::get_object_assert pod/target '{{range.spec.ephemeralContainers}}{{.name}}:{{end}}' 'debug-container:'
-  # Clean up
-  kubectl delete pod target "${kube_flags[@]:?}"
-
-  # Pre-Condition: Pod "busybox" is created that complies with the restricted policy
-  kubectl create -f hack/testdata/pod-restricted-localhost.yaml
-  kube::test::get_object_assert pod "{{range.items}}{{${id_field:?}}}:{{end}}" 'target:'
-  # Restricted profile works when pod's seccompProfile is Localhost
-  # Command: add a new debug container with restricted profile
-  kubectl debug target -it --image=gcr.io/distroless/static-debian11:debug-nonroot --attach=false -c debug-container --profile=restricted "${kube_flags[@]:?}"
-  # Post-Conditions
-  kube::test::get_object_assert pod/target '{{range.spec.ephemeralContainers}}{{.name}}:{{end}}' 'debug-container:'
-  # Clean up
-  kubectl delete pod target "${kube_flags[@]:?}"
-
   set +o nounset
   set +o errexit
 }
@@ -310,6 +272,134 @@ run_kubectl_debug_baseline_node_tests() {
   kube::test::get_object_assert "pod/${debugger:?}" '{{.spec.hostNetwork}}' '<no value>'
   kube::test::get_object_assert "pod/${debugger:?}" '{{.spec.hostPID}}' '<no value>'
   kube::test::get_object_assert "pod/${debugger:?}" '{{if (index (index .spec.containers 0) "securityContext")}}:{{end}}' ''
+  # Clean up
+  # pod.spec.nodeName is set by kubectl debug node which causes the delete to hang,
+  # presumably waiting for a kubelet that's not present. Force the delete.
+  kubectl delete --force pod "${debugger:?}" "${kube_flags[@]:?}"
+
+  set +o nounset
+  set +o errexit
+}
+
+run_kubectl_debug_restricted_tests() {
+  set -o nounset
+  set -o errexit
+
+  create_and_use_new_namespace  
+  kube::log::status "Testing kubectl debug profile restricted"
+
+  ### Pod Troubleshooting by ephemeral containers with restricted profile
+  
+  # Pre-Condition: Pod "nginx" is created
+  kubectl run target "--image=${IMAGE_NGINX:?}" "${kube_flags[@]:?}"
+  kube::test::get_object_assert pod "{{range.items}}{{${id_field:?}}}:{{end}}" 'target:'
+  # Restricted profile just works in not restricted namespace
+  # Command: add a new debug container with restricted profile
+  output_message=$(kubectl debug target -it --image=busybox --attach=false -c debug-container --profile=restricted "${kube_flags[@]:?}")
+  kube::test::if_has_not_string "${output_message}" 'forbidden: violates PodSecurity'
+  # Post-Conditions
+  kube::test::get_object_assert pod/target '{{range.spec.ephemeralContainers}}{{.name}}:{{end}}' 'debug-container:'
+  # Clean up
+  kubectl delete pod target "${kube_flags[@]:?}"
+
+  local ns_name="namespace-restricted"
+  # Command: create namespace and add a label
+  kubectl create namespace "${ns_name}"
+  kubectl label namespace "${ns_name}" pod-security.kubernetes.io/enforce=restricted
+  output_message=$(kubectl get namespaces "${ns_name}" --show-labels)
+  kube::test::if_has_string "${output_message}" 'pod-security.kubernetes.io/enforce=restricted'
+  kubectl config set-context "${CONTEXT}" --namespace="${ns_name}"
+ 
+  # Pre-Condition: Pod "busybox" is created that complies with the restricted policy
+  kubectl create -f hack/testdata/pod-restricted-runtime-default.yaml
+  kube::test::get_object_assert pod "{{range.items}}{{${id_field:?}}}:{{end}}" 'target:'
+  # Restricted profile works when pod's seccompProfile is RuntimeDefault
+  # Command: add a new debug container with restricted profile
+  output_message=$(kubectl debug target -it --image=busybox --attach=false -c debug-container --profile=restricted "${kube_flags[@]:?}")
+  kube::test::if_has_not_string "${output_message}" 'forbidden: violates PodSecurity'
+  # Post-Conditions
+  kube::test::get_object_assert pod/target '{{range.spec.ephemeralContainers}}{{.name}}:{{end}}' 'debug-container:'
+  # Clean up
+  kubectl delete pod target "${kube_flags[@]:?}"
+
+  # Pre-Condition: Pod "busybox" is created that complies with the restricted policy
+  kubectl create -f hack/testdata/pod-restricted-localhost.yaml
+  kube::test::get_object_assert pod "{{range.items}}{{${id_field:?}}}:{{end}}" 'target:'
+  # Restricted profile works when pod's seccompProfile is Localhost
+  # Command: add a new debug container with restricted profile
+  output_message=$(kubectl debug target -it --image=busybox --attach=false -c debug-container --profile=restricted "${kube_flags[@]:?}")
+  kube::test::if_has_not_string "${output_message}" 'forbidden: violates PodSecurity'
+  # Post-Conditions
+  kube::test::get_object_assert pod/target '{{range.spec.ephemeralContainers}}{{.name}}:{{end}}' 'debug-container:'
+  # Clean up
+  kubectl delete pod target "${kube_flags[@]:?}"
+
+  set +o nounset
+  set +o errexit
+}
+
+run_kubectl_debug_restricted_node_tests() {
+  set -o nounset
+  set -o errexit
+
+  create_and_use_new_namespace  
+  kube::log::status "Testing kubectl debug profile restricted (node)"
+
+  ### Debug node with restrected profile
+  
+  # Pre-Condition: node exists
+  kube::test::get_object_assert nodes "{{range.items}}{{${id_field:?}}}:{{end}}" '127.0.0.1:'
+  # Restricted profile just works in not restricted namespace
+  # Command: create a new node debugger pod
+  output_message=$(kubectl debug --profile restricted node/127.0.0.1 --image=busybox --attach=false "${kube_flags[@]:?}" -- true)
+  kube::test::if_has_not_string "${output_message}" 'forbidden: violates PodSecurity'
+  # Post-Conditions
+  kube::test::get_object_assert pod "{{(len .items)}}" '1'
+  debugger=$(kubectl get pod -o go-template="{{(index .items 0)${id_field:?}}}")
+  kube::test::if_has_string "${output_message:?}" "${debugger:?}"
+  kube::test::get_object_assert "pod/${debugger:?}" "{{${image_field:?}}}" 'busybox'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{.spec.nodeName}}' '127.0.0.1'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{.spec.hostIPC}}' '<no value>'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{.spec.hostNetwork}}' '<no value>'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{.spec.hostPID}}' '<no value>'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{index .spec.containers 0 "securityContext" "allowPrivilegeEscalation"}}' 'false'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{index .spec.containers 0 "securityContext" "capabilities" "drop"}}' '\[ALL\]'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{if (index (index .spec.containers 0) "securityContext" "capabilities" "add") }}:{{end}}' ''
+  kube::test::get_object_assert "pod/${debugger:?}" '{{index .spec.containers 0 "securityContext" "runAsNonRoot"}}' 'true'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{index .spec.containers 0 "securityContext" "seccompProfile" "type"}}' 'RuntimeDefault'
+  # Clean up
+  # pod.spec.nodeName is set by kubectl debug node which causes the delete to hang,
+  # presumably waiting for a kubelet that's not present. Force the delete.
+  kubectl delete --force pod "${debugger:?}" "${kube_flags[@]:?}"
+
+  local ns_name="namespace-restricted"
+  # Command: create namespace and add a label
+  kubectl create namespace "${ns_name}"
+  kubectl label namespace "${ns_name}" pod-security.kubernetes.io/enforce=restricted
+  output_message=$(kubectl get namespaces "${ns_name}" --show-labels)
+  kube::test::if_has_string "${output_message}" 'pod-security.kubernetes.io/enforce=restricted'
+  kubectl config set-context "${CONTEXT}" --namespace="${ns_name}"
+
+  # Pre-Condition: node exists
+  kube::test::get_object_assert nodes "{{range.items}}{{${id_field:?}}}:{{end}}" '127.0.0.1:'
+  # Restricted profile works in restricted namespace
+  # Command: create a new node debugger pod
+  output_message=$(kubectl debug --profile restricted node/127.0.0.1 --image=busybox --attach=false "${kube_flags[@]:?}" -- true)
+  kube::test::if_has_not_string "${output_message}" 'forbidden: violates PodSecurity'
+  # Post-Conditions
+  kube::test::get_object_assert pod "{{(len .items)}}" '1'
+  debugger=$(kubectl get pod -o go-template="{{(index .items 0)${id_field:?}}}")
+  kube::test::if_has_string "${output_message:?}" "${debugger:?}"
+  kube::test::get_object_assert "pod/${debugger:?}" "{{${image_field:?}}}" 'busybox'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{.spec.nodeName}}' '127.0.0.1'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{.spec.hostIPC}}' '<no value>'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{.spec.hostNetwork}}' '<no value>'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{.spec.hostPID}}' '<no value>'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{index .spec.containers 0 "securityContext" "allowPrivilegeEscalation"}}' 'false'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{index .spec.containers 0 "securityContext" "capabilities" "drop"}}' '\[ALL\]'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{if (index (index .spec.containers 0) "securityContext" "capabilities" "add") }}:{{end}}' ''
+  kube::test::get_object_assert "pod/${debugger:?}" '{{index .spec.containers 0 "securityContext" "runAsNonRoot"}}' 'true'
+  kube::test::get_object_assert "pod/${debugger:?}" '{{index .spec.containers 0 "securityContext" "seccompProfile" "type"}}' 'RuntimeDefault'
   # Clean up
   # pod.spec.nodeName is set by kubectl debug node which causes the delete to hang,
   # presumably waiting for a kubelet that's not present. Force the delete.

--- a/test/cmd/debug.sh
+++ b/test/cmd/debug.sh
@@ -302,37 +302,39 @@ run_kubectl_debug_restricted_tests() {
   # Clean up
   kubectl delete pod target "${kube_flags[@]:?}"
 
-  local ns_name="namespace-restricted"
+  ns_name="namespace-restricted"
   # Command: create namespace and add a label
   kubectl create namespace "${ns_name}"
   kubectl label namespace "${ns_name}" pod-security.kubernetes.io/enforce=restricted
   output_message=$(kubectl get namespaces "${ns_name}" --show-labels)
   kube::test::if_has_string "${output_message}" 'pod-security.kubernetes.io/enforce=restricted'
-  kubectl config set-context "${CONTEXT}" --namespace="${ns_name}"
  
   # Pre-Condition: Pod "busybox" is created that complies with the restricted policy
-  kubectl create -f hack/testdata/pod-restricted-runtime-default.yaml
-  kube::test::get_object_assert pod "{{range.items}}{{${id_field:?}}}:{{end}}" 'target:'
+  kubectl create -f hack/testdata/pod-restricted-runtime-default.yaml -n "${ns_name}"
+  kube::test::get_object_assert "pod -n ${ns_name}" "{{range.items}}{{${id_field:?}}}:{{end}}" 'target:'
   # Restricted profile works when pod's seccompProfile is RuntimeDefault
   # Command: add a new debug container with restricted profile
-  output_message=$(kubectl debug target -it --image=busybox --attach=false -c debug-container --profile=restricted "${kube_flags[@]:?}")
+  output_message=$(kubectl debug target -it --image=busybox --attach=false -c debug-container --profile=restricted -n "${ns_name}" "${kube_flags[@]:?}")
   kube::test::if_has_not_string "${output_message}" 'forbidden: violates PodSecurity'
   # Post-Conditions
-  kube::test::get_object_assert pod/target '{{range.spec.ephemeralContainers}}{{.name}}:{{end}}' 'debug-container:'
+  kube::test::get_object_assert "pod/target -n ${ns_name}" '{{range.spec.ephemeralContainers}}{{.name}}:{{end}}' 'debug-container:'
   # Clean up
-  kubectl delete pod target "${kube_flags[@]:?}"
+  kubectl delete pod target -n "${ns_name}" "${kube_flags[@]:?}"
 
   # Pre-Condition: Pod "busybox" is created that complies with the restricted policy
-  kubectl create -f hack/testdata/pod-restricted-localhost.yaml
-  kube::test::get_object_assert pod "{{range.items}}{{${id_field:?}}}:{{end}}" 'target:'
+  kubectl create -f hack/testdata/pod-restricted-localhost.yaml -n "${ns_name}"
+  kube::test::get_object_assert "pod -n ${ns_name}" "{{range.items}}{{${id_field:?}}}:{{end}}" 'target:'
   # Restricted profile works when pod's seccompProfile is Localhost
   # Command: add a new debug container with restricted profile
-  output_message=$(kubectl debug target -it --image=busybox --attach=false -c debug-container --profile=restricted "${kube_flags[@]:?}")
+  output_message=$(kubectl debug target -it --image=busybox --attach=false -c debug-container --profile=restricted -n ${ns_name} "${kube_flags[@]:?}")
   kube::test::if_has_not_string "${output_message}" 'forbidden: violates PodSecurity'
   # Post-Conditions
-  kube::test::get_object_assert pod/target '{{range.spec.ephemeralContainers}}{{.name}}:{{end}}' 'debug-container:'
+  kube::test::get_object_assert "pod/target -n ${ns_name}" '{{range.spec.ephemeralContainers}}{{.name}}:{{end}}' 'debug-container:'
   # Clean up
-  kubectl delete pod target "${kube_flags[@]:?}"
+  kubectl delete pod target -n ${ns_name} "${kube_flags[@]:?}"
+
+  # Clean up restricted namespace
+  kubectl delete namespace "${ns_name}"
 
   set +o nounset
   set +o errexit
@@ -372,38 +374,40 @@ run_kubectl_debug_restricted_node_tests() {
   # presumably waiting for a kubelet that's not present. Force the delete.
   kubectl delete --force pod "${debugger:?}" "${kube_flags[@]:?}"
 
-  local ns_name="namespace-restricted"
+  ns_name="namespace-restricted"
   # Command: create namespace and add a label
   kubectl create namespace "${ns_name}"
   kubectl label namespace "${ns_name}" pod-security.kubernetes.io/enforce=restricted
   output_message=$(kubectl get namespaces "${ns_name}" --show-labels)
   kube::test::if_has_string "${output_message}" 'pod-security.kubernetes.io/enforce=restricted'
-  kubectl config set-context "${CONTEXT}" --namespace="${ns_name}"
 
   # Pre-Condition: node exists
   kube::test::get_object_assert nodes "{{range.items}}{{${id_field:?}}}:{{end}}" '127.0.0.1:'
   # Restricted profile works in restricted namespace
   # Command: create a new node debugger pod
-  output_message=$(kubectl debug --profile restricted node/127.0.0.1 --image=busybox --attach=false "${kube_flags[@]:?}" -- true)
+  output_message=$(kubectl debug --profile restricted node/127.0.0.1 --image=busybox --attach=false -n ${ns_name} "${kube_flags[@]:?}" -- true)
   kube::test::if_has_not_string "${output_message}" 'forbidden: violates PodSecurity'
   # Post-Conditions
-  kube::test::get_object_assert pod "{{(len .items)}}" '1'
-  debugger=$(kubectl get pod -o go-template="{{(index .items 0)${id_field:?}}}")
+  kube::test::get_object_assert "pod -n ${ns_name}" "{{(len .items)}}" '1'
+  debugger=$(kubectl get pod -n ${ns_name} -o go-template="{{(index .items 0)${id_field:?}}}")
   kube::test::if_has_string "${output_message:?}" "${debugger:?}"
-  kube::test::get_object_assert "pod/${debugger:?}" "{{${image_field:?}}}" 'busybox'
-  kube::test::get_object_assert "pod/${debugger:?}" '{{.spec.nodeName}}' '127.0.0.1'
-  kube::test::get_object_assert "pod/${debugger:?}" '{{.spec.hostIPC}}' '<no value>'
-  kube::test::get_object_assert "pod/${debugger:?}" '{{.spec.hostNetwork}}' '<no value>'
-  kube::test::get_object_assert "pod/${debugger:?}" '{{.spec.hostPID}}' '<no value>'
-  kube::test::get_object_assert "pod/${debugger:?}" '{{index .spec.containers 0 "securityContext" "allowPrivilegeEscalation"}}' 'false'
-  kube::test::get_object_assert "pod/${debugger:?}" '{{index .spec.containers 0 "securityContext" "capabilities" "drop"}}' '\[ALL\]'
-  kube::test::get_object_assert "pod/${debugger:?}" '{{if (index (index .spec.containers 0) "securityContext" "capabilities" "add") }}:{{end}}' ''
-  kube::test::get_object_assert "pod/${debugger:?}" '{{index .spec.containers 0 "securityContext" "runAsNonRoot"}}' 'true'
-  kube::test::get_object_assert "pod/${debugger:?}" '{{index .spec.containers 0 "securityContext" "seccompProfile" "type"}}' 'RuntimeDefault'
+  kube::test::get_object_assert "pod/${debugger:?} -n ${ns_name}" "{{${image_field:?}}}" 'busybox'
+  kube::test::get_object_assert "pod/${debugger:?} -n ${ns_name}" '{{.spec.nodeName}}' '127.0.0.1'
+  kube::test::get_object_assert "pod/${debugger:?} -n ${ns_name}" '{{.spec.hostIPC}}' '<no value>'
+  kube::test::get_object_assert "pod/${debugger:?} -n ${ns_name}" '{{.spec.hostNetwork}}' '<no value>'
+  kube::test::get_object_assert "pod/${debugger:?} -n ${ns_name}" '{{.spec.hostPID}}' '<no value>'
+  kube::test::get_object_assert "pod/${debugger:?} -n ${ns_name}" '{{index .spec.containers 0 "securityContext" "allowPrivilegeEscalation"}}' 'false'
+  kube::test::get_object_assert "pod/${debugger:?} -n ${ns_name}" '{{index .spec.containers 0 "securityContext" "capabilities" "drop"}}' '\[ALL\]'
+  kube::test::get_object_assert "pod/${debugger:?} -n ${ns_name}" '{{if (index (index .spec.containers 0) "securityContext" "capabilities" "add") }}:{{end}}' ''
+  kube::test::get_object_assert "pod/${debugger:?} -n ${ns_name}" '{{index .spec.containers 0 "securityContext" "runAsNonRoot"}}' 'true'
+  kube::test::get_object_assert "pod/${debugger:?} -n ${ns_name}" '{{index .spec.containers 0 "securityContext" "seccompProfile" "type"}}' 'RuntimeDefault'
   # Clean up
   # pod.spec.nodeName is set by kubectl debug node which causes the delete to hang,
   # presumably waiting for a kubelet that's not present. Force the delete.
-  kubectl delete --force pod "${debugger:?}" "${kube_flags[@]:?}"
+  kubectl delete --force pod "${debugger:?}" -n ${ns_name} "${kube_flags[@]:?}"
+
+  # Clean up restricted namespace
+  kubectl delete namespace "${ns_name}"
 
   set +o nounset
   set +o errexit

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -350,6 +350,17 @@ runTests() {
     kubectl config set-context "${CONTEXT}" --namespace="${ns_name}"
   }
 
+  # Generate a namespace with restricted policy
+  create_and_use_new_restricted_namespace() {
+    local ns_name
+    ns_name="namespace-$(date +%s)-${RANDOM}"
+    kube::log::status "Creating namespace ${ns_name}"
+    kubectl create namespace "${ns_name}"
+    kubectl label namespace "${ns_name}" pod-security.kubernetes.io/enforce=restricted
+    kubectl config set-context "${CONTEXT}" --namespace="${ns_name}"
+  }
+
+
   kube_flags=( '-s' "https://127.0.0.1:${SECURE_API_PORT}" '--insecure-skip-tls-verify' )
 
   kube_flags_without_token=( "${kube_flags[@]}" )

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -350,17 +350,6 @@ runTests() {
     kubectl config set-context "${CONTEXT}" --namespace="${ns_name}"
   }
 
-  # Generate a namespace with restricted policy
-  create_and_use_new_restricted_namespace() {
-    local ns_name
-    ns_name="namespace-$(date +%s)-${RANDOM}"
-    kube::log::status "Creating namespace ${ns_name}"
-    kubectl create namespace "${ns_name}"
-    kubectl label namespace "${ns_name}" pod-security.kubernetes.io/enforce=restricted
-    kubectl config set-context "${CONTEXT}" --namespace="${ns_name}"
-  }
-
-
   kube_flags=( '-s' "https://127.0.0.1:${SECURE_API_PORT}" '--insecure-skip-tls-verify' )
 
   kube_flags_without_token=( "${kube_flags[@]}" )
@@ -1024,11 +1013,13 @@ runTests() {
     record_command run_kubectl_debug_pod_tests
     record_command run_kubectl_debug_general_tests
     record_command run_kubectl_debug_baseline_tests
+    record_command run_kubectl_debug_restricted_tests
   fi
   if kube::test::if_supports_resource "${nodes}" ; then
     record_command run_kubectl_debug_node_tests
     record_command run_kubectl_debug_general_node_tests
     record_command run_kubectl_debug_baseline_node_tests
+    record_command run_kubectl_debug_restricted_node_tests
   fi
 
   cleanup_tests


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

[debug profile](https://github.com/kubernetes/enhancements/tree/master/kepos/sig-cli/1441-kubectl-debug#debugging-profiles) was added in v1.27( #114280 ), but `restricted profile` dose not work because it is not fully complaint with [Pod Security Standard Restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted).
It seems to be a bug, so I fixed it.

#### Which issue(s) this PR fixes:

Fixes #117405

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix restricted debug profile.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
