### PR TITLE
Fail kubectl port forward if pod is not ready

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
@@ -393,7 +393,16 @@ func (o PortForwardOptions) RunPortForward() error {
 	}
 
 	if pod.Status.Phase != corev1.PodRunning {
-		return fmt.Errorf("unable to forward port because pod is not running. Current status=%v", pod.Status.Phase)
+		return fmt.Errorf("unable to forward port because pod phase is not running. Current phase=%v", pod.Status.Phase)
+	}
+
+	readyCondition, err := polymorphichelpers.GetPodCondition(pod, corev1.PodReady)
+	if err != nil {
+		return fmt.Errorf("unable to fetch Ready condition for pod %s: %w", pod.Name, err)
+	}
+
+	if readyCondition.Status == corev1.ConditionFalse {
+		return fmt.Errorf("unable to forward port because chosen pod '%s' Ready condition is False.", pod.Name)
 	}
 
 	signals := make(chan os.Signal, 1)

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/helpers.go
@@ -18,6 +18,7 @@ package polymorphichelpers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -78,6 +79,22 @@ func GetFirstPod(client coreclient.PodsGetter, namespace string, selector string
 		return nil, 0, fmt.Errorf("%#v is not a pod event", event)
 	}
 	return pod, 1, nil
+}
+
+// GetPodCondition returns the condition for the passed in pod and condition type.
+// It returns an error if the condition is not found.
+func GetPodCondition(pod *corev1.Pod, condition corev1.PodConditionType) (*corev1.PodCondition, error) {
+	if pod == nil {
+		return nil, errors.New("pod cannot be nil")
+	}
+
+	for _, c := range pod.Status.Conditions {
+		if c.Type == condition {
+			return &c, nil
+		}
+	}
+
+	return nil, fmt.Errorf("condition '%s' not found", condition)
 }
 
 // SelectorsForObject returns the pod label selector for a given object


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig cli

#### What this PR does / why we need it:

kubectl port-forward was only checking the pod phase to see if a pod was Running.

https://github.com/kubernetes/kubernetes/blob/4115b2b1803fad5233921b168b46ba346734f228/staging/src/k8s.io/api/core/v1/types.go#L2738-L2740

This would lead to a pod being selected that fails and restart loops forever leaving the command in a broken connection without the user really knowing.

This PR changes the behavior to fail if `pod.status.conditions[Ready]` is not `"True"`.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubectl/issues/1416

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl port-forward will now fail to start if the chosen pod is not ready
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
