### PR TITLE
API: use new intstr functions

### DIFF
--- a/pkg/api/service/testing/make.go
+++ b/pkg/api/service/testing/make.go
@@ -47,7 +47,7 @@ func MakeService(name string, tweaks ...Tweak) *api.Service {
 	// Default to ClusterIP
 	SetTypeClusterIP(svc)
 	// Default to 1 port
-	SetPorts(MakeServicePort("", 93, intstr.FromInt(76), api.ProtocolTCP))(svc)
+	SetPorts(MakeServicePort("", 93, intstr.FromInt32(76), api.ProtocolTCP))(svc)
 
 	for _, tweak := range tweaks {
 		tweak(svc)

--- a/pkg/api/v1/pod/util_test.go
+++ b/pkg/api/v1/pod/util_test.go
@@ -41,7 +41,7 @@ func TestFindPort(t *testing.T) {
 	}{{
 		name:       "valid int, no ports",
 		containers: []v1.Container{{}},
-		port:       intstr.FromInt(93),
+		port:       intstr.FromInt32(93),
 		expected:   93,
 		pass:       true,
 	}, {
@@ -55,7 +55,7 @@ func TestFindPort(t *testing.T) {
 			ContainerPort: 22,
 			Protocol:      "TCP",
 		}}}},
-		port:     intstr.FromInt(93),
+		port:     intstr.FromInt32(93),
 		expected: 93,
 		pass:     true,
 	}, {

--- a/pkg/apis/apps/fuzzer/fuzzer.go
+++ b/pkg/apis/apps/fuzzer/fuzzer.go
@@ -94,8 +94,8 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 			} else {
 				rollingUpdate := apps.RollingUpdateDeployment{}
 				if c.RandBool() {
-					rollingUpdate.MaxUnavailable = intstr.FromInt(int(c.Rand.Int31()))
-					rollingUpdate.MaxSurge = intstr.FromInt(int(c.Rand.Int31()))
+					rollingUpdate.MaxUnavailable = intstr.FromInt32(c.Rand.Int31())
+					rollingUpdate.MaxSurge = intstr.FromInt32(c.Rand.Int31())
 				} else {
 					rollingUpdate.MaxSurge = intstr.FromString(fmt.Sprintf("%d%%", c.Rand.Int31()))
 				}
@@ -127,8 +127,8 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 				rollingUpdate := apps.RollingUpdateDaemonSet{}
 				if c.RandBool() {
 					if c.RandBool() {
-						rollingUpdate.MaxUnavailable = intstr.FromInt(int(c.Rand.Int31()))
-						rollingUpdate.MaxSurge = intstr.FromInt(int(c.Rand.Int31()))
+						rollingUpdate.MaxUnavailable = intstr.FromInt32(c.Rand.Int31())
+						rollingUpdate.MaxSurge = intstr.FromInt32(c.Rand.Int31())
 					} else {
 						rollingUpdate.MaxSurge = intstr.FromString(fmt.Sprintf("%d%%", c.Rand.Int31()))
 					}

--- a/pkg/apis/apps/v1/conversion_test.go
+++ b/pkg/apis/apps/v1/conversion_test.go
@@ -225,8 +225,8 @@ func TestV1StatefulSetUpdateStrategyConversion(t *testing.T) {
 }
 
 func TestV1RollingUpdateDaemonSetConversion(t *testing.T) {
-	intorstr := intstr.FromInt(1)
-	maxSurge := intstr.FromInt(0)
+	intorstr := intstr.FromInt32(1)
+	maxSurge := intstr.FromInt32(0)
 	testcases := map[string]struct {
 		rollingUpdateDs1 *apps.RollingUpdateDaemonSet
 		rollingUpdateDs2 *appsv1.RollingUpdateDaemonSet
@@ -436,8 +436,8 @@ func TestV1DeploymentSpecConversion(t *testing.T) {
 }
 
 func TestV1DeploymentStrategyConversion(t *testing.T) {
-	maxUnavailable := intstr.FromInt(2)
-	maxSurge := intstr.FromInt(2)
+	maxUnavailable := intstr.FromInt32(2)
+	maxSurge := intstr.FromInt32(2)
 	appsRollingUpdate := apps.RollingUpdateDeployment{MaxUnavailable: maxUnavailable, MaxSurge: maxSurge}
 	appsv1RollingUpdate := appsv1.RollingUpdateDeployment{MaxUnavailable: &maxUnavailable, MaxSurge: &maxSurge}
 	testcases := map[string]struct {
@@ -477,8 +477,8 @@ func TestV1DeploymentStrategyConversion(t *testing.T) {
 
 func TestV1RollingUpdateDeploymentConversion(t *testing.T) {
 	nilIntStr := intstr.IntOrString{}
-	maxUnavailable := intstr.FromInt(2)
-	maxSurge := intstr.FromInt(2)
+	maxUnavailable := intstr.FromInt32(2)
+	maxSurge := intstr.FromInt32(2)
 	testcases := map[string]struct {
 		rollingUpdateDeployment1 *apps.RollingUpdateDeployment
 		rollingUpdateDeployment2 *appsv1.RollingUpdateDeployment

--- a/pkg/apis/apps/v1/defaults.go
+++ b/pkg/apis/apps/v1/defaults.go
@@ -84,12 +84,12 @@ func SetDefaults_DaemonSet(obj *appsv1.DaemonSet) {
 		}
 		if updateStrategy.RollingUpdate.MaxUnavailable == nil {
 			// Set default MaxUnavailable as 1 by default.
-			maxUnavailable := intstr.FromInt(1)
+			maxUnavailable := intstr.FromInt32(1)
 			updateStrategy.RollingUpdate.MaxUnavailable = &maxUnavailable
 		}
 		if updateStrategy.RollingUpdate.MaxSurge == nil {
 			// Set default MaxSurge as 0 by default.
-			maxSurge := intstr.FromInt(0)
+			maxSurge := intstr.FromInt32(0)
 			updateStrategy.RollingUpdate.MaxSurge = &maxSurge
 		}
 	}
@@ -121,7 +121,7 @@ func SetDefaults_StatefulSet(obj *appsv1.StatefulSet) {
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.MaxUnavailableStatefulSet) {
 			if obj.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable == nil {
-				maxUnavailable := intstr.FromInt(1)
+				maxUnavailable := intstr.FromInt32(1)
 				obj.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable = &maxUnavailable
 			}
 		}

--- a/pkg/apis/apps/v1/defaults_test.go
+++ b/pkg/apis/apps/v1/defaults_test.go
@@ -39,8 +39,8 @@ import (
 
 func TestSetDefaultDaemonSetSpec(t *testing.T) {
 	defaultLabels := map[string]string{"foo": "bar"}
-	maxUnavailable := intstr.FromInt(1)
-	maxSurge := intstr.FromInt(0)
+	maxUnavailable := intstr.FromInt32(1)
+	maxSurge := intstr.FromInt32(0)
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{
@@ -624,7 +624,7 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 
 func TestSetDefaultDeployment(t *testing.T) {
 	defaultIntOrString := intstr.FromString("25%")
-	differentIntOrString := intstr.FromInt(5)
+	differentIntOrString := intstr.FromInt32(5)
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{

--- a/pkg/apis/apps/v1beta1/defaults.go
+++ b/pkg/apis/apps/v1beta1/defaults.go
@@ -78,7 +78,7 @@ func SetDefaults_StatefulSet(obj *appsv1beta1.StatefulSet) {
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.MaxUnavailableStatefulSet) {
 			if obj.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable == nil {
-				maxUnavailable := intstr.FromInt(1)
+				maxUnavailable := intstr.FromInt32(1)
 				obj.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable = &maxUnavailable
 			}
 		}

--- a/pkg/apis/apps/v1beta1/defaults_test.go
+++ b/pkg/apis/apps/v1beta1/defaults_test.go
@@ -39,7 +39,7 @@ import (
 
 func TestSetDefaultDeployment(t *testing.T) {
 	defaultIntOrString := intstr.FromString("25%")
-	differentIntOrString := intstr.FromInt(5)
+	differentIntOrString := intstr.FromInt32(5)
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{

--- a/pkg/apis/apps/v1beta2/conversion_test.go
+++ b/pkg/apis/apps/v1beta2/conversion_test.go
@@ -152,8 +152,8 @@ func TestV1beta2StatefulSetUpdateStrategyConversion(t *testing.T) {
 }
 
 func TestV1beta2RollingUpdateDaemonSetConversion(t *testing.T) {
-	intorstr := intstr.FromInt(1)
-	maxSurge := intstr.FromInt(0)
+	intorstr := intstr.FromInt32(1)
+	maxSurge := intstr.FromInt32(0)
 	testcases := map[string]struct {
 		rollingUpdateDs1 *apps.RollingUpdateDaemonSet
 		rollingUpdateDs2 *v1beta2.RollingUpdateDaemonSet
@@ -489,8 +489,8 @@ func TestV1beta2DeploymentSpecConversion(t *testing.T) {
 }
 
 func TestV1beta2DeploymentStrategyConversion(t *testing.T) {
-	maxUnavailable := intstr.FromInt(2)
-	maxSurge := intstr.FromInt(2)
+	maxUnavailable := intstr.FromInt32(2)
+	maxSurge := intstr.FromInt32(2)
 	extensionsRollingUpdate := apps.RollingUpdateDeployment{MaxUnavailable: maxUnavailable, MaxSurge: maxSurge}
 	v1beta2RollingUpdate := v1beta2.RollingUpdateDeployment{MaxUnavailable: &maxUnavailable, MaxSurge: &maxSurge}
 	testcases := map[string]struct {
@@ -530,8 +530,8 @@ func TestV1beta2DeploymentStrategyConversion(t *testing.T) {
 
 func TestV1beta2RollingUpdateDeploymentConversion(t *testing.T) {
 	nilIntStr := intstr.IntOrString{}
-	maxUnavailable := intstr.FromInt(2)
-	maxSurge := intstr.FromInt(2)
+	maxUnavailable := intstr.FromInt32(2)
+	maxSurge := intstr.FromInt32(2)
 	testcases := map[string]struct {
 		rollingUpdateDeployment1 *apps.RollingUpdateDeployment
 		rollingUpdateDeployment2 *v1beta2.RollingUpdateDeployment

--- a/pkg/apis/apps/v1beta2/defaults.go
+++ b/pkg/apis/apps/v1beta2/defaults.go
@@ -41,12 +41,12 @@ func SetDefaults_DaemonSet(obj *appsv1beta2.DaemonSet) {
 		}
 		if updateStrategy.RollingUpdate.MaxUnavailable == nil {
 			// Set default MaxUnavailable as 1 by default.
-			maxUnavailable := intstr.FromInt(1)
+			maxUnavailable := intstr.FromInt32(1)
 			updateStrategy.RollingUpdate.MaxUnavailable = &maxUnavailable
 		}
 		if updateStrategy.RollingUpdate.MaxSurge == nil {
 			// Set default MaxSurge as 0 by default.
-			maxSurge := intstr.FromInt(0)
+			maxSurge := intstr.FromInt32(0)
 			updateStrategy.RollingUpdate.MaxSurge = &maxSurge
 		}
 	}
@@ -78,7 +78,7 @@ func SetDefaults_StatefulSet(obj *appsv1beta2.StatefulSet) {
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.MaxUnavailableStatefulSet) {
 			if obj.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable == nil {
-				maxUnavailable := intstr.FromInt(1)
+				maxUnavailable := intstr.FromInt32(1)
 				obj.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable = &maxUnavailable
 			}
 		}

--- a/pkg/apis/apps/v1beta2/defaults_test.go
+++ b/pkg/apis/apps/v1beta2/defaults_test.go
@@ -39,8 +39,8 @@ import (
 
 func TestSetDefaultDaemonSetSpec(t *testing.T) {
 	defaultLabels := map[string]string{"foo": "bar"}
-	maxUnavailable := intstr.FromInt(1)
-	maxSurge := intstr.FromInt(0)
+	maxUnavailable := intstr.FromInt32(1)
+	maxSurge := intstr.FromInt32(0)
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{
@@ -494,7 +494,7 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 
 func TestSetDefaultDeployment(t *testing.T) {
 	defaultIntOrString := intstr.FromString("25%")
-	differentIntOrString := intstr.FromInt(5)
+	differentIntOrString := intstr.FromInt32(5)
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{

--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -288,7 +288,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				tweakReplicas(3),
 				tweakUpdateStrategyType(apps.RollingUpdateStatefulSetStrategyType),
 				tweakRollingUpdatePartition(2),
-				tweakMaxUnavailable(intstr.FromInt(2)),
+				tweakMaxUnavailable(intstr.FromInt32(2)),
 			),
 		},
 		{
@@ -495,7 +495,7 @@ func TestValidateStatefulSet(t *testing.T) {
 			set: mkStatefulSet(&validPodTemplate,
 				tweakReplicas(3),
 				tweakUpdateStrategyType(apps.RollingUpdateStatefulSetStrategyType),
-				tweakMaxUnavailable(intstr.FromInt(0)),
+				tweakMaxUnavailable(intstr.FromInt32(0)),
 			),
 			errs: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "updateStrategy", "rollingUpdate", "maxUnavailable"), nil, ""),
@@ -1742,7 +1742,7 @@ func TestValidateDaemonSetUpdate(t *testing.T) {
 					UpdateStrategy: apps.DaemonSetUpdateStrategy{
 						Type: apps.RollingUpdateDaemonSetStrategyType,
 						RollingUpdate: &apps.RollingUpdateDaemonSet{
-							MaxUnavailable: intstr.FromInt(1),
+							MaxUnavailable: intstr.FromInt32(1),
 						},
 					},
 				},
@@ -1769,7 +1769,7 @@ func TestValidateDaemonSetUpdate(t *testing.T) {
 					UpdateStrategy: apps.DaemonSetUpdateStrategy{
 						Type: apps.RollingUpdateDaemonSetStrategyType,
 						RollingUpdate: &apps.RollingUpdateDaemonSet{
-							MaxUnavailable: intstr.FromInt(1),
+							MaxUnavailable: intstr.FromInt32(1),
 						},
 					},
 				},
@@ -2275,8 +2275,8 @@ func validDeployment() *apps.Deployment {
 			Strategy: apps.DeploymentStrategy{
 				Type: apps.RollingUpdateDeploymentStrategyType,
 				RollingUpdate: &apps.RollingUpdateDeployment{
-					MaxSurge:       intstr.FromInt(1),
-					MaxUnavailable: intstr.FromInt(1),
+					MaxSurge:       intstr.FromInt32(1),
+					MaxUnavailable: intstr.FromInt32(1),
 				},
 			},
 			Template: api.PodTemplateSpec{
@@ -2366,7 +2366,7 @@ func TestValidateDeployment(t *testing.T) {
 		Type: apps.RollingUpdateDeploymentStrategyType,
 		RollingUpdate: &apps.RollingUpdateDeployment{
 			MaxSurge:       intstr.FromString("0%"),
-			MaxUnavailable: intstr.FromInt(0),
+			MaxUnavailable: intstr.FromInt32(0),
 		},
 	}
 	errorCases["may not be 0 when `maxSurge` is 0"] = invalidRollingUpdateDeployment
@@ -3497,13 +3497,13 @@ func TestDaemonSetUpdateMaxSurge(t *testing.T) {
 		},
 		"invalid: zero": {
 			ds: &apps.RollingUpdateDaemonSet{
-				MaxUnavailable: intstr.FromInt(0),
+				MaxUnavailable: intstr.FromInt32(0),
 			},
 			expectError: true,
 		},
 		"valid: one": {
 			ds: &apps.RollingUpdateDaemonSet{
-				MaxUnavailable: intstr.FromInt(1),
+				MaxUnavailable: intstr.FromInt32(1),
 			},
 		},
 		"valid: one percent": {
@@ -3539,13 +3539,13 @@ func TestDaemonSetUpdateMaxSurge(t *testing.T) {
 		},
 		"invalid: surge enabled, unavailable zero": {
 			ds: &apps.RollingUpdateDaemonSet{
-				MaxUnavailable: intstr.FromInt(0),
+				MaxUnavailable: intstr.FromInt32(0),
 			},
 			expectError: true,
 		},
 		"valid: surge enabled, unavailable one": {
 			ds: &apps.RollingUpdateDaemonSet{
-				MaxUnavailable: intstr.FromInt(1),
+				MaxUnavailable: intstr.FromInt32(1),
 			},
 		},
 		"valid: surge enabled, unavailable one percent": {
@@ -3573,13 +3573,13 @@ func TestDaemonSetUpdateMaxSurge(t *testing.T) {
 		},
 		"invalid: surge enabled, surge zero": {
 			ds: &apps.RollingUpdateDaemonSet{
-				MaxSurge: intstr.FromInt(0),
+				MaxSurge: intstr.FromInt32(0),
 			},
 			expectError: true,
 		},
 		"valid: surge enabled, surge one": {
 			ds: &apps.RollingUpdateDaemonSet{
-				MaxSurge: intstr.FromInt(1),
+				MaxSurge: intstr.FromInt32(1),
 			},
 		},
 		"valid: surge enabled, surge one percent": {
@@ -3616,14 +3616,14 @@ func TestDaemonSetUpdateMaxSurge(t *testing.T) {
 		},
 		"invalid: surge enabled, surge and unavailable zero": {
 			ds: &apps.RollingUpdateDaemonSet{
-				MaxUnavailable: intstr.FromInt(0),
-				MaxSurge:       intstr.FromInt(0),
+				MaxUnavailable: intstr.FromInt32(0),
+				MaxSurge:       intstr.FromInt32(0),
 			},
 			expectError: true,
 		},
 		"invalid: surge enabled, surge and unavailable mixed zero": {
 			ds: &apps.RollingUpdateDaemonSet{
-				MaxUnavailable: intstr.FromInt(0),
+				MaxUnavailable: intstr.FromInt32(0),
 				MaxSurge:       intstr.FromString("0%"),
 			},
 			expectError: true,

--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -118,8 +118,8 @@ func SetDefaults_Service(obj *v1.Service) {
 		if sp.Protocol == "" {
 			sp.Protocol = v1.ProtocolTCP
 		}
-		if sp.TargetPort == intstr.FromInt(0) || sp.TargetPort == intstr.FromString("") {
-			sp.TargetPort = intstr.FromInt(int(sp.Port))
+		if sp.TargetPort == intstr.FromInt32(0) || sp.TargetPort == intstr.FromString("") {
+			sp.TargetPort = intstr.FromInt32(sp.Port)
 		}
 	}
 	// Defaults ExternalTrafficPolicy field for NodePort / LoadBalancer service

--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -1365,14 +1365,14 @@ func TestSetDefaultServiceTargetPort(t *testing.T) {
 	in := &v1.Service{Spec: v1.ServiceSpec{Ports: []v1.ServicePort{{Port: 1234}}}}
 	obj := roundTrip(t, runtime.Object(in))
 	out := obj.(*v1.Service)
-	if out.Spec.Ports[0].TargetPort != intstr.FromInt(1234) {
+	if out.Spec.Ports[0].TargetPort != intstr.FromInt32(1234) {
 		t.Errorf("Expected TargetPort to be defaulted, got %v", out.Spec.Ports[0].TargetPort)
 	}
 
-	in = &v1.Service{Spec: v1.ServiceSpec{Ports: []v1.ServicePort{{Port: 1234, TargetPort: intstr.FromInt(5678)}}}}
+	in = &v1.Service{Spec: v1.ServiceSpec{Ports: []v1.ServicePort{{Port: 1234, TargetPort: intstr.FromInt32(5678)}}}}
 	obj = roundTrip(t, runtime.Object(in))
 	out = obj.(*v1.Service)
-	if out.Spec.Ports[0].TargetPort != intstr.FromInt(5678) {
+	if out.Spec.Ports[0].TargetPort != intstr.FromInt32(5678) {
 		t.Errorf("Expected TargetPort to be unchanged, got %v", out.Spec.Ports[0].TargetPort)
 	}
 }
@@ -1382,7 +1382,7 @@ func TestSetDefaultServicePort(t *testing.T) {
 	in := &v1.Service{Spec: v1.ServiceSpec{
 		Ports: []v1.ServicePort{
 			{Protocol: "UDP", Port: 9376, TargetPort: intstr.FromString("p")},
-			{Protocol: "UDP", Port: 8675, TargetPort: intstr.FromInt(309)},
+			{Protocol: "UDP", Port: 8675, TargetPort: intstr.FromInt32(309)},
 		},
 	}}
 	out := roundTrip(t, runtime.Object(in)).(*v1.Service)
@@ -1395,7 +1395,7 @@ func TestSetDefaultServicePort(t *testing.T) {
 	if out.Spec.Ports[1].Protocol != v1.ProtocolUDP {
 		t.Errorf("Expected protocol %s, got %s", v1.ProtocolUDP, out.Spec.Ports[1].Protocol)
 	}
-	if out.Spec.Ports[1].TargetPort != intstr.FromInt(309) {
+	if out.Spec.Ports[1].TargetPort != intstr.FromInt32(309) {
 		t.Errorf("Expected port %v, got %v", in.Spec.Ports[1].Port, out.Spec.Ports[1].TargetPort)
 	}
 
@@ -1403,20 +1403,20 @@ func TestSetDefaultServicePort(t *testing.T) {
 	in = &v1.Service{Spec: v1.ServiceSpec{
 		Ports: []v1.ServicePort{
 			{Protocol: "", Port: 9376, TargetPort: intstr.FromString("")},
-			{Protocol: "", Port: 8675, TargetPort: intstr.FromInt(0)},
+			{Protocol: "", Port: 8675, TargetPort: intstr.FromInt32(0)},
 		},
 	}}
 	out = roundTrip(t, runtime.Object(in)).(*v1.Service)
 	if out.Spec.Ports[0].Protocol != v1.ProtocolTCP {
 		t.Errorf("Expected protocol %s, got %s", v1.ProtocolTCP, out.Spec.Ports[0].Protocol)
 	}
-	if out.Spec.Ports[0].TargetPort != intstr.FromInt(int(in.Spec.Ports[0].Port)) {
+	if out.Spec.Ports[0].TargetPort != intstr.FromInt32(in.Spec.Ports[0].Port) {
 		t.Errorf("Expected port %v, got %v", in.Spec.Ports[0].Port, out.Spec.Ports[0].TargetPort)
 	}
 	if out.Spec.Ports[1].Protocol != v1.ProtocolTCP {
 		t.Errorf("Expected protocol %s, got %s", v1.ProtocolTCP, out.Spec.Ports[1].Protocol)
 	}
-	if out.Spec.Ports[1].TargetPort != intstr.FromInt(int(in.Spec.Ports[1].Port)) {
+	if out.Spec.Ports[1].TargetPort != intstr.FromInt32(in.Spec.Ports[1].Port) {
 		t.Errorf("Expected port %v, got %v", in.Spec.Ports[1].Port, out.Spec.Ports[1].TargetPort)
 	}
 }

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -2970,7 +2970,7 @@ func validateTCPSocketAction(tcp *core.TCPSocketAction, fldPath *field.Path) fie
 	return ValidatePortNumOrName(tcp.Port, fldPath.Child("port"))
 }
 func validateGRPCAction(grpc *core.GRPCAction, fldPath *field.Path) field.ErrorList {
-	return ValidatePortNumOrName(intstr.FromInt(int(grpc.Port)), fldPath.Child("port"))
+	return ValidatePortNumOrName(intstr.FromInt32(grpc.Port), fldPath.Child("port"))
 }
 func validateHandler(handler commonHandler, fldPath *field.Path) field.ErrorList {
 	numHandlers := 0

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -7040,8 +7040,8 @@ func Test_validateProbe(t *testing.T) {
 func TestValidateHandler(t *testing.T) {
 	successCases := []core.ProbeHandler{
 		{Exec: &core.ExecAction{Command: []string{"echo"}}},
-		{HTTPGet: &core.HTTPGetAction{Path: "/", Port: intstr.FromInt(1), Host: "", Scheme: "HTTP"}},
-		{HTTPGet: &core.HTTPGetAction{Path: "/foo", Port: intstr.FromInt(65535), Host: "host", Scheme: "HTTP"}},
+		{HTTPGet: &core.HTTPGetAction{Path: "/", Port: intstr.FromInt32(1), Host: "", Scheme: "HTTP"}},
+		{HTTPGet: &core.HTTPGetAction{Path: "/foo", Port: intstr.FromInt32(65535), Host: "host", Scheme: "HTTP"}},
 		{HTTPGet: &core.HTTPGetAction{Path: "/", Port: intstr.FromString("port"), Host: "", Scheme: "HTTP"}},
 		{HTTPGet: &core.HTTPGetAction{Path: "/", Port: intstr.FromString("port"), Host: "", Scheme: "HTTP", HTTPHeaders: []core.HTTPHeader{{Name: "Host", Value: "foo.example.com"}}}},
 		{HTTPGet: &core.HTTPGetAction{Path: "/", Port: intstr.FromString("port"), Host: "", Scheme: "HTTP", HTTPHeaders: []core.HTTPHeader{{Name: "X-Forwarded-For", Value: "1.2.3.4"}, {Name: "X-Forwarded-For", Value: "5.6.7.8"}}}},
@@ -7055,8 +7055,8 @@ func TestValidateHandler(t *testing.T) {
 	errorCases := []core.ProbeHandler{
 		{},
 		{Exec: &core.ExecAction{Command: []string{}}},
-		{HTTPGet: &core.HTTPGetAction{Path: "", Port: intstr.FromInt(0), Host: ""}},
-		{HTTPGet: &core.HTTPGetAction{Path: "/foo", Port: intstr.FromInt(65536), Host: "host"}},
+		{HTTPGet: &core.HTTPGetAction{Path: "", Port: intstr.FromInt32(0), Host: ""}},
+		{HTTPGet: &core.HTTPGetAction{Path: "/foo", Port: intstr.FromInt32(65536), Host: "host"}},
 		{HTTPGet: &core.HTTPGetAction{Path: "", Port: intstr.FromString(""), Host: ""}},
 		{HTTPGet: &core.HTTPGetAction{Path: "/", Port: intstr.FromString("port"), Host: "", Scheme: "HTTP", HTTPHeaders: []core.HTTPHeader{{Name: "Host:", Value: "foo.example.com"}}}},
 		{HTTPGet: &core.HTTPGetAction{Path: "/", Port: intstr.FromString("port"), Host: "", Scheme: "HTTP", HTTPHeaders: []core.HTTPHeader{{Name: "X_Forwarded_For", Value: "foo.example.com"}}}},
@@ -7423,7 +7423,7 @@ func TestValidateEphemeralContainers(t *testing.T) {
 						TerminationMessagePolicy: "File",
 						LivenessProbe: &core.Probe{
 							ProbeHandler: core.ProbeHandler{
-								TCPSocket: &core.TCPSocketAction{Port: intstr.FromInt(80)},
+								TCPSocket: &core.TCPSocketAction{Port: intstr.FromInt32(80)},
 							},
 							SuccessThreshold: 1,
 						},
@@ -7462,7 +7462,7 @@ func TestValidateEphemeralContainers(t *testing.T) {
 						TerminationMessagePolicy: "File",
 						ReadinessProbe: &core.Probe{
 							ProbeHandler: core.ProbeHandler{
-								TCPSocket: &core.TCPSocketAction{Port: intstr.FromInt(80)},
+								TCPSocket: &core.TCPSocketAction{Port: intstr.FromInt32(80)},
 							},
 						},
 					},
@@ -7482,7 +7482,7 @@ func TestValidateEphemeralContainers(t *testing.T) {
 						TerminationMessagePolicy: "File",
 						StartupProbe: &core.Probe{
 							ProbeHandler: core.ProbeHandler{
-								TCPSocket: &core.TCPSocketAction{Port: intstr.FromInt(80)},
+								TCPSocket: &core.TCPSocketAction{Port: intstr.FromInt32(80)},
 							},
 							SuccessThreshold: 1,
 						},
@@ -7857,7 +7857,7 @@ func TestValidateContainers(t *testing.T) {
 			LivenessProbe: &core.Probe{
 				ProbeHandler: core.ProbeHandler{
 					TCPSocket: &core.TCPSocketAction{
-						Port: intstr.FromInt(80),
+						Port: intstr.FromInt32(80),
 					},
 				},
 				SuccessThreshold: 1,
@@ -7871,7 +7871,7 @@ func TestValidateContainers(t *testing.T) {
 			StartupProbe: &core.Probe{
 				ProbeHandler: core.ProbeHandler{
 					TCPSocket: &core.TCPSocketAction{
-						Port: intstr.FromInt(80),
+						Port: intstr.FromInt32(80),
 					},
 				},
 				SuccessThreshold: 1,
@@ -8015,7 +8015,7 @@ func TestValidateContainers(t *testing.T) {
 					Lifecycle: &core.Lifecycle{
 						PreStop: &core.LifecycleHandler{
 							HTTPGet: &core.HTTPGetAction{
-								Port:   intstr.FromInt(80),
+								Port:   intstr.FromInt32(80),
 								Scheme: "HTTP",
 							},
 						},
@@ -8058,7 +8058,7 @@ func TestValidateContainers(t *testing.T) {
 						PreStop: &core.LifecycleHandler{
 							HTTPGet: &core.HTTPGetAction{
 								Path: "/",
-								Port: intstr.FromInt(80),
+								Port: intstr.FromInt32(80),
 							},
 						},
 					},
@@ -8096,7 +8096,7 @@ func TestValidateContainers(t *testing.T) {
 					Lifecycle: &core.Lifecycle{
 						PreStop: &core.LifecycleHandler{
 							TCPSocket: &core.TCPSocketAction{
-								Port: intstr.FromInt(0),
+								Port: intstr.FromInt32(0),
 							},
 						},
 					},
@@ -8132,7 +8132,7 @@ func TestValidateContainers(t *testing.T) {
 					ReadinessProbe: &core.Probe{
 						ProbeHandler: core.ProbeHandler{
 							TCPSocket: &core.TCPSocketAction{
-								Port: intstr.FromInt(80),
+								Port: intstr.FromInt32(80),
 							},
 						},
 						TerminationGracePeriodSeconds: utilpointer.Int64(10),
@@ -8189,7 +8189,7 @@ func TestValidateContainers(t *testing.T) {
 					LivenessProbe: &core.Probe{
 						ProbeHandler: core.ProbeHandler{
 							TCPSocket: &core.TCPSocketAction{
-								Port: intstr.FromInt(80),
+								Port: intstr.FromInt32(80),
 							},
 						},
 						SuccessThreshold: 2,
@@ -8210,7 +8210,7 @@ func TestValidateContainers(t *testing.T) {
 					StartupProbe: &core.Probe{
 						ProbeHandler: core.ProbeHandler{
 							TCPSocket: &core.TCPSocketAction{
-								Port: intstr.FromInt(80),
+								Port: intstr.FromInt32(80),
 							},
 						},
 						SuccessThreshold: 2,
@@ -8231,7 +8231,7 @@ func TestValidateContainers(t *testing.T) {
 					LivenessProbe: &core.Probe{
 						ProbeHandler: core.ProbeHandler{
 							TCPSocket: &core.TCPSocketAction{
-								Port: intstr.FromInt(80),
+								Port: intstr.FromInt32(80),
 							},
 						},
 						InitialDelaySeconds:           -1,
@@ -8265,7 +8265,7 @@ func TestValidateContainers(t *testing.T) {
 					ReadinessProbe: &core.Probe{
 						ProbeHandler: core.ProbeHandler{
 							TCPSocket: &core.TCPSocketAction{
-								Port: intstr.FromInt(80),
+								Port: intstr.FromInt32(80),
 							},
 						},
 						InitialDelaySeconds:           -1,
@@ -8302,7 +8302,7 @@ func TestValidateContainers(t *testing.T) {
 					StartupProbe: &core.Probe{
 						ProbeHandler: core.ProbeHandler{
 							TCPSocket: &core.TCPSocketAction{
-								Port: intstr.FromInt(80),
+								Port: intstr.FromInt32(80),
 							},
 						},
 						InitialDelaySeconds:           -1,
@@ -8734,7 +8734,7 @@ func TestValidateInitContainers(t *testing.T) {
 					TerminationMessagePolicy: "File",
 					LivenessProbe: &core.Probe{
 						ProbeHandler: core.ProbeHandler{
-							TCPSocket: &core.TCPSocketAction{Port: intstr.FromInt(80)},
+							TCPSocket: &core.TCPSocketAction{Port: intstr.FromInt32(80)},
 						},
 						SuccessThreshold: 1,
 					},
@@ -8753,7 +8753,7 @@ func TestValidateInitContainers(t *testing.T) {
 					TerminationMessagePolicy: "File",
 					ReadinessProbe: &core.Probe{
 						ProbeHandler: core.ProbeHandler{
-							TCPSocket: &core.TCPSocketAction{Port: intstr.FromInt(80)},
+							TCPSocket: &core.TCPSocketAction{Port: intstr.FromInt32(80)},
 						},
 					},
 				},
@@ -8771,7 +8771,7 @@ func TestValidateInitContainers(t *testing.T) {
 					TerminationMessagePolicy: "File",
 					StartupProbe: &core.Probe{
 						ProbeHandler: core.ProbeHandler{
-							TCPSocket: &core.TCPSocketAction{Port: intstr.FromInt(80)},
+							TCPSocket: &core.TCPSocketAction{Port: intstr.FromInt32(80)},
 						},
 						SuccessThreshold: 1,
 					},
@@ -8790,7 +8790,7 @@ func TestValidateInitContainers(t *testing.T) {
 					TerminationMessagePolicy: "File",
 					StartupProbe: &core.Probe{
 						ProbeHandler: core.ProbeHandler{
-							TCPSocket: &core.TCPSocketAction{Port: intstr.FromInt(80)},
+							TCPSocket: &core.TCPSocketAction{Port: intstr.FromInt32(80)},
 						},
 						InitialDelaySeconds:           -1,
 						TimeoutSeconds:                -1,
@@ -14475,7 +14475,7 @@ func makeValidService() core.Service {
 			Selector:              map[string]string{"key": "val"},
 			SessionAffinity:       "None",
 			Type:                  core.ServiceTypeClusterIP,
-			Ports:                 []core.ServicePort{{Name: "p", Protocol: "TCP", Port: 8675, TargetPort: intstr.FromInt(8675)}},
+			Ports:                 []core.ServicePort{{Name: "p", Protocol: "TCP", Port: 8675, TargetPort: intstr.FromInt32(8675)}},
 			InternalTrafficPolicy: &clusterInternalTrafficPolicy,
 		},
 	}
@@ -15001,7 +15001,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		{
 			name: "empty port[1] name",
 			tweakSvc: func(s *core.Service) {
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "", Protocol: "TCP", Port: 12345, TargetPort: intstr.FromInt(12345)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "", Protocol: "TCP", Port: 12345, TargetPort: intstr.FromInt32(12345)})
 			},
 			numErrs: 1,
 		},
@@ -15009,7 +15009,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "empty multi-port port[0] name",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Ports[0].Name = ""
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "p", Protocol: "TCP", Port: 12345, TargetPort: intstr.FromInt(12345)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "p", Protocol: "TCP", Port: 12345, TargetPort: intstr.FromInt32(12345)})
 			},
 			numErrs: 1,
 		},
@@ -15059,7 +15059,7 @@ func TestValidateServiceCreate(t *testing.T) {
 		{
 			name: "invalid TargetPort int",
 			tweakSvc: func(s *core.Service) {
-				s.Spec.Ports[0].TargetPort = intstr.FromInt(65536)
+				s.Spec.Ports[0].TargetPort = intstr.FromInt32(65536)
 			},
 			numErrs: 1,
 		},
@@ -15067,7 +15067,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "valid port headless",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Ports[0].Port = 11722
-				s.Spec.Ports[0].TargetPort = intstr.FromInt(11722)
+				s.Spec.Ports[0].TargetPort = intstr.FromInt32(11722)
 				s.Spec.ClusterIP = core.ClusterIPNone
 				s.Spec.ClusterIPs = []string{core.ClusterIPNone}
 			},
@@ -15077,7 +15077,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "invalid port headless 1",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Ports[0].Port = 11722
-				s.Spec.Ports[0].TargetPort = intstr.FromInt(11721)
+				s.Spec.Ports[0].TargetPort = intstr.FromInt32(11721)
 				s.Spec.ClusterIP = core.ClusterIPNone
 				s.Spec.ClusterIPs = []string{core.ClusterIPNone}
 			},
@@ -15131,7 +15131,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "dup port name",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Ports[0].Name = "p"
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "p", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt(12345)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "p", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 			},
 			numErrs: 1,
 		},
@@ -15151,7 +15151,7 @@ func TestValidateServiceCreate(t *testing.T) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				s.Spec.Ports[0] = core.ServicePort{Name: "q", Port: 12345, Protocol: "UDP", TargetPort: intstr.FromInt(12345)}
+				s.Spec.Ports[0] = core.ServicePort{Name: "q", Port: 12345, Protocol: "UDP", TargetPort: intstr.FromInt32(12345)}
 			},
 			numErrs: 0,
 		},
@@ -15161,7 +15161,7 @@ func TestValidateServiceCreate(t *testing.T) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "UDP", TargetPort: intstr.FromInt(12345)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "UDP", TargetPort: intstr.FromInt32(12345)})
 			},
 			numErrs: 0,
 		},
@@ -15176,7 +15176,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "valid 2",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Ports[0].Protocol = "UDP"
-				s.Spec.Ports[0].TargetPort = intstr.FromInt(12345)
+				s.Spec.Ports[0].TargetPort = intstr.FromInt32(12345)
 			},
 			numErrs: 0,
 		},
@@ -15242,7 +15242,7 @@ func TestValidateServiceCreate(t *testing.T) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt(12345)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 			},
 			numErrs: 0,
 		},
@@ -15252,7 +15252,7 @@ func TestValidateServiceCreate(t *testing.T) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt(12345)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 			},
 			numErrs: 0,
 		},
@@ -15261,8 +15261,8 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeNodePort
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 1, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt(1)})
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "r", Port: 2, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt(2)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 1, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt32(1)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "r", Port: 2, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt32(2)})
 			},
 			numErrs: 1,
 		},
@@ -15271,9 +15271,9 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeNodePort
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 1, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt(1)})
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "r", Port: 2, Protocol: "UDP", NodePort: 1, TargetPort: intstr.FromInt(2)})
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "s", Port: 3, Protocol: "SCTP", NodePort: 1, TargetPort: intstr.FromInt(3)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 1, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt32(1)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "r", Port: 2, Protocol: "UDP", NodePort: 1, TargetPort: intstr.FromInt32(2)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "s", Port: 3, Protocol: "SCTP", NodePort: 1, TargetPort: intstr.FromInt32(3)})
 			},
 			numErrs: 0,
 		},
@@ -15281,8 +15281,8 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "invalid duplicate ports (with same protocol)",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeClusterIP
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt(8080)})
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "r", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt(80)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "r", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(80)})
 			},
 			numErrs: 1,
 		},
@@ -15290,9 +15290,9 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "valid duplicate ports (with different protocols)",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeClusterIP
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt(8080)})
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "r", Port: 12345, Protocol: "UDP", TargetPort: intstr.FromInt(80)})
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "s", Port: 12345, Protocol: "SCTP", TargetPort: intstr.FromInt(8088)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(8080)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "r", Port: 12345, Protocol: "UDP", TargetPort: intstr.FromInt32(80)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "s", Port: 12345, Protocol: "SCTP", TargetPort: intstr.FromInt32(8088)})
 			},
 			numErrs: 0,
 		},
@@ -15326,7 +15326,7 @@ func TestValidateServiceCreate(t *testing.T) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt(12345)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 			},
 			numErrs: 0,
 		},
@@ -15336,7 +15336,7 @@ func TestValidateServiceCreate(t *testing.T) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", NodePort: 12345, TargetPort: intstr.FromInt(12345)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", NodePort: 12345, TargetPort: intstr.FromInt32(12345)})
 			},
 			numErrs: 0,
 		},
@@ -15345,7 +15345,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeNodePort
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", NodePort: 12345, TargetPort: intstr.FromInt(12345)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", NodePort: 12345, TargetPort: intstr.FromInt32(12345)})
 			},
 			numErrs: 0,
 		},
@@ -15354,7 +15354,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeNodePort
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt(12345)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 			},
 			numErrs: 0,
 		},
@@ -15362,7 +15362,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "valid cluster service without NodePort",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeClusterIP
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt(12345)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 			},
 			numErrs: 0,
 		},
@@ -15370,7 +15370,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			name: "invalid cluster service with NodePort",
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeClusterIP
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", NodePort: 12345, TargetPort: intstr.FromInt(12345)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", NodePort: 12345, TargetPort: intstr.FromInt32(12345)})
 			},
 			numErrs: 1,
 		},
@@ -15379,8 +15379,8 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeNodePort
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "p1", Port: 1, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt(1)})
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "p2", Port: 2, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt(2)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "p1", Port: 1, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt32(1)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "p2", Port: 2, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt32(2)})
 			},
 			numErrs: 1,
 		},
