### PR TITLE
Add missing /metrics rbac for metrics-server

### DIFF
--- a/cluster/addons/metrics-server/resource-reader.yaml
+++ b/cluster/addons/metrics-server/resource-reader.yaml
@@ -19,6 +19,10 @@ rules:
       - get
       - list
       - watch
+  - nonResourceURLs:
+    - /metrics
+    verbs:
+    - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
It has been dropped in https://github.com/kubernetes/kubernetes/pull/117120, but it's still needed as pod_nanny is using /metrics to get number of nodes.

WIthout that, we see a lot of 403s in the logs:
```
➜  latest grep nanny kube-apiserver.log
I0517 17:09:42.416260      11 httplog.go:132] "HTTP" verb="GET" URI="/metrics" latency="395.912µs" userAgent="pod_nanny/1.8.14" audit-ID="c22e16af-03da-4ca2-b314-da1b018ed15d" srcIP="10.64.1.5:52092" apf_pl="workload-high" apf_fs="kube-system-service-accounts" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_execution_time="101.716µs" resp=403
I0517 17:10:12.516158      11 httplog.go:132] "HTTP" verb="GET" URI="/metrics" latency="567.486µs" userAgent="pod_nanny/1.8.14" audit-ID="e7b31723-4d60-4339-8769-911188ff95e7" srcIP="10.64.1.5:52092" apf_pl="workload-high" apf_fs="kube-system-service-accounts" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_execution_time="187.707µs" resp=403
I0517 17:10:42.517920      11 httplog.go:132] "HTTP" verb="GET" URI="/metrics" latency="554.668µs" userAgent="pod_nanny/1.8.14" audit-ID="5b4e4c63-bb9f-4293-bd2d-2e62409adc95" srcIP="10.64.1.5:52092" apf_pl="workload-high" apf_fs="kube-system-service-accounts" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_execution_time="133.04µs" resp=403
I0517 17:11:12.519884      11 httplog.go:132] "HTTP" verb="GET" URI="/metrics" latency="447.983µs" userAgent="pod_nanny/1.8.14" audit-ID="1154d19e-7b22-4fec-afa3-a355a53fe1da" srcIP="10.64.1.5:52092" apf_pl="workload-high" apf_fs="kube-system-service-accounts" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_execution_time="74.523µs" resp=403
I0517 17:11:42.525213      11 httplog.go:132] "HTTP" verb="GET" URI="/metrics" latency="415.112µs" userAgent="pod_nanny/1.8.14" audit-ID="bc3da8bf-2ae7-40af-a5a7-86e3123ee9a4" srcIP="10.64.1.5:52092" apf_pl="workload-high" apf_fs="kube-system-service-accounts" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_execution_time="137.509µs" resp=403
I0517 17:12:12.528229      11 httplog.go:132] "HTTP" verb="GET" URI="/metrics" latency="506.312µs" userAgent="pod_nanny/1.8.14" audit-ID="6259b896-33c0-4a7a-9bbd-7e50ca52c304" srcIP="10.64.1.5:52092" apf_pl="workload-high" apf_fs="kube-system-service-accounts" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_execution_time="102.895µs" resp=403
I0517 17:12:42.530172      11 httplog.go:132] "HTTP" verb="GET" URI="/metrics" latency="375.156µs" userAgent="pod_nanny/1.8.14" audit-ID="5fc6a91b-8a21-409c-bb5e-5b61f35d867d" srcIP="10.64.1.5:52092" apf_pl="workload-high" apf_fs="kube-system-service-accounts" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_execution_time="107.313µs" resp=403
I0517 17:13:12.532099      11 httplog.go:132] "HTTP" verb="GET" URI="/metrics" latency="305.642µs" userAgent="pod_nanny/1.8.14" audit-ID="649279ae-c9aa-4bd8-90f2-0fbd8e58c9f5" srcIP="10.64.1.5:52092" apf_pl="workload-high" apf_fs="kube-system-service-accounts" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_execution_time="100.109µs" resp=403
I0517 17:13:42.542181      11 httplog.go:132] "HTTP" verb="GET" URI="/metrics" latency="765.602µs" userAgent="pod_nanny/1.8.14" audit-ID="550d8190-cca6-42d7-81c7-0441b6912d3e" srcIP="10.64.1.5:52092" apf_pl="workload-high" apf_fs="kube-system-service-accounts" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_execution_time="234.628µs" resp=403
I0517 17:14:12.543649      11 httplog.go:132] "HTTP" verb="GET" URI="/metrics" latency="397.699µs" userAgent="pod_nanny/1.8.14" audit-ID="a75ba781-c795-43d2-9fd0-eaf589eafe43" srcIP="10.64.1.5:52092" apf_pl="workload-high" apf_fs="kube-system-service-accounts" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_execution_time="112.211µs" resp=403
I0517 17:14:42.545270      11 httplog.go:132] "HTTP" verb="GET" URI="/metrics" latency="376.4µs" userAgent="pod_nanny/1.8.14" audit-ID="c653face-6bcd-402e-a47c-a09a2fce1071" srcIP="10.64.1.5:52092" apf_pl="workload-high" apf_fs="kube-system-service-accounts" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_execution_time="105.94µs" resp=403
(..)
I0517 18:50:13.694973      11 httplog.go:132] "HTTP" verb="GET" URI="/metrics" latency="1.123175ms" userAgent="pod_nanny/1.8.14" audit-ID="8542e761-394d-46f8-90a0-ca330987eb63" srcIP="10.64.1.5:52092" apf_pl="workload-high" apf_fs="kube-system-service-accounts" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_execution_time="120.336µs" resp=403
```

/kind bug
```release-note
NONE
```