### PR TITLE
Support BackoffLimitPerIndex in Jobs

### DIFF
--- a/pkg/controller/job/backoff_utils_test.go
+++ b/pkg/controller/job/backoff_utils_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/ktesting"
 	clocktesting "k8s.io/utils/clock/testing"
 	"k8s.io/utils/pointer"
 )
@@ -460,6 +461,49 @@ func TestGetRemainingBackoffTime(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			fakeClock := clocktesting.NewFakeClock(tc.currentTime.Truncate(time.Second))
 			d := tc.backoffRecord.getRemainingTime(fakeClock, tc.defaultBackoff, tc.maxBackoff)
+			if d.Seconds() != tc.wantDuration.Seconds() {
+				t.Errorf("Expected value of duration %v; got %v", tc.wantDuration, d)
+			}
+		})
+	}
+}
+
+func TestGetRemainingBackoffTimePerIndex(t *testing.T) {
+	defaultTestTime := metav1.NewTime(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC))
+	testCases := map[string]struct {
+		currentTime    time.Time
+		maxBackoff     time.Duration
+		defaultBackoff time.Duration
+		lastFailedPod  *v1.Pod
+		wantDuration   time.Duration
+	}{
+		"no failures": {
+			lastFailedPod:  nil,
+			defaultBackoff: 5 * time.Second,
+			maxBackoff:     700 * time.Second,
+			wantDuration:   0 * time.Second,
+		},
+		"two prev failures; current time and failure time are same": {
+			lastFailedPod:  buildPod().phase(v1.PodFailed).indexFailureCount("2").customDeletionTimestamp(defaultTestTime.Time).Pod,
+			currentTime:    defaultTestTime.Time,
+			defaultBackoff: 5 * time.Second,
+			maxBackoff:     700 * time.Second,
+			wantDuration:   20 * time.Second,
+		},
+		"one prev failure counted and one ignored; current time and failure time are same": {
+			lastFailedPod:  buildPod().phase(v1.PodFailed).indexFailureCount("1").indexIgnoredFailureCount("1").customDeletionTimestamp(defaultTestTime.Time).Pod,
+			currentTime:    defaultTestTime.Time,
+			defaultBackoff: 5 * time.Second,
+			maxBackoff:     700 * time.Second,
+			wantDuration:   20 * time.Second,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			fakeClock := clocktesting.NewFakeClock(tc.currentTime.Truncate(time.Second))
+			d := getRemainingTimePerIndex(logger, fakeClock, tc.defaultBackoff, tc.maxBackoff, tc.lastFailedPod)
 			if d.Seconds() != tc.wantDuration.Seconds() {
 				t.Errorf("Expected value of duration %v; got %v", tc.wantDuration, d)
 			}

--- a/pkg/controller/job/indexed_job_utils.go
+++ b/pkg/controller/job/indexed_job_utils.go
@@ -18,6 +18,7 @@ package job
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -41,6 +42,10 @@ func isIndexedJob(job *batch.Job) bool {
 	return job.Spec.CompletionMode != nil && *job.Spec.CompletionMode == batch.IndexedCompletion
 }
 
+func hasBackoffLimitPerIndex(job *batch.Job) bool {
+	return feature.DefaultFeatureGate.Enabled(features.JobBackoffLimitPerIndex) && job.Spec.BackoffLimitPerIndex != nil
+}
+
 type interval struct {
 	First int
 	Last  int
@@ -54,7 +59,7 @@ type orderedIntervals []interval
 // empty list if this Job is not tracked with finalizers. The new list includes
 // the indexes that succeeded since the last sync.
 func calculateSucceededIndexes(logger klog.Logger, job *batch.Job, pods []*v1.Pod) (orderedIntervals, orderedIntervals) {
-	prevIntervals := succeededIndexesFromString(logger, job.Status.CompletedIndexes, int(*job.Spec.Completions))
+	prevIntervals := parseIndexesFromString(logger, job.Status.CompletedIndexes, int(*job.Spec.Completions))
 	newSucceeded := sets.New[int]()
 	for _, p := range pods {
 		ix := getCompletionIndex(p.Annotations)
@@ -69,9 +74,55 @@ func calculateSucceededIndexes(logger klog.Logger, job *batch.Job, pods []*v1.Po
 	return prevIntervals, result
 }
 
+// calculateFailedIndexes returns the list of failed indexes in compressed
+// format (intervals). The list includes indexes already present in
+// .status.failedIndexes and indexes that failed since the last sync.
+func calculateFailedIndexes(logger klog.Logger, job *batch.Job, pods []*v1.Pod) *orderedIntervals {
+	var prevIntervals orderedIntervals
+	if job.Status.FailedIndexes != nil {
+		prevIntervals = parseIndexesFromString(logger, *job.Status.FailedIndexes, int(*job.Spec.Completions))
+	}
+	newFailed := sets.New[int]()
+	for _, p := range pods {
+		ix := getCompletionIndex(p.Annotations)
+		// Failed Pod with valid index and has a finalizer (meaning that it is not counted yet).
+		if ix != unknownCompletionIndex && ix < int(*job.Spec.Completions) && hasJobTrackingFinalizer(p) && isIndexFailed(logger, job, p) {
+			newFailed.Insert(ix)
+		}
+	}
+	// List returns the items of the set in order.
+	result := prevIntervals.withOrderedIndexes(sets.List(newFailed))
+	return &result
+}
+
+func isIndexFailed(logger klog.Logger, job *batch.Job, pod *v1.Pod) bool {
+	isPodFailedCounted := false
+	if isPodFailed(pod, job) {
+		if feature.DefaultFeatureGate.Enabled(features.JobPodFailurePolicy) && job.Spec.PodFailurePolicy != nil {
+			_, countFailed, action := matchPodFailurePolicy(job.Spec.PodFailurePolicy, pod)
+			if action != nil && *action == batch.PodFailurePolicyActionFailIndex {
+				return true
+			}
+			isPodFailedCounted = countFailed
+		} else {
+			isPodFailedCounted = true
+		}
+	}
+	return isPodFailedCounted && getIndexFailureCount(logger, pod) >= *job.Spec.BackoffLimitPerIndex
+}
+
 // withOrderedIndexes returns a new list of ordered intervals that contains
 // the newIndexes, provided in increasing order.
 func (oi orderedIntervals) withOrderedIndexes(newIndexes []int) orderedIntervals {
+	newIndexIntervals := make(orderedIntervals, len(newIndexes))
+	for i, newIndex := range newIndexes {
+		newIndexIntervals[i] = interval{newIndex, newIndex}
+	}
+	return oi.merge(newIndexIntervals)
+}
+
+// with returns a new list of ordered intervals that contains the newOrderedIntervals.
+func (oi orderedIntervals) merge(newOi orderedIntervals) orderedIntervals {
 	var result orderedIntervals
 	i := 0
 	j := 0
@@ -84,12 +135,12 @@ func (oi orderedIntervals) withOrderedIndexes(newIndexes []int) orderedIntervals
 			lastInterval.Last = thisInterval.Last
 		}
 	}
-	for i < len(oi) && j < len(newIndexes) {
-		if oi[i].First < newIndexes[j] {
+	for i < len(oi) && j < len(newOi) {
+		if oi[i].First < newOi[j].First {
 			appendOrMergeWithLastInterval(oi[i])
 			i++
 		} else {
-			appendOrMergeWithLastInterval(interval{newIndexes[j], newIndexes[j]})
+			appendOrMergeWithLastInterval(newOi[j])
 			j++
 		}
 	}
@@ -97,8 +148,8 @@ func (oi orderedIntervals) withOrderedIndexes(newIndexes []int) orderedIntervals
 		appendOrMergeWithLastInterval(oi[i])
 		i++
 	}
-	for j < len(newIndexes) {
-		appendOrMergeWithLastInterval(interval{newIndexes[j], newIndexes[j]})
+	for j < len(newOi) {
+		appendOrMergeWithLastInterval(newOi[j])
 		j++
 	}
 	return result
@@ -150,19 +201,19 @@ func (oi orderedIntervals) has(ix int) bool {
 	return oi[hi].First <= ix
 }
 
-func succeededIndexesFromString(logger klog.Logger, completedIndexes string, completions int) orderedIntervals {
-	if completedIndexes == "" {
+func parseIndexesFromString(logger klog.Logger, indexesStr string, completions int) orderedIntervals {
+	if indexesStr == "" {
 		return nil
 	}
 	var result orderedIntervals
 	var lastInterval *interval
-	for _, intervalStr := range strings.Split(completedIndexes, ",") {
+	for _, intervalStr := range strings.Split(indexesStr, ",") {
 		limitsStr := strings.Split(intervalStr, "-")
 		var inter interval
 		var err error
 		inter.First, err = strconv.Atoi(limitsStr[0])
 		if err != nil {
-			logger.Info("Corrupted completed indexes interval, ignoring", "interval", intervalStr, "err", err)
+			logger.Info("Corrupted indexes interval, ignoring", "interval", intervalStr, "err", err)
 			continue
 		}
 		if inter.First >= completions {
@@ -171,7 +222,7 @@ func succeededIndexesFromString(logger klog.Logger, completedIndexes string, com
 		if len(limitsStr) > 1 {
 			inter.Last, err = strconv.Atoi(limitsStr[1])
 			if err != nil {
-				logger.Info("Corrupted completed indexes interval, ignoring", "interval", intervalStr, "err", err)
+				logger.Info("Corrupted indexes interval, ignoring", "interval", intervalStr, "err", err)
 				continue
 			}
 			if inter.Last >= completions {
@@ -191,20 +242,17 @@ func succeededIndexesFromString(logger klog.Logger, completedIndexes string, com
 }
 
 // firstPendingIndexes returns `count` indexes less than `completions` that are
-// not covered by `activePods` or `succeededIndexes`.
+// not covered by `activePods`, `succeededIndexes` or `failedIndexes`.
 func firstPendingIndexes(jobCtx *syncJobCtx, count, completions int) []int {
 	if count == 0 {
 		return nil
 	}
-	active := sets.New[int]()
-	for _, p := range jobCtx.activePods {
-		ix := getCompletionIndex(p.Annotations)
-		if ix != unknownCompletionIndex {
-			active.Insert(ix)
-		}
-	}
+	active := getIndexes(jobCtx.activePods)
 	result := make([]int, 0, count)
 	nonPending := jobCtx.succeededIndexes.withOrderedIndexes(sets.List(active))
+	if jobCtx.failedIndexes != nil {
+		nonPending = nonPending.merge(*jobCtx.failedIndexes)
+	}
 	// The following algorithm is bounded by len(nonPending) and count.
 	candidate := 0
 	for _, sInterval := range nonPending {
@@ -217,6 +265,18 @@ func firstPendingIndexes(jobCtx *syncJobCtx, count, completions int) []int {
 	}
 	for ; candidate < completions && len(result) < count; candidate++ {
 		result = append(result, candidate)
+	}
+	return result
+}
+
+// Returns the list of indexes corresponding to the set of pods
+func getIndexes(pods []*v1.Pod) sets.Set[int] {
+	result := sets.New[int]()
+	for _, p := range pods {
+		ix := getCompletionIndex(p.Annotations)
+		if ix != unknownCompletionIndex {
+			result.Insert(ix)
+		}
 	}
 	return result
 }
@@ -246,6 +306,69 @@ func appendDuplicatedIndexPodsForRemoval(rm, left, pods []*v1.Pod, completions i
 		countLooped += 1
 	}
 	return appendPodsWithSameIndexForRemovalAndRemaining(rm, left, pods[firstRepeatPos:countLooped], lastIndex)
+}
+
+// getPodsWithDelayedDeletionPerIndex returns the pod which removal is delayed
+// in order to await for recreation. This map is used when BackoffLimitPerIndex
+// is enabled to delay pod finalizer removal, and thus pod deletion, until the
+// replacement pod is created. The pod deletion is delayed so that the
+// replacement pod can have the batch.kubernetes.io/job-index-failure-count
+// annotation set properly keeping track of the number of failed pods within
+// the index.
+func getPodsWithDelayedDeletionPerIndex(logger klog.Logger, jobCtx *syncJobCtx) map[int]*v1.Pod {
+	// the failed pods corresponding to currently active indexes can be safely
+	// deleted as the failure count annotation is present in the currently
+	// active pods.
+	activeIndexes := getIndexes(jobCtx.activePods)
+
+	podsWithDelayedDeletionPerIndex := make(map[int]*v1.Pod)
+	getValidPodsWithFilter(jobCtx, nil, func(p *v1.Pod) bool {
+		if isPodFailed(p, jobCtx.job) {
+			if ix := getCompletionIndex(p.Annotations); ix != unknownCompletionIndex && ix < int(*jobCtx.job.Spec.Completions) {
+				if jobCtx.succeededIndexes.has(ix) || jobCtx.failedIndexes.has(ix) || activeIndexes.Has(ix) {
+					return false
+				}
+				if lastPodWithDelayedDeletion, ok := podsWithDelayedDeletionPerIndex[ix]; ok {
+					if getIndexAbsoluteFailureCount(logger, lastPodWithDelayedDeletion) <= getIndexAbsoluteFailureCount(logger, p) && !getFinishedTime(p).Before(getFinishedTime(lastPodWithDelayedDeletion)) {
+						podsWithDelayedDeletionPerIndex[ix] = p
+					}
+				} else {
+					podsWithDelayedDeletionPerIndex[ix] = p
+				}
+			}
+		}
+		return false
+	})
+	return podsWithDelayedDeletionPerIndex
+}
+
+func addIndexFailureCountAnnotation(logger klog.Logger, template *v1.PodTemplateSpec, job *batch.Job, podBeingReplaced *v1.Pod) {
+	indexFailureCount, indexIgnoredFailureCount := getNewIndexFailureCounts(logger, job, podBeingReplaced)
+	template.Annotations[batch.JobIndexFailureCountAnnotation] = strconv.Itoa(int(indexFailureCount))
+	if indexIgnoredFailureCount > 0 {
+		template.Annotations[batch.JobIndexIgnoredFailureCountAnnotation] = strconv.Itoa(int(indexIgnoredFailureCount))
+	}
+}
+
+// getNewIndexFailureCount returns the value of the index-failure-count
+// annotation for the new pod being created
+func getNewIndexFailureCounts(logger klog.Logger, job *batch.Job, podBeingReplaced *v1.Pod) (int32, int32) {
+	if podBeingReplaced != nil {
+		indexFailureCount := parseIndexFailureCountAnnotation(logger, podBeingReplaced)
+		indexIgnoredFailureCount := parseIndexFailureIgnoreCountAnnotation(logger, podBeingReplaced)
+		if feature.DefaultFeatureGate.Enabled(features.JobPodFailurePolicy) && job.Spec.PodFailurePolicy != nil {
+			_, countFailed, _ := matchPodFailurePolicy(job.Spec.PodFailurePolicy, podBeingReplaced)
+			if countFailed {
+				indexFailureCount++
+			} else {
+				indexIgnoredFailureCount++
+			}
+		} else {
+			indexFailureCount++
+		}
+		return indexFailureCount, indexIgnoredFailureCount
+	}
+	return 0, 0
 }
 
 func appendPodsWithSameIndexForRemovalAndRemaining(rm, left, pods []*v1.Pod, ix int) ([]*v1.Pod, []*v1.Pod) {
@@ -279,6 +402,49 @@ func getCompletionIndex(annotations map[string]string) int {
 		return unknownCompletionIndex
 	}
 	return i
+}
+
+// getIndexFailureCount returns the value of the batch.kubernetes.io/job-index-failure-count
+// annotation as int32. It fallbacks to 0 when:
+//   - there is no annotation - for example the pod was created when the BackoffLimitPerIndex
+//     feature was temporarily disabled, or the annotation was manually removed by the user,
+//   - the value of the annotation isn't parsable as int - for example because
+//     it was set by a malicious user,
+//   - the value of the annotation is negative or greater by int32 - for example
+//     because it was set by a malicious user.
+func getIndexFailureCount(logger klog.Logger, pod *v1.Pod) int32 {
+	return parseIndexFailureCountAnnotation(logger, pod)
+}
+
+func getIndexAbsoluteFailureCount(logger klog.Logger, pod *v1.Pod) int32 {
+	return parseIndexFailureCountAnnotation(logger, pod) + parseIndexFailureIgnoreCountAnnotation(logger, pod)
+}
+
+func parseIndexFailureCountAnnotation(logger klog.Logger, pod *v1.Pod) int32 {
+	if value, ok := pod.Annotations[batch.JobIndexFailureCountAnnotation]; ok {
+		return parseInt32(logger, value)
+	}
+	logger.V(3).Info("There is no expected annotation", "annotationKey", batch.JobIndexFailureCountAnnotation, "pod", klog.KObj(pod), "podUID", pod.UID)
+	return 0
+}
+
+func parseIndexFailureIgnoreCountAnnotation(logger klog.Logger, pod *v1.Pod) int32 {
+	if value, ok := pod.Annotations[batch.JobIndexIgnoredFailureCountAnnotation]; ok {
+		return parseInt32(logger, value)
+	}
+	return 0
+}
+
+func parseInt32(logger klog.Logger, vStr string) int32 {
+	if vInt, err := strconv.Atoi(vStr); err != nil {
+		logger.Error(err, "Failed to parse the value", "value", vStr)
+		return 0
+	} else if vInt < 0 || vInt > math.MaxInt32 {
+		logger.Info("The value is invalid", "value", vInt)
+		return 0
+	} else {
+		return int32(vInt)
+	}
 }
 
 func addCompletionIndexEnvVariables(template *v1.PodTemplateSpec) {

--- a/pkg/controller/job/indexed_job_utils_test.go
+++ b/pkg/controller/job/indexed_job_utils_test.go
@@ -17,12 +17,20 @@ limitations under the License.
 package job
 
 import (
+	"math"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2/ktesting"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/utils/pointer"
 )
 
@@ -219,6 +227,427 @@ func TestCalculateSucceededIndexes(t *testing.T) {
 	}
 }
 
+func TestIsIndexFailed(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	cases := map[string]struct {
+		enableJobPodFailurePolicy bool
+		job                       batch.Job
+		pod                       *v1.Pod
+		wantResult                bool
+	}{
+		"failed pod exceeding backoffLimitPerIndex, when backoffLimitPerIndex=0": {
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(0),
+				},
+			},
+			pod:        buildPod().indexFailureCount("0").phase(v1.PodFailed).index("0").trackingFinalizer().Pod,
+			wantResult: true,
+		},
+		"failed pod exceeding backoffLimitPerIndex, when backoffLimitPerIndex=1": {
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(1),
+				},
+			},
+			pod:        buildPod().indexFailureCount("1").phase(v1.PodFailed).index("1").trackingFinalizer().Pod,
+			wantResult: true,
+		},
+		"matching FailIndex pod failure policy; JobPodFailurePolicy enabled": {
+			enableJobPodFailurePolicy: true,
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(1),
+					PodFailurePolicy: &batch.PodFailurePolicy{
+						Rules: []batch.PodFailurePolicyRule{
+							{
+								Action: batch.PodFailurePolicyActionFailIndex,
+								OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
+									Operator: batch.PodFailurePolicyOnExitCodesOpIn,
+									Values:   []int32{3},
+								},
+							},
+						},
+					},
+				},
+			},
+			pod: buildPod().indexFailureCount("0").status(v1.PodStatus{
+				Phase: v1.PodFailed,
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						State: v1.ContainerState{
+							Terminated: &v1.ContainerStateTerminated{
+								ExitCode: 3,
+							},
+						},
+					},
+				},
+			}).index("0").trackingFinalizer().Pod,
+			wantResult: true,
+		},
+		"matching FailIndex pod failure policy; JobPodFailurePolicy disabled": {
+			enableJobPodFailurePolicy: false,
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(1),
+					PodFailurePolicy: &batch.PodFailurePolicy{
+						Rules: []batch.PodFailurePolicyRule{
+							{
+								Action: batch.PodFailurePolicyActionFailIndex,
+								OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
+									Operator: batch.PodFailurePolicyOnExitCodesOpIn,
+									Values:   []int32{3},
+								},
+							},
+						},
+					},
+				},
+			},
+			pod: buildPod().indexFailureCount("0").status(v1.PodStatus{
+				Phase: v1.PodFailed,
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						State: v1.ContainerState{
+							Terminated: &v1.ContainerStateTerminated{
+								ExitCode: 3,
+							},
+						},
+					},
+				},
+			}).index("0").trackingFinalizer().Pod,
+			wantResult: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobBackoffLimitPerIndex, true)()
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobPodFailurePolicy, tc.enableJobPodFailurePolicy)()
+			gotResult := isIndexFailed(logger, &tc.job, tc.pod)
+			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
+				t.Errorf("Unexpected result (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCalculateFailedIndexes(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	cases := map[string]struct {
+		enableJobPodFailurePolicy bool
+		job                       batch.Job
+		pods                      []*v1.Pod
+		wantPrevFailedIndexes     orderedIntervals
+		wantFailedIndexes         orderedIntervals
+	}{
+		"one new index failed": {
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(1),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().indexFailureCount("0").phase(v1.PodFailed).index("0").trackingFinalizer().Pod,
+				buildPod().indexFailureCount("1").phase(v1.PodFailed).index("1").trackingFinalizer().Pod,
+			},
+			wantFailedIndexes: []interval{{1, 1}},
+		},
+		"pod without finalizer is ignored": {
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(0),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().indexFailureCount("0").phase(v1.PodFailed).index("0").Pod,
+			},
+			wantFailedIndexes: nil,
+		},
+		"pod outside completions is ignored": {
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(0),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().indexFailureCount("0").phase(v1.PodFailed).index("3").Pod,
+			},
+			wantFailedIndexes: nil,
+		},
+		"extend the failed indexes": {
+			job: batch.Job{
+				Status: batch.JobStatus{
+					FailedIndexes: pointer.String("0"),
+				},
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(0),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().indexFailureCount("0").phase(v1.PodFailed).index("1").trackingFinalizer().Pod,
+			},
+			wantFailedIndexes: []interval{{0, 1}},
+		},
+		"prev failed indexes empty": {
+			job: batch.Job{
+				Status: batch.JobStatus{
+					FailedIndexes: pointer.String(""),
+				},
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(0),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().indexFailureCount("0").phase(v1.PodFailed).index("1").trackingFinalizer().Pod,
+			},
+			wantFailedIndexes: []interval{{1, 1}},
+		},
+		"prev failed indexes outside the completions": {
+			job: batch.Job{
+				Status: batch.JobStatus{
+					FailedIndexes: pointer.String("9"),
+				},
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(0),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().indexFailureCount("0").phase(v1.PodFailed).index("1").trackingFinalizer().Pod,
+			},
+			wantFailedIndexes: []interval{{1, 1}},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			failedIndexes := calculateFailedIndexes(logger, &tc.job, tc.pods)
+			if diff := cmp.Diff(&tc.wantFailedIndexes, failedIndexes); diff != "" {
+				t.Errorf("Unexpected failed indexes (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetPodsWithDelayedDeletionPerIndex(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	now := time.Now()
+	cases := map[string]struct {
+		enableJobPodFailurePolicy           bool
+		job                                 batch.Job
+		pods                                []*v1.Pod
+		expectedRmFinalizers                sets.Set[string]
+		wantPodsWithDelayedDeletionPerIndex []string
+	}{
+		"failed pods are kept corresponding to non-failed indexes are kept": {
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(3),
+					BackoffLimitPerIndex: pointer.Int32(1),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().uid("a").indexFailureCount("0").phase(v1.PodFailed).index("0").trackingFinalizer().Pod,
+				buildPod().uid("b").indexFailureCount("1").phase(v1.PodFailed).index("1").trackingFinalizer().Pod,
+				buildPod().uid("c").indexFailureCount("0").phase(v1.PodFailed).index("2").trackingFinalizer().Pod,
+			},
+			wantPodsWithDelayedDeletionPerIndex: []string{"a", "c"},
+		},
+		"failed pod without finalizer; the pod's deletion is not delayed as it already started": {
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(0),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().uid("a").indexFailureCount("0").phase(v1.PodFailed).index("0").Pod,
+			},
+			wantPodsWithDelayedDeletionPerIndex: []string{},
+		},
+		"failed pod with expected finalizer removal; the pod's deletion is not delayed as it already started": {
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(0),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().uid("a").indexFailureCount("0").phase(v1.PodFailed).index("0").trackingFinalizer().Pod,
+			},
+			expectedRmFinalizers:                sets.New("a"),
+			wantPodsWithDelayedDeletionPerIndex: []string{},
+		},
+		"failed pod with index outside of completions; the pod's deletion is not delayed": {
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(0),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().uid("a").indexFailureCount("0").phase(v1.PodFailed).index("4").trackingFinalizer().Pod,
+			},
+			wantPodsWithDelayedDeletionPerIndex: []string{},
+		},
+		"failed pod for active index; the pod's deletion is not delayed as it is already replaced": {
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(1),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().uid("a1").indexFailureCount("0").phase(v1.PodFailed).index("0").trackingFinalizer().Pod,
+				buildPod().uid("a2").indexFailureCount("1").phase(v1.PodRunning).index("0").trackingFinalizer().Pod,
+			},
+			wantPodsWithDelayedDeletionPerIndex: []string{},
+		},
+		"failed pod for succeeded index; the pod's deletion is not delayed as it is already replaced": {
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(1),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().uid("a1").indexFailureCount("0").phase(v1.PodFailed).index("0").trackingFinalizer().Pod,
+				buildPod().uid("a2").indexFailureCount("1").phase(v1.PodSucceeded).index("0").trackingFinalizer().Pod,
+			},
+			wantPodsWithDelayedDeletionPerIndex: []string{},
+		},
+		"multiple failed pods for index with different failure count; only the pod with highest failure count is kept": {
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(4),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().uid("a1").indexFailureCount("0").phase(v1.PodFailed).index("0").trackingFinalizer().Pod,
+				buildPod().uid("a3").indexFailureCount("2").phase(v1.PodFailed).index("0").trackingFinalizer().Pod,
+				buildPod().uid("a2").indexFailureCount("1").phase(v1.PodFailed).index("0").trackingFinalizer().Pod,
+			},
+			wantPodsWithDelayedDeletionPerIndex: []string{"a3"},
+		},
+		"multiple failed pods for index with different finish times; only the last failed pod is kept": {
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					Completions:          pointer.Int32(2),
+					BackoffLimitPerIndex: pointer.Int32(4),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().uid("a1").indexFailureCount("1").phase(v1.PodFailed).index("0").customDeletionTimestamp(now.Add(-time.Second)).trackingFinalizer().Pod,
+				buildPod().uid("a3").indexFailureCount("1").phase(v1.PodFailed).index("0").customDeletionTimestamp(now).trackingFinalizer().Pod,
+				buildPod().uid("a2").indexFailureCount("1").phase(v1.PodFailed).index("0").customDeletionTimestamp(now.Add(-2 * time.Second)).trackingFinalizer().Pod,
+			},
+			wantPodsWithDelayedDeletionPerIndex: []string{"a3"},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobBackoffLimitPerIndex, true)()
+			activePods := controller.FilterActivePods(logger, tc.pods)
+			failedIndexes := calculateFailedIndexes(logger, &tc.job, tc.pods)
+			_, succeededIndexes := calculateSucceededIndexes(logger, &tc.job, tc.pods)
+			jobCtx := &syncJobCtx{
+				job:                  &tc.job,
+				pods:                 tc.pods,
+				activePods:           activePods,
+				succeededIndexes:     succeededIndexes,
+				failedIndexes:        failedIndexes,
+				expectedRmFinalizers: tc.expectedRmFinalizers,
+			}
+			gotPodsWithDelayedDeletionPerIndex := getPodsWithDelayedDeletionPerIndex(logger, jobCtx)
+			gotPodsWithDelayedDeletionPerIndexSet := sets.New[string]()
+			for _, pod := range gotPodsWithDelayedDeletionPerIndex {
+				gotPodsWithDelayedDeletionPerIndexSet.Insert(string(pod.UID))
+			}
+			if diff := cmp.Diff(tc.wantPodsWithDelayedDeletionPerIndex, sets.List(gotPodsWithDelayedDeletionPerIndexSet)); diff != "" {
+				t.Errorf("Unexpected set of pods with delayed deletion (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetNewIndexFailureCountValue(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	cases := map[string]struct {
+		enableJobPodFailurePolicy       bool
+		job                             batch.Job
+		pod                             *v1.Pod
+		wantNewIndexFailureCount        int32
+		wantNewIndexIgnoredFailureCount int32
+	}{
+		"first pod created": {
+			job:                      batch.Job{},
+			wantNewIndexFailureCount: 0,
+		},
+		"failed pod being replaced with 0 index failure count": {
+			job:                      batch.Job{},
+			pod:                      buildPod().uid("a").indexFailureCount("0").phase(v1.PodFailed).index("0").trackingFinalizer().Pod,
+			wantNewIndexFailureCount: 1,
+		},
+		"failed pod being replaced with >0 index failure count": {
+			job:                      batch.Job{},
+			pod:                      buildPod().uid("a").indexFailureCount("3").phase(v1.PodFailed).index("0").trackingFinalizer().Pod,
+			wantNewIndexFailureCount: 4,
+		},
+		"failed pod being replaced, matching the ignore rule; JobPodFailurePolicy enabled": {
+			enableJobPodFailurePolicy: true,
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					PodFailurePolicy: &batch.PodFailurePolicy{
+						Rules: []batch.PodFailurePolicyRule{
+							{
+								Action: batch.PodFailurePolicyActionIgnore,
+								OnPodConditions: []batch.PodFailurePolicyOnPodConditionsPattern{
+									{
+										Type:   v1.DisruptionTarget,
+										Status: v1.ConditionTrue,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			pod: buildPod().uid("a").indexFailureCount("3").status(v1.PodStatus{
+				Phase: v1.PodFailed,
+				Conditions: []v1.PodCondition{
+					{
+						Type:   v1.DisruptionTarget,
+						Status: v1.ConditionTrue,
+					},
+				},
+			}).index("3").trackingFinalizer().Pod,
+			wantNewIndexFailureCount:        3,
+			wantNewIndexIgnoredFailureCount: 1,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobBackoffLimitPerIndex, true)()
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobPodFailurePolicy, tc.enableJobPodFailurePolicy)()
+			gotNewIndexFailureCount, gotNewIndexIgnoredFailureCount := getNewIndexFailureCounts(logger, &tc.job, tc.pod)
+			if diff := cmp.Diff(tc.wantNewIndexFailureCount, gotNewIndexFailureCount); diff != "" {
+				t.Errorf("Unexpected set of pods with delayed deletion (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantNewIndexIgnoredFailureCount, gotNewIndexIgnoredFailureCount); diff != "" {
+				t.Errorf("Unexpected set of pods with delayed deletion (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestIntervalsHaveIndex(t *testing.T) {
 	cases := map[string]struct {
 		intervals orderedIntervals
@@ -267,6 +696,7 @@ func TestFirstPendingIndexes(t *testing.T) {
 		completions      int
 		activePods       []indexPhase
 		succeededIndexes []interval
+		failedIndexes    *orderedIntervals
 		want             []int
 	}{
 		"cnt greater than completions": {
@@ -310,12 +740,24 @@ func TestFirstPendingIndexes(t *testing.T) {
 			completions:      20,
 			want:             []int{0, 1, 6, 7, 10},
 		},
+		"with failed indexes": {
+			activePods: []indexPhase{
+				{"3", v1.PodPending},
+				{"9", v1.PodPending},
+			},
+			succeededIndexes: []interval{{1, 1}, {5, 5}, {9, 9}},
+			failedIndexes:    &orderedIntervals{{2, 2}, {6, 7}},
+			cnt:              5,
+			completions:      20,
+			want:             []int{0, 4, 8, 10, 11},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			jobCtx := &syncJobCtx{
 				activePods:       hollowPodsWithIndexPhase(tc.activePods),
 				succeededIndexes: tc.succeededIndexes,
+				failedIndexes:    tc.failedIndexes,
 			}
 			got := firstPendingIndexes(jobCtx, tc.cnt, tc.completions)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
@@ -441,6 +883,47 @@ func TestPodGenerateNameWithIndex(t *testing.T) {
 			podGenerateName := podGenerateNameWithIndex(tc.jobname, tc.index)
 			if diff := cmp.Equal(tc.wantPodGenerateName, podGenerateName); !diff {
 				t.Errorf("Got pod generateName %s, want %s", podGenerateName, tc.wantPodGenerateName)
+			}
+		})
+	}
+}
+
+func TestGetIndexFailureCount(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	cases := map[string]struct {
+		pod        *v1.Pod
+		wantResult int32
+	}{
+		"no annotation": {
+			pod:        &v1.Pod{},
+			wantResult: 0,
+		},
+		"valid value": {
+			pod:        buildPod().indexFailureCount("2").Pod,
+			wantResult: 2,
+		},
+		"valid maxint32 value": {
+			pod:        buildPod().indexFailureCount(strconv.Itoa(math.MaxInt32)).Pod,
+			wantResult: math.MaxInt32,
+		},
+		"too large value": {
+			pod:        buildPod().indexFailureCount(strconv.Itoa(math.MaxInt32 + 1)).Pod,
+			wantResult: 0,
+		},
+		"negative value": {
+			pod:        buildPod().indexFailureCount("-1").Pod,
+			wantResult: 0,
+		},
+		"invalid int value": {
+			pod:        buildPod().indexFailureCount("xyz").Pod,
+			wantResult: 0,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotResult := getIndexFailureCount(logger, tc.pod)
+			if diff := cmp.Equal(tc.wantResult, gotResult); !diff {
+				t.Errorf("Unexpected result. want: %d, got: %d", tc.wantResult, gotResult)
 			}
 		})
 	}

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"testing"
@@ -1128,6 +1129,9 @@ func TestTrackJobStatusAndRemoveFinalizers(t *testing.T) {
 		wantStatusUpdates       []batch.JobStatus
 		wantSucceededPodsMetric int
 		wantFailedPodsMetric    int
+
+		// features
+		enableJobBackoffLimitPerIndex bool
 	}{
 		"no updates": {},
 		"new active": {
@@ -1649,9 +1653,91 @@ func TestTrackJobStatusAndRemoveFinalizers(t *testing.T) {
 			},
 			wantFailedPodsMetric: 2,
 		},
+		"indexed job with a failed pod with delayed finalizer removal; the pod is not counted": {
+			enableJobBackoffLimitPerIndex: true,
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					CompletionMode:       &indexedCompletion,
+					Completions:          pointer.Int32(6),
+					BackoffLimitPerIndex: pointer.Int32(1),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().uid("a").phase(v1.PodFailed).indexFailureCount("0").trackingFinalizer().index("1").Pod,
+			},
+			wantStatusUpdates: []batch.JobStatus{
+				{
+					UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
+					FailedIndexes:           pointer.String(""),
+				},
+			},
+		},
+		"indexed job with a failed pod which is recreated by a running pod; the pod is counted": {
+			enableJobBackoffLimitPerIndex: true,
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					CompletionMode:       &indexedCompletion,
+					Completions:          pointer.Int32(6),
+					BackoffLimitPerIndex: pointer.Int32(1),
+				},
+				Status: batch.JobStatus{
+					Active: 1,
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().uid("a1").phase(v1.PodFailed).indexFailureCount("0").trackingFinalizer().index("1").Pod,
+				buildPod().uid("a2").phase(v1.PodRunning).indexFailureCount("1").trackingFinalizer().index("1").Pod,
+			},
+			wantRmFinalizers: 1,
+			wantStatusUpdates: []batch.JobStatus{
+				{
+					Active: 1,
+					UncountedTerminatedPods: &batch.UncountedTerminatedPods{
+						Failed: []types.UID{"a1"},
+					},
+					FailedIndexes: pointer.String(""),
+				},
+				{
+					Active:                  1,
+					Failed:                  1,
+					UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
+					FailedIndexes:           pointer.String(""),
+				},
+			},
+			wantFailedPodsMetric: 1,
+		},
+		"indexed job with a failed pod for a failed index; the pod is counted": {
+			enableJobBackoffLimitPerIndex: true,
+			job: batch.Job{
+				Spec: batch.JobSpec{
+					CompletionMode:       &indexedCompletion,
+					Completions:          pointer.Int32(6),
+					BackoffLimitPerIndex: pointer.Int32(1),
+				},
+			},
+			pods: []*v1.Pod{
+				buildPod().uid("a").phase(v1.PodFailed).indexFailureCount("1").trackingFinalizer().index("1").Pod,
+			},
+			wantRmFinalizers: 1,
+			wantStatusUpdates: []batch.JobStatus{
+				{
+					FailedIndexes: pointer.String("1"),
+					UncountedTerminatedPods: &batch.UncountedTerminatedPods{
+						Failed: []types.UID{"a"},
+					},
+				},
+				{
+					Failed:                  1,
+					FailedIndexes:           pointer.String("1"),
+					UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
+				},
+			},
+			wantFailedPodsMetric: 1,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobBackoffLimitPerIndex, tc.enableJobBackoffLimitPerIndex)()
 			clientSet := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
 			manager, _ := newControllerFromClient(ctx, clientSet, controller.NoResyncPeriodFunc)
 			fakePodControl := controller.FakePodControl{Err: tc.podControlErr}
@@ -1666,20 +1752,22 @@ func TestTrackJobStatusAndRemoveFinalizers(t *testing.T) {
 			if job.Status.UncountedTerminatedPods == nil {
 				job.Status.UncountedTerminatedPods = &batch.UncountedTerminatedPods{}
 			}
-			uncounted := newUncountedTerminatedPods(*job.Status.UncountedTerminatedPods)
-			var succeededIndexes orderedIntervals
-			if isIndexedJob(job) {
-				succeededIndexes = succeededIndexesFromString(logger, job.Status.CompletedIndexes, int(*job.Spec.Completions))
-			}
 			jobCtx := &syncJobCtx{
 				job:                  job,
 				pods:                 tc.pods,
-				succeededIndexes:     succeededIndexes,
-				uncounted:            uncounted,
+				uncounted:            newUncountedTerminatedPods(*job.Status.UncountedTerminatedPods),
 				expectedRmFinalizers: tc.expectedRmFinalizers,
 				finishedCondition:    tc.finishedCond,
-				newBackoffRecord:     backoffRecord{},
 			}
+			if isIndexedJob(job) {
+				jobCtx.succeededIndexes = parseIndexesFromString(logger, job.Status.CompletedIndexes, int(*job.Spec.Completions))
+				if tc.enableJobBackoffLimitPerIndex && job.Spec.BackoffLimitPerIndex != nil {
+					jobCtx.failedIndexes = calculateFailedIndexes(logger, job, tc.pods)
+					jobCtx.activePods = controller.FilterActivePods(logger, tc.pods)
+					jobCtx.podsWithDelayedDeletionPerIndex = getPodsWithDelayedDeletionPerIndex(logger, jobCtx)
+				}
+			}
+
 			err := manager.trackJobStatusAndRemoveFinalizers(ctx, jobCtx, tc.needsFlush)
 			if !errors.Is(err, tc.wantErr) {
 				t.Errorf("Got error %v, want %v", err, tc.wantErr)
@@ -3123,6 +3211,484 @@ func TestSyncJobWithJobPodFailurePolicy(t *testing.T) {
 	}
 }
 
+func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	now := time.Now()
+	validObjectMeta := metav1.ObjectMeta{
+		Name:      "foobar",
+		UID:       uuid.NewUUID(),
+		Namespace: metav1.NamespaceDefault,
+	}
+	validSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"foo": "bar"},
+	}
+	validTemplate := v1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{Image: "foo/bar"},
+			},
+		},
+	}
+
+	testCases := map[string]struct {
+		enableJobBackoffLimitPerIndex bool
+		enableJobPodFailurePolicy     bool
+		job                           batch.Job
+		pods                          []v1.Pod
+		wantStatus                    batch.JobStatus
+	}{
+		"successful job after a single failure within index": {
+			enableJobBackoffLimitPerIndex: true,
+			job: batch.Job{
+				TypeMeta:   metav1.TypeMeta{Kind: "Job"},
+				ObjectMeta: validObjectMeta,
+				Spec: batch.JobSpec{
+					Selector:             validSelector,
+					Template:             validTemplate,
+					Parallelism:          pointer.Int32(2),
+					Completions:          pointer.Int32(2),
+					BackoffLimit:         pointer.Int32(math.MaxInt32),
+					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					BackoffLimitPerIndex: pointer.Int32(1),
+				},
+			},
+			pods: []v1.Pod{
+				*buildPod().uid("a1").index("0").phase(v1.PodFailed).indexFailureCount("0").trackingFinalizer().Pod,
+				*buildPod().uid("a2").index("0").phase(v1.PodSucceeded).indexFailureCount("1").trackingFinalizer().Pod,
+				*buildPod().uid("b").index("1").phase(v1.PodSucceeded).indexFailureCount("0").trackingFinalizer().Pod,
+			},
+			wantStatus: batch.JobStatus{
+				Failed:                  1,
+				Succeeded:               2,
+				CompletedIndexes:        "0,1",
+				FailedIndexes:           pointer.String(""),
+				UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
+				Conditions: []batch.JobCondition{
+					{
+						Type:   batch.JobComplete,
+						Status: v1.ConditionTrue,
+					},
+				},
+			},
+		},
+		"single failed pod, not counted as the replacement pod creation is delayed": {
+			enableJobBackoffLimitPerIndex: true,
+			job: batch.Job{
+				TypeMeta:   metav1.TypeMeta{Kind: "Job"},
+				ObjectMeta: validObjectMeta,
+				Spec: batch.JobSpec{
+					Selector:             validSelector,
+					Template:             validTemplate,
+					Parallelism:          pointer.Int32(2),
+					Completions:          pointer.Int32(2),
+					BackoffLimit:         pointer.Int32(math.MaxInt32),
+					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					BackoffLimitPerIndex: pointer.Int32(1),
+				},
+			},
+			pods: []v1.Pod{
+				*buildPod().uid("a").index("0").phase(v1.PodFailed).indexFailureCount("0").trackingFinalizer().Pod,
+			},
+			wantStatus: batch.JobStatus{
+				Active:                  2,
+				UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
+				FailedIndexes:           pointer.String(""),
+			},
+		},
+		"single failed pod replaced already": {
+			enableJobBackoffLimitPerIndex: true,
+			job: batch.Job{
+				TypeMeta:   metav1.TypeMeta{Kind: "Job"},
+				ObjectMeta: validObjectMeta,
+				Spec: batch.JobSpec{
+					Selector:             validSelector,
+					Template:             validTemplate,
+					Parallelism:          pointer.Int32(2),
+					Completions:          pointer.Int32(2),
+					BackoffLimit:         pointer.Int32(math.MaxInt32),
+					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					BackoffLimitPerIndex: pointer.Int32(1),
+				},
+			},
+			pods: []v1.Pod{
+				*buildPod().uid("a").index("0").phase(v1.PodFailed).indexFailureCount("0").trackingFinalizer().Pod,
+				*buildPod().uid("b").index("0").phase(v1.PodPending).indexFailureCount("1").trackingFinalizer().Pod,
+			},
+			wantStatus: batch.JobStatus{
+				Active:                  2,
+				Failed:                  1,
+				UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
+				FailedIndexes:           pointer.String(""),
+			},
+		},
+		"single failed index due to exceeding the backoff limit per index, the job continues": {
+			enableJobBackoffLimitPerIndex: true,
+			job: batch.Job{
+				TypeMeta:   metav1.TypeMeta{Kind: "Job"},
+				ObjectMeta: validObjectMeta,
+				Spec: batch.JobSpec{
+					Selector:             validSelector,
+					Template:             validTemplate,
+					Parallelism:          pointer.Int32(2),
+					Completions:          pointer.Int32(2),
+					BackoffLimit:         pointer.Int32(math.MaxInt32),
+					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					BackoffLimitPerIndex: pointer.Int32(1),
+				},
+			},
+			pods: []v1.Pod{
+				*buildPod().uid("a").index("0").phase(v1.PodFailed).indexFailureCount("1").trackingFinalizer().Pod,
+			},
+			wantStatus: batch.JobStatus{
+				Active:                  1,
+				Failed:                  1,
+				FailedIndexes:           pointer.String("0"),
+				UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
+			},
+		},
+		"single failed index due to FailIndex action, the job continues": {
+			enableJobBackoffLimitPerIndex: true,
+			enableJobPodFailurePolicy:     true,
+			job: batch.Job{
+				TypeMeta:   metav1.TypeMeta{Kind: "Job"},
+				ObjectMeta: validObjectMeta,
+				Spec: batch.JobSpec{
+					Selector:             validSelector,
+					Template:             validTemplate,
+					Parallelism:          pointer.Int32(2),
+					Completions:          pointer.Int32(2),
+					BackoffLimit:         pointer.Int32(math.MaxInt32),
+					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					BackoffLimitPerIndex: pointer.Int32(1),
+					PodFailurePolicy: &batch.PodFailurePolicy{
+						Rules: []batch.PodFailurePolicyRule{
+							{
+								Action: batch.PodFailurePolicyActionFailIndex,
+								OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
+									Operator: batch.PodFailurePolicyOnExitCodesOpIn,
+									Values:   []int32{3},
+								},
+							},
+						},
+					},
+				},
+			},
+			pods: []v1.Pod{
+				*buildPod().uid("a").index("0").status(v1.PodStatus{
+					Phase: v1.PodFailed,
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									ExitCode: 3,
+								},
+							},
+						},
+					},
+				}).indexFailureCount("0").trackingFinalizer().Pod,
+			},
+			wantStatus: batch.JobStatus{
+				Active:                  1,
+				Failed:                  1,
+				FailedIndexes:           pointer.String("0"),
+				UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
+			},
+		},
+		"job failed index due to FailJob action": {
+			enableJobBackoffLimitPerIndex: true,
+			enableJobPodFailurePolicy:     true,
+			job: batch.Job{
+				TypeMeta:   metav1.TypeMeta{Kind: "Job"},
+				ObjectMeta: validObjectMeta,
+				Spec: batch.JobSpec{
+					Selector:             validSelector,
+					Template:             validTemplate,
+					Parallelism:          pointer.Int32(2),
+					Completions:          pointer.Int32(2),
+					BackoffLimit:         pointer.Int32(6),
+					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					BackoffLimitPerIndex: pointer.Int32(1),
+					PodFailurePolicy: &batch.PodFailurePolicy{
+						Rules: []batch.PodFailurePolicyRule{
+							{
+								Action: batch.PodFailurePolicyActionFailJob,
+								OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
+									Operator: batch.PodFailurePolicyOnExitCodesOpIn,
+									Values:   []int32{3},
+								},
+							},
+						},
+					},
+				},
+			},
+			pods: []v1.Pod{
+				*buildPod().uid("a").index("0").status(v1.PodStatus{
+					Phase: v1.PodFailed,
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "x",
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									ExitCode: 3,
+								},
+							},
+						},
+					},
+				}).indexFailureCount("0").trackingFinalizer().Pod,
+			},
+			wantStatus: batch.JobStatus{
+				Active:                  0,
+				Failed:                  1,
+				FailedIndexes:           pointer.String(""),
+				UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
+				Conditions: []batch.JobCondition{
+					{
+						Type:    batch.JobFailureTarget,
+						Status:  v1.ConditionTrue,
+						Reason:  "PodFailurePolicy",
+						Message: "Container x for pod default/mypod-0 failed with exit code 3 matching FailJob rule at index 0",
+					},
+					{
+						Type:    batch.JobFailed,
+						Status:  v1.ConditionTrue,
+						Reason:  "PodFailurePolicy",
+						Message: "Container x for pod default/mypod-0 failed with exit code 3 matching FailJob rule at index 0",
+					},
+				},
+			},
+		},
+		"job pod failure ignored due to matching Ignore action": {
+			enableJobBackoffLimitPerIndex: true,
+			enableJobPodFailurePolicy:     true,
+			job: batch.Job{
+				TypeMeta:   metav1.TypeMeta{Kind: "Job"},
+				ObjectMeta: validObjectMeta,
+				Spec: batch.JobSpec{
+					Selector:             validSelector,
+					Template:             validTemplate,
+					Parallelism:          pointer.Int32(2),
+					Completions:          pointer.Int32(2),
+					BackoffLimit:         pointer.Int32(6),
+					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					BackoffLimitPerIndex: pointer.Int32(1),
+					PodFailurePolicy: &batch.PodFailurePolicy{
+						Rules: []batch.PodFailurePolicyRule{
+							{
+								Action: batch.PodFailurePolicyActionIgnore,
+								OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
+									Operator: batch.PodFailurePolicyOnExitCodesOpIn,
+									Values:   []int32{3},
+								},
+							},
+						},
+					},
+				},
+			},
+			pods: []v1.Pod{
+				*buildPod().uid("a").index("0").status(v1.PodStatus{
+					Phase: v1.PodFailed,
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name: "x",
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									ExitCode: 3,
+								},
+							},
+						},
+					},
+				}).indexFailureCount("0").trackingFinalizer().Pod,
+			},
+			wantStatus: batch.JobStatus{
+				Active:                  2,
+				Failed:                  0,
+				FailedIndexes:           pointer.String(""),
+				UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
+			},
+		},
+		"job failed due to exceeding backoffLimit before backoffLimitPerIndex": {
+			enableJobBackoffLimitPerIndex: true,
+			job: batch.Job{
+				TypeMeta:   metav1.TypeMeta{Kind: "Job"},
+				ObjectMeta: validObjectMeta,
+				Spec: batch.JobSpec{
+					Selector:             validSelector,
+					Template:             validTemplate,
+					Parallelism:          pointer.Int32(2),
+					Completions:          pointer.Int32(2),
+					BackoffLimit:         pointer.Int32(1),
+					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					BackoffLimitPerIndex: pointer.Int32(1),
+				},
+			},
+			pods: []v1.Pod{
+				*buildPod().uid("a").index("0").phase(v1.PodFailed).indexFailureCount("0").trackingFinalizer().Pod,
+				*buildPod().uid("b").index("1").phase(v1.PodFailed).indexFailureCount("0").trackingFinalizer().Pod,
+			},
+			wantStatus: batch.JobStatus{
+				Failed:                  2,
+				Succeeded:               0,
+				FailedIndexes:           pointer.String(""),
+				UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
+				Conditions: []batch.JobCondition{
+					{
+						Type:    batch.JobFailed,
+						Status:  v1.ConditionTrue,
+						Reason:  "BackoffLimitExceeded",
+						Message: "Job has reached the specified backoff limit",
+					},
+				},
+			},
+		},
+		"job failed due to failed indexes": {
+			enableJobBackoffLimitPerIndex: true,
+			job: batch.Job{
+				TypeMeta:   metav1.TypeMeta{Kind: "Job"},
+				ObjectMeta: validObjectMeta,
+				Spec: batch.JobSpec{
+					Selector:             validSelector,
+					Template:             validTemplate,
+					Parallelism:          pointer.Int32(2),
+					Completions:          pointer.Int32(2),
+					BackoffLimit:         pointer.Int32(math.MaxInt32),
+					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					BackoffLimitPerIndex: pointer.Int32(1),
+				},
+			},
+			pods: []v1.Pod{
+				*buildPod().uid("a").index("0").phase(v1.PodFailed).indexFailureCount("1").trackingFinalizer().Pod,
+				*buildPod().uid("b").index("1").phase(v1.PodSucceeded).indexFailureCount("0").trackingFinalizer().Pod,
+			},
+			wantStatus: batch.JobStatus{
+				Failed:                  1,
+				Succeeded:               1,
+				FailedIndexes:           pointer.String("0"),
+				CompletedIndexes:        "1",
+				UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
+				Conditions: []batch.JobCondition{
+					{
+						Type:    batch.JobFailed,
+						Status:  v1.ConditionTrue,
+						Reason:  "FailedIndexes",
+						Message: "Job has failed indexes",
+					},
+				},
+			},
+		},
+		"job failed due to exceeding max failed indexes": {
+			enableJobBackoffLimitPerIndex: true,
+			job: batch.Job{
+				TypeMeta:   metav1.TypeMeta{Kind: "Job"},
+				ObjectMeta: validObjectMeta,
+				Spec: batch.JobSpec{
+					Selector:             validSelector,
+					Template:             validTemplate,
+					Parallelism:          pointer.Int32(4),
+					Completions:          pointer.Int32(4),
+					BackoffLimit:         pointer.Int32(math.MaxInt32),
+					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					BackoffLimitPerIndex: pointer.Int32(1),
+					MaxFailedIndexes:     pointer.Int32(1),
+				},
+			},
+			pods: []v1.Pod{
+				*buildPod().uid("a").index("0").phase(v1.PodFailed).indexFailureCount("1").trackingFinalizer().Pod,
+				*buildPod().uid("b").index("1").phase(v1.PodSucceeded).indexFailureCount("0").trackingFinalizer().Pod,
+				*buildPod().uid("c").index("2").phase(v1.PodFailed).indexFailureCount("1").trackingFinalizer().Pod,
+				*buildPod().uid("d").index("3").phase(v1.PodRunning).indexFailureCount("0").trackingFinalizer().Pod,
+			},
+			wantStatus: batch.JobStatus{
+				Failed:                  3,
+				Succeeded:               1,
+				FailedIndexes:           pointer.String("0,2"),
+				CompletedIndexes:        "1",
+				UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
+				Conditions: []batch.JobCondition{
+					{
+						Type:    batch.JobFailed,
+						Status:  v1.ConditionTrue,
+						Reason:  "MaxFailedIndexesExceeded",
+						Message: "Job has exceeded the specified maximal number of failed indexes",
+					},
+				},
+			},
+		},
+		"job with finished indexes; failedIndexes are cleaned when JobBackoffLimitPerIndex disabled": {
+			enableJobBackoffLimitPerIndex: false,
+			job: batch.Job{
+				TypeMeta:   metav1.TypeMeta{Kind: "Job"},
+				ObjectMeta: validObjectMeta,
+				Spec: batch.JobSpec{
+					Selector:             validSelector,
+					Template:             validTemplate,
+					Parallelism:          pointer.Int32(3),
+					Completions:          pointer.Int32(3),
+					BackoffLimit:         pointer.Int32(math.MaxInt32),
+					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					BackoffLimitPerIndex: pointer.Int32(1),
+				},
+				Status: batch.JobStatus{
+					FailedIndexes:    pointer.String("0"),
+					CompletedIndexes: "1",
+				},
+			},
+			pods: []v1.Pod{
+				*buildPod().uid("c").index("2").phase(v1.PodPending).indexFailureCount("1").trackingFinalizer().Pod,
+			},
+			wantStatus: batch.JobStatus{
+				Active:                  2,
+				Succeeded:               1,
+				CompletedIndexes:        "1",
+				UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobBackoffLimitPerIndex, tc.enableJobBackoffLimitPerIndex)()
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobPodFailurePolicy, tc.enableJobPodFailurePolicy)()
+			clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
+			fakeClock := clocktesting.NewFakeClock(now)
+			manager, sharedInformerFactory := newControllerFromClientWithClock(ctx, clientset, controller.NoResyncPeriodFunc, fakeClock)
+			fakePodControl := controller.FakePodControl{}
+			manager.podControl = &fakePodControl
+			manager.podStoreSynced = alwaysReady
+			manager.jobStoreSynced = alwaysReady
+			job := &tc.job
+
+			actual := job
+			manager.updateStatusHandler = func(ctx context.Context, job *batch.Job) (*batch.Job, error) {
+				actual = job
+				return job, nil
+			}
+			sharedInformerFactory.Batch().V1().Jobs().Informer().GetIndexer().Add(job)
+			for i, pod := range tc.pods {
+				pod := pod
+				pb := podBuilder{Pod: &pod}.name(fmt.Sprintf("mypod-%d", i)).job(job)
+				if job.Spec.CompletionMode != nil && *job.Spec.CompletionMode == batch.IndexedCompletion {
+					pb.index(fmt.Sprintf("%v", getCompletionIndex(pod.Annotations)))
+				}
+				pb = pb.trackingFinalizer()
+				sharedInformerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pb.Pod)
+			}
+
+			manager.syncJob(context.TODO(), testutil.GetKey(job, t))
+
+			// validate relevant fields of the status
+			if diff := cmp.Diff(tc.wantStatus, actual.Status,
+				cmpopts.IgnoreFields(batch.JobStatus{}, "StartTime", "CompletionTime", "Ready"),
+				cmpopts.IgnoreFields(batch.JobCondition{}, "LastProbeTime", "LastTransitionTime")); diff != "" {
+				t.Errorf("unexpected job status. Diff: %s\n", diff)
+			}
+		})
+	}
+}
+
 func TestSyncJobUpdateRequeue(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
@@ -3212,6 +3778,69 @@ func TestUpdateJobRequeue(t *testing.T) {
 			gotRequeuedImmediately := manager.queue.Len() > 0
 			if tc.wantRequeuedImmediately != gotRequeuedImmediately {
 				t.Fatalf("Want immediate requeue: %v, got immediate requeue: %v", tc.wantRequeuedImmediately, gotRequeuedImmediately)
+			}
+		})
+	}
+}
+
+func TestGetPodCreationInfoForIndependentIndexes(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	now := time.Now()
+	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
+	cases := map[string]struct {
+		indexesToAdd                    []int
+		podsWithDelayedDeletionPerIndex map[int]*v1.Pod
+		wantIndexesToAdd                []int
+		wantRemainingTime               time.Duration
+	}{
+		"simple index creation": {
+			indexesToAdd:     []int{1, 3},
+			wantIndexesToAdd: []int{1, 3},
+		},
+		"subset of indexes can be recreated now": {
+			indexesToAdd: []int{1, 3},
+			podsWithDelayedDeletionPerIndex: map[int]*v1.Pod{
+				1: buildPod().indexFailureCount("0").index("1").customDeletionTimestamp(now).Pod,
+			},
+			wantIndexesToAdd: []int{3},
+		},
+		"subset of indexes can be recreated now as the pods failed long time ago": {
+			indexesToAdd: []int{1, 3},
+			podsWithDelayedDeletionPerIndex: map[int]*v1.Pod{
+				1: buildPod().indexFailureCount("0").customDeletionTimestamp(now).Pod,
+				3: buildPod().indexFailureCount("0").customDeletionTimestamp(now.Add(-DefaultJobPodFailureBackOff)).Pod,
+			},
+			wantIndexesToAdd: []int{3},
+		},
+		"no indexes can be recreated now, need to wait default pod failure backoff": {
+			indexesToAdd: []int{1, 2, 3},
+			podsWithDelayedDeletionPerIndex: map[int]*v1.Pod{
+				1: buildPod().indexFailureCount("1").customDeletionTimestamp(now).Pod,
+				2: buildPod().indexFailureCount("0").customDeletionTimestamp(now).Pod,
+				3: buildPod().indexFailureCount("2").customDeletionTimestamp(now).Pod,
+			},
+			wantRemainingTime: DefaultJobPodFailureBackOff,
+		},
+		"no indexes can be recreated now, need to wait but 1s already passed": {
+			indexesToAdd: []int{1, 2, 3},
+			podsWithDelayedDeletionPerIndex: map[int]*v1.Pod{
+				1: buildPod().indexFailureCount("1").customDeletionTimestamp(now.Add(-time.Second)).Pod,
+				2: buildPod().indexFailureCount("0").customDeletionTimestamp(now.Add(-time.Second)).Pod,
+				3: buildPod().indexFailureCount("2").customDeletionTimestamp(now.Add(-time.Second)).Pod,
+			},
+			wantRemainingTime: DefaultJobPodFailureBackOff - time.Second,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			fakeClock := clocktesting.NewFakeClock(now)
+			manager, _ := newControllerFromClientWithClock(ctx, clientset, controller.NoResyncPeriodFunc, fakeClock)
+			gotIndexesToAdd, gotRemainingTime := manager.getPodCreationInfoForIndependentIndexes(logger, tc.indexesToAdd, tc.podsWithDelayedDeletionPerIndex)
+			if diff := cmp.Diff(tc.wantIndexesToAdd, gotIndexesToAdd); diff != "" {
+				t.Fatalf("Unexpected indexes to add: %s", diff)
+			}
+			if diff := cmp.Diff(tc.wantRemainingTime, gotRemainingTime); diff != "" {
+				t.Fatalf("Unexpected remaining time: %s", diff)
 			}
 		})
 	}
