### PR TITLE
Deprecate admission plugins PodNodeSelector and PodTolerationRestriction

### DIFF
--- a/pkg/kubeapiserver/options/admission.go
+++ b/pkg/kubeapiserver/options/admission.go
@@ -23,6 +23,9 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/plugin/pkg/admission/podnodeselector"
+	"k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
@@ -121,6 +124,13 @@ func (a *AdmissionOptions) ApplyTo(
 	if a.PluginNames != nil {
 		// pass PluginNames to generic AdmissionOptions
 		a.GenericAdmission.EnablePlugins, a.GenericAdmission.DisablePlugins = computePluginNames(a.PluginNames, a.GenericAdmission.RecommendedPluginOrder)
+	}
+
+	if sets.New(a.GenericAdmission.EnablePlugins...).Has(podnodeselector.PluginName) {
+		klog.InfoS("PodNodeSelector admission plugin is deprecated and will be replaced by CEL admission in the future. It will be removed when mutating CEL admission becomes beta.")
+	}
+	if sets.New(a.GenericAdmission.EnablePlugins...).Has(podtolerationrestriction.PluginName) {
+		klog.InfoS("PodTolerationRestriction admission plugin is deprecated and will be replaced by CEL admission in the future. It will be removed when mutating CEL admission becomes beta.")
 	}
 
 	return a.GenericAdmission.ApplyTo(c, informers, kubeClient, dynamicClient, features, pluginInitializers...)

--- a/pkg/kubeapiserver/options/plugins.go
+++ b/pkg/kubeapiserver/options/plugins.go
@@ -125,9 +125,9 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	exists.Register(plugins)
 	noderestriction.Register(plugins)
 	nodetaint.Register(plugins)
-	label.Register(plugins) // DEPRECATED, future PVs should not rely on labels for zone topology
-	podnodeselector.Register(plugins)
-	podtolerationrestriction.Register(plugins)
+	label.Register(plugins)                    // DEPRECATED, future PVs should not rely on labels for zone topology
+	podnodeselector.Register(plugins)          // DEPRECATED, it will be replaced by CEL in the future.
+	podtolerationrestriction.Register(plugins) // DEPRECATED, it will be replaced by CEL in the future.
 	runtimeclass.Register(plugins)
 	resourcequota.Register(plugins)
 	podsecurity.Register(plugins)

--- a/plugin/pkg/admission/podnodeselector/admission.go
+++ b/plugin/pkg/admission/podnodeselector/admission.go
@@ -37,6 +37,10 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 )
 
+// This is deprecated. PodNodeSelector will be replaced by CEL admission
+// in the future.
+// See https://github.com/kubernetes/kubernetes/issues/113474 for details.
+
 // NamespaceNodeSelectors is for assigning node selectors labels to
 // namespaces. Default value is the annotation key
 // scheduler.alpha.kubernetes.io/node-selector

--- a/plugin/pkg/admission/podtolerationrestriction/admission.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission.go
@@ -39,6 +39,10 @@ import (
 	pluginapi "k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction"
 )
 
+// This is deprecated. PodTolerationRestriction will be replaced by CEL admission
+// in the future.
+// See https://github.com/kubernetes/kubernetes/issues/113474 for details.
+
 // PluginName is a string with the name of the plugin
 const PluginName = "PodTolerationRestriction"
 


### PR DESCRIPTION
PodNodeSelector admission plugin and PodTolerationRestriction has been in alpha for a long time, and now we have other more moden validation/mutation tools in-tree like CEL which is more lightweight and helps to reduce the maintenance cost. So we deprecated these two plugins and hope to migrate to CEL admission in the future. The mutating CEL admission is still under developing now and we will not remove these two plugins until it becomes beta

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind cleanup
/sig scheduling

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubernetes/issues/113474

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Deprecated admission plugins `PodNodeSelector` and `PodTolerationRestriction`, 
they will be replaced by CEL admissions in the future. 
We will not remove these two plugins until the mutating CEL admission becomes beta.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
