### PR TITLE
respect local GOPROXY setting in build/common.sh

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -30,6 +30,7 @@ GROUP_ID=$(id -g)
 DOCKER_OPTS=${DOCKER_OPTS:-""}
 IFS=" " read -r -a DOCKER <<< "docker ${DOCKER_OPTS}"
 DOCKER_HOST=${DOCKER_HOST:-""}
+GOPROXY=${GOPROXY:-""}
 
 # This will canonicalize the path
 KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd -P)
@@ -502,6 +503,7 @@ function kube::build::run_build_command_ex() {
     "--name=${container_name}"
     "--user=$(id -u):$(id -g)"
     "--hostname=${HOSTNAME}"
+    "-e=GOPROXY=${GOPROXY}"
     "${DOCKER_MOUNT_ARGS[@]}"
   )
 


### PR DESCRIPTION
/kind cleanup

When I run local build script, I failed for go proxy. 

```
export GOPROXY=https://goproxy.cn
```
Without the GOPROXY, we always failed to build. For instance, `hack/update-codegen.sh`

```release-note
None
```
