### PR TITLE
lavalamp is taking a long break

### DIFF
--- a/build/OWNERS
+++ b/build/OWNERS
@@ -10,7 +10,6 @@ reviewers:
   - dims
   - jeremyrickard # SIG Technical Lead / RelEng subproject owner
   #- justaugustus # SIG Chair / RelEng subproject owner / Release Manager - approvals only
-  - lavalamp
   - liggitt
   - palnabarun # Release Manager
   - puerco # SIG Technical Lead / RelEng subproject owner / Release Manager
@@ -24,7 +23,6 @@ approvers:
   - cblecker
   - dims
   - justaugustus
-  - lavalamp
   - liggitt
   - mikedanese
   - spiffxp
@@ -33,3 +31,4 @@ emeritus_approvers:
   - fejta
   - jbeda
   - zmerlynn
+  - lavalamp

--- a/cmd/OWNERS
+++ b/cmd/OWNERS
@@ -6,7 +6,6 @@ options:
 reviewers:
   - dchen1107
   - dims
-  - lavalamp
   - liggitt
   - mikedanese
   - smarterclayton
@@ -15,9 +14,10 @@ reviewers:
 approvers:
   - dchen1107
   - dims
-  - lavalamp
   - liggitt
   - mikedanese
   - smarterclayton
   - thockin
   - wojtek-t
+emeritus_approvers:
+  - lavalamp

--- a/cmd/kube-apiserver/OWNERS
+++ b/cmd/kube-apiserver/OWNERS
@@ -3,12 +3,10 @@
 approvers:
   - caesarxuchao
   - deads2k
-  - lavalamp
   - liggitt
   - smarterclayton
   - sttts
 reviewers:
-  - lavalamp
   - cheftako
   - smarterclayton
   - wojtek-t
@@ -27,3 +25,4 @@ labels:
   - area/apiserver
 emeritus_approvers:
   - nikhiljindal
+  - lavalamp

--- a/cmd/kube-controller-manager/OWNERS
+++ b/cmd/kube-controller-manager/OWNERS
@@ -3,7 +3,6 @@
 approvers:
   - cheftako
   - deads2k
-  - lavalamp
   - mikedanese
   - soltysh
   - sttts
@@ -20,7 +19,6 @@ reviewers:
   - jayunit100
   - jsafrane
   - justinsb
-  - lavalamp
   - liggitt
   - luxas
   - mikedanese
@@ -36,3 +34,5 @@ reviewers:
   - wojtek-t
 labels:
   - sig/api-machinery
+emeritus_approvers:
+  - lavalamp

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -9,7 +9,6 @@ reviewers:
   - dchen1107
   - hwdef
   - justaugustus
-  - lavalamp
   - liggitt
   - mikedanese
   - pohly
@@ -26,7 +25,6 @@ approvers:
   - deads2k
   - dims # for local-up-cluster related files
   - enj # for sig-auth related stuff like cert testdata
-  - lavalamp
   - liggitt
   - mikedanese
   - pohly # for logging and linting
@@ -43,5 +41,6 @@ emeritus_approvers:
   - fejta
   - ixdy
   - jbeda
+  - lavalamp
   - zmerlynn
   - vishh

--- a/pkg/OWNERS
+++ b/pkg/OWNERS
@@ -6,7 +6,6 @@ options:
 reviewers:
   - dchen1107
   - dims
-  - lavalamp
   - liggitt
   - smarterclayton
   - thockin
@@ -14,10 +13,10 @@ reviewers:
 approvers:
   - dchen1107
   - dims
-  - lavalamp
   - liggitt
   - smarterclayton
   - thockin
   - wojtek-t
 emeritus_approvers:
   - brendandburns
+  - lavalamp

--- a/pkg/api/testing/OWNERS
+++ b/pkg/api/testing/OWNERS
@@ -2,7 +2,6 @@
 
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k

--- a/pkg/api/v1/OWNERS
+++ b/pkg/api/v1/OWNERS
@@ -2,7 +2,6 @@
 
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k

--- a/pkg/apis/autoscaling/OWNERS
+++ b/pkg/apis/autoscaling/OWNERS
@@ -2,7 +2,6 @@
 
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k

--- a/pkg/apis/core/install/OWNERS
+++ b/pkg/apis/core/install/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - lavalamp
   - smarterclayton
   - deads2k
   - caesarxuchao

