### PR TITLE
Add image pull policy to run command

### DIFF
--- a/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/README.md
+++ b/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/README.md
@@ -37,7 +37,7 @@ kubectl create clusterrolebinding default-view --clusterrole=view --serviceaccou
 
 Then, run the image in a Pod with a single instance Deployment:
 
-    kubectl run --rm -i demo --image=in-cluster
+    kubectl run --rm -i demo --image=in-cluster --image-pull-policy=IfNotPresent
 
     There are 4 pods in the cluster
     There are 4 pods in the cluster


### PR DESCRIPTION
The default image pull policy would try and pull the `in-cluster` image from the docker repository. Since this was a local image, we should instruct kubernetes to not pull, but use the image that is inside of its docker instance.

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Updates the example for running inside of a minikube instance with the correct image pull policy

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
