### PR TITLE
Add tests to capture discovery output

### DIFF
--- a/api/discovery/aggregated_v2beta1.json
+++ b/api/discovery/aggregated_v2beta1.json
@@ -1,0 +1,1843 @@
+{
+  "apiVersion": "apidiscovery.k8s.io/v2beta1",
+  "items": [
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "apiregistration.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "categories": [
+                "api-extensions"
+              ],
+              "resource": "apiservices",
+              "responseKind": {
+                "group": "",
+                "kind": "APIService",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "apiservice",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "APIService",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "apps"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "controllerrevisions",
+              "responseKind": {
+                "group": "",
+                "kind": "ControllerRevision",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "singularResource": "controllerrevision",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "categories": [
+                "all"
+              ],
+              "resource": "daemonsets",
+              "responseKind": {
+                "group": "",
+                "kind": "DaemonSet",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "shortNames": [
+                "ds"
+              ],
+              "singularResource": "daemonset",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "DaemonSet",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "categories": [
+                "all"
+              ],
+              "resource": "deployments",
+              "responseKind": {
+                "group": "",
+                "kind": "Deployment",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "shortNames": [
+                "deploy"
+              ],
+              "singularResource": "deployment",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "autoscaling",
+                    "kind": "Scale",
+                    "version": "v1"
+                  },
+                  "subresource": "scale",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                },
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "Deployment",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "categories": [
+                "all"
+              ],
+              "resource": "replicasets",
+              "responseKind": {
+                "group": "",
+                "kind": "ReplicaSet",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "shortNames": [
+                "rs"
+              ],
+              "singularResource": "replicaset",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "autoscaling",
+                    "kind": "Scale",
+                    "version": "v1"
+                  },
+                  "subresource": "scale",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                },
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "ReplicaSet",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "categories": [
+                "all"
+              ],
+              "resource": "statefulsets",
+              "responseKind": {
+                "group": "",
+                "kind": "StatefulSet",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "shortNames": [
+                "sts"
+              ],
+              "singularResource": "statefulset",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "autoscaling",
+                    "kind": "Scale",
+                    "version": "v1"
+                  },
+                  "subresource": "scale",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                },
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "StatefulSet",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "events.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "events",
+              "responseKind": {
+                "group": "",
+                "kind": "Event",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "shortNames": [
+                "ev"
+              ],
+              "singularResource": "event",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "authentication.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "selfsubjectreviews",
+              "responseKind": {
+                "group": "",
+                "kind": "SelfSubjectReview",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "selfsubjectreview",
+              "verbs": [
+                "create"
+              ]
+            },
+            {
+              "resource": "tokenreviews",
+              "responseKind": {
+                "group": "",
+                "kind": "TokenReview",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "tokenreview",
+              "verbs": [
+                "create"
+              ]
+            }
+          ],
+          "version": "v1"
+        },
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "selfsubjectreviews",
+              "responseKind": {
+                "group": "",
+                "kind": "SelfSubjectReview",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "selfsubjectreview",
+              "verbs": [
+                "create"
+              ]
+            }
+          ],
+          "version": "v1beta1"
+        },
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "selfsubjectreviews",
+              "responseKind": {
+                "group": "",
+                "kind": "SelfSubjectReview",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "selfsubjectreview",
+              "verbs": [
+                "create"
+              ]
+            }
+          ],
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "authorization.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "localsubjectaccessreviews",
+              "responseKind": {
+                "group": "",
+                "kind": "LocalSubjectAccessReview",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "singularResource": "localsubjectaccessreview",
+              "verbs": [
+                "create"
+              ]
+            },
+            {
+              "resource": "selfsubjectaccessreviews",
+              "responseKind": {
+                "group": "",
+                "kind": "SelfSubjectAccessReview",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "selfsubjectaccessreview",
+              "verbs": [
+                "create"
+              ]
+            },
+            {
+              "resource": "selfsubjectrulesreviews",
+              "responseKind": {
+                "group": "",
+                "kind": "SelfSubjectRulesReview",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "selfsubjectrulesreview",
+              "verbs": [
+                "create"
+              ]
+            },
+            {
+              "resource": "subjectaccessreviews",
+              "responseKind": {
+                "group": "",
+                "kind": "SubjectAccessReview",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "subjectaccessreview",
+              "verbs": [
+                "create"
+              ]
+            }
+          ],
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "autoscaling"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "categories": [
+                "all"
+              ],
+              "resource": "horizontalpodautoscalers",
+              "responseKind": {
+                "group": "",
+                "kind": "HorizontalPodAutoscaler",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "shortNames": [
+                "hpa"
+              ],
+              "singularResource": "horizontalpodautoscaler",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "HorizontalPodAutoscaler",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v2"
+        },
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "categories": [
+                "all"
+              ],
+              "resource": "horizontalpodautoscalers",
+              "responseKind": {
+                "group": "",
+                "kind": "HorizontalPodAutoscaler",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "shortNames": [
+                "hpa"
+              ],
+              "singularResource": "horizontalpodautoscaler",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "HorizontalPodAutoscaler",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "batch"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "categories": [
+                "all"
+              ],
+              "resource": "cronjobs",
+              "responseKind": {
+                "group": "",
+                "kind": "CronJob",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "shortNames": [
+                "cj"
+              ],
+              "singularResource": "cronjob",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "CronJob",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "categories": [
+                "all"
+              ],
+              "resource": "jobs",
+              "responseKind": {
+                "group": "",
+                "kind": "Job",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "singularResource": "job",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "Job",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "certificates.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "certificatesigningrequests",
+              "responseKind": {
+                "group": "",
+                "kind": "CertificateSigningRequest",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "shortNames": [
+                "csr"
+              ],
+              "singularResource": "certificatesigningrequest",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "CertificateSigningRequest",
+                    "version": ""
+                  },
+                  "subresource": "approval",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                },
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "CertificateSigningRequest",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        },
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "clustertrustbundles",
+              "responseKind": {
+                "group": "",
+                "kind": "ClusterTrustBundle",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "clustertrustbundle",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "networking.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "ingressclasses",
+              "responseKind": {
+                "group": "",
+                "kind": "IngressClass",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "ingressclass",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "resource": "ingresses",
+              "responseKind": {
+                "group": "",
+                "kind": "Ingress",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "shortNames": [
+                "ing"
+              ],
+              "singularResource": "ingress",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "Ingress",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "resource": "networkpolicies",
+              "responseKind": {
+                "group": "",
+                "kind": "NetworkPolicy",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "shortNames": [
+                "netpol"
+              ],
+              "singularResource": "networkpolicy",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        },
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "clustercidrs",
+              "responseKind": {
+                "group": "",
+                "kind": "ClusterCIDR",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "shortNames": [
+                "cc"
+              ],
+              "singularResource": "clustercidr",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "resource": "ipaddresses",
+              "responseKind": {
+                "group": "",
+                "kind": "IPAddress",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "shortNames": [
+                "ip"
+              ],
+              "singularResource": "ipaddress",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "policy"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "poddisruptionbudgets",
+              "responseKind": {
+                "group": "",
+                "kind": "PodDisruptionBudget",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "shortNames": [
+                "pdb"
+              ],
+              "singularResource": "poddisruptionbudget",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "PodDisruptionBudget",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "rbac.authorization.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "clusterrolebindings",
+              "responseKind": {
+                "group": "",
+                "kind": "ClusterRoleBinding",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "clusterrolebinding",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "resource": "clusterroles",
+              "responseKind": {
+                "group": "",
+                "kind": "ClusterRole",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "clusterrole",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "resource": "rolebindings",
+              "responseKind": {
+                "group": "",
+                "kind": "RoleBinding",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "singularResource": "rolebinding",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "resource": "roles",
+              "responseKind": {
+                "group": "",
+                "kind": "Role",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "singularResource": "role",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "storage.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "csidrivers",
+              "responseKind": {
+                "group": "",
+                "kind": "CSIDriver",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "csidriver",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "resource": "csinodes",
+              "responseKind": {
+                "group": "",
+                "kind": "CSINode",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "csinode",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "resource": "csistoragecapacities",
+              "responseKind": {
+                "group": "",
+                "kind": "CSIStorageCapacity",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "singularResource": "csistoragecapacity",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "resource": "storageclasses",
+              "responseKind": {
+                "group": "",
+                "kind": "StorageClass",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "shortNames": [
+                "sc"
+              ],
+              "singularResource": "storageclass",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "resource": "volumeattachments",
+              "responseKind": {
+                "group": "",
+                "kind": "VolumeAttachment",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "volumeattachment",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "VolumeAttachment",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "admissionregistration.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "categories": [
+                "api-extensions"
+              ],
+              "resource": "mutatingwebhookconfigurations",
+              "responseKind": {
+                "group": "",
+                "kind": "MutatingWebhookConfiguration",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "mutatingwebhookconfiguration",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "categories": [
+                "api-extensions"
+              ],
+              "resource": "validatingwebhookconfigurations",
+              "responseKind": {
+                "group": "",
+                "kind": "ValidatingWebhookConfiguration",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "validatingwebhookconfiguration",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        },
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "categories": [
+                "api-extensions"
+              ],
+              "resource": "validatingadmissionpolicies",
+              "responseKind": {
+                "group": "",
+                "kind": "ValidatingAdmissionPolicy",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "validatingadmissionpolicy",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "ValidatingAdmissionPolicy",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "categories": [
+                "api-extensions"
+              ],
+              "resource": "validatingadmissionpolicybindings",
+              "responseKind": {
+                "group": "",
+                "kind": "ValidatingAdmissionPolicyBinding",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "validatingadmissionpolicybinding",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "apiextensions.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "categories": [
+                "api-extensions"
+              ],
+              "resource": "customresourcedefinitions",
+              "responseKind": {
+                "group": "",
+                "kind": "CustomResourceDefinition",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "shortNames": [
+                "crd",
+                "crds"
+              ],
+              "singularResource": "customresourcedefinition",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "CustomResourceDefinition",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "scheduling.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "priorityclasses",
+              "responseKind": {
+                "group": "",
+                "kind": "PriorityClass",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "shortNames": [
+                "pc"
+              ],
+              "singularResource": "priorityclass",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "coordination.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "leases",
+              "responseKind": {
+                "group": "",
+                "kind": "Lease",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "singularResource": "lease",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "node.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "runtimeclasses",
+              "responseKind": {
+                "group": "",
+                "kind": "RuntimeClass",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "runtimeclass",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "discovery.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "endpointslices",
+              "responseKind": {
+                "group": "",
+                "kind": "EndpointSlice",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "singularResource": "endpointslice",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "flowcontrol.apiserver.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "flowschemas",
+              "responseKind": {
+                "group": "",
+                "kind": "FlowSchema",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "flowschema",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "FlowSchema",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "resource": "prioritylevelconfigurations",
+              "responseKind": {
+                "group": "",
+                "kind": "PriorityLevelConfiguration",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "prioritylevelconfiguration",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "PriorityLevelConfiguration",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1beta3"
+        },
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "flowschemas",
+              "responseKind": {
+                "group": "",
+                "kind": "FlowSchema",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "flowschema",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "FlowSchema",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "resource": "prioritylevelconfigurations",
+              "responseKind": {
+                "group": "",
+                "kind": "PriorityLevelConfiguration",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "prioritylevelconfiguration",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "PriorityLevelConfiguration",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1beta2"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "internal.apiserver.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "storageversions",
+              "responseKind": {
+                "group": "",
+                "kind": "StorageVersion",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "storageversion",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "StorageVersion",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "creationTimestamp": null,
+        "name": "resource.k8s.io"
+      },
+      "versions": [
+        {
+          "freshness": "Current",
+          "resources": [
+            {
+              "resource": "podschedulingcontexts",
+              "responseKind": {
+                "group": "",
+                "kind": "PodSchedulingContext",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "singularResource": "podschedulingcontext",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "PodSchedulingContext",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "resource": "resourceclaims",
+              "responseKind": {
+                "group": "",
+                "kind": "ResourceClaim",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "singularResource": "resourceclaim",
+              "subresources": [
+                {
+                  "responseKind": {
+                    "group": "",
+                    "kind": "ResourceClaim",
+                    "version": ""
+                  },
+                  "subresource": "status",
+                  "verbs": [
+                    "get",
+                    "patch",
+                    "update"
+                  ]
+                }
+              ],
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "resource": "resourceclaimtemplates",
+              "responseKind": {
+                "group": "",
+                "kind": "ResourceClaimTemplate",
+                "version": ""
+              },
+              "scope": "Namespaced",
+              "singularResource": "resourceclaimtemplate",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            },
+            {
+              "resource": "resourceclasses",
+              "responseKind": {
+                "group": "",
+                "kind": "ResourceClass",
+                "version": ""
+              },
+              "scope": "Cluster",
+              "singularResource": "resourceclass",
+              "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+              ]
+            }
+          ],
+          "version": "v1alpha2"
+        }
+      ]
+    }
+  ],
+  "kind": "APIGroupDiscoveryList",
+  "metadata": {}
+}

--- a/api/discovery/api.json
+++ b/api/discovery/api.json
@@ -1,0 +1,12 @@
+{
+  "kind": "APIVersions",
+  "serverAddressByClientCIDRs": [
+    {
+      "clientCIDR": "0.0.0.0/0",
+      "serverAddress": "10.10.10.10:8050"
+    }
+  ],
+  "versions": [
+    "v1"
+  ]
+}

--- a/api/discovery/api__v1.json
+++ b/api/discovery/api__v1.json
@@ -1,0 +1,560 @@
+{
+  "groupVersion": "v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "Binding",
+      "name": "bindings",
+      "namespaced": true,
+      "singularName": "binding",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "kind": "ComponentStatus",
+      "name": "componentstatuses",
+      "namespaced": false,
+      "shortNames": [
+        "cs"
+      ],
+      "singularName": "componentstatus",
+      "verbs": [
+        "get",
+        "list"
+      ]
+    },
+    {
+      "kind": "ConfigMap",
+      "name": "configmaps",
+      "namespaced": true,
+      "shortNames": [
+        "cm"
+      ],
+      "singularName": "configmap",
+      "storageVersionHash": "qFsyl6wFWjQ=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "Endpoints",
+      "name": "endpoints",
+      "namespaced": true,
+      "shortNames": [
+        "ep"
+      ],
+      "singularName": "endpoints",
+      "storageVersionHash": "fWeeMqaN/OA=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "Event",
+      "name": "events",
+      "namespaced": true,
+      "shortNames": [
+        "ev"
+      ],
+      "singularName": "event",
+      "storageVersionHash": "r2yiGXH7wu8=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "LimitRange",
+      "name": "limitranges",
+      "namespaced": true,
+      "shortNames": [
+        "limits"
+      ],
+      "singularName": "limitrange",
+      "storageVersionHash": "EBKMFVe6cwo=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "Namespace",
+      "name": "namespaces",
+      "namespaced": false,
+      "shortNames": [
+        "ns"
+      ],
+      "singularName": "namespace",
+      "storageVersionHash": "Q3oi5N2YM8M=",
+      "verbs": [
+        "create",
+        "delete",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "Namespace",
+      "name": "namespaces/finalize",
+      "namespaced": false,
+      "singularName": "",
+      "verbs": [
+        "update"
+      ]
+    },
+    {
+      "kind": "Namespace",
+      "name": "namespaces/status",
+      "namespaced": false,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "Node",
+      "name": "nodes",
+      "namespaced": false,
+      "shortNames": [
+        "no"
+      ],
+      "singularName": "node",
+      "storageVersionHash": "XwShjMxG9Fs=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "NodeProxyOptions",
+      "name": "nodes/proxy",
+      "namespaced": false,
+      "singularName": "",
+      "verbs": [
+        "create",
+        "delete",
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "Node",
+      "name": "nodes/status",
+      "namespaced": false,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "name": "persistentvolumeclaims",
+      "namespaced": true,
+      "shortNames": [
+        "pvc"
+      ],
+      "singularName": "persistentvolumeclaim",
+      "storageVersionHash": "QWTyNDq0dC4=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "name": "persistentvolumeclaims/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "PersistentVolume",
+      "name": "persistentvolumes",
+      "namespaced": false,
+      "shortNames": [
+        "pv"
+      ],
+      "singularName": "persistentvolume",
+      "storageVersionHash": "HN/zwEC+JgM=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "PersistentVolume",
+      "name": "persistentvolumes/status",
+      "namespaced": false,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "categories": [
+        "all"
+      ],
+      "kind": "Pod",
+      "name": "pods",
+      "namespaced": true,
+      "shortNames": [
+        "po"
+      ],
+      "singularName": "pod",
+      "storageVersionHash": "xPOwRZ+Yhw8=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "PodAttachOptions",
+      "name": "pods/attach",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "create",
+        "get"
+      ]
+    },
+    {
+      "kind": "Binding",
+      "name": "pods/binding",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "kind": "Pod",
+      "name": "pods/ephemeralcontainers",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "group": "policy",
+      "kind": "Eviction",
+      "name": "pods/eviction",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "create"
+      ],
+      "version": "v1"
+    },
+    {
+      "kind": "PodExecOptions",
+      "name": "pods/exec",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "create",
+        "get"
+      ]
+    },
+    {
+      "kind": "Pod",
+      "name": "pods/log",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get"
+      ]
+    },
+    {
+      "kind": "PodPortForwardOptions",
+      "name": "pods/portforward",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "create",
+        "get"
+      ]
+    },
+    {
+      "kind": "PodProxyOptions",
+      "name": "pods/proxy",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "create",
+        "delete",
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "Pod",
+      "name": "pods/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "PodTemplate",
+      "name": "podtemplates",
+      "namespaced": true,
+      "singularName": "podtemplate",
+      "storageVersionHash": "LIXB2x4IFpk=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "categories": [
+        "all"
+      ],
+      "kind": "ReplicationController",
+      "name": "replicationcontrollers",
+      "namespaced": true,
+      "shortNames": [
+        "rc"
+      ],
+      "singularName": "replicationcontroller",
+      "storageVersionHash": "Jond2If31h0=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "group": "autoscaling",
+      "kind": "Scale",
+      "name": "replicationcontrollers/scale",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ],
+      "version": "v1"
+    },
+    {
+      "kind": "ReplicationController",
+      "name": "replicationcontrollers/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "ResourceQuota",
+      "name": "resourcequotas",
+      "namespaced": true,
+      "shortNames": [
+        "quota"
+      ],
+      "singularName": "resourcequota",
+      "storageVersionHash": "8uhSgffRX6w=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "ResourceQuota",
+      "name": "resourcequotas/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "Secret",
+      "name": "secrets",
+      "namespaced": true,
+      "singularName": "secret",
+      "storageVersionHash": "S6u1pOWzb84=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "ServiceAccount",
+      "name": "serviceaccounts",
+      "namespaced": true,
+      "shortNames": [
+        "sa"
+      ],
+      "singularName": "serviceaccount",
+      "storageVersionHash": "pbx9ZvyFpBE=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "group": "authentication.k8s.io",
+      "kind": "TokenRequest",
+      "name": "serviceaccounts/token",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "create"
+      ],
+      "version": "v1"
+    },
+    {
+      "categories": [
+        "all"
+      ],
+      "kind": "Service",
+      "name": "services",
+      "namespaced": true,
+      "shortNames": [
+        "svc"
+      ],
+      "singularName": "service",
+      "storageVersionHash": "0/CO1lhkEBI=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "ServiceProxyOptions",
+      "name": "services/proxy",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "create",
+        "delete",
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "Service",
+      "name": "services/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis.json
+++ b/api/discovery/apis.json
@@ -1,0 +1,307 @@
+{
+  "apiVersion": "v1",
+  "groups": [
+    {
+      "name": "apiregistration.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "apiregistration.k8s.io/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "apiregistration.k8s.io/v1",
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "name": "apps",
+      "preferredVersion": {
+        "groupVersion": "apps/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "apps/v1",
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "name": "events.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "events.k8s.io/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "events.k8s.io/v1",
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "name": "authentication.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "authentication.k8s.io/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "authentication.k8s.io/v1",
+          "version": "v1"
+        },
+        {
+          "groupVersion": "authentication.k8s.io/v1beta1",
+          "version": "v1beta1"
+        },
+        {
+          "groupVersion": "authentication.k8s.io/v1alpha1",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    {
+      "name": "authorization.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "authorization.k8s.io/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "authorization.k8s.io/v1",
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "name": "autoscaling",
+      "preferredVersion": {
+        "groupVersion": "autoscaling/v2",
+        "version": "v2"
+      },
+      "versions": [
+        {
+          "groupVersion": "autoscaling/v2",
+          "version": "v2"
+        },
+        {
+          "groupVersion": "autoscaling/v1",
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "name": "batch",
+      "preferredVersion": {
+        "groupVersion": "batch/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "batch/v1",
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "name": "certificates.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "certificates.k8s.io/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "certificates.k8s.io/v1",
+          "version": "v1"
+        },
+        {
+          "groupVersion": "certificates.k8s.io/v1alpha1",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    {
+      "name": "networking.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "networking.k8s.io/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "networking.k8s.io/v1",
+          "version": "v1"
+        },
+        {
+          "groupVersion": "networking.k8s.io/v1alpha1",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    {
+      "name": "policy",
+      "preferredVersion": {
+        "groupVersion": "policy/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "policy/v1",
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "name": "rbac.authorization.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "rbac.authorization.k8s.io/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "rbac.authorization.k8s.io/v1",
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "name": "storage.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "storage.k8s.io/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "storage.k8s.io/v1",
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "name": "admissionregistration.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "admissionregistration.k8s.io/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "admissionregistration.k8s.io/v1",
+          "version": "v1"
+        },
+        {
+          "groupVersion": "admissionregistration.k8s.io/v1alpha1",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    {
+      "name": "apiextensions.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "apiextensions.k8s.io/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "apiextensions.k8s.io/v1",
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "name": "scheduling.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "scheduling.k8s.io/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "scheduling.k8s.io/v1",
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "name": "coordination.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "coordination.k8s.io/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "coordination.k8s.io/v1",
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "name": "node.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "node.k8s.io/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "node.k8s.io/v1",
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "name": "discovery.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "discovery.k8s.io/v1",
+        "version": "v1"
+      },
+      "versions": [
+        {
+          "groupVersion": "discovery.k8s.io/v1",
+          "version": "v1"
+        }
+      ]
+    },
+    {
+      "name": "flowcontrol.apiserver.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "flowcontrol.apiserver.k8s.io/v1beta3",
+        "version": "v1beta3"
+      },
+      "versions": [
+        {
+          "groupVersion": "flowcontrol.apiserver.k8s.io/v1beta3",
+          "version": "v1beta3"
+        },
+        {
+          "groupVersion": "flowcontrol.apiserver.k8s.io/v1beta2",
+          "version": "v1beta2"
+        }
+      ]
+    },
+    {
+      "name": "internal.apiserver.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "internal.apiserver.k8s.io/v1alpha1",
+        "version": "v1alpha1"
+      },
+      "versions": [
+        {
+          "groupVersion": "internal.apiserver.k8s.io/v1alpha1",
+          "version": "v1alpha1"
+        }
+      ]
+    },
+    {
+      "name": "resource.k8s.io",
+      "preferredVersion": {
+        "groupVersion": "resource.k8s.io/v1alpha2",
+        "version": "v1alpha2"
+      },
+      "versions": [
+        {
+          "groupVersion": "resource.k8s.io/v1alpha2",
+          "version": "v1alpha2"
+        }
+      ]
+    }
+  ],
+  "kind": "APIGroupList"
+}

--- a/api/discovery/apis__admissionregistration.k8s.io.json
+++ b/api/discovery/apis__admissionregistration.k8s.io.json
@@ -1,0 +1,19 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "admissionregistration.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "admissionregistration.k8s.io/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "admissionregistration.k8s.io/v1",
+      "version": "v1"
+    },
+    {
+      "groupVersion": "admissionregistration.k8s.io/v1alpha1",
+      "version": "v1alpha1"
+    }
+  ]
+}

--- a/api/discovery/apis__admissionregistration.k8s.io__v1.json
+++ b/api/discovery/apis__admissionregistration.k8s.io__v1.json
@@ -1,0 +1,47 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "admissionregistration.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "categories": [
+        "api-extensions"
+      ],
+      "kind": "MutatingWebhookConfiguration",
+      "name": "mutatingwebhookconfigurations",
+      "namespaced": false,
+      "singularName": "mutatingwebhookconfiguration",
+      "storageVersionHash": "Sqi0GUgDaX0=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "categories": [
+        "api-extensions"
+      ],
+      "kind": "ValidatingWebhookConfiguration",
+      "name": "validatingwebhookconfigurations",
+      "namespaced": false,
+      "singularName": "validatingwebhookconfiguration",
+      "storageVersionHash": "B0wHjQmsGNk=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__admissionregistration.k8s.io__v1alpha1.json
+++ b/api/discovery/apis__admissionregistration.k8s.io__v1alpha1.json
@@ -1,0 +1,58 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "admissionregistration.k8s.io/v1alpha1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "categories": [
+        "api-extensions"
+      ],
+      "kind": "ValidatingAdmissionPolicy",
+      "name": "validatingadmissionpolicies",
+      "namespaced": false,
+      "singularName": "validatingadmissionpolicy",
+      "storageVersionHash": "Vd+hadMG3gs=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "ValidatingAdmissionPolicy",
+      "name": "validatingadmissionpolicies/status",
+      "namespaced": false,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "categories": [
+        "api-extensions"
+      ],
+      "kind": "ValidatingAdmissionPolicyBinding",
+      "name": "validatingadmissionpolicybindings",
+      "namespaced": false,
+      "singularName": "validatingadmissionpolicybinding",
+      "storageVersionHash": "Yc3M4GKADk4=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__apiextensions.k8s.io.json
+++ b/api/discovery/apis__apiextensions.k8s.io.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "apiextensions.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "apiextensions.k8s.io/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "apiextensions.k8s.io/v1",
+      "version": "v1"
+    }
+  ]
+}

--- a/api/discovery/apis__apiextensions.k8s.io__v1.json
+++ b/api/discovery/apis__apiextensions.k8s.io__v1.json
@@ -1,0 +1,42 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "apiextensions.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "categories": [
+        "api-extensions"
+      ],
+      "kind": "CustomResourceDefinition",
+      "name": "customresourcedefinitions",
+      "namespaced": false,
+      "shortNames": [
+        "crd",
+        "crds"
+      ],
+      "singularName": "customresourcedefinition",
+      "storageVersionHash": "jfWCUB31mvA=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "CustomResourceDefinition",
+      "name": "customresourcedefinitions/status",
+      "namespaced": false,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__apps.json
+++ b/api/discovery/apis__apps.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "apps",
+  "preferredVersion": {
+    "groupVersion": "apps/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "apps/v1",
+      "version": "v1"
+    }
+  ]
+}

--- a/api/discovery/apis__apps__v1.json
+++ b/api/discovery/apis__apps__v1.json
@@ -1,0 +1,199 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "apps/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "ControllerRevision",
+      "name": "controllerrevisions",
+      "namespaced": true,
+      "singularName": "controllerrevision",
+      "storageVersionHash": "85nkx63pcBU=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "categories": [
+        "all"
+      ],
+      "kind": "DaemonSet",
+      "name": "daemonsets",
+      "namespaced": true,
+      "shortNames": [
+        "ds"
+      ],
+      "singularName": "daemonset",
+      "storageVersionHash": "dd7pWHUlMKQ=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "DaemonSet",
+      "name": "daemonsets/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "categories": [
+        "all"
+      ],
+      "kind": "Deployment",
+      "name": "deployments",
+      "namespaced": true,
+      "shortNames": [
+        "deploy"
+      ],
+      "singularName": "deployment",
+      "storageVersionHash": "8aSe+NMegvE=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "group": "autoscaling",
+      "kind": "Scale",
+      "name": "deployments/scale",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ],
+      "version": "v1"
+    },
+    {
+      "kind": "Deployment",
+      "name": "deployments/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "categories": [
+        "all"
+      ],
+      "kind": "ReplicaSet",
+      "name": "replicasets",
+      "namespaced": true,
+      "shortNames": [
+        "rs"
+      ],
+      "singularName": "replicaset",
+      "storageVersionHash": "P1RzHs8/mWQ=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "group": "autoscaling",
+      "kind": "Scale",
+      "name": "replicasets/scale",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ],
+      "version": "v1"
+    },
+    {
+      "kind": "ReplicaSet",
+      "name": "replicasets/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "categories": [
+        "all"
+      ],
+      "kind": "StatefulSet",
+      "name": "statefulsets",
+      "namespaced": true,
+      "shortNames": [
+        "sts"
+      ],
+      "singularName": "statefulset",
+      "storageVersionHash": "H+vl74LkKdo=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "group": "autoscaling",
+      "kind": "Scale",
+      "name": "statefulsets/scale",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ],
+      "version": "v1"
+    },
+    {
+      "kind": "StatefulSet",
+      "name": "statefulsets/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__authentication.k8s.io.json
+++ b/api/discovery/apis__authentication.k8s.io.json
@@ -1,0 +1,23 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "authentication.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "authentication.k8s.io/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "authentication.k8s.io/v1",
+      "version": "v1"
+    },
+    {
+      "groupVersion": "authentication.k8s.io/v1beta1",
+      "version": "v1beta1"
+    },
+    {
+      "groupVersion": "authentication.k8s.io/v1alpha1",
+      "version": "v1alpha1"
+    }
+  ]
+}

--- a/api/discovery/apis__authentication.k8s.io__v1.json
+++ b/api/discovery/apis__authentication.k8s.io__v1.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "authentication.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "SelfSubjectReview",
+      "name": "selfsubjectreviews",
+      "namespaced": false,
+      "singularName": "selfsubjectreview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "kind": "TokenReview",
+      "name": "tokenreviews",
+      "namespaced": false,
+      "singularName": "tokenreview",
+      "verbs": [
+        "create"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__authentication.k8s.io__v1alpha1.json
+++ b/api/discovery/apis__authentication.k8s.io__v1alpha1.json
@@ -1,0 +1,16 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "authentication.k8s.io/v1alpha1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "SelfSubjectReview",
+      "name": "selfsubjectreviews",
+      "namespaced": false,
+      "singularName": "selfsubjectreview",
+      "verbs": [
+        "create"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__authentication.k8s.io__v1beta1.json
+++ b/api/discovery/apis__authentication.k8s.io__v1beta1.json
@@ -1,0 +1,16 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "authentication.k8s.io/v1beta1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "SelfSubjectReview",
+      "name": "selfsubjectreviews",
+      "namespaced": false,
+      "singularName": "selfsubjectreview",
+      "verbs": [
+        "create"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__authorization.k8s.io.json
+++ b/api/discovery/apis__authorization.k8s.io.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "authorization.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "authorization.k8s.io/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "authorization.k8s.io/v1",
+      "version": "v1"
+    }
+  ]
+}

--- a/api/discovery/apis__authorization.k8s.io__v1.json
+++ b/api/discovery/apis__authorization.k8s.io__v1.json
@@ -1,0 +1,43 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "authorization.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "LocalSubjectAccessReview",
+      "name": "localsubjectaccessreviews",
+      "namespaced": true,
+      "singularName": "localsubjectaccessreview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "kind": "SelfSubjectAccessReview",
+      "name": "selfsubjectaccessreviews",
+      "namespaced": false,
+      "singularName": "selfsubjectaccessreview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "kind": "SelfSubjectRulesReview",
+      "name": "selfsubjectrulesreviews",
+      "namespaced": false,
+      "singularName": "selfsubjectrulesreview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "kind": "SubjectAccessReview",
+      "name": "subjectaccessreviews",
+      "namespaced": false,
+      "singularName": "subjectaccessreview",
+      "verbs": [
+        "create"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__autoscaling.json
+++ b/api/discovery/apis__autoscaling.json
@@ -1,0 +1,19 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "autoscaling",
+  "preferredVersion": {
+    "groupVersion": "autoscaling/v2",
+    "version": "v2"
+  },
+  "versions": [
+    {
+      "groupVersion": "autoscaling/v2",
+      "version": "v2"
+    },
+    {
+      "groupVersion": "autoscaling/v1",
+      "version": "v1"
+    }
+  ]
+}

--- a/api/discovery/apis__autoscaling__v1.json
+++ b/api/discovery/apis__autoscaling__v1.json
@@ -1,0 +1,41 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "autoscaling/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "categories": [
+        "all"
+      ],
+      "kind": "HorizontalPodAutoscaler",
+      "name": "horizontalpodautoscalers",
+      "namespaced": true,
+      "shortNames": [
+        "hpa"
+      ],
+      "singularName": "horizontalpodautoscaler",
+      "storageVersionHash": "qwQve8ut294=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "HorizontalPodAutoscaler",
+      "name": "horizontalpodautoscalers/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__autoscaling__v2.json
+++ b/api/discovery/apis__autoscaling__v2.json
@@ -1,0 +1,41 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "autoscaling/v2",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "categories": [
+        "all"
+      ],
+      "kind": "HorizontalPodAutoscaler",
+      "name": "horizontalpodautoscalers",
+      "namespaced": true,
+      "shortNames": [
+        "hpa"
+      ],
+      "singularName": "horizontalpodautoscaler",
+      "storageVersionHash": "qwQve8ut294=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "HorizontalPodAutoscaler",
+      "name": "horizontalpodautoscalers/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__batch.json
+++ b/api/discovery/apis__batch.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "batch",
+  "preferredVersion": {
+    "groupVersion": "batch/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "batch/v1",
+      "version": "v1"
+    }
+  ]
+}

--- a/api/discovery/apis__batch__v1.json
+++ b/api/discovery/apis__batch__v1.json
@@ -1,0 +1,72 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "batch/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "categories": [
+        "all"
+      ],
+      "kind": "CronJob",
+      "name": "cronjobs",
+      "namespaced": true,
+      "shortNames": [
+        "cj"
+      ],
+      "singularName": "cronjob",
+      "storageVersionHash": "sd5LIXh4Fjs=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "CronJob",
+      "name": "cronjobs/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "categories": [
+        "all"
+      ],
+      "kind": "Job",
+      "name": "jobs",
+      "namespaced": true,
+      "singularName": "job",
+      "storageVersionHash": "mudhfqk/qZY=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "Job",
+      "name": "jobs/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__certificates.k8s.io.json
+++ b/api/discovery/apis__certificates.k8s.io.json
@@ -1,0 +1,19 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "certificates.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "certificates.k8s.io/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "certificates.k8s.io/v1",
+      "version": "v1"
+    },
+    {
+      "groupVersion": "certificates.k8s.io/v1alpha1",
+      "version": "v1alpha1"
+    }
+  ]
+}

