### PR TITLE
belated cleanup of some kube-proxy stuff for old versions

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -384,10 +384,9 @@ var iptablesKubeletJumpChains = []iptablesJumpChain{
 	{utiliptables.TableNAT, kubePostroutingChain, utiliptables.ChainPostrouting, "kubernetes postrouting rules", nil},
 }
 
-var iptablesCleanupOnlyChains = []iptablesJumpChain{
-	// Present in kube 1.13 - 1.19. Removed by #95252 in favor of adding reject rules for incoming/forwarding packets to kubeExternalServicesChain
-	{utiliptables.TableFilter, kubeServicesChain, utiliptables.ChainInput, "kubernetes service portals", []string{"-m", "conntrack", "--ctstate", "NEW"}},
-}
+// When chains get removed from iptablesJumpChains, add them here so they get cleaned up
+// on upgrade.
+var iptablesCleanupOnlyChains = []iptablesJumpChain{}
 
 // CleanupLeftovers removes all iptables rules and chains created by the Proxier
 // It returns true if an error was encountered. Errors are logged.
@@ -683,9 +682,6 @@ const (
 	serviceFirewallChainNamePrefix          = "KUBE-FW-"
 	serviceExternalChainNamePrefix          = "KUBE-EXT-"
 	servicePortEndpointChainNamePrefix      = "KUBE-SEP-"
-
-	// For cleanup.  This can be removed after 1.26 is released.
-	deprecatedServiceLBChainNamePrefix = "KUBE-XLB-"
 )
 
 // servicePortPolicyClusterChain returns the name of the KUBE-SVC-XXXX chain for a service, which is the
@@ -731,7 +727,6 @@ func isServiceChainName(chainString string) bool {
 		servicePortEndpointChainNamePrefix,
 		serviceFirewallChainNamePrefix,
 		serviceExternalChainNamePrefix,
-		deprecatedServiceLBChainNamePrefix,
 	}
 
 	for _, p := range prefixes {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig network
/priority backlog

#### What this PR does / why we need it:
Just removes some stuff that was needed in older releases to ensure old iptables chains got removed during upgrades

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
