### PR TITLE
Validate lock identity

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -99,6 +99,11 @@ func NewLeaderElector(lec LeaderElectionConfig) (*LeaderElector, error) {
 	if lec.Lock == nil {
 		return nil, fmt.Errorf("Lock must not be nil.")
 	}
+	id := lec.Lock.Identity()
+	if id == "" {
+		return nil, fmt.Errorf("Lock identity is empty")
+	}
+
 	le := LeaderElector{
 		config:  lec,
 		clock:   clock.RealClock{},


### PR DESCRIPTION
This PR adds one more validation in the leader election client package. Check that the lock identity is not empty. This can cause unexpected issues during leader election, including multiple leaders.

/kind bug

```release-note
NONE
```