### PR TITLE
Automated cherry pick of #117712: Set Pod phase to Failed if init container gets OOMKilled but

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1368,7 +1368,7 @@ func getPhase(spec *v1.PodSpec, info []v1.ContainerStatus) v1.PodPhase {
 		case containerStatus.State.Running != nil:
 			pendingInitialization++
 		case containerStatus.State.Terminated != nil:
-			if containerStatus.State.Terminated.ExitCode != 0 {
+			if containerStatus.State.Terminated.ExitCode != 0 || containerStatus.State.Terminated.Reason == "OOMKilled" {
 				failedInitialization++
 			}
 		case containerStatus.State.Waiting != nil:

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -2261,6 +2261,26 @@ func TestPodPhaseWithRestartNeverInitContainers(t *testing.T) {
 			v1.PodRunning,
 			"init container succeeded",
 		},
+		{
+			&v1.Pod{
+				Spec: desiredState,
+				Status: v1.PodStatus{
+					InitContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "containerX",
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									ExitCode: 0,
+									Reason:   "OOMKilled",
+								},
+							},
+						},
+					},
+				},
+			},
+			v1.PodFailed,
+			"init container terminated with OOMkilled and exit-code zero",
+		},
 	}
 	for _, test := range tests {
 		statusInfo := append(test.pod.Status.InitContainerStatuses[:], test.pod.Status.ContainerStatuses[:]...)


### PR DESCRIPTION
Cherry pick of #117712 on release-1.26.

#117712: Set Pod phase to Failed if init container gets OOMKilled but

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

Please see https://github.com/kubernetes/kubernetes/pull/117788 for details.

Since this issue is fixed in 1.27 by https://github.com/kubernetes/kubernetes/pull/115331. But https://github.com/kubernetes/kubernetes/pull/115331 is probably too big to be backported. I created this PR to backport the fix to only 1.26.

**Note that the plan is to only backport this to 1.26 and 1.25, without merging to 1.27 and main branch.** Please let me know if this is not a recommended approach.

```release-note
A pod's phase will be set to Failed, when its init container gets OOMKilled but the exit code of the main process of the init container is 0. This usually happens when an init container spawns child processes which get OOMKilled, but the main process exits with exit code 0.
```