### PR TITLE
DRA: use containerd 1.7 in kind image

### DIFF
--- a/test/e2e/dra/kind-build-image.sh
+++ b/test/e2e/dra/kind-build-image.sh
@@ -23,7 +23,7 @@ set -ex
 set -o pipefail
 
 tag="$1"
-containerd="containerd-1.6.0-830-g34d078e99" # from https://github.com/kind-ci/containerd-nightlies/releases
+containerd="containerd-1.7.0-79-g2503bef58" # from https://github.com/kind-ci/containerd-nightlies/releases
 
 tmpdir="$(mktemp -d)"
 cleanup() {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As Containerd 1.6 doesn't support CDI we want to stay closer to 1.7

Containerd 1.7 is going to be the first official release with full CDI support required by DRA.

#### Special notes for your reviewer:

Tested on Ubuntu x86_64 and Macbook Pro M2 arm64 machines.
All 22 DRA e2e tests passed.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

