### PR TITLE
test/e2e_node: move getSampleDevicePluginPod to a test-only source file

### DIFF
--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -828,3 +828,26 @@ func matchContainerDevices(ident string, contDevs []*kubeletpodresourcesv1.Conta
 	}
 	return nil
 }
+
+// getSampleDevicePluginPod returns the Sample Device Plugin pod to be used e2e tests.
+func getSampleDevicePluginPod(pluginSockDir string) *v1.Pod {
+	data, err := e2etestfiles.Read(SampleDevicePluginDSYAML)
+	if err != nil {
+		framework.Fail(err.Error())
+	}
+
+	ds := readDaemonSetV1OrDie(data)
+	dp := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: SampleDevicePluginName,
+		},
+		Spec: ds.Spec.Template.Spec,
+	}
+	for i := range dp.Spec.Containers[0].Env {
+		if dp.Spec.Containers[0].Env[i].Name == SampleDeviceEnvVarNamePluginSockDir {
+			dp.Spec.Containers[0].Env[i].Value = pluginSockDir
+		}
+	}
+
+	return dp
+}

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -24,16 +24,13 @@ import (
 	"sync"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	commontest "k8s.io/kubernetes/test/e2e/common"
-	"k8s.io/kubernetes/test/e2e/framework"
 	e2egpu "k8s.io/kubernetes/test/e2e/framework/gpu"
 	e2emanifest "k8s.io/kubernetes/test/e2e/framework/manifest"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -242,29 +239,6 @@ func getContainerImageFromE2ETestDaemonset(dsYamlPath string) (string, error) {
 		return "", fmt.Errorf("failed to parse the container image: cannot extract the container from YAML")
 	}
 	return ds.Spec.Template.Spec.Containers[0].Image, nil
-}
-
-// getSampleDevicePluginPod returns the Sample Device Plugin pod to be used e2e tests.
-func getSampleDevicePluginPod(pluginSockDir string) *v1.Pod {
-	data, err := e2etestfiles.Read(SampleDevicePluginDSYAML)
-	if err != nil {
-		framework.Fail(err.Error())
-	}
-
-	ds := readDaemonSetV1OrDie(data)
-	dp := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: SampleDevicePluginName,
-		},
-		Spec: ds.Spec.Template.Spec,
-	}
-	for i := range dp.Spec.Containers[0].Env {
-		if dp.Spec.Containers[0].Env[i].Name == SampleDeviceEnvVarNamePluginSockDir {
-			dp.Spec.Containers[0].Env[i].Value = pluginSockDir
-		}
-	}
-
-	return dp
 }
 
 // getSRIOVDevicePluginImage returns the image of SRIOV device plugin.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`image_list.go` is one of the files included in the non-test variant Go build list, but its `getSampleDevicePluginPod` function references `readDaemonSetV1OrDie` function defined in `device_plugin_test.go` which is included in the test variant Go build list only. (The file name is *_test.go).

As a result, "go build" fails with the undefined reference error.

In practice, that may not be an issue since k8s project contributors aren't meant to run go build on this package. However, tools that depend on `go build` to operate - e.g., gopls or govulncheck ./... - will report this as an error.

Fix this error and make test/e2e package pass `go build` by moving this file to also test-only source code (device_plugin_test.go)

#### Does this PR introduce a user-facing change?

NONE
