### PR TITLE
Cleanup: add unequal LastProbeTime UpdatePodCondition unittest case

### DIFF
--- a/pkg/api/v1/pod/util_test.go
+++ b/pkg/api/v1/pod/util_test.go
@@ -913,6 +913,18 @@ func TestUpdatePodCondition(t *testing.T) {
 			expected: true,
 			desc:     "not equal Status, should get updated",
 		},
+		{
+			status: &podStatus,
+			conditions: v1.PodCondition{
+				Type:               v1.PodReady,
+				Status:             v1.ConditionFalse,
+				Reason:             "successfully",
+				Message:            "sync pod successfully",
+				LastProbeTime:      metav1.NewTime(time.Add(1000)),
+				LastTransitionTime: metav1.NewTime(time.Add(1000))},
+			expected: true,
+			desc:     "not equal LastProbeTime, should get updated",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
What type of PR is this?

/kind cleanup
/sig testing

What this PR does / why we need it:
increased test coverage of the UpdatePodCondition function; added a case to test for unequal LastProbeTime which didn't exist beforehand.

Which issue(s) this PR fixes:

Special notes for your reviewer:

Does this PR introduce a user-facing change?
```release-note
NONE
```