### PR TITLE
kubectl: optimize usage message of commands which have subcommands.

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
@@ -44,10 +44,11 @@ import (
 // This is the entry point of create_secret.go which will be called by create.go
 func NewCmdCreateSecret(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "secret",
-		Short: i18n.T("Create a secret using specified subcommand"),
-		Long:  i18n.T("Create a secret using specified subcommand."),
-		Run:   cmdutil.DefaultSubCommandRun(ioStreams.ErrOut),
+		Use:                   "secret (docker-registry | generic | tls)",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Create a secret using a specified subcommand"),
+		Long:                  secretLong,
+		Run:                   cmdutil.DefaultSubCommandRun(ioStreams.ErrOut),
 	}
 	cmd.AddCommand(NewCmdCreateSecretDockerRegistry(f, ioStreams))
 	cmd.AddCommand(NewCmdCreateSecretTLS(f, ioStreams))
@@ -58,6 +59,15 @@ func NewCmdCreateSecret(f cmdutil.Factory, ioStreams genericiooptions.IOStreams)
 
 var (
 	secretLong = templates.LongDesc(i18n.T(`
+		Create a secret with specified type.
+		
+		A docker-registry type secret is for accessing a container registry.
+
+		A generic type secret indicate an Opaque secret type.
+
+		A tls type secret holds TLS certificate and its associated key.`))
+
+	secretForGenericLong = templates.LongDesc(i18n.T(`
 		Create a secret based on a file, directory, or specified literal value.
 
 		A single secret may package one or more key/value pairs.
@@ -70,7 +80,7 @@ var (
 		packaged into the secret. Any directory entries except regular files are ignored (e.g. subdirectories,
 		symlinks, devices, pipes, etc).`))
 
-	secretExample = templates.Examples(i18n.T(`
+	secretForGenericExample = templates.Examples(i18n.T(`
 	  # Create a new secret named my-secret with keys for each file in folder bar
 	  kubectl create secret generic my-secret --from-file=path/to/bar
 
@@ -134,8 +144,8 @@ func NewCmdCreateSecretGeneric(f cmdutil.Factory, ioStreams genericiooptions.IOS
 		Use:                   "generic NAME [--type=string] [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Create a secret from a local file, directory, or literal value"),
-		Long:                  secretLong,
-		Example:               secretExample,
+		Long:                  secretForGenericLong,
+		Example:               secretForGenericExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/util/templates/templater.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/templater.go
@@ -126,6 +126,7 @@ func (templater *templater) templateFuncs(exposedFlags ...string) template.FuncM
 		"isRootCmd":           templater.isRootCmd,
 		"optionsCmdFor":       templater.optionsCmdFor,
 		"usageLine":           templater.usageLine,
+		"reverseParentsNames": templater.reverseParentsNames,
 		"exposed": func(c *cobra.Command) *flag.FlagSet {
 			exposed := flag.NewFlagSet("exposed", flag.ContinueOnError)
 			if len(exposedFlags) > 0 {
@@ -170,6 +171,15 @@ func (t *templater) cmdGroupsString(c *cobra.Command) string {
 
 func (t *templater) rootCmdName(c *cobra.Command) string {
 	return t.rootCmd(c).CommandPath()
+}
+
+func (t *templater) reverseParentsNames(c *cobra.Command) []string {
+	reverseParentsNames := []string{}
+	parents := t.parents(c)
+	for i := len(parents) - 1; i >= 0; i-- {
+		reverseParentsNames = append(reverseParentsNames, parents[i].Name())
+	}
+	return reverseParentsNames
 }
 
 func (t *templater) isRootCmd(c *cobra.Command) bool {

--- a/staging/src/k8s.io/kubectl/pkg/util/templates/templates.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/templates.go
@@ -28,7 +28,8 @@ const (
 		`{{$visibleFlags := visibleFlags (flagsNotIntersected .LocalFlags .PersistentFlags)}}` +
 		`{{$explicitlyExposedFlags := exposed .}}` +
 		`{{$optionsCmdFor := optionsCmdFor .}}` +
-		`{{$usageLine := usageLine .}}`
+		`{{$usageLine := usageLine .}}` +
+		`{{$reverseParentsNames := reverseParentsNames .}}`
 
 	// SectionAliases is the help template section that displays command aliases.
 	SectionAliases = `{{if gt .Aliases 0}}Aliases:
@@ -61,7 +62,7 @@ const (
 {{end}}`
 
 	// SectionTipsHelp is the help template section that displays the '--help' hint.
-	SectionTipsHelp = `{{if .HasSubCommands}}Use "{{$rootCmd}} <command> --help" for more information about a given command.
+	SectionTipsHelp = `{{if .HasSubCommands}}Use "{{range $reverseParentsNames}}{{.}} {{end}}<command> --help" for more information about a given command.
 {{end}}`
 
 	// SectionTipsGlobalOptions is the help template section that displays the 'options' hint for displaying global flags.

--- a/test/cmd/help.sh
+++ b/test/cmd/help.sh
@@ -47,6 +47,24 @@ run_kubectl_help_tests() {
   kube::test::if_has_string "$(LANG=zh_CN.UTF-8 kubectl uncordon --help)" "标记节点为可调度。"
   kube::test::if_has_string "$(LANG=zh_TW.UTF-8 kubectl uncordon --help)" "Mark node as schedulable."
 
+  # This part of test is to check those commands that have subcommands output the correct usage prompts.
+  # If a new command with subcommands is added, it is best to be added here.
+  # If some refactoring causes the command to become without subcommands, it needs to be removed here to ensure that the test passes.
+
+  kube::test::if_has_string "$(kubectl --help)" "Use \"kubectl <command> --help\" for more information about a given command."
+  kube::test::if_has_string "$(kubectl apply --help)" "Use \"kubectl apply <command> --help\" for more information about a given command."
+  kube::test::if_has_string "$(kubectl auth --help)" "Use \"kubectl auth <command> --help\" for more information about a given command."
+  kube::test::if_has_string "$(kubectl certificate --help)" "Use \"kubectl certificate <command> --help\" for more information about a given command."
+  kube::test::if_has_string "$(kubectl cluster-info --help)" "Use \"kubectl cluster-info <command> --help\" for more information about a given command."
+  kube::test::if_has_string "$(kubectl config --help)" "Use \"kubectl config <command> --help\" for more information about a given command."
+  kube::test::if_has_string "$(kubectl create --help)" "Use \"kubectl create <command> --help\" for more information about a given command."
+  kube::test::if_has_string "$(kubectl create secret --help)" "Use \"kubectl create secret <command> --help\" for more information about a given command."
+  kube::test::if_has_string "$(kubectl create service --help)" "Use \"kubectl create service <command> --help\" for more information about a given command."
+  kube::test::if_has_string "$(kubectl plugin --help)" "Use \"kubectl plugin <command> --help\" for more information about a given command."
+  kube::test::if_has_string "$(kubectl rollout --help)" "Use \"kubectl rollout <command> --help\" for more information about a given command."
+  kube::test::if_has_string "$(kubectl set --help)" "Use \"kubectl set <command> --help\" for more information about a given command."
+  kube::test::if_has_string "$(kubectl top --help)" "Use \"kubectl top <command> --help\" for more information about a given command."
+
   set +o nounset
   set +o errexit
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#1395](https://github.com/kubernetes/kubectl/issues/1395)

#### Special notes for your reviewer:

Hi, community! It's my first PR of Kubernetes. I made a change to the cobra Command object and it will affects all the "Usage" string when executing `kubectl xxx --help`. I also added some descriptive sentences to `kubectl create secret` command. Please kindly review this PR and give your suggestions and guides! 

You can find a quick look here what this PR would change, I've already tested it as below:
```shell
kubectl create -h

# BEFORE
Usage:
...
Use "kubectl <command> --help" for more information about a given command.
...

# AFTER
...
Use "kubectl create <command> --help" for more information about a given command.
...
```

```shell
kubectl create secret -h 

# BEFORE
Create a secret using specified subcommand.

Available Commands:
  docker-registry   Create a secret for use with a Docker registry
  generic           Create a secret from a local file, directory, or literal value
  tls               Create a TLS secret

Usage:
  kubectl create secret [flags] [options]

Use "kubectl <command> --help" for more information about a given command.
Use "kubectl options" for a list of global command-line options (applies to all commands).

# AFTER
Create a secret with specified type.

 A docker-registry type secret is for accessing a container registry.

 A generic type secret indicate an Opaque secret type.

 A tls type secret holds TLS certificate and its associated key.

Available Commands:
  docker-registry   Create a secret for use with a Docker registry
  generic           Create a secret from a local file, directory, or literal value
  tls               Create a TLS secret

Usage:
  kubectl create secret (docker-registry | generic | tls) [options]

Use "kubectl create secret <command> --help" for more information about a given command.
Use "kubectl options" for a list of global command-line options (applies to all commands).
```
```shell
kubectl config -h

# BEFORE
...
Use "kubectl <command> --help" for more information about a given command.
...

# AFTER
...
Use "kubectl config <command> --help" for more information about a given command.
...
```

#### Does this PR introduce a user-facing change? 

```release-note
The helping message of commands which have sub-commands is now clearer and more instructive. It will show the full command instead of 'kubectl <command> --help ...'

Changed 'kubectl create secret --help' description. There will be a short introduction to the three secret types and clearer guidance on how to use the command.
```