### PR TITLE
When expecting pods count only active ones

### DIFF
--- a/test/e2e/framework/statefulset/wait.go
+++ b/test/e2e/framework/statefulset/wait.go
@@ -98,7 +98,7 @@ func WaitForPodReady(ctx context.Context, c clientset.Interface, set *appsv1.Sta
 
 // WaitForStatusReadyReplicas waits for the ss.Status.ReadyReplicas to be equal to expectedReplicas
 func WaitForStatusReadyReplicas(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet, expectedReplicas int32) {
-	framework.Logf("Waiting for statefulset status.replicas updated to %d", expectedReplicas)
+	framework.Logf("Waiting for statefulset status.readyReplicas updated to %d", expectedReplicas)
 
 	ns, name := ss.Namespace, ss.Name
 	pollErr := wait.PollImmediateWithContext(ctx, StatefulSetPoll, StatefulSetTimeout,
@@ -111,13 +111,13 @@ func WaitForStatusReadyReplicas(ctx context.Context, c clientset.Interface, ss *
 				return false, nil
 			}
 			if ssGet.Status.ReadyReplicas != expectedReplicas {
-				framework.Logf("Waiting for stateful set status.readyReplicas to become %d, currently %d", expectedReplicas, ssGet.Status.ReadyReplicas)
+				framework.Logf("Waiting for statefulset status.readyReplicas to become %d, currently %d", expectedReplicas, ssGet.Status.ReadyReplicas)
 				return false, nil
 			}
 			return true, nil
 		})
 	if pollErr != nil {
-		framework.Failf("Failed waiting for stateful set status.readyReplicas updated to %d: %v", expectedReplicas, pollErr)
+		framework.Failf("Failed waiting for statefulset status.readyReplicas updated to %d: %v", expectedReplicas, pollErr)
 	}
 }
 
@@ -136,13 +136,13 @@ func WaitForStatusAvailableReplicas(ctx context.Context, c clientset.Interface, 
 				return false, nil
 			}
 			if ssGet.Status.AvailableReplicas != expectedReplicas {
-				framework.Logf("Waiting for stateful set status.AvailableReplicas to become %d, currently %d", expectedReplicas, ssGet.Status.AvailableReplicas)
+				framework.Logf("Waiting for statefulset status.AvailableReplicas to become %d, currently %d", expectedReplicas, ssGet.Status.AvailableReplicas)
 				return false, nil
 			}
 			return true, nil
 		})
 	if pollErr != nil {
-		framework.Failf("Failed waiting for stateful set status.AvailableReplicas updated to %d: %v", expectedReplicas, pollErr)
+		framework.Failf("Failed waiting for statefulset status.AvailableReplicas updated to %d: %v", expectedReplicas, pollErr)
 	}
 }
 
@@ -161,13 +161,13 @@ func WaitForStatusReplicas(ctx context.Context, c clientset.Interface, ss *appsv
 				return false, nil
 			}
 			if ssGet.Status.Replicas != expectedReplicas {
-				framework.Logf("Waiting for stateful set status.replicas to become %d, currently %d", expectedReplicas, ssGet.Status.Replicas)
+				framework.Logf("Waiting for statefulset status.replicas to become %d, currently %d", expectedReplicas, ssGet.Status.Replicas)
 				return false, nil
 			}
 			return true, nil
 		})
 	if pollErr != nil {
-		framework.Failf("Failed waiting for stateful set status.replicas updated to %d: %v", expectedReplicas, pollErr)
+		framework.Failf("Failed waiting for statefulset status.replicas updated to %d: %v", expectedReplicas, pollErr)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
I've noticed this happening in some edge cases when it'll take a bit longer for the pod to be cleaned up by the garbage collector or due to extended pv detachment. When we check the running pod names we should only count the running ones and not all. 

I've also fixed a few minor bits around printing information while waiting for statefulsets for accuracy. 

#### Special notes for your reviewer:
/assign @atiratree 
/cc @pwschuurman 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
