### PR TITLE
fix flaky test 'TestConnectionPings'

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/connection_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/connection_test.go
@@ -210,7 +210,7 @@ func TestConnectionPings(t *testing.T) {
 			return
 		}
 
-		var pingsSent int64
+		pingsSent := &atomic.Int64{}
 		srvSPDYConn := newConnection(
 			spdyConn,
 			func(stream httpstream.Stream, replySent <-chan struct{}) error {
@@ -220,7 +220,7 @@ func TestConnectionPings(t *testing.T) {
 			},
 			pingPeriod,
 			func() (time.Duration, error) {
-				atomic.AddInt64(&pingsSent, 1)
+				pingsSent.Add(1)
 				return 0, nil
 			})
 		defer srvSPDYConn.Close()
@@ -235,7 +235,7 @@ func TestConnectionPings(t *testing.T) {
 		}
 
 		// Count pings sent by the server.
-		gotPings := atomic.LoadInt64(&pingsSent)
+		gotPings := pingsSent.Load()
 		if gotPings < 1 {
 			t.Errorf("server: failed to send any pings (check logs)")
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind flake

#### What this PR does / why we need it:

If applied this commit will fix flaky test `TestConnectionPings` ([link](https://storage.googleapis.com/k8s-triage/index.html?pr=1&test=TestConnectionPings))

- before changes
<img width="687" alt="Screenshot 2023-05-07 at 23 17 27" src="https://user-images.githubusercontent.com/9576370/236703786-ce9330e1-8f8d-4226-8991-60c88b0bc05c.png">

- after changes
<img width="312" alt="Screenshot 2023-05-07 at 23 34 15" src="https://user-images.githubusercontent.com/9576370/236703796-6f0330e0-0192-45e4-aa60-81fbcb5c145d.png">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Spent a lot of time trying to understand why this test is flaky, not sure about my solution. According Go doc, [Int64.Add] is less error-prone. After hours this was the only thing I came up with, the test looks perfectly correct.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
