### PR TITLE
Allow empty condition for jsonpath

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -1047,6 +1047,18 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 			expectedErr: "timed out waiting for the condition on theresource/foo-b6699dcfb-rnv7t",
 		},
 		{
+			name: "JSONPath condition not given",
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				fakeClient := dynamicfakeclient.NewSimpleDynamicClientWithCustomListKinds(scheme, listMapping)
+				fakeClient.PrependReactor("list", "theresource", listReactionfunc)
+				return fakeClient
+			},
+			jsonPathExp:  "{.status.containerStatuses[0].ready}",
+			jsonPathCond: "",
+
+			expectedErr: None,
+		},
+		{
 			name: "compare boolean JSONPath entry",
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				fakeClient := dynamicfakeclient.NewSimpleDynamicClientWithCustomListKinds(scheme, listMapping)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -1027,10 +1027,10 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		fakeClient   func() *dynamicfakeclient.FakeDynamicClient
-		jsonPathExp  string
-		jsonPathCond string
+		name                   string
+		fakeClient             func() *dynamicfakeclient.FakeDynamicClient
+		jsonPathExp            string
+		jsonPathExpectedResult string
 
 		expectedErr string
 	}{
@@ -1041,20 +1041,20 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 				fakeClient.PrependReactor("list", "theresource", listReactionfunc)
 				return fakeClient
 			},
-			jsonPathExp:  "{.foo.bar}",
-			jsonPathCond: "baz",
+			jsonPathExp:            "{.foo.bar}",
+			jsonPathExpectedResult: "baz",
 
 			expectedErr: "timed out waiting for the condition on theresource/foo-b6699dcfb-rnv7t",
 		},
 		{
-			name: "JSONPath condition not given",
+			name: "JSONPathExpectedResult not given",
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				fakeClient := dynamicfakeclient.NewSimpleDynamicClientWithCustomListKinds(scheme, listMapping)
 				fakeClient.PrependReactor("list", "theresource", listReactionfunc)
 				return fakeClient
 			},
-			jsonPathExp:  "{.status.containerStatuses[0].ready}",
-			jsonPathCond: "",
+			jsonPathExp:            "{.status.containerStatuses[0].ready}",
+			jsonPathExpectedResult: "",
 
 			expectedErr: None,
 		},
@@ -1065,8 +1065,8 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 				fakeClient.PrependReactor("list", "theresource", listReactionfunc)
 				return fakeClient
 			},
-			jsonPathExp:  "{.status.containerStatuses[0].ready}",
-			jsonPathCond: "true",
+			jsonPathExp:            "{.status.containerStatuses[0].ready}",
+			jsonPathExpectedResult: "true",
 
 			expectedErr: None,
 		},
@@ -1077,8 +1077,8 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 				fakeClient.PrependReactor("list", "theresource", listReactionfunc)
 				return fakeClient
 			},
-			jsonPathExp:  "{.status.containerStatuses[0].ready}",
-			jsonPathCond: "false",
+			jsonPathExp:            "{.status.containerStatuses[0].ready}",
+			jsonPathExpectedResult: "false",
 
 			expectedErr: "timed out waiting for the condition on theresource/foo-b6699dcfb-rnv7t",
 		},
@@ -1089,8 +1089,8 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 				fakeClient.PrependReactor("list", "theresource", listReactionfunc)
 				return fakeClient
 			},
-			jsonPathExp:  "{.spec.containers[0].ports[0].containerPort}",
-			jsonPathCond: "80",
+			jsonPathExp:            "{.spec.containers[0].ports[0].containerPort}",
+			jsonPathExpectedResult: "80",
 
 			expectedErr: None,
 		},
@@ -1101,8 +1101,8 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 				fakeClient.PrependReactor("list", "theresource", listReactionfunc)
 				return fakeClient
 			},
-			jsonPathExp:  "{.spec.containers[0].ports[0].containerPort}",
-			jsonPathCond: "81",
+			jsonPathExp:            "{.spec.containers[0].ports[0].containerPort}",
+			jsonPathExpectedResult: "81",
 
 			expectedErr: "timed out waiting for the condition on theresource/foo-b6699dcfb-rnv7t",
 		},
