### PR TITLE
Add api-machinery TL owners permissions for jpbetz

### DIFF
--- a/cmd/kube-apiserver/OWNERS
+++ b/cmd/kube-apiserver/OWNERS
@@ -6,6 +6,7 @@ approvers:
   - liggitt
   - smarterclayton
   - sttts
+  - jpbetz
 reviewers:
   - cheftako
   - smarterclayton
@@ -20,6 +21,7 @@ reviewers:
   - hzxuzhonghu
   - logicalhan
   - yue9944882
+  - jpbetz
 labels:
   - sig/api-machinery
   - area/apiserver

--- a/cmd/kube-controller-manager/OWNERS
+++ b/cmd/kube-controller-manager/OWNERS
@@ -6,6 +6,7 @@ approvers:
   - mikedanese
   - soltysh
   - sttts
+  - jpbetz
 reviewers:
   - caesarxuchao
   - cheftako
@@ -32,6 +33,7 @@ reviewers:
   - sttts
   - thockin
   - wojtek-t
+  - jpbetz
 labels:
   - sig/api-machinery
 emeritus_approvers:

--- a/pkg/apis/extensions/OWNERS
+++ b/pkg/apis/extensions/OWNERS
@@ -18,5 +18,6 @@ reviewers:
   - mwielgus
   - soltysh
   - dims
+  - jpbetz
 labels:
   - sig/apps

--- a/pkg/client/OWNERS
+++ b/pkg/client/OWNERS
@@ -5,6 +5,7 @@ approvers:
   - deads2k
   - liggitt
   - smarterclayton
+  - jpbetz
 reviewers:
   - thockin
   - smarterclayton
@@ -26,6 +27,7 @@ reviewers:
   - feiskyer
   - soltysh
   - jsafrane
+  - jpbetz
 emeritus_approvers:
   - krousey
   - lavalamp

--- a/pkg/controller/garbagecollector/OWNERS
+++ b/pkg/controller/garbagecollector/OWNERS
@@ -6,6 +6,7 @@ approvers:
 reviewers:
   - caesarxuchao
   - deads2k
+  - jpbetz
 labels:
   - sig/api-machinery
 emeritus_approvers:

--- a/pkg/controlplane/OWNERS
+++ b/pkg/controlplane/OWNERS
@@ -6,6 +6,7 @@ approvers:
   - mikedanese
   - sttts
   - wojtek-t
+  - jpbetz
 reviewers:
   - thockin
   - smarterclayton
@@ -26,6 +27,7 @@ reviewers:
   - mwielgus
   - soltysh
   - enj
+  - jpbetz
 labels:
   - sig/api-machinery
 emeritus_approvers:

--- a/pkg/kubeapiserver/OWNERS
+++ b/pkg/kubeapiserver/OWNERS
@@ -4,12 +4,14 @@ approvers:
   - deads2k
   - liggitt
   - sttts
+  - jpbetz
 reviewers:
   - deads2k
   - liggitt
   - sttts
   - cheftako
   - logicalhan
+  - jpbetz
 labels:
   - sig/api-machinery
   - area/apiserver

--- a/pkg/registry/OWNERS
+++ b/pkg/registry/OWNERS
@@ -25,5 +25,6 @@ reviewers:
   - soltysh
   - dims
   - enj
+  - jpbetz
 emeritus_approvers:
   - lavalamp

--- a/pkg/routes/OWNERS
+++ b/pkg/routes/OWNERS
@@ -4,6 +4,7 @@ reviewers:
   - deads2k
   - sttts
   - caesarxuchao
+  - jpbetz
 approvers:
   - deads2k
   - sttts

--- a/plugin/OWNERS
+++ b/plugin/OWNERS
@@ -10,6 +10,7 @@ reviewers:
   - smarterclayton
   - thockin
   - wojtek-t
+  - jpbetz
 approvers:
   - dchen1107
   - dims

