### PR TITLE
[WIP] Allow disabling random offset in preemption

### DIFF
--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -898,6 +898,7 @@ profiles:
 								Args: &kubeschedulerconfig.DefaultPreemptionArgs{
 									MinCandidateNodesPercentage: 10,
 									MinCandidateNodesAbsolute:   100,
+									DisableRandomOffset:         false,
 								},
 							},
 							{
@@ -1020,6 +1021,7 @@ profiles:
 								Args: &kubeschedulerconfig.DefaultPreemptionArgs{
 									MinCandidateNodesPercentage: 10,
 									MinCandidateNodesAbsolute:   100,
+									DisableRandomOffset:         false,
 								},
 							},
 							{
@@ -1135,6 +1137,7 @@ profiles:
 								Args: &kubeschedulerconfig.DefaultPreemptionArgs{
 									MinCandidateNodesPercentage: 10,
 									MinCandidateNodesAbsolute:   100,
+									DisableRandomOffset:         false,
 								},
 							},
 							{
@@ -1243,6 +1246,7 @@ profiles:
 								Args: &kubeschedulerconfig.DefaultPreemptionArgs{
 									MinCandidateNodesPercentage: 10,
 									MinCandidateNodesAbsolute:   100,
+									DisableRandomOffset:         false,
 								},
 							},
 							{
@@ -1357,6 +1361,7 @@ profiles:
 								Args: &kubeschedulerconfig.DefaultPreemptionArgs{
 									MinCandidateNodesPercentage: 10,
 									MinCandidateNodesAbsolute:   100,
+									DisableRandomOffset:         false,
 								},
 							},
 							{
@@ -1464,6 +1469,7 @@ profiles:
 								Args: &kubeschedulerconfig.DefaultPreemptionArgs{
 									MinCandidateNodesPercentage: 10,
 									MinCandidateNodesAbsolute:   100,
+									DisableRandomOffset:         false,
 								},
 							},
 							{
@@ -1599,6 +1605,7 @@ profiles:
 								Args: &kubeschedulerconfig.DefaultPreemptionArgs{
 									MinCandidateNodesPercentage: 10,
 									MinCandidateNodesAbsolute:   100,
+									DisableRandomOffset:         false,
 								},
 							},
 							{

--- a/pkg/scheduler/apis/config/scheme/scheme_test.go
+++ b/pkg/scheduler/apis/config/scheme/scheme_test.go
@@ -55,6 +55,7 @@ profiles:
     args:
       minCandidateNodesPercentage: 50
       minCandidateNodesAbsolute: 500
+      disableRandomOffset: true
   - name: InterPodAffinity
     args:
       hardPodAffinityWeight: 5
@@ -101,7 +102,7 @@ profiles:
 					PluginConfig: []config.PluginConfig{
 						{
 							Name: "DefaultPreemption",
-							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 50, MinCandidateNodesAbsolute: 500},
+							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 50, MinCandidateNodesAbsolute: 500, DisableRandomOffset: true},
 						},
 						{
 							Name: "InterPodAffinity",
@@ -207,7 +208,7 @@ profiles:
 					PluginConfig: []config.PluginConfig{
 						{
 							Name: "DefaultPreemption",
-							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 50, MinCandidateNodesAbsolute: 100},
+							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 50, MinCandidateNodesAbsolute: 100, DisableRandomOffset: false},
 						},
 						{
 							Name: "InterPodAffinity",
@@ -354,7 +355,7 @@ profiles:
 					PluginConfig: []config.PluginConfig{
 						{
 							Name: "DefaultPreemption",
-							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 10, MinCandidateNodesAbsolute: 100},
+							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 10, MinCandidateNodesAbsolute: 100, DisableRandomOffset: false},
 						},
 						{
 							Name: "InterPodAffinity",
@@ -413,6 +414,7 @@ profiles:
     args:
       minCandidateNodesPercentage: 50
       minCandidateNodesAbsolute: 500
+      disableRandomOffset: true
   - name: InterPodAffinity
     args:
       hardPodAffinityWeight: 5
@@ -458,7 +460,7 @@ profiles:
 					PluginConfig: []config.PluginConfig{
 						{
 							Name: "DefaultPreemption",
-							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 50, MinCandidateNodesAbsolute: 500},
+							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 50, MinCandidateNodesAbsolute: 500, DisableRandomOffset: true},
 						},
 						{
 							Name: "InterPodAffinity",
@@ -564,7 +566,7 @@ profiles:
 					PluginConfig: []config.PluginConfig{
 						{
 							Name: "DefaultPreemption",
-							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 50, MinCandidateNodesAbsolute: 100},
+							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 50, MinCandidateNodesAbsolute: 100, DisableRandomOffset: false},
 						},
 						{
 							Name: "InterPodAffinity",
@@ -711,7 +713,7 @@ profiles:
 					PluginConfig: []config.PluginConfig{
 						{
 							Name: "DefaultPreemption",
-							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 10, MinCandidateNodesAbsolute: 100},
+							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 10, MinCandidateNodesAbsolute: 100, DisableRandomOffset: false},
 						},
 						{
 							Name: "InterPodAffinity",
@@ -770,6 +772,7 @@ profiles:
     args:
       minCandidateNodesPercentage: 50
       minCandidateNodesAbsolute: 500
+      disableRandomOffset: true
   - name: InterPodAffinity
     args:
       hardPodAffinityWeight: 5
@@ -816,7 +819,7 @@ profiles:
 					PluginConfig: []config.PluginConfig{
 						{
 							Name: "DefaultPreemption",
-							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 50, MinCandidateNodesAbsolute: 500},
+							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 50, MinCandidateNodesAbsolute: 500, DisableRandomOffset: true},
 						},
 						{
 							Name: "InterPodAffinity",
@@ -940,7 +943,7 @@ profiles:
 					PluginConfig: []config.PluginConfig{
 						{
 							Name: "DefaultPreemption",
-							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 50, MinCandidateNodesAbsolute: 100},
+							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 50, MinCandidateNodesAbsolute: 100, DisableRandomOffset: false},
 						},
 						{
 							Name: "InterPodAffinity",
@@ -1087,7 +1090,7 @@ profiles:
 					PluginConfig: []config.PluginConfig{
 						{
 							Name: "DefaultPreemption",
-							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 10, MinCandidateNodesAbsolute: 100},
+							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 10, MinCandidateNodesAbsolute: 100, DisableRandomOffset: false},
 						},
 						{
 							Name: "InterPodAffinity",
@@ -1159,7 +1162,7 @@ profiles:
 						},
 						{
 							Name: "DefaultPreemption",
-							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 10, MinCandidateNodesAbsolute: 100},
+							Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 10, MinCandidateNodesAbsolute: 100, DisableRandomOffset: false},
 						},
 						{
 							Name: "NodeAffinity",

--- a/pkg/scheduler/apis/config/testing/defaults/defaults.go
+++ b/pkg/scheduler/apis/config/testing/defaults/defaults.go
@@ -122,6 +122,7 @@ var PluginConfigsV1beta2 = []config.PluginConfig{
 		Args: &config.DefaultPreemptionArgs{
 			MinCandidateNodesPercentage: 10,
 			MinCandidateNodesAbsolute:   100,
+			DisableRandomOffset:         false,
 		},
 	},
 	{
@@ -305,6 +306,7 @@ var PluginConfigsV1beta3 = []config.PluginConfig{
 		Args: &config.DefaultPreemptionArgs{
 			MinCandidateNodesPercentage: 10,
 			MinCandidateNodesAbsolute:   100,
+			DisableRandomOffset:         false,
 		},
 	},
 	{
@@ -488,6 +490,7 @@ var PluginConfigsV1 = []config.PluginConfig{
 		Args: &config.DefaultPreemptionArgs{
 			MinCandidateNodesPercentage: 10,
 			MinCandidateNodesAbsolute:   100,
+			DisableRandomOffset:         false,
 		},
 	},
 	{

--- a/pkg/scheduler/apis/config/types_pluginargs.go
+++ b/pkg/scheduler/apis/config/types_pluginargs.go
@@ -41,6 +41,8 @@ type DefaultPreemptionArgs struct {
 	// that play a role in the number of candidates shortlisted. Must be at least
 	// 0 nodes. Defaults to 100 nodes if unspecified.
 	MinCandidateNodesAbsolute int32
+	// Disable random offset ennumeration. Evaluate all potential nodes.
+	DisableRandomOffset bool
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -250,6 +250,9 @@ func autoConvert_v1_DefaultPreemptionArgs_To_config_DefaultPreemptionArgs(in *v1
 	if err := metav1.Convert_Pointer_int32_To_int32(&in.MinCandidateNodesAbsolute, &out.MinCandidateNodesAbsolute, s); err != nil {
 		return err
 	}
+	if err := metav1.Convert_Pointer_bool_To_bool(&in.DisableRandomOffset, &out.DisableRandomOffset, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -263,6 +266,9 @@ func autoConvert_config_DefaultPreemptionArgs_To_v1_DefaultPreemptionArgs(in *co
 		return err
 	}
 	if err := metav1.Convert_int32_To_Pointer_int32(&in.MinCandidateNodesAbsolute, &out.MinCandidateNodesAbsolute, s); err != nil {
+		return err
+	}
+	if err := metav1.Convert_bool_To_Pointer_bool(&in.DisableRandomOffset, &out.DisableRandomOffset, s); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta2/zz_generated.conversion.go
@@ -250,6 +250,9 @@ func autoConvert_v1beta2_DefaultPreemptionArgs_To_config_DefaultPreemptionArgs(i
 	if err := v1.Convert_Pointer_int32_To_int32(&in.MinCandidateNodesAbsolute, &out.MinCandidateNodesAbsolute, s); err != nil {
 		return err
 	}
+	if err := v1.Convert_Pointer_bool_To_bool(&in.DisableRandomOffset, &out.DisableRandomOffset, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -263,6 +266,9 @@ func autoConvert_config_DefaultPreemptionArgs_To_v1beta2_DefaultPreemptionArgs(i
 		return err
 	}
 	if err := v1.Convert_int32_To_Pointer_int32(&in.MinCandidateNodesAbsolute, &out.MinCandidateNodesAbsolute, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_bool_To_Pointer_bool(&in.DisableRandomOffset, &out.DisableRandomOffset, s); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
@@ -250,6 +250,9 @@ func autoConvert_v1beta3_DefaultPreemptionArgs_To_config_DefaultPreemptionArgs(i
 	if err := v1.Convert_Pointer_int32_To_int32(&in.MinCandidateNodesAbsolute, &out.MinCandidateNodesAbsolute, s); err != nil {
 		return err
 	}
+	if err := v1.Convert_Pointer_bool_To_bool(&in.DisableRandomOffset, &out.DisableRandomOffset, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -263,6 +266,9 @@ func autoConvert_config_DefaultPreemptionArgs_To_v1beta3_DefaultPreemptionArgs(i
 		return err
 	}
 	if err := v1.Convert_int32_To_Pointer_int32(&in.MinCandidateNodesAbsolute, &out.MinCandidateNodesAbsolute, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_bool_To_Pointer_bool(&in.DisableRandomOffset, &out.DisableRandomOffset, s); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/scheduler/apis/config/validation/validation_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_test.go
@@ -71,7 +71,7 @@ func TestValidateKubeSchedulerConfigurationV1beta2(t *testing.T) {
 				PluginConfig: []config.PluginConfig{
 					{
 						Name: "DefaultPreemption",
-						Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 10, MinCandidateNodesAbsolute: 100},
+						Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 10, MinCandidateNodesAbsolute: 100, DisableRandomOffset: false},
 					},
 				},
 			},
@@ -148,7 +148,7 @@ func TestValidateKubeSchedulerConfigurationV1beta2(t *testing.T) {
 	invalidNodePercentage.Profiles[0].PluginConfig = []config.PluginConfig{
 		{
 			Name: "DefaultPreemption",
-			Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 200, MinCandidateNodesAbsolute: 100},
+			Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 200, MinCandidateNodesAbsolute: 100, DisableRandomOffset: false},
 		},
 	}
 
@@ -469,7 +469,7 @@ func TestValidateKubeSchedulerConfigurationV1beta3(t *testing.T) {
 				PluginConfig: []config.PluginConfig{
 					{
 						Name: "DefaultPreemption",
-						Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 10, MinCandidateNodesAbsolute: 100},
+						Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 10, MinCandidateNodesAbsolute: 100, DisableRandomOffset: false},
 					},
 				},
 			},
@@ -546,7 +546,7 @@ func TestValidateKubeSchedulerConfigurationV1beta3(t *testing.T) {
 	invalidNodePercentage.Profiles[0].PluginConfig = []config.PluginConfig{
 		{
 			Name: "DefaultPreemption",
-			Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 200, MinCandidateNodesAbsolute: 100},
+			Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 200, MinCandidateNodesAbsolute: 100, DisableRandomOffset: false},
 		},
 	}
 
@@ -873,7 +873,7 @@ func TestValidateKubeSchedulerConfigurationV1(t *testing.T) {
 				PluginConfig: []config.PluginConfig{
 					{
 						Name: "DefaultPreemption",
-						Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 10, MinCandidateNodesAbsolute: 100},
+						Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 10, MinCandidateNodesAbsolute: 100, DisableRandomOffset: false},
 					},
 				},
 			},
@@ -951,7 +951,7 @@ func TestValidateKubeSchedulerConfigurationV1(t *testing.T) {
 	invalidNodePercentage.Profiles[0].PluginConfig = []config.PluginConfig{
 		{
 			Name: "DefaultPreemption",
-			Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 200, MinCandidateNodesAbsolute: 100},
+			Args: &config.DefaultPreemptionArgs{MinCandidateNodesPercentage: 200, MinCandidateNodesAbsolute: 100, DisableRandomOffset: false},
 		},
 	}
 

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -121,6 +121,9 @@ func (pl *DefaultPreemption) calculateNumCandidates(numNodes int32) int32 {
 // GetOffsetAndNumCandidates chooses a random offset and calculates the number
 // of candidates that should be shortlisted for dry running preemption.
 func (pl *DefaultPreemption) GetOffsetAndNumCandidates(numNodes int32) (int32, int32) {
+	if pl.args.DisableRandomOffset {
+		return 0, pl.calculateNumCandidates(numNodes)
+	}
 	return rand.Int31n(numNodes), pl.calculateNumCandidates(numNodes)
 }
 

--- a/staging/src/k8s.io/kube-scheduler/config/v1/types_pluginargs.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/types_pluginargs.go
@@ -41,6 +41,8 @@ type DefaultPreemptionArgs struct {
 	// that play a role in the number of candidates shortlisted. Must be at least
 	// 0 nodes. Defaults to 100 nodes if unspecified.
 	MinCandidateNodesAbsolute *int32 `json:"minCandidateNodesAbsolute,omitempty"`
+	// Disable random offset ennumeration. Evaluate all potential nodes.
+	DisableRandomOffset *bool `json:"disableRandomOffset,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
@@ -40,6 +40,11 @@ func (in *DefaultPreemptionArgs) DeepCopyInto(out *DefaultPreemptionArgs) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.DisableRandomOffset != nil {
+		in, out := &in.DisableRandomOffset, &out.DisableRandomOffset
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta2/types_pluginargs.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta2/types_pluginargs.go
@@ -41,6 +41,8 @@ type DefaultPreemptionArgs struct {
 	// that play a role in the number of candidates shortlisted. Must be at least
 	// 0 nodes. Defaults to 100 nodes if unspecified.
 	MinCandidateNodesAbsolute *int32 `json:"minCandidateNodesAbsolute,omitempty"`
+	// Disable random offset ennumeration. Evaluate all potential nodes.
+	DisableRandomOffset *bool `json:"disableRandomOffset,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta2/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta2/zz_generated.deepcopy.go
@@ -40,6 +40,11 @@ func (in *DefaultPreemptionArgs) DeepCopyInto(out *DefaultPreemptionArgs) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.DisableRandomOffset != nil {
+		in, out := &in.DisableRandomOffset, &out.DisableRandomOffset
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta3/types_pluginargs.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta3/types_pluginargs.go
@@ -41,6 +41,8 @@ type DefaultPreemptionArgs struct {
 	// that play a role in the number of candidates shortlisted. Must be at least
 	// 0 nodes. Defaults to 100 nodes if unspecified.
 	MinCandidateNodesAbsolute *int32 `json:"minCandidateNodesAbsolute,omitempty"`
+	// Disable random offset ennumeration. Evaluate all potential nodes.
+	DisableRandomOffset *bool `json:"disableRandomOffset,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta3/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta3/zz_generated.deepcopy.go
@@ -40,6 +40,11 @@ func (in *DefaultPreemptionArgs) DeepCopyInto(out *DefaultPreemptionArgs) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.DisableRandomOffset != nil {
+		in, out := &in.DisableRandomOffset, &out.DisableRandomOffset
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Pre-emption (cluster autoscaler + pause pods) in our use case needs to look at every node. `rand` function ignores good chunk of nodes every time, missing the pause pods that can be preempted. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #117707

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
