### PR TITLE
Codegen: subprojects openapi

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -898,8 +898,8 @@ function codegen::subprojects() {
         vendor/k8s.io/kube-aggregator
         vendor/k8s.io/sample-apiserver
         vendor/k8s.io/sample-controller
-        vendor/k8s.io/apiextensions-apiserver
         vendor/k8s.io/metrics
+        vendor/k8s.io/apiextensions-apiserver
         vendor/k8s.io/apiextensions-apiserver/examples/client-go
     )
 

--- a/staging/src/k8s.io/apiextensions-apiserver/hack/update-codegen.sh
+++ b/staging/src/k8s.io/apiextensions-apiserver/hack/update-codegen.sh
@@ -28,6 +28,13 @@ kube::codegen::gen_helpers \
     --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
     --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
 
+kube::codegen::gen_openapi \
+    --input-pkg-root k8s.io/apiextensions-apiserver/pkg \
+    --extra-pkgs k8s.io/api/autoscaling/v1 `# needed for Scale type` \
+    --output-pkg-root k8s.io/apiextensions-apiserver/pkg/generated \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+
 kube::codegen::gen_client \
     --with-watch \
     --input-pkg-root k8s.io/apiextensions-apiserver/pkg/apis \

--- a/staging/src/k8s.io/kube-aggregator/hack/update-codegen.sh
+++ b/staging/src/k8s.io/kube-aggregator/hack/update-codegen.sh
@@ -28,6 +28,12 @@ kube::codegen::gen_helpers \
     --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
     --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
 
+kube::codegen::gen_openapi \
+    --input-pkg-root k8s.io/kube-aggregator/pkg/apis \
+    --output-pkg-root k8s.io/kube-aggregator/pkg/generated \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+
 kube::codegen::gen_client \
     --with-watch \
     --input-pkg-root k8s.io/kube-aggregator/pkg/apis \


### PR DESCRIPTION
Use the "subprojects" aspect of update-codegen to generate openapi for the subprojects.  Next we can simplify and remove the generic support.

apiextensions-apiserver seems like it was ALWAYS broken: k8s.io/apiextensions/ doesn't exist, but k8s.io/apiextensions-apiserver does.

Fixing that causes different openapi results, obviously.

/kind bug
/kind cleanup

```release-note
NONE
```
