### PR TITLE
scheduler-perf: measure workload runtime and relabel workloads

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -1,5 +1,4 @@
 - name: SchedulingBasic
-  labels: [performance]
   defaultPodTemplatePath: config/pod-default.yaml
   workloadTemplate:
   - opcode: createNodes
@@ -17,13 +16,13 @@
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
+    labels: [performance, fast]
     params:
       initNodes: 5000
       initPods: 1000
       measurePods: 1000
 
 - name: SchedulingPodAntiAffinity
-  labels: [performance]
   defaultPodTemplatePath: config/pod-with-pod-anti-affinity.yaml
   workloadTemplate:
   - opcode: createNodes
@@ -46,13 +45,13 @@
       initPods: 100
       measurePods: 400
   - name: 5000Nodes
+    labels: [performance, fast]
     params:
       initNodes: 5000
       initPods: 1000
       measurePods: 1000
 
 - name: SchedulingSecrets
-  labels: [performance]
   defaultPodTemplatePath: config/pod-with-secret-volume.yaml
   workloadTemplate:
   - opcode: createNodes
@@ -70,6 +69,7 @@
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
+    labels: [performance, fast]
     params:
       initNodes: 5000
       initPods: 5000
@@ -173,7 +173,6 @@
       measurePods: 1000
 
 - name: SchedulingPodAffinity
-  labels: [performance]
   defaultPodTemplatePath: config/pod-with-pod-affinity.yaml
   workloadTemplate:
   - opcode: createNodes
@@ -200,6 +199,7 @@
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
+    labels: [performance, fast]
     params:
       initNodes: 5000
       initPods: 5000
@@ -235,7 +235,6 @@
       measurePods: 1000
 
 - name: SchedulingPreferredPodAntiAffinity
-  labels: [performance]
   defaultPodTemplatePath: config/pod-with-preferred-pod-affinity.yaml
   workloadTemplate:
   - opcode: createNodes
@@ -258,13 +257,13 @@
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
+    labels: [performance, fast]
     params:
       initNodes: 5000
       initPods: 5000
       measurePods: 1000
 
 - name: SchedulingNodeAffinity
-  labels: [performance]
   defaultPodTemplatePath: config/pod-with-node-affinity.yaml
   workloadTemplate:
   - opcode: createNodes
@@ -286,13 +285,13 @@
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
+    labels: [performance, fast]
     params:
       initNodes: 5000
       initPods: 5000
       measurePods: 1000
 
 - name: TopologySpreading
-  labels: [performance]
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -315,6 +314,7 @@
       initPods: 1000
       measurePods: 1000
   - name: 5000Nodes
+    labels: [performance, fast]
     params:
       initNodes: 5000
       initPods: 5000
@@ -411,6 +411,7 @@
     collectMetrics: true
   workloads:
   - name: 500Nodes
+    labels: [fast]
     params:
       initNodes: 500
       initPods: 2000
@@ -455,7 +456,6 @@
 #      measurePods: 5000
 
 - name: Unschedulable
-  labels: [performance]
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -475,6 +475,7 @@
       initPods: 200
       measurePods: 1000
   - name: 5000Nodes/200InitPods
+    labels: [performance, fast]
     params:
       initNodes: 5000
       initPods: 200
@@ -508,11 +509,13 @@
       initNodes: 1000
       measurePods: 1000
   - name: 5000Nodes
+    labels: [performance, fast]
     params:
       initNodes: 5000
       measurePods: 2000
 
 - name: SchedulingRequiredPodAntiAffinityWithNSSelector
+  labels: [performance]
   defaultPodTemplatePath: config/pod-anti-affinity-ns-selector.yaml
   workloadTemplate:
   - opcode: createNodes
@@ -536,6 +539,13 @@
     collectMetrics: true
     namespace: measure-ns-0
   workloads:
+  - name: 500Nodes
+    labels: [fast]
+    params:
+      initNodes: 500
+      initPodsPerNamespace: 4
+      initNamespaces: 10
+      measurePods: 100
   - name: 5000Nodes
     params:
       initNodes: 5000
@@ -544,6 +554,7 @@
       measurePods: 1000
 
 - name: SchedulingPreferredAntiAffinityWithNSSelector
+  labels: [performance]
   defaultPodTemplatePath: config/pod-preferred-anti-affinity-ns-selector.yaml
   workloadTemplate:
   - opcode: createNodes
@@ -567,6 +578,13 @@
     collectMetrics: true
     namespace: measure-ns-0
   workloads:
+  - name: 500Nodes
+    labels: [fast]
+    params:
+      initNodes: 500
+      initPodsPerNamespace: 4
+      initNamespaces: 10
+      measurePods: 100
   - name: 5000Nodes
     params:
       initNodes: 5000
@@ -575,6 +593,7 @@
       measurePods: 1000
 
 - name: SchedulingRequiredPodAffinityWithNSSelector
+  labels: [performance]
   defaultPodTemplatePath: config/pod-affinity-ns-selector.yaml
   workloadTemplate:
   - opcode: createNodes
