### PR TITLE
Update cluster/gce OWNERS to include sig-node members 

### DIFF
--- a/cluster/gce/OWNERS
+++ b/cluster/gce/OWNERS
@@ -5,15 +5,17 @@ reviewers:
   - cjcullen
   - mwielgus
   - yujuhong
-  - mtaufen
+  - SergeyKanzhelev
   - ibabou
+  - ndixita
   - sig-scalability-reviewers
 approvers:
+  - bobbypage
   - bowei
   - cjcullen
   - mwielgus
+  - SergeyKanzhelev
   - yujuhong
-  - mtaufen
   - ibabou
   - sig-scalability-approvers
 emeritus_approvers:


### PR DESCRIPTION
The changes in here are routed to members who are not actively involved in maintaining the scripts. Adding some sig node members as owners. 
/kind cleanup