@@ -1113,8 +1113,8 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 				fakeClient.PrependReactor("list", "theresource", listReactionfunc)
 				return fakeClient
 			},
-			jsonPathExp:  "{.spec.nodeName}",
-			jsonPathCond: "knode0",
+			jsonPathExp:            "{.spec.nodeName}",
+			jsonPathExpectedResult: "knode0",
 
 			expectedErr: None,
 		},
@@ -1125,8 +1125,8 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 				fakeClient.PrependReactor("list", "theresource", listReactionfunc)
 				return fakeClient
 			},
-			jsonPathExp:  "{.spec.nodeName}",
-			jsonPathCond: "kmaster",
+			jsonPathExp:            "{.spec.nodeName}",
+			jsonPathExpectedResult: "kmaster",
 
 			expectedErr: "timed out waiting for the condition on theresource/foo-b6699dcfb-rnv7t",
 		},
@@ -1137,8 +1137,8 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 				fakeClient.PrependReactor("list", "theresource", listReactionfunc)
 				return fakeClient
 			},
-			jsonPathExp:  "{.status.conditions[*]}",
-			jsonPathCond: "foo",
+			jsonPathExp:            "{.status.conditions[*]}",
+			jsonPathExpectedResult: "foo",
 
 			expectedErr: "given jsonpath expression matches more than one value",
 		},
@@ -1149,8 +1149,8 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 				fakeClient.PrependReactor("list", "theresource", listReactionfunc)
 				return fakeClient
 			},
-			jsonPathExp:  "{range .status.conditions[*]}[{.status}] {end}",
-			jsonPathCond: "foo",
+			jsonPathExp:            "{range .status.conditions[*]}[{.status}] {end}",
+			jsonPathExpectedResult: "foo",
 
 			expectedErr: "given jsonpath expression matches more than one list",
 		},
@@ -1161,8 +1161,8 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 				fakeClient.PrependReactor("list", "theresource", listReactionfunc)
 				return fakeClient
 			},
-			jsonPathExp:  "{.status.conditions}",
-			jsonPathCond: "True",
+			jsonPathExp:            "{.status.conditions}",
+			jsonPathExpectedResult: "True",
 
 			expectedErr: "jsonpath leads to a nested object or list which is not supported",
 		},
@@ -1175,8 +1175,8 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 				})
 				return fakeClient
 			},
-			jsonPathExp:  "{.spec}",
-			jsonPathCond: "foo",
+			jsonPathExp:            "{.spec}",
+			jsonPathExpectedResult: "foo",
 
 			expectedErr: "jsonpath leads to a nested object or list which is not supported",
 		},
@@ -1192,9 +1192,9 @@ func TestWaitForDifferentJSONPathExpression(t *testing.T) {
 
 				Printer: printers.NewDiscardingPrinter(),
 				ConditionFn: JSONPathWait{
-					jsonPathCondition: test.jsonPathCond,
-					jsonPathParser:    j,
-					errOut:            io.Discard}.IsJSONPathConditionMet,
+					jsonPathExpectedResult: test.jsonPathExpectedResult,
+					jsonPathParser:         j,
+					errOut:                 io.Discard}.IsJSONPathExpectedResultMet,
 				IOStreams: genericiooptions.NewTestIOStreamsDiscard(),
 			}
 
@@ -1224,12 +1224,12 @@ func TestWaitForJSONPathCondition(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		infos        []*resource.Info
-		fakeClient   func() *dynamicfakeclient.FakeDynamicClient
-		timeout      time.Duration
-		jsonPathExp  string
-		jsonPathCond string
+		name                   string
+		infos                  []*resource.Info
+		fakeClient             func() *dynamicfakeclient.FakeDynamicClient
+		timeout                time.Duration
+		jsonPathExp            string
+		jsonPathExpectedResult string
 
 		expectedErr string
 	}{
@@ -1252,9 +1252,9 @@ func TestWaitForJSONPathCondition(t *testing.T) {
 				})
 				return fakeClient
 			},