--- a/staging/src/k8s.io/apimachinery/OWNERS
+++ b/staging/src/k8s.io/apimachinery/OWNERS
@@ -6,6 +6,7 @@ approvers:
   - sttts
   - liggitt
   - caesarxuchao
+  - jpbetz
 reviewers:
   - apelisse
   - thockin
@@ -20,6 +21,7 @@ reviewers:
   - sttts
   - ncdc
   - logicalhan
+  - jpbetz
 labels:
   - sig/api-machinery
 emeritus_approvers:

--- a/staging/src/k8s.io/apiserver/OWNERS
+++ b/staging/src/k8s.io/apiserver/OWNERS
@@ -5,6 +5,7 @@ approvers:
   - deads2k
   - sttts
   - liggitt
+  - jpbetz
 reviewers:
   - smarterclayton
   - wojtek-t

--- a/staging/src/k8s.io/client-go/OWNERS
+++ b/staging/src/k8s.io/client-go/OWNERS
@@ -7,6 +7,7 @@ approvers:
   - smarterclayton
   - sttts
   - yliaog
+  - jpbetz
 reviewers:
   - aojea
   - apelisse
@@ -17,6 +18,7 @@ reviewers:
   - soltysh
   - sttts
   - yliaog
+  - jpbetz
 labels:
   - sig/api-machinery
 emeritus_approvers:

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/OWNERS
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/OWNERS
@@ -6,5 +6,6 @@ approvers:
 reviewers:
   - wojtek-t
   - caesarxuchao
+  - jpbetz
 emeritus_approvers:
   - lavalamp

--- a/staging/src/k8s.io/controller-manager/OWNERS
+++ b/staging/src/k8s.io/controller-manager/OWNERS
@@ -7,6 +7,7 @@ approvers:
   - liggitt
   - mtaufen
   - sttts
+  - jpbetz
 reviewers:
   - andrewsykim
   - cheftako
@@ -18,6 +19,7 @@ reviewers:
   - luxas
   - mtaufen
   - sttts
+  - jpbetz
 labels:
   - sig/api-machinery
   - sig/cloud-provider

--- a/staging/src/k8s.io/kube-aggregator/OWNERS
+++ b/staging/src/k8s.io/kube-aggregator/OWNERS
@@ -4,6 +4,7 @@ approvers:
   - deads2k
   - smarterclayton
   - sttts
+  - jpbetz
 reviewers:
   - caesarxuchao
   - deads2k
@@ -14,6 +15,7 @@ reviewers:
   - logicalhan
   - alexzielenski
   - jefftree
+  - jpbetz
 labels:
   - sig/api-machinery
 emeritus_approvers:

--- a/staging/src/k8s.io/sample-apiserver/OWNERS
+++ b/staging/src/k8s.io/sample-apiserver/OWNERS
@@ -5,12 +5,14 @@ approvers:
   - deads2k
   - sttts
   - liggitt
+  - jpbetz
 reviewers:
   - smarterclayton
   - deads2k
   - sttts
   - liggitt
   - cheftako
+  - jpbetz
 labels:
   - sig/api-machinery
 emeritus_approvers:

--- a/test/e2e/apimachinery/OWNERS
+++ b/test/e2e/apimachinery/OWNERS
@@ -6,6 +6,7 @@ approvers:
   - sttts
   - liggitt
   - caesarxuchao
+  - jpbetz
 reviewers:
   - thockin
   - smarterclayton
@@ -19,6 +20,7 @@ reviewers:
   - sttts
   - ncdc
   - logicalhan
+  - jpbetz
 labels:
   - sig/api-machinery
 emeritus_approvers:


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Add api-machinery TL roles to owners files.

#### Special notes for your reviewer:

This is a subset of the roles @lavalamp is stepping down from via https://github.com/kubernetes/kubernetes/pull/117946.  I've limited my role to reviewer for some areas.
#### Does this PR introduce a user-facing change?

```release-note
NONE
```

