### PR TITLE
Write e2e test for PodEphemeralcontainers endpoints + 2 Endpoints

### DIFF
--- a/test/e2e/common/node/ephemeral_containers.go
+++ b/test/e2e/common/node/ephemeral_containers.go
@@ -18,10 +18,16 @@ package node
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -80,4 +86,88 @@ var _ = SIGDescribe("Ephemeral Containers [NodeConformance]", func() {
 		framework.ExpectNoError(err, "Failed to get logs for pod %q ephemeral container %q", e2epod.FormatPod(pod), ecName)
 		gomega.Expect(log).To(gomega.ContainSubstring("polo"))
 	})
+
+	ginkgo.It("should update the ephemeral containers in an existing pod", func(ctx context.Context) {
+		ginkgo.By("creating a target pod")
+		pod := podClient.CreateSync(ctx, &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "ephemeral-containers-target-pod"},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:    "test-container-1",
+						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+						Command: []string{"/bin/sleep"},
+						Args:    []string{"10000"},
+					},
+				},
+			},
+		})
+
+		ginkgo.By("adding an ephemeral container")
+		ecName := "debugger"
+		ec := &v1.EphemeralContainer{
+			EphemeralContainerCommon: v1.EphemeralContainerCommon{
+				Name:    ecName,
+				Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+				Command: e2epod.GenerateScriptCmd("while true; do echo polo; sleep 2; done"),
+				Stdin:   true,
+				TTY:     true,
+			},
+		}
+		err := podClient.AddEphemeralContainerSync(ctx, pod, ec, time.Minute)
+		framework.ExpectNoError(err, "Failed to patch ephemeral containers in pod %q", e2epod.FormatPod(pod))
+
+		ginkgo.By("checking pod container endpoints")
+		// Can't use anything depending on kubectl here because it's not available in the node test environment
+		output := e2epod.ExecCommandInContainer(f, pod.Name, ecName, "/bin/echo", "marco")
+		gomega.Expect(output).To(gomega.ContainSubstring("marco"))
+		log, err := e2epod.GetPodLogs(ctx, f.ClientSet, pod.Namespace, pod.Name, ecName)
+		framework.ExpectNoError(err, "Failed to get logs for pod %q ephemeral container %q", e2epod.FormatPod(pod), ecName)
+		gomega.Expect(log).To(gomega.ContainSubstring("polo"))
+
+		ginkgo.By(fmt.Sprintf("checking pod %q has only one ephemeralcontainer", pod.Name))
+		podResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+		unstruct, err := f.DynamicClient.Resource(podResource).Namespace(f.Namespace.Name).Get(ctx, "ephemeral-containers-target-pod", metav1.GetOptions{}, "ephemeralcontainers")
+		framework.ExpectNoError(err, "can't get ephermalcontainers")
+		verifyPod, err := unstructuredToPod(unstruct)
+		framework.ExpectNoError(err, "Getting the %q pod's ephemeralcontainers", verifyPod.Name)
+		gomega.Expect(verifyPod.Spec.EphemeralContainers).To(gomega.HaveLen(1), "checking ephemeralContainer count")
+
+		ginkgo.By(fmt.Sprintf("adding another ephemeralcontainer to pod %q", pod.Name))
+		var podToUpdate *v1.Pod
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			podToUpdate, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err, "Unable to retrieve pod %s", pod.Name)
+
+			podToUpdate.Spec.EphemeralContainers = append(podToUpdate.Spec.EphemeralContainers, v1.EphemeralContainer{
+				EphemeralContainerCommon: v1.EphemeralContainerCommon{
+					Name:                     "debugger2",
+					Image:                    imageutils.GetE2EImage(imageutils.Agnhost),
+					ImagePullPolicy:          "IfNotPresent",
+					TerminationMessagePolicy: "File",
+				},
+			})
+			_, err = podClient.UpdateEphemeralContainers(context.TODO(), pod.Name, podToUpdate, metav1.UpdateOptions{})
+			return err
+		})
+		framework.ExpectNoError(err, "Failed to update ephemeral container.")
+
+		ginkgo.By(fmt.Sprintf("checking pod %q has only two ephemeralcontainers", pod.Name))
+		unstruct, err = f.DynamicClient.Resource(podResource).Namespace(f.Namespace.Name).Get(ctx, "ephemeral-containers-target-pod", metav1.GetOptions{}, "ephemeralcontainers")
+		framework.ExpectNoError(err, "can't get ephermalcontainers")
+		verifyPod, err = unstructuredToPod(unstruct)
+		framework.ExpectNoError(err, "Getting the %q pod's ephemeralcontainers", verifyPod.Name)
+		gomega.Expect(verifyPod.Spec.EphemeralContainers).To(gomega.HaveLen(2), "checking ephemeralContainer count")
+	})
 })
+
+func unstructuredToPod(obj *unstructured.Unstructured) (*v1.Pod, error) {
+	json, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+	p := &v1.Pod{}
+	err = runtime.DecodeInto(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), json, p)
+
+	return p, err
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- readCoreV1NamespacedPodEphemeralcontainers
- replaceCoreV1NamespacedPodEphemeralcontainers

**Which issue(s) this PR fixes:**
Fixes #117894

**Testgrid Link:**
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.update.the.ephemeral.containers.in.an.existing.pod)


**Special notes for your reviewer:**
Adds +2 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance