### PR TITLE
Exclude `ErrSignatureValidationFailed` from pull backoff

### DIFF
--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -420,30 +420,33 @@ func TestEvalCRIPullErr(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		input  error
-		assert func(string, error)
+		assert func(string, error, bool)
 	}{
 		{
 			name:  "fallback error",
 			input: errors.New("test"),
-			assert: func(msg string, err error) {
+			assert: func(msg string, err error, exclude bool) {
 				assert.ErrorIs(t, err, ErrImagePull)
 				assert.Contains(t, msg, "test")
+				assert.False(t, exclude)
 			},
 		},
 		{
 			name:  "registry is unavailable",
 			input: crierrors.ErrRegistryUnavailable,
-			assert: func(msg string, err error) {
+			assert: func(msg string, err error, exclude bool) {
 				assert.ErrorIs(t, err, crierrors.ErrRegistryUnavailable)
 				assert.Contains(t, msg, "registry is unavailable")
+				assert.False(t, exclude)
 			},
 		},
 		{
 			name:  "signature is invalid",
 			input: crierrors.ErrSignatureValidationFailed,
-			assert: func(msg string, err error) {
+			assert: func(msg string, err error, exclude bool) {
 				assert.ErrorIs(t, err, crierrors.ErrSignatureValidationFailed)
 				assert.Contains(t, msg, "signature validation failed")
+				assert.True(t, exclude)
 			},
 		},
 	} {
@@ -452,8 +455,8 @@ func TestEvalCRIPullErr(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			msg, err := evalCRIPullErr(&v1.Container{}, testInput)
-			testAssert(msg, err)
+			msg, err, exclude := evalCRIPullErr(&v1.Container{}, testInput)
+			testAssert(msg, err, exclude)
 		})
 	}
 }

--- a/staging/src/k8s.io/cri-api/pkg/errors/errors.go
+++ b/staging/src/k8s.io/cri-api/pkg/errors/errors.go
@@ -25,9 +25,11 @@ import (
 
 var (
 	// ErrRegistryUnavailable - Get http error on the PullImage RPC call.
+	// The kubelet will retry to pull the image using the standard backoff period.
 	ErrRegistryUnavailable = errors.New("RegistryUnavailable")
 
 	// ErrSignatureValidationFailed - Unable to validate the image signature on the PullImage RPC call.
+	// The kubelet will not retry to pull the image again on that error.
 	ErrSignatureValidationFailed = errors.New("SignatureValidationFailed")
 )
 


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
This allows to not re-pull the image if the signature verification failed by using a simple map for storing the previous error.

Follow-up on: https://github.com/kubernetes/kubernetes/pull/117717#discussion_r1182822512

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:
cc @haircommander 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Exclude `ErrSignatureValidationFailed` from pull backoff, means on that error the kubelet will not try to pull the image again.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
