### PR TITLE
test: images: add sample-device-plugin to the config

### DIFF
--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -62,6 +62,7 @@ var NodePrePullImageList = sets.NewString(
 	imageutils.GetE2EImage(imageutils.NodePerfNpbEp),
 	imageutils.GetE2EImage(imageutils.NodePerfNpbIs),
 	imageutils.GetE2EImage(imageutils.Etcd),
+	imageutils.GetE2EImage(imageutils.SampleDevicePlugin),
 )
 
 // updateImageAllowList updates the e2epod.ImagePrePullList with
@@ -88,15 +89,11 @@ func updateImageAllowList(ctx context.Context) {
 	} else {
 		e2epod.ImagePrePullList.Insert(gpuDevicePluginImage)
 	}
+	// TODO: unify the sample device plugin image, use the latest for everything
 	if samplePluginImage, err := getContainerImageFromE2ETestDaemonset(SampleDevicePluginDSYAML); err != nil {
 		klog.Errorln(err)
 	} else {
 		e2epod.ImagePrePullList.Insert(samplePluginImage)
-	}
-	if samplePluginImageCtrlReg, err := getContainerImageFromE2ETestDaemonset(SampleDevicePluginControlRegistrationDSYAML); err != nil {
-		klog.Errorln(err)
-	} else {
-		e2epod.ImagePrePullList.Insert(samplePluginImageCtrlReg)
 	}
 }
 

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -156,12 +156,16 @@ func getV1NodeDevices(ctx context.Context) (*kubeletpodresourcesv1.ListPodResour
 		return nil, fmt.Errorf("Error getting gRPC client: %w", err)
 	}
 	defer conn.Close()
+	framework.Logf("podresources gRPC client available")
+
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	resp, err := client.List(ctx, &kubeletpodresourcesv1.ListPodResourcesRequest{})
 	if err != nil {
 		return nil, fmt.Errorf("%v.Get(_) = _, %v", client, err)
 	}
+	framework.Logf("podresources List call done (%d entries)", len(resp.PodResources))
+
 	return resp, nil
 }
 

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -256,7 +256,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[Redis] = Config{list.PromoterE2eRegistry, "redis", "5.0.5-3"}
 	configs[RegressionIssue74839] = Config{list.PromoterE2eRegistry, "regression-issue-74839", "1.2"}
 	configs[ResourceConsumer] = Config{list.PromoterE2eRegistry, "resource-consumer", "1.13"}
-	configs[SampleDevicePlugin] = Config{list.PromoterE2eRegistry, "sample-device-plugin", "1.5"}
+	configs[SampleDevicePlugin] = Config{list.PromoterE2eRegistry, "sample-device-plugin", "1.7"}
 	configs[SdDummyExporter] = Config{list.GcRegistry, "sd-dummy-exporter", "v0.2.0"}
 	configs[VolumeNFSServer] = Config{list.PromoterE2eRegistry, "volume/nfs", "1.3"}
 	configs[VolumeISCSIServer] = Config{list.PromoterE2eRegistry, "volume/iscsi", "2.6"}

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -212,6 +212,10 @@ const (
 	RegressionIssue74839
 	// ResourceConsumer image
 	ResourceConsumer
+	// SampleDevicePlugin image
+	SampleDevicePlugin
+	// SdDummyExporter image
+	SdDummyExporter
 	// VolumeNFSServer image
 	VolumeNFSServer
 	// VolumeISCSIServer image
@@ -252,7 +256,9 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[Redis] = Config{list.PromoterE2eRegistry, "redis", "5.0.5-3"}
 	configs[RegressionIssue74839] = Config{list.PromoterE2eRegistry, "regression-issue-74839", "1.2"}
 	configs[ResourceConsumer] = Config{list.PromoterE2eRegistry, "resource-consumer", "1.13"}
-	configs[VolumeNFSServer] = Config{list.PromoterE2eRegistry, "volume/nfs", "1.4"}
+	configs[SampleDevicePlugin] = Config{list.PromoterE2eRegistry, "sample-device-plugin", "1.5"}
+	configs[SdDummyExporter] = Config{list.GcRegistry, "sd-dummy-exporter", "v0.2.0"}
+	configs[VolumeNFSServer] = Config{list.PromoterE2eRegistry, "volume/nfs", "1.3"}
 	configs[VolumeISCSIServer] = Config{list.PromoterE2eRegistry, "volume/iscsi", "2.6"}
 
 	// This adds more config entries. Those have no pre-defined ImageID number,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
cleanup: instead of having special handling of the sample device plugin image, add it to the standard list of e2e images.
Note the e2e_node tests will still need some exceptions because they consume container images maintained externally to the project, but this one *is* maintained by the kubernetes project.

#### Which issue(s) this PR fixes:
Fixes N/A

#### Special notes for your reviewer:
At this point in time, only `e2e_node` tests consume this image, but moving it here is very cheap and enables `e2e/node` tests to consume it.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
