### PR TITLE
update the etcd base image to v1.4.2

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -123,7 +123,7 @@ dependencies:
 
   # Base images
   - name: "registry.k8s.io/debian-base: dependents"
-    version: bullseye-v1.3.0
+    version: bullseye-v1.4.2
     refPaths:
     - path: cluster/images/etcd/Makefile
       match: BASEIMAGE\?\=registry\.k8s\.io\/build-image\/debian-base:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -92,19 +92,19 @@ DOCKERFILE.windows = Dockerfile.windows
 DOCKERFILE := ${DOCKERFILE.${OS}}
 
 ifeq ($(ARCH),amd64)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base:bullseye-v1.3.0
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base:bullseye-v1.4.2
 endif
 ifeq ($(ARCH),arm)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm:bullseye-v1.3.0
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm:bullseye-v1.4.2
 endif
 ifeq ($(ARCH),arm64)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm64:bullseye-v1.3.0
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm64:bullseye-v1.4.2
 endif
 ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-ppc64le:bullseye-v1.3.0
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-ppc64le:bullseye-v1.4.2
 endif
 ifeq ($(ARCH),s390x)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-s390x:bullseye-v1.3.0
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-s390x:bullseye-v1.4.2
 endif
 
 BASE.windows = mcr.microsoft.com/windows/nanoserver

--- a/test/conformance/image/Makefile
+++ b/test/conformance/image/Makefile
@@ -33,7 +33,7 @@ CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
 # This is defined in root Makefile, but some build contexts do not refer to them
 KUBE_BASE_IMAGE_REGISTRY?=registry.k8s.io
-BASE_IMAGE_VERSION?=bullseye-v1.3.0
+BASE_IMAGE_VERSION?=bullseye-v1.4.2
 BASEIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base-${ARCH}:${BASE_IMAGE_VERSION}
 
 # Keep debian releases (e.g. debian 11 == bullseye) consistent 


### PR DESCRIPTION
The current base v1.3.0 has  CVEs[1] which are addressed in latest versions of the bullseye image

[1] ex:
CVE-2022-2509
CVE-2021-46828


/kind cleanup

```release-note
NONE
```

Additional note for reviewer:

The plan was to update the etcd docker file base image to v1.4.2, however the external dependencies check fails while we update only this part, so the base image version has been bumped  to v1.4.2 in general. I am not sure, were there any specific reason to stick to v1.3.0 of bullseye in the dependencies.yaml and conformance test image.