### PR TITLE
Add support for CRI `ErrSignatureValidationFailed`

### DIFF
--- a/pkg/kubelet/images/types.go
+++ b/pkg/kubelet/images/types.go
@@ -37,9 +37,6 @@ var (
 	// ErrImageNeverPull - Required Image is absent on host and PullPolicy is NeverPullImage
 	ErrImageNeverPull = errors.New("ErrImageNeverPull")
 
-	// ErrRegistryUnavailable - Get http error when pulling image from registry
-	ErrRegistryUnavailable = errors.New("RegistryUnavailable")
-
 	// ErrInvalidImageName - Unable to parse the image name.
 	ErrInvalidImageName = errors.New("InvalidImageName")
 )

--- a/staging/src/k8s.io/cri-api/pkg/errors/errors.go
+++ b/staging/src/k8s.io/cri-api/pkg/errors/errors.go
@@ -17,8 +17,18 @@ limitations under the License.
 package errors
 
 import (
+	"errors"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+)
+
+var (
+	// ErrRegistryUnavailable - Get http error on the PullImage RPC call.
+	ErrRegistryUnavailable = errors.New("RegistryUnavailable")
+
+	// ErrSignatureValidationFailed - Unable to validate the image signature on the PullImage RPC call.
+	ErrSignatureValidationFailed = errors.New("SignatureValidationFailed")
 )
 
 // IsNotFound returns a boolean indicating whether the error


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
This allows container runtimes to propagate an image signature verification error through the CRI and display that to the end user during image pull. There is no other behavioral difference compared to a regular image pull failure.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Follow-up on https://github.com/kubernetes/kubernetes/pull/117612

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow container runtimes to use `ErrSignatureValidationFailed` as possible image pull failure.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
