### PR TITLE
merge duplicated linux/windows kube-proxy setup code

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -35,23 +35,16 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/events"
 
 	"k8s.io/apimachinery/pkg/fields"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
 	toolswatch "k8s.io/client-go/tools/watch"
-	"k8s.io/component-base/configz"
-	"k8s.io/component-base/metrics"
-	nodeutil "k8s.io/component-helpers/node/util"
 	utilsysctl "k8s.io/component-helpers/node/util/sysctl"
 	"k8s.io/kubernetes/pkg/proxy"
 	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
-	"k8s.io/kubernetes/pkg/proxy/apis/config/scheme"
-	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/iptables"
 	"k8s.io/kubernetes/pkg/proxy/ipvs"
 	proxymetrics "k8s.io/kubernetes/pkg/proxy/metrics"
@@ -83,63 +76,15 @@ func (o *Options) platformApplyDefaults(config *proxyconfigapi.KubeProxyConfigur
 	klog.V(2).InfoS("DetectLocalMode", "localMode", string(config.DetectLocalMode))
 }
 
-// NewProxyServer returns a new ProxyServer.
-func NewProxyServer(o *Options) (*ProxyServer, error) {
-	return newProxyServer(o.config, o.master)
-}
-
-func newProxyServer(
-	config *proxyconfigapi.KubeProxyConfiguration,
-	master string) (*ProxyServer, error) {
-
-	if c, err := configz.New(proxyconfigapi.GroupName); err == nil {
-		c.Set(config)
-	} else {
-		return nil, fmt.Errorf("unable to register configz: %s", err)
-	}
-
-	var ipvsInterface utilipvs.Interface
-	var ipsetInterface utilipset.Interface
-
-	if len(config.ShowHiddenMetricsForVersion) > 0 {
-		metrics.SetShowHidden()
-	}
-
-	hostname, err := nodeutil.GetHostname(config.HostnameOverride)
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := createClient(config.ClientConnection, master)
-	if err != nil {
-		return nil, err
-	}
-
-	nodeIP := detectNodeIP(client, hostname, config.BindAddress)
-	klog.InfoS("Detected node IP", "address", nodeIP.String())
-
-	// Create event recorder
-	eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client.EventsV1()})
-	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, "kube-proxy")
-
-	nodeRef := &v1.ObjectReference{
-		Kind:      "Node",
-		Name:      hostname,
-		UID:       types.UID(hostname),
-		Namespace: "",
-	}
-
-	var healthzServer healthcheck.ProxierHealthUpdater
-	if len(config.HealthzBindAddress) > 0 {
-		healthzServer = healthcheck.NewProxierHealthServer(config.HealthzBindAddress, 2*config.IPTables.SyncPeriod.Duration, recorder, nodeRef)
-	}
-
+// createProxier creates the proxy.Provider
+func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguration) (proxy.Provider, error) {
 	var proxier proxy.Provider
+	var err error
 
 	var nodeInfo *v1.Node
 	if config.DetectLocalMode == proxyconfigapi.LocalModeNodeCIDR {
-		klog.InfoS("Watching for node, awaiting podCIDR allocation", "hostname", hostname)
-		nodeInfo, err = waitForPodCIDR(client, hostname)
+		klog.InfoS("Watching for node, awaiting podCIDR allocation", "hostname", s.Hostname)
+		nodeInfo, err = waitForPodCIDR(s.Client, s.Hostname)
 		if err != nil {
 			return nil, err
 		}
@@ -148,7 +93,7 @@ func newProxyServer(
 
 	primaryFamily := v1.IPv4Protocol
 	primaryProtocol := utiliptables.ProtocolIPv4
-	if netutils.IsIPv6(nodeIP) {
+	if netutils.IsIPv6(s.NodeIP) {
 		primaryFamily = v1.IPv6Protocol
 		primaryProtocol = utiliptables.ProtocolIPv6
 	}
@@ -210,10 +155,10 @@ func newProxyServer(
 				*config.IPTables.LocalhostNodePorts,
 				int(*config.IPTables.MasqueradeBit),
 				localDetectors,
-				hostname,
+				s.Hostname,
 				nodeIPTuple(config.BindAddress),
-				recorder,
-				healthzServer,
+				s.Recorder,
+				s.HealthzServer,
 				nodePortAddresses,
 			)
 		} else {
@@ -236,10 +181,10 @@ func newProxyServer(
 				*config.IPTables.LocalhostNodePorts,
 				int(*config.IPTables.MasqueradeBit),
 				localDetector,
-				hostname,
-				nodeIP,
-				recorder,
-				healthzServer,
+				s.Hostname,
+				s.NodeIP,
+				s.Recorder,
+				s.HealthzServer,
 				nodePortAddresses,
 			)
 		}
@@ -249,8 +194,8 @@ func newProxyServer(
 		}
 	} else if config.Mode == proxyconfigapi.ProxyModeIPVS {
 		kernelHandler := ipvs.NewLinuxKernelHandler()
-		ipsetInterface = utilipset.New(execer)
-		ipvsInterface = utilipvs.New()
+		ipsetInterface := utilipset.New(execer)
+		ipvsInterface := utilipvs.New()
 		if err := ipvs.CanUseIPVSProxier(ipvsInterface, ipsetInterface, config.IPVS.Scheduler); err != nil {
 			return nil, fmt.Errorf("can't use the IPVS proxier: %v", err)
 		}
@@ -284,10 +229,10 @@ func newProxyServer(
 				config.IPTables.MasqueradeAll,
 				int(*config.IPTables.MasqueradeBit),
 				localDetectors,
-				hostname,
+				s.Hostname,
 				nodeIPs,
-				recorder,
-				healthzServer,
+				s.Recorder,
+				s.HealthzServer,
 				config.IPVS.Scheduler,
 				nodePortAddresses,
 				kernelHandler,
@@ -316,10 +261,10 @@ func newProxyServer(
 				config.IPTables.MasqueradeAll,
 				int(*config.IPTables.MasqueradeBit),
 				localDetector,
-				hostname,
-				nodeIP,
-				recorder,
-				healthzServer,
+				s.Hostname,
+				s.NodeIP,
+				s.Recorder,
+				s.HealthzServer,
 				config.IPVS.Scheduler,
 				nodePortAddresses,
 				kernelHandler,
@@ -330,15 +275,7 @@ func newProxyServer(
 		}
 	}
 
-	return &ProxyServer{
-		Config:        config,
-		Client:        client,
-		Proxier:       proxier,
-		Broadcaster:   eventBroadcaster,
-		Recorder:      recorder,
-		NodeRef:       nodeRef,
-		HealthzServer: healthzServer,
-	}, nil
+	return proxier, nil
 }
 
 func (s *ProxyServer) platformSetup() error {

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -20,8 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -35,52 +33,6 @@ import (
 	componentbaseconfig "k8s.io/component-base/config"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 )
-
-func TestGetConntrackMax(t *testing.T) {
-	ncores := runtime.NumCPU()
-	testCases := []struct {
-		min        int32
-		maxPerCore int32
-		expected   int
-		err        string
-	}{
-		{
-			expected: 0,
-		},
-		{
-			maxPerCore: 67890, // use this if Max is 0
-			min:        1,     // avoid 0 default
-			expected:   67890 * ncores,
-		},
-		{
-			maxPerCore: 1, // ensure that Min is considered
-			min:        123456,
-			expected:   123456,
-		},
-		{
-			maxPerCore: 0, // leave system setting
-			min:        123456,
-			expected:   0,
-		},
-	}
-
-	for i, tc := range testCases {
-		cfg := kubeproxyconfig.KubeProxyConntrackConfiguration{
-			Min:        pointer.Int32(tc.min),
-			MaxPerCore: pointer.Int32(tc.maxPerCore),
-		}
-		x, e := getConntrackMax(cfg)
-		if e != nil {
-			if tc.err == "" {
-				t.Errorf("[%d] unexpected error: %v", i, e)
-			} else if !strings.Contains(e.Error(), tc.err) {
-				t.Errorf("[%d] expected an error containing %q: %v", i, tc.err, e)
-			}
-		} else if x != tc.expected {
-			t.Errorf("[%d] expected %d, got %d", i, tc.expected, x)
-		}
-	}
-}
 
 // TestLoadConfig tests proper operation of loadConfig()
 func TestLoadConfig(t *testing.T) {

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -30,17 +30,9 @@ import (
 	// Enable pprof HTTP handlers.
 	_ "net/http/pprof"
 
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/events"
-	"k8s.io/component-base/configz"
-	"k8s.io/component-base/metrics"
-	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/proxy"
 	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
-	proxyconfigscheme "k8s.io/kubernetes/pkg/proxy/apis/config/scheme"
-	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/winkernel"
 )
 
@@ -50,49 +42,10 @@ func (o *Options) platformApplyDefaults(config *proxyconfigapi.KubeProxyConfigur
 	}
 }
 
-// NewProxyServer returns a new ProxyServer.
-func NewProxyServer(o *Options) (*ProxyServer, error) {
-	return newProxyServer(o.config, o.master)
-}
-
-func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, master string) (*ProxyServer, error) {
-	if c, err := configz.New(proxyconfigapi.GroupName); err == nil {
-		c.Set(config)
-	} else {
-		return nil, fmt.Errorf("unable to register configz: %s", err)
-	}
-
-	if len(config.ShowHiddenMetricsForVersion) > 0 {
-		metrics.SetShowHidden()
-	}
-
-	client, err := createClient(config.ClientConnection, master)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create event recorder
-	hostname, err := nodeutil.GetHostname(config.HostnameOverride)
-	if err != nil {
-		return nil, err
-	}
-	nodeIP := detectNodeIP(client, hostname, config.BindAddress)
-	klog.InfoS("Detected node IP", "IP", nodeIP.String())
-
-	eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client.EventsV1()})
-	recorder := eventBroadcaster.NewRecorder(proxyconfigscheme.Scheme, "kube-proxy")
-
-	nodeRef := &v1.ObjectReference{
-		Kind:      "Node",
-		Name:      hostname,
-		UID:       types.UID(hostname),
-		Namespace: "",
-	}
-
-	var healthzServer healthcheck.ProxierHealthUpdater
+// createProxier creates the proxy.Provider
+func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguration) (proxy.Provider, error) {
 	var healthzPort int
 	if len(config.HealthzBindAddress) > 0 {
-		healthzServer = healthcheck.NewProxierHealthServer(config.HealthzBindAddress, 2*config.IPTables.SyncPeriod.Duration, recorder, nodeRef)
 		_, port, _ := net.SplitHostPort(config.HealthzBindAddress)
 		healthzPort, _ = strconv.Atoi(port)
 	}
@@ -113,10 +66,10 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, master string
 			config.IPTables.SyncPeriod.Duration,
 			config.IPTables.MinSyncPeriod.Duration,
 			config.ClusterCIDR,
-			hostname,
+			s.Hostname,
 			nodeIPTuple(config.BindAddress),
-			recorder,
-			healthzServer,
+			s.Recorder,
+			s.HealthzServer,
 			config.Winkernel,
 			healthzPort,
 		)
@@ -125,10 +78,10 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, master string
 			config.IPTables.SyncPeriod.Duration,
 			config.IPTables.MinSyncPeriod.Duration,
 			config.ClusterCIDR,
-			hostname,
-			nodeIP,
-			recorder,
-			healthzServer,
+			s.Hostname,
+			s.NodeIP,
+			s.Recorder,
+			s.HealthzServer,
 			config.Winkernel,
 			healthzPort,
 		)
@@ -137,15 +90,7 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, master string
 		return nil, fmt.Errorf("unable to create proxier: %v", err)
 	}
 
-	return &ProxyServer{
-		Config:        config,
-		Client:        client,
-		Proxier:       proxier,
-		Broadcaster:   eventBroadcaster,
-		Recorder:      recorder,
-		NodeRef:       nodeRef,
-		HealthzServer: healthzServer,
-	}, nil
+	return proxier, nil
 }
 
 func (s *ProxyServer) platformSetup() error {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
There is currently a lot of duplicated code between the linux (iptables/ipvs) and windows (winkernel) kube-proxy setup. This extracts it out to the shared code, along with a bit of other platform-related refactoring.

extracted from #117436

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig network