### PR TITLE
Add information about supported MetricTarget types

### DIFF
--- a/api/openapi-spec/v3/apis__autoscaling__v2_openapi.json
+++ b/api/openapi-spec/v3/apis__autoscaling__v2_openapi.json
@@ -2,7 +2,7 @@
   "components": {
     "schemas": {
       "io.k8s.api.autoscaling.v2.ContainerResourceMetricSource": {
-        "description": "ContainerResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.  Only one \"target\" type should be set.",
+        "description": "ContainerResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. Supports \"AverageUtilization\" and \"AverageValue\" MetricTarget types.",
         "properties": {
           "container": {
             "default": "",
@@ -86,7 +86,7 @@
         "type": "object"
       },
       "io.k8s.api.autoscaling.v2.ExternalMetricSource": {
-        "description": "ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).",
+        "description": "ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster). Supports \"Value\" and \"AverageValue\" MetricTarget types.",
         "properties": {
           "metric": {
             "allOf": [
@@ -495,7 +495,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource"
               }
             ],
-            "description": "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag."
+            "description": "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. As of 1.27 this is a beta feature and is enabled by default via the HPAContainerMetrics feature flag."
           },
           "external": {
             "allOf": [
@@ -598,7 +598,7 @@
         "description": "MetricTarget defines the target value, average value, or average utilization of a specific metric",
         "properties": {
           "averageUtilization": {
-            "description": "averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type",
+            "description": "averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource and ContainerResource metric source types. Should only be used together with Utilization type.",
             "format": "int32",
             "type": "integer"
           },
@@ -608,7 +608,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
               }
             ],
-            "description": "averageValue is the target value of the average of the metric across all relevant pods (as a quantity)"
+            "description": "averageValue is the target value of the average of the metric across all relevant pods (as a quantity). Should only be used together with AverageValue type."
           },
           "type": {
             "default": "",
@@ -621,7 +621,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity"
               }
             ],
-            "description": "value is the target value of the metric (as a quantity)."
+            "description": "value is the target value of the metric (as a quantity). Should only be used together with Value type."
           }
         },
         "required": [
@@ -657,7 +657,7 @@
         "type": "object"
       },
       "io.k8s.api.autoscaling.v2.ObjectMetricSource": {
-        "description": "ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).",
+        "description": "ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object). Supports \"Value\" and \"AverageValue\" MetricTarget types.",
         "properties": {
           "describedObject": {
             "allOf": [
@@ -733,7 +733,7 @@
         "type": "object"
       },
       "io.k8s.api.autoscaling.v2.PodsMetricSource": {
-        "description": "PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.",
+        "description": "PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value. Supports only \"AverageValue\" MetricTarget type.",
         "properties": {
           "metric": {
             "allOf": [
@@ -789,7 +789,7 @@
         "type": "object"
       },
       "io.k8s.api.autoscaling.v2.ResourceMetricSource": {
-        "description": "ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.  Only one \"target\" type should be set.",
+        "description": "ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. Supports \"AverageUtilization\" and \"AverageValue\" MetricTarget types.",
         "properties": {
           "name": {
             "default": "",

--- a/pkg/apis/autoscaling/types.go
+++ b/pkg/apis/autoscaling/types.go
@@ -192,36 +192,44 @@ type MetricSourceType string
 const (
 	// ObjectMetricSourceType is a metric describing a kubernetes object
 	// (for example, hits-per-second on an Ingress object).
+	// Supports "Value" and "AverageValue" MetricTarget types.
 	ObjectMetricSourceType MetricSourceType = "Object"
 	// PodsMetricSourceType is a metric describing each pod in the current scale
-	// target (for example, transactions-processed-per-second).  The values
+	// target (for example, transactions-processed-per-second). The values
 	// will be averaged together before being compared to the target value.
+	// Supports only "AverageValue" MetricTarget type.
 	PodsMetricSourceType MetricSourceType = "Pods"
 	// ResourceMetricSourceType is a resource metric known to Kubernetes, as
 	// specified in requests and limits, describing each pod in the current
 	// scale target (e.g. CPU or memory).  Such metrics are built in to
 	// Kubernetes, and have special scaling options on top of those available
 	// to normal per-pod metrics (the "pods" source).
+	// Supports "AverageUtilization" and "AverageValue" MetricTarget types.
 	ResourceMetricSourceType MetricSourceType = "Resource"
 	// ExternalMetricSourceType is a global metric that is not associated
 	// with any Kubernetes object. It allows autoscaling based on information
 	// coming from components running outside of cluster
 	// (for example length of queue in cloud messaging service, or
 	// QPS from loadbalancer running outside of cluster).
+	// Supports "Value" and "AverageValue" MetricTarget types.
 	ExternalMetricSourceType MetricSourceType = "External"
 	// ContainerResourceMetricSourceType is a resource metric known to Kubernetes, as
 	// specified in requests and limits, describing a single container in each pod in the current
 	// scale target (e.g. CPU or memory).  Such metrics are built in to
 	// Kubernetes, and have special scaling options on top of those available
 	// to normal per-pod metrics (the "pods" source).
+	// Supports "AverageUtilization" and "AverageValue" MetricTarget types.
 	ContainerResourceMetricSourceType MetricSourceType = "ContainerResource"
 )
 
 // MetricSpec specifies how to scale based on a single metric
 // (only `type` and one other matching field should be set at once).
 type MetricSpec struct {
-	// Type is the type of metric source.  It should be one of "Object",
-	// "Pods" or "Resource", each mapping to a matching field in the object.
+	// Type is the type of metric source.  It should be one of "ContainerResource",
+	// "External", "Object", "Pods" or "Resource", each mapping to a matching
+	// field in the object.
+	// Note: "ContainerResource" type is available on when the feature-gate
+	// HPAContainerMetrics is enabled.
 	Type MetricSourceType
 
 	// Object refers to a metric describing a single kubernetes object
@@ -245,6 +253,8 @@ type MetricSpec struct {
 	// current scale target (e.g. CPU or memory). Such metrics are built in to
 	// Kubernetes, and have special scaling options on top of those available
 	// to normal per-pod metrics using the "pods" source.
+	// As of 1.27 this is a beta feature and is enabled by default via the
+	// HPAContainerMetrics feature flag.
 	// +optional
 	ContainerResource *ContainerResourceMetricSource
 	// External refers to a global metric that is not associated
@@ -258,6 +268,7 @@ type MetricSpec struct {
 
 // ObjectMetricSource indicates how to scale on a metric describing a
 // kubernetes object (for example, hits-per-second on an Ingress object).
+// Supports "Value" and "AverageValue" MetricTarget types.
 type ObjectMetricSource struct {
 	DescribedObject CrossVersionObjectReference
 	Target          MetricTarget
@@ -268,6 +279,7 @@ type ObjectMetricSource struct {
 // the current scale target (for example, transactions-processed-per-second).
 // The values will be averaged together before being compared to the target
 // value.
+// Supports only "AverageValue" MetricTarget type.
 type PodsMetricSource struct {
 	// metric identifies the target metric by name and selector
 	Metric MetricIdentifier
@@ -280,8 +292,8 @@ type PodsMetricSource struct {
 // current scale target (e.g. CPU or memory).  The values will be averaged
 // together before being compared to the target.  Such metrics are built in to
 // Kubernetes, and have special scaling options on top of those available to
-// normal per-pod metrics using the "pods" source.  Only one "target" type
-// should be set.
+// normal per-pod metrics using the "pods" source.
+// Supports "AverageUtilization" and "AverageValue" MetricTarget types.
 type ResourceMetricSource struct {
 	// Name is the name of the resource in question.
 	Name api.ResourceName
@@ -294,8 +306,8 @@ type ResourceMetricSource struct {
 // each of the pods of the current scale target(e.g. CPU or memory). The values will be
 // averaged together before being compared to the target. Such metrics are built into
 // Kubernetes, and have special scaling options on top of those available to
-// normal per-pod metrics using the "pods" source. Only one "target" type
-// should be set.
+// normal per-pod metrics using the "pods" source.
+// Supports "Value" and "AverageValue" MetricTarget types.
 type ContainerResourceMetricSource struct {
 	// name is the name of the of the resource
 	Name api.ResourceName
@@ -308,6 +320,7 @@ type ContainerResourceMetricSource struct {
 // ExternalMetricSource indicates how to scale on a metric not associated with
 // any Kubernetes object (for example length of queue in cloud
 // messaging service, or QPS from loadbalancer running outside of cluster).
+// Supports "Value" and "AverageValue" MetricTarget types.
 type ExternalMetricSource struct {
 	// Metric identifies the target metric by name and selector
 	Metric MetricIdentifier
@@ -330,15 +343,18 @@ type MetricTarget struct {
 	// Type represents whether the metric type is Utilization, Value, or AverageValue
 	Type MetricTargetType
 	// Value is the target value of the metric (as a quantity).
+	// Should only be used together with Value type.
 	Value *resource.Quantity
 	// TargetAverageValue is the target value of the average of the
 	// metric across all relevant pods (as a quantity)
+	// Should only be used together with AverageValue type.
 	AverageValue *resource.Quantity
 
 	// AverageUtilization is the target value of the average of the
 	// resource metric across all relevant pods, represented as a percentage of
 	// the requested value of the resource for the pods.
-	// Currently only valid for Resource metric source type
+	// Currently only valid for Resource and ContainerResource metric source types.
+	// Should only be used together with Utilization type.
 	AverageUtilization *int32
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -11353,7 +11353,7 @@ func schema_k8sio_api_autoscaling_v2_ContainerResourceMetricSource(ref common.Re
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ContainerResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.  Only one \"target\" type should be set.",
+				Description: "ContainerResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. Supports \"AverageUtilization\" and \"AverageValue\" MetricTarget types.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
@@ -11468,7 +11468,7 @@ func schema_k8sio_api_autoscaling_v2_ExternalMetricSource(ref common.ReferenceCa
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).",
+				Description: "ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster). Supports \"Value\" and \"AverageValue\" MetricTarget types.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"metric": {
@@ -12006,7 +12006,7 @@ func schema_k8sio_api_autoscaling_v2_MetricSpec(ref common.ReferenceCallback) co
 					},
 					"containerResource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.",
+							Description: "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. As of 1.27 this is a beta feature and is enabled by default via the HPAContainerMetrics feature flag.",
 							Ref:         ref("k8s.io/api/autoscaling/v2.ContainerResourceMetricSource"),
 						},
 					},
@@ -12096,19 +12096,19 @@ func schema_k8sio_api_autoscaling_v2_MetricTarget(ref common.ReferenceCallback) 
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "value is the target value of the metric (as a quantity).",
+							Description: "value is the target value of the metric (as a quantity). Should only be used together with Value type.",
 							Ref:         ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 						},
 					},
 					"averageValue": {
 						SchemaProps: spec.SchemaProps{
-							Description: "averageValue is the target value of the average of the metric across all relevant pods (as a quantity)",
+							Description: "averageValue is the target value of the average of the metric across all relevant pods (as a quantity). Should only be used together with AverageValue type.",
 							Ref:         ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 						},
 					},
 					"averageUtilization": {
 						SchemaProps: spec.SchemaProps{
-							Description: "averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type",
+							Description: "averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource and ContainerResource metric source types. Should only be used together with Utilization type.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -12160,7 +12160,7 @@ func schema_k8sio_api_autoscaling_v2_ObjectMetricSource(ref common.ReferenceCall
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).",
+				Description: "ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object). Supports \"Value\" and \"AverageValue\" MetricTarget types.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"describedObject": {
@@ -12234,7 +12234,7 @@ func schema_k8sio_api_autoscaling_v2_PodsMetricSource(ref common.ReferenceCallba
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.",
+				Description: "PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value. Supports only \"AverageValue\" MetricTarget type.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"metric": {
@@ -12294,7 +12294,7 @@ func schema_k8sio_api_autoscaling_v2_ResourceMetricSource(ref common.ReferenceCa
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.  Only one \"target\" type should be set.",
+				Description: "ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. Supports \"AverageUtilization\" and \"AverageValue\" MetricTarget types.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {

--- a/staging/src/k8s.io/api/autoscaling/v2/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2/generated.proto
@@ -35,8 +35,8 @@ option go_package = "k8s.io/api/autoscaling/v2";
 // current scale target (e.g. CPU or memory).  The values will be averaged
 // together before being compared to the target.  Such metrics are built in to
 // Kubernetes, and have special scaling options on top of those available to
-// normal per-pod metrics using the "pods" source.  Only one "target" type
-// should be set.
+// normal per-pod metrics using the "pods" source.
+// Supports "AverageUtilization" and "AverageValue" MetricTarget types.
 message ContainerResourceMetricSource {
   // name is the name of the resource in question.
   optional string name = 1;
@@ -80,6 +80,7 @@ message CrossVersionObjectReference {
 // ExternalMetricSource indicates how to scale on a metric not associated with
 // any Kubernetes object (for example length of queue in cloud
 // messaging service, or QPS from loadbalancer running outside of cluster).
+// Supports "Value" and "AverageValue" MetricTarget types.
 message ExternalMetricSource {
   // metric identifies the target metric by name and selector
   optional MetricIdentifier metric = 1;
@@ -329,7 +330,8 @@ message MetricSpec {
   // each pod of the current scale target (e.g. CPU or memory). Such metrics are
   // built in to Kubernetes, and have special scaling options on top of those
   // available to normal per-pod metrics using the "pods" source.
-  // This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
+  // As of 1.27 this is a beta feature and is enabled by default via the
+  // HPAContainerMetrics feature flag.
   // +optional
   optional ContainerResourceMetricSource containerResource = 7;
 
@@ -392,18 +394,21 @@ message MetricTarget {
   optional string type = 1;
 
   // value is the target value of the metric (as a quantity).
+  // Should only be used together with Value type.
   // +optional
   optional k8s.io.apimachinery.pkg.api.resource.Quantity value = 2;
 
   // averageValue is the target value of the average of the
-  // metric across all relevant pods (as a quantity)
+  // metric across all relevant pods (as a quantity).
+  // Should only be used together with AverageValue type.
   // +optional
   optional k8s.io.apimachinery.pkg.api.resource.Quantity averageValue = 3;
 
   // averageUtilization is the target value of the average of the
   // resource metric across all relevant pods, represented as a percentage of
   // the requested value of the resource for the pods.
-  // Currently only valid for Resource metric source type
+  // Currently only valid for Resource and ContainerResource metric source types.
+  // Should only be used together with Utilization type.
   // +optional
   optional int32 averageUtilization = 4;
 }
@@ -428,6 +433,7 @@ message MetricValueStatus {
 
 // ObjectMetricSource indicates how to scale on a metric describing a
 // kubernetes object (for example, hits-per-second on an Ingress object).
+// Supports "Value" and "AverageValue" MetricTarget types.
 message ObjectMetricSource {
   // describedObject specifies the descriptions of a object,such as kind,name apiVersion
   optional CrossVersionObjectReference describedObject = 1;
@@ -456,6 +462,7 @@ message ObjectMetricStatus {
 // the current scale target (for example, transactions-processed-per-second).
 // The values will be averaged together before being compared to the target
 // value.
+// Supports only "AverageValue" MetricTarget type.
 message PodsMetricSource {
   // metric identifies the target metric by name and selector
   optional MetricIdentifier metric = 1;
@@ -479,8 +486,8 @@ message PodsMetricStatus {
 // current scale target (e.g. CPU or memory).  The values will be averaged
 // together before being compared to the target.  Such metrics are built in to
 // Kubernetes, and have special scaling options on top of those available to
-// normal per-pod metrics using the "pods" source.  Only one "target" type
-// should be set.
+// normal per-pod metrics using the "pods" source.
+// Supports "AverageUtilization" and "AverageValue" MetricTarget types.
 message ResourceMetricSource {
   // name is the name of the resource in question.
   optional string name = 1;

--- a/staging/src/k8s.io/api/autoscaling/v2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types_swagger_doc_generated.go
@@ -28,7 +28,7 @@ package v2
 
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_ContainerResourceMetricSource = map[string]string{
-	"":          "ContainerResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.  Only one \"target\" type should be set.",
+	"":          "ContainerResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. Supports \"AverageUtilization\" and \"AverageValue\" MetricTarget types.",
 	"name":      "name is the name of the resource in question.",
 	"target":    "target specifies the target value for the given metric",
 	"container": "container is the name of the container in the pods of the scaling target",
@@ -61,7 +61,7 @@ func (CrossVersionObjectReference) SwaggerDoc() map[string]string {
 }
 
 var map_ExternalMetricSource = map[string]string{
-	"":       "ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).",
+	"":       "ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster). Supports \"Value\" and \"AverageValue\" MetricTarget types.",
 	"metric": "metric identifies the target metric by name and selector",
 	"target": "target specifies the target value for the given metric",
 }
@@ -189,7 +189,7 @@ var map_MetricSpec = map[string]string{
 	"object":            "object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).",
 	"pods":              "pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.",
 	"resource":          "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
-	"containerResource": "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.",
+	"containerResource": "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. As of 1.27 this is a beta feature and is enabled by default via the HPAContainerMetrics feature flag.",
 	"external":          "external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).",
 }
 
@@ -214,9 +214,9 @@ func (MetricStatus) SwaggerDoc() map[string]string {
 var map_MetricTarget = map[string]string{
 	"":                   "MetricTarget defines the target value, average value, or average utilization of a specific metric",
 	"type":               "type represents whether the metric type is Utilization, Value, or AverageValue",
-	"value":              "value is the target value of the metric (as a quantity).",
-	"averageValue":       "averageValue is the target value of the average of the metric across all relevant pods (as a quantity)",
-	"averageUtilization": "averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type",
+	"value":              "value is the target value of the metric (as a quantity). Should only be used together with Value type.",
+	"averageValue":       "averageValue is the target value of the average of the metric across all relevant pods (as a quantity). Should only be used together with AverageValue type.",
+	"averageUtilization": "averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource and ContainerResource metric source types. Should only be used together with Utilization type.",
 }
 
 func (MetricTarget) SwaggerDoc() map[string]string {
@@ -235,7 +235,7 @@ func (MetricValueStatus) SwaggerDoc() map[string]string {
 }
 
 var map_ObjectMetricSource = map[string]string{
-	"":                "ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).",
+	"":                "ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object). Supports \"Value\" and \"AverageValue\" MetricTarget types.",
 	"describedObject": "describedObject specifies the descriptions of a object,such as kind,name apiVersion",
 	"target":          "target specifies the target value for the given metric",
 	"metric":          "metric identifies the target metric by name and selector",
@@ -257,7 +257,7 @@ func (ObjectMetricStatus) SwaggerDoc() map[string]string {
 }
 
 var map_PodsMetricSource = map[string]string{
-	"":       "PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.",
+	"":       "PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value. Supports only \"AverageValue\" MetricTarget type.",
 	"metric": "metric identifies the target metric by name and selector",
 	"target": "target specifies the target value for the given metric",
 }
@@ -277,7 +277,7 @@ func (PodsMetricStatus) SwaggerDoc() map[string]string {
 }
 
 var map_ResourceMetricSource = map[string]string{
-	"":       "ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.  Only one \"target\" type should be set.",
+	"":       "ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source. Supports \"AverageUtilization\" and \"AverageValue\" MetricTarget types.",
 	"name":   "name is the name of the resource in question.",
 	"target": "target specifies the target value for the given metric",
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds information about supported HPA `MetricTarget` types for each `MetricSourceType`.

Additionally clarifies current state of ContainerResourceMetricSourceType and aligns both staging & api version of `types.go` a little bit.

Accompanies #117947 to help people avoid the same confusion I encountered when working on that PR.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
