### PR TITLE
Fix scheduler performance regression after adding plugin metrics

### DIFF
--- a/pkg/scheduler/framework/runtime/instrumented_plugins.go
+++ b/pkg/scheduler/framework/runtime/instrumented_plugins.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	compbasemetrics "k8s.io/component-base/metrics"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+type instrumentedFilterPlugin struct {
+	framework.FilterPlugin
+
+	metric compbasemetrics.CounterMetric
+}
+
+var _ framework.FilterPlugin = &instrumentedFilterPlugin{}
+
+func (p *instrumentedFilterPlugin) Filter(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+	p.metric.Inc()
+	return p.FilterPlugin.Filter(ctx, state, pod, nodeInfo)
+}
+
+type instrumentedPreFilterPlugin struct {
+	framework.PreFilterPlugin
+
+	metric compbasemetrics.CounterMetric
+}
+
+var _ framework.PreFilterPlugin = &instrumentedPreFilterPlugin{}
+
+func (p *instrumentedPreFilterPlugin) PreFilter(ctx context.Context, state *framework.CycleState, pod *v1.Pod) (*framework.PreFilterResult, *framework.Status) {
+	result, status := p.PreFilterPlugin.PreFilter(ctx, state, pod)
+	if !status.IsSkip() {
+		p.metric.Inc()
+	}
+	return result, status
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In https://github.com/kubernetes/kubernetes/issues/117592 we see that the `WithLabelValues` generates visible CPU load in scheduler, negatively impacting the pod scheduling throughput.

Instead of performing metric lookup unnecessarily many times, let's cache the particular streams inside the filter and prefilter plugins.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/117592.

#### Special notes for your reviewer:

/assign @alculquicondor
/assign @mborsz
/kind bug
/sig scheduling

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix 1.27 performance regression in scheduler caused by frequent metric lookup on critical code path.
```