### PR TITLE
cluster/gce: update cloud-provider-gcp image to latest tagged version

### DIFF
--- a/cluster/gce/manifests/cloud-controller-manager.manifest
+++ b/cluster/gce/manifests/cloud-controller-manager.manifest
@@ -29,10 +29,11 @@
         "cpu": "{{cpurequest}}"
       }
     },
-    "command": ["/cloud-controller-manager"],
     "args": [
       "--log-file=/var/log/cloud-controller-manager.log",
-      "--logtostderr=false",
+      "--also-stdout=false",
+      "--redirect-stderr=true",
+      "/cloud-controller-manager",
       {{params}}
     ],
     {{container_env}}

--- a/cluster/gce/manifests/cloud-controller-manager.manifest
+++ b/cluster/gce/manifests/cloud-controller-manager.manifest
@@ -23,7 +23,7 @@
 "containers":[
     {
     "name": "cloud-controller-manager",
-    "image": "gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v1.25.2-alpha_ae91c1fc0c443c464a4c878ffa2a4544483c6d1f",
+    "image": "gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v26.2.4",
     "resources": {
       "requests": {
         "cpu": "{{cpurequest}}"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Update cloud-provider-gcp image used in CI to latest tagged version based on 1.26

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
