### PR TITLE
Scheduler: Pass the supported nodeSelectorOperators to the field.NotSupported

### DIFF
--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity.go
@@ -200,6 +200,15 @@ func (t *nodeSelectorTerm) match(nodeLabels labels.Set, nodeFields fields.Set) (
 	return true, nil
 }
 
+var validSelectorOperators = []string{
+	string(v1.NodeSelectorOpIn),
+	string(v1.NodeSelectorOpNotIn),
+	string(v1.NodeSelectorOpExists),
+	string(v1.NodeSelectorOpDoesNotExist),
+	string(v1.NodeSelectorOpGt),
+	string(v1.NodeSelectorOpLt),
+}
+
 // nodeSelectorRequirementsAsSelector converts the []NodeSelectorRequirement api type into a struct that implements
 // labels.Selector.
 func nodeSelectorRequirementsAsSelector(nsm []v1.NodeSelectorRequirement, path *field.Path) (labels.Selector, []error) {
@@ -225,7 +234,7 @@ func nodeSelectorRequirementsAsSelector(nsm []v1.NodeSelectorRequirement, path *
 		case v1.NodeSelectorOpLt:
 			op = selection.LessThan
 		default:
-			errs = append(errs, field.NotSupported(p.Child("operator"), expr.Operator, nil))
+			errs = append(errs, field.NotSupported(p.Child("operator"), expr.Operator, validSelectorOperators))
 			continue
 		}
 		r, err := labels.NewRequirement(expr.Key, op, expr.Values, field.WithPath(p))

--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity_test.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity_test.go
@@ -346,6 +346,16 @@ func TestNodeSelectorRequirementsAsSelector(t *testing.T) {
 			}},
 			out: mustParse("bar<7"),
 		},
+		{
+			in: []v1.NodeSelectorRequirement{{
+				Key:      "baz",
+				Operator: "invalid",
+				Values:   []string{"5"},
+			}},
+			wantErr: []error{
+				field.NotSupported(field.NewPath("root").Index(0).Child("operator"), v1.NodeSelectorOperator("invalid"), validSelectorOperators),
+			},
+		},
 	}
 
 	for i, tc := range tc {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Currently, the `nodeSelectorRequirementsAsSelector` doesn't pass the supported nodeSelectorOperations to the `field.NotSupported` and passes `nil`.
So to obtain an appropriate error message, it passes the supported nodeSelectorOperations to the `field.NotSupported`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
I discussed this with @alculquicondor at https://github.com/kubernetes/kubernetes/pull/117852#discussion_r1187608346.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