@@ -15390,7 +15390,7 @@ func TestValidateServiceCreate(t *testing.T) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt(12345)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 12345, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 			},
 			numErrs: 0,
 		},
@@ -15402,7 +15402,7 @@ func TestValidateServiceCreate(t *testing.T) {
 				s.Spec.Type = core.ServiceTypeLoadBalancer
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 				s.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "kubelet", Port: 10250, Protocol: "TCP", TargetPort: intstr.FromInt(12345)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "kubelet", Port: 10250, Protocol: "TCP", TargetPort: intstr.FromInt32(12345)})
 			},
 			numErrs: 1,
 		},
@@ -15540,7 +15540,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Type = core.ServiceTypeNodePort
 				s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
-				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 1, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt(1)})
+				s.Spec.Ports = append(s.Spec.Ports, core.ServicePort{Name: "q", Port: 1, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt32(1)})
 				s.Spec.ClusterIP = "None"
 				s.Spec.ClusterIPs = []string{"None"}
 			},
@@ -16042,7 +16042,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Ports = []core.ServicePort{{
 					Port:        12345,
-					TargetPort:  intstr.FromInt(12345),
+					TargetPort:  intstr.FromInt32(12345),
 					Protocol:    "TCP",
 					AppProtocol: utilpointer.String("HTTP"),
 				}}