--- a/api/discovery/apis__certificates.k8s.io__v1.json
+++ b/api/discovery/apis__certificates.k8s.io__v1.json
@@ -1,0 +1,49 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "certificates.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "CertificateSigningRequest",
+      "name": "certificatesigningrequests",
+      "namespaced": false,
+      "shortNames": [
+        "csr"
+      ],
+      "singularName": "certificatesigningrequest",
+      "storageVersionHash": "95fRKMXA+00=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "CertificateSigningRequest",
+      "name": "certificatesigningrequests/approval",
+      "namespaced": false,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "CertificateSigningRequest",
+      "name": "certificatesigningrequests/status",
+      "namespaced": false,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__certificates.k8s.io__v1alpha1.json
+++ b/api/discovery/apis__certificates.k8s.io__v1alpha1.json
@@ -1,0 +1,24 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "certificates.k8s.io/v1alpha1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "ClusterTrustBundle",
+      "name": "clustertrustbundles",
+      "namespaced": false,
+      "singularName": "clustertrustbundle",
+      "storageVersionHash": "XGGGW2kGm+w=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__coordination.k8s.io.json
+++ b/api/discovery/apis__coordination.k8s.io.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "coordination.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "coordination.k8s.io/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "coordination.k8s.io/v1",
+      "version": "v1"
+    }
+  ]
+}

