### PR TITLE
fix: move to `dl.k8s.io` from `kubernetes-release` bucket

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -288,12 +288,7 @@ function load-or-gen-kube-basicauth() {
 #   KUBE_VERSION
 function set_binary_version() {
   if [[ "${1}" =~ "/" ]]; then
-    IFS='/' read -r -a path <<< "${1}"
-    if [[ "${path[0]}" == "release" ]]; then
-      KUBE_VERSION=$(gsutil cat "gs://kubernetes-release/${1}.txt")
-    else
-      KUBE_VERSION=$(gsutil cat "gs://k8s-release-dev/${1}.txt")
-    fi
+    KUBE_VERSION=$(curl -sL "https://dl.k8s.io/${1}.txt")
   else
     KUBE_VERSION=${1}
   fi

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -61,9 +61,9 @@ function usage() {
   local release_latest
   local ci_latest
 
-  release_stable=$(gsutil cat gs://kubernetes-release/release/stable.txt)
-  release_latest=$(gsutil cat gs://kubernetes-release/release/latest.txt)
-  ci_latest=$(gsutil cat gs://k8s-release-dev/ci/latest.txt)
+  release_stable=$(curl -sL https://dl.k8s.io/release/stable.txt)
+  release_latest=$(curl -sL https://dl.k8s.io/release/latest.txt)
+  ci_latest=$(curl -sL https://dl.k8s.io/ci/latest.txt)
 
   echo "Right now, versions are as follows:"
   echo "  release/stable: ${0} ${release_stable}"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
There are still references to gcs buckets instead of https://dl.k8s.io/

dl.k8s.io is the correct advertised download host and will eventually move to be fastly shielding a fully community-owned bucket

ref: https://github.com/kubernetes/k8s.io/issues/2396

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

/priority important-soon
/milestone v1.28