@@ -16054,7 +16054,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Ports = []core.ServicePort{{
 					Port:        12345,
-					TargetPort:  intstr.FromInt(12345),
+					TargetPort:  intstr.FromInt32(12345),
 					Protocol:    "TCP",
 					AppProtocol: utilpointer.String("example.com/protocol"),
 				}}
@@ -16066,7 +16066,7 @@ func TestValidateServiceCreate(t *testing.T) {
 			tweakSvc: func(s *core.Service) {
 				s.Spec.Ports = []core.ServicePort{{
 					Port:        12345,
-					TargetPort:  intstr.FromInt(12345),
+					TargetPort:  intstr.FromInt32(12345),
 					Protocol:    "TCP",
 					AppProtocol: utilpointer.String("example.com/protocol_with{invalid}[characters]"),
 				}}
@@ -18145,8 +18145,8 @@ func TestValidateServiceUpdate(t *testing.T) {
 				newSvc.Spec.Type = core.ServiceTypeNodePort
 				newSvc.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 
-				oldSvc.Spec.Ports = append(oldSvc.Spec.Ports, core.ServicePort{Name: "q", Port: 1, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt(1)})
-				newSvc.Spec.Ports = append(newSvc.Spec.Ports, core.ServicePort{Name: "q", Port: 1, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt(1)})
+				oldSvc.Spec.Ports = append(oldSvc.Spec.Ports, core.ServicePort{Name: "q", Port: 1, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt32(1)})
+				newSvc.Spec.Ports = append(newSvc.Spec.Ports, core.ServicePort{Name: "q", Port: 1, Protocol: "TCP", NodePort: 1, TargetPort: intstr.FromInt32(1)})
 
 				oldSvc.Spec.ClusterIP = ""
 				oldSvc.Spec.ClusterIPs = nil
@@ -18568,16 +18568,16 @@ func TestValidateServiceUpdate(t *testing.T) {
 		{
 			name: "update to valid app protocol",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
-				oldSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP"}}
-				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP", AppProtocol: utilpointer.String("https")}}
+				oldSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP"}}
+				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP", AppProtocol: utilpointer.String("https")}}
 			},
 			numErrs: 0,
 		},
 		{
 			name: "update to invalid app protocol",
 			tweakSvc: func(oldSvc, newSvc *core.Service) {
-				oldSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP"}}
-				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt(3000), Protocol: "TCP", AppProtocol: utilpointer.String("~https")}}
+				oldSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP"}}
+				newSvc.Spec.Ports = []core.ServicePort{{Name: "a", Port: 443, TargetPort: intstr.FromInt32(3000), Protocol: "TCP", AppProtocol: utilpointer.String("~https")}}
 			},
 			numErrs: 1,
 		},

--- a/pkg/apis/extensions/v1beta1/conversion.go
+++ b/pkg/apis/extensions/v1beta1/conversion.go
@@ -181,7 +181,7 @@ func Convert_networking_IngressBackend_To_v1beta1_IngressBackend(in *networking.
 		if len(in.Service.Port.Name) > 0 {
 			out.ServicePort = intstr.FromString(in.Service.Port.Name)
 		} else {
-			out.ServicePort = intstr.FromInt(int(in.Service.Port.Number))
+			out.ServicePort = intstr.FromInt32(in.Service.Port.Number)
 		}
 	}
 	return nil

--- a/pkg/apis/extensions/v1beta1/conversion_test.go
+++ b/pkg/apis/extensions/v1beta1/conversion_test.go
@@ -39,7 +39,7 @@ func TestIngressBackendConversion(t *testing.T) {
 			external: v1beta1.IngressSpec{
 				Backend: &v1beta1.IngressBackend{
 					ServiceName: "test-backend",
-					ServicePort: intstr.FromInt(8080),
+					ServicePort: intstr.FromInt32(8080),
 				},
 			},
 			internal: networking.IngressSpec{

--- a/pkg/apis/extensions/v1beta1/defaults.go
+++ b/pkg/apis/extensions/v1beta1/defaults.go
@@ -55,12 +55,12 @@ func SetDefaults_DaemonSet(obj *extensionsv1beta1.DaemonSet) {
 		}
 		if updateStrategy.RollingUpdate.MaxUnavailable == nil {
 			// Set default MaxUnavailable as 1 by default.
-			maxUnavailable := intstr.FromInt(1)
+			maxUnavailable := intstr.FromInt32(1)
 			updateStrategy.RollingUpdate.MaxUnavailable = &maxUnavailable
 		}
 		if updateStrategy.RollingUpdate.MaxSurge == nil {
 			// Set default MaxSurge as 0 by default.
-			maxSurge := intstr.FromInt(0)
+			maxSurge := intstr.FromInt32(0)
 			updateStrategy.RollingUpdate.MaxSurge = &maxSurge
 		}
 	}
@@ -99,12 +99,12 @@ func SetDefaults_Deployment(obj *extensionsv1beta1.Deployment) {
 		}
 		if strategy.RollingUpdate.MaxUnavailable == nil {
 			// Set default MaxUnavailable as 1 by default.
-			maxUnavailable := intstr.FromInt(1)
+			maxUnavailable := intstr.FromInt32(1)
 			strategy.RollingUpdate.MaxUnavailable = &maxUnavailable
 		}
 		if strategy.RollingUpdate.MaxSurge == nil {
 			// Set default MaxSurge as 1 by default.
-			maxSurge := intstr.FromInt(1)
+			maxSurge := intstr.FromInt32(1)
 			strategy.RollingUpdate.MaxSurge = &maxSurge
 		}
 	}

--- a/pkg/apis/extensions/v1beta1/defaults_test.go
+++ b/pkg/apis/extensions/v1beta1/defaults_test.go
@@ -160,8 +160,8 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 }
 
 func TestSetDefaultDeployment(t *testing.T) {
-	defaultIntOrString := intstr.FromInt(1)
-	differentIntOrString := intstr.FromInt(5)
+	defaultIntOrString := intstr.FromInt32(1)
+	differentIntOrString := intstr.FromInt32(5)
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{

--- a/pkg/apis/networking/v1beta1/conversion.go
+++ b/pkg/apis/networking/v1beta1/conversion.go
@@ -45,7 +45,7 @@ func Convert_networking_IngressBackend_To_v1beta1_IngressBackend(in *networking.
 		if len(in.Service.Port.Name) > 0 {
 			out.ServicePort = intstr.FromString(in.Service.Port.Name)
 		} else {
-			out.ServicePort = intstr.FromInt(int(in.Service.Port.Number))
+			out.ServicePort = intstr.FromInt32(in.Service.Port.Number)
 		}
 	}
 	return nil

--- a/pkg/apis/networking/v1beta1/conversion_test.go
+++ b/pkg/apis/networking/v1beta1/conversion_test.go
@@ -39,7 +39,7 @@ func TestIngressBackendConversion(t *testing.T) {
 			external: v1beta1.IngressSpec{
 				Backend: &v1beta1.IngressBackend{
 					ServiceName: "test-backend",
-					ServicePort: intstr.FromInt(8080),
+					ServicePort: intstr.FromInt32(8080),
 				},
 			},
 			internal: networking.IngressSpec{

--- a/pkg/apis/networking/validation/validation_test.go
+++ b/pkg/apis/networking/validation/validation_test.go
@@ -57,7 +57,7 @@ func makePort(proto *api.Protocol, port intstr.IntOrString, endPort int32) netwo
 		Protocol: proto,
 		Port:     nil,
 	}
-	if port != intstr.FromInt(0) && port != intstr.FromString("") && port != intstr.FromString("0") {
+	if port != intstr.FromInt32(0) && port != intstr.FromString("") && port != intstr.FromString("0") {
 		r.Port = &port
 	}
 	if endPort != 0 {
@@ -213,11 +213,11 @@ func TestValidateNetworkPolicy(t *testing.T) {
 		makeNetworkPolicyCustom(setIngressEmptyFirstElement),
 		makeNetworkPolicyCustom(setIngressFromEmptyFirstElement, setIngressEmptyPorts),
 		makeNetworkPolicyCustom(setIngressPorts(
-			makePort(nil, intstr.FromInt(80), 0),
-			makePort(&protocolTCP, intstr.FromInt(0), 0),
-			makePort(&protocolTCP, intstr.FromInt(443), 0),
+			makePort(nil, intstr.FromInt32(80), 0),
+			makePort(&protocolTCP, intstr.FromInt32(0), 0),
+			makePort(&protocolTCP, intstr.FromInt32(443), 0),
 			makePort(&protocolUDP, intstr.FromString("dns"), 0),
-			makePort(&protocolSCTP, intstr.FromInt(7777), 0),
+			makePort(&protocolSCTP, intstr.FromInt32(7777), 0),
 		)),
 		makeNetworkPolicyCustom(setIngressFromPodSelector("c", "d")),
 		makeNetworkPolicyCustom(setIngressFromNamespaceSelector),
@@ -227,25 +227,25 @@ func TestValidateNetworkPolicy(t *testing.T) {
 		makeNetworkPolicyCustom(setEgressToIPBlockIPV4, setPolicyTypesEgress),
 		makeNetworkPolicyCustom(setEgressToIPBlockIPV4, setPolicyTypesIngressEgress),
 		makeNetworkPolicyCustom(setEgressPorts(
-			makePort(nil, intstr.FromInt(80), 0),
-			makePort(&protocolTCP, intstr.FromInt(0), 0),
-			makePort(&protocolTCP, intstr.FromInt(443), 0),
+			makePort(nil, intstr.FromInt32(80), 0),
+			makePort(&protocolTCP, intstr.FromInt32(0), 0),
+			makePort(&protocolTCP, intstr.FromInt32(443), 0),
 			makePort(&protocolUDP, intstr.FromString("dns"), 0),
-			makePort(&protocolSCTP, intstr.FromInt(7777), 0),
+			makePort(&protocolSCTP, intstr.FromInt32(7777), 0),
 		)),
 		makeNetworkPolicyCustom(setEgressToNamespaceSelector, setIngressFromIPBlockIPV6),
 		makeNetworkPolicyCustom(setIngressFromIPBlockIPV6),
 		makeNetworkPolicyCustom(setEgressToIPBlockIPV6, setPolicyTypesEgress),
 		makeNetworkPolicyCustom(setEgressToIPBlockIPV6, setPolicyTypesIngressEgress),
-		makeNetworkPolicyCustom(setEgressPorts(makePort(nil, intstr.FromInt(32000), 32768), makePort(&protocolUDP, intstr.FromString("dns"), 0))),
+		makeNetworkPolicyCustom(setEgressPorts(makePort(nil, intstr.FromInt32(32000), 32768), makePort(&protocolUDP, intstr.FromString("dns"), 0))),
 		makeNetworkPolicyCustom(
 			setEgressToNamespaceSelector,
 			setEgressPorts(
-				makePort(nil, intstr.FromInt(30000), 32768),
-				makePort(nil, intstr.FromInt(32000), 32768),
+				makePort(nil, intstr.FromInt32(30000), 32768),
+				makePort(nil, intstr.FromInt32(32000), 32768),
 			),
 			setIngressFromPodSelector("e", "f"),
-			setIngressPorts(makePort(&protocolTCP, intstr.FromInt(32768), 32768))),
+			setIngressPorts(makePort(&protocolTCP, intstr.FromInt32(32768), 32768))),
 	}
 
 	// Success cases are expected to pass validation.
@@ -269,8 +269,8 @@ func TestValidateNetworkPolicy(t *testing.T) {
 				},
 			}
 		}),
-		"invalid ingress.ports.protocol":   makeNetworkPolicyCustom(setIngressPorts(makePort(&protocolICMP, intstr.FromInt(80), 0))),
-		"invalid ingress.ports.port (int)": makeNetworkPolicyCustom(setIngressPorts(makePort(&protocolTCP, intstr.FromInt(123456789), 0))),
+		"invalid ingress.ports.protocol":   makeNetworkPolicyCustom(setIngressPorts(makePort(&protocolICMP, intstr.FromInt32(80), 0))),
+		"invalid ingress.ports.port (int)": makeNetworkPolicyCustom(setIngressPorts(makePort(&protocolTCP, intstr.FromInt32(123456789), 0))),
 		"invalid ingress.ports.port (str)": makeNetworkPolicyCustom(
 			setIngressPorts(makePort(&protocolTCP, intstr.FromString("!@#$"), 0))),
 		"invalid ingress.from.podSelector": makeNetworkPolicyCustom(setIngressFromEmptyFirstElement, func(networkPolicy *networking.NetworkPolicy) {
@@ -283,8 +283,8 @@ func TestValidateNetworkPolicy(t *testing.T) {
 				MatchLabels: invalidSelector,
 			}
 		}),
-		"invalid egress.ports.protocol":   makeNetworkPolicyCustom(setEgressPorts(makePort(&protocolICMP, intstr.FromInt(80), 0))),
-		"invalid egress.ports.port (int)": makeNetworkPolicyCustom(setEgressPorts(makePort(&protocolTCP, intstr.FromInt(123456789), 0))),
+		"invalid egress.ports.protocol":   makeNetworkPolicyCustom(setEgressPorts(makePort(&protocolICMP, intstr.FromInt32(80), 0))),
+		"invalid egress.ports.port (int)": makeNetworkPolicyCustom(setEgressPorts(makePort(&protocolTCP, intstr.FromInt32(123456789), 0))),
 		"invalid egress.ports.port (str)": makeNetworkPolicyCustom(setEgressPorts(makePort(&protocolTCP, intstr.FromString("!@#$"), 0))),
 		"invalid ingress.from.namespaceSelector": makeNetworkPolicyCustom(setIngressFromEmptyFirstElement, func(networkPolicy *networking.NetworkPolicy) {
 			networkPolicy.Spec.Ingress[0].From[0].NamespaceSelector = &metav1.LabelSelector{
@@ -336,34 +336,34 @@ func TestValidateNetworkPolicy(t *testing.T) {
 		"multiple ports defined, one port range is invalid": makeNetworkPolicyCustom(
 			setEgressToNamespaceSelector,
 			setEgressPorts(
-				makePort(&protocolUDP, intstr.FromInt(35000), 32768),
-				makePort(nil, intstr.FromInt(32000), 32768),
+				makePort(&protocolUDP, intstr.FromInt32(35000), 32768),
+				makePort(nil, intstr.FromInt32(32000), 32768),
 			),
 		),
 		"endPort defined with named/string port": makeNetworkPolicyCustom(
 			setEgressToNamespaceSelector,
 			setEgressPorts(
 				makePort(&protocolUDP, intstr.FromString("dns"), 32768),
-				makePort(nil, intstr.FromInt(32000), 32768),
+				makePort(nil, intstr.FromInt32(32000), 32768),
 			),
 		),
 		"endPort defined without port defined": makeNetworkPolicyCustom(
 			setEgressToNamespaceSelector,
-			setEgressPorts(makePort(&protocolTCP, intstr.FromInt(0), 32768)),
+			setEgressPorts(makePort(&protocolTCP, intstr.FromInt32(0), 32768)),
 		),
 		"port is greater than endPort": makeNetworkPolicyCustom(
 			setEgressToNamespaceSelector,
-			setEgressPorts(makePort(&protocolSCTP, intstr.FromInt(35000), 32768)),
+			setEgressPorts(makePort(&protocolSCTP, intstr.FromInt32(35000), 32768)),
 		),
 		"multiple invalid port ranges defined": makeNetworkPolicyCustom(
 			setEgressToNamespaceSelector,
 			setEgressPorts(
-				makePort(&protocolUDP, intstr.FromInt(35000), 32768),
-				makePort(&protocolTCP, intstr.FromInt(0), 32768),
+				makePort(&protocolUDP, intstr.FromInt32(35000), 32768),
+				makePort(&protocolTCP, intstr.FromInt32(0), 32768),
 				makePort(&protocolTCP, intstr.FromString("https"), 32768),
 			),
 		),
-		"invalid endport range defined": makeNetworkPolicyCustom(setEgressToNamespaceSelector, setEgressPorts(makePort(&protocolTCP, intstr.FromInt(30000), 65537))),
+		"invalid endport range defined": makeNetworkPolicyCustom(setEgressToNamespaceSelector, setEgressPorts(makePort(&protocolTCP, intstr.FromInt32(30000), 65537))),
 	}
 
 	// Error cases are not expected to pass validation.

--- a/pkg/apis/policy/validation/validation_test.go
+++ b/pkg/apis/policy/validation/validation_test.go
@@ -52,9 +52,9 @@ func TestValidateMinAvailablePodDisruptionBudgetSpec(t *testing.T) {
 		intstr.FromString("0%"),
 		intstr.FromString("1%"),
 		intstr.FromString("100%"),
-		intstr.FromInt(0),
-		intstr.FromInt(1),
-		intstr.FromInt(100),
+		intstr.FromInt32(0),
+		intstr.FromInt32(1),
+		intstr.FromInt32(100),
 	}
 	for _, c := range successCases {
 		spec := policy.PodDisruptionBudgetSpec{
@@ -71,7 +71,7 @@ func TestValidateMinAvailablePodDisruptionBudgetSpec(t *testing.T) {
 		intstr.FromString("nope"),
 		intstr.FromString("-1%"),
 		intstr.FromString("101%"),
-		intstr.FromInt(-1),
+		intstr.FromInt32(-1),
 	}
 	for _, c := range failureCases {
 		spec := policy.PodDisruptionBudgetSpec{
@@ -86,7 +86,7 @@ func TestValidateMinAvailablePodDisruptionBudgetSpec(t *testing.T) {
 
 func TestValidateMinAvailablePodAndMaxUnavailableDisruptionBudgetSpec(t *testing.T) {
 	c1 := intstr.FromString("10%")
-	c2 := intstr.FromInt(1)
+	c2 := intstr.FromInt32(1)
 
 	spec := policy.PodDisruptionBudgetSpec{
 		MinAvailable:   &c1,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#116665 introduces `intstr` contructors from `int32`; this PR updates code to use them.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
