### PR TITLE
scheduler + DRA: per-event filter callbacks

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -320,7 +320,8 @@ type QueueSortPlugin interface {
 
 // EnqueueExtensions is an optional interface that plugins can implement to efficiently
 // move unschedulable Pods in internal scheduling queues. Plugins
-// that fail pod scheduling (e.g., Filter plugins) are expected to implement this interface.
+// that fail pod scheduling (e.g., Filter plugins) are expected to implement this interface
+// or EnqueueExtensionsWithHints.
 type EnqueueExtensions interface {
 	// EventsToRegister returns a series of possible events that may cause a Pod
 	// failed by this plugin schedulable.
@@ -329,6 +330,29 @@ type EnqueueExtensions interface {
 	// Note: the returned list needs to be static (not depend on configuration parameters);
 	// otherwise it would lead to undefined behavior.
 	EventsToRegister() []ClusterEvent
+}
+
+// EnqueueExtensionsWithHints is an optional interface that plugins can implement to efficiently
+// move unschedulable Pods in internal scheduling queues. Plugins
+// that fail pod scheduling (e.g., Filter plugins) are expected to implement this interface
+// or EnqueueExtensions.
+type EnqueueExtensionsWithHints interface {
+	// EventsToRegister returns a series of possible events that may cause a Pod
+	// failed by this plugin schedulable.
+	// The events will be registered when instantiating the internal scheduling queue,
+	// and leveraged to build event handlers dynamically.
+	// Optionally, each event may have a SchedulingHintFn which helps identify
+	// whether a specific event affects scheduling of a pod.
+	//
+	// Note: the returned list needs to be static (not depend on configuration parameters);
+	// otherwise it would lead to undefined behavior.
+	//
+	// Note: although the SchedulingHintFn gets registered together with a certain
+	// ActionType through this API, at runtime it might also get called for other
+	// actions. This is done to minimize overhead in the event handlers.
+	//
+	// Note: it is an error to register more than one SchedulingHintFn per resource.
+	EventsToRegisterWithHints() ClusterEvents
 }
 
 // PreFilterExtensions is an interface that is included in plugins that allow specifying

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -173,7 +173,7 @@ func (d *stateData) publishPodSchedulingContexts(ctx context.Context, clientset 
 	}
 	if loggerV := logger.V(6); loggerV.Enabled() {
 		// At a high enough log level, dump the entire object.
-		loggerV.Info(msg, "podSchedulingCtxDump", schedulingCtx)
+		loggerV.Info(msg, "podSchedulingCtxDump", klog.Format(schedulingCtx))
 	} else {
 		logger.V(5).Info(msg, "podSchedulingCtx", klog.KObj(schedulingCtx))
 	}
@@ -792,7 +792,7 @@ func (pl *dynamicResources) PreScore(ctx context.Context, cs *framework.CycleSta
 		sort.Strings(schedulingCtx.Spec.PotentialNodes)
 		state.storePodSchedulingContexts(schedulingCtx)
 	}
-	logger.V(5).Info("all potential nodes already set", "pod", klog.KObj(pod), "potentialnodes", nodes)
+	logger.V(5).Info("all potential nodes already set", "pod", klog.KObj(pod), "potentialnodes", klog.KObjSlice(nodes))
 	return nil
 }
 

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -23,14 +23,18 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/google/go-cmp/cmp"
+
 	v1 "k8s.io/api/core/v1"
 	resourcev1alpha2 "k8s.io/api/resource/v1alpha2"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	resourcev1alpha2listers "k8s.io/client-go/listers/resource/v1alpha2"
+	"k8s.io/client-go/tools/cache"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 	"k8s.io/dynamic-resource-allocation/resourceclaim"
@@ -207,11 +211,16 @@ func statusForClaim(schedulingCtx *resourcev1alpha2.PodSchedulingContext, podCla
 
 // dynamicResources is a plugin that ensures that ResourceClaims are allocated.
 type dynamicResources struct {
-	enabled                    bool
-	clientset                  kubernetes.Interface
-	claimLister                resourcev1alpha2listers.ResourceClaimLister
-	classLister                resourcev1alpha2listers.ResourceClassLister
-	podSchedulingContextLister resourcev1alpha2listers.PodSchedulingContextLister
+	enabled             bool
+	fh                  framework.Handle
+	clientset           kubernetes.Interface
+	claimLister         resourcev1alpha2listers.ResourceClaimLister
+	classLister         resourcev1alpha2listers.ResourceClassLister
+	podSchedulingLister resourcev1alpha2listers.PodSchedulingContextLister
+
+	// logger is only meant to be used by background activities which don't
+	// have some other logger in their parent callstack.
+	logger klog.Logger
 }
 
 // New initializes a new plugin and returns it.
@@ -221,13 +230,17 @@ func New(plArgs runtime.Object, fh framework.Handle, fts feature.Features) (fram
 		return &dynamicResources{}, nil
 	}
 
-	return &dynamicResources{
-		enabled:                    true,
-		clientset:                  fh.ClientSet(),
-		claimLister:                fh.SharedInformerFactory().Resource().V1alpha2().ResourceClaims().Lister(),
-		classLister:                fh.SharedInformerFactory().Resource().V1alpha2().ResourceClasses().Lister(),
-		podSchedulingContextLister: fh.SharedInformerFactory().Resource().V1alpha2().PodSchedulingContexts().Lister(),
-	}, nil
+	pl := &dynamicResources{
+		enabled:             true,
+		fh:                  fh,
+		clientset:           fh.ClientSet(),
+		claimLister:         fh.SharedInformerFactory().Resource().V1alpha2().ResourceClaims().Lister(),
+		classLister:         fh.SharedInformerFactory().Resource().V1alpha2().ResourceClasses().Lister(),
+		podSchedulingLister: fh.SharedInformerFactory().Resource().V1alpha2().PodSchedulingContexts().Lister(),
+		logger:              klog.LoggerWithName(klog.TODO(), Name),
+	}
+
+	return pl, nil
 }
 
 var _ framework.PreFilterPlugin = &dynamicResources{}
@@ -235,7 +248,7 @@ var _ framework.FilterPlugin = &dynamicResources{}
 var _ framework.PostFilterPlugin = &dynamicResources{}
 var _ framework.PreScorePlugin = &dynamicResources{}
 var _ framework.ReservePlugin = &dynamicResources{}
-var _ framework.EnqueueExtensions = &dynamicResources{}
+var _ framework.EnqueueExtensionsWithHints = &dynamicResources{}
 var _ framework.PostBindPlugin = &dynamicResources{}
 
 // Name returns name of the plugin. It is used in logs, etc.
@@ -243,31 +256,236 @@ func (pl *dynamicResources) Name() string {
 	return Name
 }
 
-// EventsToRegister returns the possible events that may make a Pod
+// EventsToRegisterWithHints returns the possible events that may make a Pod
 // failed by this plugin schedulable.
-func (pl *dynamicResources) EventsToRegister() []framework.ClusterEvent {
+func (pl *dynamicResources) EventsToRegisterWithHints() framework.ClusterEvents {
 	if !pl.enabled {
 		return nil
 	}
 
-	events := []framework.ClusterEvent{
+	events := framework.ClusterEvents{
 		// Allocation is tracked in ResourceClaims, so any changes may make the pods schedulable.
-		{Resource: framework.ResourceClaim, ActionType: framework.Add | framework.Update},
+		{Resource: framework.ResourceClaim, ActionType: framework.Add | framework.Update}: pl.isSchedulableAfterClaimChange,
+
 		// When a driver has provided additional information, a pod waiting for that information
 		// may be schedulable.
-		// TODO (#113702): can we change this so that such an event does not trigger *all* pods?
-		// Yes: https://github.com/kubernetes/kubernetes/blob/abcbaed0784baf5ed2382aae9705a8918f2daa18/pkg/scheduler/eventhandlers.go#L70
-		{Resource: framework.PodSchedulingContext, ActionType: framework.Add | framework.Update},
+		{Resource: framework.PodSchedulingContext, ActionType: framework.Add | framework.Update | framework.Delete}: pl.isSchedulableAfterPodSchedulingChange,
+
 		// A resource might depend on node labels for topology filtering.
 		// A new or updated node may make pods schedulable.
-		{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeLabel},
+		{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeLabel}: nil,
 	}
 	return events
+}
+
+// PreEnqueue checks if there are known reasons why a pod currently cannot be
+// scheduled. When this fails, one of the registered events can trigger another
+// attempt.
+func (pl *dynamicResources) PreEnqueue(ctx context.Context, pod *v1.Pod) (status *framework.Status) {
+	logger := klog.FromContext(ctx)
+	defer func() {
+		logger.V(5).Info("PreEnqueue", "pod", klog.KObj(pod), "status", status)
+	}()
+	if err := pl.foreachPodResourceClaim(pod, nil); err != nil {
+		return statusUnschedulable(logger, err.Error())
+	}
+	return nil
+}
+
+// isSchedulableAfterClaimChange is invoked whenever a claim changed. It checks whether
+// that change made a previously unschedulable pod schedulable. It errs on the side of
+// letting a pod scheduling attempt happen.
+func (pl *dynamicResources) isSchedulableAfterClaimChange(oldObj, newObj interface{}, pod *v1.Pod) framework.SchedulingHint {
+	if newObj == nil {
+		// Deletes don't make a pod schedulable.
+		return framework.PodNotAffected
+	}
+
+	modifiedClaim, ok := newObj.(*resourcev1alpha2.ResourceClaim)
+	if !ok {
+		// Shouldn't happen.
+		pl.logger.Error(nil, "unexpected new object in isSchedulableAfterClaimAddOrUpdate", "obj", newObj)
+		return framework.PodMaybeSchedulable
+	}
+
+	usesClaim := false
+	if err := pl.foreachPodResourceClaim(pod, func(_ string, claim *resourcev1alpha2.ResourceClaim) {
+		if claim.UID == modifiedClaim.UID {
+			usesClaim = true
+		}
+	}); err != nil {
+		// This is not an unexpected error: we know that
+		// foreachPodResourceClaim only returns errors for "not
+		// schedulable".
+		pl.logger.V(4).Info("pod is not schedulable", "pod", klog.KObj(pod), "claim", klog.KObj(modifiedClaim), "reason", err.Error())
+		return framework.PodNotAffected
+	}
+
+	if usesClaim {
+		if oldObj == nil {
+			pl.logger.V(4).Info("claim for pod got created", "pod", klog.KObj(pod), "claim", klog.KObj(modifiedClaim))
+			return framework.PodImmediatelySchedulable
+		}
+
+		// Modifications may or may not be relevant. If the entire
+		// status is as before, then something else must have changed
+		// and we don't care. What happens in practice is that the
+		// resource driver adds the finalizer.
+		originalClaim, ok := oldObj.(*resourcev1alpha2.ResourceClaim)
+		if !ok {
+			// Shouldn't happen.
+			pl.logger.Error(nil, "unexpected old object in isSchedulableAfterClaimAddOrUpdate", "obj", oldObj)
+			return framework.PodMaybeSchedulable
+		}
+		if apiequality.Semantic.DeepEqual(&originalClaim.Status, &modifiedClaim.Status) {
+			if loggerV := pl.logger.V(7); loggerV.Enabled() {
+				// Log more information.
+				loggerV.Info("claim for pod got modified where the pod doesn't care", "pod", klog.KObj(pod), "claim", klog.KObj(modifiedClaim), "diff", cmp.Diff(originalClaim, modifiedClaim))
+			} else {
+				pl.logger.V(6).Info("claim for pod got modified where the pod doesn't care", "pod", klog.KObj(pod), "claim", klog.KObj(modifiedClaim))
+			}
+			return framework.PodNotAffected
+		}
+
+		pl.logger.V(4).Info("status of claim for pod got updated", "pod", klog.KObj(pod), "claim", klog.KObj(modifiedClaim))
+		return framework.PodImmediatelySchedulable
+	}
+
+	// This was not the claim the pod was waiting for.
+	pl.logger.V(6).Info("unrelated claim got modified", "pod", klog.KObj(pod), "claim", klog.KObj(modifiedClaim))
+	return framework.PodNotAffected
+}
+
+// isSchedulableAfterPodSchedulingChange is invoked whenever a
+// PodScheduling object is updated or deleted. It checks whether that change
+// made a previously unschedulable pod schedulable (updated) or a new attempt
+// is needed to re-create the object (deleted). It errs on the side of letting
+// a pod scheduling attempt happen.
+func (pl *dynamicResources) isSchedulableAfterPodSchedulingChange(oldObj, newObj interface{}, pod *v1.Pod) framework.SchedulingHint {
+	obj := newObj
+	if obj == nil {
+		// Delete event.
+		obj = oldObj
+	}
+
+	var podScheduling *resourcev1alpha2.PodSchedulingContext
+	switch obj := obj.(type) {
+	case cache.DeletedFinalStateUnknown:
+		p, ok := obj.Obj.(*resourcev1alpha2.PodSchedulingContext)
+		if !ok {
+			// Shouldn't happen.
+			pl.logger.Error(nil, "unexpected deleted object in isSchedulableAfterPodSchedulingUpdateOrDelete", "obj", obj.Obj)
+			return framework.PodMaybeSchedulable
+		}
+		podScheduling = p
+	case *resourcev1alpha2.PodSchedulingContext:
+		podScheduling = obj
+	default:
+		// Shouldn't happen.
+		pl.logger.Error(nil, "unexpected object in isSchedulableAfterPodSchedulingUpdateOrDelete", "obj", obj)
+		return framework.PodMaybeSchedulable
+	}
+
+	if podScheduling.Name == pod.Name && podScheduling.Namespace == pod.Namespace {
+		// Deleted? That can happen because we ourselves delete the PodSchedulingContext while
+		// working on the pod. This can be ignored.
+		if oldObj != nil && newObj == nil {
+			pl.logger.V(4).Info("PodSchedulingContext for pod got deleted", "pod", klog.KObj(pod))
+			return framework.PodNotAffected
+		}
+
+		// If the drivers have provided information about all
+		// unallocated claims with delayed allocation, then the next
+		// scheduling attempt is able to pick a node, so we let it run
+		// immediately.
+		pendingDelayedClaims := 0
+		if err := pl.foreachPodResourceClaim(pod, func(podResourceName string, claim *resourcev1alpha2.ResourceClaim) {
+			if claim.Spec.AllocationMode == resourcev1alpha2.AllocationModeWaitForFirstConsumer &&
+				claim.Status.Allocation == nil &&
+				!podSchedulingHasClaimInfo(podScheduling, podResourceName) {
+				pendingDelayedClaims++
+			}
+		}); err != nil {
+			// This is not an unexpected error: we know that
+			// foreachPodResourceClaim only returns errors for "not
+			// schedulable".
+			pl.logger.V(4).Info("pod is not schedulable", "pod", klog.KObj(pod), "reason", err.Error())
+			return framework.PodNotAffected
+		}
+		if pendingDelayedClaims == 0 {
+			pl.logger.V(4).Info("PodSchedulingContext for pod got completed", "pod", klog.KObj(pod))
+			return framework.PodImmediatelySchedulable
+		}
+
+		// The other situation where the scheduler needs to do
+		// something immediately is when the selected node doesn't
+		// work: waiting in the backoff queue only helps eventually
+		// resources on the selected node become available again. It's
+		// much more likely, in particular when trying to fill up the
+		// cluster, that the choice simply didn't work out. The risk
+		// here is that in a situation where the cluster really is
+		// full, backoff won't be used because the scheduler keeps
+		// trying different nodes. This should not happen when it has
+		// full knowledge about resource availability (=
+		// PodSchedulingContext.*.UnsuitableNodes is complete) but may happen
+		// when it doesn't (= PodSchedulingContext.*.UnsuitableNodes had to be
+		// truncated).
+		if podScheduling.Spec.SelectedNode != "" {
+			for _, claimStatus := range podScheduling.Status.ResourceClaims {
+				if sliceContains(claimStatus.UnsuitableNodes, podScheduling.Spec.SelectedNode) {
+					pl.logger.V(5).Info("PodSchedulingContext has unsuitable selected node", "pod", klog.KObj(pod), "selectedNode", podScheduling.Spec.SelectedNode, "podResourceName", claimStatus.Name)
+					return framework.PodImmediatelySchedulable
+				}
+			}
+		}
+		// We could start a pod scheduling attempt to refresh the
+		// potential nodes list.  But pod scheduling attempts are
+		// expensive and doing them too often causes the pod to enter
+		// backoff. Let's wait instead for all drivers to reply.
+		pl.logger.V(5).Info("PodSchedulingContext for pod still incomplete", "pod", klog.KObj(pod))
+		return framework.PodNotAffected
+	}
+
+	pl.logger.V(7).Info("PodSchedulingContext for unrelated pod got modified", "pod", klog.KObj(pod), "podScheduling", klog.KObj(podScheduling))
+	return framework.PodNotAffected
+}
+
+func podSchedulingHasClaimInfo(podScheduling *resourcev1alpha2.PodSchedulingContext, podResourceName string) bool {
+	for _, claimStatus := range podScheduling.Status.ResourceClaims {
+		if claimStatus.Name == podResourceName {
+			return true
+		}
+	}
+	return false
+}
+
+func sliceContains(hay []string, needle string) bool {
+	for _, item := range hay {
+		if item == needle {
+			return true
+		}
+	}
+	return false
 }
 
 // podResourceClaims returns the ResourceClaims for all pod.Spec.PodResourceClaims.
 func (pl *dynamicResources) podResourceClaims(pod *v1.Pod) ([]*resourcev1alpha2.ResourceClaim, error) {
 	claims := make([]*resourcev1alpha2.ResourceClaim, 0, len(pod.Spec.ResourceClaims))
+	if err := pl.foreachPodResourceClaim(pod, func(_ string, claim *resourcev1alpha2.ResourceClaim) {
+		// We store the pointer as returned by the lister. The
+		// assumption is that if a claim gets modified while our code
+		// runs, the cache will store a new pointer, not mutate the
+		// existing object that we point to here.
+		claims = append(claims, claim)
+	}); err != nil {
+		return nil, err
+	}
+	return claims, nil
+}
+
+// foreachPodResourceClaim checks that each ResourceClaim for the pod exists.
+// It calls an optional handler for those claims that it finds.
+func (pl *dynamicResources) foreachPodResourceClaim(pod *v1.Pod, cb func(podResourceName string, claim *resourcev1alpha2.ResourceClaim)) error {
 	for _, resource := range pod.Spec.ResourceClaims {
 		claimName := resourceclaim.Name(pod, &resource)
 		isEphemeral := resource.Source.ResourceClaimTemplateName != nil
@@ -279,25 +497,23 @@ func (pl *dynamicResources) podResourceClaims(pod *v1.Pod) ([]*resourcev1alpha2.
 			if isEphemeral && apierrors.IsNotFound(err) {
 				err = fmt.Errorf("waiting for dynamic resource controller to create the resourceclaim %q", claimName)
 			}
-			return nil, err
+			return err
 		}
 
 		if claim.DeletionTimestamp != nil {
-			return nil, fmt.Errorf("resourceclaim %q is being deleted", claim.Name)
+			return fmt.Errorf("resourceclaim %q is being deleted", claim.Name)
 		}
 
 		if isEphemeral {
 			if err := resourceclaim.IsForPod(pod, claim); err != nil {
-				return nil, err
+				return err
 			}
 		}
-		// We store the pointer as returned by the lister. The
-		// assumption is that if a claim gets modified while our code
-		// runs, the cache will store a new pointer, not mutate the
-		// existing object that we point to here.
-		claims = append(claims, claim)
+		if cb != nil {
+			cb(resource.Name, claim)
+		}
 	}
-	return claims, nil
+	return nil
 }
 
 // PreFilter invoked at the prefilter extension point to check if pod has all
@@ -436,7 +652,7 @@ func (pl *dynamicResources) Filter(ctx context.Context, cs *framework.CycleState
 			}
 
 			// Now we need information from drivers.
-			schedulingCtx, err := state.initializePodSchedulingContexts(ctx, pod, pl.podSchedulingContextLister)
+			schedulingCtx, err := state.initializePodSchedulingContexts(ctx, pod, pl.podSchedulingLister)
 			if err != nil {
 				return statusError(logger, err)
 			}
@@ -530,7 +746,7 @@ func (pl *dynamicResources) PreScore(ctx context.Context, cs *framework.CycleSta
 	}
 
 	logger := klog.FromContext(ctx)
-	schedulingCtx, err := state.initializePodSchedulingContexts(ctx, pod, pl.podSchedulingContextLister)
+	schedulingCtx, err := state.initializePodSchedulingContexts(ctx, pod, pl.podSchedulingLister)
 	if err != nil {
 		return statusError(logger, err)
 	}
@@ -614,7 +830,7 @@ func (pl *dynamicResources) Reserve(ctx context.Context, cs *framework.CycleStat
 	numDelayedAllocationPending := 0
 	numClaimsWithStatusInfo := 0
 	logger := klog.FromContext(ctx)
-	schedulingCtx, err := state.initializePodSchedulingContexts(ctx, pod, pl.podSchedulingContextLister)
+	schedulingCtx, err := state.initializePodSchedulingContexts(ctx, pod, pl.podSchedulingLister)
 	if err != nil {
 		return statusError(logger, err)
 	}

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -554,14 +554,12 @@ func fillEventToPluginMap(p framework.Plugin, eventToPlugins *framework.ClusterE
 	}
 
 	if okWithHints {
+		// The logic here is the same as for EnqueueExtensions above, just with a slightly
+		// different API.
 		events := extWithHints.EventsToRegisterWithHints()
-		// It's rare that a plugin implements EnqueueExtensionsWithHints but returns nil.
-		// We treat it as: the plugin is not interested in any event, and hence pod failed by that plugin
-		// cannot be moved by any regular cluster event.
 		if len(events) == 0 {
 			klog.InfoS("Plugin's EventsToRegisterWithHints() returned nil", "plugin", p.Name())
 		} else {
-			// The most common case: a plugin implements EnqueueExtensions and returns non-nil result.
 			eventToPlugins.RegisterClusterEventsWithHints(p.Name(), events)
 		}
 	}

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -1024,7 +1024,7 @@ func TestNewFrameworkFillEventToPluginMap(t *testing.T) {
 			name:    "filter pod plugins",
 			plugins: []framework.Plugin{fakeFilterPodPluginA, fakeFilterPodPluginB},
 			want: framework.ClusterEventMap{
-				{Resource: framework.Pod, ActionType: framework.All}:                   framework.ClusterEventPlugins{bindPlugin: nil, queueSortPlugin: nil, "fakeFilterPodPlugin": schedulingHint, "fakeFilterPodPlugin2": schedulingHint2},
+				{Resource: framework.Pod, ActionType: framework.All}:                   framework.HintingByPlugin{bindPlugin: nil, queueSortPlugin: nil, "fakeFilterPodPlugin": schedulingHint, "fakeFilterPodPlugin2": schedulingHint2},
 				{Resource: framework.Node, ActionType: framework.All}:                  framework.MakeClusterEventPlugins(bindPlugin, queueSortPlugin),
 				{Resource: framework.CSINode, ActionType: framework.All}:               framework.MakeClusterEventPlugins(bindPlugin, queueSortPlugin),
 				{Resource: framework.PersistentVolume, ActionType: framework.All}:      framework.MakeClusterEventPlugins(bindPlugin, queueSortPlugin),

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -126,7 +126,7 @@ type ClusterEventMap map[ClusterEvent]ClusterEventPlugins
 // The function may be nil.
 type ClusterEventPlugins map[string]SchedulingHintFn
 
-// ClusterEvents maps events to the optional hint function for that each event.
+// ClusterEvents maps events to the optional hint function for each event.
 type ClusterEvents map[ClusterEvent]SchedulingHintFn
 
 // RegisterClusterEvents registers the events that a plugin is interested in.
@@ -173,7 +173,7 @@ func MakeClusterEventPlugins(names ...string) ClusterEventPlugins {
 	if len(names) == 0 {
 		return nil
 	}
-	events := make(ClusterEventPlugins)
+	events := make(ClusterEventPlugins, len(names))
 	for _, name := range names {
 		events[name] = nil
 	}

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -120,11 +120,11 @@ func (ce ClusterEvent) IsWildCard() bool {
 // ClusterEventMap maps a ClusterEvent to the names of all plugins that have
 // registered for that event. Each plugin may provide provide a
 // SchedulingHintFn for that event.
-type ClusterEventMap map[ClusterEvent]ClusterEventPlugins
+type ClusterEventMap map[ClusterEvent]HintingByPlugin
 
-// ClusterEventPlugins maps the name of a plugin to its SchedulingHintFn.
+// HintingByPlugin maps the name of a plugin to its SchedulingHintFn.
 // The function may be nil.
-type ClusterEventPlugins map[string]SchedulingHintFn
+type HintingByPlugin map[string]SchedulingHintFn
 
 // ClusterEvents maps events to the optional hint function for each event.
 type ClusterEvents map[ClusterEvent]SchedulingHintFn
@@ -161,7 +161,7 @@ func (m *ClusterEventMap) RegisterClusterEventWithHint(name string, event Cluste
 	}
 	plugins := (*m)[event]
 	if plugins == nil {
-		plugins = make(ClusterEventPlugins)
+		plugins = make(HintingByPlugin)
 	}
 	plugins[name] = schedulingHintFn
 	(*m)[event] = plugins
@@ -169,11 +169,11 @@ func (m *ClusterEventMap) RegisterClusterEventWithHint(name string, event Cluste
 
 // MakeClusterEventPlugins is a helper function for constructing a
 // ClusterEventPlugins instance from a list of plugin names.
-func MakeClusterEventPlugins(names ...string) ClusterEventPlugins {
+func MakeClusterEventPlugins(names ...string) HintingByPlugin {
 	if len(names) == 0 {
 		return nil
 	}
-	events := make(ClusterEventPlugins, len(names))
+	events := make(HintingByPlugin, len(names))
 	for _, name := range names {
 		events[name] = nil
 	}

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -1191,7 +1191,7 @@ func (p *PriorityQueue) podMatchesEvent(podInfo *framework.QueuedPodInfo, cluste
 	return false
 }
 
-func intersect(x framework.ClusterEventPlugins, y sets.Set[string]) bool {
+func intersect(x framework.HintingByPlugin, y sets.Set[string]) bool {
 	if len(x) > len(y) {
 		for v := range y {
 			if _, ok := x[v]; ok {

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -287,8 +287,11 @@ func (sched *Scheduler) handleBindingCycleError(
 		// It's intentional to "defer" this operation; otherwise MoveAllToActiveOrBackoffQueue() would
 		// update `q.moveRequest` and thus move the assumed pod to backoffQ anyways.
 		if status.IsUnschedulable() {
-			defer sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(internalqueue.AssignedPodDelete, func(pod *v1.Pod) bool {
-				return assumedPod.UID != pod.UID
+			defer sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(internalqueue.AssignedPodDelete, func(pod *v1.Pod) framework.SchedulingHint {
+				if assumedPod.UID == pod.UID {
+					return framework.PodNotAffected
+				}
+				return framework.PodMaybeSchedulable
 			})
 		} else {
 			sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(internalqueue.AssignedPodDelete, nil)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -24,7 +24,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
@@ -282,7 +281,7 @@ func New(client clientset.Interface,
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 
 	snapshot := internalcache.NewEmptySnapshot()
-	clusterEventMap := make(map[framework.ClusterEvent]sets.Set[string])
+	var clusterEventMap framework.ClusterEventMap
 	metricsRecorder := metrics.NewMetricsAsyncRecorder(1000, time.Second, stopCh)
 
 	profiles, err := profile.NewMap(options.profiles, registry, recorderFactory, stopCh,
@@ -292,7 +291,7 @@ func New(client clientset.Interface,
 		frameworkruntime.WithInformerFactory(informerFactory),
 		frameworkruntime.WithSnapshotSharedLister(snapshot),
 		frameworkruntime.WithCaptureProfile(frameworkruntime.CaptureProfile(options.frameworkCapturer)),
-		frameworkruntime.WithClusterEventMap(clusterEventMap),
+		frameworkruntime.WithClusterEventMap(&clusterEventMap),
 		frameworkruntime.WithParallelism(int(options.parallelism)),
 		frameworkruntime.WithExtenders(extenders),
 		frameworkruntime.WithMetricsRecorder(metricsRecorder),
@@ -345,7 +344,7 @@ func New(client clientset.Interface,
 	}
 	sched.applyDefaultHandlers()
 
-	addAllEventHandlers(sched, informerFactory, dynInformerFactory, unionedGVKs(clusterEventMap))
+	addAllEventHandlers(sched, informerFactory, dynInformerFactory, clusterEventMap)
 
 	return sched, nil
 }
@@ -433,18 +432,6 @@ func buildExtenders(extenders []schedulerapi.Extender, profiles []schedulerapi.K
 }
 
 type FailureHandlerFn func(ctx context.Context, fwk framework.Framework, podInfo *framework.QueuedPodInfo, status *framework.Status, nominatingInfo *framework.NominatingInfo, start time.Time)
-
-func unionedGVKs(m map[framework.ClusterEvent]sets.Set[string]) map[framework.GVK]framework.ActionType {
-	gvkMap := make(map[framework.GVK]framework.ActionType)
-	for evt := range m {
-		if _, ok := gvkMap[evt.Resource]; ok {
-			gvkMap[evt.Resource] |= evt.ActionType
-		} else {
-			gvkMap[evt.Resource] = evt.ActionType
-		}
-	}
-	return gvkMap
-}
 
 // newPodInformer creates a shared index informer that returns only non-terminal pods.
 // The PodInformer allows indexers to be added, but note that only non-conflict indexers are allowed.

--- a/staging/src/k8s.io/dynamic-resource-allocation/controller/controller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/controller/controller.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -238,7 +237,7 @@ const (
 
 func (ctrl *controller) add(logger *klog.Logger, obj interface{}) {
 	if logger != nil {
-		logger.Info("new object", "content", prettyPrint(obj))
+		logger.Info("new object", "content", klog.Format(obj))
 	}
 	ctrl.addNewOrUpdated("Adding new work item", obj)
 }
@@ -246,7 +245,7 @@ func (ctrl *controller) add(logger *klog.Logger, obj interface{}) {
 func (ctrl *controller) update(logger *klog.Logger, oldObj, newObj interface{}) {
 	if logger != nil {
 		diff := cmp.Diff(oldObj, newObj)
-		logger.Info("updated object", "content", prettyPrint(newObj), "diff", diff)
+		logger.Info("updated object", "content", klog.Format(newObj), "diff", diff)
 	}
 	ctrl.addNewOrUpdated("Adding updated work item", newObj)
 }
@@ -721,7 +720,7 @@ func (ctrl *controller) syncPodSchedulingContexts(ctx context.Context, schedulin
 		}
 	}
 	if modified {
-		logger.V(6).Info("Updating pod scheduling with modified unsuitable nodes", "podSchedulingCtx", schedulingCtx)
+		logger.V(6).Info("Updating pod scheduling with modified unsuitable nodes", "podSchedulingCtxDump", klog.Format(schedulingCtx))
 		if _, err := ctrl.kubeClient.ResourceV1alpha2().PodSchedulingContexts(schedulingCtx.Namespace).UpdateStatus(ctx, schedulingCtx, metav1.UpdateOptions{}); err != nil {
 			return fmt.Errorf("update unsuitable node status: %v", err)
 		}
@@ -801,13 +800,4 @@ func (ctrl *controller) removeFinalizer(in []string) []string {
 		return nil
 	}
 	return out
-}
-
-// prettyPrint formats arbitrary objects as JSON or, if that fails, with Sprintf.
-func prettyPrint(obj interface{}) string {
-	buffer, err := json.Marshal(obj)
-	if err != nil {
-		return fmt.Sprintf("%s", obj)
-	}
-	return string(buffer)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR has two specific advantages:
- The latency of sequential creation and scheduling of pods with ResourceClaim templates gets reduces from 5 seconds (mostly spent on waiting) to 0.02 seconds (only limited by network and CPU).
- The additional filter callbacks enable further optimizations for scheduling many pods in parallel (see https://github.com/kubernetes/kubernetes/pull/115796, which builds on top of this PR).

#### Special notes for your reviewer:

This could be merged together with https://github.com/kubernetes/kubernetes/pull/115796, but it is easier to review by itself and has some benefit also without the following changes. See commit messages for additional explanations.

#### Does this PR introduce a user-facing change?
```release-note
Latency for scheduling of pods with  ResourceClaim template gets reduced.
```

/cc @Huang-Wei @alculquicondor @kerthcet 