### PR TITLE
[WIP] kubelet: Add swap memory to the Kubelet summary stats API

### DIFF
--- a/pkg/kubelet/stats/helper.go
+++ b/pkg/kubelet/stats/helper.go
@@ -65,6 +65,7 @@ func cadvisorInfoToCPUandMemoryStats(info *cadvisorapiv2.ContainerInfo) (*statsa
 			RSSBytes:        &cstat.Memory.RSS,
 			PageFaults:      &pageFaults,
 			MajorPageFaults: &majorPageFaults,
+			SwapBytes:       &cstat.Memory.Swap,
 		}
 		// availableBytes = memory limit (if known) - workingset
 		if !isMemoryUnlimited(info.Spec.Memory.Limit) {

--- a/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go
+++ b/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go
@@ -235,6 +235,9 @@ type MemoryStats struct {
 	// Cumulative number of major page faults.
 	// +optional
 	MajorPageFaults *uint64 `json:"majorPageFaults,omitempty"`
+	// The amount of swap used
+	// +optional: enabled by feature gate NodeSwap
+	SwapBytes *uint64 `json:"swapBytes,omitempty"`
 }
 
 // AcceleratorStats contains stats for accelerators attached to the container.

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -111,6 +111,7 @@ var _ = SIGDescribe("Summary API [NodeConformance]", func() {
 						"RSSBytes":        bounded(1*e2evolume.Mb, memoryLimit),
 						"PageFaults":      bounded(1000, 1e9),
 						"MajorPageFaults": bounded(0, 100000),
+						"SwapBytes":       bounded(0, memoryLimit),
 					}),
 					"Accelerators":       gomega.BeEmpty(),
 					"Rootfs":             gomega.BeNil(),
@@ -137,6 +138,7 @@ var _ = SIGDescribe("Summary API [NodeConformance]", func() {
 				"RSSBytes":        bounded(1*e2evolume.Kb, memoryLimit),
 				"PageFaults":      bounded(0, expectedPageFaultsUpperBound),
 				"MajorPageFaults": bounded(0, expectedMajorPageFaultsUpperBound),
+				"SwapBytes":       bounded(0, memoryLimit),
 			})
 			runtimeContExpectations := sysContExpectations().(*gstruct.FieldsMatcher)
 			systemContainers := gstruct.Elements{
@@ -158,6 +160,7 @@ var _ = SIGDescribe("Summary API [NodeConformance]", func() {
 					"RSSBytes":        bounded(100*e2evolume.Kb, memoryLimit),
 					"PageFaults":      bounded(1000, 1e9),
 					"MajorPageFaults": bounded(0, 100000),
+					"SwapBytes":       bounded(0, memoryLimit),
 				})
 				systemContainers["misc"] = miscContExpectations
 			}
@@ -182,6 +185,7 @@ var _ = SIGDescribe("Summary API [NodeConformance]", func() {
 							"RSSBytes":        bounded(1*e2evolume.Kb, 80*e2evolume.Mb),
 							"PageFaults":      bounded(100, expectedPageFaultsUpperBound),
 							"MajorPageFaults": bounded(0, expectedMajorPageFaultsUpperBound),
+							"SwapBytes":       bounded(1*e2evolume.Kb, 80*e2evolume.Mb),
 						}),
 						"Accelerators": gomega.BeEmpty(),
 						"Rootfs": ptrMatchAllFields(gstruct.Fields{
@@ -229,6 +233,7 @@ var _ = SIGDescribe("Summary API [NodeConformance]", func() {
 					"RSSBytes":        bounded(1*e2evolume.Kb, 80*e2evolume.Mb),
 					"PageFaults":      bounded(0, expectedPageFaultsUpperBound),
 					"MajorPageFaults": bounded(0, expectedMajorPageFaultsUpperBound),
+					"SwapBytes":       bounded(0, expectedPageFaultsUpperBound),
 				}),
 				"VolumeStats": gstruct.MatchAllElements(summaryObjectID, gstruct.Elements{
 					"test-empty-dir": gstruct.MatchAllFields(gstruct.Fields{
@@ -279,6 +284,7 @@ var _ = SIGDescribe("Summary API [NodeConformance]", func() {
 						"RSSBytes":        bounded(1*e2evolume.Kb, memoryLimit),
 						"PageFaults":      bounded(1000, 1e9),
 						"MajorPageFaults": bounded(0, 100000),
+						"SwapBytes":       bounded(0, memoryLimit),
 					}),
 					// TODO(#28407): Handle non-eth0 network interface names.
 					"Network": ptrMatchAllFields(gstruct.Fields{


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Part of [kubernetes/enhancements#105021](https://github.com/kubernetes/enhancements/issues/105021)
This PR adds reporting for swap in kubelet summary API.

#### Which issue(s) this PR fixes:
Fixes #105021 

#### Does this PR introduce a user-facing change?
```
Add swap to kubelet memory stats
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
https://github.com/kubernetes/enhancements/pull/3957/files#diff-32d9cbd2b6817965ecee751dfe43b0d91269aee738a5799c9c9a68d04a329ec6R616
```
