### PR TITLE
[KCCM]:  have providerID trigger re-sync, but not be required for load balancer syncs

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -683,8 +683,8 @@ func shouldSyncUpdatedNode(oldNode, newNode *v1.Node) bool {
 	if respectsPredicates(oldNode, nodeIncludedPredicate) != respectsPredicates(newNode, nodeIncludedPredicate) {
 		return true
 	}
-	// For the same reason as above, also check for changes to the providerID
-	if respectsPredicates(oldNode, nodeHasProviderIDPredicate) != respectsPredicates(newNode, nodeHasProviderIDPredicate) {
+	// For the same reason as above, also check for any change to the providerID
+	if oldNode.Spec.ProviderID != newNode.Spec.ProviderID {
 		return true
 	}
 	if !utilfeature.DefaultFeatureGate.Enabled(features.StableLoadBalancerNodeSet) {
@@ -973,13 +973,6 @@ func getNodePredicatesForService(service *v1.Service) []NodeConditionPredicate {
 		return etpLocalNodePredicates
 	}
 	return allNodePredicates
-}
-
-// This predicate just validates if the providerID has been set and triggers a
-// node sync. It is _not_ used when determining which nodes to use when
-// configuring the load balancer's backend pool.
-func nodeHasProviderIDPredicate(node *v1.Node) bool {
-	return node.Spec.ProviderID != ""
 }
 
 // We consider the node for load balancing only when the node is not labelled for exclusion.

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -948,17 +948,14 @@ var (
 		nodeIncludedPredicate,
 		nodeUnTaintedPredicate,
 		nodeReadyPredicate,
-		nodeHasProviderIDPredicate,
 	}
 	etpLocalNodePredicates []NodeConditionPredicate = []NodeConditionPredicate{
 		nodeIncludedPredicate,
 		nodeUnTaintedPredicate,
-		nodeHasProviderIDPredicate,
 	}
 	stableNodeSetPredicates []NodeConditionPredicate = []NodeConditionPredicate{
 		nodeNotDeletedPredicate,
 		nodeIncludedPredicate,
-		nodeHasProviderIDPredicate,
 		// This is not perfect, but probably good enough. We won't update the
 		// LBs just because the taint was added (see shouldSyncUpdatedNode) but
 		// if any other situation causes an LB sync, tainted nodes will be
@@ -978,14 +975,17 @@ func getNodePredicatesForService(service *v1.Service) []NodeConditionPredicate {
 	return allNodePredicates
 }
 
+// This predicate just validates if the providerID has been set and triggers a
+// node sync. It is _not_ used when determining which nodes to use when
+// configuring the load balancer's backend pool.
+func nodeHasProviderIDPredicate(node *v1.Node) bool {
+	return node.Spec.ProviderID != ""
+}
+
 // We consider the node for load balancing only when the node is not labelled for exclusion.
 func nodeIncludedPredicate(node *v1.Node) bool {
 	_, hasExcludeBalancerLabel := node.Labels[v1.LabelNodeExcludeBalancers]
 	return !hasExcludeBalancerLabel
-}
-
-func nodeHasProviderIDPredicate(node *v1.Node) bool {
-	return node.Spec.ProviderID != ""
 }
 
 // We consider the node for load balancing only when its not tainted for deletion by the cluster autoscaler.

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
@@ -1957,9 +1957,9 @@ func tweakDeleted() nodeTweak {
 	}
 }
 
-func tweakUnsetProviderID() nodeTweak {
+func tweakProviderID(id string) nodeTweak {
 	return func(n *v1.Node) {
-		n.Spec.ProviderID = ""
+		n.Spec.ProviderID = id
 	}
 }
 
@@ -2122,13 +2122,35 @@ func Test_shouldSyncUpdatedNode_individualPredicates(t *testing.T) {
 		stableNodeSetEnabled: true,
 	}, {
 		name:       "providerID set F -> T",
-		oldNode:    makeNode(tweakUnsetProviderID()),
+		oldNode:    makeNode(tweakProviderID("")),
 		newNode:    makeNode(),
 		shouldSync: true,
 	}, {
 		name:                 "providerID set F -> T",
-		oldNode:              makeNode(tweakUnsetProviderID()),
+		oldNode:              makeNode(tweakProviderID("")),
 		newNode:              makeNode(),
+		shouldSync:           true,
+		stableNodeSetEnabled: true,
+	}, {
+		name:       "providerID set T-> F",
+		oldNode:    makeNode(),
+		newNode:    makeNode(tweakProviderID("")),
+		shouldSync: true,
+	}, {
+		name:                 "providerID set T-> F",
+		oldNode:              makeNode(),
+		newNode:              makeNode(tweakProviderID("")),
+		shouldSync:           true,
+		stableNodeSetEnabled: true,
+	}, {
+		name:       "providerID change",
+		oldNode:    makeNode(),
+		newNode:    makeNode(tweakProviderID(providerID + "-2")),
+		shouldSync: true,
+	}, {
+		name:                 "providerID change",
+		oldNode:              makeNode(),
+		newNode:              makeNode(tweakProviderID(providerID + "-2")),
 		shouldSync:           true,
 		stableNodeSetEnabled: true,
 	}}
@@ -2168,14 +2190,20 @@ func Test_shouldSyncUpdatedNode_compoundedPredicates(t *testing.T) {
 				fgEnabled:  fgEnabled,
 			}, {
 				name:       "tainted T, providerID set F->T",
-				oldNode:    makeNode(tweakAddTaint(ToBeDeletedTaint), tweakUnsetProviderID()),
+				oldNode:    makeNode(tweakAddTaint(ToBeDeletedTaint), tweakProviderID("")),
 				newNode:    makeNode(tweakAddTaint(ToBeDeletedTaint)),
 				shouldSync: true,
 				fgEnabled:  fgEnabled,
 			}, {
 				name:       "tainted T, providerID set T->F",
 				oldNode:    makeNode(tweakAddTaint(ToBeDeletedTaint)),
-				newNode:    makeNode(tweakAddTaint(ToBeDeletedTaint), tweakUnsetProviderID()),
+				newNode:    makeNode(tweakAddTaint(ToBeDeletedTaint), tweakProviderID("")),
+				shouldSync: true,
+				fgEnabled:  fgEnabled,
+			}, {
+				name:       "tainted T, providerID change",
+				oldNode:    makeNode(tweakAddTaint(ToBeDeletedTaint)),
+				newNode:    makeNode(tweakAddTaint(ToBeDeletedTaint), tweakProviderID(providerID+"-2")),
 				shouldSync: true,
 				fgEnabled:  fgEnabled,
 			}, {
@@ -2216,14 +2244,20 @@ func Test_shouldSyncUpdatedNode_compoundedPredicates(t *testing.T) {
 				fgEnabled:  fgEnabled,
 			}, {
 				name:       "excluded T, providerID set F->T",
-				oldNode:    makeNode(tweakSetLabel(v1.LabelNodeExcludeBalancers, ""), tweakUnsetProviderID()),
+				oldNode:    makeNode(tweakSetLabel(v1.LabelNodeExcludeBalancers, ""), tweakProviderID("")),
 				newNode:    makeNode(tweakSetLabel(v1.LabelNodeExcludeBalancers, "")),
 				shouldSync: true,
 				fgEnabled:  fgEnabled,
 			}, {
 				name:       "excluded T, providerID set T->F",
 				oldNode:    makeNode(tweakSetLabel(v1.LabelNodeExcludeBalancers, "")),
-				newNode:    makeNode(tweakSetLabel(v1.LabelNodeExcludeBalancers, ""), tweakUnsetProviderID()),
+				newNode:    makeNode(tweakSetLabel(v1.LabelNodeExcludeBalancers, ""), tweakProviderID("")),
+				shouldSync: true,
+				fgEnabled:  fgEnabled,
+			}, {
+				name:       "excluded T, providerID change",
+				oldNode:    makeNode(tweakSetLabel(v1.LabelNodeExcludeBalancers, "")),
+				newNode:    makeNode(tweakSetLabel(v1.LabelNodeExcludeBalancers, ""), tweakProviderID(providerID+"-2")),
 				shouldSync: true,
 				fgEnabled:  fgEnabled,
 			}, {
@@ -2252,32 +2286,38 @@ func Test_shouldSyncUpdatedNode_compoundedPredicates(t *testing.T) {
 				fgEnabled:  fgEnabled,
 			}, {
 				name:       "ready F, providerID set F->T",
-				oldNode:    makeNode(tweakSetReady(false), tweakUnsetProviderID()),
+				oldNode:    makeNode(tweakSetReady(false), tweakProviderID("")),
 				newNode:    makeNode(tweakSetReady(false)),
 				shouldSync: true,
 				fgEnabled:  fgEnabled,
 			}, {
 				name:       "ready F, providerID set T->F",
 				oldNode:    makeNode(tweakSetReady(false)),
-				newNode:    makeNode(tweakSetReady(false), tweakUnsetProviderID()),
+				newNode:    makeNode(tweakSetReady(false), tweakProviderID("")),
+				shouldSync: true,
+				fgEnabled:  fgEnabled,
+			}, {
+				name:       "ready F, providerID change",
+				oldNode:    makeNode(tweakSetReady(false)),
+				newNode:    makeNode(tweakSetReady(false), tweakProviderID(providerID+"-2")),
 				shouldSync: true,
 				fgEnabled:  fgEnabled,
 			}, {
 				name:       "providerID unset, excluded F->T",
-				oldNode:    makeNode(tweakUnsetProviderID()),
-				newNode:    makeNode(tweakUnsetProviderID(), tweakSetLabel(v1.LabelNodeExcludeBalancers, "")),
+				oldNode:    makeNode(tweakProviderID("")),
+				newNode:    makeNode(tweakProviderID(""), tweakSetLabel(v1.LabelNodeExcludeBalancers, "")),
 				shouldSync: true,
 				fgEnabled:  fgEnabled,
 			}, {
 				name:       "providerID unset, excluded T->F",
-				oldNode:    makeNode(tweakUnsetProviderID(), tweakSetLabel(v1.LabelNodeExcludeBalancers, "")),
-				newNode:    makeNode(tweakUnsetProviderID()),
+				oldNode:    makeNode(tweakProviderID(""), tweakSetLabel(v1.LabelNodeExcludeBalancers, "")),
+				newNode:    makeNode(tweakProviderID("")),
 				shouldSync: true,
 				fgEnabled:  fgEnabled,
 			}, {
 				name:       "providerID unset, ready T->F",
-				oldNode:    makeNode(tweakUnsetProviderID()),
-				newNode:    makeNode(tweakUnsetProviderID(), tweakSetReady(true)),
+				oldNode:    makeNode(tweakProviderID("")),
+				newNode:    makeNode(tweakProviderID(""), tweakSetReady(true)),
 				shouldSync: false,
 				fgEnabled:  fgEnabled,
 			},
@@ -2286,40 +2326,40 @@ func Test_shouldSyncUpdatedNode_compoundedPredicates(t *testing.T) {
 	testcases = append(testcases, []testCase{
 		{
 			name:       "providerID unset, ready F->T",
-			oldNode:    makeNode(tweakUnsetProviderID()),
-			newNode:    makeNode(tweakUnsetProviderID(), tweakSetReady(false)),
+			oldNode:    makeNode(tweakProviderID("")),
+			newNode:    makeNode(tweakProviderID(""), tweakSetReady(false)),
 			shouldSync: false,
 			fgEnabled:  true,
 		},
 		{
 			name:       "providerID unset, ready F->T",
-			oldNode:    makeNode(tweakUnsetProviderID()),
-			newNode:    makeNode(tweakUnsetProviderID(), tweakSetReady(false)),
+			oldNode:    makeNode(tweakProviderID("")),
+			newNode:    makeNode(tweakProviderID(""), tweakSetReady(false)),
 			shouldSync: true,
 			fgEnabled:  false,
 		}, {
 			name:       "providerID unset, tainted T->F",
-			oldNode:    makeNode(tweakUnsetProviderID(), tweakAddTaint(ToBeDeletedTaint)),
-			newNode:    makeNode(tweakUnsetProviderID()),
+			oldNode:    makeNode(tweakProviderID(""), tweakAddTaint(ToBeDeletedTaint)),
+			newNode:    makeNode(tweakProviderID("")),
 			shouldSync: false,
 			fgEnabled:  true,
 		},
 		{
 			name:       "providerID unset, tainted T->F",
-			oldNode:    makeNode(tweakUnsetProviderID(), tweakAddTaint(ToBeDeletedTaint)),
-			newNode:    makeNode(tweakUnsetProviderID()),
+			oldNode:    makeNode(tweakProviderID(""), tweakAddTaint(ToBeDeletedTaint)),
+			newNode:    makeNode(tweakProviderID("")),
 			shouldSync: true,
 			fgEnabled:  false,
 		}, {
 			name:       "providerID unset, tainted F->T",
-			oldNode:    makeNode(tweakUnsetProviderID()),
-			newNode:    makeNode(tweakUnsetProviderID(), tweakAddTaint(ToBeDeletedTaint)),
+			oldNode:    makeNode(tweakProviderID("")),
+			newNode:    makeNode(tweakProviderID(""), tweakAddTaint(ToBeDeletedTaint)),
 			shouldSync: false,
 			fgEnabled:  true,
 		}, {
 			name:       "providerID unset, tainted F->T",
-			oldNode:    makeNode(tweakUnsetProviderID()),
-			newNode:    makeNode(tweakUnsetProviderID(), tweakAddTaint(ToBeDeletedTaint)),
+			oldNode:    makeNode(tweakProviderID("")),
+			newNode:    makeNode(tweakProviderID(""), tweakAddTaint(ToBeDeletedTaint)),
 			shouldSync: true,
 			fgEnabled:  false,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

#117388 left some open ended questions around "are we sure all cloud providers even set a providerID at all?"...we are not. Should a cloud provider not set the providerID but still expect the service controller to provision LBs: then this won't work for them, because #117388 enforces that the providerID is defined on all nodes that we pass to the cloud provider when configuring load balancers. 

This PR revises that logic, and instead triggers a resync when any node gets the providerID assigned, but does not filter nodes based on it.    

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[KCCM] drop filtering nodes for the providerID when syncing load balancers, but have changes to the field trigger a re-sync of load balancers. This should ensure that cloud providers which don't specify providerID, can still use the service controller implementation to provision load balancers.   
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @thockin 