--- a/api/discovery/apis__coordination.k8s.io__v1.json
+++ b/api/discovery/apis__coordination.k8s.io__v1.json
@@ -1,0 +1,24 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "coordination.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "Lease",
+      "name": "leases",
+      "namespaced": true,
+      "singularName": "lease",
+      "storageVersionHash": "gqkMMb/YqFM=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__discovery.k8s.io.json
+++ b/api/discovery/apis__discovery.k8s.io.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "discovery.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "discovery.k8s.io/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "discovery.k8s.io/v1",
+      "version": "v1"
+    }
+  ]
+}

--- a/api/discovery/apis__discovery.k8s.io__v1.json
+++ b/api/discovery/apis__discovery.k8s.io__v1.json
@@ -1,0 +1,24 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "discovery.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "EndpointSlice",
+      "name": "endpointslices",
+      "namespaced": true,
+      "singularName": "endpointslice",
+      "storageVersionHash": "Nx3SIv6I0mE=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__events.k8s.io.json
+++ b/api/discovery/apis__events.k8s.io.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "events.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "events.k8s.io/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "events.k8s.io/v1",
+      "version": "v1"
+    }
+  ]
+}

--- a/api/discovery/apis__events.k8s.io__v1.json
+++ b/api/discovery/apis__events.k8s.io__v1.json
@@ -1,0 +1,27 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "events.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "Event",
+      "name": "events",
+      "namespaced": true,
+      "shortNames": [
+        "ev"
+      ],
+      "singularName": "event",
+      "storageVersionHash": "r2yiGXH7wu8=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__flowcontrol.apiserver.k8s.io.json
+++ b/api/discovery/apis__flowcontrol.apiserver.k8s.io.json
@@ -1,0 +1,19 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "flowcontrol.apiserver.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "flowcontrol.apiserver.k8s.io/v1beta3",
+    "version": "v1beta3"
+  },
+  "versions": [
+    {
+      "groupVersion": "flowcontrol.apiserver.k8s.io/v1beta3",
+      "version": "v1beta3"
+    },
+    {
+      "groupVersion": "flowcontrol.apiserver.k8s.io/v1beta2",
+      "version": "v1beta2"
+    }
+  ]
+}