--- a/pkg/apis/core/v1/OWNERS
+++ b/pkg/apis/core/v1/OWNERS
@@ -2,7 +2,6 @@
 
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k

--- a/pkg/apis/core/validation/OWNERS
+++ b/pkg/apis/core/validation/OWNERS
@@ -2,7 +2,6 @@
 
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k

--- a/pkg/apis/extensions/OWNERS
+++ b/pkg/apis/extensions/OWNERS
@@ -2,7 +2,6 @@
 
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k

--- a/pkg/client/OWNERS
+++ b/pkg/client/OWNERS
@@ -3,12 +3,10 @@
 approvers:
   - caesarxuchao
   - deads2k
-  - lavalamp
   - liggitt
   - smarterclayton
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k
@@ -30,3 +28,4 @@ reviewers:
   - jsafrane
 emeritus_approvers:
   - krousey
+  - lavalamp

--- a/pkg/cloudprovider/OWNERS
+++ b/pkg/cloudprovider/OWNERS
@@ -7,7 +7,6 @@ approvers:
   - cheftako
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k

--- a/pkg/controller/garbagecollector/OWNERS
+++ b/pkg/controller/garbagecollector/OWNERS
@@ -2,11 +2,11 @@
 
 approvers:
   - caesarxuchao
-  - lavalamp
   - deads2k
 reviewers:
   - caesarxuchao
-  - lavalamp
   - deads2k
 labels:
   - sig/api-machinery
+emeritus_approvers:
+  - lavalamp

--- a/pkg/controlplane/OWNERS
+++ b/pkg/controlplane/OWNERS
@@ -3,13 +3,11 @@
 approvers:
   - deads2k
   - derekwaynecarr
-  - lavalamp
   - mikedanese
   - sttts
   - wojtek-t
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k
@@ -32,3 +30,4 @@ labels:
   - sig/api-machinery
 emeritus_approvers:
   - nikhiljindal
+  - lavalamp

--- a/pkg/kubeapiserver/OWNERS
+++ b/pkg/kubeapiserver/OWNERS
@@ -2,12 +2,10 @@
 
 approvers:
   - deads2k
-  - lavalamp
   - liggitt
   - sttts
 reviewers:
   - deads2k
-  - lavalamp
   - liggitt
   - sttts
   - cheftako
@@ -15,3 +13,5 @@ reviewers:
 labels:
   - sig/api-machinery
   - area/apiserver
+emeritus_approvers:
+  - lavalamp

--- a/pkg/proxy/config/OWNERS
+++ b/pkg/proxy/config/OWNERS
@@ -2,7 +2,6 @@
 
 reviewers:
   - sig-network-reviewers
-  - lavalamp
   - smarterclayton
 labels:
   - sig/network

--- a/pkg/registry/OWNERS
+++ b/pkg/registry/OWNERS
@@ -2,13 +2,11 @@
 
 approvers:
   - deads2k
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - liggitt
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k
@@ -27,3 +25,5 @@ reviewers:
   - soltysh
   - dims
   - enj
+emeritus_approvers:
+  - lavalamp

--- a/pkg/registry/registrytest/OWNERS
+++ b/pkg/registry/registrytest/OWNERS
@@ -2,7 +2,6 @@
 
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k

--- a/pkg/routes/OWNERS
+++ b/pkg/routes/OWNERS
@@ -2,10 +2,10 @@
 
 reviewers:
   - deads2k
-  - lavalamp
   - sttts
   - caesarxuchao
 approvers:
   - deads2k
-  - lavalamp
   - sttts
+emeritus_approvers:
+  - lavalamp

--- a/plugin/OWNERS
+++ b/plugin/OWNERS
@@ -6,7 +6,6 @@ options:
 reviewers:
   - dchen1107
   - dims
-  - lavalamp
   - liggitt
   - smarterclayton
   - thockin
@@ -14,7 +13,6 @@ reviewers:
 approvers:
   - dchen1107
   - dims
-  - lavalamp
   - liggitt
   - smarterclayton
   - thockin
@@ -22,3 +20,4 @@ approvers:
 emeritus_approvers:
   - davidopp
   - brendandburns
+  - lavalamp

--- a/staging/OWNERS
+++ b/staging/OWNERS
@@ -6,7 +6,6 @@ options:
 approvers:
   - dchen1107
   - dims
-  - lavalamp
   - liggitt
   - smarterclayton
   - thockin
