### PR TITLE
fix nodeipamcontroller ipv4 cidr judge condtion.

### DIFF
--- a/cmd/cloud-controller-manager/nodeipamcontroller.go
+++ b/cmd/cloud-controller-manager/nodeipamcontroller.go
@@ -181,7 +181,7 @@ func setNodeCIDRMaskSizes(cfg nodeipamconfig.NodeIPAMControllerConfiguration, cl
 		for idx, clusterCIDR := range clusterCIDRs {
 			if netutils.IsIPv6CIDR(clusterCIDR) {
 				nodeMaskCIDRs[idx] = maskSizeIPv6
-			} else {
+			} else if netutils.IsIPv4CIDR(clusterCIDR) {
 				nodeMaskCIDRs[idx] = maskSizeIPv4
 			}
 		}

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -634,7 +634,7 @@ func setNodeCIDRMaskSizes(cfg nodeipamconfig.NodeIPAMControllerConfiguration, cl
 		for idx, clusterCIDR := range clusterCIDRs {
 			if netutils.IsIPv6CIDR(clusterCIDR) {
 				nodeMaskCIDRs[idx] = maskSizeIPv6
-			} else {
+			} else if netutils.IsIPv4CIDR(clusterCIDR) {
 				nodeMaskCIDRs[idx] = maskSizeIPv4
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it: 
```
const (
	IPFamilyUnknown IPFamily = ""

	IPv4 IPFamily = "4"
	IPv6 IPFamily = "6"
)
```
When the cidr is not ipv6 , there is a possibility to be the ```IPv4``` or ```IPFamilyUnknown```.

So fix the if condtion for the ```netutils.IsIPv6CIDR```.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```