### PR TITLE
Drop AvailableResources from controller context

### DIFF
--- a/cmd/kube-controller-manager/app/autoscaling.go
+++ b/cmd/kube-controller-manager/app/autoscaling.go
@@ -22,7 +22,6 @@ package app
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/scale"
@@ -37,10 +36,6 @@ import (
 )
 
 func startHPAController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
-	if !controllerContext.AvailableResources[schema.GroupVersionResource{Group: "autoscaling", Version: "v1", Resource: "horizontalpodautoscalers"}] {
-		return nil, false, nil
-	}
-
 	return startHPAControllerWithRESTClient(ctx, controllerContext)
 }
 

--- a/cmd/kube-controller-manager/app/rbac.go
+++ b/cmd/kube-controller-manager/app/rbac.go
@@ -19,15 +19,11 @@ package app
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/controller-manager/controller"
 	"k8s.io/kubernetes/pkg/controller/clusterroleaggregation"
 )
 
 func startClusterRoleAggregrationController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
-	if !controllerContext.AvailableResources[schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}] {
-		return nil, false, nil
-	}
 	go clusterroleaggregation.NewClusterRoleAggregation(
 		controllerContext.InformerFactory.Rbac().V1().ClusterRoles(),
 		controllerContext.ClientBuilder.ClientOrDie("clusterrole-aggregation-controller").RbacV1(),

--- a/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
+++ b/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
@@ -19,7 +19,6 @@ package app
 import (
 	"context"
 
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	pluginvalidatingadmissionpolicy "k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy"
 	"k8s.io/apiserver/pkg/cel/openapi/resolver"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -28,14 +27,8 @@ import (
 	"k8s.io/kubernetes/pkg/generated/openapi"
 )
 
-var validatingAdmissionPolicyResource = admissionregistrationv1beta1.SchemeGroupVersion.WithResource("validatingadmissionpolicies")
-
 func startValidatingAdmissionPolicyStatusController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
-	// intended check against served resource but not feature gate.
 	// KCM won't start the controller without the feature gate set.
-	if !controllerContext.AvailableResources[validatingAdmissionPolicyResource] {
-		return nil, false, nil
-	}
 	typeChecker := &pluginvalidatingadmissionpolicy.TypeChecker{
 		SchemaResolver: resolver.NewDefinitionsSchemaResolver(scheme.Scheme, openapi.GetOpenAPIDefinitions),
 		RestMapper:     controllerContext.RESTMapper,

--- a/staging/src/k8s.io/controller-manager/app/controllercontext.go
+++ b/staging/src/k8s.io/controller-manager/app/controllercontext.go
@@ -19,7 +19,6 @@ package app
 import (
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/restmapper"
 	controllersmetrics "k8s.io/component-base/metrics/prometheus/controllers"
@@ -45,9 +44,6 @@ type ControllerContext struct {
 	// initialization of the RESTMapper until the first mapping is
 	// requested.
 	RESTMapper *restmapper.DeferredDiscoveryRESTMapper
-
-	// AvailableResources is a map listing currently available resources
-	AvailableResources map[schema.GroupVersionResource]bool
 
 	// Stop is the stop channel
 	Stop <-chan struct{}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Drops AvailableResources from controller context. Any controller using this information to decide whether to run or not at startup is not resilient to changes in available resources during runtime or flakes in discovery resolution at controller startup.

The only default-enabled uses in-tree were of GA enabled-by-default APIs.

The comment by the GetAvailableResources function (`TODO: In general, any controller checking this needs to be dynamic`) was explicitly unsupported by the fixed-at-startup population in the controller context.

#### Does this PR introduce a user-facing change?
```release-note
The `horizontalpodautoscaling` and `clusterrole-aggregation` controllers now assume the `autoscaling/v1` and `rbac.authorization.k8s.io/v1` APIs are available. If you disable those APIs and do not want to run those controllers, exclude them by passing `--controllers=-horizontalpodautoscaling` or `--controllers=-clusterrole-aggregation` to `kube-controller-manager`.
```


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
