### PR TITLE
Automated cherry pick of #118069: kubeadm: fix a bug where the static pod changes detection

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -630,6 +630,35 @@ spec:
   - image: gcr.io/google_containers/etcd-amd64:3.1.11
 status: {}
 `
+	validPodWithDifferentFieldsOrder = `
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    tier: control-plane
+    component: etcd
+  name: etcd
+  namespace: kube-system
+spec:
+  containers:
+  - image: gcr.io/google_containers/etcd-amd64:3.1.11
+status: {}
+`
+	validPod2 = `
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: etcd
+    tier: control-plane
+  name: etcd
+  namespace: kube-system
+spec:
+  containers:
+  - image: gcr.io/google_containers/etcd-amd64:3.1.12
+status: {}
+`
+
 	invalidPod = `---{ broken yaml @@@`
 )
 
@@ -701,8 +730,14 @@ func TestManifestFilesAreEqual(t *testing.T) {
 			expectErr:      false,
 		},
 		{
+			description:    "manifests are equal, ignore different fields order",
+			podYamls:       []string{validPod, validPodWithDifferentFieldsOrder},
+			expectedResult: true,
+			expectErr:      false,
+		},
+		{
 			description:    "manifests are not equal",
-			podYamls:       []string{validPod, validPod + "\n"},
+			podYamls:       []string{validPod, validPod2},
 			expectedResult: false,
 			expectErr:      false,
 		},


### PR DESCRIPTION
Cherry pick of #118069 on release-1.27.

#118069: kubeadm: fix a bug where the static pod changes detection

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```