### PR TITLE
Fix image pull error type `ErrRegistryUnavailable`

### DIFF
--- a/pkg/kubelet/cri/remote/remote_image.go
+++ b/pkg/kubelet/cri/remote/remote_image.go
@@ -25,7 +25,9 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	tracing "k8s.io/component-base/tracing"
 	"k8s.io/klog/v2"
@@ -165,6 +167,17 @@ func (r *remoteImageService) pullImageV1(ctx context.Context, image *runtimeapi.
 	})
 	if err != nil {
 		klog.ErrorS(err, "PullImage from image service failed", "image", image.Image)
+
+		// We can strip the code from unknown status errors since they add no value
+		// and will make them easier to read in the logs/events.
+		//
+		// It also ensures that checking custom error types from pkg/kubelet/images/types.go
+		// works in `imageManager.EnsureImageExists` (pkg/kubelet/images/image_manager.go).
+		statusErr, ok := status.FromError(err)
+		if ok && statusErr.Code() == codes.Unknown {
+			return "", errors.New(statusErr.Message())
+		}
+
 		return "", err
 	}
 

--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -157,7 +157,10 @@ func (m *imageManager) EnsureImageExists(ctx context.Context, pod *v1.Pod, conta
 	if imagePullResult.err != nil {
 		m.logIt(ref, v1.EventTypeWarning, events.FailedToPullImage, logPrefix, fmt.Sprintf("Failed to pull image %q: %v", container.Image, imagePullResult.err), klog.Warning)
 		m.backOff.Next(backOffKey, m.backOff.Clock.Now())
-		if imagePullResult.err == ErrRegistryUnavailable {
+
+		// Error assertions via errors.Is is not supported by gRPC (remote runtime) errors right now.
+		// See https://github.com/grpc/grpc-go/issues/3616
+		if imagePullResult.err.Error() == ErrRegistryUnavailable.Error() {
 			msg := fmt.Sprintf("image pull failed for %s because the registry is unavailable.", container.Image)
 			return "", msg, imagePullResult.err
 		}


### PR DESCRIPTION


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The current error comparison `imagePullResult.err == ErrRegistryUnavailable` will never work with any remote runtime, because we produce gRPC errors which wrap a code and a description, like:

```
rpc error: code = Unknown desc = This is the error description
```

To be able to check custom error types from `pkg/kubelet/images/types.go`, we now strip the code if the status is unknown on image pull.

Beside that, we use a string comparison to check against `ErrRegistryUnavailable.Error()`, because validating them via the `errors` package is not yet supported by grpc-go: https://github.com/grpc/grpc-go/issues/3616

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed bug to correctly report `ErrRegistryUnavailable` on pulling container images for remote CRI runtimes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
