### PR TITLE
Fix the issue in CPU static policy when containers shouldn't be sched…

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -176,6 +176,9 @@ func NewManager(cpuPolicyName string, cpuPolicyOptions map[string]string, reconc
 			// The static policy cannot initialize without this information.
 			return nil, fmt.Errorf("[cpumanager] unable to determine reserved CPU resources for static policy")
 		}
+		// TODO: We should remove this check as reserved CPU are no longer part of
+		// shared pool now, so setting sits size to be 0 won't leave non-gu pods
+		// without CPUs to run.
 		if reservedCPUs.IsZero() {
 			// The static policy requires this to be nonzero. Zero CPU reservation
 			// would allow the shared pool to be completely exhausted. At that point

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -1256,7 +1256,7 @@ func TestCPUManagerAddWithResvList(t *testing.T) {
 			description:        "cpu manager add - no error",
 			updateErr:          nil,
 			policy:             testPolicy,
-			expCPUSet:          cpuset.New(0, 3),
+			expCPUSet:          cpuset.New(2, 3),
 			expAllocateErr:     nil,
 			expAddContainerErr: nil,
 		},

--- a/pkg/kubelet/cm/cpumanager/policy.go
+++ b/pkg/kubelet/cm/cpumanager/policy.go
@@ -41,5 +41,5 @@ type Policy interface {
 	// among this and other resource controllers.
 	GetPodTopologyHints(s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint
 	// GetAllocatableCPUs returns the total set of CPUs available for allocation.
-	GetAllocatableCPUs(m state.State) cpuset.CPUSet
+	GetAllocatableCPUs(s state.State) cpuset.CPUSet
 }

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -200,17 +200,16 @@ func (p *staticPolicy) validateState(s state.State) error {
 			return fmt.Errorf("default cpuset cannot be empty")
 		}
 		// state is empty initialize
-		allCPUs := p.topology.CPUDetails.CPUs()
-		s.SetDefaultCPUSet(allCPUs)
+		s.SetDefaultCPUSet(p.GetAllocatableCPUs(s))
 		return nil
 	}
 
 	// State has already been initialized from file (is not empty)
-	// 1. Check if the reserved cpuset is not part of default cpuset because:
+	// 1. Check if any reserved CPU is in default cpuset because:
 	// - kube/system reserved have changed (increased) - may lead to some containers not being able to start
 	// - user tampered with file
-	if !p.reservedCPUs.Intersection(tmpDefaultCPUset).Equals(p.reservedCPUs) {
-		return fmt.Errorf("not all reserved cpus: \"%s\" are present in defaultCpuSet: \"%s\"",
+	if !p.reservedCPUs.Intersection(tmpDefaultCPUset).IsEmpty() {
+		return fmt.Errorf("none of the reserved cpus: \"%s\" should be present in defaultCpuSet: \"%s\"",
 			p.reservedCPUs.String(), tmpDefaultCPUset.String())
 	}
 
@@ -239,9 +238,11 @@ func (p *staticPolicy) validateState(s state.State) error {
 			tmpCPUSets = append(tmpCPUSets, cset)
 		}
 	}
-	totalKnownCPUs = totalKnownCPUs.Union(tmpCPUSets...)
+	// Total CPUs in topology = shared default CPUs + assigned exclusive CPUs +
+	// reserved CPUs for system processes.
+	totalKnownCPUs = totalKnownCPUs.Union(append(tmpCPUSets, p.reservedCPUs)...)
 	if !totalKnownCPUs.Equals(p.topology.CPUDetails.CPUs()) {
-		return fmt.Errorf("current set of available CPUs \"%s\" doesn't match with CPUs in state \"%s\"",
+		return fmt.Errorf("topology CPU set \"%s\" doesn't match all known CPU set from current CPU state \"%s\"",
 			p.topology.CPUDetails.CPUs().String(), totalKnownCPUs.String())
 	}
 
@@ -255,7 +256,7 @@ func (p *staticPolicy) GetAllocatableCPUs(s state.State) cpuset.CPUSet {
 
 // GetAvailableCPUs returns the set of unassigned CPUs minus the reserved set.
 func (p *staticPolicy) GetAvailableCPUs(s state.State) cpuset.CPUSet {
-	return s.GetDefaultCPUSet().Difference(p.reservedCPUs)
+	return s.GetDefaultCPUSet()
 }
 
 func (p *staticPolicy) GetAvailablePhysicalCPUs(s state.State) cpuset.CPUSet {

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -97,15 +97,15 @@ func TestStaticPolicyStart(t *testing.T) {
 			numReservedCPUs: 1,
 			stAssignments:   state.ContainerCPUAssignments{},
 			stDefaultCPUSet: cpuset.New(),
-			expCSet:         cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			expCSet:         cpuset.New(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
 		},
 		{
-			description:     "reserved cores 0 & 6 are not present in available cpuset",
+			description:     "reserved cores 0 & 6 present in available cpuset",
 			topo:            topoDualSocketHT,
 			numReservedCPUs: 2,
 			stAssignments:   state.ContainerCPUAssignments{},
 			stDefaultCPUSet: cpuset.New(0, 1),
-			expErr:          fmt.Errorf("not all reserved cpus: \"0,6\" are present in defaultCpuSet: \"0-1\""),
+			expErr:          fmt.Errorf("none of the reserved cpus: \"0,6\" should be present in defaultCpuSet: \"0-1\""),
 		},
 		{
 			description: "assigned core 2 is still present in available cpuset",
@@ -128,7 +128,7 @@ func TestStaticPolicyStart(t *testing.T) {
 				},
 			},
 			stDefaultCPUSet: cpuset.New(5, 6, 7, 8, 9, 10, 11, 12),
-			expErr:          fmt.Errorf("current set of available CPUs \"0-11\" doesn't match with CPUs in state \"0-12\""),
+			expErr:          fmt.Errorf("topology CPU set \"0-11\" doesn't match all known CPU set from current CPU state \"0-12\""),
 		},
 		{
 			description: "core 11 is present in topology but is not in state cpuset",
@@ -140,7 +140,7 @@ func TestStaticPolicyStart(t *testing.T) {
 				},
 			},
 			stDefaultCPUSet: cpuset.New(5, 6, 7, 8, 9, 10),
-			expErr:          fmt.Errorf("current set of available CPUs \"0-11\" doesn't match with CPUs in state \"0-10\""),
+			expErr:          fmt.Errorf("topology CPU set \"0-11\" doesn't match all known CPU set from current CPU state \"0-10\""),
 		},
 	}
 	for _, testCase := range testCases {
@@ -171,7 +171,9 @@ func TestStaticPolicyStart(t *testing.T) {
 				t.Errorf("State CPUSet is different than expected. Have %q wants: %q", st.GetDefaultCPUSet(),
 					testCase.expCSet)
 			}
-
+			if !policy.GetAvailableCPUs(st).Equals(st.GetDefaultCPUSet()) {
+				t.Errorf("None of the reserved CPUs should be present in defaultCPUSet, and therefore available CPUs should be the same as defaultCPUSet. Available CPUs: %q, defaultCPUSet: %q", policy.GetAvailableCPUs(st), st.GetDefaultCPUSet())
+			}
 		})
 	}
 }
