### PR TITLE
Automated cherry pick of #117792: kubeadm: Use internal etcd client through an interface
#117724: kubeadm: Make etcd member removal idempotent

### DIFF
--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -118,6 +118,10 @@ func RemoveStackedEtcdMemberFromCluster(client clientset.Interface, cfg *kubeadm
 	klog.V(2).Infof("[etcd] get the member id from peer: %s", etcdPeerAddress)
 	id, err := etcdClient.GetMemberID(etcdPeerAddress)
 	if err != nil {
+		if errors.Is(etcdutil.ErrNoMemberIDForPeerURL, err) {
+			klog.V(5).Infof("[etcd] member was already removed, because no member id exists for peer %s", etcdPeerAddress)
+			return nil
+		}
 		return err
 	}
 

--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -53,6 +53,8 @@ var etcdBackoff = wait.Backoff{
 	Jitter:   0.1,
 }
 
+var ErrNoMemberIDForPeerURL = errors.New("no member id found for peer URL")
+
 // ClusterInterrogator is an interface to get etcd cluster related information
 type ClusterInterrogator interface {
 	CheckClusterHealth() error
@@ -308,7 +310,7 @@ func (c *Client) GetMemberID(peerURL string) (uint64, error) {
 			return member.GetID(), nil
 		}
 	}
-	return 0, nil
+	return 0, ErrNoMemberIDForPeerURL
 }
 
 // ListMembers returns the member list.
