### PR TITLE
wait: fix PollUntilContextTimeout godoc comment

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/poll.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/poll.go
@@ -41,7 +41,7 @@ func PollUntilContextCancel(ctx context.Context, interval time.Duration, immedia
 //	err := PollUntilContextCancel(ctx, interval, immediate, condition)
 //
 // The deadline context will be cancelled if the Poll succeeds before the timeout, simplifying
-// inline usage. All other behavior is identical to PollUntilContextTimeout.
+// inline usage. All other behavior is identical to PollUntilContextCancel.
 func PollUntilContextTimeout(ctx context.Context, interval, timeout time.Duration, immediate bool, condition ConditionWithContextFunc) error {
 	deadlineCtx, deadlineCancel := context.WithTimeout(ctx, timeout)
 	defer deadlineCancel()


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

`PollUntilContextTimeout`'s godoc comment references itself. Adjust the godoc comment to instead reference `PollUntilContextCancel` to which it is identical apart from the deadline context.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