--- a/api/discovery/apis__flowcontrol.apiserver.k8s.io__v1beta2.json
+++ b/api/discovery/apis__flowcontrol.apiserver.k8s.io__v1beta2.json
@@ -1,0 +1,63 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "flowcontrol.apiserver.k8s.io/v1beta2",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "FlowSchema",
+      "name": "flowschemas",
+      "namespaced": false,
+      "singularName": "flowschema",
+      "storageVersionHash": "9NnFrw7ZEmA=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "FlowSchema",
+      "name": "flowschemas/status",
+      "namespaced": false,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "PriorityLevelConfiguration",
+      "name": "prioritylevelconfigurations",
+      "namespaced": false,
+      "singularName": "prioritylevelconfiguration",
+      "storageVersionHash": "+CwSrEWTDhc=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "PriorityLevelConfiguration",
+      "name": "prioritylevelconfigurations/status",
+      "namespaced": false,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__flowcontrol.apiserver.k8s.io__v1beta3.json
+++ b/api/discovery/apis__flowcontrol.apiserver.k8s.io__v1beta3.json
@@ -1,0 +1,63 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "flowcontrol.apiserver.k8s.io/v1beta3",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "FlowSchema",
+      "name": "flowschemas",
+      "namespaced": false,
+      "singularName": "flowschema",
+      "storageVersionHash": "9NnFrw7ZEmA=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "FlowSchema",
+      "name": "flowschemas/status",
+      "namespaced": false,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "PriorityLevelConfiguration",
+      "name": "prioritylevelconfigurations",
+      "namespaced": false,
+      "singularName": "prioritylevelconfiguration",
+      "storageVersionHash": "+CwSrEWTDhc=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "PriorityLevelConfiguration",
+      "name": "prioritylevelconfigurations/status",
+      "namespaced": false,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__internal.apiserver.k8s.io.json
+++ b/api/discovery/apis__internal.apiserver.k8s.io.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "internal.apiserver.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "internal.apiserver.k8s.io/v1alpha1",
+    "version": "v1alpha1"
+  },
+  "versions": [
+    {
+      "groupVersion": "internal.apiserver.k8s.io/v1alpha1",
+      "version": "v1alpha1"
+    }
+  ]
+}

