### PR TITLE
Automated cherry pick of #117954: OpenAPI V3 invalid document checks

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier_v3.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier_v3.go
@@ -110,6 +110,9 @@ func supportsQueryParamV3(doc *spec3.OpenAPI, gvk schema.GroupVersionKind, query
 	}
 	for _, path := range doc.Paths.Paths {
 		// If operation is not PATCH, then continue.
+		if path == nil {
+			continue
+		}
 		op := path.PathProps.Patch
 		if op == nil {
 			continue
@@ -127,5 +130,5 @@ func supportsQueryParamV3(doc *spec3.OpenAPI, gvk schema.GroupVersionKind, query
 		}
 		return NewParamUnsupportedError(gvk, queryParam)
 	}
-	return NewParamUnsupportedError(gvk, queryParam)
+	return fmt.Errorf("Path not found for GVK (%s) in OpenAPI V3 doc", gvk)
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier_v3_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/query_param_verifier_v3_test.go
@@ -141,18 +141,43 @@ func TestV3SupportsQueryParamBatchV1(t *testing.T) {
 func TestInvalidOpenAPIV3Document(t *testing.T) {
 	tests := map[string]struct {
 		spec *spec3.OpenAPI
+		err  string
 	}{
 		"nil document returns error": {
 			spec: nil,
+			err:  "Invalid OpenAPI V3 document",
 		},
 		"empty document returns error": {
 			spec: &spec3.OpenAPI{},
+			err:  "Invalid OpenAPI V3 document",
 		},
 		"minimal document returns error": {
 			spec: &spec3.OpenAPI{
 				Version: "openapi 3.0.0",
 				Paths:   nil,
 			},
+			err: "Invalid OpenAPI V3 document",
+		},
+		"empty Paths returns error": {
+			spec: &spec3.OpenAPI{
+				Version: "openapi 3.0.0",
+				Paths:   &spec3.Paths{},
+			},
+			err: "Path not found for GVK",
+		},
+		"nil Path returns error": {
+			spec: &spec3.OpenAPI{
+				Version: "openapi 3.0.0",
+				Paths:   &spec3.Paths{Paths: map[string]*spec3.Path{"/version": nil}},
+			},
+			err: "Path not found for GVK",
+		},
+		"empty Path returns error": {
+			spec: &spec3.OpenAPI{
+				Version: "openapi 3.0.0",
+				Paths:   &spec3.Paths{Paths: map[string]*spec3.Path{"/version": {}}},
+			},
+			err: "Path not found for GVK",
 		},
 	}
 
@@ -172,8 +197,8 @@ func TestInvalidOpenAPIV3Document(t *testing.T) {
 				queryParam: QueryParamFieldValidation,
 			}
 			err := verifier.HasSupport(gvk)
-			if !strings.Contains(err.Error(), "Invalid OpenAPI V3 document") {
-				t.Errorf("Expected invalid document error, but none received.")
+			if !strings.Contains(err.Error(), tc.err) {
+				t.Errorf("Expected error (%s), but received (%s)", tc.err, err.Error())
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #117954 on release-1.27.

#117954: OpenAPI V3 invalid document checks

/kind bug
/priority important-soon

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.27 regression in kubectl detecting server side support for dry run or server-side field validation
```
