### PR TITLE
[bug] Fix server-side errors during validation

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
@@ -147,7 +147,10 @@ func (c *CreateClusterRoleOptions) Validate() error {
 			}
 		}
 		if err := c.validateResource(); err != nil {
-			return err
+			if c.DryRunStrategy != cmdutil.DryRunClient {
+				return err
+			}
+			fmt.Fprintf(c.ErrOut, "Warning (Server side): '%v'\n", err.Error())
 		}
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 )
 
@@ -213,9 +214,25 @@ func TestClusterRoleValidate(t *testing.T) {
 							Group: "extensions",
 						},
 					},
+					DryRunStrategy: cmdutil.DryRunServer,
 				},
 			},
 			expectErr: true,
+		},
+		"test-missing-resource-existing-apigroup-with-clientside-dryRun": {
+			clusterRoleOptions: &CreateClusterRoleOptions{
+				CreateRoleOptions: &CreateRoleOptions{
+					Name:  "my-clusterrole",
+					Verbs: []string{"get"},
+					Resources: []ResourceOptions{
+						{
+							Group: "extensions",
+						},
+					},
+					DryRunStrategy: cmdutil.DryRunClient,
+				},
+			},
+			expectErr: false,
 		},
 		"test-missing-resource-existing-subresource": {
 			clusterRoleOptions: &CreateClusterRoleOptions{
@@ -230,6 +247,21 @@ func TestClusterRoleValidate(t *testing.T) {
 				},
 			},
 			expectErr: true,
+		},
+		"test-missing-resource-existing-subresource-with-clientside-dryRun": {
+			clusterRoleOptions: &CreateClusterRoleOptions{
+				CreateRoleOptions: &CreateRoleOptions{
+					Name:  "my-clusterrole",
+					Verbs: []string{"get"},
+					Resources: []ResourceOptions{
+						{
+							SubResource: "scale",
+						},
+					},
+					DryRunStrategy: cmdutil.DryRunClient,
+				},
+			},
+			expectErr: false,
 		},
 		"test-invalid-verb": {
 			clusterRoleOptions: &CreateClusterRoleOptions{
@@ -317,6 +349,21 @@ func TestClusterRoleValidate(t *testing.T) {
 				},
 			},
 			expectErr: true,
+		},
+		"test-invalid-resource-with-clientside-dryRun": {
+			clusterRoleOptions: &CreateClusterRoleOptions{
+				CreateRoleOptions: &CreateRoleOptions{
+					Name:  "my-clusterrole",
+					Verbs: []string{"get"},
+					Resources: []ResourceOptions{
+						{
+							Resource: "invalid-resource",
+						},
+					},
+					DryRunStrategy: cmdutil.DryRunClient,
+				},
+			},
+			expectErr: false,
 		},
 		"test-resource-name-with-multiple-resources": {
 			clusterRoleOptions: &CreateClusterRoleOptions{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -309,7 +309,15 @@ func (o *CreateRoleOptions) Validate() error {
 		return fmt.Errorf("at least one resource must be specified")
 	}
 
-	return o.validateResource()
+	err := o.validateResource()
+
+	if err != nil {
+		if o.DryRunStrategy != cmdutil.DryRunClient {
+			return err
+		}
+		fmt.Fprintf(o.ErrOut, "Warning (Server side): '%v'\n", err.Error())
+	}
+	return nil
 }
 
 func (o *CreateRoleOptions) validateResource() error {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 )
 
@@ -193,6 +194,19 @@ func TestValidate(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		"test-missing-resource-existing-apigroup-with-clientside-dryRun": {
+			roleOptions: &CreateRoleOptions{
+				Name:  "my-role",
+				Verbs: []string{"get"},
+				Resources: []ResourceOptions{
+					{
+						Group: "extensions",
+					},
+				},
+				DryRunStrategy: cmdutil.DryRunClient,
+			},
+			expectErr: false,
+		},
 		"test-missing-resource-existing-subresource": {
 			roleOptions: &CreateRoleOptions{
 				Name:  "my-role",
@@ -204,6 +218,19 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			expectErr: true,
+		},
+		"test-missing-resource-existing-subresource-with-clientside-dryRun": {
+			roleOptions: &CreateRoleOptions{
+				Name:  "my-role",
+				Verbs: []string{"get"},
+				Resources: []ResourceOptions{
+					{
+						SubResource: "scale",
+					},
+				},
+				DryRunStrategy: cmdutil.DryRunClient,
+			},
+			expectErr: false,
 		},
 		"test-invalid-verb": {
 			roleOptions: &CreateRoleOptions{


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently, when the user specifies client side dryRun, the create command errors during validation with a server side errors, wherein we validate if the requested resource is available through mapper. This PR fixes the issue of not erroring in that scenario, and instead printing a warning of the server-side errors.

#### Which issue(s) this PR fixes:
No issue has been opened for this yet.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No.

This should be the expected behaviour and is a bug. 
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
Ref slack thread: https://kubernetes.slack.com/archives/C2GL57FJ4/p1683313785671629