@@ -16,10 +15,11 @@ reviewers:
   - dchen1107
   - deads2k
   - dims
-  - lavalamp
   - liggitt
   - mikedanese
   - smarterclayton
   - sttts
   - thockin
   - wojtek-t
+emeritus_approvers:
+  - lavalamp

--- a/staging/src/k8s.io/api/autoscaling/OWNERS
+++ b/staging/src/k8s.io/api/autoscaling/OWNERS
@@ -2,7 +2,6 @@
 
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k

--- a/staging/src/k8s.io/api/extensions/OWNERS
+++ b/staging/src/k8s.io/api/extensions/OWNERS
@@ -2,7 +2,6 @@
 
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k

--- a/staging/src/k8s.io/apiextensions-apiserver/OWNERS
+++ b/staging/src/k8s.io/apiextensions-apiserver/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
   - deads2k
-  - lavalamp
   - sttts
   - jpbetz
 reviewers:
@@ -16,3 +15,5 @@ reviewers:
   - jefftree
 labels:
   - sig/api-machinery
+emeritus_approvers:
+  - lavalamp

--- a/staging/src/k8s.io/apimachinery/OWNERS
+++ b/staging/src/k8s.io/apimachinery/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - lavalamp
   - smarterclayton
   - deads2k
   - sttts
@@ -10,7 +9,6 @@ approvers:
 reviewers:
   - apelisse
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k
@@ -24,3 +22,5 @@ reviewers:
   - logicalhan
 labels:
   - sig/api-machinery
+emeritus_approvers:
+  - lavalamp

--- a/staging/src/k8s.io/apimachinery/pkg/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/OWNERS
@@ -3,6 +3,7 @@
 approvers:
   - caesarxuchao
   - deads2k
-  - lavalamp
   - smarterclayton
   - liggitt
+emeritus_approvers:
+  - lavalamp

--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/OWNERS
@@ -2,7 +2,6 @@
 
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/OWNERS
@@ -2,7 +2,6 @@
 
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - derekwaynecarr

--- a/staging/src/k8s.io/apiserver/OWNERS
+++ b/staging/src/k8s.io/apiserver/OWNERS
@@ -1,13 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - lavalamp
   - smarterclayton
   - deads2k
   - sttts
   - liggitt
 reviewers:
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k
@@ -23,3 +21,5 @@ reviewers:
 labels:
   - sig/api-machinery
   - area/apiserver
+emeritus_approvers:
+  - lavalamp

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/OWNERS
@@ -2,7 +2,6 @@
 
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k

--- a/staging/src/k8s.io/apiserver/pkg/storage/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/storage/OWNERS
@@ -1,11 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - lavalamp
   - liggitt
   - wojtek-t
 reviewers:
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k
@@ -19,3 +17,4 @@ reviewers:
 emeritus_approvers:
   - xiang90
   - timothysc
+  - lavalamp

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/OWNERS
@@ -1,6 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - lavalamp
   - smarterclayton
   - wojtek-t

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/OWNERS
@@ -1,15 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - lavalamp
   - deads2k
   - yue9944882
   - MikeSpreitzer
 reviewers:
-  - lavalamp
   - deads2k
   - yue9944882
   - MikeSpreitzer
 labels:
   - sig/api-machinery
   - area/apiserver
+emeritus_approvers:
+  - lavalamp

--- a/staging/src/k8s.io/client-go/OWNERS
+++ b/staging/src/k8s.io/client-go/OWNERS
@@ -3,7 +3,6 @@
 approvers:
   - caesarxuchao
   - deads2k
-  - lavalamp
   - liggitt
   - smarterclayton
   - sttts
@@ -14,10 +13,11 @@ reviewers:
   - caesarxuchao
   - deads2k
   - jpbetz
-  - lavalamp
   - liggitt
   - soltysh
   - sttts
   - yliaog
 labels:
   - sig/api-machinery
+emeritus_approvers:
+  - lavalamp

--- a/staging/src/k8s.io/client-go/tools/cache/OWNERS
+++ b/staging/src/k8s.io/client-go/tools/cache/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k
@@ -11,7 +10,6 @@ approvers:
   - ncdc
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k
@@ -26,3 +24,5 @@ reviewers:
   - dims
   - ingvagabund
   - ncdc
+emeritus_approvers:
+  - lavalamp

