### PR TITLE
deps: go-gcfg update to the v1.2.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21
 	google.golang.org/grpc v1.51.0
 	google.golang.org/protobuf v1.30.0
-	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1218,8 +1218,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/gcfg.v1 v1.2.0 h1:0HIbH907iBTAntm+88IJV2qmJALDAh8sPekI9Vc1fm0=
-gopkg.in/gcfg.v1 v1.2.0/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
+gopkg.in/gcfg.v1 v1.2.3 h1:m8OOJ4ccYHnx2f4gQwpno8nAX5OGOh7RLaaz0pj3Ogs=
+gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/staging/src/k8s.io/legacy-cloud-providers/go.mod
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.mod
@@ -19,7 +19,7 @@ require (
 	golang.org/x/crypto v0.6.0
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b
 	google.golang.org/api v0.60.0
-	gopkg.in/gcfg.v1 v1.2.0
+	gopkg.in/gcfg.v1 v1.2.3
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0

--- a/staging/src/k8s.io/legacy-cloud-providers/go.sum
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.sum
@@ -778,8 +778,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/gcfg.v1 v1.2.0 h1:0HIbH907iBTAntm+88IJV2qmJALDAh8sPekI9Vc1fm0=
-gopkg.in/gcfg.v1 v1.2.0/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
+gopkg.in/gcfg.v1 v1.2.3 h1:m8OOJ4ccYHnx2f4gQwpno8nAX5OGOh7RLaaz0pj3Ogs=
+gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=

--- a/vendor/gopkg.in/gcfg.v1/errors.go
+++ b/vendor/gopkg.in/gcfg.v1/errors.go
@@ -1,8 +1,6 @@
 package gcfg
 
-import (
-	"gopkg.in/warnings.v0"
-)
+import warnings "gopkg.in/warnings.v0"
 
 // FatalOnly filters the results of a Read*Into invocation and returns only
 // fatal errors. That is, errors (warnings) indicating data for unknown
@@ -21,21 +19,39 @@ func isFatal(err error) bool {
 	return !ok
 }
 
-type extraData struct {
+type loc struct {
 	section    string
 	subsection *string
 	variable   *string
 }
 
-func (e extraData) Error() string {
-	s := "can't store data at section \"" + e.section + "\""
-	if e.subsection != nil {
-		s += ", subsection \"" + *e.subsection + "\""
+type extraData struct {
+	loc
+}
+
+type locErr struct {
+	msg string
+	loc
+}
+
+func (l loc) String() string {
+	s := "section \"" + l.section + "\""
+	if l.subsection != nil {
+		s += ", subsection \"" + *l.subsection + "\""
 	}
-	if e.variable != nil {
-		s += ", variable \"" + *e.variable + "\""
+	if l.variable != nil {
+		s += ", variable \"" + *l.variable + "\""
 	}
 	return s
 }
 
+func (e extraData) Error() string {
+	return "can't store data at " + e.loc.String()
+}
+
+func (e locErr) Error() string {
+	return e.msg + " at " + e.loc.String()
+}
+
 var _ error = extraData{}
+var _ error = locErr{}

--- a/vendor/gopkg.in/gcfg.v1/go1_0.go
+++ b/vendor/gopkg.in/gcfg.v1/go1_0.go
@@ -1,7 +1,0 @@
-// +build !go1.2
-
-package gcfg
-
-type textUnmarshaler interface {
-	UnmarshalText(text []byte) error
-}

--- a/vendor/gopkg.in/gcfg.v1/go1_2.go
+++ b/vendor/gopkg.in/gcfg.v1/go1_2.go
@@ -1,9 +1,0 @@
-// +build go1.2
-
-package gcfg
-
-import (
-	"encoding"
-)
-
-type textUnmarshaler encoding.TextUnmarshaler

--- a/vendor/gopkg.in/gcfg.v1/read.go
+++ b/vendor/gopkg.in/gcfg.v1/read.go
@@ -1,6 +1,7 @@
 package gcfg
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,6 +14,7 @@ import (
 )
 
 var unescape = map[rune]rune{'\\': '\\', '"': '"', 'n': '\n', 't': '\t'}
+var utf8Bom = []byte("\ufeff")
 
 // no error: invalid literals should be caught by scanner
 func unquote(s string) string {
@@ -183,7 +185,6 @@ func readIntoPass(c *warnings.Collector, config interface{}, fset *token.FileSet
 			}
 		}
 	}
-	panic("never reached")
 }
 
 func readInto(config interface{}, fset *token.FileSet, file *token.File,
@@ -222,6 +223,9 @@ func ReadStringInto(config interface{}, str string) error {
 
 // ReadFileInto reads gcfg formatted data from the file filename and sets the
 // values into the corresponding fields in config.
+//
+// For compatibility with files created on Windows, the ReadFileInto skips a
+// single leading UTF8 BOM sequence if it exists.
 func ReadFileInto(config interface{}, filename string) error {
 	f, err := os.Open(filename)
 	if err != nil {
@@ -232,7 +236,22 @@ func ReadFileInto(config interface{}, filename string) error {
 	if err != nil {
 		return err
 	}
+
+	// Skips a single leading UTF8 BOM sequence if it exists.
+	src = skipLeadingUtf8Bom(src)
+
 	fset := token.NewFileSet()
 	file := fset.AddFile(filename, fset.Base(), len(src))
 	return readInto(config, fset, file, src)
+}
+
+func skipLeadingUtf8Bom(src []byte) []byte {
+	lengthUtf8Bom := len(utf8Bom)
+
+	if len(src) >= lengthUtf8Bom {
+		if bytes.Equal(src[:lengthUtf8Bom], utf8Bom) {
+			return src[lengthUtf8Bom:]
+		}
+	}
+	return src
 }

--- a/vendor/gopkg.in/gcfg.v1/scanner/scanner.go
+++ b/vendor/gopkg.in/gcfg.v1/scanner/scanner.go
@@ -231,8 +231,8 @@ loop:
 				hasCR = true
 				s.next()
 			}
-			if s.ch != '\n' {
-				s.error(offs, "unquoted '\\' must be followed by new line")
+			if s.ch != '\n' && s.ch != '"' {
+				s.error(offs, "unquoted '\\' must be followed by new line or double quote")
 				break loop
 			}
 			s.next()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1187,7 +1187,7 @@ google.golang.org/protobuf/types/known/fieldmaskpb
 google.golang.org/protobuf/types/known/structpb
 google.golang.org/protobuf/types/known/timestamppb
 google.golang.org/protobuf/types/known/wrapperspb
-# gopkg.in/gcfg.v1 v1.2.0
+# gopkg.in/gcfg.v1 v1.2.3
 ## explicit
 gopkg.in/gcfg.v1
 gopkg.in/gcfg.v1/scanner


### PR DESCRIPTION
https://github.com/go-gcfg/gcfg/compare/v1.2.0...v1.2.3


/kind cleanup

-->
```release-note
NONE
```

Additional note for reviewer:

if we look at the go version declared on the  version of the package we use in k/k its really old, even this updated version is old.. but afacit, its good to use atleast the available latest.
