### PR TITLE
kubelet: no double sort on podStatus.ContainerStatuses

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1958,15 +1958,9 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 		statuses[container.Name] = status
 	}
 
-	// Copy the slice before sorting it
-	containerStatusesCopy := make([]*kubecontainer.Status, len(podStatus.ContainerStatuses))
-	copy(containerStatusesCopy, podStatus.ContainerStatuses)
-
-	// Make the latest container status comes first.
-	sort.Sort(sort.Reverse(kubecontainer.SortContainerStatusesByCreationTime(containerStatusesCopy)))
 	// Set container statuses according to the statuses seen in pod status
 	containerSeen := map[string]int{}
-	for _, cStatus := range containerStatusesCopy {
+	for _, cStatus := range podStatus.ContainerStatuses {
 		cName := cStatus.Name
 		if _, ok := statuses[cName]; !ok {
 			// This would also ignore the infra container.


### PR DESCRIPTION
podStatus is populated by PLEG and stored in pod cache. During each relist cycle within PLEG, the podStatus is already populated with sorted container statuses. There is no need to sort is again.

/kind cleanup

```release-note
NONE
```

The sort is already done in:

https://github.com/kubernetes/kubernetes/blob/4115b2b1803fad5233921b168b46ba346734f228/pkg/kubelet/kuberuntime/kuberuntime_container.go#L582

The call path from pleg looks like below:

[pleg.Relist][1] -> [pleg.updateCache][2] ->  [kuberuntime_manager.GetPodStatus][3] -> [kuberuntime_manager.getPodContainerStatuses][4]

[1]: https://github.com/kubernetes/kubernetes/blob/4115b2b1803fad5233921b168b46ba346734f228/pkg/kubelet/pleg/generic.go#L283
[2]: https://github.com/kubernetes/kubernetes/blob/4115b2b1803fad5233921b168b46ba346734f228/pkg/kubelet/pleg/generic.go#L445 
[3]: https://github.com/kubernetes/kubernetes/blob/4115b2b1803fad5233921b168b46ba346734f228/pkg/kubelet/kuberuntime/kuberuntime_manager.go#L1429
[4]: https://github.com/kubernetes/kubernetes/blob/4115b2b1803fad5233921b168b46ba346734f228/pkg/kubelet/kuberuntime/kuberuntime_container.go#L582