### PR TITLE
Revert "proxy startup-time config handling cleanup"

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -452,8 +452,6 @@ func (o *Options) ApplyDefaults(in *kubeproxyconfig.KubeProxyConfiguration) (*ku
 
 	out := internal.(*kubeproxyconfig.KubeProxyConfiguration)
 
-	o.platformApplyDefaults(out)
-
 	return out, nil
 }
 
@@ -524,16 +522,21 @@ with the apiserver API to configure the proxy.`,
 // ProxyServer represents all the parameters required to start the Kubernetes proxy server. All
 // fields are required.
 type ProxyServer struct {
-	Config *kubeproxyconfig.KubeProxyConfiguration
-
-	Client        clientset.Interface
-	Broadcaster   events.EventBroadcaster
-	Recorder      events.EventRecorder
-	Conntracker   Conntracker // if nil, ignored
-	NodeRef       *v1.ObjectReference
-	HealthzServer healthcheck.ProxierHealthUpdater
-
-	Proxier proxy.Provider
+	Client                 clientset.Interface
+	Proxier                proxy.Provider
+	Broadcaster            events.EventBroadcaster
+	Recorder               events.EventRecorder
+	ConntrackConfiguration kubeproxyconfig.KubeProxyConntrackConfiguration
+	Conntracker            Conntracker // if nil, ignored
+	ProxyMode              kubeproxyconfig.ProxyMode
+	NodeRef                *v1.ObjectReference
+	MetricsBindAddress     string
+	BindAddressHardFail    bool
+	EnableProfiling        bool
+	OOMScoreAdj            *int32
+	ConfigSyncPeriod       time.Duration
+	HealthzServer          healthcheck.ProxierHealthUpdater
+	localDetectorMode      kubeproxyconfig.LocalMode
 }
 
 // createClient creates a kube client from the given config and masterOverride.
@@ -642,9 +645,9 @@ func (s *ProxyServer) Run() error {
 
 	// TODO(vmarmol): Use container config for this.
 	var oomAdjuster *oom.OOMAdjuster
-	if s.Config.OOMScoreAdj != nil {
+	if s.OOMScoreAdj != nil {
 		oomAdjuster = oom.NewOOMAdjuster()
-		if err := oomAdjuster.ApplyOOMScoreAdj(0, int(*s.Config.OOMScoreAdj)); err != nil {
+		if err := oomAdjuster.ApplyOOMScoreAdj(0, int(*s.OOMScoreAdj)); err != nil {
 			klog.V(2).InfoS("Failed to apply OOMScore", "err", err)
 		}
 	}
@@ -657,7 +660,7 @@ func (s *ProxyServer) Run() error {
 	// TODO(thockin): make it possible for healthz and metrics to be on the same port.
 
 	var errCh chan error
-	if s.Config.BindAddressHardFail {
+	if s.BindAddressHardFail {
 		errCh = make(chan error)
 	}
 
@@ -665,12 +668,12 @@ func (s *ProxyServer) Run() error {
 	serveHealthz(s.HealthzServer, errCh)
 
 	// Start up a metrics server if requested
-	serveMetrics(s.Config.MetricsBindAddress, s.Config.Mode, s.Config.EnableProfiling, errCh)
+	serveMetrics(s.MetricsBindAddress, s.ProxyMode, s.EnableProfiling, errCh)
 
 	// Tune conntrack, if requested
 	// Conntracker is always nil for windows
 	if s.Conntracker != nil {
-		max, err := getConntrackMax(s.Config.Conntrack)
+		max, err := getConntrackMax(s.ConntrackConfiguration)
 		if err != nil {
 			return err
 		}
@@ -693,15 +696,15 @@ func (s *ProxyServer) Run() error {
 			}
 		}
 
-		if s.Config.Conntrack.TCPEstablishedTimeout != nil && s.Config.Conntrack.TCPEstablishedTimeout.Duration > 0 {
-			timeout := int(s.Config.Conntrack.TCPEstablishedTimeout.Duration / time.Second)
+		if s.ConntrackConfiguration.TCPEstablishedTimeout != nil && s.ConntrackConfiguration.TCPEstablishedTimeout.Duration > 0 {
+			timeout := int(s.ConntrackConfiguration.TCPEstablishedTimeout.Duration / time.Second)
 			if err := s.Conntracker.SetTCPEstablishedTimeout(timeout); err != nil {
 				return err
 			}
 		}
 
-		if s.Config.Conntrack.TCPCloseWaitTimeout != nil && s.Config.Conntrack.TCPCloseWaitTimeout.Duration > 0 {
-			timeout := int(s.Config.Conntrack.TCPCloseWaitTimeout.Duration / time.Second)
+		if s.ConntrackConfiguration.TCPCloseWaitTimeout != nil && s.ConntrackConfiguration.TCPCloseWaitTimeout.Duration > 0 {
+			timeout := int(s.ConntrackConfiguration.TCPCloseWaitTimeout.Duration / time.Second)
 			if err := s.Conntracker.SetTCPCloseWaitTimeout(timeout); err != nil {
 				return err
 			}
@@ -722,7 +725,7 @@ func (s *ProxyServer) Run() error {
 	labelSelector = labelSelector.Add(*noProxyName, *noHeadlessEndpoints)
 
 	// Make informers that filter out objects that want a non-default service proxy.
-	informerFactory := informers.NewSharedInformerFactoryWithOptions(s.Client, s.Config.ConfigSyncPeriod.Duration,
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(s.Client, s.ConfigSyncPeriod,
 		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
 			options.LabelSelector = labelSelector.String()
 		}))
@@ -731,11 +734,11 @@ func (s *ProxyServer) Run() error {
 	// Note: RegisterHandler() calls need to happen before creation of Sources because sources
 	// only notify on changes, and the initial update (on process start) may be lost if no handlers
 	// are registered yet.
-	serviceConfig := config.NewServiceConfig(informerFactory.Core().V1().Services(), s.Config.ConfigSyncPeriod.Duration)
+	serviceConfig := config.NewServiceConfig(informerFactory.Core().V1().Services(), s.ConfigSyncPeriod)
 	serviceConfig.RegisterEventHandler(s.Proxier)
 	go serviceConfig.Run(wait.NeverStop)
 
-	endpointSliceConfig := config.NewEndpointSliceConfig(informerFactory.Discovery().V1().EndpointSlices(), s.Config.ConfigSyncPeriod.Duration)
+	endpointSliceConfig := config.NewEndpointSliceConfig(informerFactory.Discovery().V1().EndpointSlices(), s.ConfigSyncPeriod)
 	endpointSliceConfig.RegisterEventHandler(s.Proxier)
 	go endpointSliceConfig.Run(wait.NeverStop)
 
@@ -744,13 +747,13 @@ func (s *ProxyServer) Run() error {
 	informerFactory.Start(wait.NeverStop)
 
 	// Make an informer that selects for our nodename.
-	currentNodeInformerFactory := informers.NewSharedInformerFactoryWithOptions(s.Client, s.Config.ConfigSyncPeriod.Duration,
+	currentNodeInformerFactory := informers.NewSharedInformerFactoryWithOptions(s.Client, s.ConfigSyncPeriod,
 		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
 			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", s.NodeRef.Name).String()
 		}))
-	nodeConfig := config.NewNodeConfig(currentNodeInformerFactory.Core().V1().Nodes(), s.Config.ConfigSyncPeriod.Duration)
+	nodeConfig := config.NewNodeConfig(currentNodeInformerFactory.Core().V1().Nodes(), s.ConfigSyncPeriod)
 	// https://issues.k8s.io/111321
-	if s.Config.DetectLocalMode == kubeproxyconfig.LocalModeNodeCIDR {
+	if s.localDetectorMode == kubeproxyconfig.LocalModeNodeCIDR {
 		nodeConfig.RegisterEventHandler(&proxy.NodePodCIDRHandler{})
 	}
 	nodeConfig.RegisterEventHandler(s.Proxier)

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -45,18 +45,16 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/winkernel"
 )
 
-func (o *Options) platformApplyDefaults(config *proxyconfigapi.KubeProxyConfiguration) {
-	if config.Mode == "" {
-		config.Mode = proxyconfigapi.ProxyModeKernelspace
-	}
-}
-
 // NewProxyServer returns a new ProxyServer.
 func NewProxyServer(o *Options) (*ProxyServer, error) {
 	return newProxyServer(o.config, o.master)
 }
 
 func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, master string) (*ProxyServer, error) {
+	if config == nil {
+		return nil, errors.New("config is required")
+	}
+
 	if c, err := configz.New(proxyconfigapi.GroupName); err == nil {
 		c.Set(config)
 	} else {
@@ -105,6 +103,7 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, master string
 	}
 
 	var proxier proxy.Provider
+	proxyMode := proxyconfigapi.ProxyModeKernelspace
 	dualStackMode := getDualStackMode(config.Winkernel.NetworkName, winkernel.DualStackCompatTester{})
 	if dualStackMode {
 		klog.InfoS("Creating dualStackProxier for Windows kernel.")
@@ -139,13 +138,18 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, master string
 	winkernel.RegisterMetrics()
 
 	return &ProxyServer{
-		Config:        config,
-		Client:        client,
-		Proxier:       proxier,
-		Broadcaster:   eventBroadcaster,
-		Recorder:      recorder,
-		NodeRef:       nodeRef,
-		HealthzServer: healthzServer,
+		Client:              client,
+		Proxier:             proxier,
+		Broadcaster:         eventBroadcaster,
+		Recorder:            recorder,
+		ProxyMode:           proxyMode,
+		NodeRef:             nodeRef,
+		MetricsBindAddress:  config.MetricsBindAddress,
+		BindAddressHardFail: config.BindAddressHardFail,
+		EnableProfiling:     config.EnableProfiling,
+		OOMScoreAdj:         config.OOMScoreAdj,
+		ConfigSyncPeriod:    config.ConfigSyncPeriod.Duration,
+		HealthzServer:       healthzServer,
 	}, nil
 }
 

--- a/pkg/proxy/apis/config/validation/validation.go
+++ b/pkg/proxy/apis/config/validation/validation.go
@@ -95,8 +95,6 @@ func Validate(config *kubeproxyconfig.KubeProxyConfiguration) field.ErrorList {
 
 	allErrs = append(allErrs, validateKubeProxyNodePortAddress(config.NodePortAddresses, newPath.Child("NodePortAddresses"))...)
 	allErrs = append(allErrs, validateShowHiddenMetricsVersion(config.ShowHiddenMetricsForVersion, newPath.Child("ShowHiddenMetricsForVersion"))...)
-
-	allErrs = append(allErrs, validateDetectLocalMode(config.DetectLocalMode, newPath.Child("DetectLocalMode"))...)
 	if config.DetectLocalMode == kubeproxyconfig.LocalModeBridgeInterface {
 		allErrs = append(allErrs, validateInterface(config.DetectLocal.BridgeInterface, newPath.Child("InterfaceName"))...)
 	}
@@ -205,22 +203,6 @@ func validateProxyModeWindows(mode kubeproxyconfig.ProxyMode, fldPath *field.Pat
 
 	errMsg := fmt.Sprintf("must be %s or blank (blank means the most-available proxy [currently 'kernelspace'])", strings.Join(validModes.List(), ","))
 	return field.ErrorList{field.Invalid(fldPath.Child("ProxyMode"), string(mode), errMsg)}
-}
-
-func validateDetectLocalMode(mode kubeproxyconfig.LocalMode, fldPath *field.Path) field.ErrorList {
-	validModes := []string{
-		string(kubeproxyconfig.LocalModeClusterCIDR),
-		string(kubeproxyconfig.LocalModeNodeCIDR),
-		string(kubeproxyconfig.LocalModeBridgeInterface),
-		string(kubeproxyconfig.LocalModeInterfaceNamePrefix),
-		"",
-	}
-
-	if sets.New(validModes...).Has(string(mode)) {
-		return nil
-	}
-
-	return field.ErrorList{field.NotSupported(fldPath, string(mode), validModes)}
 }
 
 func validateClientConnectionConfiguration(config componentbaseconfig.ClientConnectionConfiguration, fldPath *field.Path) field.ErrorList {

--- a/pkg/proxy/apis/config/validation/validation_test.go
+++ b/pkg/proxy/apis/config/validation/validation_test.go
@@ -424,28 +424,6 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			},
 			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("InterfaceName"), "", "must not be empty")},
 		},
-		"invalid DetectLocalMode": {
-			config: kubeproxyconfig.KubeProxyConfiguration{
-				BindAddress:        "10.10.12.11",
-				HealthzBindAddress: "0.0.0.0:12345",
-				MetricsBindAddress: "127.0.0.1:10249",
-				ClusterCIDR:        "192.168.59.0/24",
-				ConfigSyncPeriod:   metav1.Duration{Duration: 1 * time.Second},
-				IPTables: kubeproxyconfig.KubeProxyIPTablesConfiguration{
-					MasqueradeAll: true,
-					SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
-					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
-				},
-				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-					MaxPerCore:            pointer.Int32(1),
-					Min:                   pointer.Int32(1),
-					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
-					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
-				},
-				DetectLocalMode: "Guess",
-			},
-			expectedErrs: field.ErrorList{field.NotSupported(newPath.Child("DetectLocalMode"), "Guess", []string{"ClusterCIDR", "NodeCIDR", "BridgeInterface", "InterfaceNamePrefix", ""})},
-		},
 	}
 
 	for name, testCase := range testCases {

--- a/pkg/proxy/kubemark/hollow_proxy.go
+++ b/pkg/proxy/kubemark/hollow_proxy.go
@@ -22,7 +22,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -30,7 +29,6 @@ import (
 	utilsysctl "k8s.io/component-helpers/node/util/sysctl"
 	proxyapp "k8s.io/kubernetes/cmd/kube-proxy/app"
 	"k8s.io/kubernetes/pkg/proxy"
-	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
 	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
 	"k8s.io/kubernetes/pkg/proxy/iptables"
 	proxyutiliptables "k8s.io/kubernetes/pkg/proxy/util/iptables"
@@ -126,17 +124,14 @@ func NewHollowProxyOrDie(
 	}
 	return &HollowProxy{
 		ProxyServer: &proxyapp.ProxyServer{
-			Config: &proxyconfigapi.KubeProxyConfiguration{
-				Mode:             proxyconfigapi.ProxyMode("fake"),
-				ConfigSyncPeriod: metav1.Duration{Duration: 30 * time.Second},
-				OOMScoreAdj:      utilpointer.Int32Ptr(0),
-			},
-
-			Client:      client,
-			Proxier:     proxier,
-			Broadcaster: broadcaster,
-			Recorder:    recorder,
-			NodeRef:     nodeRef,
+			Client:           client,
+			Proxier:          proxier,
+			Broadcaster:      broadcaster,
+			Recorder:         recorder,
+			ProxyMode:        "fake",
+			NodeRef:          nodeRef,
+			OOMScoreAdj:      utilpointer.Int32Ptr(0),
+			ConfigSyncPeriod: 30 * time.Second,
 		},
 	}, nil
 }


### PR DESCRIPTION
Reverts kubernetes/kubernetes#117297

Fixes https://github.com/kubernetes/kubeadm/issues/2868

Fix failure in https://testgrid.k8s.io/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-latest and several other ci failures.

The kube-proxy 
```
2023-04-29T04:50:47.850779535Z stderr F panic: runtime error: invalid memory address or nil pointer dereference
2023-04-29T04:50:47.850808505Z stderr F [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1c659b0]
2023-04-29T04:50:47.850814857Z stderr F 
2023-04-29T04:50:47.850821558Z stderr F goroutine 132 [running]:
2023-04-29T04:50:47.850828198Z stderr F k8s.io/kubernetes/cmd/kube-proxy/app.(*ProxyServer).Run(0xc00084ecb0)
2023-04-29T04:50:47.850835219Z stderr F 	cmd/kube-proxy/app/server.go:767 +0x1130
2023-04-29T04:50:47.850841683Z stderr F k8s.io/kubernetes/cmd/kube-proxy/app.(*Options).runLoop.func1()
2023-04-29T04:50:47.850847097Z stderr F 	cmd/kube-proxy/app/server.go:326 +0x2b
2023-04-29T04:50:47.850852342Z stderr F created by k8s.io/kubernetes/cmd/kube-proxy/app.(*Options).runLoop
2023-04-29T04:50:47.850858125Z stderr F 	cmd/kube-proxy/app/server.go:325 +0x70
```