@@ -601,6 +620,13 @@
     collectMetrics: true
     namespace: measure-ns-0
   workloads:
+  - name: 500Nodes
+    labels: [fast]
+    params:
+      initNodes: 500
+      initPodsPerNamespace: 4
+      initNamespaces: 10
+      measurePods: 100
   - name: 5000Nodes
     params:
       initNodes: 5000
@@ -609,6 +635,7 @@
       measurePods: 1000
 
 - name: SchedulingPreferredAffinityWithNSSelector
+  labels: [performance]
   defaultPodTemplatePath: config/pod-preferred-affinity-ns-selector.yaml
   workloadTemplate:
   - opcode: createNodes
@@ -632,6 +659,13 @@
     collectMetrics: true
     namespace: measure-ns-0
   workloads:
+  - name: 500Nodes
+    labels: [fast]
+    params:
+      initNodes: 500
+      initPodsPerNamespace: 4
+      initNamespaces: 10
+      measurePods: 100
   - name: 5000Nodes
     params:
       initNodes: 5000
@@ -660,6 +694,7 @@
       normalNodes: 400
       measurePods: 400
   - name: 5000Nodes
+    labels: [performance, fast]
     params:
       taintNodes: 1000
       normalNodes: 4000

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -748,6 +748,15 @@ func unrollWorkloadTemplate(b *testing.B, wt []op, w *workload) []op {
 }
 
 func runWorkload(ctx context.Context, b *testing.B, tc *testCase, w *workload) []DataItem {
+	start := time.Now()
+	b.Cleanup(func() {
+		duration := time.Now().Sub(start)
+		// This includes startup and shutdown time and thus does not
+		// reflect scheduling performance. It's useful to get a feeling
+		// for how long each workload runs overall.
+		b.ReportMetric(duration.Seconds(), "runtime_seconds")
+	})
+
 	var cfg *config.KubeSchedulerConfiguration
 	var err error
 	if tc.SchedulerConfigPath != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The goal is to only label workloads as "performance" which actually run long enough to provide useful metrics. The throughput collector samples once per second, so a workload should run at least 5, better 10 seconds to get at least a minimal amount of samples for the percentile calculation.

For benchstat analysis of runs with sufficient repetitions to get statistically meaningful results, each workload shouldn't run more than one minute, otherwise before/after analysis becomes too slow.

The labels were chosen based on benchmark runs on a reasonably fast desktop. To know how long each workload takes, a new "runtime_seconds" benchmark result gets added.

#### Special notes for your reviewer:

When running all workloads on my desktop, I get for workload runtime in seconds:
```
PerfScheduling/SchedulingBasic/500Nodes-36                                                                                 7.02 ± 0%
PerfScheduling/SchedulingBasic/5000Nodes-36                                                                                20.4 ± 0%
PerfScheduling/SchedulingPodAntiAffinity/500Nodes-36                                                                       7.53 ± 0%
PerfScheduling/SchedulingPodAntiAffinity/5000Nodes-36                                                                      32.2 ± 0%
PerfScheduling/SchedulingSecrets/500Nodes-36                                                                               6.67 ± 0%
PerfScheduling/SchedulingSecrets/5000Nodes-36                                                                              25.5 ± 0%
PerfScheduling/SchedulingInTreePVs/500Nodes-36                                                                             8.39 ± 0%
PerfScheduling/SchedulingInTreePVs/5000Nodes-36                                                                            52.1 ± 0%
PerfScheduling/SchedulingMigratedInTreePVs/500Nodes-36                                                                     12.5 ± 0%
PerfScheduling/SchedulingMigratedInTreePVs/5000Nodes-36                                                                    91.7 ± 0%
PerfScheduling/SchedulingCSIPVs/500Nodes-36                                                                                12.4 ± 0%
PerfScheduling/SchedulingCSIPVs/5000Nodes-36                                                                               89.4 ± 0%
PerfScheduling/SchedulingPodAffinity/500Nodes-36                                                                           10.0 ± 0%
PerfScheduling/SchedulingPodAffinity/5000Nodes-36                                                                          91.7 ± 0%
PerfScheduling/SchedulingPreferredPodAffinity/500Nodes-36                                                                  7.30 ± 0%
PerfScheduling/SchedulingPreferredPodAffinity/5000Nodes-36                                                                 33.3 ± 0%
PerfScheduling/SchedulingPreferredPodAntiAffinity/500Nodes-36                                                              7.46 ± 0%
PerfScheduling/SchedulingPreferredPodAntiAffinity/5000Nodes-36                                                             35.4 ± 0%
PerfScheduling/SchedulingNodeAffinity/500Nodes-36                                                                          8.27 ± 0%
PerfScheduling/SchedulingNodeAffinity/5000Nodes-36                                                                         43.2 ± 0%
PerfScheduling/TopologySpreading/500Nodes-36                                                                               9.05 ± 0%
PerfScheduling/TopologySpreading/5000Nodes-36                                                                              52.4 ± 0%
PerfScheduling/PreferredTopologySpreading/500Nodes-36                                                                      8.87 ± 0%
PerfScheduling/PreferredTopologySpreading/5000Nodes-36                                                                     46.5 ± 0%
PerfScheduling/MixedSchedulingBasePod/500Nodes-36                                                                          10.3 ± 0%
PerfScheduling/MixedSchedulingBasePod/5000Nodes-36                                                                         86.1 ± 0%
PerfScheduling/PreemptionBasic/500Nodes-36                                                                                 17.8 ± 0%
PerfScheduling/PreemptionPVs/500Nodes-36                                                                                   17.9 ± 0%
PerfScheduling/Unschedulable/500Nodes/200InitPods-36                                                                       7.35 ± 0%
PerfScheduling/Unschedulable/5000Nodes/200InitPods-36                                                                      30.1 ± 0%
PerfScheduling/Unschedulable/5000Nodes/2000InitPods-36                                                                     84.3 ± 0%
PerfScheduling/SchedulingWithMixedChurn/1000Nodes-36                                                                       7.79 ± 0%
PerfScheduling/SchedulingWithMixedChurn/5000Nodes-36                                                                       19.6 ± 0%
PerfScheduling/SchedulingRequiredPodAntiAffinityWithNSSelector/5000Nodes-36                                                 146 ± 0%
PerfScheduling/SchedulingPreferredAntiAffinityWithNSSelector/5000Nodes-36                                                   128 ± 0%
PerfScheduling/SchedulingRequiredPodAffinityWithNSSelector/5000Nodes-36                                                     149 ± 0%
PerfScheduling/SchedulingPreferredAffinityWithNSSelector/5000Nodes-36                                                       123 ± 0%
PerfScheduling/SchedulingWithNodeInclusionPolicy/500Nodes-36                                                               5.42 ± 0%
PerfScheduling/SchedulingWithNodeInclusionPolicy/5000Nodes-36                                                              57.2 ± 0%
```

I've added new workloads and chosen labels so that the following have "performance,fast" as labels:
```
PerfScheduling/SchedulingBasic/5000Nodes-36                                                                               21.0 ± 0%
PerfScheduling/SchedulingPodAntiAffinity/5000Nodes-36                                                                     32.4 ± 0%
PerfScheduling/SchedulingSecrets/5000Nodes-36                                                                             25.1 ± 0%
PerfScheduling/SchedulingInTreePVs/500Nodes-36                                                                            8.07 ± 0%
PerfScheduling/SchedulingMigratedInTreePVs/500Nodes-36                                                                    12.1 ± 0%
PerfScheduling/SchedulingCSIPVs/500Nodes-36                                                                               11.8 ± 0%
PerfScheduling/SchedulingPodAffinity/5000Nodes-36                                                                         90.7 ± 0%
PerfScheduling/SchedulingPreferredPodAffinity/500Nodes-36                                                                 7.29 ± 0%
PerfScheduling/SchedulingPreferredPodAntiAffinity/5000Nodes-36                                                            32.9 ± 0%
PerfScheduling/SchedulingNodeAffinity/5000Nodes-36                                                                        42.8 ± 0%
PerfScheduling/TopologySpreading/5000Nodes-36                                                                             51.7 ± 0%
PerfScheduling/PreferredTopologySpreading/500Nodes-36                                                                     9.57 ± 0%
PerfScheduling/MixedSchedulingBasePod/500Nodes-36                                                                         10.3 ± 0%
PerfScheduling/PreemptionBasic/500Nodes-36                                                                                17.7 ± 0%
PerfScheduling/PreemptionPVs/500Nodes-36                                                                                  17.8 ± 0%
PerfScheduling/Unschedulable/5000Nodes/200InitPods-36                                                                     29.6 ± 0%
PerfScheduling/SchedulingWithMixedChurn/5000Nodes-36                                                                      19.5 ± 0%
PerfScheduling/SchedulingRequiredPodAntiAffinityWithNSSelector/500Nodes-36                                                15.3 ± 0%
PerfScheduling/SchedulingPreferredAntiAffinityWithNSSelector/500Nodes-36                                                  15.3 ± 0%
PerfScheduling/SchedulingRequiredPodAffinityWithNSSelector/500Nodes-36                                                    17.0 ± 0%
PerfScheduling/SchedulingPreferredAffinityWithNSSelector/500Nodes-36                                                      15.3 ± 0%
PerfScheduling/SchedulingWithNodeInclusionPolicy/5000Nodes-36                                                             56.8 ± 0%
```

This covers each type once (for real now!).

The very fast workloads don't have the "performance" label. Running them doesn't cost much in our Prow job, but also isn't useful.

`PerfScheduling/SchedulingPodAffinity/5000Node` runs a bit long for my taste, but I didn't want to add an entirely new workload for it because I wasn't sure about the parameters.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @Huang-Wei 

Because you brought this up on Slack.