### PR TITLE
cidrset, multicidrset: directly use getIndexForIP method

### DIFF
--- a/pkg/controller/nodeipam/ipam/cidrset/cidr_set.go
+++ b/pkg/controller/nodeipam/ipam/cidrset/cidr_set.go
@@ -195,10 +195,7 @@ func (s *CidrSet) getBeginningAndEndIndices(cidr *net.IPNet) (begin, end int, er
 		if cidr.IP.To4() == nil {
 			ipSize = net.IPv6len
 		}
-		begin, err = s.getIndexForCIDR(&net.IPNet{
-			IP:   cidr.IP.Mask(s.nodeMask),
-			Mask: s.nodeMask,
-		})
+		begin, err = s.getIndexForIP(cidr.IP.Mask(s.nodeMask))
 		if err != nil {
 			return -1, -1, err
 		}
@@ -214,10 +211,7 @@ func (s *CidrSet) getBeginningAndEndIndices(cidr *net.IPNet) (begin, end int, er
 			binary.BigEndian.PutUint64(ip[:net.IPv6len/2], ipIntLeft)
 			binary.BigEndian.PutUint64(ip[net.IPv6len/2:], ipIntRight)
 		}
-		end, err = s.getIndexForCIDR(&net.IPNet{
-			IP:   net.IP(ip).Mask(s.nodeMask),
-			Mask: s.nodeMask,
-		})
+		end, err = s.getIndexForIP(net.IP(ip).Mask(s.nodeMask))
 		if err != nil {
 			return -1, -1, err
 		}
@@ -268,10 +262,6 @@ func (s *CidrSet) Occupy(cidr *net.IPNet) (err error) {
 
 	cidrSetUsage.WithLabelValues(s.label).Set(float64(s.allocatedCIDRs) / float64(s.maxCIDRs))
 	return nil
-}
-
-func (s *CidrSet) getIndexForCIDR(cidr *net.IPNet) (int, error) {
-	return s.getIndexForIP(cidr.IP)
 }
 
 func (s *CidrSet) getIndexForIP(ip net.IP) (int, error) {

--- a/pkg/controller/nodeipam/ipam/cidrset/cidr_set_test.go
+++ b/pkg/controller/nodeipam/ipam/cidrset/cidr_set_test.go
@@ -571,7 +571,7 @@ func TestGetBitforCIDR(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			got, err := cs.getIndexForCIDR(subnetCIDR)
+			got, err := cs.getIndexForIP(subnetCIDR.IP)
 			if err == nil && tc.expectErr {
 				t.Errorf("expected error but got null")
 				return

--- a/pkg/controller/nodeipam/ipam/multicidrset/multi_cidr_set.go
+++ b/pkg/controller/nodeipam/ipam/multicidrset/multi_cidr_set.go
@@ -247,10 +247,7 @@ func (s *MultiCIDRSet) getBeginningAndEndIndices(cidr *net.IPNet) (int, int, err
 		if netutils.IsIPv6(cidr.IP) {
 			ipSize = net.IPv6len
 		}
-		begin, err = s.getIndexForCIDR(&net.IPNet{
-			IP:   cidr.IP.Mask(s.nodeMask),
-			Mask: s.nodeMask,
-		})
+		begin, err = s.getIndexForIP(cidr.IP.Mask(s.nodeMask))
 		if err != nil {
 			return -1, -1, err
 		}
@@ -266,10 +263,7 @@ func (s *MultiCIDRSet) getBeginningAndEndIndices(cidr *net.IPNet) (int, int, err
 			binary.BigEndian.PutUint64(ip[:net.IPv6len/2], ipIntLeft)
 			binary.BigEndian.PutUint64(ip[net.IPv6len/2:], ipIntRight)
 		}
-		end, err = s.getIndexForCIDR(&net.IPNet{
-			IP:   net.IP(ip).Mask(s.nodeMask),
-			Mask: s.nodeMask,
-		})
+		end, err = s.getIndexForIP(net.IP(ip).Mask(s.nodeMask))
 		if err != nil {
 			return -1, -1, err
 		}
@@ -331,10 +325,6 @@ func (s *MultiCIDRSet) Occupy(cidr *net.IPNet) (err error) {
 	cidrSetUsage.WithLabelValues(s.Label).Set(float64(s.allocatedCIDRs) / float64(s.MaxCIDRs))
 
 	return nil
-}
-
-func (s *MultiCIDRSet) getIndexForCIDR(cidr *net.IPNet) (int, error) {
-	return s.getIndexForIP(cidr.IP)
 }
 
 func (s *MultiCIDRSet) getIndexForIP(ip net.IP) (int, error) {

--- a/pkg/controller/nodeipam/ipam/multicidrset/multi_cidr_set_test.go
+++ b/pkg/controller/nodeipam/ipam/multicidrset/multi_cidr_set_test.go
@@ -584,7 +584,7 @@ func TestGetBitforCIDR(t *testing.T) {
 			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
 
-		got, err := cs.getIndexForCIDR(subnetCIDR)
+		got, err := cs.getIndexForIP(subnetCIDR.IP)
 		if err == nil && tc.expectErr {
 			logger.Error(nil, "Expected error but got null", "description", tc.description)
 			continue


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Instead of constructing a `*net.IPnet` whose `.Mask` field is never used, call the `getIndexForIP` method of `*CidrSet` and `*MultiCIDRSet` directly.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
