### PR TITLE
Fix make etcd image failed

### DIFF
--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -180,9 +180,9 @@ else
 
 	# Add this ENV variable in order to workaround an unsupported arch blocker
 	# On arm (which is 32-bit), it can't handle >1GB data in-memory
-	ifeq ($(ARCH),arm)
+        ifeq ($(ARCH),arm)
 		cd $(TEMP_DIR) && echo "ENV ETCD_UNSUPPORTED_ARCH=$(ARCH)" >> $(DOCKERFILE)
-	endif
+        endif
 endif
 
 	docker run --rm --privileged multiarch/qemu-user-static:$(QEMUVERSION) --reset -p yes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/117557


The failed messages are because `ifeq` is must be `white-space`,  but in https://github.com/kubernetes/kubernetes/pull/115255/files#diff-de315dbb88d6d341b1682ef2fb0798723139fb4202ac607a334fc301e9359ec7R184, it is `TAB` .  So make failed.
 
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-kubernetes-push-image-etcd/1649533793343639552#1:build-log.txt%3A664
````
done
# Add this ENV variable in order to workaround an unsupported arch blocker
# On arm (which is 32-bit), it can't handle >1GB data in-memory
ifeq (arm,arm)
/bin/sh: syntax error: unexpected word (expecting ")")
make[1]: *** [Makefile:133: build] Error 2
make[1]: Leaving directory '/workspace/cluster/images/etcd'
make: *** [Makefile:215: sub-push-image-linux-arm] Error 2
````


# Before: 
```
make OUTPUT_TYPE=registry OS=linux ARCH=arm OSVERSION= REGISTRY=gcr.io/k8s-staging-etcd 
# Explicitly copy files to the temp directory
# Download etcd in a golang container and cross-compile it statically
# For each release create a tmp dir 'etcd_release_tmp_dir' and unpack the release tar there.
arch_prefix=""
arch_prefix="GOARM=7"
# use '/go/src/go.etcd.io/etcd' to build etcd 3.4 and later.
# Add this ENV variable in order to workaround an unsupported arch blocker
# On arm (which is 32-bit), it can't handle >1GB data in-memory
ifeq (arm,arm)
/bin/sh: 1: Syntax error: word unexpected (expecting ")")
make: *** [Makefile:127: build] Error 2
```


# After:
```
make OUTPUT_TYPE=registry OS=linux ARCH=arm OSVERSION= REGISTRY=gcr.io/k8s-staging-etcd 
# Explicitly copy files to the temp directory
# Download etcd in a golang container and cross-compile it statically
# For each release create a tmp dir 'etcd_release_tmp_dir' and unpack the release tar there.
arch_prefix=""
arch_prefix="GOARM=7"
# use '/go/src/go.etcd.io/etcd' to build etcd 3.4 and later.
# Add this ENV variable in order to workaround an unsupported arch blocker
# On arm (which is 32-bit), it can't handle >1GB data in-memory
cd /tmp/tmp.Ss3koCa796 && echo "ENV ETCD_UNSUPPORTED_ARCH=arm" >> Dockerfile
docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2 --reset -p yes
Setting /usr/bin/qemu-alpha-static as binfmt interpreter for alpha
Setting /usr/bin/qemu-arm-static as binfmt interpreter for arm
Setting /usr/bin/qemu-armeb-static as binfmt interpreter for armeb
Setting /usr/bin/qemu-sparc-static as binfmt interpreter for sparc
Setting /usr/bin/qemu-sparc32plus-static as binfmt interpreter for sparc32plus
Setting /usr/bin/qemu-sparc64-static as binfmt interpreter for sparc64
Setting /usr/bin/qemu-ppc-static as binfmt interpreter for ppc
Setting /usr/bin/qemu-ppc64-static as binfmt interpreter for ppc64
Setting /usr/bin/qemu-ppc64le-static as binfmt interpreter for ppc64le
Setting /usr/bin/qemu-m68k-static as binfmt interpreter for m68k
Setting /usr/bin/qemu-mips-static as binfmt interpreter for mips
Setting /usr/bin/qemu-mipsel-static as binfmt interpreter for mipsel
Setting /usr/bin/qemu-mipsn32-static as binfmt interpreter for mipsn32
Setting /usr/bin/qemu-mipsn32el-static as binfmt interpreter for mipsn32el
Setting /usr/bin/qemu-mips64-static as binfmt interpreter for mips64
Setting /usr/bin/qemu-mips64el-static as binfmt interpreter for mips64el
Setting /usr/bin/qemu-sh4-static as binfmt interpreter for sh4
Setting /usr/bin/qemu-sh4eb-static as binfmt interpreter for sh4eb
Setting /usr/bin/qemu-s390x-static as binfmt interpreter for s390x
```




#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
