### PR TITLE
Deprecate generate*groups.sh -> kube_codegen.sh

### DIFF
--- a/staging/src/k8s.io/code-generator/generate-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-groups.sh
@@ -49,6 +49,10 @@ APIS_PKG="$3"
 GROUPS_WITH_VERSIONS="$4"
 shift 4
 
+echo "WARNING: $(basename "$0") is deprecated."
+echo "WARNING: Please use k8s.io/code-generator/kube_codegen.sh instead."
+echo
+
 if [ "${GENS}" = "all" ] || grep -qw "all" <<<"${GENS}"; then
     ALL="applyconfiguration,client,deepcopy,informer,lister"
     echo "WARNING: Specifying \"all\" as a generator is deprecated."

--- a/staging/src/k8s.io/code-generator/generate-internal-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-internal-groups.sh
@@ -51,6 +51,10 @@ EXT_APIS_PKG="$4"
 GROUPS_WITH_VERSIONS="$5"
 shift 5
 
+echo "WARNING: $(basename "$0") is deprecated."
+echo "WARNING: Please use k8s.io/code-generator/kube_codegen.sh instead."
+echo
+
 if [ "${GENS}" = "all" ] || grep -qw "all" <<<"${GENS}"; then
     ALL="client,conversion,deepcopy,defaulter,informer,lister,openapi"
     echo "WARNING: Specifying \"all\" as a generator is deprecated."


### PR DESCRIPTION
/kind cleanup

```release-note
The `generate_groups.sh` and `generate_internal_groups.sh` scripts from the k8s.io/code-generator repo are deprecated (but still work) in favor of `kube_codegen.sh` in that same repo.  Projects which use the old scripts are encouraged to look at adopting the new one.
```
