### PR TITLE
test/e2e/dra: fix kind cluster creation

### DIFF
--- a/test/e2e/dra/kind.yaml
+++ b/test/e2e/dra/kind.yaml
@@ -1,5 +1,11 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+# Enable CDI as described in
+# https://github.com/container-orchestrated-devices/container-device-interface#containerd-configuration
+- |-
+  [plugins."io.containerd.grpc.v1.cri"]
+    enable_cdi = true
 nodes:
 - role: control-plane
   kubeadmConfigPatches:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

The nightly containerd binary no longer works in the current kind base images:

    May 15 16:32:31 kind-worker containerd[222]: /usr/local/bin/containerd:
    /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by
    /usr/local/bin/containerd)

kind now builds containerd directly with the base images. The official base images still use containerd 1.6, so we have to use a special base image that was prepared for this purpose.

Because the containerd config can be patched through kind, we don't need to modify the generated node image anymore.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
