### PR TITLE
kubelet: metrix fix for container_start_time_seconds's timestamp

### DIFF
--- a/pkg/kubelet/metrics/collectors/resource_metrics.go
+++ b/pkg/kubelet/metrics/collectors/resource_metrics.go
@@ -165,9 +165,7 @@ func (rc *resourceMetricsCollector) collectContainerStartTime(ch chan<- metrics.
 	if s.StartTime.Unix() <= 0 {
 		return
 	}
-
-	ch <- metrics.NewLazyMetricWithTimestamp(s.StartTime.Time,
-		metrics.NewLazyConstMetric(containerStartTimeDesc, metrics.GaugeValue, float64(s.StartTime.UnixNano())/float64(time.Second), s.Name, pod.PodRef.Name, pod.PodRef.Namespace))
+	ch <- metrics.NewLazyConstMetric(containerStartTimeDesc, metrics.GaugeValue, float64(s.StartTime.UnixNano())/float64(time.Second), s.Name, pod.PodRef.Name, pod.PodRef.Namespace)
 }
 
 func (rc *resourceMetricsCollector) collectContainerCPUMetrics(ch chan<- metrics.Metric, pod summary.PodStats, s summary.ContainerStats) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
It fixed the metric in container_start_time_seconds we have removed it because the time is equal to the container runtime timestamp.

#### Which issue(s) this PR fixes:
[117880](https://github.com/kubernetes/kubernetes/issues/117880)

#### Does this PR introduce a user-facing change?
NONE