### PR TITLE
Mark grpc-gateway v1 as an unwanted dependency

### DIFF
--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -20,6 +20,7 @@
       "github.com/gorilla/rpc": "unmaintained, archive mode",
       "github.com/gorilla/schema": "unmaintained, archive mode",
       "github.com/gorilla/websocket": "unmaintained, archive mode",
+      "github.com/grpc-ecosystem/grpc-gateway": "use github.com/grpc-ecosystem/grpc-gateway/v2",
       "github.com/hashicorp/consul": "MPL license not in CNCF allowlist",
       "github.com/hashicorp/errwrap": "MPL license not in CNCF allowlist",
       "github.com/hashicorp/go-immutable-radix": "MPL license not in CNCF allowlist",
@@ -82,6 +83,10 @@
       "github.com/gorilla/websocket": [
         "github.com/moby/spdystream",
         "github.com/tmc/grpc-websocket-proxy",
+        "go.etcd.io/etcd/server/v3"
+      ],
+      "github.com/grpc-ecosystem/grpc-gateway": [
+        "go.etcd.io/etcd/api/v3",
         "go.etcd.io/etcd/server/v3"
       ],
       "github.com/json-iterator/go": [


### PR DESCRIPTION
#### What type of PR is this?

xref #113366 

used by etcd libs, but adds transitive dependencies to genproto field_mask packages, and will be difficult to update since grpc-gateway v2 is the maintained branch now

eliminating this dependency will be easier than updating it, so make sure we don't pick up new references

```release-note
NONE
```

cc @dims 