### PR TITLE
kubeadm: add deprecated FG UpgradeAddonsBeforeControlPlane

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
@@ -79,7 +79,7 @@ func runControlPlane() func(c workflow.RunData) error {
 			return errors.Wrap(err, "couldn't complete the static pod upgrade")
 		}
 
-		if features.Enabled(cfg.FeatureGates, features.UpgradeAddonsAfterControlPlane) {
+		if !features.Enabled(cfg.FeatureGates, features.UpgradeAddonsBeforeControlPlane) {
 			if err := upgrade.PerformAddonsUpgrade(client, cfg, data.OutputWriter()); err != nil {
 				return errors.Wrap(err, "failed to perform addons upgrade")
 			}

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -35,16 +35,16 @@ const (
 	RootlessControlPlane = "RootlessControlPlane"
 	// EtcdLearnerMode is expected to be in alpha in v1.27
 	EtcdLearnerMode = "EtcdLearnerMode"
-	// UpgradeAddonsAfterControlPlane is expected to be in alpha in v1.28
-	UpgradeAddonsAfterControlPlane = "UpgradeAddonsAfterControlPlane"
+	// UpgradeAddonsBeforeControlPlane is expected to be in deprecated in v1.28 and will be removed in future release
+	UpgradeAddonsBeforeControlPlane = "UpgradeAddonsBeforeControlPlane"
 )
 
 // InitFeatureGates are the default feature gates for the init command
 var InitFeatureGates = FeatureList{
-	PublicKeysECDSA:                {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
-	RootlessControlPlane:           {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
-	EtcdLearnerMode:                {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
-	UpgradeAddonsAfterControlPlane: {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
+	PublicKeysECDSA:                 {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
+	RootlessControlPlane:            {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
+	EtcdLearnerMode:                 {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
+	UpgradeAddonsBeforeControlPlane: {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Deprecated}},
 }
 
 // Feature represents a feature being gated


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
discussions in https://github.com/kubernetes/kubernetes/pull/116570#discussion_r1179352015

#### Which issue(s) this PR fixes:
xref https://github.com/kubernetes/kubeadm/issues/2346

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kubeadm: introduce a new feature gate UpgradeAddonsBeforeControlPlane to fix a kube-proxy skew policy misalignment. Its default value is `false`. Upgrade of the CoreDNS and kube-proxy addons will now trigger after all the control plane instances have been upgraded, unless the fearure gate is set to true. This feature gate will be removed in a future release.
```

- The feature gate is deprecated and default false.
- When the feature gate is disabled, the behavior is expected that kubeadm upgrades coredns and kube-proxy after all CP node is upgraded.
- When the feature gate is enabled, the behavior is as before that kubeadm upgrades coredns and kube-proxy during the first CP node upgrade no matter if there are other CP nodes with an old version.