@@ -342,6 +344,10 @@ func (c *Client) RemoveMember(id uint64) ([]Member, error) {
 		resp, err = cli.MemberRemove(ctx, id)
 		cancel()
 		if err == nil {
+			return true, nil
+		}
+		if errors.Is(rpctypes.ErrMemberNotFound, err) {
+			klog.V(5).Infof("Member was already removed, because member %016x was not found", id)
 			return true, nil
 		}
 		klog.V(5).Infof("Failed to remove etcd member: %v", err)

--- a/cmd/kubeadm/app/util/etcd/etcd_test.go
+++ b/cmd/kubeadm/app/util/etcd/etcd_test.go
@@ -423,7 +423,7 @@ func TestClient_GetMemberID(t *testing.T) {
 		fields  fields
 		args    args
 		want    uint64
-		wantErr bool
+		wantErr error
 	}{
 		{
 			name: "member ID found",
@@ -447,7 +447,7 @@ func TestClient_GetMemberID(t *testing.T) {
 			args: args{
 				peerURL: "https://member1:2380",
 			},
-			wantErr: false,
+			wantErr: nil,
 			want:    1,
 		},
 		{
@@ -472,7 +472,7 @@ func TestClient_GetMemberID(t *testing.T) {
 			args: args{
 				peerURL: "https://member2:2380",
 			},
-			wantErr: false,
+			wantErr: ErrNoMemberIDForPeerURL,
 			want:    0,
 		},
 	}
@@ -484,7 +484,7 @@ func TestClient_GetMemberID(t *testing.T) {
 			}
 
 			got, err := c.GetMemberID(tt.args.peerURL)
-			if (err != nil) != tt.wantErr {
+			if !errors.Is(tt.wantErr, err) {
 				t.Errorf("Client.GetMemberID() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}

--- a/cmd/kubeadm/app/util/etcd/etcd_test.go
+++ b/cmd/kubeadm/app/util/etcd/etcd_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package etcd
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -24,6 +25,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -35,9 +38,64 @@ import (
 	testresources "k8s.io/kubernetes/cmd/kubeadm/test/resources"
 )
 
+var errNotImplemented = errors.New("not implemented")
+
+type fakeEtcdClient struct {
+	members   []*pb.Member
+	endpoints []string
+}
+
+// Close shuts down the client's etcd connections.
+func (f *fakeEtcdClient) Close() error {
+	f.members = []*pb.Member{}
+	return nil
+}
+
+// Endpoints lists the registered endpoints for the client.
+func (f *fakeEtcdClient) Endpoints() []string {
+	return f.endpoints
+}
+
+// MemberList lists the current cluster membership.
+func (f *fakeEtcdClient) MemberList(_ context.Context) (*clientv3.MemberListResponse, error) {
+	return &clientv3.MemberListResponse{
+		Members: f.members,
+	}, nil
+}
+
+// MemberAdd adds a new member into the cluster.
+func (f *fakeEtcdClient) MemberAdd(_ context.Context, peerAddrs []string) (*clientv3.MemberAddResponse, error) {
+	return nil, errNotImplemented
+}
+
+// MemberAddAsLearner adds a new learner member into the cluster.
+func (f *fakeEtcdClient) MemberAddAsLearner(_ context.Context, peerAddrs []string) (*clientv3.MemberAddResponse, error) {
+	return nil, errNotImplemented
+}
+
+// MemberRemove removes an existing member from the cluster.
+func (f *fakeEtcdClient) MemberRemove(_ context.Context, id uint64) (*clientv3.MemberRemoveResponse, error) {
+	return nil, errNotImplemented
+}
+
+// MemberPromote promotes a member from raft learner (non-voting) to raft voting member.
+func (f *fakeEtcdClient) MemberPromote(_ context.Context, id uint64) (*clientv3.MemberPromoteResponse, error) {
+	return nil, errNotImplemented
+}
+
+// Status gets the status of the endpoint.
+func (f *fakeEtcdClient) Status(_ context.Context, endpoint string) (*clientv3.StatusResponse, error) {
+	return nil, errNotImplemented
+}
+
+// Sync synchronizes client's endpoints with the known endpoints from the etcd membership.
+func (f *fakeEtcdClient) Sync(_ context.Context) error {
+	return errNotImplemented
+}
+
 func testGetURL(t *testing.T, getURLFunc func(*kubeadmapi.APIEndpoint) string, port int) {
 	portStr := strconv.Itoa(port)
-	var tests = []struct {
+	tests := []struct {
 		name             string
 		advertiseAddress string
 		expectedURL      string
@@ -82,7 +140,7 @@ func TestGetPeerURL(t *testing.T) {
 
 func TestGetClientURLByIP(t *testing.T) {
 	portStr := strconv.Itoa(constants.EtcdListenClientPort)
-	var tests = []struct {
+	tests := []struct {
 		name        string
 		ip          string
 		expectedURL string
@@ -118,7 +176,7 @@ func TestGetClientURLByIP(t *testing.T) {
 }
 
 func TestGetEtcdEndpointsWithBackoff(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name              string
 		pods              []testresources.FakeStaticPod
 		expectedEndpoints []string
@@ -169,7 +227,7 @@ func TestGetEtcdEndpointsWithBackoff(t *testing.T) {
 }
 
 func TestGetRawEtcdEndpointsFromPodAnnotation(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name              string
 		pods              []testresources.FakeStaticPod
 		clientSetup       func(*clientsetfake.Clientset)
@@ -253,7 +311,7 @@ func TestGetRawEtcdEndpointsFromPodAnnotation(t *testing.T) {
 }
 
 func TestGetRawEtcdEndpointsFromPodAnnotationWithoutRetry(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		name              string
 		pods              []testresources.FakeStaticPod
 		clientSetup       func(*clientsetfake.Clientset)
@@ -347,6 +405,91 @@ func TestGetRawEtcdEndpointsFromPodAnnotationWithoutRetry(t *testing.T) {
 			}
 			if !reflect.DeepEqual(endpoints, rt.expectedEndpoints) {
 				t.Errorf("expected etcd endpoints: %v; got: %v", rt.expectedEndpoints, endpoints)
+			}
+		})
+	}
+}
+
+func TestClient_GetMemberID(t *testing.T) {
+	type fields struct {
+		Endpoints     []string
+		newEtcdClient func(endpoints []string) (etcdClient, error)
+	}
+	type args struct {
+		peerURL string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    uint64
+		wantErr bool
+	}{
+		{
+			name: "member ID found",
+			fields: fields{
+				Endpoints: []string{},
+				newEtcdClient: func(endpoints []string) (etcdClient, error) {
+					f := &fakeEtcdClient{
+						members: []*pb.Member{
+							{
+								ID:   1,
+								Name: "member1",
+								PeerURLs: []string{
+									"https://member1:2380",
+								},
+							},
+						},
+					}
+					return f, nil
+				},
+			},
+			args: args{
+				peerURL: "https://member1:2380",
+			},
+			wantErr: false,
+			want:    1,
+		},
+		{
+			name: "member ID not found",
+			fields: fields{
+				Endpoints: []string{},
+				newEtcdClient: func(endpoints []string) (etcdClient, error) {
+					f := &fakeEtcdClient{
+						members: []*pb.Member{
+							{
+								ID:   1,
+								Name: "member1",
+								PeerURLs: []string{
+									"https://member1:2380",
+								},
+							},
+						},
+					}
+					return f, nil
+				},
+			},
+			args: args{
+				peerURL: "https://member2:2380",
+			},
+			wantErr: false,
+			want:    0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				Endpoints:     tt.fields.Endpoints,
+				newEtcdClient: tt.fields.newEtcdClient,
+			}
+
+			got, err := c.GetMemberID(tt.args.peerURL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Client.GetMemberID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Client.GetMemberID() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #117792 #117724 on release-1.25.

#117792: kubeadm: Use internal etcd client through an interface
#117724: kubeadm: Make etcd member removal idempotent

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
If `kubeadm reset` finds no etcd member ID for the peer it removes during the `remove-etcd-member` phase, it continues immediately to other phases, instead of retrying the phase for up to 3 minutes before continuing.
```