### PR TITLE
Update distroless-iptables to v0.2.4

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -95,7 +95,7 @@ readonly KUBE_RSYNC_PORT="${KUBE_RSYNC_PORT:-}"
 readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_distroless_iptables_version=v0.2.3
+readonly __default_distroless_iptables_version=v0.2.4
 readonly __default_go_runner_version=v2.3.1-go1.20.4-bullseye.0
 readonly __default_setcap_version=bullseye-v1.4.2
 

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -139,7 +139,7 @@ dependencies:
       match: BASE_IMAGE_VERSION\?=
 
   - name: "registry.k8s.io/distroless-iptables: dependents"
-    version: v0.2.3
+    version: v0.2.4
     refPaths:
     - path: build/common.sh
       match: __default_distroless_iptables_version=

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -245,7 +245,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.29-4"}
 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.2"}
-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.2.3"}
+	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.2.4"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.7-0"}
 	configs[GlusterDynamicProvisioner] = Config{list.PromoterE2eRegistry, "glusterdynamic-provisioner", "v1.3"}
 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

* Updated distroless iptables to use released image `registry.k8s.io/build-image/distroless-iptables:v0.2.4`

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3025

#### Does this PR introduce a user-facing change?
```release-note
Updated distroless iptables to use released image `registry.k8s.io/build-image/distroless-iptables:v0.2.4`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

/assign @saschagrunert @cpanato @dims 
cc @kubernetes/release-engineering 