### PR TITLE
etcd: Update version to 3.5.9

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -62,7 +62,7 @@ dependencies:
 
   # etcd
   - name: "etcd"
-    version: 3.5.8
+    version: 3.5.9
     refPaths:
     - path: cluster/gce/manifests/etcd.manifest
       match: etcd_docker_tag|etcd_version

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -18,7 +18,7 @@
     {
     "name": "etcd-container",
     {{security_context}}
-    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.5.8-0') }}",
+    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.5.9-0') }}",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}
@@ -34,7 +34,7 @@
         "value": "{{ pillar.get('storage_backend', 'etcd3') }}"
       },
       { "name": "TARGET_VERSION",
-        "value": "{{ pillar.get('etcd_version', '3.5.8') }}"
+        "value": "{{ pillar.get('etcd_version', '3.5.9') }}"
       },
       {
         "name": "DO_NOT_MOVE_BINARIES",

--- a/cluster/gce/upgrade-aliases.sh
+++ b/cluster/gce/upgrade-aliases.sh
@@ -170,8 +170,8 @@ export KUBE_GCE_ENABLE_IP_ALIASES=true
 export SECONDARY_RANGE_NAME="pods-default"
 export STORAGE_BACKEND="etcd3"
 export STORAGE_MEDIA_TYPE="application/vnd.kubernetes.protobuf"
-export ETCD_IMAGE=3.5.8-0
-export ETCD_VERSION=3.5.8
+export ETCD_IMAGE=3.5.9-0
+export ETCD_VERSION=3.5.9
 
 # Upgrade master with updated kube envs
 "${KUBE_ROOT}/cluster/gce/upgrade.sh" -M -l

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -309,7 +309,7 @@ const (
 	MinExternalEtcdVersion = "3.2.18"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
-	DefaultEtcdVersion = "3.5.8-0"
+	DefaultEtcdVersion = "3.5.9-0"
 
 	// Etcd defines variable used internally when referring to etcd component
 	Etcd = "etcd"
@@ -482,6 +482,7 @@ var (
 		25: "3.5.8-0",
 		26: "3.5.8-0",
 		27: "3.5.8-0",
+		28: "3.5.9-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -160,7 +160,7 @@ kube::etcd::install() {
 
     if [[ ${os} == "darwin" ]]; then
       download_file="etcd-v${ETCD_VERSION}-${os}-${arch}.zip"
-      url="https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/${download_file}"
+      url="https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/${download_file}"
       kube::util::download_file "${url}" "${download_file}"
       unzip -o "${download_file}"
       ln -fns "etcd-v${ETCD_VERSION}-${os}-${arch}" etcd

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,7 +16,7 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-3.5.8}
+ETCD_VERSION=${ETCD_VERSION:-3.5.9}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 # This is intentionally not called ETCD_LOG_LEVEL:

--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
@@ -26,4 +26,4 @@ spec:
         imagePullPolicy: Never
         args: [ "--etcd-servers=http://localhost:2379" ]
       - name: etcd
-        image: gcr.io/etcd-development/etcd:v3.5.8
+        image: gcr.io/etcd-development/etcd:v3.5.9

--- a/test/e2e/framework/providers/gcp.go
+++ b/test/e2e/framework/providers/gcp.go
@@ -26,7 +26,7 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 )
 
-const etcdImage = "3.5.8-0"
+const etcdImage = "3.5.9-0"
 
 // EtcdUpgrade upgrades etcd on GCE.
 func EtcdUpgrade(targetStorage, targetVersion string) error {

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -246,7 +246,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.2"}
 	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.2.4"}
-	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.8-0"}
+	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.9-0"}
 	configs[GlusterDynamicProvisioner] = Config{list.PromoterE2eRegistry, "glusterdynamic-provisioner", "v1.3"}
 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}
 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-4"}


### PR DESCRIPTION
- [x] update etcd version to 3.5.9
- [x] use etcd v3.5.9 in the installation script
- [x]  use upstream etcd github path instead of redirecting one
    
    In the installation script we use coreos/etcd path which redirect
    to etcd-io/etcd. This commit replace the same.

/kind cleanup


Depends on #https://github.com/kubernetes/kubernetes/pull/117999
