### PR TITLE
support `WebhookAccessors` smart reload

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
@@ -53,7 +53,8 @@ var _ generic.Source = &mutatingWebhookConfigurationManager{}
 func NewMutatingWebhookConfigurationManager(f informers.SharedInformerFactory) generic.Source {
 	informer := f.Admissionregistration().V1().MutatingWebhookConfigurations()
 	manager := &mutatingWebhookConfigurationManager{
-		lister: informer.Lister(),
+		lister:                        informer.Lister(),
+		createMutatingWebhookAccessor: webhook.NewMutatingWebhookAccessor,
 	}
 	manager.lazy.Evaluate = manager.getConfiguration
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
@@ -119,7 +119,12 @@ func (m *mutatingWebhookConfigurationManager) getMutatingWebhookConfigurations(c
 	// but configurations themselves can be in any order. As we are going to run these
 	// webhooks in serial, they are sorted here to have a deterministic order.
 	sort.SliceStable(configurations, MutatingWebhookConfigurationSorter(configurations).ByName)
-	accessors := []webhook.WebhookAccessor{}
+	size := 0
+	for _, cfg := range configurations {
+		size += len(cfg.Webhooks)
+	}
+	accessors := make([]webhook.WebhookAccessor, 0, size)
+
 	for _, c := range configurations {
 		cachedConfigurationAccessors, ok := m.configurationsCache.Load(c.Name)
 		if ok {
@@ -131,7 +136,7 @@ func (m *mutatingWebhookConfigurationManager) getMutatingWebhookConfigurations(c
 		// webhook names are not validated for uniqueness, so we check for duplicates and
 		// add a int suffix to distinguish between them
 		names := map[string]int{}
-		configurationAccessors := []webhook.WebhookAccessor{}
+		configurationAccessors := make([]webhook.WebhookAccessor, 0, len(c.Webhooks))
 		for i := range c.Webhooks {
 			n := c.Webhooks[i].Name
 			uid := fmt.Sprintf("%s/%s/%d", c.Name, n, names[n])

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
@@ -70,12 +70,12 @@ func NewMutatingWebhookConfigurationManager(f informers.SharedInformerFactory) g
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 				if !ok {
-					klog.Errorf("Couldn't get object from tombstone %#v", obj)
+					klog.V(2).Infof("Couldn't get object from tombstone %#v", obj)
 					return
 				}
 				vwc, ok = tombstone.Obj.(*v1.MutatingWebhookConfiguration)
 				if !ok {
-					klog.Errorf("Tombstone contained object that is not expected %#v", obj)
+					klog.V(2).Infof("Tombstone contained object that is not expected %#v", obj)
 					return
 				}
 			}

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager_test.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -79,5 +80,204 @@ func TestGetMutatingWebhookConfig(t *testing.T) {
 		if !reflect.DeepEqual(h, &webhookConfiguration.Webhooks[i]) {
 			t.Errorf("Expected\n%#v\ngot\n%#v", &webhookConfiguration.Webhooks[i], h)
 		}
+	}
+}
+
+// mockCreateMutatingWebhookAccessor is a struct used to compute how many times
+// the function webhook.NewMutatingWebhookAccessor is being called when refreshing
+// webhookAccessors.
+//
+// NOTE: Maybe there some testing help that we can import and reuse instead.
+type mockCreateMutatingWebhookAccessor struct {
+	numberOfCalls int
+}
+
+func (mock *mockCreateMutatingWebhookAccessor) calledNTimes() int { return mock.numberOfCalls }
+func (mock *mockCreateMutatingWebhookAccessor) resetCounter()     { mock.numberOfCalls = 0 }
+func (mock *mockCreateMutatingWebhookAccessor) incrementCounter() { mock.numberOfCalls++ }
+
+func (mock *mockCreateMutatingWebhookAccessor) fn(uid string, configurationName string, h *v1.MutatingWebhook) webhook.WebhookAccessor {
+	mock.incrementCounter()
+	return webhook.NewMutatingWebhookAccessor(uid, configurationName, h)
+}
+
+func mutatingConfigurationTotalWebhooks(configurations []*v1.MutatingWebhookConfiguration) int {
+	total := 0
+	for _, configuration := range configurations {
+		total += len(configuration.Webhooks)
+	}
+	return total
+}
+
+func TestGetMutatingWebhookConfigSmartReload(t *testing.T) {
+	type args struct {
+		createWebhookConfigurations []*v1.MutatingWebhookConfiguration
+		updateWebhookConfigurations []*v1.MutatingWebhookConfiguration
+	}
+	tests := []struct {
+		name              string
+		args              args
+		numberOfCreations int
+		// number of refreshes are number of times we pulled a webhook configuration
+		// from the cache without having to create new ones from scratch.
+		numberOfRefreshes             int
+		finalNumberOfWebhookAccessors int
+	}{
+		{
+			name: "no creations and no updates",
+			args: args{
+				nil,
+				nil,
+			},
+			numberOfCreations:             0,
+			numberOfRefreshes:             0,
+			finalNumberOfWebhookAccessors: 0,
+		},
+		{
+			name: "create configurations and no updates",
+			args: args{
+				[]*v1.MutatingWebhookConfiguration{
+					&v1.MutatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook1"},
+						Webhooks:   []v1.MutatingWebhook{{Name: "webhook1.1"}, {Name: "webhook1.2"}},
+					},
+					&v1.MutatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook2"},
+						Webhooks:   []v1.MutatingWebhook{{Name: "webhook2.1"}, {Name: "webhook2.2"}},
+					},
+				},
+				nil,
+			},
+			numberOfCreations:             4,
+			numberOfRefreshes:             0,
+			finalNumberOfWebhookAccessors: 4,
+		},
+		{
+			name: "create configurations and update some of them",
+			args: args{
+				[]*v1.MutatingWebhookConfiguration{
+					&v1.MutatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook3"},
+						Webhooks:   []v1.MutatingWebhook{{Name: "webhook3.1"}},
+					},
+					&v1.MutatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook4"},
+						Webhooks:   []v1.MutatingWebhook{{Name: "webhook4.1"}},
+					},
+				},
+				[]*v1.MutatingWebhookConfiguration{
+					&v1.MutatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook4"},
+						Webhooks:   []v1.MutatingWebhook{{Name: "webhook4.1-updated"}, {Name: "webhook4.2"}},
+					},
+				},
+			},
+			numberOfCreations:             2,
+			numberOfRefreshes:             2,
+			finalNumberOfWebhookAccessors: 3,
+		},
+		{
+			name: "create configuration and update moar of them",
+			args: args{
+				[]*v1.MutatingWebhookConfiguration{
+					&v1.MutatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook5"},
+						Webhooks:   []v1.MutatingWebhook{{Name: "webhook5.1"}, {Name: "webhook5.2"}},
+					},
+					&v1.MutatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook6"},
+						Webhooks:   []v1.MutatingWebhook{{Name: "webhook6.1"}},
+					},
+					&v1.MutatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook7"},
+						Webhooks:   []v1.MutatingWebhook{{Name: "webhook7.1"}},
+					},
+				},
+				[]*v1.MutatingWebhookConfiguration{
+					&v1.MutatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook6"},
+						Webhooks:   []v1.MutatingWebhook{{Name: "webhook6.1-updated"}},
+					},
+					&v1.MutatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook7"},
+						Webhooks:   []v1.MutatingWebhook{{Name: "webhook7.1-updated"}, {Name: "webhook7.2"}},
+					},
+				},
+			},
+			numberOfCreations:             4,
+			numberOfRefreshes:             3,
+			finalNumberOfWebhookAccessors: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			stop := make(chan struct{})
+			defer close(stop)
+			manager := NewMutatingWebhookConfigurationManager(informerFactory)
+			managerStructPtr := manager.(*mutatingWebhookConfigurationManager)
+			fakeWebhookAccessorCreator := &mockCreateMutatingWebhookAccessor{}
+			managerStructPtr.createMutatingWebhookAccessor = fakeWebhookAccessorCreator.fn
+			informerFactory.Start(stop)
+			informerFactory.WaitForCacheSync(stop)
+
+			// Create webhooks
+			for _, configurations := range tt.args.createWebhookConfigurations {
+				client.
+					AdmissionregistrationV1().
+					MutatingWebhookConfigurations().
+					Create(context.TODO(), configurations, metav1.CreateOptions{})
+			}
+			// TODO use channels to wait for manager.createMutatingWebhookAccessor
+			// to be called instead of using time.Sleep
+			time.Sleep(1 * time.Second)
+			webhooks := manager.Webhooks()
+			if mutatingConfigurationTotalWebhooks(tt.args.createWebhookConfigurations) != len(webhooks) {
+				t.Errorf("Expected number of webhooks %d received %d",
+					mutatingConfigurationTotalWebhooks(tt.args.createWebhookConfigurations),
+					len(webhooks),
+				)
+			}
+			// assert creations
+			if tt.numberOfCreations != fakeWebhookAccessorCreator.calledNTimes() {
+				t.Errorf(
+					"Expected number of creations %d received %d",
+					tt.numberOfCreations, fakeWebhookAccessorCreator.calledNTimes(),
+				)
+			}
+
+			// reset mock counter
+			fakeWebhookAccessorCreator.resetCounter()
+
+			// Update webhooks
+			for _, configurations := range tt.args.updateWebhookConfigurations {
+				client.
+					AdmissionregistrationV1().
+					MutatingWebhookConfigurations().
+					Update(context.TODO(), configurations, metav1.UpdateOptions{})
+			}
+			// TODO use channels to wait for manager.createMutatingWebhookAccessor
+			// to be called instead of using time.Sleep
+			time.Sleep(1 * time.Second)
+			webhooks = manager.Webhooks()
+			if tt.finalNumberOfWebhookAccessors != len(webhooks) {
+				t.Errorf("Expected final number of webhooks %d received %d",
+					tt.finalNumberOfWebhookAccessors,
+					len(webhooks),
+				)
+			}
+
+			// assert updates
+			if tt.numberOfRefreshes != fakeWebhookAccessorCreator.calledNTimes() {
+				t.Errorf(
+					"Expected number of refreshes %d received %d",
+					tt.numberOfRefreshes, fakeWebhookAccessorCreator.calledNTimes(),
+				)
+			}
+			// reset mock counter for the next test cases
+			fakeWebhookAccessorCreator.resetCounter()
+		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager_test.go
@@ -137,11 +137,11 @@ func TestGetMutatingWebhookConfigSmartReload(t *testing.T) {
 			name: "create configurations and no updates",
 			args: args{
 				[]*v1.MutatingWebhookConfiguration{
-					&v1.MutatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook1"},
 						Webhooks:   []v1.MutatingWebhook{{Name: "webhook1.1"}, {Name: "webhook1.2"}},
 					},
-					&v1.MutatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook2"},
 						Webhooks:   []v1.MutatingWebhook{{Name: "webhook2.1"}, {Name: "webhook2.2"}},
 					},
@@ -156,17 +156,17 @@ func TestGetMutatingWebhookConfigSmartReload(t *testing.T) {
 			name: "create configurations and update some of them",
 			args: args{
 				[]*v1.MutatingWebhookConfiguration{
-					&v1.MutatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook3"},
 						Webhooks:   []v1.MutatingWebhook{{Name: "webhook3.1"}},
 					},
-					&v1.MutatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook4"},
 						Webhooks:   []v1.MutatingWebhook{{Name: "webhook4.1"}},
 					},
 				},
 				[]*v1.MutatingWebhookConfiguration{
-					&v1.MutatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook4"},
 						Webhooks:   []v1.MutatingWebhook{{Name: "webhook4.1-updated"}, {Name: "webhook4.2"}},
 					},
@@ -180,25 +180,25 @@ func TestGetMutatingWebhookConfigSmartReload(t *testing.T) {
 			name: "create configuration and update moar of them",
 			args: args{
 				[]*v1.MutatingWebhookConfiguration{
-					&v1.MutatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook5"},
 						Webhooks:   []v1.MutatingWebhook{{Name: "webhook5.1"}, {Name: "webhook5.2"}},
 					},
-					&v1.MutatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook6"},
 						Webhooks:   []v1.MutatingWebhook{{Name: "webhook6.1"}},
 					},
-					&v1.MutatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook7"},
 						Webhooks:   []v1.MutatingWebhook{{Name: "webhook7.1"}},
 					},
 				},
 				[]*v1.MutatingWebhookConfiguration{
-					&v1.MutatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook6"},
 						Webhooks:   []v1.MutatingWebhook{{Name: "webhook6.1-updated"}},
 					},
