### PR TITLE
fix logging of podactions

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -210,6 +210,12 @@ type ContainerID struct {
 	ID string
 }
 
+// MarshalText marshals the ContainerID into a text string and is used so it can be logged
+// with structured logging as a map key.
+func (c ContainerID) MarshalText() (text []byte, err error) {
+	return []byte(fmt.Sprintf("%s/%s", c.Type, c.ID)), nil
+}
+
 // BuildContainerID returns the ContainerID given type and id.
 func BuildContainerID(typ, ID string) ContainerID {
 	return ContainerID{Type: typ, ID: ID}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -942,10 +942,10 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(pod *v1.Pod, pod
 							// If the restartable init container failed the startup probe,
 							// restart it.
 							changes.ContainersToKill[status.ID] = containerToKillInfo{
-								name:      container.Name,
-								container: container,
-								message:   fmt.Sprintf("Init container %s failed startup probe", container.Name),
-								reason:    reasonStartupProbe,
+								Name:      container.Name,
+								Container: container,
+								Message:   fmt.Sprintf("Init container %s failed startup probe", container.Name),
+								Reason:    reasonStartupProbe,
 							}
 							changes.InitContainersToStart = append(changes.InitContainersToStart, i)
 						}
@@ -994,11 +994,11 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(pod *v1.Pod, pod
 			if types.IsRestartableInitContainer(container) {
 				// If the restartable init container is in unknown state, restart it.
 				changes.ContainersToKill[status.ID] = containerToKillInfo{
-					name:      container.Name,
-					container: container,
-					message: fmt.Sprintf("Init container is in %q state, try killing it before restart",
+					Name:      container.Name,
+					Container: container,
+					Message: fmt.Sprintf("Init container is in %q state, try killing it before restart",
 						status.State),
-					reason: reasonUnknown,
+					Reason: reasonUnknown,
 				}
 				changes.InitContainersToStart = append(changes.InitContainersToStart, i)
 			} else { // init container
@@ -1014,11 +1014,11 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(pod *v1.Pod, pod
 
 				// If the init container is in unknown state, restart it.
 				changes.ContainersToKill[status.ID] = containerToKillInfo{
-					name:      container.Name,
-					container: container,
-					message: fmt.Sprintf("Init container is in %q state, try killing it before restart",
+					Name:      container.Name,
+					Container: container,
+					Message: fmt.Sprintf("Init container is in %q state, try killing it before restart",
 						status.State),
-					reason: reasonUnknown,
+					Reason: reasonUnknown,
 				}
 				changes.InitContainersToStart = append(changes.InitContainersToStart, i)
 			}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -450,14 +450,14 @@ const (
 // containerToKillInfo contains necessary information to kill a container.
 type containerToKillInfo struct {
 	// The spec of the container.
-	container *v1.Container
+	Container *v1.Container
 	// The name of the container.
-	name string
+	Name string
 	// The message indicates why the container will be killed.
-	message string
+	Message string
 	// The reason is a clearer source of info on why a container will be killed
 	// TODO: replace message with reason?
-	reason containerKillReason
+	Reason containerKillReason
 }
 
 // containerResources holds the set of resources applicable to the running container
@@ -633,9 +633,9 @@ func (m *kubeGenericRuntimeManager) computePodResizeAction(pod *v1.Pod, containe
 	if restartCPULim || restartCPUReq || restartMemLim {
 		// resize policy requires this container to restart
 		changes.ContainersToKill[kubeContainerStatus.ID] = containerToKillInfo{
-			name:      kubeContainerStatus.Name,
-			container: &pod.Spec.Containers[containerIdx],
-			message:   fmt.Sprintf("Container %s resize requires restart", container.Name),
+			Name:      kubeContainerStatus.Name,
+			Container: &pod.Spec.Containers[containerIdx],
+			Message:   fmt.Sprintf("Container %s resize requires restart", container.Name),
 		}
 		changes.ContainersToStart = append(changes.ContainersToStart, containerIdx)
 		changes.UpdatePodResources = true
@@ -922,11 +922,11 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 					// is actually running or not, always try killing it before
 					// restart to avoid having 2 running instances of the same container.
 					changes.ContainersToKill[containerStatus.ID] = containerToKillInfo{
-						name:      containerStatus.Name,
-						container: &pod.Spec.Containers[idx],
-						message: fmt.Sprintf("Container is in %q state, try killing it before restart",
+						Name:      containerStatus.Name,
+						Container: &pod.Spec.Containers[idx],
+						Message: fmt.Sprintf("Container is in %q state, try killing it before restart",
 							containerStatus.State),
-						reason: reasonUnknown,
+						Reason: reasonUnknown,
 					}
 				}
 			}
@@ -970,10 +970,10 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 		}
 
 		changes.ContainersToKill[containerStatus.ID] = containerToKillInfo{
-			name:      containerStatus.Name,
-			container: &pod.Spec.Containers[idx],
-			message:   message,
-			reason:    reason,
+			Name:      containerStatus.Name,
+			Container: &pod.Spec.Containers[idx],
+			Message:   message,
+			Reason:    reason,
 		}
 		klog.V(2).InfoS("Message for Container of pod", "containerName", container.Name, "containerStatusID", containerStatus.ID, "pod", klog.KObj(pod), "containerMessage", message)
 	}
@@ -1035,12 +1035,12 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 	} else {
 		// Step 3: kill any running containers in this pod which are not to keep.
 		for containerID, containerInfo := range podContainerChanges.ContainersToKill {
-			klog.V(3).InfoS("Killing unwanted container for pod", "containerName", containerInfo.name, "containerID", containerID, "pod", klog.KObj(pod))
-			killContainerResult := kubecontainer.NewSyncResult(kubecontainer.KillContainer, containerInfo.name)
+			klog.V(3).InfoS("Killing unwanted container for pod", "containerName", containerInfo.Name, "containerID", containerID, "pod", klog.KObj(pod))
+			killContainerResult := kubecontainer.NewSyncResult(kubecontainer.KillContainer, containerInfo.Name)
 			result.AddSyncResult(killContainerResult)
-			if err := m.killContainer(ctx, pod, containerID, containerInfo.name, containerInfo.message, containerInfo.reason, nil); err != nil {
+			if err := m.killContainer(ctx, pod, containerID, containerInfo.Name, containerInfo.Message, containerInfo.Reason, nil); err != nil {
 				killContainerResult.Fail(kubecontainer.ErrKillContainer, err.Error())
-				klog.ErrorS(err, "killContainer for pod failed", "containerName", containerInfo.name, "containerID", containerID, "pod", klog.KObj(pod))
+				klog.ErrorS(err, "killContainer for pod failed", "containerName", containerInfo.Name, "containerID", containerID, "pod", klog.KObj(pod))
 				return
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Fixes the logging of computed pod actions

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

Prior to this change:

```log
I0516 07:36:18.533011   74089 kuberuntime_manager.go:1014] "computePodActions got for pod" podActions="<internal error: json: unsupported type: map[container.ContainerID]kuberuntime.containerToKillInfo>" pod="default/test-pod"
```

After this change:

```log
I0516 08:10:44.727468   96410 kuberuntime_manager.go:1014] "computePodActions got for pod" podActions={"KillPod":true,"CreateSandbox":true,"SandboxID":"d0a5f039e2d27c0000a0e47dbc1a150a6423bb9eaa02dc532118abf12ce223d1","Attempt":2,"NextInitContainerToStart":null,"ContainersToStart":[0],"ContainersToKill":{},"EphemeralContainersToStart":null,"ContainersToUpdate":null,"UpdatePodResources":false} pod="default/test-pod"
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
