### PR TITLE
reset ResourceVersion when restart reflector in configmap/secret objectCache

### DIFF
--- a/pkg/kubelet/util/manager/watch_based_manager.go
+++ b/pkg/kubelet/util/manager/watch_based_manager.go
@@ -121,6 +121,15 @@ func (i *objectCacheItem) startReflector() {
 	i.waitGroup.Wait()
 	i.waitGroup.Add(1)
 	defer i.waitGroup.Done()
+	resourceVersion := ""
+	// store has only a single item at most
+	for _, obj := range i.store.List() {
+		if item, ok := obj.(metav1.Object); ok {
+			resourceVersion = item.GetResourceVersion()
+		}
+	}
+	// Avoid "Too large resource version" error caused by bookmark
+	i.reflector.SetLastSyncResourceVersion(resourceVersion)
 	i.reflector.Run(i.stopCh)
 }
 

--- a/pkg/kubelet/util/manager/watch_based_manager_test.go
+++ b/pkg/kubelet/util/manager/watch_based_manager_test.go
@@ -26,7 +26,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -218,7 +217,7 @@ func TestSecretCacheWithLargeBookmark(t *testing.T) {
 				if resourceVersionInt > currentResourceVersion {
 					// mock the "too large resource version" latency
 					time.Sleep(1 * time.Second)
-					return true, nil, errors.NewTimeoutError(fmt.Sprintf("Too large resource version: %d, current: %d", resourceVersionInt, currentResourceVersion), 3)
+					return true, nil, apierrors.NewTimeoutError(fmt.Sprintf("Too large resource version: %d, current: %d", resourceVersionInt, currentResourceVersion), 3)
 				}
 			}
 		}
@@ -227,7 +226,7 @@ func TestSecretCacheWithLargeBookmark(t *testing.T) {
 				ResourceVersion: "123",
 			},
 			Items: []v1.Secret{
-				v1.Secret{
+				{
 					ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: "ns", ResourceVersion: "123"},
 				},
 			},
@@ -291,7 +290,7 @@ func TestSecretCacheWithTooOld(t *testing.T) {
 			ResourceVersion: "123",
 		},
 		Items: []v1.Secret{
-			v1.Secret{
+			{
 				ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: "ns", ResourceVersion: "123"},
 			},
 		},
@@ -306,7 +305,7 @@ func TestSecretCacheWithTooOld(t *testing.T) {
 					return true, nil, fmt.Errorf("Failed to parse resource version")
 				}
 				if resourceVersionInt < getCurrentResourceVersion() {
-					return true, nil, errors.NewResourceExpired(fmt.Sprintf("too old resource version: %s (%d)", listResourceVersion, 125))
+					return true, nil, apierrors.NewResourceExpired(fmt.Sprintf("too old resource version: %s (%d)", listResourceVersion, 125))
 				}
 			}
 		}

--- a/staging/src/k8s.io/client-go/testing/actions.go
+++ b/staging/src/k8s.io/client-go/testing/actions.go
@@ -74,8 +74,8 @@ func NewRootListAction(resource schema.GroupVersionResource, kind schema.GroupVe
 	action.Verb = "list"
 	action.Resource = resource
 	action.Kind = kind
-	labelSelector, fieldSelector, _ := ExtractFromListOptions(opts)
-	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector}
+	labelSelector, fieldSelector, resourceVersion := ExtractFromListOptions(opts)
+	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector, resourceVersion}
 
 	return action
 }
@@ -86,8 +86,8 @@ func NewListAction(resource schema.GroupVersionResource, kind schema.GroupVersio
 	action.Resource = resource
 	action.Kind = kind
 	action.Namespace = namespace
-	labelSelector, fieldSelector, _ := ExtractFromListOptions(opts)
-	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector}
+	labelSelector, fieldSelector, resourceVersion := ExtractFromListOptions(opts)
+	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector, resourceVersion}
 
 	return action
 }
@@ -275,8 +275,8 @@ func NewRootDeleteCollectionAction(resource schema.GroupVersionResource, opts in
 	action := DeleteCollectionActionImpl{}
 	action.Verb = "delete-collection"
 	action.Resource = resource
-	labelSelector, fieldSelector, _ := ExtractFromListOptions(opts)
-	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector}
+	labelSelector, fieldSelector, resourceVersion := ExtractFromListOptions(opts)
+	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector, resourceVersion}
 
 	return action
 }
@@ -286,8 +286,8 @@ func NewDeleteCollectionAction(resource schema.GroupVersionResource, namespace s
 	action.Verb = "delete-collection"
 	action.Resource = resource
 	action.Namespace = namespace
-	labelSelector, fieldSelector, _ := ExtractFromListOptions(opts)
-	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector}
+	labelSelector, fieldSelector, resourceVersion := ExtractFromListOptions(opts)
+	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector, resourceVersion}
 
 	return action
 }
@@ -352,8 +352,9 @@ func NewProxyGetAction(resource schema.GroupVersionResource, namespace, scheme, 
 }
 
 type ListRestrictions struct {
-	Labels labels.Selector
-	Fields fields.Selector
+	Labels          labels.Selector
+	Fields          fields.Selector
+	ResourceVersion string
 }
 type WatchRestrictions struct {
 	Labels          labels.Selector
@@ -522,8 +523,9 @@ func (a ListActionImpl) DeepCopy() Action {
 		Kind:       a.Kind,
 		Name:       a.Name,
 		ListRestrictions: ListRestrictions{
-			Labels: a.ListRestrictions.Labels.DeepCopySelector(),
-			Fields: a.ListRestrictions.Fields.DeepCopySelector(),
+			Labels:          a.ListRestrictions.Labels.DeepCopySelector(),
+			Fields:          a.ListRestrictions.Fields.DeepCopySelector(),
+			ResourceVersion: a.ListRestrictions.ResourceVersion,
 		},
 	}
 }