-			timeout:      3 * time.Second,
-			jsonPathExp:  "{.metadata.name}",
-			jsonPathCond: "foo-b6699dcfb-rnv7t",
+			timeout:                3 * time.Second,
+			jsonPathExp:            "{.metadata.name}",
+			jsonPathExpectedResult: "foo-b6699dcfb-rnv7t",
 
 			expectedErr: None,
 		},
@@ -1342,9 +1342,9 @@ func TestWaitForJSONPathCondition(t *testing.T) {
 				})
 				return fakeClient
 			},
-			timeout:      3 * time.Second,
-			jsonPathExp:  "{.metadata.name}",
-			jsonPathCond: "foo", // use incorrect name so it'll keep waiting
+			timeout:                3 * time.Second,
+			jsonPathExp:            "{.metadata.name}",
+			jsonPathExpectedResult: "foo", // use incorrect name so it'll keep waiting
 
 			expectedErr: "timed out waiting for the condition on theresource/foo-b6699dcfb-rnv7t",
 		},
@@ -1372,9 +1372,9 @@ func TestWaitForJSONPathCondition(t *testing.T) {
 				})
 				return fakeClient
 			},
-			timeout:      10 * time.Second,
-			jsonPathExp:  "{.metadata.name}",
-			jsonPathCond: "foo-b6699dcfb-rnv7t",
+			timeout:                10 * time.Second,
+			jsonPathExp:            "{.metadata.name}",
+			jsonPathExpectedResult: "foo-b6699dcfb-rnv7t",
 
 			expectedErr: None,
 		},
@@ -1397,9 +1397,9 @@ func TestWaitForJSONPathCondition(t *testing.T) {
 				})
 				return fakeClient
 			},
-			timeout:      1 * time.Second,
-			jsonPathExp:  "{.spec.containers[0].image}",
-			jsonPathCond: "nginx",
+			timeout:                1 * time.Second,
+			jsonPathExp:            "{.spec.containers[0].image}",
+			jsonPathExpectedResult: "nginx",
 
 			expectedErr: None,
 		},
@@ -1438,9 +1438,9 @@ func TestWaitForJSONPathCondition(t *testing.T) {
 				})
 				return fakeClient
 			},
-			timeout:      10 * time.Second,
-			jsonPathExp:  "{.metadata.name}",
-			jsonPathCond: "foo-b6699dcfb-rnv7t",
+			timeout:                10 * time.Second,
+			jsonPathExp:            "{.metadata.name}",
+			jsonPathExpectedResult: "foo-b6699dcfb-rnv7t",
 
 			expectedErr: None,
 		},
@@ -1456,8 +1456,9 @@ func TestWaitForJSONPathCondition(t *testing.T) {
 
 				Printer: printers.NewDiscardingPrinter(),
 				ConditionFn: JSONPathWait{
-					jsonPathCondition: test.jsonPathCond,
-					jsonPathParser:    j, errOut: io.Discard}.IsJSONPathConditionMet,
+					jsonPathExpectedResult: test.jsonPathExpectedResult,
+					jsonPathParser:         j,
+					errOut:                 io.Discard}.IsJSONPathExpectedResultMet,
 				IOStreams: genericiooptions.NewTestIOStreamsDiscard(),
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Extends current JSONPath condition logic to support matching "any" value for the provided JSON path expression.
With this change, users will be able to wait on JSON path conditions with values they cannot know ahead including simple or complex (object or array) values. See https://github.com/kubernetes/kubernetes/issues/117761 for more details.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #117761 

#### Special notes for your reviewer:
This is my first contribution! Please go easy on me haha

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The "value" part in the `wait --for=jsonpath='{expression}'[=value]` is now optional. If the value is not provided i.e. the command looks like `wait --for=jsonpath='{expression}'` then the wait condition is interpreted as matched when the expression returns *any* single JSON value like object or a literal.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