@@ -4541,10 +5170,27 @@ func (pb podBuilder) clearLabels() podBuilder {
 }
 
 func (pb podBuilder) index(ix string) podBuilder {
+	return pb.annotation(batch.JobCompletionIndexAnnotation, ix)
+}
+
+func (pb podBuilder) indexFailureCount(count string) podBuilder {
+	return pb.annotation(batch.JobIndexFailureCountAnnotation, count)
+}
+
+func (pb podBuilder) indexIgnoredFailureCount(count string) podBuilder {
+	return pb.annotation(batch.JobIndexIgnoredFailureCountAnnotation, count)
+}
+
+func (pb podBuilder) annotation(key, value string) podBuilder {
 	if pb.Annotations == nil {
 		pb.Annotations = make(map[string]string)
 	}
-	pb.Annotations[batch.JobCompletionIndexAnnotation] = ix
+	pb.Annotations[key] = value
+	return pb
+}
+
+func (pb podBuilder) status(s v1.PodStatus) podBuilder {
+	pb.Status = s
 	return pb
 }
 
@@ -4566,6 +5212,15 @@ func (pb podBuilder) trackingFinalizer() podBuilder {
 func (pb podBuilder) deletionTimestamp() podBuilder {
 	pb.DeletionTimestamp = &metav1.Time{}
 	return pb
+}
+
+func (pb podBuilder) customDeletionTimestamp(t time.Time) podBuilder {
+	pb.DeletionTimestamp = &metav1.Time{Time: t}
+	return pb
+}
+
+func completionModePtr(m batch.CompletionMode) *batch.CompletionMode {
+	return &m
 }
 
 func setDurationDuringTest(val *time.Duration, newVal time.Duration) func() {

--- a/pkg/controller/job/pod_failure_policy_test.go
+++ b/pkg/controller/job/pod_failure_policy_test.go
@@ -23,7 +23,10 @@ import (
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/utils/pointer"
 )
 
@@ -34,14 +37,16 @@ func TestMatchPodFailurePolicy(t *testing.T) {
 	}
 	ignore := batch.PodFailurePolicyActionIgnore
 	failJob := batch.PodFailurePolicyActionFailJob
+	failIndex := batch.PodFailurePolicyActionFailIndex
 	count := batch.PodFailurePolicyActionCount
 
 	testCases := map[string]struct {
-		podFailurePolicy      *batch.PodFailurePolicy
-		failedPod             *v1.Pod
-		wantJobFailureMessage *string
-		wantCountFailed       bool
-		wantAction            *batch.PodFailurePolicyAction
+		enableJobBackoffLimitPerIndex bool
+		podFailurePolicy              *batch.PodFailurePolicy
+		failedPod                     *v1.Pod
+		wantJobFailureMessage         *string
+		wantCountFailed               bool
+		wantAction                    *batch.PodFailurePolicyAction
 	}{
 		"unknown action for rule matching by exit codes - skip rule with unknown action": {
 			podFailurePolicy: &batch.PodFailurePolicy{
@@ -292,6 +297,68 @@ func TestMatchPodFailurePolicy(t *testing.T) {
 			wantJobFailureMessage: nil,
 			wantCountFailed:       true,
 		},
+		"FailIndex rule matched for exit codes; JobBackoffLimitPerIndex enabled": {
+			enableJobBackoffLimitPerIndex: true,
+			podFailurePolicy: &batch.PodFailurePolicy{
+				Rules: []batch.PodFailurePolicyRule{
+					{
+						Action: batch.PodFailurePolicyActionFailIndex,
+						OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
+							Operator: batch.PodFailurePolicyOnExitCodesOpIn,
+							Values:   []int32{1, 2, 3},
+						},
+					},
+				},
+			},
+			failedPod: &v1.Pod{
+				ObjectMeta: validPodObjectMeta,
+				Status: v1.PodStatus{
+					Phase: v1.PodFailed,
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									ExitCode: 2,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCountFailed: true,
+			wantAction:      &failIndex,
+		},
+		"FailIndex rule matched for exit codes; JobBackoffLimitPerIndex disabled": {
+			enableJobBackoffLimitPerIndex: false,
+			podFailurePolicy: &batch.PodFailurePolicy{
+				Rules: []batch.PodFailurePolicyRule{
+					{
+						Action: batch.PodFailurePolicyActionFailIndex,
+						OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
+							Operator: batch.PodFailurePolicyOnExitCodesOpIn,
+							Values:   []int32{1, 2, 3},
+						},
+					},
+				},
+			},
+			failedPod: &v1.Pod{
+				ObjectMeta: validPodObjectMeta,
+				Status: v1.PodStatus{
+					Phase: v1.PodFailed,
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{
+									ExitCode: 2,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCountFailed: true,
+			wantAction:      nil,
+		},
 		"pod failure policy with NotIn operator and value 0": {
 			podFailurePolicy: &batch.PodFailurePolicy{
 				Rules: []batch.PodFailurePolicyRule{
@@ -405,6 +472,66 @@ func TestMatchPodFailurePolicy(t *testing.T) {
 			wantJobFailureMessage: nil,
 			wantCountFailed:       true,
 			wantAction:            &count,
+		},
+		"FailIndex rule matched for pod conditions; JobBackoffLimitPerIndex enabled": {
+			enableJobBackoffLimitPerIndex: true,
+			podFailurePolicy: &batch.PodFailurePolicy{
+				Rules: []batch.PodFailurePolicyRule{
+					{
+						Action: batch.PodFailurePolicyActionFailIndex,
+						OnPodConditions: []batch.PodFailurePolicyOnPodConditionsPattern{
+							{
+								Type:   v1.DisruptionTarget,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			failedPod: &v1.Pod{
+				ObjectMeta: validPodObjectMeta,
+				Status: v1.PodStatus{
+					Phase: v1.PodFailed,
+					Conditions: []v1.PodCondition{
+						{
+							Type:   v1.DisruptionTarget,
+							Status: v1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantCountFailed: true,
+			wantAction:      &failIndex,
+		},
+		"FailIndex rule matched for pod conditions; JobBackoffLimitPerIndex disabled": {
+			enableJobBackoffLimitPerIndex: false,
+			podFailurePolicy: &batch.PodFailurePolicy{
+				Rules: []batch.PodFailurePolicyRule{
+					{
+						Action: batch.PodFailurePolicyActionFailIndex,
+						OnPodConditions: []batch.PodFailurePolicyOnPodConditionsPattern{
+							{
+								Type:   v1.DisruptionTarget,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			failedPod: &v1.Pod{
+				ObjectMeta: validPodObjectMeta,
+				Status: v1.PodStatus{
+					Phase: v1.PodFailed,
+					Conditions: []v1.PodCondition{
+						{
+							Type:   v1.DisruptionTarget,
+							Status: v1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantCountFailed: true,
+			wantAction:      nil,
 		},
 		"ignore rule matched for pod conditions": {
 			podFailurePolicy: &batch.PodFailurePolicy{
@@ -709,6 +836,7 @@ func TestMatchPodFailurePolicy(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.JobBackoffLimitPerIndex, tc.enableJobBackoffLimitPerIndex)()
 			jobFailMessage, countFailed, action := matchPodFailurePolicy(tc.podFailurePolicy, tc.failedPod)
 			if diff := cmp.Diff(tc.wantJobFailureMessage, jobFailMessage); diff != "" {
 				t.Errorf("Unexpected job failure message: %s", diff)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Tracking Issue: https://github.com/kubernetes/enhancements/issues/3850

#### Special notes for your reviewer:

The API changes are now extracted to a dedicated PR: https://github.com/kubernetes/kubernetes/pull/119294. Please leave you API review comments there.

Changes compared to KEP:
1. The .spec.BackoffLimitPerIndex is immutable - the KEP says it just couldn't be unset. It can be as in KEP, but I thought the usefulness of mutability is low for this field, and so there is not need to complicate the validation code.
2. The messages for the job failures are static without computing the set of failed indexes

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Support BackoffLimitPerIndex in Jobs
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3850-backoff-limits-per-index-for-indexed-jobs
```