-					&v1.MutatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook7"},
 						Webhooks:   []v1.MutatingWebhook{{Name: "webhook7.1-updated"}, {Name: "webhook7.2"}},
 					},

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager_test.go
@@ -118,8 +118,8 @@ func TestGetMutatingWebhookConfigSmartReload(t *testing.T) {
 		name              string
 		args              args
 		numberOfCreations int
-		// number of refreshes are number of times we pulled a webhook configuration
-		// from the cache without having to create new ones from scratch.
+		// number of refreshes are number of times we recrated a webhook accessor
+		// instead of pulling from the cache.
 		numberOfRefreshes             int
 		finalNumberOfWebhookAccessors int
 	}{

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
@@ -70,12 +70,12 @@ func NewValidatingWebhookConfigurationManager(f informers.SharedInformerFactory)
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 				if !ok {
-					klog.Errorf("Couldn't get object from tombstone %#v", obj)
+					klog.V(2).Infof("Couldn't get object from tombstone %#v", obj)
 					return
 				}
 				vwc, ok = tombstone.Obj.(*v1.ValidatingWebhookConfiguration)
 				if !ok {
-					klog.Errorf("Tombstone contained object that is not expected %#v", obj)
+					klog.V(2).Infof("Tombstone contained object that is not expected %#v", obj)
 					return
 				}
 			}

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
@@ -106,10 +106,15 @@ func (v *validatingWebhookConfigurationManager) getConfiguration() ([]webhook.We
 	if err != nil {
 		return []webhook.WebhookAccessor{}, err
 	}
-	return v.smartReloadValidatingWebhookConfigurations(configurations), nil
+	return v.getValidatingWebhookConfigurations(configurations), nil
 }
 
