### PR TITLE
WIP: scheduler_perf: track and visualize progress over time

### DIFF
--- a/test/integration/scheduler_perf/README.md
+++ b/test/integration/scheduler_perf/README.md
@@ -100,3 +100,22 @@ performance.
 
 During interactive debugging sessions it is possible to enable per-test output
 via -use-testing-log.
+
+### Visualization
+
+Some support for visualizing progress over time is built into the
+benchmarks. The measurement operation which creates pods writes .dat files like
+this:
+
+     test/integration/scheduler_perf/SchedulingBasic_5000Nodes_2023-03-17T14:52:09Z.dat
+
+This file is in a text format that [gnuplot](http://www.gnuplot.info/) can
+read. A wrapper script selects some suitable parameters:
+
+     test/integration/scheduler_perf/gnuplot.sh test/integration/scheduler_perf/*.dat
+
+It plots in an interactive window by default. To write into a file, use
+
+    test/integration/scheduler_perf/gnuplot.sh \
+       -e "set term png; set output <output>.png" \
+       test/integration/scheduler_perf/*.dat

--- a/test/integration/scheduler_perf/gnuplot.sh
+++ b/test/integration/scheduler_perf/gnuplot.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Invoke this script with a list of *.dat and it'll plot them with gnuplot.
+# Any non-file parameter is passed through to gnuplot. By default,
+# an X11 window is used to display the result. To write into a file,
+# use
+#  -e "set term png; set output <output>.png"
+
+files=()
+args=( -e "set term x11 persist" )
+
+for i in "$@"; do
+    if [ -f "$i" ]; then
+        files+=("$i")
+    else
+        args+=("$i")
+    fi
+done
+
+(
+    cat <<EOF
+set ytics autofreq nomirror tc lt 1
+set ylabel 'scheduled' tc lt 1
+set y2tics autofreq nomirror tc lt 2
+set y2label 'attempts/scheduled' tc lt 2
+EOF
+    echo -n "plot "
+    for file in "${files[@]}"; do
+        echo -n "'${file}' using 1:2 with linespoints title '$(basename "$file" .dat) scheduled' axis x1y1, "
+        echo -n "'${file}' using 1:(\$3/\$2) with linespoints title '$(basename "$file" .dat) attempts/scheduled' axis x1y2, "
+    done
+    echo
+) | tee /dev/stderr | gnuplot "${args[@]}" -


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is useful to see whether pod scheduling happens in bursts and how it behaves over time, which is relevant in particular for dynamic resource allocation where it may become harder at the end to find the node which still has resources available.

Besides "pods scheduled" it's also useful to know how many attempts were needed, so schedule_attempts_total also gets sampled and stored.

To visualize the result of one or more test runs, use:

     gnuplot.sh *.dat

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
