### PR TITLE
Log a warning if a ImagePullSecrets does not exist

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -895,7 +895,7 @@ func (kl *Kubelet) getPullSecretsForPod(pod *v1.Pod) []v1.Secret {
 	}
 
 	if len(failedPullSecrets) > 0 {
-		kl.recorder.Eventf(pod, v1.EventTypeWarning, "FailedToRetrieveImagePullSecret", "Unable to retrieve image pull secrets %s, the image pull may not succeed.", strings.Join(failedPullSecrets, ", "))
+		kl.recorder.Eventf(pod, v1.EventTypeWarning, "FailedToRetrieveImagePullSecret", "Unable to retrieve image pull secrets %s; attempting to pull the image may not succeed.", strings.Join(failedPullSecrets, ", "))
 	}
 
 	return pullSecrets

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -895,7 +895,7 @@ func (kl *Kubelet) getPullSecretsForPod(pod *v1.Pod) []v1.Secret {
 	}
 
 	if len(failedPullSecrets) > 0 {
-		kl.recorder.Eventf(pod, v1.EventTypeWarning, "FailedToRetrieveImagePullSecret", "Unable to retrieve image pull secrets %s; attempting to pull the image may not succeed.", strings.Join(failedPullSecrets, ", "))
+		kl.recorder.Eventf(pod, v1.EventTypeWarning, "FailedToRetrieveImagePullSecret", "Unable to retrieve some image pull secrets (%s); attempting to pull the image may not succeed.", strings.Join(failedPullSecrets, ", "))
 	}
 
 	return pullSecrets

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -5406,7 +5406,7 @@ func TestGetNonExistentImagePullSecret(t *testing.T) {
 	testKubelet.kubelet.secretManager = secret.NewFakeManagerWithSecrets(secrets)
 	defer testKubelet.Cleanup()
 
-	expectedEvent := "Warning FailedToRetrieveImagePullSecret Unable to retrieve image pull secrets secretFoo, the image pull may not succeed."
+	expectedEvent := "Warning FailedToRetrieveImagePullSecret Unable to retrieve image pull secrets secretFoo; attempting to pull the image may not succeed."
 	testPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   "nsFoo",

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -5406,7 +5406,8 @@ func TestGetNonExistentImagePullSecret(t *testing.T) {
 	testKubelet.kubelet.secretManager = secret.NewFakeManagerWithSecrets(secrets)
 	defer testKubelet.Cleanup()
 
-	expectedEvent := "Warning FailedToRetrieveImagePullSecret Unable to retrieve image pull secrets secretFoo; attempting to pull the image may not succeed."
+	expectedEvent := "Warning FailedToRetrieveImagePullSecret Unable to retrieve some image pull secrets (secretFoo); attempting to pull the image may not succeed."
+
 	testPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   "nsFoo",

--- a/pkg/kubelet/secret/fake_manager.go
+++ b/pkg/kubelet/secret/fake_manager.go
@@ -16,11 +16,16 @@ limitations under the License.
 
 package secret
 
-import v1 "k8s.io/api/core/v1"
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+)
 
 // fakeManager implements Manager interface for testing purposes.
 // simple operations to apiserver.
 type fakeManager struct {
+	secrets []*v1.Secret
 }
 
 // NewFakeManager creates empty/fake secret manager
@@ -28,9 +33,27 @@ func NewFakeManager() Manager {
 	return &fakeManager{}
 }
 
-// GetSecret returns a nil secret for testing
+// NewFakeManagerWithSecrets creates a fake secret manager with the provided secrets
+func NewFakeManagerWithSecrets(secrets []*v1.Secret) Manager {
+	return &fakeManager{
+		secrets: secrets,
+	}
+}
+
+// GetSecret function returns the searched secret if it was provided during the manager initialization, otherwise, it returns an error.
+// If the manager was initialized without any secrets, it returns a nil secret."
 func (s *fakeManager) GetSecret(namespace, name string) (*v1.Secret, error) {
-	return nil, nil
+	if s.secrets == nil {
+		return nil, nil
+	}
+
+	for _, secret := range s.secrets {
+		if secret.Name == name {
+			return secret, nil
+		}
+	}
+
+	return nil, fmt.Errorf("secret %s not found", name)
 }
 
 // RegisterPod implements the RegisterPod method for testing purposes.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Currently, if a pod references a secret containing registry credentials (in the `ImagePullSecrets` field) and the secret doesn't exist, there's no warning message. This PR addresses that problem by logging a warning event in that case.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #104432

#### Special notes for your reviewer:

This is my first PR on Kubernetes. Thanks for the review! 😊 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a new event `FailedToRetrieveImagePullSecret` which will be generated when a pod references an `ImagePullSecret` that doesn't exist.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```

```