-func (v *validatingWebhookConfigurationManager) smartReloadValidatingWebhookConfigurations(configurations []*v1.ValidatingWebhookConfiguration) []webhook.WebhookAccessor {
+// getMutatingWebhookConfigurations returns the webhook accessors for a given list of
+// mutating webhook configurations.
+//
+// This function will, first, try to load the webhook accessors from the cache and avoid
+// recreating them, which can be expessive (requiring CEL expression recompilation).
+func (v *validatingWebhookConfigurationManager) getValidatingWebhookConfigurations(configurations []*v1.ValidatingWebhookConfiguration) []webhook.WebhookAccessor {
 	sort.SliceStable(configurations, ValidatingWebhookConfigurationSorter(configurations).ByName)
 	accessors := []webhook.WebhookAccessor{}
 	for _, c := range configurations {

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager_test.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -79,5 +80,178 @@ func TestGetValidatingWebhookConfig(t *testing.T) {
 		if !reflect.DeepEqual(h, &webhookConfiguration.Webhooks[i]) {
 			t.Errorf("Expected\n%#v\ngot\n%#v", &webhookConfiguration.Webhooks[i], h)
 		}
+	}
+}
+
+// mockCreateValidatingWebhookAccessor is a struct used to compute how many times
+// the function webhook.NewValidatingWebhookAccessor is being called when refreshing
+// webhookAccessors.
+//
+// NOTE: Maybe there some testing help that we can import and reuse instead.
+type mockCreateValidatingWebhookAccessor struct {
+	numberOfCalls int
+}
+
+func (mock *mockCreateValidatingWebhookAccessor) calledNTimes() int { return mock.numberOfCalls }
+func (mock *mockCreateValidatingWebhookAccessor) resetCounter()     { mock.numberOfCalls = 0 }
+func (mock *mockCreateValidatingWebhookAccessor) incrementCounter() { mock.numberOfCalls++ }
+
+func (mock *mockCreateValidatingWebhookAccessor) fn(uid string, configurationName string, h *v1.ValidatingWebhook) webhook.WebhookAccessor {
+	mock.incrementCounter()
+	return webhook.NewValidatingWebhookAccessor(uid, configurationName, h)
+}
+
+func TestGetValidatingWebhookConfigSmartReload(t *testing.T) {
+	type args struct {
+		createWebhookConfigurations []*v1.ValidatingWebhookConfiguration
+		updateWebhookConfigurations []*v1.ValidatingWebhookConfiguration
+	}
+	tests := []struct {
+		name              string
+		args              args
+		numberOfCreations int
+		// number of refreshes are number of times we pulled a webhook configuration
+		// from the cache without having to create new ones from scratch.
+		numberOfRefreshes int
+	}{
+		{
+			name: "no creations and no updates",
+			args: args{
+				nil,
+				nil,
+			},
+			numberOfCreations: 0,
+			numberOfRefreshes: 0,
+		},
+		{
+			name: "create configurations and no updates",
+			args: args{
+				[]*v1.ValidatingWebhookConfiguration{
+					&v1.ValidatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook1"},
+						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook1.1"}},
+					},
+					&v1.ValidatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook2"},
+						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook2.1"}},
+					},
+				},
+				nil,
+			},
+			numberOfCreations: 2,
+			numberOfRefreshes: 0,
+		},
+		{
+			name: "create configuration and update some of them",
+			args: args{
+				[]*v1.ValidatingWebhookConfiguration{
+					&v1.ValidatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook3"},
+						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook3.1"}},
+					},
+					&v1.ValidatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook4"},
+						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook4.1"}},
+					},
+				},
+				[]*v1.ValidatingWebhookConfiguration{
+					&v1.ValidatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook3"},
+						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook3.1-updated"}},
+					},
+				},
+			},
+			numberOfCreations: 2,
+			numberOfRefreshes: 1,
+		},
+		{
+			name: "create configuration and update moar of them",
+			args: args{
+				[]*v1.ValidatingWebhookConfiguration{
+					&v1.ValidatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook5"},
+						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook5.1"}, {Name: "webhook5.2"}},
+					},
+					&v1.ValidatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook6"},
+						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook6.1"}},
+					},
+					&v1.ValidatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook7"},
+						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook7.1"}, {Name: "webhook7.1"}},
+					},
+				},
+				[]*v1.ValidatingWebhookConfiguration{
+					&v1.ValidatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook5"},
+						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook5.1-updated"}},
+					},
+					&v1.ValidatingWebhookConfiguration{
+						ObjectMeta: metav1.ObjectMeta{Name: "webhook7"},
+						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook7.1-updated"}, {Name: "webhook7.2-updated"}},
+					},
+				},
+			},
+			numberOfCreations: 5,
+			numberOfRefreshes: 3,
+		},
+	}
+
+	client := fake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	stop := make(chan struct{})
+	defer close(stop)
+
+	manager := NewValidatingWebhookConfigurationManager(informerFactory)
+	managerStructPtr := manager.(*validatingWebhookConfigurationManager)
+	fakeWebhookAccessorCreator := &mockCreateValidatingWebhookAccessor{}
+	managerStructPtr.createValidatingWebhookAccessor = fakeWebhookAccessorCreator.fn
+
+	informerFactory.Start(stop)
+	informerFactory.WaitForCacheSync(stop)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create webhooks
+			for _, configurations := range tt.args.createWebhookConfigurations {
+				client.
+					AdmissionregistrationV1().
+					ValidatingWebhookConfigurations().
+					Create(context.TODO(), configurations, metav1.CreateOptions{})
+			}
+			// TODO use channels to wait for manager.createValidatingWebhookAccessor
+			// to be called instead of using time.Sleep
+			time.Sleep(1 * time.Second)
+			_ = manager.Webhooks()
+			// assert creations
+			if tt.numberOfCreations != fakeWebhookAccessorCreator.calledNTimes() {
+				t.Errorf(
+					"Expected number of creations %d received %d",
+					tt.numberOfCreations, fakeWebhookAccessorCreator.calledNTimes(),
+				)
+			}
+			// reset mock counter
+			fakeWebhookAccessorCreator.resetCounter()
+			// Update webhooks
+			for _, configurations := range tt.args.updateWebhookConfigurations {
+				client.
+					AdmissionregistrationV1().
+					ValidatingWebhookConfigurations().
+					Update(context.TODO(), configurations, metav1.UpdateOptions{})
+			}
+			// TODO use channels to wait for manager.createValidatingWebhookAccessor
+			// to be called instead of using time.Sleep
+			time.Sleep(1 * time.Second)
+			_ = manager.Webhooks()
+			// assert updates
+			if tt.numberOfRefreshes != fakeWebhookAccessorCreator.calledNTimes() {
+				t.Errorf(
+					"Expected number of refreshes %d received %d",
+					tt.numberOfRefreshes, fakeWebhookAccessorCreator.calledNTimes(),
+				)
+			}
+			// reset mock counter for the next test cases
+			fakeWebhookAccessorCreator.resetCounter()
+		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager_test.go
@@ -137,11 +137,11 @@ func TestGetValidatingWebhookConfigSmartReload(t *testing.T) {
 			name: "create configurations and no updates",
 			args: args{
 				[]*v1.ValidatingWebhookConfiguration{
-					&v1.ValidatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook1"},
 						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook1.1"}},
 					},
-					&v1.ValidatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook2"},
 						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook2.1"}},
 					},
@@ -156,17 +156,17 @@ func TestGetValidatingWebhookConfigSmartReload(t *testing.T) {
 			name: "create configurations and update some of them",
 			args: args{
 				[]*v1.ValidatingWebhookConfiguration{
-					&v1.ValidatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook3"},
 						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook3.1"}},
 					},
-					&v1.ValidatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook4"},
 						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook4.1"}},
 					},
 				},
 				[]*v1.ValidatingWebhookConfiguration{
-					&v1.ValidatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook3"},
 						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook3.1-updated"}},
 					},
@@ -180,25 +180,25 @@ func TestGetValidatingWebhookConfigSmartReload(t *testing.T) {
 			name: "create configuration and update moar of them",
 			args: args{
 				[]*v1.ValidatingWebhookConfiguration{
-					&v1.ValidatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook5"},
 						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook5.1"}, {Name: "webhook5.2"}},
 					},
-					&v1.ValidatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook6"},
 						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook6.1"}},
 					},
-					&v1.ValidatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook7"},
 						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook7.1"}, {Name: "webhook7.1"}},
 					},
 				},
 				[]*v1.ValidatingWebhookConfiguration{
-					&v1.ValidatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook5"},
 						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook5.1-updated"}},
 					},
