### PR TITLE
Export GOMAXPROCS environment variable

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -568,6 +568,7 @@ kube::golang::setup_env() {
   fi
 
   GOMAXPROCS=${GOMAXPROCS:-$(ncpu)}
+  export GOMAXPROCS
   kube::log::status "Setting GOMAXPROCS: ${GOMAXPROCS}"
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It seems that just setting GOMAXPROCS environment variable doesn't have effect for all jobs. For example, `ci-benchmark-scheduler-perf-master-eks-canary` has autodetection but it doesn't have any effect:

```
+++ [0509 09:49:56] Setting GOMAXPROCS: 6
```

Even with that, the job was consistently failing until we didn't explicitly set GOMAXPROCS in https://github.com/kubernetes/test-infra/pull/29423

Additionally, I think this change makes sense because we export all other Go-related environment variables (such as GOPATH, GOROOT, GOOS, GOARCH).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

/assign @dims 