### PR TITLE
hack: spellcheck Go files via golangci-linter

### DIFF
--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -30,6 +30,7 @@ linters:
     - govet
     - ineffassign
     - logcheck
+    - misspell
     - staticcheck
     - stylecheck
     - unused
@@ -42,6 +43,11 @@ linters-settings: # please keep this alphabetized
       description: structured logging checker
       original-url: k8s.io/logtools/logcheck
   gocritic:
+  misspell:
+    ignore-words:
+      - Creater
+      - creater
+      - ect
   staticcheck:
     checks:
       - "all"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -31,6 +31,7 @@ linters:
     - govet
     - ineffassign
     - logcheck
+    - misspell
     - staticcheck
     - stylecheck
     - unused
@@ -46,6 +47,11 @@ linters-settings: # please keep this alphabetized
     enabled-checks:             # not limited in golangci-strict.yaml
       - equalFold               # not limited in golangci-strict.yaml
       - boolExprSimplify        # not limited in golangci-strict.yaml
+  misspell:
+    ignore-words:
+      - Creater
+      - creater
+      - ect
   staticcheck:
     checks:
       - "all"

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -38,4 +38,4 @@ popd >/dev/null
 # All the skipping files are defined in hack/.spelling_failures
 skipping_file="${KUBE_ROOT}/hack/.spelling_failures"
 failing_packages=$(sed "s| | -e |g" "${skipping_file}")
-git ls-files | grep -v -e "${failing_packages}" | xargs misspell -i "Creater,creater,ect" -error -o stderr
+git ls-files | grep -v -e '\.go$' -e "${failing_packages}" | xargs misspell -i "Creater,creater,ect" -error -o stderr


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

misspell is so fast, there's no significant performance advantage. The real benefit is more consistent failure reporting. This will become even more important once we have the ability to post annotations to GitHub for a PR.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
