### PR TITLE
Improve the performance of schedulinggates

### DIFF
--- a/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates.go
+++ b/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates.go
@@ -46,7 +46,7 @@ func (pl *SchedulingGates) PreEnqueue(ctx context.Context, p *v1.Pod) *framework
 	if !pl.enablePodSchedulingReadiness || len(p.Spec.SchedulingGates) == 0 {
 		return nil
 	}
-	var gates []string
+	gates := make([]string, 0, len(p.Spec.SchedulingGates))
 	for _, gate := range p.Spec.SchedulingGates {
 		gates = append(gates, gate.Name)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig scheduling

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
I wrote a benchmak in my local env, like this:
```
func BenchmarkPreEnqueue(b *testing.B) {
	b.ResetTimer()
	p, _ := New(nil, nil, feature.Features{EnablePodSchedulingReadiness: true})
	pod := st.MakePod().Name("p").SchedulingGates([]string{"foo", "bar", "a", "b", "c"}).Obj()
	for i := 0; i < b.N; i++ {
		p.(framework.PreEnqueuePlugin).PreEnqueue(context.Background(), pod)
	}
}
```
- original: 
```
goos: darwin
goarch: amd64
pkg: k8s.io/kubernetes/pkg/scheduler/framework/plugins/schedulinggates
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkPreEnqueue-16    	 1220508	       993.1 ns/op	     472 B/op	      13 allocs/op
BenchmarkPreEnqueue-16    	 1000000	      1028 ns/op	     472 B/op	      13 allocs/op
BenchmarkPreEnqueue-16    	 1000000	      1029 ns/op	     472 B/op	      13 allocs/op
BenchmarkPreEnqueue-16    	 1000000	      1020 ns/op	     472 B/op	      13 allocs/op
```

- PR:
```
goos: darwin
goarch: amd64
pkg: k8s.io/kubernetes/pkg/scheduler/framework/plugins/schedulinggates
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkPreEnqueue-16    	 1437207	       796.2 ns/op	     312 B/op	      10 allocs/op
BenchmarkPreEnqueue-16    	 1521619	       795.2 ns/op	     312 B/op	      10 allocs/op
BenchmarkPreEnqueue-16    	 1519863	       784.1 ns/op	     312 B/op	      10 allocs/op
BenchmarkPreEnqueue-16    	 1523612	       799.1 ns/op	     312 B/op	      10 allocs/op
```
The execution time of the PR version is reduced by **20%** compared to the master version.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
