### PR TITLE
fix false positive kubectl plugin unit tests

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
@@ -28,6 +28,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/kubectl/pkg/cmd/plugin"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
@@ -79,7 +80,7 @@ func TestKubectlSubcommandShadowPlugin(t *testing.T) {
 		},
 		{
 			name:             "test that normal commands are able to be executed, when builtin subcommand exists",
-			args:             []string{"kubectl", "create", "role", "--bar", "--bar2", "--namespace", "test-namespace"},
+			args:             []string{"kubectl", "create", "job", "foo", "--image=busybox", "--dry-run=client", "--namespace", "test-namespace"},
 			expectPlugin:     "",
 			expectPluginArgs: []string{},
 		},
@@ -87,7 +88,7 @@ func TestKubectlSubcommandShadowPlugin(t *testing.T) {
 		// just to retest them also when feature is enabled.
 		{
 			name:             "test that normal commands are able to be executed, when no plugin overshadows them",
-			args:             []string{"kubectl", "get", "foo"},
+			args:             []string{"kubectl", "config", "get-clusters"},
 			expectPlugin:     "",
 			expectPluginArgs: []string{},
 		},
@@ -99,7 +100,7 @@ func TestKubectlSubcommandShadowPlugin(t *testing.T) {
 		},
 		{
 			name: "test that a plugin does not execute over an existing command by the same name",
-			args: []string{"kubectl", "version"},
+			args: []string{"kubectl", "version", "--client=true"},
 		},
 		{
 			name: "test that a plugin does not execute over Cobra's help command",
@@ -107,11 +108,11 @@ func TestKubectlSubcommandShadowPlugin(t *testing.T) {
 		},
 		{
 			name: "test that a plugin does not execute over Cobra's __complete command",
-			args: []string{"kubectl", cobra.ShellCompRequestCmd},
+			args: []string{"kubectl", cobra.ShellCompRequestCmd, "de"},
 		},
 		{
 			name: "test that a plugin does not execute over Cobra's __completeNoDesc command",
-			args: []string{"kubectl", cobra.ShellCompNoDescRequestCmd},
+			args: []string{"kubectl", cobra.ShellCompNoDescRequestCmd, "de"},
 		},
 		{
 			name: "test that a flag does not break Cobra's help command",
@@ -132,20 +133,37 @@ func TestKubectlSubcommandShadowPlugin(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				pluginsHandler := &testPluginHandler{
 					pluginsDirectory: "plugin/testdata",
+					validPrefixes:    plugin.ValidPluginFilenamePrefixes,
 				}
 				ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
-
 				root := NewDefaultKubectlCommandWithArgs(KubectlOptions{PluginHandler: pluginsHandler, Arguments: test.args, IOStreams: ioStreams})
-				if err := root.Execute(); err != nil {
-					t.Fatalf("unexpected error: %v", err)
+				// original plugin handler (DefaultPluginHandler) is implemented by exec call so no additional actions are expected on the cobra command if we activate the plugin flow
+				if !pluginsHandler.lookedup && !pluginsHandler.executed {
+					// args must be set, otherwise Execute will use os.Args (args used for starting the test) and test.args would not be passed
+					// to the command which might invoke only "kubectl" without any additional args and give false positives
+					root.SetArgs(test.args[1:])
+					// Important note! Incorrect command or command failing validation might just call os.Exit(1) which would interrupt execution of the test
+					if err := root.Execute(); err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
 				}
 
-				if pluginsHandler.err != nil && pluginsHandler.err.Error() != test.expectError {
+				if (pluginsHandler.err != nil && pluginsHandler.err.Error() != test.expectError) ||
+					(pluginsHandler.err == nil && len(test.expectError) > 0) {
 					t.Fatalf("unexpected error: expected %q to occur, but got %q", test.expectError, pluginsHandler.err)
+				}
+
+				if pluginsHandler.lookedup && !pluginsHandler.executed && len(test.expectError) == 0 {
+					// we have to fail here, because we have found the plugin, but not executed the plugin, nor the command (this would normally result in an error: unknown command)
+					t.Fatalf("expected plugin execution, but did not occur")
 				}
 
 				if pluginsHandler.executedPlugin != test.expectPlugin {
 					t.Fatalf("unexpected plugin execution: expected %q, got %q", test.expectPlugin, pluginsHandler.executedPlugin)
+				}
+
+				if pluginsHandler.executed && len(test.expectPlugin) == 0 {
+					t.Fatalf("unexpected plugin execution: expected no plugin, got %q", pluginsHandler.executedPlugin)
 				}
 
 				if !cmp.Equal(pluginsHandler.withArgs, test.expectPluginArgs, cmpopts.EquateEmpty()) {
@@ -166,13 +184,13 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 	}{
 		{
 			name:             "test that normal commands are able to be executed, when no plugin overshadows them",
-			args:             []string{"kubectl", "get", "foo"},
+			args:             []string{"kubectl", "config", "get-clusters"},
 			expectPlugin:     "",
 			expectPluginArgs: []string{},
 		},
 		{
 			name:             "test that normal commands are able to be executed, when no plugin overshadows them and shadowing feature is not enabled",
-			args:             []string{"kubectl", "create", "foo"},
+			args:             []string{"kubectl", "create", "job", "foo", "--image=busybox", "--dry-run=client"},
 			expectPlugin:     "",
 			expectPluginArgs: []string{},
 		},
@@ -184,7 +202,7 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 		},
 		{
 			name: "test that a plugin does not execute over an existing command by the same name",
-			args: []string{"kubectl", "version"},
+			args: []string{"kubectl", "version", "--client=true"},
 		},
 		// The following tests make sure that commands added by Cobra cannot be shadowed by a plugin
 		// See https://github.com/kubernetes/kubectl/issues/1116
@@ -194,11 +212,11 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 		},
 		{
 			name: "test that a plugin does not execute over Cobra's __complete command",
-			args: []string{"kubectl", cobra.ShellCompRequestCmd},
+			args: []string{"kubectl", cobra.ShellCompRequestCmd, "de"},
 		},
 		{
 			name: "test that a plugin does not execute over Cobra's __completeNoDesc command",
-			args: []string{"kubectl", cobra.ShellCompNoDescRequestCmd},
+			args: []string{"kubectl", cobra.ShellCompNoDescRequestCmd, "de"},
 		},
 		// The following tests make sure that commands added by Cobra cannot be shadowed by a plugin
 		// even when a flag is specified first.  This can happen when using aliases.
@@ -236,20 +254,37 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			pluginsHandler := &testPluginHandler{
 				pluginsDirectory: "plugin/testdata",
+				validPrefixes:    plugin.ValidPluginFilenamePrefixes,
 			}
 			ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
-
 			root := NewDefaultKubectlCommandWithArgs(KubectlOptions{PluginHandler: pluginsHandler, Arguments: test.args, IOStreams: ioStreams})
-			if err := root.Execute(); err != nil {
-				t.Fatalf("unexpected error: %v", err)
+			// original plugin handler (DefaultPluginHandler) is implemented by exec call so no additional actions are expected on the cobra command if we activate the plugin flow
+			if !pluginsHandler.lookedup && !pluginsHandler.executed {
+				// args must be set, otherwise Execute will use os.Args (args used for starting the test) and test.args would not be passed
+				// to the command which might invoke only "kubectl" without any additional args and give false positives
+				root.SetArgs(test.args[1:])
+				// Important note! Incorrect command or command failing validation might just call os.Exit(1) which would interrupt execution of the test
+				if err := root.Execute(); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
 			}
 
-			if pluginsHandler.err != nil && pluginsHandler.err.Error() != test.expectError {
+			if (pluginsHandler.err != nil && pluginsHandler.err.Error() != test.expectError) ||
+				(pluginsHandler.err == nil && len(test.expectError) > 0) {
 				t.Fatalf("unexpected error: expected %q to occur, but got %q", test.expectError, pluginsHandler.err)
+			}
+
+			if pluginsHandler.lookedup && !pluginsHandler.executed && len(test.expectError) == 0 {
+				// we have to fail here, because we have found the plugin, but not executed the plugin, nor the command (this would normally result in an error: unknown command)
+				t.Fatalf("expected plugin execution, but did not occur")
 			}
 
 			if pluginsHandler.executedPlugin != test.expectPlugin {
 				t.Fatalf("unexpected plugin execution: expected %q, got %q", test.expectPlugin, pluginsHandler.executedPlugin)
+			}
+
+			if pluginsHandler.executed && len(test.expectPlugin) == 0 {
+				t.Fatalf("unexpected plugin execution: expected no plugin, got %q", pluginsHandler.executedPlugin)
 			}
 
 			if !cmp.Equal(pluginsHandler.withArgs, test.expectPluginArgs, cmpopts.EquateEmpty()) {
@@ -261,18 +296,21 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 
 type testPluginHandler struct {
 	pluginsDirectory string
+	validPrefixes    []string
+
+	// lookup results
+	lookedup bool
+	err      error
 
 	// execution results
+	executed       bool
 	executedPlugin string
 	withArgs       []string
 	withEnv        []string
-
-	err error
 }
 
 func (h *testPluginHandler) Lookup(filename string) (string, bool) {
-	// append supported plugin prefix to the filename
-	filename = fmt.Sprintf("%s-%s", "kubectl", filename)
+	h.lookedup = true
 
 	dir, err := os.Stat(h.pluginsDirectory)
 	if err != nil {
@@ -291,17 +329,22 @@ func (h *testPluginHandler) Lookup(filename string) (string, bool) {
 		return "", false
 	}
 
-	for _, p := range plugins {
-		if p.Name() == filename {
-			return fmt.Sprintf("%s/%s", h.pluginsDirectory, p.Name()), true
+	filenameWithSuportedPrefix := ""
+	for _, prefix := range h.validPrefixes {
+		for _, p := range plugins {
+			filenameWithSuportedPrefix = fmt.Sprintf("%s-%s", prefix, filename)
+			if p.Name() == filenameWithSuportedPrefix {
+				return fmt.Sprintf("%s/%s", h.pluginsDirectory, p.Name()), true
+			}
 		}
 	}
 
-	h.err = fmt.Errorf("unable to find a plugin executable %q", filename)
+	h.err = fmt.Errorf("unable to find a plugin executable %q", filenameWithSuportedPrefix)
 	return "", false
 }
 
 func (h *testPluginHandler) Execute(executablePath string, cmdArgs, env []string) error {
+	h.executed = true
 	h.executedPlugin = executablePath
 	h.withArgs = cmdArgs
 	h.withEnv = env


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind failing-test
^ kind test-fails-at-failing would be more appropriate

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

I have been playing with TestKubectlCommandHandlesPlugins and TestKubectlSubcommandShadowPlugin tests and noticed that they actually do not run properly. Our goal is to test different commands to test conflicts with plugins, but the test mostly just executes without args (just `kubectl`), depending on how you run the tests. This in turn just calls help and exists with 0 and no conflicts are tested. This PR tries to remedy that to prevent future regressions in the plugin logic.

- test.args should be passed instead of the os.Args of the test framework to prevent simple invocation of kubectl without args that could manifest in false positive test runs
- plugin execution should have a different test path
- tests should invoke functioning kubectl commands instead of the mock ones to ensure the correct subcommand is executed without a failure

@ardaguclu @soltysh 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
