### PR TITLE
Automated cherry pick of #117723: Kube-proxy/ipvs: accept access to healthCheckNodePort on LbIP

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1735,6 +1735,9 @@ func (proxier *Proxier) writeIptablesRules() {
 		"-m", "set", "--match-set", proxier.ipsetList[kubeExternalIPSet].Name, "dst,dst", "-j", "RETURN")
 	proxier.filterRules.Write(
 		"-A", string(kubeIPVSFilterChain),
+		"-m", "set", "--match-set", proxier.ipsetList[kubeHealthCheckNodePortSet].Name, "dst", "-j", "RETURN")
+	proxier.filterRules.Write(
+		"-A", string(kubeIPVSFilterChain),
 		"-m", "conntrack", "--ctstate", "NEW",
 		"-m", "set", "--match-set", proxier.ipsetList[kubeIPVSSet].Name, "dst", "-j", "REJECT")
 


### PR DESCRIPTION
Cherry pick of #117723 on release-1.27.

#117723: Kube-proxy/ipvs: accept access to healthCheckNodePort on LbIP

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
fixes 1.26 regression in kube-proxy ipvs accepting healthCheckNodePorts on the loadBalancerIP
```