--- a/staging/src/k8s.io/code-generator/OWNERS
+++ b/staging/src/k8s.io/code-generator/OWNERS
@@ -2,14 +2,14 @@
 
 approvers:
   - deads2k
-  - lavalamp
   - wojtek-t
   - sttts
 reviewers:
   - deads2k
-  - lavalamp
   - wojtek-t
   - sttts
 labels:
   - sig/api-machinery
   - area/code-generation
+emeritus_approvers:
+  - lavalamp

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/OWNERS
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - lavalamp
   - wojtek-t
   - caesarxuchao
 reviewers:
-  - lavalamp
   - wojtek-t
   - caesarxuchao
+emeritus_approvers:
+  - lavalamp

--- a/staging/src/k8s.io/controller-manager/OWNERS
+++ b/staging/src/k8s.io/controller-manager/OWNERS
@@ -4,7 +4,6 @@ approvers:
   - andrewsykim
   - cheftako
   - deads2k
-  - lavalamp
   - liggitt
   - mtaufen
   - sttts
@@ -15,7 +14,6 @@ reviewers:
   - deads2k
   - jiahuif
   - jpbetz
-  - lavalamp
   - liggitt
   - luxas
   - mtaufen
@@ -23,3 +21,5 @@ reviewers:
 labels:
   - sig/api-machinery
   - sig/cloud-provider
+emeritus_approvers:
+  - lavalamp

--- a/staging/src/k8s.io/kube-aggregator/OWNERS
+++ b/staging/src/k8s.io/kube-aggregator/OWNERS
@@ -2,13 +2,11 @@
 
 approvers:
   - deads2k
-  - lavalamp
   - smarterclayton
   - sttts
 reviewers:
   - caesarxuchao
   - deads2k
-  - lavalamp
   - smarterclayton
   - liggitt
   - sttts
@@ -18,3 +16,5 @@ reviewers:
   - jefftree
 labels:
   - sig/api-machinery
+emeritus_approvers:
+  - lavalamp

--- a/staging/src/k8s.io/sample-apiserver/OWNERS
+++ b/staging/src/k8s.io/sample-apiserver/OWNERS
@@ -1,13 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - lavalamp
   - smarterclayton
   - deads2k
   - sttts
   - liggitt
 reviewers:
-  - lavalamp
   - smarterclayton
   - deads2k
   - sttts
@@ -15,3 +13,5 @@ reviewers:
   - cheftako
 labels:
   - sig/api-machinery
+emeritus_approvers:
+  - lavalamp

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -7,7 +7,6 @@ reviewers:
   - aojea
   - dchen1107
   - johnSchnake
-  - lavalamp
   - liggitt
   - neolit123
   - SataQiu
@@ -26,7 +25,6 @@ approvers:
   - dims
   - enj
   - janetkuo
-  - lavalamp
   - liggitt
   - mikedanese
   - MrHohn
@@ -51,6 +49,7 @@ emeritus_approvers:
   - krousey
   - krzyzacy
   - kow3ns
+  - lavalamp
   - madhusudancs
   - marun
   - zmerlynn

--- a/test/e2e/apimachinery/OWNERS
+++ b/test/e2e/apimachinery/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - lavalamp
   - smarterclayton
   - deads2k
   - sttts
@@ -9,7 +8,6 @@ approvers:
   - caesarxuchao
 reviewers:
   - thockin
-  - lavalamp
   - smarterclayton
   - wojtek-t
   - deads2k
@@ -23,3 +21,5 @@ reviewers:
   - logicalhan
 labels:
   - sig/api-machinery
+emeritus_approvers:
+  - lavalamp

--- a/test/integration/dryrun/OWNERS
+++ b/test/integration/dryrun/OWNERS
@@ -6,4 +6,3 @@ approvers:
 reviewers:
   - deads2k
   - liggitt
-  - lavalamp

--- a/third_party/OWNERS
+++ b/third_party/OWNERS
@@ -5,11 +5,11 @@ options:
   no_parent_owners: true
 reviewers:
   - dims
-  - lavalamp
   - smarterclayton
   - thockin
 approvers:
   - dep-approvers
-  - lavalamp
   - smarterclayton
   - thockin
+emeritus_approvers:
+  - lavalamp


### PR DESCRIPTION
As announce on the API Machinery and dev lists, I'm taking a long break.

/kind cleanup

Release note:

```release-note
NONE
```

I'm here for another day so:

/hold

/assign @liggitt