--- a/api/discovery/apis__internal.apiserver.k8s.io__v1alpha1.json
+++ b/api/discovery/apis__internal.apiserver.k8s.io__v1alpha1.json
@@ -1,0 +1,35 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "internal.apiserver.k8s.io/v1alpha1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "StorageVersion",
+      "name": "storageversions",
+      "namespaced": false,
+      "singularName": "storageversion",
+      "storageVersionHash": "c8YZt5U0nPk=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "StorageVersion",
+      "name": "storageversions/status",
+      "namespaced": false,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__networking.k8s.io.json
+++ b/api/discovery/apis__networking.k8s.io.json
@@ -1,0 +1,19 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "networking.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "networking.k8s.io/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "networking.k8s.io/v1",
+      "version": "v1"
+    },
+    {
+      "groupVersion": "networking.k8s.io/v1alpha1",
+      "version": "v1alpha1"
+    }
+  ]
+}

--- a/api/discovery/apis__networking.k8s.io__v1.json
+++ b/api/discovery/apis__networking.k8s.io__v1.json
@@ -1,0 +1,75 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "networking.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "IngressClass",
+      "name": "ingressclasses",
+      "namespaced": false,
+      "singularName": "ingressclass",
+      "storageVersionHash": "l/iqIbDgFyQ=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "Ingress",
+      "name": "ingresses",
+      "namespaced": true,
+      "shortNames": [
+        "ing"
+      ],
+      "singularName": "ingress",
+      "storageVersionHash": "39NQlfNR+bo=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "Ingress",
+      "name": "ingresses/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "NetworkPolicy",
+      "name": "networkpolicies",
+      "namespaced": true,
+      "shortNames": [
+        "netpol"
+      ],
+      "singularName": "networkpolicy",
+      "storageVersionHash": "YpfwF18m1G8=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__networking.k8s.io__v1alpha1.json
+++ b/api/discovery/apis__networking.k8s.io__v1alpha1.json
@@ -1,0 +1,47 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "networking.k8s.io/v1alpha1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "ClusterCIDR",
+      "name": "clustercidrs",
+      "namespaced": false,
+      "shortNames": [
+        "cc"
+      ],
+      "singularName": "clustercidr",
+      "storageVersionHash": "iC0u25BTSsc=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "IPAddress",
+      "name": "ipaddresses",
+      "namespaced": false,
+      "shortNames": [
+        "ip"
+      ],
+      "singularName": "ipaddress",
+      "storageVersionHash": "3APLM23DOxw=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__node.k8s.io.json
+++ b/api/discovery/apis__node.k8s.io.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "node.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "node.k8s.io/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "node.k8s.io/v1",
+      "version": "v1"
+    }
+  ]
+}

