### PR TITLE
Updated INSTALL.md

### DIFF
--- a/staging/src/k8s.io/client-go/INSTALL.md
+++ b/staging/src/k8s.io/client-go/INSTALL.md
@@ -5,7 +5,7 @@
 If you want to use the latest version of this library, use go1.16+ and run:
 
 ```sh
-go get k8s.io/client-go@latest
+go install k8s.io/client-go@latest
 ```
 
 This will record a dependency on `k8s.io/client-go` in your go module.
@@ -24,14 +24,14 @@ you can indicate which version of `client-go` your project requires:
   For example, `k8s.io/client-go@v0.20.4` corresponds to Kubernetes `v1.20.4`:
 
 ```sh
-go get k8s.io/client-go@v0.20.4
+go install k8s.io/client-go@v0.20.4
 ```
 
 - If you are using Kubernetes versions < `v1.17.0`, use a corresponding `kubernetes-1.x.y` tag.
   For example, `k8s.io/client-go@kubernetes-1.16.3` corresponds to Kubernetes `v1.16.3`:
 
 ```sh
-go get k8s.io/client-go@kubernetes-1.16.3
+go install k8s.io/client-go@kubernetes-1.16.3
 ```
 
 You can now import and use the `k8s.io/client-go` APIs in your project.
@@ -49,7 +49,7 @@ If you get a message like
 you are likely using a go version prior to 1.16 and must explicitly specify the k8s.io/client-go version you want.
 For example:
 ```sh
-go get k8s.io/client-go@v0.20.4
+go install k8s.io/client-go@v0.20.4
 ```
 
 ### Conflicting requirements for older client-go versions
@@ -60,7 +60,7 @@ something in your build is likely requiring an old version of `k8s.io/client-go`
 
 First, try to fetch a more recent version. For example:
 ```sh
-go get k8s.io/client-go@v0.20.4
+go install k8s.io/client-go@v0.20.4
 ```
 
 If that doesn't resolve the problem, see what is requiring an `...+incompatible` version of client-go,
@@ -73,7 +73,7 @@ As a last resort, you can force the build to use a specific version of client-go
 even if some of your dependencies still want `...+incompatible` versions. For example:
 ```sh
 go mod edit -replace=k8s.io/client-go=k8s.io/client-go@v0.20.4
-go get k8s.io/client-go@v0.20.4
+go install k8s.io/client-go@v0.20.4
 ```
 
 ### Go modules disabled


### PR DESCRIPTION
"go get is already deprecated"
Replaced all occurrences of "go get" with "go install" in INSTALL.md'

/kind documentation
/kind deprecation


