### PR TITLE
add --concurrent-cron-job-syncs flag for kube-controller-manager

### DIFF
--- a/cmd/kube-controller-manager/app/options/cronjobcontroller.go
+++ b/cmd/kube-controller-manager/app/options/cronjobcontroller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 
 	cronjobconfig "k8s.io/kubernetes/pkg/controller/cronjob/config"
@@ -32,6 +34,8 @@ func (o *CronJobControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	if o == nil {
 		return
 	}
+
+	fs.Int32Var(&o.ConcurrentCronJobSyncs, "concurrent-cron-job-syncs", o.ConcurrentCronJobSyncs, "The number of cron job objects that are allowed to sync concurrently. Larger number = more responsive jobs, but more CPU (and network) load")
 }
 
 // ApplyTo fills up JobController config with options.
@@ -52,5 +56,9 @@ func (o *CronJobControllerOptions) Validate() []error {
 	}
 
 	errs := []error{}
+	if o.ConcurrentCronJobSyncs < 1 {
+		errs = append(errs, fmt.Errorf("concurrent-cron-job-syncs must be greater than 0, but got %d", o.ConcurrentCronJobSyncs))
+	}
+
 	return errs
 }

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -95,6 +95,7 @@ var args = []string{
 	"--concurrent-gc-syncs=30",
 	"--concurrent-namespace-syncs=20",
 	"--concurrent-job-syncs=10",
+	"--concurrent-cron-job-syncs=10",
 	"--concurrent-replicaset-syncs=10",
 	"--concurrent-resource-quota-syncs=10",
 	"--concurrent-service-syncs=2",
@@ -325,7 +326,7 @@ func TestAddFlags(t *testing.T) {
 		},
 		CronJobController: &CronJobControllerOptions{
 			&cronjobconfig.CronJobControllerConfiguration{
-				ConcurrentCronJobSyncs: 5,
+				ConcurrentCronJobSyncs: 10,
 			},
 		},
 		NamespaceController: &NamespaceControllerOptions{
@@ -574,7 +575,7 @@ func TestApplyTo(t *testing.T) {
 				ConcurrentJobSyncs: 10,
 			},
 			CronJobController: cronjobconfig.CronJobControllerConfiguration{
-				ConcurrentCronJobSyncs: 5,
+				ConcurrentCronJobSyncs: 10,
 			},
 			NamespaceController: namespaceconfig.NamespaceControllerConfiguration{
 				NamespaceSyncPeriod:      metav1.Duration{Duration: 10 * time.Minute},
@@ -1087,13 +1088,23 @@ func TestValidateControllersOptions(t *testing.T) {
 				},
 			}).Validate,
 		},
+		{
+			name:                   "CronJobControllerOptions ConcurrentCronJobSyncs equal 0",
+			expectErrors:           true,
+			expectedErrorSubString: "concurrent-cron-job-syncs must be greater than 0",
+			validate: (&CronJobControllerOptions{
+				&cronjobconfig.CronJobControllerConfiguration{
+					ConcurrentCronJobSyncs: 0,
+				},
+			}).Validate,
+		},
 		/* empty errs */
 		{
 			name:         "CronJobControllerOptions",
 			expectErrors: false,
 			validate: (&CronJobControllerOptions{
 				&cronjobconfig.CronJobControllerConfiguration{
-					ConcurrentCronJobSyncs: 5,
+					ConcurrentCronJobSyncs: 10,
 				},
 			}).Validate,
 		},


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Some clients use cronjob heavily and run >5000 cronjobs in a cluster. The default worker number of 5 is quite not enough in such case.
Whith this PR, they can set desired number of workers of cronjob controller by `--concurrent-cron-job-syncs` flag.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add '--concurrent-cron-job-syncs' flag for kube-controller-manager to set the number of workers for cron job controller
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