--- a/api/discovery/apis__node.k8s.io__v1.json
+++ b/api/discovery/apis__node.k8s.io__v1.json
@@ -1,0 +1,24 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "node.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "RuntimeClass",
+      "name": "runtimeclasses",
+      "namespaced": false,
+      "singularName": "runtimeclass",
+      "storageVersionHash": "WQTu1GL3T2Q=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__policy.json
+++ b/api/discovery/apis__policy.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "policy",
+  "preferredVersion": {
+    "groupVersion": "policy/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "policy/v1",
+      "version": "v1"
+    }
+  ]
+}

--- a/api/discovery/apis__policy__v1.json
+++ b/api/discovery/apis__policy__v1.json
@@ -1,0 +1,38 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "policy/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "PodDisruptionBudget",
+      "name": "poddisruptionbudgets",
+      "namespaced": true,
+      "shortNames": [
+        "pdb"
+      ],
+      "singularName": "poddisruptionbudget",
+      "storageVersionHash": "EVWiDmWqyJw=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "PodDisruptionBudget",
+      "name": "poddisruptionbudgets/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__rbac.authorization.k8s.io.json
+++ b/api/discovery/apis__rbac.authorization.k8s.io.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "rbac.authorization.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "rbac.authorization.k8s.io/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "rbac.authorization.k8s.io/v1",
+      "version": "v1"
+    }
+  ]
+}

--- a/api/discovery/apis__rbac.authorization.k8s.io__v1.json
+++ b/api/discovery/apis__rbac.authorization.k8s.io__v1.json
@@ -1,0 +1,75 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "rbac.authorization.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "ClusterRoleBinding",
+      "name": "clusterrolebindings",
+      "namespaced": false,
+      "singularName": "clusterrolebinding",
+      "storageVersionHash": "48tpQ8gZHFc=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "ClusterRole",
+      "name": "clusterroles",
+      "namespaced": false,
+      "singularName": "clusterrole",
+      "storageVersionHash": "bYE5ZWDrJ44=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "RoleBinding",
+      "name": "rolebindings",
+      "namespaced": true,
+      "singularName": "rolebinding",
+      "storageVersionHash": "eGsCzGH6b1g=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "Role",
+      "name": "roles",
+      "namespaced": true,
+      "singularName": "role",
+      "storageVersionHash": "7FuwZcIIItM=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__resource.k8s.io.json
+++ b/api/discovery/apis__resource.k8s.io.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "resource.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "resource.k8s.io/v1alpha2",
+    "version": "v1alpha2"
+  },
+  "versions": [
+    {
+      "groupVersion": "resource.k8s.io/v1alpha2",
+      "version": "v1alpha2"
+    }
+  ]
+}

