### PR TITLE
apimachinery/util: stop using deprecated io/ioutil

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/framer/framer_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/framer/framer_test.go
@@ -19,7 +19,6 @@ package framer
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 )
 
@@ -34,7 +33,7 @@ func TestRead(t *testing.T) {
 		0x08,
 	}
 	b := bytes.NewBuffer(data)
-	r := NewLengthDelimitedFrameReader(ioutil.NopCloser(b))
+	r := NewLengthDelimitedFrameReader(io.NopCloser(b))
 	buf := make([]byte, 1)
 	if n, err := r.Read(buf); err != io.ErrShortBuffer && n != 1 && bytes.Equal(buf, []byte{0x01}) {
 		t.Fatalf("unexpected: %v %d %v", err, n, buf)
@@ -79,7 +78,7 @@ func TestReadLarge(t *testing.T) {
 		0x08,
 	}
 	b := bytes.NewBuffer(data)
-	r := NewLengthDelimitedFrameReader(ioutil.NopCloser(b))
+	r := NewLengthDelimitedFrameReader(io.NopCloser(b))
 	buf := make([]byte, 40)
 	if n, err := r.Read(buf); err != nil && n != 4 && bytes.Equal(buf, []byte{0x01, 0x02, 0x03, 0x04}) {
 		t.Fatalf("unexpected: %v %d %v", err, n, buf)
@@ -104,7 +103,7 @@ func TestReadInvalidFrame(t *testing.T) {
 		0x01, 0x02,
 	}
 	b := bytes.NewBuffer(data)
-	r := NewLengthDelimitedFrameReader(ioutil.NopCloser(b))
+	r := NewLengthDelimitedFrameReader(io.NopCloser(b))
 	buf := make([]byte, 1)
 	if n, err := r.Read(buf); err != io.ErrShortBuffer && n != 1 && bytes.Equal(buf, []byte{0x01}) {
 		t.Fatalf("unexpected: %v %d %v", err, n, buf)
@@ -122,7 +121,7 @@ func TestReadInvalidFrame(t *testing.T) {
 
 func TestJSONFrameReader(t *testing.T) {
 	b := bytes.NewBufferString("{\"test\":true}\n1\n[\"a\"]")
-	r := NewJSONFramedReader(ioutil.NopCloser(b))
+	r := NewJSONFramedReader(io.NopCloser(b))
 	buf := make([]byte, 20)
 	if n, err := r.Read(buf); err != nil || n != 13 || string(buf[:n]) != `{"test":true}` {
 		t.Fatalf("unexpected: %v %d %q", err, n, buf)
@@ -140,7 +139,7 @@ func TestJSONFrameReader(t *testing.T) {
 
 func TestJSONFrameReaderShortBuffer(t *testing.T) {
 	b := bytes.NewBufferString("{\"test\":true}\n1\n[\"a\"]")
-	r := NewJSONFramedReader(ioutil.NopCloser(b))
+	r := NewJSONFramedReader(io.NopCloser(b))
 	buf := make([]byte, 3)
 
 	if n, err := r.Read(buf); err != io.ErrShortBuffer || n != 3 || string(buf[:n]) != `{"t` {

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -23,7 +23,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -337,7 +337,7 @@ func (s *SpdyRoundTripper) NewConnection(resp *http.Response) (httpstream.Connec
 	if (resp.StatusCode != http.StatusSwitchingProtocols) || !strings.Contains(connectionHeader, strings.ToLower(httpstream.HeaderUpgrade)) || !strings.Contains(upgradeHeader, strings.ToLower(HeaderSpdy31)) {
 		defer resp.Body.Close()
 		responseError := ""
-		responseErrorBytes, err := ioutil.ReadAll(resp.Body)
+		responseErrorBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			responseError = "unable to read error from server response"
 		} else {

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/fieldmanager_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/fieldmanager_test.go
@@ -19,8 +19,8 @@ package managedfields_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -42,7 +42,7 @@ import (
 )
 
 var fakeTypeConverter = func() managedfields.TypeConverter {
-	data, err := ioutil.ReadFile(filepath.Join(strings.Repeat(".."+string(filepath.Separator), 7),
+	data, err := os.ReadFile(filepath.Join(strings.Repeat(".."+string(filepath.Separator), 7),
 		"api", "openapi-spec", "swagger.json"))
 	if err != nil {
 		panic(err)
@@ -264,7 +264,7 @@ func TestApplyDoesNotStripLabels(t *testing.T) {
 }
 
 func getObjectBytes(file string) []byte {
-	s, err := ioutil.ReadFile(file)
+	s, err := os.ReadFile(file)
 	if err != nil {
 		panic(err)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/fieldmanager_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/fieldmanager_test.go
@@ -18,7 +18,7 @@ package internal_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -27,7 +27,7 @@ import (
 )
 
 var fakeTypeConverter = func() internal.TypeConverter {
-	data, err := ioutil.ReadFile(filepath.Join(
+	data, err := os.ReadFile(filepath.Join(
 		strings.Repeat(".."+string(filepath.Separator), 8),
 		"api", "openapi-spec", "swagger.json"))
 	if err != nil {

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/versionconverter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/versionconverter_test.go
@@ -19,7 +19,7 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -32,7 +32,7 @@ import (
 )
 
 var testTypeConverter = func() TypeConverter {
-	data, err := ioutil.ReadFile(filepath.Join("testdata", "swagger.json"))
+	data, err := os.ReadFile(filepath.Join("testdata", "swagger.json"))
 	if err != nil {
 		panic(err)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
@@ -18,7 +18,6 @@ package net
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -700,7 +699,7 @@ func TestGetIPFromHostInterfaces(t *testing.T) {
 }
 
 func makeRouteFile(content string, t *testing.T) (*os.File, error) {
-	routeFile, err := ioutil.TempFile("", "route")
+	routeFile, err := os.CreateTemp("", "route")
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport.go
@@ -22,7 +22,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -263,7 +262,7 @@ func (t *Transport) rewriteResponse(req *http.Request, resp *http.Response) (*ht
 		return resp, err
 	}
 
-	resp.Body = ioutil.NopCloser(newContent)
+	resp.Body = io.NopCloser(newContent)
 	// Update header node with new content-length
 	// TODO: Remove any hash/signature headers here?
 	resp.Header.Del("Content-Length")

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport_test.go
@@ -21,7 +21,7 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -300,7 +300,7 @@ func TestProxyTransport(t *testing.T) {
 			}
 			return
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Errorf("%v: Unexpected error: %v", name, err)
 			return
@@ -342,12 +342,12 @@ func TestRewriteResponse(t *testing.T) {
 				gzw.Write([]byte(ept))
 				gzw.Flush()
 				return &http.Response{
-					Body: ioutil.NopCloser(gzipbuf),
+					Body: io.NopCloser(gzipbuf),
 				}
 			},
 			reader: func(rep *http.Response) string {
 				reader, _ := gzip.NewReader(rep.Body)
-				s, _ := ioutil.ReadAll(reader)
+				s, _ := io.ReadAll(reader)
 				return string(s)
 			},
 		},
@@ -360,12 +360,12 @@ func TestRewriteResponse(t *testing.T) {
 				flw.Write([]byte(ept))
 				flw.Flush()
 				return &http.Response{
-					Body: ioutil.NopCloser(flatebuf),
+					Body: io.NopCloser(flatebuf),
 				}
 			},
 			reader: func(rep *http.Response) string {
 				reader := flate.NewReader(rep.Body)
-				s, _ := ioutil.ReadAll(reader)
+				s, _ := io.ReadAll(reader)
 				return string(s)
 			},
 		},

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -148,7 +147,7 @@ func (onewayRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		Status:     "200 OK",
 		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(&bytes.Buffer{}),
+		Body:       io.NopCloser(&bytes.Buffer{}),
 		Request:    req,
 	}, nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -100,7 +99,7 @@ func (s *SimpleBackendHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 	s.requestHeader = req.Header
 	s.requestMethod = req.Method
 	var err error
-	s.requestBody, err = ioutil.ReadAll(req.Body)
+	s.requestBody, err = io.ReadAll(req.Body)
 	if err != nil {
 		s.t.Errorf("Unexpected error: %v", err)
 		return
@@ -370,7 +369,7 @@ func TestServeHTTP(t *testing.T) {
 			validateHeaders(t, test.name+" backend headers", res.Header, test.expectedRespHeader, test.notExpectedRespHeader)
 
 			// Validate Body
-			responseBody, err := ioutil.ReadAll(res.Body)
+			responseBody, err := io.ReadAll(res.Body)
 			if err != nil {
 				t.Errorf("Unexpected error reading response body: %v", err)
 			}
@@ -601,7 +600,7 @@ func TestProxyUpgradeConnectionErrorResponse(t *testing.T) {
 	// Expect error response.
 	assert.True(t, responder.called)
 	assert.Equal(t, fakeStatusCode, resp.StatusCode)
-	msg, err := ioutil.ReadAll(resp.Body)
+	msg, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Contains(t, string(msg), expectedErr.Error())
 }
@@ -640,7 +639,7 @@ func TestProxyUpgradeErrorResponseTerminates(t *testing.T) {
 			// Verify we get the correct response and full message body content
 			resp, err := http.ReadResponse(bufferedReader, nil)
 			require.NoError(t, err)
-			data, err := ioutil.ReadAll(resp.Body)
+			data, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			require.Equal(t, resp.StatusCode, code)
 			require.Equal(t, data, []byte(`some data`))
@@ -790,7 +789,7 @@ func TestRejectForwardingRedirectsOption(t *testing.T) {
 			resp, err := http.ReadResponse(bufferedReader, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectStatusCode, resp.StatusCode)
-			data, err := ioutil.ReadAll(resp.Body)
+			data, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectBody, data)
 			assert.Equal(t, int64(len(tc.expectBody)), resp.ContentLength)
@@ -976,7 +975,7 @@ func TestProxyRequestContentLengthAndTransferEncoding(t *testing.T) {
 			}
 
 			// Read body
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			if err != nil {
 				t.Errorf("%s: unexpected error %v", k, err)
 			}
@@ -1039,7 +1038,7 @@ func TestProxyRequestContentLengthAndTransferEncoding(t *testing.T) {
 		}
 
 		// Read response
-		response, err := ioutil.ReadAll(conn)
+		response, err := io.ReadAll(conn)
 		if err != nil {
 			t.Errorf("%s: unexpected error %v", k, err)
 			continue

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/testing/openapi.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/testing/openapi.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testing
 
 import (
-	"io/ioutil"
 	"os"
 	"sync"
 
@@ -43,7 +42,7 @@ func (f *Fake) OpenAPISchema() (*openapi_v2.Document, error) {
 			f.err = err
 			return
 		}
-		spec, err := ioutil.ReadFile(f.Path)
+		spec, err := os.ReadFile(f.Path)
 		if err != nil {
 			f.err = err
 			return

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"reflect"
 	"strings"
@@ -45,7 +44,7 @@ stuff: 1
 	}
 
 	for i, testCase := range testCases {
-		r := NewDocumentDecoder(ioutil.NopCloser(bytes.NewReader([]byte(d))))
+		r := NewDocumentDecoder(io.NopCloser(bytes.NewReader([]byte(d))))
 		b := make([]byte, testCase.bufLen)
 		n, err := r.Read(b)
 		if err != testCase.expectErr || n != testCase.expectLen {
@@ -62,7 +61,7 @@ stuff: 1
 	bufferLen := 4 * 1024
 	//  maxLen 5 M
 	dd := strings.Repeat(d, 512*1024)
-	r := NewDocumentDecoder(ioutil.NopCloser(bytes.NewReader([]byte(dd[:maxLen-1]))))
+	r := NewDocumentDecoder(io.NopCloser(bytes.NewReader([]byte(dd[:maxLen-1]))))
 	b := make([]byte, bufferLen)
 	n, err := r.Read(b)
 	if err != io.ErrShortBuffer {
@@ -73,7 +72,7 @@ stuff: 1
 	if err != nil {
 		t.Fatalf("expected nil: %d / %v", n, err)
 	}
-	r = NewDocumentDecoder(ioutil.NopCloser(bytes.NewReader([]byte(dd))))
+	r = NewDocumentDecoder(io.NopCloser(bytes.NewReader([]byte(dd))))
 	b = make([]byte, maxLen)
 	n, err = r.Read(b)
 	if err != bufio.ErrTooLong {
@@ -85,7 +84,7 @@ func TestYAMLDecoderCallsAfterErrShortBufferRestOfFrame(t *testing.T) {
 	d := `---
 stuff: 1
 	test-foo: 1`
-	r := NewDocumentDecoder(ioutil.NopCloser(bytes.NewReader([]byte(d))))
+	r := NewDocumentDecoder(io.NopCloser(bytes.NewReader([]byte(d))))
 	b := make([]byte, 12)
 	n, err := r.Read(b)
 	if err != io.ErrShortBuffer || n != 12 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This replaces deprecated `ioutil` functions as follows:

* `ioutil.NopCloser` → `io.NopCloser`
* `ioutil.ReadAll` → `io.ReadAll`
* `ioutil.ReadFile` → `os.ReadFile`
* `ioutil.TempFile` → `os.CreateTemp`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
