### PR TITLE
Fix flaky HPA e2e tests by not failing on context cancelled

### DIFF
--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -354,10 +354,7 @@ func (rc *ResourceConsumer) makeConsumeCustomMetric(ctx context.Context) {
 }
 
 func (rc *ResourceConsumer) sendConsumeCPURequest(ctx context.Context, millicores int) {
-	ctx, cancel := context.WithTimeout(ctx, serviceInitializationTimeout)
-	defer cancel()
-
-	err := wait.PollUntilContextCancel(ctx, serviceInitializationInterval, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, serviceInitializationInterval, serviceInitializationTimeout, true, func(ctx context.Context) (bool, error) {
 		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
@@ -375,18 +372,18 @@ func (rc *ResourceConsumer) sendConsumeCPURequest(ctx context.Context, millicore
 		return true, nil
 	})
 
-	// consuming resources is a repeating background operation, getting cancelled is not a failure
-	if err != context.Canceled {
-		framework.ExpectNoError(err)
+	// Test has already finished (ctx got canceled), so don't fail on err from PollUntilContextTimeout
+	// which is a side-effect to context cancelling from the cleanup task.
+	if ctx.Err() != nil {
+		return
 	}
+
+	framework.ExpectNoError(err)
 }
 
 // sendConsumeMemRequest sends POST request for memory consumption
 func (rc *ResourceConsumer) sendConsumeMemRequest(ctx context.Context, megabytes int) {
-	ctx, cancel := context.WithTimeout(ctx, serviceInitializationTimeout)
-	defer cancel()
-
-	err := wait.PollUntilContextCancel(ctx, serviceInitializationInterval, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, serviceInitializationInterval, serviceInitializationTimeout, true, func(ctx context.Context) (bool, error) {
 		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
@@ -404,18 +401,18 @@ func (rc *ResourceConsumer) sendConsumeMemRequest(ctx context.Context, megabytes
 		return true, nil
 	})
 
-	// consuming resources is a repeating background operation, getting cancelled is not a failure
-	if err != context.Canceled {
-		framework.ExpectNoError(err)
+	// Test has already finished (ctx got canceled), so don't fail on err from PollUntilContextTimeout
+	// which is a side-effect to context cancelling from the cleanup task.
+	if ctx.Err() != nil {
+		return
 	}
+
+	framework.ExpectNoError(err)
 }
 
 // sendConsumeCustomMetric sends POST request for custom metric consumption
 func (rc *ResourceConsumer) sendConsumeCustomMetric(ctx context.Context, delta int) {
-	ctx, cancel := context.WithTimeout(ctx, serviceInitializationTimeout)
-	defer cancel()
-
-	err := wait.PollUntilContextCancel(ctx, serviceInitializationInterval, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, serviceInitializationInterval, serviceInitializationTimeout, true, func(ctx context.Context) (bool, error) {
 		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
@@ -434,10 +431,13 @@ func (rc *ResourceConsumer) sendConsumeCustomMetric(ctx context.Context, delta i
 		return true, nil
 	})
 
-	// consuming resources is a repeating background operation, getting cancelled is not a failure
-	if err != context.Canceled {
-		framework.ExpectNoError(err)
+	// Test has already finished (ctx got canceled), so don't fail on err from PollUntilContextTimeout
+	// which is a side-effect to context cancelling from the cleanup task.
+	if ctx.Err() != nil {
+		return
 	}
+
+	framework.ExpectNoError(err)
 }
 
 // GetReplicas get the replicas


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Makes context cancelled on resource consumption in e2e HPA tests not fail their test execution.

In HPA e2e tests, consume requests are sent during test execution in a loop in a separate goroutine. Once the test completes, it is expected that a consumption request may be pending. Cancelling the request during cleanup should not cause test failures.

Tests started being flaky since #112923 introduced passing test context that gets cancelled during cleanup.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig autoscaling