### PR TITLE
kubelet: use new intstr functions

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -437,7 +437,7 @@ func TestLifeCycleHook(t *testing.T) {
 		t.Run("consistent", func(t *testing.T) {
 			ctx := context.Background()
 			defer func() { fakeHTTP.req = nil }()
-			httpLifeCycle.PreStop.HTTPGet.Port = intstr.FromInt(80)
+			httpLifeCycle.PreStop.HTTPGet.Port = intstr.FromInt32(80)
 			testPod.Spec.Containers[0].Lifecycle = httpLifeCycle
 			m.killContainer(ctx, testPod, cID, "foo", "testKill", "", &gracePeriod)
 

--- a/pkg/kubelet/kuberuntime/labels_test.go
+++ b/pkg/kubelet/kuberuntime/labels_test.go
@@ -41,7 +41,7 @@ func TestContainerLabels(t *testing.T) {
 			HTTPGet: &v1.HTTPGetAction{
 				Path:   "path",
 				Host:   "host",
-				Port:   intstr.FromInt(8080),
+				Port:   intstr.FromInt32(8080),
 				Scheme: "scheme",
 			},
 			TCPSocket: &v1.TCPSocketAction{
@@ -110,7 +110,7 @@ func TestContainerAnnotations(t *testing.T) {
 			HTTPGet: &v1.HTTPGetAction{
 				Path:   "path",
 				Host:   "host",
-				Port:   intstr.FromInt(8080),
+				Port:   intstr.FromInt32(8080),
 				Scheme: "scheme",
 			},
 			TCPSocket: &v1.TCPSocketAction{

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -179,7 +179,7 @@ func TestRunHandlerHttp(t *testing.T) {
 			PostStart: &v1.LifecycleHandler{
 				HTTPGet: &v1.HTTPGetAction{
 					Host: "foo",
-					Port: intstr.FromInt(8080),
+					Port: intstr.FromInt32(8080),
 					Path: "bar",
 				},
 			},
@@ -216,7 +216,7 @@ func TestRunHandlerHttpWithHeaders(t *testing.T) {
 			PostStart: &v1.LifecycleHandler{
 				HTTPGet: &v1.HTTPGetAction{
 					Host: "foo",
-					Port: intstr.FromInt(8080),
+					Port: intstr.FromInt32(8080),
 					Path: "/bar",
 					HTTPHeaders: []v1.HTTPHeader{
 						{Name: "Foo", Value: "bar"},
@@ -739,7 +739,7 @@ func TestRunHandlerHttpFailure(t *testing.T) {
 			PostStart: &v1.LifecycleHandler{
 				HTTPGet: &v1.HTTPGetAction{
 					Host: "foo",
-					Port: intstr.FromInt(8080),
+					Port: intstr.FromInt32(8080),
 					Path: "bar",
 				},
 			},

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -44,14 +44,14 @@ func TestGetURLParts(t *testing.T) {
 		port  int
 		path  string
 	}{
-		{&v1.HTTPGetAction{Host: "", Port: intstr.FromInt(-1), Path: ""}, false, "", -1, ""},
+		{&v1.HTTPGetAction{Host: "", Port: intstr.FromInt32(-1), Path: ""}, false, "", -1, ""},
 		{&v1.HTTPGetAction{Host: "", Port: intstr.FromString(""), Path: ""}, false, "", -1, ""},
 		{&v1.HTTPGetAction{Host: "", Port: intstr.FromString("-1"), Path: ""}, false, "", -1, ""},
 		{&v1.HTTPGetAction{Host: "", Port: intstr.FromString("not-found"), Path: ""}, false, "", -1, ""},
 		{&v1.HTTPGetAction{Host: "", Port: intstr.FromString("found"), Path: ""}, true, "127.0.0.1", 93, ""},
-		{&v1.HTTPGetAction{Host: "", Port: intstr.FromInt(76), Path: ""}, true, "127.0.0.1", 76, ""},
+		{&v1.HTTPGetAction{Host: "", Port: intstr.FromInt32(76), Path: ""}, true, "127.0.0.1", 76, ""},
 		{&v1.HTTPGetAction{Host: "", Port: intstr.FromString("118"), Path: ""}, true, "127.0.0.1", 118, ""},
-		{&v1.HTTPGetAction{Host: "hostname", Port: intstr.FromInt(76), Path: "path"}, true, "hostname", 76, "path"},
+		{&v1.HTTPGetAction{Host: "hostname", Port: intstr.FromInt32(76), Path: "path"}, true, "hostname", 76, "path"},
 	}
 
 	for _, test := range testCases {
@@ -98,12 +98,12 @@ func TestGetTCPAddrParts(t *testing.T) {
 		host  string
 		port  int
 	}{
-		{&v1.TCPSocketAction{Port: intstr.FromInt(-1)}, false, "", -1},
+		{&v1.TCPSocketAction{Port: intstr.FromInt32(-1)}, false, "", -1},
 		{&v1.TCPSocketAction{Port: intstr.FromString("")}, false, "", -1},
 		{&v1.TCPSocketAction{Port: intstr.FromString("-1")}, false, "", -1},
 		{&v1.TCPSocketAction{Port: intstr.FromString("not-found")}, false, "", -1},
 		{&v1.TCPSocketAction{Port: intstr.FromString("found")}, true, "1.2.3.4", 93},
-		{&v1.TCPSocketAction{Port: intstr.FromInt(76)}, true, "1.2.3.4", 76},
+		{&v1.TCPSocketAction{Port: intstr.FromInt32(76)}, true, "1.2.3.4", 76},
 		{&v1.TCPSocketAction{Port: intstr.FromString("118")}, true, "1.2.3.4", 118},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#116665 introduces `intstr` contructors from `int32`; this PR updates code to use them.

/hold pending #116665

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