@@ -206,7 +208,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 					"fakeContainer100": cpuset.New(2, 3, 6, 7),
 				},
 			},
-			stDefaultCPUSet: cpuset.New(0, 1, 4, 5),
+			stDefaultCPUSet: cpuset.New(1, 4, 5),
 			pod:             makePod("fakePod", "fakeContainer3", "2000m", "2000m"),
 			expErr:          nil,
 			expCPUAlloc:     true,
@@ -236,7 +238,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 					"fakeContainer100": cpuset.New(1, 5),
 				},
 			},
-			stDefaultCPUSet: cpuset.New(0, 2, 3, 4, 6, 7, 8, 9, 10, 11),
+			stDefaultCPUSet: cpuset.New(2, 3, 4, 6, 7, 8, 9, 10, 11),
 			pod:             makePod("fakePod", "fakeContainer3", "6000m", "6000m"),
 			expErr:          nil,
 			expCPUAlloc:     true,
@@ -266,7 +268,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 					"fakeContainer100": cpuset.New(4, 5),
 				},
 			},
-			stDefaultCPUSet: cpuset.New(0, 1, 3, 6, 7),
+			stDefaultCPUSet: cpuset.New(1, 3, 6, 7),
 			pod:             makePod("fakePod", "fakeContainer1", "4000m", "4000m"),
 			expErr:          nil,
 			expCPUAlloc:     true,
