### PR TITLE
test/e2e: remove redundunt type conversion, unused variable...etc

### DIFF
--- a/test/images/agnhost/connect/connect.go
+++ b/test/images/agnhost/connect/connect.go
@@ -111,7 +111,7 @@ func connectSCTP(dest string, timeout time.Duration) {
 	}
 
 	timeoutCh := time.After(timeout)
-	errCh := make(chan (error))
+	errCh := make(chan error)
 
 	go func() {
 		conn, err := sctp.DialSCTP("sctp", nil, addr)

--- a/test/images/agnhost/openidmetadata/openidmetadata.go
+++ b/test/images/agnhost/openidmetadata/openidmetadata.go
@@ -29,7 +29,7 @@ import (
 	"runtime"
 	"time"
 
-	oidc "github.com/coreos/go-oidc"
+	"github.com/coreos/go-oidc"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 	"gopkg.in/square/go-jose.v2/jwt"

--- a/test/images/agnhost/webhook/addlabel_test.go
+++ b/test/images/agnhost/webhook/addlabel_test.go
@@ -61,7 +61,7 @@ func TestAddLabel(t *testing.T) {
 			review := v1.AdmissionReview{Request: &v1.AdmissionRequest{Object: runtime.RawExtension{Raw: raw}}}
 			response := addLabel(review)
 			if response.Patch != nil {
-				patchObj, err := jsonpatch.DecodePatch([]byte(response.Patch))
+				patchObj, err := jsonpatch.DecodePatch(response.Patch)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/images/resource-consumer/common/common.go
+++ b/test/images/resource-consumer/common/common.go
@@ -37,6 +37,4 @@ const (
 	UnknownFunction           = "unknown function"
 	IncorrectFunctionArgument = "incorrect function argument"
 	NotGivenFunctionArgument  = "not given function argument"
-
-	FrameworkName = "horizontal-pod-autoscaling"
 )


### PR DESCRIPTION
`Framework` variable has been removed from test/*
unwanted `[]byte` conversion has been removed
import alias has been avoided


/kind cleanup

```release-note
NONE
```