@@ -627,8 +629,9 @@ func (a DeleteCollectionActionImpl) DeepCopy() Action {
 	return DeleteCollectionActionImpl{
 		ActionImpl: a.ActionImpl.DeepCopy().(ActionImpl),
 		ListRestrictions: ListRestrictions{
-			Labels: a.ListRestrictions.Labels.DeepCopySelector(),
-			Fields: a.ListRestrictions.Fields.DeepCopySelector(),
+			Labels:          a.ListRestrictions.Labels.DeepCopySelector(),
+			Fields:          a.ListRestrictions.Fields.DeepCopySelector(),
+			ResourceVersion: a.ListRestrictions.ResourceVersion,
 		},
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -442,7 +442,7 @@ func (r *Reflector) watch(w watch.Interface, stopCh <-chan struct{}, resyncerrc 
 			}
 		}
 
-		err = watchHandler(start, w, r.store, r.expectedType, r.expectedGVK, r.name, r.typeDescription, r.setLastSyncResourceVersion, nil, r.clock, resyncerrc, stopCh)
+		err = watchHandler(start, w, r.store, r.expectedType, r.expectedGVK, r.name, r.typeDescription, r.SetLastSyncResourceVersion, nil, r.clock, resyncerrc, stopCh)
 		// Ensure that watch will not be reused across iterations.
 		w.Stop()
 		w = nil
@@ -578,7 +578,7 @@ func (r *Reflector) list(stopCh <-chan struct{}) error {
 		return fmt.Errorf("unable to sync list result: %v", err)
 	}
 	initTrace.Step("SyncWith done")
-	r.setLastSyncResourceVersion(resourceVersion)
+	r.SetLastSyncResourceVersion(resourceVersion)
 	initTrace.Step("Resource version updated")
 	return nil
 }
@@ -692,7 +692,7 @@ func (r *Reflector) watchList(stopCh <-chan struct{}) (watch.Interface, error) {
 		return nil, fmt.Errorf("unable to sync watch-list result: %v", err)
 	}
 	initTrace.Step("SyncWith done")
-	r.setLastSyncResourceVersion(resourceVersion)
+	r.SetLastSyncResourceVersion(resourceVersion)
 
 	return w, nil
 }
@@ -817,7 +817,7 @@ func (r *Reflector) LastSyncResourceVersion() string {
 	return r.lastSyncResourceVersion
 }
 
-func (r *Reflector) setLastSyncResourceVersion(v string) {
+func (r *Reflector) SetLastSyncResourceVersion(v string) {
 	r.lastSyncResourceVersionMutex.Lock()
 	defer r.lastSyncResourceVersionMutex.Unlock()
 	r.lastSyncResourceVersion = v

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -165,7 +165,7 @@ func TestReflectorWatchHandlerError(t *testing.T) {
 	go func() {
 		fw.Stop()
 	}()
-	err := watchHandler(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, nil, g.clock, nevererrc, wait.NeverStop)
+	err := watchHandler(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.SetLastSyncResourceVersion, nil, g.clock, nevererrc, wait.NeverStop)
 	if err == nil {
 		t.Errorf("unexpected non-error")
 	}
@@ -184,7 +184,7 @@ func TestReflectorWatchHandler(t *testing.T) {
 		fw.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "baz", ResourceVersion: "32"}})
 		fw.Stop()
 	}()
-	err := watchHandler(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, nil, g.clock, nevererrc, wait.NeverStop)
+	err := watchHandler(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.SetLastSyncResourceVersion, nil, g.clock, nevererrc, wait.NeverStop)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -232,7 +232,7 @@ func TestReflectorStopWatch(t *testing.T) {
 	fw := watch.NewFake()
 	stopWatch := make(chan struct{}, 1)
 	stopWatch <- struct{}{}
-	err := watchHandler(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, nil, g.clock, nevererrc, stopWatch)
+	err := watchHandler(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.SetLastSyncResourceVersion, nil, g.clock, nevererrc, stopWatch)
 	if err != errorStopRequested {
 		t.Errorf("expected stop error, got %q", err)
 	}
@@ -655,7 +655,7 @@ func TestReflectorWatchListPageSize(t *testing.T) {
 	}
 	r := NewReflector(lw, &v1.Pod{}, s, 0)
 	// Set resource version to test pagination also for not consistent reads.
-	r.setLastSyncResourceVersion("10")
+	r.SetLastSyncResourceVersion("10")
 	// Set the reflector to paginate the list request in 4 item chunks.
 	r.WatchListPageSize = 4
 	r.ListAndWatch(stopCh)
@@ -692,7 +692,7 @@ func TestReflectorNotPaginatingNotConsistentReads(t *testing.T) {
 		},
 	}
 	r := NewReflector(lw, &v1.Pod{}, s, 0)
-	r.setLastSyncResourceVersion("10")
+	r.SetLastSyncResourceVersion("10")
 	r.ListAndWatch(stopCh)
 
 	results := s.List()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This change help to avoid error "failed to sync secret cache: timed out waiting for the condition"

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #117972 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
