### PR TITLE
golangci-lint: allow exceptions for Go naming convention

### DIFF
--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -15,6 +15,12 @@ issues:
     - path: conversion\.go
       linters:
         - ineffassign
+    # The Kubernetes naming convention for conversion functions uses underscores
+    # and intentionally deviates from normal Go conventions to make those function
+    # names more readable. Same for SetDefaults_*.
+    - linters:
+        - stylecheck
+      text: "ST1003: should not use underscores in Go names; func (Convert_.*_To_.*|SetDefaults_)"
 
 linters:
   disable-all: false # in contrast to golangci.yaml, the default set of linters remains enabled

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -16,6 +16,12 @@ issues:
     - path: (pkg/volume/*|test/*|azure/*|pkg/cmd/wait*|request/bearertoken/*|metrics/*|filters/*) # not in golangci-strict.yaml
       linters:                                                                                    # not in golangci-strict.yaml
         - gocritic                                                                                # not in golangci-strict.yaml
+    # The Kubernetes naming convention for conversion functions uses underscores
+    # and intentionally deviates from normal Go conventions to make those function
+    # names more readable. Same for SetDefaults_*.
+    - linters:
+        - stylecheck
+      text: "ST1003: should not use underscores in Go names; func (Convert_.*_To_.*|SetDefaults_)"
 
 linters:
   disable-all: true # not disabled in golangci-strict.yaml


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In strict mode, stylecheck complains about Convert_* and SetDefaults_* functions in Kubernetes because they use underscores. We want to allow that to make the functions more readable.

#### Which issue(s) this PR fixes:
Related-to https://github.com/kubernetes/kubernetes/issues/117288

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```