### PR TITLE
QueryParamVerifierV3 resilient to minimal OpenAPI V3 documents

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier_v3.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier_v3.go
@@ -106,6 +106,9 @@ func hasGVKExtensionV3(extensions spec.Extensions, gvk schema.GroupVersionKind) 
 // the PATCH end-point. Returns true if the query param is supported by the
 // spec for the passed GVK; false otherwise.
 func supportsQueryParamV3(doc *spec3.OpenAPI, gvk schema.GroupVersionKind, queryParam VerifiableQueryParam) bool {
+	if doc == nil || doc.Paths == nil {
+		return false
+	}
 	for _, path := range doc.Paths.Paths {
 		// If operation is not PATCH, then continue.
 		op := path.PathProps.Patch


### PR DESCRIPTION
* Ensures `QueryParamVerifierV3` handles OpenAPI V3 documents that are missing standard fields.

/kind bug
/kind regression

Fixes https://github.com/kubernetes/kubernetes/issues/117762

```release-note
Fixes a 1.27 regression in client-go where an incomplete OpenAPI V3 document can cause a nil-pointer crash.
```