### PR TITLE
Preserve code blocks in templates.Normalizer

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/templates/markdown.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/markdown.go
@@ -60,7 +60,7 @@ func (r *ASCIIRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering
 			trimmed := strings.Trim(line, " \t")
 			// Adding 4 times of indentation will let blackfriday to accept
 			// this literal as Code or CodeBlock again in next invocation
-			indented := r.Indentation + r.Indentation + r.Indentation + r.Indentation + trimmed
+			indented := strings.Repeat(r.Indentation, 4) + trimmed
 			lines = append(lines, indented)
 		}
 		w.Write([]byte(strings.Join(lines, linebreak)))

--- a/staging/src/k8s.io/kubectl/pkg/util/templates/markdown.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/markdown.go
@@ -58,7 +58,9 @@ func (r *ASCIIRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering
 		lines := []string{}
 		for _, line := range strings.Split(string(node.Literal), linebreak) {
 			trimmed := strings.Trim(line, " \t")
-			indented := r.Indentation + trimmed
+			// Adding 4 times of indentation will let blackfriday to accept
+			// this literal as Code or CodeBlock again in next invocation
+			indented := r.Indentation + r.Indentation + r.Indentation + r.Indentation + trimmed
 			lines = append(lines, indented)
 		}
 		w.Write([]byte(strings.Join(lines, linebreak)))

--- a/staging/src/k8s.io/kubectl/pkg/util/templates/normalizers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/normalizers_test.go
@@ -66,11 +66,64 @@ func TestLongDescMarkdown(t *testing.T) {
 			in:   "\t\t\t\t\tDescriptions.\n\n * Item.\n * Item2.",
 			out:  "Descriptions.\n  \n  *  Item.\n  *  Item2.",
 		},
+		{
+			desc: "With code block",
+			in:   "Line1\n\n\t<type>.<fieldName>[.<fieldName>]\n\nLine2",
+			out:  "Line1\n\n        <type>.<fieldName>[.<fieldName>]\n        \n Line2",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			got := LongDesc(test.in)
+			if got != test.out {
+				t.Errorf("expected(%d):\n%s\n=====\ngot(%d):\n%s\n", len(test.out), test.out, len(got), got)
+			}
+		})
+	}
+}
+
+func TestMultiLongDescInvocation(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   string
+		out  string
+	}{
+		{
+			desc: "Empty input produces empty output",
+			in:   "",
+			out:  "",
+		},
+		{
+			desc: "Single line text is preserved as is",
+			in:   "Some text",
+			out:  "Some text",
+		},
+		{
+			desc: "Consecutive new lines are combined into a single paragraph",
+			in:   "Line1\nLine2",
+			out:  "Line1 Line2",
+		},
+		{
+			desc: "Two paragraphs",
+			in:   "Line1\n\nLine2",
+			out:  "Line1\n\n Line2",
+		},
+		{
+			desc: "Leading and trailing spaces are stripped (single line)",
+			in:   "\t  \nThe text line  \n  \t",
+			out:  "The text line",
+		},
+		{
+			desc: "With code block",
+			in:   "Line1\n\n\t<type>.<fieldName>[.<fieldName>]\n\nLine2",
+			out:  "Line1\n\n        <type>.<fieldName>[.<fieldName>]\n        \n Line2",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			got := LongDesc(LongDesc(test.in))
 			if got != test.out {
 				t.Errorf("expected(%d):\n%s\n=====\ngot(%d):\n%s\n", len(test.out), test.out, len(got), got)
 			}

--- a/staging/src/k8s.io/kubectl/pkg/util/templates/normalizers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/normalizers_test.go
@@ -64,7 +64,7 @@ func TestLongDescMarkdown(t *testing.T) {
 		{
 			desc: "Multi lines without order",
 			in:   "\t\t\t\t\tDescriptions.\n\n * Item.\n * Item2.",
-			out:  "Descriptions.\n  \n  *  Item.\n  *  Item2.",
+			out:  "Descriptions.\n        \n  *  Item.\n  *  Item2.",
 		},
 		{
 			desc: "With code block",


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Currently, if templates.LongDesc function is invoked multiple times for a string including a code block, this code block is converted to invalid code block.

The reason of this issue is that blackfriday package, which templates package uses, relies on 4 * indentation to detect code blocks. This PR always preserves 4 * indentation in code blocks to always detect it code blocks in also post invocations.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/118028

#### Special notes for your reviewer:
/assign @pacoxu 

#### Does this PR introduce a user-facing change?
```release-note
 code blocks in kubectl {$COMMAND}--help will move right by 3 indentation.
```