@@ -281,7 +283,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 					"fakeContainer100": cpuset.New(2),
 				},
 			},
-			stDefaultCPUSet: cpuset.New(0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			stDefaultCPUSet: cpuset.New(1, 3, 4, 5, 6, 7, 8, 9, 10, 11),
 			pod:             makePod("fakePod", "fakeContainer3", "8000m", "8000m"),
 			expErr:          nil,
 			expCPUAlloc:     true,
@@ -370,7 +372,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			topo:            topoSingleSocketHT,
 			numReservedCPUs: 1,
 			stAssignments:   state.ContainerCPUAssignments{},
-			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			stDefaultCPUSet: cpuset.New(1, 2, 3, 4, 5, 6, 7),
 			pod:             makePod("fakePod", "fakeContainer2", "1000m", "1000m"),
 			expErr:          nil,
 			expCPUAlloc:     true,
@@ -397,7 +399,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			topo:            topoSingleSocketHT,
 			numReservedCPUs: 1,
 			stAssignments:   state.ContainerCPUAssignments{},
-			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			stDefaultCPUSet: cpuset.New(1, 2, 3, 4, 5, 6, 7),
 			pod:             makePod("fakePod", "fakeContainer2", "8000m", "8000m"),
 			expErr:          fmt.Errorf("not enough cpus available to satisfy request"),
 			expCPUAlloc:     false,
@@ -442,7 +444,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 					"fakeContainer100": cpuset.New(1, 2, 3, 4, 5, 6),
 				},
 			},
-			stDefaultCPUSet: cpuset.New(0, 7),
+			stDefaultCPUSet: cpuset.New(7),
 			pod:             makePod("fakePod", "fakeContainer5", "2000m", "2000m"),
 			expErr:          fmt.Errorf("not enough cpus available to satisfy request"),
 			expCPUAlloc:     false,
@@ -477,7 +479,7 @@ func TestStaticPolicyAdd(t *testing.T) {
 			},
 			numReservedCPUs: 1,
 			stAssignments:   state.ContainerCPUAssignments{},
-			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			stDefaultCPUSet: cpuset.New(1, 2, 3, 4, 5, 6, 7),
 			pod:             makePod("fakePod", "fakeContainer2", "1000m", "1000m"),
 			expErr:          SMTAlignmentError{RequestedCPUs: 1, CpusPerCore: 2},
 			expCPUAlloc:     false,
@@ -916,16 +918,16 @@ func TestStaticPolicyStartWithResvList(t *testing.T) {
 			reserved:        cpuset.New(0, 1),
 			stAssignments:   state.ContainerCPUAssignments{},
 			stDefaultCPUSet: cpuset.New(),
-			expCSet:         cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			expCSet:         cpuset.New(2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
 		},
 		{
-			description:     "reserved cores 0 & 1 are not present in available cpuset",
+			description:     "cpus 6-11 are missing from current known CPU set",
 			topo:            topoDualSocketHT,
 			numReservedCPUs: 2,
 			reserved:        cpuset.New(0, 1),
 			stAssignments:   state.ContainerCPUAssignments{},
 			stDefaultCPUSet: cpuset.New(2, 3, 4, 5),
-			expErr:          fmt.Errorf("not all reserved cpus: \"0-1\" are present in defaultCpuSet: \"2-5\""),
+			expErr:          fmt.Errorf("topology CPU set \"0-11\" doesn't match all known CPU set from current CPU state \"0-5\""),
 		},
 		{
 			description:     "inconsistency between numReservedCPUs and reserved",
@@ -965,7 +967,9 @@ func TestStaticPolicyStartWithResvList(t *testing.T) {
 				t.Errorf("State CPUSet is different than expected. Have %q wants: %q", st.GetDefaultCPUSet(),
 					testCase.expCSet)
 			}
-
+			if !policy.GetAvailableCPUs(st).Equals(st.GetDefaultCPUSet()) {
+				t.Errorf("None of the reserved CPUs should be present in defaultCPUSet, and therefore available CPUs should be the same as defaultCPUSet. Available CPUs: %q, defaultCPUSet: %q", policy.GetAvailableCPUs(st), st.GetDefaultCPUSet())
+			}
 		})
 	}
 }