-					&v1.ValidatingWebhookConfiguration{
+					{
 						ObjectMeta: metav1.ObjectMeta{Name: "webhook7"},
 						Webhooks:   []v1.ValidatingWebhook{{Name: "webhook7.1-updated"}, {Name: "webhook7.2-updated"}, {Name: "webhook7.3"}},
 					},

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager_test.go
@@ -118,8 +118,8 @@ func TestGetValidatingWebhookConfigSmartReload(t *testing.T) {
 		name              string
 		args              args
 		numberOfCreations int
-		// number of refreshes are number of times we pulled a webhook configuration
-		// from the cache without having to create new ones from scratch.
+		// number of refreshes are number of times we recrated a webhook accessor
+		// instead of pulling from the cache.
 		numberOfRefreshes             int
 		finalNumberOfWebhookAccessors int
 	}{

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/webhook_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/webhook_cache.go
@@ -1,1 +1,0 @@
-package configuration

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/webhook_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/webhook_cache.go
@@ -1,0 +1,1 @@
+package configuration

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
@@ -216,24 +216,6 @@ func NewValidatingWebhookAccessor(uid, configurationName string, h *v1.Validatin
 	return &validatingWebhookAccessor{uid: uid, configurationName: configurationName, ValidatingWebhook: h}
 }
 
-// NOTE: we're thinking about adding a new NewValidatingWebhookAccessorWithOptions to allow
-// recreating webhookAccessor with existing restClient, compiled CELs, selectors etc... to
-// avoid remaking unnecessary expensive operations.
-
-type Options struct {
-	// rest client
-
-	// compiled CELs
-	namespaceSelector labels.Selector
-
-	// selectors...
-}
-
-// NewValidatingWebhookAccessorWithOptions creates an accessor for a ValidatingWebhook.
-func NewValidatingWebhookAccessorWithOptions(uid, configurationName string, h *v1.ValidatingWebhook, opt *Options) WebhookAccessor {
-	return &validatingWebhookAccessor{uid: uid, configurationName: configurationName, ValidatingWebhook: h}
-}
-
 type validatingWebhookAccessor struct {
 	*v1.ValidatingWebhook
 	uid               string

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
@@ -219,10 +219,13 @@ func NewValidatingWebhookAccessor(uid, configurationName string, h *v1.Validatin
 // NOTE: we're thinking about adding a new NewValidatingWebhookAccessorWithOptions to allow
 // recreating webhookAccessor with existing restClient, compiled CELs, selectors etc... to
 // avoid remaking unnecessary expensive operations.
-/*
+
 type Options struct {
 	// rest client
+
 	// compiled CELs
+	namespaceSelector labels.Selector
+
 	// selectors...
 }
 
@@ -230,7 +233,6 @@ type Options struct {
 func NewValidatingWebhookAccessorWithOptions(uid, configurationName string, h *v1.ValidatingWebhook, opt *Options) WebhookAccessor {
 	return &validatingWebhookAccessor{uid: uid, configurationName: configurationName, ValidatingWebhook: h}
 }
-*/
 
 type validatingWebhookAccessor struct {
 	*v1.ValidatingWebhook

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
@@ -123,7 +123,6 @@ func (m *mutatingWebhookAccessor) GetRESTClient(clientManager *webhookutil.Clien
 	return m.client, m.clientErr
 }
 
-// TODO: graduation to beta: resolve the fact that we rebuild ALL items whenever ANY config changes in NewMutatingWebhookConfigurationManager and NewValidatingWebhookConfigurationManager ... now that we're doing CEL compilation, we probably want to avoid that
 func (m *mutatingWebhookAccessor) GetCompiledMatcher(compiler cel.FilterCompiler) matchconditions.Matcher {
 	m.compileMatcher.Do(func() {
 		expressions := make([]cel.ExpressionAccessor, len(m.MutatingWebhook.MatchConditions))

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
@@ -216,6 +216,22 @@ func NewValidatingWebhookAccessor(uid, configurationName string, h *v1.Validatin
 	return &validatingWebhookAccessor{uid: uid, configurationName: configurationName, ValidatingWebhook: h}
 }
 
+// NOTE: we're thinking about adding a new NewValidatingWebhookAccessorWithOptions to allow
+// recreating webhookAccessor with existing restClient, compiled CELs, selectors etc... to
+// avoid remaking unnecessary expensive operations.
+/*
+type Options struct {
+	// rest client
+	// compiled CELs
+	// selectors...
+}
+
+// NewValidatingWebhookAccessorWithOptions creates an accessor for a ValidatingWebhook.
+func NewValidatingWebhookAccessorWithOptions(uid, configurationName string, h *v1.ValidatingWebhook, opt *Options) WebhookAccessor {
+	return &validatingWebhookAccessor{uid: uid, configurationName: configurationName, ValidatingWebhook: h}
+}
+*/
+
 type validatingWebhookAccessor struct {
 	*v1.ValidatingWebhook
 	uid               string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Originally, whenever a new Webhook was created, all the `WebhookAccessors` for all the existing webhooks were recreated as well. This was fine until we started compiling CEL experessions when creating `WebhookAccessors`, making it more costly from a resource usage point of view.

This patch changes `validatingWebhookConfigurationManager` and mutatingWebhookConfigurationManager` to start caching created `WebhookAccessors` and only recreate them when their associated Validating/Mutating webhook is modified

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/116588

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/pull/3978
```
