### PR TITLE
DRA: fix image build on Mac

### DIFF
--- a/test/e2e/dra/kind-build-image.sh
+++ b/test/e2e/dra/kind-build-image.sh
@@ -31,9 +31,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
+goarch=$(go env GOARCH)
+
 kind build node-image --image "$tag" "$(pwd)"
-curl -L --silent https://github.com/kind-ci/containerd-nightlies/releases/download/$containerd/$containerd-linux-amd64.tar.gz | tar -C "$tmpdir" -vzxf -
-curl -L --silent https://github.com/kind-ci/containerd-nightlies/releases/download/$containerd/runc.amd64 >"$tmpdir/runc"
+curl -L --silent https://github.com/kind-ci/containerd-nightlies/releases/download/$containerd/$containerd-linux-"$goarch".tar.gz | tar -C "$tmpdir" -vzxf -
+curl -L --silent https://github.com/kind-ci/containerd-nightlies/releases/download/$containerd/runc."$goarch" >"$tmpdir/runc"
 
 cat >"$tmpdir/Dockerfile" <<EOF
 FROM $tag


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR fixes DRA e2e image build on non-amd64 architectures.

#### Which issue(s) this PR fixes:
Fixes #117878

#### Does this PR introduce a user-facing change?
```release-note
Fixed dra e2e image build on non-amd64 architectures
```

