### PR TITLE
feat: rename PodHasNetwork to PodReadyToStartContainers

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -630,9 +630,9 @@ const (
 	// owner: @ddebroy
 	// alpha: v1.25
 	//
-	// Enables reporting of PodHasNetwork condition in pod status after pod
+	// Enables reporting of PodReadyToStartContainersCondition condition in pod status after pod
 	// sandbox creation and network configuration completes successfully
-	PodHasNetworkCondition featuregate.Feature = "PodHasNetworkCondition"
+	PodReadyToStartContainersCondition featuregate.Feature = "PodReadyToStartContainersCondition"
 
 	// owner: @Huang-Wei
 	// kep: https://kep.k8s.io/3521
@@ -1043,7 +1043,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	PodDisruptionConditions: {Default: true, PreRelease: featuregate.Beta},
 
-	PodHasNetworkCondition: {Default: false, PreRelease: featuregate.Alpha},
+	PodReadyToStartContainersCondition: {Default: false, PreRelease: featuregate.Alpha},
 
 	PodSchedulingReadiness: {Default: true, PreRelease: featuregate.Beta},
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1605,8 +1605,8 @@ func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.Po
 	}
 
 	// set all Kubelet-owned conditions
-	if utilfeature.DefaultFeatureGate.Enabled(features.PodHasNetworkCondition) {
-		s.Conditions = append(s.Conditions, status.GeneratePodHasNetworkCondition(pod, podStatus))
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodReadyToStartContainersCondition) {
+		s.Conditions = append(s.Conditions, status.GeneratePodReadyToStartContainersCondition(pod, podStatus))
 	}
 	s.Conditions = append(s.Conditions, status.GeneratePodInitializedCondition(&pod.Spec, s.InitContainerStatuses, s.Phase))
 	s.Conditions = append(s.Conditions, status.GeneratePodReadyCondition(&pod.Spec, s.Conditions, s.ContainerStatuses, s.Phase))

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -2819,16 +2819,16 @@ func Test_generateAPIPodStatus(t *testing.T) {
 	normalized_now := now.Rfc3339Copy()
 
 	tests := []struct {
-		name                           string
-		pod                            *v1.Pod
-		currentStatus                  *kubecontainer.PodStatus
-		unreadyContainer               []string
-		previousStatus                 v1.PodStatus
-		isPodTerminal                  bool
-		enablePodDisruptionConditions  bool
-		expected                       v1.PodStatus
-		expectedPodDisruptionCondition v1.PodCondition
-		expectedPodHasNetworkCondition v1.PodCondition
+		name                                       string
+		pod                                        *v1.Pod
+		currentStatus                              *kubecontainer.PodStatus
+		unreadyContainer                           []string
+		previousStatus                             v1.PodStatus
+		isPodTerminal                              bool
+		enablePodDisruptionConditions              bool
+		expected                                   v1.PodStatus
+		expectedPodDisruptionCondition             v1.PodCondition
+		expectedPodReadyToStartContainersCondition v1.PodCondition
 	}{
 		{
 			name: "pod disruption condition is copied over and the phase is set to failed when deleted; PodDisruptionConditions enabled",
@@ -2881,8 +2881,8 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				Status:             v1.ConditionTrue,
 				LastTransitionTime: normalized_now,
 			},
-			expectedPodHasNetworkCondition: v1.PodCondition{
-				Type:   kubetypes.PodHasNetwork,
+			expectedPodReadyToStartContainersCondition: v1.PodCondition{
+				Type:   kubetypes.PodReadyToStartContainers,
 				Status: v1.ConditionTrue,
 			},
 		},
@@ -2920,8 +2920,8 @@ func Test_generateAPIPodStatus(t *testing.T) {
 					ready(waitingWithLastTerminationUnknown("containerB", 0)),
 				},
 			},
-			expectedPodHasNetworkCondition: v1.PodCondition{
-				Type:   kubetypes.PodHasNetwork,
+			expectedPodReadyToStartContainersCondition: v1.PodCondition{
+				Type:   kubetypes.PodReadyToStartContainers,
 				Status: v1.ConditionTrue,
 			},
 		},
@@ -2958,8 +2958,8 @@ func Test_generateAPIPodStatus(t *testing.T) {
 					ready(waitingWithLastTerminationUnknown("containerB", 1)),
 				},
 			},
-			expectedPodHasNetworkCondition: v1.PodCondition{
-				Type:   kubetypes.PodHasNetwork,
+			expectedPodReadyToStartContainersCondition: v1.PodCondition{
+				Type:   kubetypes.PodReadyToStartContainers,
 				Status: v1.ConditionTrue,
 			},
 		},
@@ -2997,8 +2997,8 @@ func Test_generateAPIPodStatus(t *testing.T) {
 					ready(waitingWithLastTerminationUnknown("containerB", 1)),
 				},
 			},
