### PR TITLE
Use getter function for plugin subcommand resolution

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -84,10 +84,6 @@ import (
 
 const kubectlCmdHeaders = "KUBECTL_COMMAND_HEADERS"
 
-var (
-	allowedCmdsSubcommandPlugin = map[string]struct{}{"create": {}}
-)
-
 type KubectlOptions struct {
 	PluginHandler PluginHandler
 	Arguments     []string
@@ -146,7 +142,7 @@ func NewDefaultKubectlCommandWithArgs(o KubectlOptions) *cobra.Command {
 			if cmdutil.CmdPluginAsSubcommand.IsEnabled() {
 				// Command exists(e.g. kubectl create), but it is not certain that
 				// subcommand also exists (e.g. kubectl create networkpolicy)
-				if _, ok := allowedCmdsSubcommandPlugin[foundCmd.Name()]; ok {
+				if _, ok := GetAllowedCmdsAsSubcommandPlugins()[foundCmd.Name()]; ok {
 					var subcommand string
 					for _, arg := range foundArgs { // first "non-flag" argument as subcommand
 						if !strings.HasPrefix(arg, "-") {
@@ -174,6 +170,13 @@ func NewDefaultKubectlCommandWithArgs(o KubectlOptions) *cobra.Command {
 	}
 
 	return cmd
+}
+
+// GetAllowedCmdsAsSubcommandPlugins returns the list of builtin commands
+// that plugins are allowed to be used as subcommands only if the passed subcommand
+// does not exist as builtin.
+func GetAllowedCmdsAsSubcommandPlugins() map[string]struct{} {
+	return map[string]struct{}{"create": {}}
 }
 
 // PluginHandler is capable of parsing command line arguments

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -142,7 +142,7 @@ func NewDefaultKubectlCommandWithArgs(o KubectlOptions) *cobra.Command {
 			if cmdutil.CmdPluginAsSubcommand.IsEnabled() {
 				// Command exists(e.g. kubectl create), but it is not certain that
 				// subcommand also exists (e.g. kubectl create networkpolicy)
-				if _, ok := GetAllowedCmdsAsSubcommandPlugins()[foundCmd.Name()]; ok {
+				if IsSubcommandPluginAllowed(foundCmd.Name()) {
 					var subcommand string
 					for _, arg := range foundArgs { // first "non-flag" argument as subcommand
 						if !strings.HasPrefix(arg, "-") {
@@ -172,11 +172,12 @@ func NewDefaultKubectlCommandWithArgs(o KubectlOptions) *cobra.Command {
 	return cmd
 }
 
-// GetAllowedCmdsAsSubcommandPlugins returns the list of builtin commands
-// that plugins are allowed to be used as subcommands only if the passed subcommand
-// does not exist as builtin.
-func GetAllowedCmdsAsSubcommandPlugins() map[string]struct{} {
-	return map[string]struct{}{"create": {}}
+// IsSubcommandPluginAllowed returns the given command is allowed
+// to use plugin as subcommand if the subcommand does not exist as builtin.
+func IsSubcommandPluginAllowed(foundCmd string) bool {
+	allowedCmds := map[string]struct{}{"create": {}}
+	_, ok := allowedCmds[foundCmd]
+	return ok
 }
 
 // PluginHandler is capable of parsing command line arguments


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Plugin subcommand resolution is relatively less used than the builtin subcommands. That's why, instead always initializing a hash map on memory, it would be better to use a getter function only serves as needed.

In addition to that this function will be exported to let that external libraries can use it.

#### Does this PR introduce a user-facing change?
```release-note
None
```