### PR TITLE
Optimize the performance of the Clone method of preFilterState

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -93,8 +93,7 @@ func (s *preFilterState) Clone() framework.StateData {
 		copy.TpKeyToCriticalPaths[tpKey] = &criticalPaths{paths[0], paths[1]}
 	}
 	for tpPair, matchNum := range s.TpPairToMatchNum {
-		copyPair := topologyPair{key: tpPair.key, value: tpPair.value}
-		copy.TpPairToMatchNum[copyPair] = matchNum
+		copy.TpPairToMatchNum[tpPair] = matchNum
 	}
 	return &copy
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig scheduling
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Because the type of TpPairToMatchNum is: map[topologyPair]int, and the **key(topologyPair)** is a value type rather than a pointer type. For a map whose key is a value type, it is not necessary to recreate the object.

I wrote a benchmak in my local env, like this:
```
func BenchmarkClone(b *testing.B) {
	s, _ := metav1.LabelSelectorAsSelector(st.MakeLabelSelector().Label("foo", "bar").Obj())
	want := &preFilterState{
		Constraints: []topologySpreadConstraint{
			{
				MaxSkew:            5,
				TopologyKey:        "zone",
				Selector:           s,
				MinDomains:         1,
				NodeAffinityPolicy: v1.NodeInclusionPolicyHonor,
				NodeTaintsPolicy:   v1.NodeInclusionPolicyIgnore,
			},
		},
		TpKeyToCriticalPaths: map[string]*criticalPaths{
			"zone": {{"zone1", 0}, {"zone2", 0}},
		},
		TpPairToMatchNum: map[topologyPair]int{
			{key: "zone", value: "zone1"}: 0,
			{key: "zone", value: "zone2"}: 0,
		},
	}
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		want.Clone()
	}
}
```
- original:
```
goos: darwin
goarch: amd64
pkg: k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkClone-16    	 2556600	       463.9 ns/op	     752 B/op	       6 allocs/op
BenchmarkClone-16    	 2587473	       466.4 ns/op	     752 B/op	       6 allocs/op
BenchmarkClone-16    	 2539706	       464.2 ns/op	     752 B/op	       6 allocs/op
```

- PR:
```
goos: darwin
goarch: amd64
pkg: k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkClone-16    	 6047665	       184.1 ns/op	      48 B/op	       1 allocs/op
BenchmarkClone-16    	 6503575	       181.1 ns/op	      48 B/op	       1 allocs/op
BenchmarkClone-16    	 6381550	       181.1 ns/op	      48 B/op	       1 allocs/op
```
The execution time of the PR version is reduced by **60%** compared to the master version.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
