### PR TITLE
kubeadm: Remove leading zeros from etcd member ID in log messages

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -349,7 +349,7 @@ func (c *Client) RemoveMember(id uint64) ([]Member, error) {
 			return true, nil
 		}
 		if errors.Is(rpctypes.ErrMemberNotFound, err) {
-			klog.V(5).Infof("Member was already removed, because member %016x was not found", id)
+			klog.V(5).Infof("Member was already removed, because member %s was not found", strconv.FormatUint(id, 16))
 			return true, nil
 		}
 		klog.V(5).Infof("Failed to remove etcd member: %v", err)
@@ -496,11 +496,11 @@ func (c *Client) MemberPromote(learnerID uint64) error {
 		return err
 	}
 	if !isLearner {
-		klog.V(1).Infof("[etcd] Member %016x already promoted.", learnerID)
+		klog.V(1).Infof("[etcd] Member %s already promoted.", strconv.FormatUint(learnerID, 16))
 		return nil
 	}
 
-	klog.V(1).Infof("[etcd] Promoting a learner as a voting member: %016x", learnerID)
+	klog.V(1).Infof("[etcd] Promoting a learner as a voting member: %s", strconv.FormatUint(learnerID, 16))
 	cli, err := c.newEtcdClient(c.Endpoints)
 	if err != nil {
 		return err
@@ -522,10 +522,10 @@ func (c *Client) MemberPromote(learnerID uint64) error {
 
 		_, err = cli.MemberPromote(ctx, learnerID)
 		if err == nil {
-			klog.V(1).Infof("[etcd] The learner was promoted as a voting member: %016x", learnerID)
+			klog.V(1).Infof("[etcd] The learner was promoted as a voting member: %s", strconv.FormatUint(learnerID, 16))
 			return true, nil
 		}
-		klog.V(5).Infof("[etcd] Promoting the learner %016x failed: %v", learnerID, err)
+		klog.V(5).Infof("[etcd] Promoting the learner %s failed: %v", strconv.FormatUint(learnerID, 16), err)
 		lastError = err
 		return false, nil
 	})

--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -410,7 +410,7 @@ func (c *Client) addMember(name string, peerAddrs string, isLearner bool) ([]Mem
 		if isLearner {
 			// if learnerID is set, it means the etcd member is already added successfully.
 			if learnerID == 0 {
-				klog.V(1).Infof("[etcd] Adding etcd member as learner: %016x", peerAddrs)
+				klog.V(1).Info("[etcd] Adding etcd member as learner")
 				resp, err = cli.MemberAddAsLearner(ctx, []string{peerAddrs})
 				if err != nil {
 					lastError = err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This fixes the log message format, as suggested by @SataQiu in https://github.com/kubernetes/kubernetes/pull/117724#discussion_r1186678580.

I also fixed a mistake in one log message: the peer URLs were being formatted as hexadecimal number.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Removed leading zeros from the etcd member ID in kubeadm log messages.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
