### PR TITLE
Begin basic auth deprecation in kubectl

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
@@ -140,9 +140,11 @@ type AuthInfo struct {
 	ImpersonateUserExtra map[string][]string `json:"act-as-user-extra,omitempty"`
 	// Username is the username for basic authentication to the kubernetes cluster.
 	// +optional
+	// Deprecated Basic authentication has been deprecated. This flag will be removed in release 1.31
 	Username string `json:"username,omitempty"`
 	// Password is the password for basic authentication to the kubernetes cluster.
 	// +optional
+	// Deprecated Basic authentication has been deprecated. This flag will be removed in release 1.31
 	Password string `json:"password,omitempty" datapolicy:"password"`
 	// AuthProvider specifies a custom authentication plugin for the kubernetes cluster.
 	// +optional

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
@@ -130,9 +130,11 @@ type AuthInfo struct {
 	ImpersonateUserExtra map[string][]string `json:"as-user-extra,omitempty"`
 	// Username is the username for basic authentication to the kubernetes cluster.
 	// +optional
+	// Deprecated Basic authentication has been deprecated. This flag will be removed in release 1.31
 	Username string `json:"username,omitempty"`
 	// Password is the password for basic authentication to the kubernetes cluster.
 	// +optional
+	// Deprecated Basic authentication has been deprecated. This flag will be removed in release 1.31
 	Password string `json:"password,omitempty" datapolicy:"password"`
 	// AuthProvider specifies a custom authentication plugin for the kubernetes cluster.
 	// +optional

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
@@ -57,7 +57,7 @@ func NewCmdConfig(pathOptions *clientcmd.PathOptions, streams genericiooptions.I
 	// TODO(juanvallejo): update all subcommands to work with genericiooptions.IOStreams
 	cmd.AddCommand(NewCmdConfigView(streams, pathOptions))
 	cmd.AddCommand(NewCmdConfigSetCluster(streams.Out, pathOptions))
-	cmd.AddCommand(NewCmdConfigSetCredentials(streams.Out, pathOptions))
+	cmd.AddCommand(NewCmdConfigSetCredentials(streams, pathOptions))
 	cmd.AddCommand(NewCmdConfigSetContext(streams.Out, pathOptions))
 	cmd.AddCommand(NewCmdConfigSet(streams.Out, pathOptions))
 	cmd.AddCommand(NewCmdConfigUnset(streams.Out, pathOptions))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_credentials_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_credentials_test.go
@@ -417,7 +417,7 @@ func TestModifyExistingAuthInfo(t *testing.T) {
 				return
 			}
 
-			modifiedAuthInfo := opts.modifyAuthInfo(tt.existingAuthInfo)
+			modifiedAuthInfo := opts.modifyAuthInfo(tt.existingAuthInfo, os.Stdout)
 
 			if !reflect.DeepEqual(modifiedAuthInfo, tt.wantAuthInfo) {
 				t.Errorf("case %s: flags %q: mis-matched auth info,\nwanted=%#v\ngot=   %#v", tt.name, tt.flags, tt.wantAuthInfo, modifiedAuthInfo)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/set_credentials_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/set_credentials_test.go
@@ -17,12 +17,11 @@ limitations under the License.
 package config
 
 import (
-	"bytes"
-	utiltesting "k8s.io/client-go/util/testing"
 	"os"
 	"reflect"
 	"testing"
 
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -202,29 +201,29 @@ func TestSetCredentialsOptions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buff := new(bytes.Buffer)
+			streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 			opts := new(setCredentialsOptions)
-			cmd := newCmdConfigSetCredentials(buff, opts)
+			cmd := newCmdConfigSetCredentials(streams, opts)
 			if err := cmd.ParseFlags(tt.flags); err != nil {
 				if !tt.wantParseErr {
-					t.Errorf("case %s: parsing error for flags %q: %v: %s", tt.name, tt.flags, err, buff)
+					t.Errorf("case %s: parsing error for flags %q: %v: %s", tt.name, tt.flags, err, buf)
 				}
 				return
 			}
 			if tt.wantParseErr {
-				t.Errorf("case %s: expected parsing error for flags %q: %s", tt.name, tt.flags, buff)
+				t.Errorf("case %s: expected parsing error for flags %q: %s", tt.name, tt.flags, buf)
 				return
 			}
 
 			if err := opts.complete(cmd); err != nil {
 				if !tt.wantCompleteErr {
-					t.Errorf("case %s: complete() error for flags %q: %s", tt.name, tt.flags, buff)
+					t.Errorf("case %s: complete() error for flags %q: %s", tt.name, tt.flags, buf)
 				}
 				return
 			}
 			if tt.wantCompleteErr {
-				t.Errorf("case %s: complete() expected errors for flags %q: %s", tt.name, tt.flags, buff)
+				t.Errorf("case %s: complete() expected errors for flags %q: %s", tt.name, tt.flags, buf)
 				return
 			}
 
@@ -379,29 +378,29 @@ func TestModifyExistingAuthInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buff := new(bytes.Buffer)
+			streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 			opts := new(setCredentialsOptions)
-			cmd := newCmdConfigSetCredentials(buff, opts)
+			cmd := newCmdConfigSetCredentials(streams, opts)
 			if err := cmd.ParseFlags(tt.flags); err != nil {
 				if !tt.wantParseErr {
-					t.Errorf("case %s: parsing error for flags %q: %v: %s", tt.name, tt.flags, err, buff)
+					t.Errorf("case %s: parsing error for flags %q: %v: %s", tt.name, tt.flags, err, buf)
 				}
 				return
 			}
 			if tt.wantParseErr {
-				t.Errorf("case %s: expected parsing error for flags %q: %s", tt.name, tt.flags, buff)
+				t.Errorf("case %s: expected parsing error for flags %q: %s", tt.name, tt.flags, buf)
 				return
 			}
 
 			if err := opts.complete(cmd); err != nil {
 				if !tt.wantCompleteErr {
-					t.Errorf("case %s: complete() error for flags %q: %s", tt.name, tt.flags, buff)
+					t.Errorf("case %s: complete() error for flags %q: %s", tt.name, tt.flags, buf)
 				}
 				return
 			}
 			if tt.wantCompleteErr {
-				t.Errorf("case %s: complete() expected errors for flags %q: %s", tt.name, tt.flags, buff)
+				t.Errorf("case %s: complete() expected errors for flags %q: %s", tt.name, tt.flags, buf)
 				return
 			}
 
@@ -417,7 +416,7 @@ func TestModifyExistingAuthInfo(t *testing.T) {
 				return
 			}
 
-			modifiedAuthInfo := opts.modifyAuthInfo(tt.existingAuthInfo, os.Stdout)
+			modifiedAuthInfo := opts.modifyAuthInfo(tt.existingAuthInfo, streams)
 
 			if !reflect.DeepEqual(modifiedAuthInfo, tt.wantAuthInfo) {
 				t.Errorf("case %s: flags %q: mis-matched auth info,\nwanted=%#v\ngot=   %#v", tt.name, tt.flags, tt.wantAuthInfo, modifiedAuthInfo)
@@ -467,8 +466,8 @@ func (test setCredentialsTest) run(t *testing.T) {
 	pathOptions := clientcmd.NewDefaultPathOptions()
 	pathOptions.GlobalFile = fakeKubeFile.Name()
 	pathOptions.EnvVar = ""
-	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdConfigSetCredentials(buf, pathOptions)
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+	cmd := NewCmdConfigSetCredentials(streams, pathOptions)
 	cmd.SetArgs(test.args)
 	cmd.Flags().Parse(test.flags)
 	if err := cmd.Execute(); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR begins the deprecation process for basic auth in kubectl set-credentials.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1389

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added deprecation message to `kubectl config set-credentials` subcommand when used in HTTP Basic
authentication mode.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
