### PR TITLE
Refactored Run command into flags and options. Broke out validation into separate function

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -227,7 +227,7 @@ func NewCmdRun(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Com
 
 	addRunFlags(cmd, flags)
 	//cmdutil.AddApplyAnnotationFlags(cmd)
-	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodAttachTimeout)
+	//cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodAttachTimeout)
 
 	// Deprecate the cascade flag. If set, it has no practical effect since the created pod has no dependents.
 	// TODO: Remove the cascade flag from the run command in kubectl 1.29
@@ -281,7 +281,7 @@ func addRunFlags(cmd *cobra.Command, flags *RunFlags) {
 	cmd.Flags().BoolVarP(&flags.Quiet, "quiet", "q", flags.Quiet, "If true, suppress prompt messages.")
 	cmd.Flags().BoolVar(&flags.Privileged, "privileged", flags.Privileged, i18n.T("If true, run the container in privileged mode."))
 	cmd.Flags().BoolVar(&flags.SaveConfig, "save-config", false, i18n.T("TODO Save config description"))
-	//cmd.Flags().DurationVar(&flags.PodRunningTimeout, "pod-running-timeout", flags.PodRunningTimeout, "TODO message about pod timeouts that makes sense")
+	cmd.Flags().DurationVar(&flags.PodRunningTimeout, "pod-running-timeout", flags.PodRunningTimeout, "TODO message about pod timeouts that makes sense")
 
 	cmdutil.AddFieldManagerFlagVar(cmd, &flags.fieldManager, "kubectl-run")
 	flags.AddOverrideFlags(cmd)
@@ -321,10 +321,10 @@ func (flags *RunFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, args []s
 	}
 
 	// TODO do we need this anymore
-	// attachFlag := cmd.Flags().Lookup("attach")
-	// if !attachFlag.Changed && flags.Interactive {
-	// 	flags.Attach = true
-	// }
+	attachFlag := cmd.Flags().Lookup("attach")
+	if !attachFlag.Changed && flags.Interactive {
+		flags.Attach = true
+	}
 
 	namespace, enforceNamespace, err := f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
@@ -355,6 +355,7 @@ func (flags *RunFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, args []s
 		TTY:            flags.TTY,
 		fieldManager:   flags.fieldManager,
 		SaveConfig:     flags.SaveConfig,
+		Restart:        flags.Restart,
 
 		Namespace:         namespace,
 		EnforceNamespace:  enforceNamespace,
@@ -370,7 +371,7 @@ func (flags *RunFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, args []s
 			TTY:       options.TTY,
 			Quiet:     options.Quiet,
 		},
-		GetPodTimeout: options.timeout,
+		GetPodTimeout: options.PodRunningTimeout,
 		CommandName:   cmd.CommandPath() + " attach",
 
 		Attach: &attach.DefaultRemoteAttach{},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -186,6 +186,7 @@ func NewRunFlags(streams genericiooptions.IOStreams) *RunFlags {
 		IOStreams:         streams,
 		PodRunningTimeout: defaultPodAttachTimeout,
 		DryRunStrategy:    "none",
+		LeaveStdinOpen:    true,
 	}
 }
 
@@ -400,7 +401,7 @@ func (o *RunOptions) Validate(args []string) error {
 	}
 
 	if !reference.ReferenceRegexp.MatchString(o.Image) {
-		return fmt.Errorf("Invalid image name %q: %v", o.Image, reference.ErrReferenceInvalidFormat)
+		return fmt.Errorf("invalid image name %q: %v", o.Image, reference.ErrReferenceInvalidFormat)
 	}
 
 	if o.TTY && !o.Interactive {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -35,6 +35,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -122,7 +123,8 @@ type RunFlags struct {
 	Namespace        string
 	EnforceNamespace bool
 
-	genericclioptions.IOStreams
+
+	genericiooptions.IOStreams
 }
 
 // runtime dependencies of the command
@@ -151,7 +153,6 @@ type RunOptions struct {
 	TTY            bool
 	fieldManager   string
 
-	//new
 	restartPolicy corev1.RestartPolicy
 	timeout       time.Duration
 	remove        bool
@@ -159,10 +160,10 @@ type RunOptions struct {
 	Namespace        string
 	EnforceNamespace bool
 
-	genericclioptions.IOStreams
+	genericiooptions.IOStreams
 }
 
-func NewRunFlags(streams genericclioptions.IOStreams) *RunFlags {
+func NewRunFlags(streams genericiooptions.IOStreams) *RunFlags {
 	return &RunFlags{
 		PrintFlags:  genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		DeleteFlags: cmddelete.NewDeleteFlags("to use to replace the resource."),
@@ -171,7 +172,7 @@ func NewRunFlags(streams genericclioptions.IOStreams) *RunFlags {
 	}
 }
 
-func NewCmdRun(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdRun(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	flags := NewRunFlags(streams)
 
 	cmd := &cobra.Command{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -226,8 +226,8 @@ func NewCmdRun(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Com
 	flags.RecordFlags.AddFlags(cmd)
 
 	addRunFlags(cmd, flags)
-	//cmdutil.AddApplyAnnotationFlags(cmd)
-	//cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodAttachTimeout)
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodAttachTimeout)
 
 	// Deprecate the cascade flag. If set, it has no practical effect since the created pod has no dependents.
 	// TODO: Remove the cascade flag from the run command in kubectl 1.29
@@ -281,8 +281,8 @@ func addRunFlags(cmd *cobra.Command, flags *RunFlags) {
 	cmd.Flags().BoolVarP(&flags.Quiet, "quiet", "q", flags.Quiet, "If true, suppress prompt messages.")
 	cmd.Flags().BoolVar(&flags.Privileged, "privileged", flags.Privileged, i18n.T("If true, run the container in privileged mode."))
 
-	cmd.Flags().BoolVar(&flags.SaveConfig, "save-config", flags.SaveConfig, i18n.T("TODO Save config description"))
-	cmd.Flags().DurationVar(&flags.PodRunningTimeout, "pod-running-timeout", flags.PodRunningTimeout, "TODO message about pod timeouts that makes sense")
+	//cmd.Flags().BoolVar(&flags.SaveConfig, "save-config", flags.SaveConfig, i18n.T("TODO Save config description"))
+	//cmd.Flags().DurationVar(&flags.PodRunningTimeout, "pod-running-timeout", flags.PodRunningTimeout, "TODO message about pod timeouts that makes sense")
 
 	cmdutil.AddFieldManagerFlagVar(cmd, &flags.fieldManager, "kubectl-run")
 	flags.AddOverrideFlags(cmd)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -191,7 +191,6 @@ func NewCmdRun(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Com
 				cmdutil.CheckErr(err)
 				return
 			}
-			cmdutil.CheckErr(o.Validate(cmd, args))
 			cmdutil.CheckErr(o.Run(f, cmd, args))
 		},
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -186,7 +186,12 @@ func NewCmdRun(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Com
 				return
 			}
 			cmdutil.CheckErr(o.Complete())
-			cmdutil.CheckErr(o.Validate(cmd,args))
+			err = o.Validate(cmd, args)
+			if err != nil {
+				cmdutil.CheckErr(err)
+				return
+			}
+			cmdutil.CheckErr(o.Validate(cmd, args))
 			cmdutil.CheckErr(o.Run(f, cmd, args))
 		},
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -123,7 +123,6 @@ type RunFlags struct {
 	Namespace        string
 	EnforceNamespace bool
 
-
 	genericiooptions.IOStreams
 }
 
@@ -173,7 +172,7 @@ func NewRunFlags(streams genericiooptions.IOStreams) *RunFlags {
 }
 
 func NewCmdRun(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
-	flags := NewRunFlags(streams) 
+	flags := NewRunFlags(streams)
 
 	cmd := &cobra.Command{
 		Use:                   "run NAME --image=image [--env=\"key=value\"] [--port=port] [--dry-run=server|client] [--overrides=inline-json] [--command] -- [COMMAND] [args...]",
@@ -314,6 +313,7 @@ func (flags *RunFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, args []s
 
 		Namespace:        namespace,
 		EnforceNamespace: enforceNamespace,
+		IOStreams:        flags.IOStreams,
 	}
 
 	return options, nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -100,7 +100,7 @@ type RunObject struct {
 	Mapping *meta.RESTMapping
 }
 
-// cli flags being passed
+// cli flags being passed into command
 type RunFlags struct {
 	cmdutil.OverrideOptions
 
@@ -173,7 +173,7 @@ func NewRunFlags(streams genericiooptions.IOStreams) *RunFlags {
 }
 
 func NewCmdRun(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
-	flags := NewRunFlags(streams)
+	flags := NewRunFlags(streams) 
 
 	cmd := &cobra.Command{
 		Use:                   "run NAME --image=image [--env=\"key=value\"] [--port=port] [--dry-run=server|client] [--overrides=inline-json] [--command] -- [COMMAND] [args...]",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -186,7 +186,7 @@ func NewRunFlags(streams genericiooptions.IOStreams) *RunFlags {
 		IOStreams:         streams,
 		PodRunningTimeout: defaultPodAttachTimeout,
 		DryRunStrategy:    "none",
-		LeaveStdinOpen:    true,
+		LeaveStdinOpen:    false,
 	}
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -186,10 +186,7 @@ func NewCmdRun(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Com
 				return
 			}
 			cmdutil.CheckErr(o.Complete())
-			err = o.Validate(cmd, args)
-			if err != nil {
-				return
-			}
+			cmdutil.CheckErr(o.Validate(cmd,args))
 			cmdutil.CheckErr(o.Run(f, cmd, args))
 		},
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run_test.go
@@ -41,7 +41,6 @@ import (
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
-	"k8s.io/kubectl/pkg/util/i18n"
 )
 
 func TestGetRestartPolicy(t *testing.T) {
@@ -84,10 +83,7 @@ func TestGetRestartPolicy(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		cmd := &cobra.Command{}
-		cmd.Flags().String("restart", "", i18n.T("dummy restart flag)"))
-		cmd.Flags().Lookup("restart").Value.Set(test.input)
-		policy, err := getRestartPolicy(cmd, test.interactive)
+		policy, err := getRestartPolicy(test.input, test.interactive)
 		if test.expectErr && err == nil {
 			t.Error("unexpected non-error")
 		}
@@ -383,7 +379,7 @@ func TestGenerateService(t *testing.T) {
 				test.params["port"] = test.port
 			}
 
-			_, err = opts.generateService(tf, cmd, test.params)
+			_, err = opts.generateService(tf, test.params)
 			if test.expectErr {
 				if err == nil {
 					t.Error("unexpected non-error")
@@ -422,7 +418,7 @@ func TestRunValidations(t *testing.T) {
 			flags: map[string]string{
 				"image": "#",
 			},
-			expectedErr: "Invalid image name",
+			expectedErr: "invalid image name \"#\": invalid reference format",
 		},
 		{
 			name: "test rm errors when used on non-attached containers",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	
+
 	"reflect"
 	"strconv"
 	"strings"
@@ -204,7 +204,7 @@ func TestRunArgsFollowDashRules(t *testing.T) {
 			if err != nil && !test.expectError {
 				t.Errorf("unexpected error: %v", err)
 			}
-			
+
 		})
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -684,11 +684,15 @@ const (
 
 func GetDryRunStrategy(cmd *cobra.Command) (DryRunStrategy, error) {
 	var dryRunFlag = GetFlagString(cmd, "dry-run")
+	return GetDryRunStrategyFromFlag(dryRunFlag)
+}
+
+func GetDryRunStrategyFromFlag(dryRunFlag string) (DryRunStrategy, error) {
 	b, err := strconv.ParseBool(dryRunFlag)
 	// The flag is not a boolean
 	if err != nil {
 		switch dryRunFlag {
-		case cmd.Flag("dry-run").NoOptDefVal:
+		case "unchanged":
 			klog.Warning(`--dry-run is deprecated and can be replaced with --dry-run=client.`)
 			return DryRunClient, nil
 		case "client":

--- a/test/cmd/run.sh
+++ b/test/cmd/run.sh
@@ -46,7 +46,7 @@ run_kubectl_run_tests() {
   kubectl delete pods test1
   # test invalid image name
   output_message=$(! kubectl run test2 --image=InvalidImageName 2>&1)
-  kube::test::if_has_string "${output_message}" 'error: Invalid image name "InvalidImageName": invalid reference format'
+  kube::test::if_has_string "${output_message}" 'error: invalid image name "InvalidImageName": invalid reference format'
 
   set +o nounset
   set +o errexit


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR decouples the command options from the input flags. The input flags from the command are then translated to options which are further used while running the command. Part of https://github.com/kubernetes/kubectl/issues/1046

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
