### PR TITLE
Use early return pattern to avoid nested conditions

### DIFF
--- a/pkg/kubelet/config/file_linux.go
+++ b/pkg/kubelet/config/file_linux.go
@@ -140,14 +140,14 @@ func (s *sourceFile) consumeWatchEvent(e *watchEvent) error {
 			pod, podExist, err := s.store.GetByKey(objKey)
 			if err != nil {
 				return err
-			} else if !podExist {
-				return fmt.Errorf("the pod with key %s doesn't exist in cache", objKey)
-			} else {
-				if err = s.store.Delete(pod); err != nil {
-					return fmt.Errorf("failed to remove deleted pod from cache: %v", err)
-				}
-				delete(s.fileKeyMapping, e.fileName)
 			}
+			if !podExist {
+				return fmt.Errorf("the pod with key %s doesn't exist in cache", objKey)
+			}
+			if err = s.store.Delete(pod); err != nil {
+				return fmt.Errorf("failed to remove deleted pod from cache: %v", err)
+			}
+			delete(s.fileKeyMapping, e.fileName)
 		}
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

> Return early is the way of writing functions or methods so that the expected positive result is returned at the end of the function and the rest of the code terminates the execution (by returning or throwing an exception) when conditions are not met.

`if` block ends with a `return` statement, so drop this `else` and outdent its block.

**AS-IS**

```go
case podDelete:
    if objKey, keyExist := s.fileKeyMapping[e.fileName]; keyExist {
        pod, podExist, err := s.store.GetByKey(objKey)
        if err != nil {
            return err
        } else if !podExist {
            return fmt.Errorf("the pod with key %s doesn't exist in cache", objKey)
        } else {
            if err = s.store.Delete(pod); err != nil {
                return fmt.Errorf("failed to remove deleted pod from cache: %v", err)
            }
            delete(s.fileKeyMapping, e.fileName)
        }
    }
}
```

**TO-BE**

```go
case podDelete:
    if objKey, keyExist := s.fileKeyMapping[e.fileName]; keyExist {
        pod, podExist, err := s.store.GetByKey(objKey)
        if err != nil {
            return err
        }
        if !podExist {
            return fmt.Errorf("the pod with key %s doesn't exist in cache", objKey)
        }
        if err = s.store.Delete(pod); err != nil {
            return fmt.Errorf("failed to remove deleted pod from cache: %v", err)
        }
        delete(s.fileKeyMapping, e.fileName)
    }
}
```

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```