### PR TITLE
kubeadm: Add etcd client unit tests

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -66,27 +66,69 @@ type ClusterInterrogator interface {
 	RemoveMember(id uint64) ([]Member, error)
 }
 
+type etcdClient interface {
+	// Close shuts down the client's etcd connections.
+	Close() error
+
+	// Endpoints lists the registered endpoints for the client.
+	Endpoints() []string
+
+	// MemberList lists the current cluster membership.
+	MemberList(ctx context.Context) (*clientv3.MemberListResponse, error)
+
+	// MemberAdd adds a new member into the cluster.
+	MemberAdd(ctx context.Context, peerAddrs []string) (*clientv3.MemberAddResponse, error)
+
+	// MemberAddAsLearner adds a new learner member into the cluster.
+	MemberAddAsLearner(ctx context.Context, peerAddrs []string) (*clientv3.MemberAddResponse, error)
+
+	// MemberRemove removes an existing member from the cluster.
+	MemberRemove(ctx context.Context, id uint64) (*clientv3.MemberRemoveResponse, error)
+
+	// MemberPromote promotes a member from raft learner (non-voting) to raft voting member.
+	MemberPromote(ctx context.Context, id uint64) (*clientv3.MemberPromoteResponse, error)
+
+	// Status gets the status of the endpoint.
+	Status(ctx context.Context, endpoint string) (*clientv3.StatusResponse, error)
+
+	// Sync synchronizes client's endpoints with the known endpoints from the etcd membership.
+	Sync(ctx context.Context) error
+}
+
 // Client provides connection parameters for an etcd cluster
 type Client struct {
 	Endpoints []string
-	TLS       *tls.Config
+
+	newEtcdClient func(endpoints []string) (etcdClient, error)
 }
 
 // New creates a new EtcdCluster client
 func New(endpoints []string, ca, cert, key string) (*Client, error) {
 	client := Client{Endpoints: endpoints}
 
+	var err error
+	var tlsConfig *tls.Config
 	if ca != "" || cert != "" || key != "" {
 		tlsInfo := transport.TLSInfo{
 			CertFile:      cert,
 			KeyFile:       key,
 			TrustedCAFile: ca,
 		}
-		tlsConfig, err := tlsInfo.ClientConfig()
+		tlsConfig, err = tlsInfo.ClientConfig()
 		if err != nil {
 			return nil, err
 		}
-		client.TLS = tlsConfig
+	}
+
+	client.newEtcdClient = func(endpoints []string) (etcdClient, error) {
+		return clientv3.New(clientv3.Config{
+			Endpoints:   endpoints,
+			DialTimeout: etcdTimeout,
+			DialOptions: []grpc.DialOption{
+				grpc.WithBlock(), // block until the underlying connection is up
+			},
+			TLS: tlsConfig,
+		})
 	}
 
 	return &client, nil
@@ -192,24 +234,16 @@ func getRawEtcdEndpointsFromPodAnnotationWithoutRetry(client clientset.Interface
 // Sync synchronizes client's endpoints with the known endpoints from the etcd membership.
 func (c *Client) Sync() error {
 	// Syncs the list of endpoints
-	var cli *clientv3.Client
+	var cli etcdClient
 	var lastError error
 	err := wait.ExponentialBackoff(etcdBackoff, func() (bool, error) {
 		var err error
-		cli, err = clientv3.New(clientv3.Config{
-			Endpoints:   c.Endpoints,
-			DialTimeout: etcdTimeout,
-			DialOptions: []grpc.DialOption{
-				grpc.WithBlock(), // block until the underlying connection is up
-			},
-			TLS: c.TLS,
-		})
+		cli, err = c.newEtcdClient(c.Endpoints)
 		if err != nil {
 			lastError = err
 			return false, nil
 		}
 		defer cli.Close()
-
 		ctx, cancel := context.WithTimeout(context.Background(), etcdTimeout)
 		err = cli.Sync(ctx)
 		cancel()
@@ -241,14 +275,7 @@ func (c *Client) listMembers() (*clientv3.MemberListResponse, error) {
 	var lastError error
 	var resp *clientv3.MemberListResponse
 	err := wait.ExponentialBackoff(etcdBackoff, func() (bool, error) {
-		cli, err := clientv3.New(clientv3.Config{
-			Endpoints:   c.Endpoints,
-			DialTimeout: etcdTimeout,
-			DialOptions: []grpc.DialOption{
-				grpc.WithBlock(), // block until the underlying connection is up
-			},
-			TLS: c.TLS,
-		})
+		cli, err := c.newEtcdClient(c.Endpoints)
 		if err != nil {
 			lastError = err
 			return false, nil
@@ -306,14 +333,7 @@ func (c *Client) RemoveMember(id uint64) ([]Member, error) {
 	var lastError error
 	var resp *clientv3.MemberRemoveResponse
 	err := wait.ExponentialBackoff(etcdBackoff, func() (bool, error) {
-		cli, err := clientv3.New(clientv3.Config{
-			Endpoints:   c.Endpoints,
-			DialTimeout: etcdTimeout,
-			DialOptions: []grpc.DialOption{
-				grpc.WithBlock(), // block until the underlying connection is up
-			},
-			TLS: c.TLS,
-		})
+		cli, err := c.newEtcdClient(c.Endpoints)
 		if err != nil {
 			lastError = err
 			return false, nil
@@ -365,14 +385,7 @@ func (c *Client) addMember(name string, peerAddrs string, isLearner bool) ([]Mem
 		return nil, errors.Wrapf(err, "error parsing peer address %s", peerAddrs)
 	}
 
-	cli, err := clientv3.New(clientv3.Config{
-		Endpoints:   c.Endpoints,
-		DialTimeout: etcdTimeout,
-		DialOptions: []grpc.DialOption{
-			grpc.WithBlock(), // block until the underlying connection is up
-		},
-		TLS: c.TLS,
-	})
+	cli, err := c.newEtcdClient(c.Endpoints)
 	if err != nil {
 		return nil, err
 	}
@@ -482,14 +495,7 @@ func (c *Client) MemberPromote(learnerID uint64) error {
 	}
 
 	klog.V(1).Infof("[etcd] Promoting a learner as a voting member: %016x", learnerID)
-	cli, err := clientv3.New(clientv3.Config{
-		Endpoints:   c.Endpoints,
-		DialTimeout: etcdTimeout,
-		DialOptions: []grpc.DialOption{
-			grpc.WithBlock(), // block until the underlying connection is up
-		},
-		TLS: c.TLS,
-	})
+	cli, err := c.newEtcdClient(c.Endpoints)
 	if err != nil {
 		return err
 	}
@@ -537,14 +543,7 @@ func (c *Client) getClusterStatus() (map[string]*clientv3.StatusResponse, error)
 		var lastError error
 		var resp *clientv3.StatusResponse
 		err := wait.ExponentialBackoff(etcdBackoff, func() (bool, error) {
-			cli, err := clientv3.New(clientv3.Config{
-				Endpoints:   c.Endpoints,
-				DialTimeout: etcdTimeout,
-				DialOptions: []grpc.DialOption{
-					grpc.WithBlock(), // block until the underlying connection is up
-				},
-				TLS: c.TLS,
-			})
+			cli, err := c.newEtcdClient(c.Endpoints)
 			if err != nil {
 				lastError = err
 				return false, nil

--- a/cmd/kubeadm/app/util/etcd/etcd_test.go
+++ b/cmd/kubeadm/app/util/etcd/etcd_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package etcd
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -24,6 +25,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -35,9 +38,64 @@ import (
 	testresources "k8s.io/kubernetes/cmd/kubeadm/test/resources"
 )
 
+var errNotImplemented = errors.New("not implemented")
+
+type fakeEtcdClient struct {
+	members   []*pb.Member
+	endpoints []string
+}
+
+// Close shuts down the client's etcd connections.
+func (f *fakeEtcdClient) Close() error {
+	f.members = []*pb.Member{}
+	return nil
+}
+
+// Endpoints lists the registered endpoints for the client.
+func (f *fakeEtcdClient) Endpoints() []string {
+	return f.endpoints
+}
+
+// MemberList lists the current cluster membership.
+func (f *fakeEtcdClient) MemberList(_ context.Context) (*clientv3.MemberListResponse, error) {
+	return &clientv3.MemberListResponse{
+		Members: f.members,
+	}, nil
+}
+
+// MemberAdd adds a new member into the cluster.
+func (f *fakeEtcdClient) MemberAdd(_ context.Context, peerAddrs []string) (*clientv3.MemberAddResponse, error) {
+	return nil, errNotImplemented
+}
+
+// MemberAddAsLearner adds a new learner member into the cluster.
+func (f *fakeEtcdClient) MemberAddAsLearner(_ context.Context, peerAddrs []string) (*clientv3.MemberAddResponse, error) {
+	return nil, errNotImplemented
+}
+
+// MemberRemove removes an existing member from the cluster.
+func (f *fakeEtcdClient) MemberRemove(_ context.Context, id uint64) (*clientv3.MemberRemoveResponse, error) {
+	return nil, errNotImplemented
+}
+
+// MemberPromote promotes a member from raft learner (non-voting) to raft voting member.
+func (f *fakeEtcdClient) MemberPromote(_ context.Context, id uint64) (*clientv3.MemberPromoteResponse, error) {
+	return nil, errNotImplemented
+}
+
+// Status gets the status of the endpoint.
+func (f *fakeEtcdClient) Status(_ context.Context, endpoint string) (*clientv3.StatusResponse, error) {
+	return nil, errNotImplemented
+}
+
+// Sync synchronizes client's endpoints with the known endpoints from the etcd membership.
+func (f *fakeEtcdClient) Sync(_ context.Context) error {
+	return errNotImplemented
+}
+
 func testGetURL(t *testing.T, getURLFunc func(*kubeadmapi.APIEndpoint) string, port int) {
 	portStr := strconv.Itoa(port)
-	var tests = []struct {
+	tests := []struct {
 		name             string
 		advertiseAddress string
 		expectedURL      string
@@ -82,7 +140,7 @@ func TestGetPeerURL(t *testing.T) {
 
 func TestGetClientURLByIP(t *testing.T) {
 	portStr := strconv.Itoa(constants.EtcdListenClientPort)
-	var tests = []struct {
+	tests := []struct {
 		name        string
 		ip          string
 		expectedURL string
@@ -118,7 +176,7 @@ func TestGetClientURLByIP(t *testing.T) {
 }
 
 func TestGetEtcdEndpointsWithBackoff(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name              string
 		pods              []testresources.FakeStaticPod
 		expectedEndpoints []string
@@ -169,7 +227,7 @@ func TestGetEtcdEndpointsWithBackoff(t *testing.T) {
 }
 
 func TestGetRawEtcdEndpointsFromPodAnnotation(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name              string
 		pods              []testresources.FakeStaticPod
 		clientSetup       func(*clientsetfake.Clientset)
@@ -253,7 +311,7 @@ func TestGetRawEtcdEndpointsFromPodAnnotation(t *testing.T) {
 }
 
 func TestGetRawEtcdEndpointsFromPodAnnotationWithoutRetry(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name              string
 		pods              []testresources.FakeStaticPod
 		clientSetup       func(*clientsetfake.Clientset)
@@ -347,6 +405,91 @@ func TestGetRawEtcdEndpointsFromPodAnnotationWithoutRetry(t *testing.T) {
 			}
 			if !reflect.DeepEqual(endpoints, rt.expectedEndpoints) {
 				t.Errorf("expected etcd endpoints: %v; got: %v", rt.expectedEndpoints, endpoints)
+			}
+		})
+	}
+}
+
+func TestClient_GetMemberID(t *testing.T) {
+	type fields struct {
+		Endpoints     []string
+		newEtcdClient func(endpoints []string) (etcdClient, error)
+	}
+	type args struct {
+		peerURL string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    uint64
+		wantErr bool
+	}{
+		{
+			name: "member ID found",
+			fields: fields{
+				Endpoints: []string{},
+				newEtcdClient: func(endpoints []string) (etcdClient, error) {
+					f := &fakeEtcdClient{
+						members: []*pb.Member{
+							{
+								ID:   1,
+								Name: "member1",
+								PeerURLs: []string{
+									"https://member1:2380",
+								},
+							},
+						},
+					}
+					return f, nil
+				},
+			},
+			args: args{
+				peerURL: "https://member1:2380",
+			},
+			wantErr: false,
+			want:    1,
+		},
+		{
+			name: "member ID not found",
+			fields: fields{
+				Endpoints: []string{},
+				newEtcdClient: func(endpoints []string) (etcdClient, error) {
+					f := &fakeEtcdClient{
+						members: []*pb.Member{
+							{
+								ID:   1,
+								Name: "member1",
+								PeerURLs: []string{
+									"https://member1:2380",
+								},
+							},
+						},
+					}
+					return f, nil
+				},
+			},
+			args: args{
+				peerURL: "https://member2:2380",
+			},
+			wantErr: false,
+			want:    0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				Endpoints:     tt.fields.Endpoints,
+				newEtcdClient: tt.fields.newEtcdClient,
+			}
+
+			got, err := c.GetMemberID(tt.args.peerURL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Client.GetMemberID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Client.GetMemberID() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
As the result of the discussion that started with https://github.com/kubernetes/kubernetes/pull/117724#issuecomment-1533322854, I created a unit test to exercise kubeadm's etcd client, which wraps the upstream etcd client. In order to create the test, I made kubdeadm consume the upstream etcd client via an interface.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
