### PR TITLE
Automated cherry pick of #118069: kubeadm: fix a bug where the static pod changes detection

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -18,7 +18,9 @@ package staticpod
 
 import (
 	"bytes"
+	"crypto/md5"
 	"fmt"
+	"hash"
 	"io"
 	"math"
 	"net/url"
@@ -27,6 +29,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 
 	v1 "k8s.io/api/core/v1"
@@ -347,16 +350,22 @@ func GetEtcdProbeEndpoint(cfg *kubeadmapi.Etcd, isIPv6 bool) (string, int, v1.UR
 
 // ManifestFilesAreEqual compares 2 files. It returns true if their contents are equal, false otherwise
 func ManifestFilesAreEqual(path1, path2 string) (bool, error) {
-	content1, err := os.ReadFile(path1)
+	pod1, err := ReadStaticPodFromDisk(path1)
 	if err != nil {
 		return false, err
 	}
-	content2, err := os.ReadFile(path2)
+	pod2, err := ReadStaticPodFromDisk(path2)
 	if err != nil {
 		return false, err
 	}
 
-	return bytes.Equal(content1, content2), nil
+	hasher := md5.New()
+	DeepHashObject(hasher, pod1)
+	hash1 := hasher.Sum(nil)[0:]
+	DeepHashObject(hasher, pod2)
+	hash2 := hasher.Sum(nil)[0:]
+
+	return bytes.Equal(hash1, hash2), nil
 }
 
 // getProbeAddress returns a valid probe address.
@@ -378,4 +387,19 @@ func GetUsersAndGroups() (*users.UsersAndGroups, error) {
 		usersAndGroups, err = users.AddUsersAndGroups()
 	})
 	return usersAndGroups, err
+}
+
+// DeepHashObject writes specified object to hash using the spew library
+// which follows pointers and prints actual values of the nested objects
+// ensuring the hash does not change when a pointer changes.
+// Copied from k8s.io/kubernetes/pkg/util/hash/hash.go#DeepHashObject
+func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
+	hasher.Reset()
+	printer := spew.ConfigState{
+		Indent:         " ",
+		SortKeys:       true,
+		DisableMethods: true,
+		SpewKeys:       true,
+	}
+	printer.Fprintf(hasher, "%#v", objectToWrite)
 }

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -627,6 +627,35 @@ spec:
   - image: gcr.io/google_containers/etcd-amd64:3.1.11
 status: {}
 `
+	validPodWithDifferentFieldsOrder = `
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    tier: control-plane
+    component: etcd
+  name: etcd
+  namespace: kube-system
+spec:
+  containers:
+  - image: gcr.io/google_containers/etcd-amd64:3.1.11
+status: {}
+`
+	validPod2 = `
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: etcd
+    tier: control-plane
+  name: etcd
+  namespace: kube-system
+spec:
+  containers:
+  - image: gcr.io/google_containers/etcd-amd64:3.1.12
+status: {}
+`
+
 	invalidPod = `---{ broken yaml @@@`
 )
 
@@ -698,8 +727,14 @@ func TestManifestFilesAreEqual(t *testing.T) {
 			expectErr:      false,
 		},
 		{
+			description:    "manifests are equal, ignore different fields order",
+			podYamls:       []string{validPod, validPodWithDifferentFieldsOrder},
+			expectedResult: true,
+			expectErr:      false,
+		},
+		{
 			description:    "manifests are not equal",
-			podYamls:       []string{validPod, validPod + "\n"},
+			podYamls:       []string{validPod, validPod2},
 			expectedResult: false,
 			expectErr:      false,
 		},


### PR DESCRIPTION
Cherry pick of #118069 on release-1.26.

#118069: kubeadm: fix a bug where the static pod changes detection

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```