### PR TITLE
update golang version of etcd build to 1.19.9

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -88,7 +88,7 @@ dependencies:
 
   # From https://github.com/etcd-io/etcd/blob/main/Makefile
   - name: "golang: etcd release version"
-    version: 1.19.8 # https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md
+    version: 1.19.9 # https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md
     refPaths:
     - path: cluster/images/etcd/Makefile
       match: 'GOLANG_VERSION := \d+.\d+(alpha|beta|rc)?\.?(\d+)?'

--- a/cluster/images/etcd-version-monitor/Makefile
+++ b/cluster/images/etcd-version-monitor/Makefile
@@ -15,10 +15,10 @@
 # Build the etcd-version-monitor image
 #
 # Usage:
-# 	[GOLANG_VERSION=1.8.3] [REGISTRY=staging-k8s.gcr.io] [TAG=test] make (build|push)
+# 	[GOLANG_VERSION=1.19.9] [REGISTRY=staging-k8s.gcr.io] [TAG=test] make (build|push)
 # TODO(shyamjvs): Support architectures other than amd64 if needed.
 ARCH:=amd64
-GOLANG_VERSION?=1.19.8
+GOLANG_VERSION?=1.19.9
 REGISTRY?=staging-k8s.gcr.io
 TAG?=0.1.3
 IMAGE:=$(REGISTRY)/etcd-version-monitor:$(TAG)

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -83,7 +83,7 @@ endif
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled
 # golang version should match the golang version of the official build from https://github.com/etcd-io/etcd/releases.
-GOLANG_VERSION := 1.19.8
+GOLANG_VERSION := 1.19.9
 GOARM?=7
 TEMP_DIR:=$(shell mktemp -d)
 


### PR DESCRIPTION
As per https://github.com/etcd-io/etcd/blob/main/.go-version it is 1.19.9.


/kind cleanup

```release-note
NONE
```

