### PR TITLE
Write e2e test for APIResources endpoints + 12 Endpoints

### DIFF
--- a/test/e2e/apimachinery/discovery.go
+++ b/test/e2e/apimachinery/discovery.go
@@ -18,6 +18,8 @@ package apimachinery
 
 import (
 	"context"
+	"fmt"
+	"path"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +33,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 var storageVersionServerVersion = utilversion.MustParseSemantic("v1.13.99")
@@ -153,6 +156,149 @@ var _ = SIGDescribe("Discovery", func() {
 				}
 			}
 			framework.ExpectEqual(true, match, "failed to find a valid version for PreferredVersion")
+		}
+	})
+
+	ginkgo.It("should locate the groupVersion and a resource within each APIGroup", func(ctx context.Context) {
+
+		tests := []struct {
+			apiBasePath   string
+			apiGroup      string
+			apiVersion    string
+			validResource string
+		}{
+			{
+				apiBasePath:   "/api",
+				apiGroup:      "",
+				apiVersion:    "v1",
+				validResource: "namespaces",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "admissionregistration.k8s.io",
+				apiVersion:    "v1",
+				validResource: "validatingwebhookconfigurations",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "apiextensions.k8s.io",
+				apiVersion:    "v1",
+				validResource: "customresourcedefinitions",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "apiregistration.k8s.io",
+				apiVersion:    "v1",
+				validResource: "apiservices",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "apps",
+				apiVersion:    "v1",
+				validResource: "deployments",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "authentication.k8s.io",
+				apiVersion:    "v1",
+				validResource: "tokenreviews",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "authorization.k8s.io",
+				apiVersion:    "v1",
+				validResource: "selfsubjectaccessreviews",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "autoscaling",
+				apiVersion:    "v1",
+				validResource: "horizontalpodautoscalers",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "autoscaling",
+				apiVersion:    "v2",
+				validResource: "horizontalpodautoscalers",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "batch",
+				apiVersion:    "v1",
+				validResource: "jobs",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "certificates.k8s.io",
+				apiVersion:    "v1",
+				validResource: "certificatesigningrequests",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "coordination.k8s.io",
+				apiVersion:    "v1",
+				validResource: "leases",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "discovery.k8s.io",
+				apiVersion:    "v1",
+				validResource: "endpointslices",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "events.k8s.io",
+				apiVersion:    "v1",
+				validResource: "events",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "networking.k8s.io",
+				apiVersion:    "v1",
+				validResource: "ingresses",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "node.k8s.io",
+				apiVersion:    "v1",
+				validResource: "runtimeclasses",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "policy",
+				apiVersion:    "v1",
+				validResource: "poddisruptionbudgets",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "scheduling.k8s.io",
+				apiVersion:    "v1",
+				validResource: "priorityclasses",
+			},
+			{
+				apiBasePath:   "/apis",
+				apiGroup:      "storage.k8s.io",
+				apiVersion:    "v1",
+				validResource: "csinodes",
+			},
+		}
+
+		for _, t := range tests {
+			resourceList := &metav1.APIResourceList{}
+			apiPath := path.Join(t.apiBasePath, t.apiGroup, t.apiVersion)
+			ginkgo.By(fmt.Sprintf("Requesting APIResourceList from %q", apiPath))
+			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath(apiPath).Do(ctx).Into(resourceList)
+			framework.ExpectNoError(err, "Fail to access: %s", apiPath)
+			gomega.Expect(resourceList.GroupVersion).To(gomega.Equal((schema.GroupVersion{Group: t.apiGroup, Version: t.apiVersion}).String()))
+
+			foundResource := false
+			for _, r := range resourceList.APIResources {
+				if t.validResource == r.Name {
+					foundResource = true
+					break
+				}
+			}
+			gomega.Expect(foundResource).To(gomega.BeTrue(), "Resource %q was not found inside of resourceList\n%#v", t.validResource, resourceList.APIResources)
 		}
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- getAutoscalingV1APIResources
- getAutoscalingV2APIResources
- getPolicyV1APIResources
- getEventsV1APIResources
- getCoordinationV1APIResources
- getSchedulingV1APIResources
- getApiregistrationV1APIResources
- getAppsV1APIResources
- getAuthenticationV1APIResources
- getAuthorizationV1APIResources
- getBatchV1APIResources
- getCoreV1APIResources

**Which issue(s) this PR fixes:**
Fixes #117610

**Testgrid Link:**
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.locate.the.groupVersion.and.a.resource.within.each.APIGroup)


**Special notes for your reviewer:**
Adds +12 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance