### PR TITLE
Promote e2e test for APIResources endpoints + 12 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -312,6 +312,14 @@
     definitions MUST be published for custom resource definitions.
   release: v1.16
   file: test/e2e/apimachinery/crd_publish_openapi.go
+- testname: Discovery, confirm the groupVerion and a resourcefrom each apiGroup
+  codename: '[sig-api-machinery] Discovery should locate the groupVersion and a resource
+    within each APIGroup [Conformance]'
+  description: A resourceList MUST be found for each apiGroup that is retrieved. For
+    each apiGroup the groupVersion MUST equal the groupVersion as reported by the
+    schema. From each resourceList a valid resource MUST be found.
+  release: v1.28
+  file: test/e2e/apimachinery/discovery.go
 - testname: Discovery, confirm the PreferredVersion for each api group
   codename: '[sig-api-machinery] Discovery should validate PreferredVersion for each
     APIGroup [Conformance]'

--- a/test/e2e/apimachinery/discovery.go
+++ b/test/e2e/apimachinery/discovery.go
@@ -159,7 +159,14 @@ var _ = SIGDescribe("Discovery", func() {
 		}
 	})
 
-	ginkgo.It("should locate the groupVersion and a resource within each APIGroup", func(ctx context.Context) {
+	/*
+		Release: v1.28
+		Testname: Discovery, confirm the groupVerion and a resourcefrom each apiGroup
+		Description: A resourceList MUST be found for each apiGroup that is retrieved.
+		For each apiGroup the groupVersion MUST equal the groupVersion as reported by
+		the schema. From each resourceList a valid resource MUST be found.
+	*/
+	framework.ConformanceIt("should locate the groupVersion and a resource within each APIGroup", func(ctx context.Context) {
 
 		tests := []struct {
 			apiBasePath   string


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR promote to conformance a test to test the following untested endpoints:
- getAutoscalingV1APIResources
- getAutoscalingV2APIResources
- getPolicyV1APIResources
- getEventsV1APIResources
- getCoordinationV1APIResources
- getSchedulingV1APIResources
- getApiregistrationV1APIResources
- getAppsV1APIResources
- getAuthenticationV1APIResources
- getAuthorizationV1APIResources
- getBatchV1APIResources
- getCoreV1APIResources

**Which issue(s) this PR fixes:**
Fixes #117610

**Testgrid Link:**
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.locate.the.groupVersion.and.a.resource.within.each.APIGroup)


**Special notes for your reviewer:**
Adds +12 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance