### PR TITLE
Switch health check port to 9053

### DIFF
--- a/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+++ b/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
@@ -67,7 +67,7 @@ data:
                 force_tcp
         }
         prometheus :9253
-        health __PILLAR__LOCAL__DNS__:8080
+        health __PILLAR__LOCAL__DNS__:9053
         }
     in-addr.arpa:53 {
         errors
@@ -162,7 +162,7 @@ spec:
           httpGet:
             host: __PILLAR__LOCAL__DNS__
             path: /health
-            port: 8080
+            port: 9053
           initialDelaySeconds: 60
           timeoutSeconds: 5
         volumeMounts:


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When installing nodelocal dns cache on some clusters, like eks, some of the daemonset pods gets stuck in crashloopbackoff, because the hostport 8080 is already used.

Port 9053 is registered as unused
https://www.speedguide.net/port.php?port=9053
and after switching the health check port, all pods boot up like they should

#### Which issue(s) this PR fixes:
I didnt open an issue

#### Special notes for your reviewer:
To verify bug:
- Install eks cluster with aws karpenter cluster autoscaler
- Install nodelocal-dns-cache
- Check pods in namespace kube-system
  - See atleast one pod failing

To verify solution:
- Roll out the fix, using an unused port.
- Check pods in namespace kube-system
  - See all pods running

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

- [Other doc]: https://www.speedguide.net/port.php?port=8080

- [Other doc]: https://www.speedguide.net/port.php?port=9053

- [Usage]: https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/

```