--- a/api/discovery/apis__resource.k8s.io__v1alpha2.json
+++ b/api/discovery/apis__resource.k8s.io__v1alpha2.json
@@ -1,0 +1,97 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "resource.k8s.io/v1alpha2",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "PodSchedulingContext",
+      "name": "podschedulingcontexts",
+      "namespaced": true,
+      "singularName": "podschedulingcontext",
+      "storageVersionHash": "qtdNX2rnDEA=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "PodSchedulingContext",
+      "name": "podschedulingcontexts/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "ResourceClaim",
+      "name": "resourceclaims",
+      "namespaced": true,
+      "singularName": "resourceclaim",
+      "storageVersionHash": "sMQbgChfibk=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "ResourceClaim",
+      "name": "resourceclaims/status",
+      "namespaced": true,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "kind": "ResourceClaimTemplate",
+      "name": "resourceclaimtemplates",
+      "namespaced": true,
+      "singularName": "resourceclaimtemplate",
+      "storageVersionHash": "1o2b66bFoGM=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "ResourceClass",
+      "name": "resourceclasses",
+      "namespaced": false,
+      "singularName": "resourceclass",
+      "storageVersionHash": "wkt0Tpte++U=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__scheduling.k8s.io.json
+++ b/api/discovery/apis__scheduling.k8s.io.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "scheduling.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "scheduling.k8s.io/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "scheduling.k8s.io/v1",
+      "version": "v1"
+    }
+  ]
+}

--- a/api/discovery/apis__scheduling.k8s.io__v1.json
+++ b/api/discovery/apis__scheduling.k8s.io__v1.json
@@ -1,0 +1,27 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "scheduling.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "PriorityClass",
+      "name": "priorityclasses",
+      "namespaced": false,
+      "shortNames": [
+        "pc"
+      ],
+      "singularName": "priorityclass",
+      "storageVersionHash": "1QwjyaZjj3Y=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/api/discovery/apis__storage.k8s.io.json
+++ b/api/discovery/apis__storage.k8s.io.json
@@ -1,0 +1,15 @@
+{
+  "apiVersion": "v1",
+  "kind": "APIGroup",
+  "name": "storage.k8s.io",
+  "preferredVersion": {
+    "groupVersion": "storage.k8s.io/v1",
+    "version": "v1"
+  },
+  "versions": [
+    {
+      "groupVersion": "storage.k8s.io/v1",
+      "version": "v1"
+    }
+  ]
+}

--- a/api/discovery/apis__storage.k8s.io__v1.json
+++ b/api/discovery/apis__storage.k8s.io__v1.json
@@ -1,0 +1,106 @@
+{
+  "apiVersion": "v1",
+  "groupVersion": "storage.k8s.io/v1",
+  "kind": "APIResourceList",
+  "resources": [
+    {
+      "kind": "CSIDriver",
+      "name": "csidrivers",
+      "namespaced": false,
+      "singularName": "csidriver",
+      "storageVersionHash": "hL6j/rwBV5w=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "CSINode",
+      "name": "csinodes",
+      "namespaced": false,
+      "singularName": "csinode",
+      "storageVersionHash": "Pe62DkZtjuo=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "CSIStorageCapacity",
+      "name": "csistoragecapacities",
+      "namespaced": true,
+      "singularName": "csistoragecapacity",
+      "storageVersionHash": "xeVl+2Ly1kE=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "StorageClass",
+      "name": "storageclasses",
+      "namespaced": false,
+      "shortNames": [
+        "sc"
+      ],
+      "singularName": "storageclass",
+      "storageVersionHash": "K+m6uJwbjGY=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "VolumeAttachment",
+      "name": "volumeattachments",
+      "namespaced": false,
+      "singularName": "volumeattachment",
+      "storageVersionHash": "tJx/ezt6UDU=",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "kind": "VolumeAttachment",
+      "name": "volumeattachments/status",
+      "namespaced": false,
+      "singularName": "",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    }
+  ]
+}

--- a/hack/verify-openapi-spec.sh
+++ b/hack/verify-openapi-spec.sh
@@ -33,13 +33,17 @@ make -C "${KUBE_ROOT}" WHAT=cmd/kube-apiserver
 
 SPECROOT="${KUBE_ROOT}/api/openapi-spec"
 SPECV3PATH="${SPECROOT}/v3"
+DISCOVERYROOT="${KUBE_ROOT}/api/discovery"
 TMP_SPECROOT="${KUBE_ROOT}/_tmp/openapi-spec"
+TMP_DISCOVERYROOT="${KUBE_ROOT}/_tmp/discovery"
 _tmp="${KUBE_ROOT}/_tmp"
 
 mkdir -p "${_tmp}"
 cp -a "${SPECROOT}" "${TMP_SPECROOT}"
-trap 'cp -a ${TMP_SPECROOT} ${SPECROOT}/..; rm -rf ${_tmp}' EXIT SIGINT
+cp -a "${DISCOVERYROOT}" "${TMP_DISCOVERYROOT}"
+trap 'cp -a ${TMP_SPECROOT} ${SPECROOT}/..; cp -a ${TMP_DISCOVERYROOT} ${DISCOVERYROOT}/..; rm -rf ${_tmp}' EXIT SIGINT
 rm -r "${SPECROOT:?}"/*
+rm -r "${DISCOVERYROOT:?}"/*
 mkdir -p "${SPECV3PATH}"
 cp "${TMP_SPECROOT}/README.md" "${SPECROOT}/README.md"
 
@@ -52,6 +56,17 @@ then
   echo "${SPECROOT} up to date."
 else
   echo "${SPECROOT} is out of date. Please run hack/update-openapi-spec.sh" >&2
+  exit 1
+fi
+
+echo "diffing ${DISCOVERYROOT} against freshly generated discovery"
+ret=0
+diff -Naupr "${DISCOVERYROOT}" "${TMP_DISCOVERYROOT}" || ret=$?
+if [[ $ret -eq 0 ]]
+then
+  echo "${DISCOVERYROOT} up to date."
+else
+  echo "${DISCOVERYROOT} is out of date. Please run hack/update-openapi-spec.sh" >&2
   exit 1
 fi
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area test

#### What this PR does / why we need it:

Captures output of discovery API (both individual and aggregated) in /api package for review

#### Which issue(s) this PR fixes:
addresses the "Shouldn’t shortnames be under api review?" aspect of https://github.com/kubernetes/kubernetes/pull/117742#issuecomment-1546411695

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @smarterclayton 