### PR TITLE
Cluster lifecycle: use new intstr functions

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/init_dryrun.go
+++ b/cmd/kubeadm/app/util/apiclient/init_dryrun.go
@@ -109,7 +109,7 @@ func (idr *InitDryRunGetter) handleKubernetesService(action core.GetAction) (boo
 				{
 					Name:       "https",
 					Port:       443,
-					TargetPort: intstr.FromInt(6443),
+					TargetPort: intstr.FromInt32(6443),
 				},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#116665 introduces `intstr` contructors from `int32`; this PR updates code to use them.

/hold pending #116665

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