@@ -979,7 +983,7 @@ func TestStaticPolicyAddWithResvList(t *testing.T) {
 			numReservedCPUs: 1,
 			reserved:        cpuset.New(0),
 			stAssignments:   state.ContainerCPUAssignments{},
-			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			stDefaultCPUSet: cpuset.New(1, 2, 3, 4, 5, 6, 7),
 			pod:             makePod("fakePod", "fakeContainer2", "8000m", "8000m"),
 			expErr:          fmt.Errorf("not enough cpus available to satisfy request"),
 			expCPUAlloc:     false,
@@ -991,7 +995,7 @@ func TestStaticPolicyAddWithResvList(t *testing.T) {
 			numReservedCPUs: 2,
 			reserved:        cpuset.New(0, 1),
 			stAssignments:   state.ContainerCPUAssignments{},
-			stDefaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			stDefaultCPUSet: cpuset.New(2, 3, 4, 5, 6, 7),
 			pod:             makePod("fakePod", "fakeContainer2", "1000m", "1000m"),
 			expErr:          nil,
 			expCPUAlloc:     true,
@@ -1007,7 +1011,7 @@ func TestStaticPolicyAddWithResvList(t *testing.T) {
 					"fakeContainer100": cpuset.New(2, 3, 6, 7),
 				},
 			},
-			stDefaultCPUSet: cpuset.New(0, 1, 4, 5),
+			stDefaultCPUSet: cpuset.New(4, 5),
 			pod:             makePod("fakePod", "fakeContainer3", "2000m", "2000m"),
 			expErr:          nil,
 			expCPUAlloc:     true,

--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -266,7 +266,7 @@ func runNonGuPodTest(ctx context.Context, f *framework.Framework, cpuCap int64) 
 	pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 	ginkgo.By("checking if the expected cpuset was assigned")
-	expAllowedCPUsListRegex = fmt.Sprintf("^0-%d\n$", cpuCap-1)
+	expAllowedCPUsListRegex = fmt.Sprintf("^1-%d\n$", cpuCap-1)
 	// on the single CPU node the only possible value is 0
 	if cpuCap == 1 {
 		expAllowedCPUsListRegex = "^0\n$"
@@ -333,7 +333,7 @@ func runMultipleGuNonGuPods(ctx context.Context, f *framework.Framework, cpuCap 
 
 	cpuListString = "0"
 	if cpuAlloc > 2 {
-		cset = mustParseCPUSet(fmt.Sprintf("0-%d", cpuCap-1))
+		cset = mustParseCPUSet(fmt.Sprintf("1-%d", cpuCap-1))
 		cpuListString = fmt.Sprintf("%s", cset.Difference(cpuset.New(cpu1)))
 	}
 	expAllowedCPUsListRegex = fmt.Sprintf("^%s\n$", cpuListString)
@@ -539,7 +539,9 @@ func runCPUManagerTests(f *framework.Framework) {
 
 		// Enable CPU Manager in the kubelet.
 		newCfg := configureCPUManagerInKubelet(oldCfg, &cpuManagerKubeletArguments{
-			policyName:         string(cpumanager.PolicyStatic),
+			policyName: string(cpumanager.PolicyStatic),
+			// Even though empty reserved CPU set is passed here, we will
+			// reserve 1 CPU in the configureCPUManagerInKubelet.
 			reservedSystemCPUs: cpuset.CPUSet{},
 		})
 		updateKubeletConfig(ctx, f, newCfg, true)


### PR DESCRIPTION
…uled on reserved CPUs.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115994

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```