### PR TITLE
Set Pod phase to Failed if init container gets OOMKilled but exitCode…

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1395,7 +1395,7 @@ func getPhase(pod *v1.Pod, info []v1.ContainerStatus, podIsTerminal bool) v1.Pod
 		case containerStatus.State.Running != nil:
 			pendingInitialization++
 		case containerStatus.State.Terminated != nil:
-			if containerStatus.State.Terminated.ExitCode != 0 {
+			if containerStatus.State.Terminated.ExitCode != 0 || containerStatus.State.Terminated.Reason == "OOMKilled" {
 				failedInitialization++
 			}
 		case containerStatus.State.Waiting != nil:

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -2578,6 +2578,26 @@ func TestPodPhaseWithRestartNeverInitContainers(t *testing.T) {
 			v1.PodRunning,
 			"init container succeeded",
 		},
+		{
+			&v1.Pod{
+				Spec: desiredState,
+				Status: v1.PodStatus{
+					InitContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "containerX",
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									ExitCode: 0,
+									Reason:   "OOMKilled",
+								},
+							},
+						},
+					},
+				},
+			},
+			v1.PodFailed,
+			"init container terminated with OOMkilled and exit-code zero",
+		},
 	}
 	for _, test := range tests {
 		statusInfo := append(test.pod.Status.InitContainerStatuses[:], test.pod.Status.ContainerStatuses[:]...)


### PR DESCRIPTION
… is 0

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When an init container gets OOM killed but the init process exits with 0, the state of the init container is correctly set as `Terminated`, but the pod status is incorrectly set as `Pending`. What should happen is that the pod status is set to `Failed`, so that pod GC can do its work to cleanup failed pods.

See also a previous bug fix (https://github.com/kubernetes/kubernetes/pull/104650) that checks OOMKilled status of init containers to decide whether the main containers should be started.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubernetes/kubernetes/issues/116676

Before this PR, deploying the image in https://github.com/kubernetes/kubernetes/issues/104454 results in pod stuck in Pending:

```
# k describe pod oomkill-init
Name:         oomkill-init
...
Status:       Pending
...
Init Containers:
  stress-init:
...
    State:          Terminated
      Reason:       OOMKilled
      Exit Code:    0
      Started:      Thu, 04 May 2023 20:32:30 +0000
      Finished:     Thu, 04 May 2023 20:32:31 +0000
```
after this PR, the pod is marked as Failed:
```
# k describe pod oomkill-init
Name:         oomkill-init
...
Status:       Failed
...
Init Containers:
  stress-init:
 ...
    State:          Terminated
      Reason:       OOMKilled
      Exit Code:    0
      Started:      Thu, 04 May 2023 20:35:01 +0000
      Finished:     Thu, 04 May 2023 20:35:02 +0000
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
