### PR TITLE
Automated cherry pick of #117768: QueryParamVerifierV3 resilient to minimal OpenAPI V3

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier_v3.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier_v3.go
@@ -106,6 +106,9 @@ func hasGVKExtensionV3(extensions spec.Extensions, gvk schema.GroupVersionKind) 
 // the PATCH end-point. Returns true if the query param is supported by the
 // spec for the passed GVK; false otherwise.
 func supportsQueryParamV3(doc *spec3.OpenAPI, gvk schema.GroupVersionKind, queryParam VerifiableQueryParam) bool {
+	if doc == nil || doc.Paths == nil {
+		return false
+	}
 	for _, path := range doc.Paths.Paths {
 		// If operation is not PATCH, then continue.
 		op := path.PathProps.Patch


### PR DESCRIPTION
Cherry pick of #117768 on release-1.27.

#117768: QueryParamVerifierV3 resilient to minimal OpenAPI V3

Fixes https://github.com/kubernetes/kubernetes/issues/117762

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes bug where an incomplete OpenAPI V3 document can cause a nil-pointer crash. 
```