### PR TITLE
unit tests: Fixes kubelet util unit tests for Windows

### DIFF
--- a/pkg/kubelet/util/util_windows.go
+++ b/pkg/kubelet/util/util_windows.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -164,6 +165,11 @@ func IsUnixDomainSocket(filePath string) (bool, error) {
 	// for the file (using FSCTL_GET_REPARSE_POINT) and checking for reparse tag: reparseTagSocket
 	// does NOT work in 1809 if the socket file is created within a bind mounted directory by a container
 	// and the FSCTL is issued in the host by the kubelet.
+
+	// If the file does not exist, it cannot be a Unix domain socket.
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return false, fmt.Errorf("File %s not found. Err: %v", filePath, err)
+	}
 
 	klog.V(6).InfoS("Function IsUnixDomainSocket starts", "filePath", filePath)
 	// As detailed in https://github.com/kubernetes/kubernetes/issues/104584 we cannot rely

--- a/pkg/kubelet/util/util_windows_test.go
+++ b/pkg/kubelet/util/util_windows_test.go
@@ -22,6 +22,8 @@ package util
 import (
 	"fmt"
 	"math/rand"
+	"net"
+	"os"
 	"reflect"
 	"runtime"
 	"sync"


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test
/sig windows
/sig testing

/priority important-soon
/milestone v1.28

#### What this PR does / why we need it:

The unit tests are currently failing due to missing imports. This PR addresses this issue.

Additionally, ``TestIsUnixDomainSocket`` expects an error to be raised by ``IsUnixDomainSocket`` if the file does not exist, but on Windows we do not raise such error.

This issue is addressed by ``Stat``-ing the file, and checking if the file exists or not. We're also handling the case in which the given ``filePath`` is a named pipe, returning ``false`` immediately, instead of trying to dial it as a Unix domain socket.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #117498
Related: https://github.com/kubernetes/kubernetes/issues/51540

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
