### PR TITLE
#118135 replace gogo/protobuf and golang/protobuf with google

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -28,8 +28,7 @@ import (
 	"sync"
 	"time"
 
-	//nolint:staticcheck // SA1019 Keep using module since it's still being maintained and the api of google.golang.org/protobuf/proto differs
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 	openapi_v2 "github.com/google/gnostic/openapiv2"
 
 	apidiscovery "k8s.io/api/apidiscovery/v2beta1"

--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -25,13 +25,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	openapi_v2 "github.com/google/gnostic/openapiv2"
 	openapi_v3 "github.com/google/gnostic/openapiv3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	golangproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 	apidiscovery "k8s.io/api/apidiscovery/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -589,7 +588,7 @@ func TestGetOpenAPISchema(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting openapi: %v", err)
 	}
-	if e, a := returnedOpenAPI(), got; !golangproto.Equal(e, a) {
+	if e, a := returnedOpenAPI(), got; !proto.Equal(e, a) {
 		t.Errorf("expected \n%v, got \n%v", e, a)
 	}
 }
@@ -647,7 +646,7 @@ func TestGetOpenAPISchemaV3(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					expectedPB, err := golangproto.Marshal(expectedGnostic)
+					expectedPB, err := proto.Marshal(expectedGnostic)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -685,7 +684,7 @@ func TestGetOpenAPISchemaForbiddenFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting openapi: %v", err)
 	}
-	if e, a := returnedOpenAPI(), got; !golangproto.Equal(e, a) {
+	if e, a := returnedOpenAPI(), got; !proto.Equal(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 }
@@ -702,7 +701,7 @@ func TestGetOpenAPISchemaNotFoundFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting openapi: %v", err)
 	}
-	if e, a := returnedOpenAPI(), got; !golangproto.Equal(e, a) {
+	if e, a := returnedOpenAPI(), got; !proto.Equal(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 }
@@ -719,7 +718,7 @@ func TestGetOpenAPISchemaNotAcceptableFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting openapi: %v", err)
 	}
-	if e, a := returnedOpenAPI(), got; !golangproto.Equal(e, a) {
+	if e, a := returnedOpenAPI(), got; !proto.Equal(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 }

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -6,9 +6,7 @@ go 1.20
 
 require (
 	github.com/evanphx/json-patch v4.12.0+incompatible
-	github.com/gogo/protobuf v1.3.2
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
-	github.com/golang/protobuf v1.5.3
 	github.com/google/gnostic v0.5.7-v3refs
 	github.com/google/go-cmp v0.5.9
 	github.com/google/gofuzz v1.2.0
@@ -40,6 +38,8 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.1 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Replace deprecated gogo/golang protobuf with google protobuf

#### Which issue(s) this PR fixes:
#118135

#### Special notes for your reviewer:
I think we can do replacing without problem. All tests passed.