### PR TITLE
kuberuntime: log container state in unusual case

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -930,7 +930,11 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 			if kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus) {
 				klog.V(3).InfoS("Container of pod is not in the desired state and shall be started", "containerName", container.Name, "pod", klog.KObj(pod))
 				changes.ContainersToStart = append(changes.ContainersToStart, idx)
-				if containerStatus != nil && containerStatus.State == kubecontainer.ContainerStateUnknown {
+				if containerStatus != nil {
+					if containerStatus.State != kubecontainer.ContainerStateUnknown {
+						klog.InfoS("Container of pod is in an unexpected state", "containerName", container.Name, "pod", klog.KObj(pod), "state", containerStatus.State, "id", containerStatus.ID.ID)
+						continue
+					}
 					// If container is in unknown state, we don't know whether it
 					// is actually running or not, always try killing it before
 					// restart to avoid having 2 running instances of the same container.


### PR DESCRIPTION
We occasionally observed that we have 2 running instances for the same container, and the second one just keeps crashing because the port it tries to listen on is already in use. I was able to trace down that there was indeed a container running after extensive analysis based on logs. I then tried to understand how it might happen, and if I understand the process correctly, in kuberuntime manager, `computePodActions` determines what to do for a specific pod, like either start a new container or kill a bad container. It appears that there is only one possibility where it may go and create a new container without killing the previous one:

```go
if containerStatus == nil || containerStatus.State != kubecontainer.ContainerStateRunning {
    if kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus) {
        ...
        changes.ContainersToStart = append(changes.ContainerToStart, idx)
        if containerStatus != nil && containerStatus.State == kubecontainer.ContainerStateUnknown {
            changes.ContainersToKill[containerStatus.ID] = ...
        }
    }
```

This change tries to log the unusual container state (for instance, `created`) which can help us investigate further.

/kind feature

```release-note
NONE
```