-			expectedPodHasNetworkCondition: v1.PodCondition{
-				Type:   kubetypes.PodHasNetwork,
+			expectedPodReadyToStartContainersCondition: v1.PodCondition{
+				Type:   kubetypes.PodReadyToStartContainers,
 				Status: v1.ConditionFalse,
 			},
 		},
@@ -3042,8 +3042,8 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				Reason:  "Test",
 				Message: "test",
 			},
-			expectedPodHasNetworkCondition: v1.PodCondition{
-				Type:   kubetypes.PodHasNetwork,
+			expectedPodReadyToStartContainersCondition: v1.PodCondition{
+				Type:   kubetypes.PodReadyToStartContainers,
 				Status: v1.ConditionFalse,
 			},
 		},
@@ -3094,8 +3094,8 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				Reason:  "Test",
 				Message: "test",
 			},
-			expectedPodHasNetworkCondition: v1.PodCondition{
-				Type:   kubetypes.PodHasNetwork,
+			expectedPodReadyToStartContainersCondition: v1.PodCondition{
+				Type:   kubetypes.PodReadyToStartContainers,
 				Status: v1.ConditionFalse,
 			},
 		},
@@ -3133,8 +3133,8 @@ func Test_generateAPIPodStatus(t *testing.T) {
 					ready(waitingStateWithReason("containerB", "ContainerCreating")),
 				},
 			},
-			expectedPodHasNetworkCondition: v1.PodCondition{
-				Type:   kubetypes.PodHasNetwork,
+			expectedPodReadyToStartContainersCondition: v1.PodCondition{
+				Type:   kubetypes.PodReadyToStartContainers,
 				Status: v1.ConditionTrue,
 			},
 		},
@@ -3187,8 +3187,8 @@ func Test_generateAPIPodStatus(t *testing.T) {
 					ready(withID(runningStateWithStartedAt("containerB", time.Unix(1, 0).UTC()), "://foo")),
 				},
 			},
-			expectedPodHasNetworkCondition: v1.PodCondition{
-				Type:   kubetypes.PodHasNetwork,
+			expectedPodReadyToStartContainersCondition: v1.PodCondition{
+				Type:   kubetypes.PodReadyToStartContainers,
 				Status: v1.ConditionTrue,
 			},
 		},
@@ -3245,17 +3245,17 @@ func Test_generateAPIPodStatus(t *testing.T) {
 					ready(withID(runningStateWithStartedAt("containerB", time.Unix(2, 0).UTC()), "://c2")),
 				},
 			},
