### PR TITLE
Cleanup duplicate DaemonSet update test case

### DIFF
--- a/pkg/controller/daemon/update_test.go
+++ b/pkg/controller/daemon/update_test.go
@@ -59,12 +59,6 @@ func TestDaemonSetUpdatesPods(t *testing.T) {
 	markPodsReady(podControl.podStore)
 
 	clearExpectations(t, manager, ds, podControl)
-	expectSyncDaemonSets(t, manager, ds, podControl, 0, maxUnavailable, 0)
-	clearExpectations(t, manager, ds, podControl)
-	expectSyncDaemonSets(t, manager, ds, podControl, maxUnavailable, 0, 0)
-	markPodsReady(podControl.podStore)
-
-	clearExpectations(t, manager, ds, podControl)
 	expectSyncDaemonSets(t, manager, ds, podControl, 0, 1, 0)
 	clearExpectations(t, manager, ds, podControl)
 	expectSyncDaemonSets(t, manager, ds, podControl, 1, 0, 0)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Cleanup the DaemonSet update test case that are duplicates of previous test case.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

This case was added at the following commit.  
But, I couldn't understand why there are two duplicate cases and I think one of them is unnecessary.

https://github.com/kubernetes/kubernetes/commit/b27308c3173eae7862e4fd68ed8fb5e044111459#diff-73cc3633d8e7a840de5abcdcb208893ef90cb291b207025bf5d0e5a3ac51740aR1028

I would appreciate it if you could let me know if it makes any sense.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
