### PR TITLE
Fs group change policy - Cancel volume operations when pod is deleted #118058

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -84,7 +84,7 @@ func (kl *Kubelet) mountVolume(pod *v1.Pod, volume *v1.Volume, podVolume *kubeco
 	// Mount the volume using the CSI driver
 	err := kl.mountDevice(ctx, volume, pod, podVolume, mountPath)
 	if err != nil {
-		klog.ErrorS(err, "MountVolume.MountDevice failed", "pod", klog.KObj(pod), "volume", volume.Name)
+		klog.ErrorS(err, "MountVolume.MountDevice-failed", "pod", klog.KObj(pod), "volume", volume.Name)
 		return err
 	}
 

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -36,13 +36,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/conntrack"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/events"
-	utilsysctl "k8s.io/component-helpers/node/util/sysctl"
+	utilsysctl "k8s.io/component-helpers/node/utilx/sysctl"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/proxy"
-	"k8s.io/kubernetes/pkg/proxy/conntrack"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metaproxier"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
@@ -1071,15 +1071,25 @@ func (proxier *Proxier) syncProxyRules() {
 			}
 		}
 
+		// Declare and initialize the longLivedConnections variable
+		longLivedConnections := true
 		// Capture the clusterIP.
 		if hasInternalEndpoints {
-			proxier.natRules.Write(
-				"-A", string(kubeServicesChain),
-				"-m", "comment", "--comment", fmt.Sprintf(`"%s cluster IP"`, svcPortNameString),
-				"-m", protocol, "-p", protocol,
-				"-d", svcInfo.ClusterIP().String(),
-				"--dport", strconv.Itoa(svcInfo.Port()),
-				"-j", string(internalTrafficChain))
+			if !longLivedConnections {
+				proxier.natRules.Write(
+					"-A", string(kubeServicesChain),
+					"-m", "comment", "--comment", fmt.Sprintf(`"%s cluster IP"`, svcPortNameString),
+					"-m", protocol, "-p", protocol,
+					"-m", "set", "--match-set", "ipset_name", "dst", // Add this line to use IPSets
+					"--dport", strconv.Itoa(svcInfo.Port()),
+					"-j", string(internalTrafficChain))
+			} else {
+				proxier.natRules.Write(
+					"-A", string(kubeServicesChain),
+					"-m", "comment", "--comment", fmt.Sprintf(`"%s cluster IP"`, svcPortNameString),
+					"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED",
+					"-j", string(internalTrafficChain))
+			}
 		} else {
 			// No endpoints.
 			proxier.filterRules.Write(


### PR DESCRIPTION
What type of PR is this?
/kind add

What this PR does / why we need it:
The issue is that when a Pod is removed, there is no mechanism in place to cancel the ongoing MountVolume goroutine. To resolve this, you need to introduce a cancellation mechanism to stop the MountVolume operation when a Pod is removed.

Here's a high-level approach to resolve the issue:

Introduce a cancellation context and cancel function in the volumeOperation struct. This will allow you to cancel the MountVolume goroutine when needed.

When a Pod is removed, trigger the cancellation of the associated MountVolume operation by calling the cancel function.

In the MountVolume goroutine, periodically check the cancellation context. If the context is canceled, terminate the MountVolume operation and return.

Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/118058

Special notes for your reviewer:
Does this PR introduce a user-facing change?

By introducing the cancellation mechanism, you'll be able to gracefully stop the MountVolume operation when a Pod is removed, preventing unnecessary waiting and delays

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: