### PR TITLE
WIP: Make update-vendor handle sub-modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -252,6 +252,7 @@ replace (
 	k8s.io/cloud-provider => ./staging/src/k8s.io/cloud-provider
 	k8s.io/cluster-bootstrap => ./staging/src/k8s.io/cluster-bootstrap
 	k8s.io/code-generator => ./staging/src/k8s.io/code-generator
+	k8s.io/code-generator/examples => ./staging/src/k8s.io/code-generator/examples
 	k8s.io/component-base => ./staging/src/k8s.io/component-base
 	k8s.io/component-helpers => ./staging/src/k8s.io/component-helpers
 	k8s.io/controller-manager => ./staging/src/k8s.io/controller-manager
@@ -259,6 +260,7 @@ replace (
 	k8s.io/csi-translation-lib => ./staging/src/k8s.io/csi-translation-lib
 	k8s.io/dynamic-resource-allocation => ./staging/src/k8s.io/dynamic-resource-allocation
 	k8s.io/kms => ./staging/src/k8s.io/kms
+	k8s.io/kms/internal/plugins/mock => ./staging/src/k8s.io/kms/internal/plugins/mock
 	k8s.io/kube-aggregator => ./staging/src/k8s.io/kube-aggregator
 	k8s.io/kube-controller-manager => ./staging/src/k8s.io/kube-controller-manager
 	k8s.io/kube-proxy => ./staging/src/k8s.io/kube-proxy

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -608,7 +608,10 @@ EOF
 function kube::util::list_staging_repos() {
   (
     cd "${KUBE_ROOT}/staging/src/k8s.io" && \
-    find . -mindepth 1 -maxdepth 1 -type d | cut -c 3- | sort
+    find . -type f -name go.mod \
+        | xargs dirname \
+        | cut -c 3- \
+        | sort
   )
 }
 

--- a/staging/src/k8s.io/code-generator/examples/go.mod
+++ b/staging/src/k8s.io/code-generator/examples/go.mod
@@ -1,8 +1,8 @@
-// This is a submodule to isolate k8s.io/code-generator from k8s.io/{api,apimachinery,client-go} dependencies in generated code
+// This is a generated file. Do not edit directly.
 
 module k8s.io/code-generator/examples
 
-go 1.19
+go 1.20
 
 require (
 	k8s.io/api v0.0.0
@@ -54,4 +54,5 @@ replace (
 	k8s.io/api => ../../api
 	k8s.io/apimachinery => ../../apimachinery
 	k8s.io/client-go => ../../client-go
+	k8s.io/code-generator/examples => ../../code-generator/examples
 )

--- a/staging/src/k8s.io/kms/internal/plugins/mock/go.mod
+++ b/staging/src/k8s.io/kms/internal/plugins/mock/go.mod
@@ -1,10 +1,12 @@
-module k8s.io/kms/plugins/mock
+// This is a generated file. Do not edit directly.
 
-go 1.19
+module k8s.io/kms/internal/plugins/mock
+
+go 1.20
 
 require (
 	k8s.io/klog/v2 v2.100.1
-	k8s.io/kms v0.0.0-00010101000000-000000000000
+	k8s.io/kms v0.0.0
 )
 
 require (
@@ -23,7 +25,9 @@ require (
 )
 
 replace (
+	k8s.io/api => ../../../../api
 	k8s.io/apimachinery => ../../../../apimachinery
 	k8s.io/client-go => ../../../../client-go
 	k8s.io/kms => ../../../../kms
+	k8s.io/kms/internal/plugins/mock => ../../../../kms/internal/plugins/mock
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2494,6 +2494,7 @@ sigs.k8s.io/yaml
 # k8s.io/cloud-provider => ./staging/src/k8s.io/cloud-provider
 # k8s.io/cluster-bootstrap => ./staging/src/k8s.io/cluster-bootstrap
 # k8s.io/code-generator => ./staging/src/k8s.io/code-generator
+# k8s.io/code-generator/examples => ./staging/src/k8s.io/code-generator/examples
 # k8s.io/component-base => ./staging/src/k8s.io/component-base
 # k8s.io/component-helpers => ./staging/src/k8s.io/component-helpers
 # k8s.io/controller-manager => ./staging/src/k8s.io/controller-manager
@@ -2501,6 +2502,7 @@ sigs.k8s.io/yaml
 # k8s.io/csi-translation-lib => ./staging/src/k8s.io/csi-translation-lib
 # k8s.io/dynamic-resource-allocation => ./staging/src/k8s.io/dynamic-resource-allocation
 # k8s.io/kms => ./staging/src/k8s.io/kms
+# k8s.io/kms/internal/plugins/mock => ./staging/src/k8s.io/kms/internal/plugins/mock
 # k8s.io/kube-aggregator => ./staging/src/k8s.io/kube-aggregator
 # k8s.io/kube-controller-manager => ./staging/src/k8s.io/kube-controller-manager
 # k8s.io/kube-proxy => ./staging/src/k8s.io/kube-proxy


### PR DESCRIPTION
If you look at
https://github.com/kubernetes/code-generator/blob/master/examples/go.mod you can see that it includes a block like:

```
replace (
	k8s.io/api => ../../api
	k8s.io/apimachinery => ../../apimachinery
	k8s.io/client-go => ../../client-go
)
```

For most of our staging repos, there's just the one go.mod, which the publishing bot (I think?) fixes as it publishes, turning those relative paths into real versions.  But these sub-modules don't get processed. We have 2 such.

This commit makes update-vendor.sh handle them.  It's unclear if the publishing bot will reify the `replace` statements.

/kind bug

```release-note
NONE
```