-			expectedPodHasNetworkCondition: v1.PodCondition{
-				Type:   kubetypes.PodHasNetwork,
+			expectedPodReadyToStartContainersCondition: v1.PodCondition{
+				Type:   kubetypes.PodReadyToStartContainers,
 				Status: v1.ConditionTrue,
 			},
 		},
 	}
 	for _, test := range tests {
-		for _, enablePodHasNetworkCondition := range []bool{false, true} {
+		for _, enablePodReadyToStartContainersCondition := range []bool{false, true} {
 			t.Run(test.name, func(t *testing.T) {
 				defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodDisruptionConditions, test.enablePodDisruptionConditions)()
-				defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodHasNetworkCondition, enablePodHasNetworkCondition)()
+				defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodReadyToStartContainersCondition, enablePodReadyToStartContainersCondition)()
 				testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 				defer testKubelet.Cleanup()
 				kl := testKubelet.kubelet
@@ -3265,8 +3265,8 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				}
 				expected := test.expected.DeepCopy()
 				actual := kl.generateAPIPodStatus(test.pod, test.currentStatus, test.isPodTerminal)
-				if enablePodHasNetworkCondition {
-					expected.Conditions = append([]v1.PodCondition{test.expectedPodHasNetworkCondition}, expected.Conditions...)
+				if enablePodReadyToStartContainersCondition {
+					expected.Conditions = append([]v1.PodCondition{test.expectedPodReadyToStartContainersCondition}, expected.Conditions...)
 				}
 				if test.enablePodDisruptionConditions {
 					expected.Conditions = append([]v1.PodCondition{test.expectedPodDisruptionCondition}, expected.Conditions...)

--- a/pkg/kubelet/status/generate.go
+++ b/pkg/kubelet/status/generate.go
@@ -198,7 +198,7 @@ func GeneratePodInitializedCondition(spec *v1.PodSpec, containerStatuses []v1.Co
 	}
 }
 
-func GeneratePodHasNetworkCondition(pod *v1.Pod, podStatus *kubecontainer.PodStatus) v1.PodCondition {
+func GeneratePodReadyToStartContainersCondition(pod *v1.Pod, podStatus *kubecontainer.PodStatus) v1.PodCondition {
 	newSandboxNeeded, _, _ := runtimeutil.PodSandboxChanged(pod, podStatus)
 	// if a new sandbox does not need to be created for a pod, it indicates that
 	// a sandbox for the pod with networking configured already exists.
@@ -206,12 +206,12 @@ func GeneratePodHasNetworkCondition(pod *v1.Pod, podStatus *kubecontainer.PodSta
 	// fresh sandbox and configure networking for the sandbox.
 	if !newSandboxNeeded {
 		return v1.PodCondition{
-			Type:   kubetypes.PodHasNetwork,
+			Type:   kubetypes.PodReadyToStartContainers,
 			Status: v1.ConditionTrue,
 		}
 	}
 	return v1.PodCondition{
-		Type:   kubetypes.PodHasNetwork,
+		Type:   kubetypes.PodReadyToStartContainers,
 		Status: v1.ConditionFalse,
 	}
 }

--- a/pkg/kubelet/status/generate_test.go
+++ b/pkg/kubelet/status/generate_test.go
@@ -422,7 +422,7 @@ func TestGeneratePodInitializedCondition(t *testing.T) {
 	}
 }
 
-func TestGeneratePodHasNetworkCondition(t *testing.T) {
+func TestGeneratePodReadyToStartContainersCondition(t *testing.T) {
 	for desc, test := range map[string]struct {
 		pod      *v1.Pod
 		status   *kubecontainer.PodStatus
@@ -485,8 +485,8 @@ func TestGeneratePodHasNetworkCondition(t *testing.T) {
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			test.expected.Type = kubetypes.PodHasNetwork
-			condition := GeneratePodHasNetworkCondition(test.pod, test.status)
+			test.expected.Type = kubetypes.PodReadyToStartContainers
+			condition := GeneratePodReadyToStartContainersCondition(test.pod, test.status)
 			require.Equal(t, test.expected.Type, condition.Type)
 			require.Equal(t, test.expected.Status, condition.Status)
 		})

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -589,8 +589,8 @@ func (m *manager) updateStatusInternal(pod *v1.Pod, status v1.PodStatus, forceUp
 	// Set InitializedCondition.LastTransitionTime.
 	updateLastTransitionTime(&status, &oldStatus, v1.PodInitialized)
 
-	// Set PodHasNetwork.LastTransitionTime.
-	updateLastTransitionTime(&status, &oldStatus, kubetypes.PodHasNetwork)
+	// Set PodReadyToStartContainersCondition.LastTransitionTime.
+	updateLastTransitionTime(&status, &oldStatus, kubetypes.PodReadyToStartContainers)
 
 	// Set PodScheduledCondition.LastTransitionTime.
 	updateLastTransitionTime(&status, &oldStatus, v1.PodScheduled)

--- a/pkg/kubelet/types/constants.go
+++ b/pkg/kubelet/types/constants.go
@@ -43,8 +43,7 @@ const (
 // entries here should be moved to staging/src/k8s.io.api/core/v1/types.go
 // once the feature managing the condition graduates to Beta.
 const (
-	// PodHasNetwork indicates networking has been configured successfully for the
-	// pod and IP address(es) assigned. Images for containers specified in the pod
-	// spec can be pulled and containers launched after this condition is true.
-	PodHasNetwork = "PodHasNetwork"
+	// PodReadyToStartContainers pod sandbox is successfully configured and
+	// the pod is ready to launch containers.
+	PodReadyToStartContainers = "PodReadyToStartContainers"
 )

--- a/pkg/kubelet/types/pod_status.go
+++ b/pkg/kubelet/types/pod_status.go
@@ -37,8 +37,8 @@ func PodConditionByKubelet(conditionType v1.PodConditionType) bool {
 			return true
 		}
 	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.PodHasNetworkCondition) {
-		if conditionType == PodHasNetwork {
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodReadyToStartContainersCondition) {
+		if conditionType == PodReadyToStartContainers {
 			return true
 		}
 	}

--- a/pkg/kubelet/types/pod_status_test.go
+++ b/pkg/kubelet/types/pod_status_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestPodConditionByKubelet(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodHasNetworkCondition, true)()
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodReadyToStartContainersCondition, true)()
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodDisruptionConditions, true)()
 
 	trueCases := []v1.PodConditionType{
@@ -34,7 +34,7 @@ func TestPodConditionByKubelet(t *testing.T) {
 		v1.PodReady,
 		v1.PodInitialized,
 		v1.ContainersReady,
-		PodHasNetwork,
+		PodReadyToStartContainers,
 	}
 
 	for _, tc := range trueCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In KEP-3085, there was a rename of PodHasNetwork to PodReadyToStartContainers.  

This PR renames fields and code.   
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Rename PodHasNetwork to PodReadyToStartContainers
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3085-pod-conditions-for-starting-completition-of-sandbox-creation
```
