### PR TITLE
Fix Strategic Merge merging leaving patch directives in objects when field doesn't exist

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1182,7 +1182,13 @@ func mergePatchIntoOriginal(original, patch map[string]interface{}, schema Looku
 			merged = originalFieldValue
 		case !foundOriginal && foundPatch:
 			// list was added
-			merged = patchFieldValue
+			v, keep := removeDirectives(patchFieldValue)
+			if !keep {
+				// Shouldn't be possible since patchFieldValue is a slice
+				continue
+			}
+
+			merged = v.([]interface{})
 		case foundOriginal && foundPatch:
 			merged, err = mergeSliceHandler(originalList, patchList, subschema,
 				patchStrategy, patchMeta.GetPatchMergeKey(), false, mergeOptions)
@@ -1270,6 +1276,42 @@ func partitionMapsByPresentInList(original, partitionBy []interface{}, mergeKey 
 	return patch, serverOnly, nil
 }
 
+// Removes directives from an object and returns value to use instead and whether
+// or not the field/index should even be kept
+// May modify input
+func removeDirectives(obj interface{}) (interface{}, bool) {
+	if obj == nil {
+		return obj, true
+	} else if typedV, ok := obj.(map[string]interface{}); ok {
+		if _, hasDirective := typedV[directiveMarker]; hasDirective {
+			return nil, false
+		}
+
+		for k, v := range typedV {
+			var keep bool
+			typedV[k], keep = removeDirectives(v)
+			if !keep {
+				delete(typedV, k)
+			}
+		}
+		return typedV, true
+	} else if typedV, ok := obj.([]interface{}); ok {
+		var res []interface{}
+		if typedV != nil {
+			// Make sure res is non-nil if patch is non-nil
+			res = []interface{}{}
+		}
+		for _, v := range typedV {
+			if newV, keep := removeDirectives(v); keep {
+				res = append(res, newV)
+			}
+		}
+		return res, true
+	} else {
+		return obj, true
+	}
+}
+
 // Merge fields from a patch map into the original map. Note: This may modify
 // both the original map and the patch because getting a deep copy of a map in
 // golang is highly non-trivial.
@@ -1333,7 +1375,10 @@ func mergeMap(original, patch map[string]interface{}, schema LookupPatchMeta, me
 				if mergeOptions.IgnoreUnmatchedNulls {
 					discardNullValuesFromPatch(patchV)
 				}
-				original[k] = patchV
+				original[k], ok = removeDirectives(patchV)
+				if !ok {
+					delete(original, k)
+				}
 			}
 			continue
 		}
@@ -1345,7 +1390,10 @@ func mergeMap(original, patch map[string]interface{}, schema LookupPatchMeta, me
 				if mergeOptions.IgnoreUnmatchedNulls {
 					discardNullValuesFromPatch(patchV)
 				}
-				original[k] = patchV
+				original[k], ok = removeDirectives(patchV)
+				if !ok {
+					delete(original, k)
+				}
 			}
 			continue
 		}
@@ -1372,7 +1420,11 @@ func mergeMap(original, patch map[string]interface{}, schema LookupPatchMeta, me
 			}
 			original[k], err = mergeSliceHandler(original[k], patchV, subschema, patchStrategy, patchMeta.GetPatchMergeKey(), isDeleteList, mergeOptions)
 		default:
-			original[k] = patchV
+			original[k], ok = removeDirectives(patchV)
+			if !ok {
+				// if patchV itself is a directive, then don't keep it
+				delete(original, k)
+			}
 		}
 		if err != nil {
 			return nil, err

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -1242,8 +1242,6 @@ $setElementOrder/mergingList:
 - name: doesntexist
 mergingList:
 - name: hello
-- $patch: delete
-  name: doesntexist
 `),
 			TwoWayResult: []byte(`
 name: hi

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -1209,6 +1209,52 @@ testCases:
 
 var strategicMergePatchRawTestCases = []StrategicMergePatchRawTestCase{
 	{
+		Description: "nested patch merge with empty list",
+		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
+			Original: []byte(`
+name: hi
+`),
+			Current: []byte(`
+name: hi
+mergingList:
+- name: hello2
+`),
+			Modified: []byte(`
+name: hi
+mergingList:
+- name: hello
+- $patch: delete
+  name: doesntexist
+`),
+			TwoWay: []byte(`
+mergingList:
+- name: hello
+- $patch: delete
+  name: doesntexist
+`),
+			ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: hello
+- name: doesntexist
+mergingList:
+- name: hello
+- $patch: delete
+  name: doesntexist
+`),
+			TwoWayResult: []byte(`
+name: hi
+mergingList:
+- name: hello
+`),
+			Result: []byte(`
+name: hi
+mergingList:
+- name: hello
+- name: hello2
+`),
+		},
+	},
+	{
 		Description: "delete items in lists of scalars",
 		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
 			Original: []byte(`


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When Strategic Merge Patch is merging a value against a non-existent field, it has logic to simply take the patch value. This causes problems when the patch value includes a nested directive which is then included in the saved object.

This PR attempts to fix this by finding all the locations where the patch value is taken and instead of simply taking the value, changes the logic to continue recursion into patch value to remove directives.

#### Which issue(s) this PR fixes:

Fixes #117470

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes bug that caused a resource to include patch directives when using strategic merge patch against a non-existent field
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

/cc @apelisse