### PR TITLE
Replace the default limiter in GCController with a customizable const…

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -559,6 +559,8 @@ func startGarbageCollectorController(ctx ControllerContext) (http.Handler, bool,
 		ignoredResources,
 		ctx.ObjectOrMetadataInformerFactory,
 		ctx.InformersStarted,
+		ctx.ComponentConfig.GarbageCollectorController.GCLimitBurst,
+		ctx.ComponentConfig.GarbageCollectorController.GCLimitRate,
 	)
 	if err != nil {
 		return nil, true, fmt.Errorf("failed to start the generic garbage collector: %v", err)

--- a/cmd/kube-controller-manager/app/options/garbagecollectorcontroller.go
+++ b/cmd/kube-controller-manager/app/options/garbagecollectorcontroller.go
@@ -32,7 +32,8 @@ func (o *GarbageCollectorControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	if o == nil {
 		return
 	}
-
+	fs.Int32Var(&o.GCLimitBurst, "go-limit-burst", o.GCLimitBurst, "The burst value of garbage collector queue.")
+	fs.Int32Var(&o.GCLimitRate, "gc-limit-rate" ,o.GCLimitRate, "The rate value of garbage collector queue.")
 	fs.Int32Var(&o.ConcurrentGCSyncs, "concurrent-gc-syncs", o.ConcurrentGCSyncs, "The number of garbage collector workers that are allowed to sync concurrently.")
 	fs.BoolVar(&o.EnableGarbageCollector, "enable-garbage-collector", o.EnableGarbageCollector, "Enables the generic garbage collector. MUST be synced with the corresponding flag of the kube-apiserver.")
 }
@@ -42,7 +43,8 @@ func (o *GarbageCollectorControllerOptions) ApplyTo(cfg *garbagecollectorconfig.
 	if o == nil {
 		return nil
 	}
-
+	cfg.GCLimitRate = o.GCLimitRate
+	cfg.GCLimitBurst = o.GCLimitBurst
 	cfg.ConcurrentGCSyncs = o.ConcurrentGCSyncs
 	cfg.GCIgnoredResources = o.GCIgnoredResources
 	cfg.EnableGarbageCollector = o.EnableGarbageCollector

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -292,6 +292,8 @@ func TestAddFlags(t *testing.T) {
 		GarbageCollectorController: &GarbageCollectorControllerOptions{
 			&garbagecollectorconfig.GarbageCollectorControllerConfiguration{
 				ConcurrentGCSyncs: 30,
+				GCLimitRate: 200,
+				GCLimitBurst: 300,
 				GCIgnoredResources: []garbagecollectorconfig.GroupResource{
 					{Group: "", Resource: "events"},
 				},

--- a/pkg/controller/garbagecollector/config/types.go
+++ b/pkg/controller/garbagecollector/config/types.go
@@ -33,6 +33,10 @@ type GarbageCollectorControllerConfiguration struct {
 	// concurrentGCSyncs is the number of garbage collector workers that are
 	// allowed to sync concurrently.
 	ConcurrentGCSyncs int32
+	// GCLimitRate is the rate of garbage collect queue
+	GCLimitRate int32
+	// GCLimitRate is the burst of garbage collect queue
+	GCLimitBurst int32
 	// gcIgnoredResources is the list of GroupResources that garbage collection should ignore.
 	GCIgnoredResources []GroupResource
 }

--- a/pkg/controller/garbagecollector/config/v1alpha1/defaults.go
+++ b/pkg/controller/garbagecollector/config/v1alpha1/defaults.go
@@ -31,6 +31,12 @@ import (
 // be no easy way to opt-out. Instead, if you want to use this defaulting method
 // run it in your wrapper struct of this type in its `SetDefaults_` method.
 func RecommendedDefaultGarbageCollectorControllerConfiguration(obj *kubectrlmgrconfigv1alpha1.GarbageCollectorControllerConfiguration) {
+	if obj.GCLimitBurst == 0 {
+		obj.GCLimitBurst = 20
+	}
+	if obj.GCLimitRate == 0 {
+		obj.GCLimitRate = 20
+	}
 	if obj.EnableGarbageCollector == nil {
 		obj.EnableGarbageCollector = utilpointer.BoolPtr(true)
 	}

--- a/staging/src/k8s.io/client-go/util/workqueue/default_rate_limiters.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/default_rate_limiters.go
@@ -44,6 +44,16 @@ func DefaultControllerRateLimiter() RateLimiter {
 	)
 }
 
+// BuildControllerRateLimiter is a no-arg constructor for a customer rate limiter for a workqueue.  It has
+// both overall and per-item rate limiting.  The overall is a token bucket and the per-item is exponential
+func BuildControllerRateLimiter(rateValue int32, sizeValue int32) RateLimiter {
+	return NewMaxOfRateLimiter(
+		NewItemExponentialFailureRateLimiter(5*time.Millisecond, 1000*time.Second),
+		// rateValue qps, sizeValue bucket size.  This is only for retry speed and its only the overall factor (not per item)
+		&BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(rateValue),int(sizeValue))},
+	)
+}
+
 // BucketRateLimiter adapts a standard bucket to the workqueue ratelimiter API
 type BucketRateLimiter struct {
 	*rate.Limiter

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -309,6 +309,10 @@ type GarbageCollectorControllerConfiguration struct {
 	// concurrentGCSyncs is the number of garbage collector workers that are
 	// allowed to sync concurrently.
 	ConcurrentGCSyncs int32
+	// GCLimitRate is the rate of garbage collect queue
+	GCLimitRate int32
+	// GCLimitRate is the burst of garbage collect queue
+	GCLimitBurst int32
 	// gcIgnoredResources is the list of GroupResources that garbage collection should ignore.
 	GCIgnoredResources []GroupResource
 }


### PR DESCRIPTION
…ructor to support faster GC rate.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
To make controller-mange gc faster by use a new customer ratelimiter
<!--
Add one of the following kinds:

/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In a production environment, if a large number of deployments are stopped in a short period of time, such as stopping 500 dpeloys/2000 pods in one minute, the cluster's GC rate for pods/rs is very slow, taking 3-5 minutes to complete the entire process. After adjusting the flow control parameters and number of worker processes of the controller manager, it still failed to optimize to the second level. Continuing analysis, I found that the GCcontroller's limit rate is also a bottleneck. I redefined it to support custom input parameters to solve this problem.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
np
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
NONE
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
