### PR TITLE
deprecate CephFS plugin from available in-tree drivers.

### DIFF
--- a/pkg/api/persistentvolume/util.go
+++ b/pkg/api/persistentvolume/util.go
@@ -79,6 +79,10 @@ func warningsForPersistentVolumeSpecAndMeta(fieldPath *field.Path, pvSpec *api.P
 			warnings = append(warnings, nodeapi.GetWarningsForNodeSelectorTerm(term, termFldPath.Index(i))...)
 		}
 	}
+	// If we are on deprecated volume plugin
+	if pvSpec.CephFS != nil {
+		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.28, non-functional in v1.31+", fieldPath.Child("spec", "persistentVolumeSource").Child("cephfs")))
+	}
 
 	return warnings
 }

--- a/pkg/api/persistentvolume/util_test.go
+++ b/pkg/api/persistentvolume/util_test.go
@@ -176,6 +176,26 @@ func TestWarnings(t *testing.T) {
 				`spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[0].key: beta.kubernetes.io/os is deprecated since v1.14; use "kubernetes.io/os" instead`,
 			},
 		},
+		{
+			name: "PV CephFS deprecation warning",
+			template: &api.PersistentVolume{
+				Spec: api.PersistentVolumeSpec{
+					PersistentVolumeSource: api.PersistentVolumeSource{
+						CephFS: &api.CephFSPersistentVolumeSource{
+							Monitors:   nil,
+							Path:       "",
+							User:       "",
+							SecretFile: "",
+							SecretRef:  nil,
+							ReadOnly:   false,
+						},
+					},
+				},
+			},
+			expected: []string{
+				`spec.persistentVolumeSource.cephfs: deprecated in v1.28, non-functional in v1.31+`,
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/api/pod/warnings.go
+++ b/pkg/api/pod/warnings.go
@@ -160,6 +160,9 @@ func warningsForPodSpecAndMeta(fieldPath *field.Path, podSpec *api.PodSpec, meta
 		if v.Ephemeral != nil && v.Ephemeral.VolumeClaimTemplate != nil {
 			warnings = append(warnings, pvcutil.GetWarningsForPersistentVolumeClaimSpec(fieldPath.Child("spec", "volumes").Index(i).Child("ephemeral").Child("volumeClaimTemplate").Child("spec"), v.Ephemeral.VolumeClaimTemplate.Spec)...)
 		}
+		if v.CephFS != nil {
+			warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.28, non-functional in v1.31+", fieldPath.Child("spec", "volumes").Index(i).Child("cephfs")))
+		}
 	}
 
 	// duplicate hostAliases (#91670, #58477)

--- a/pkg/api/pod/warnings_test.go
+++ b/pkg/api/pod/warnings_test.go
@@ -214,7 +214,16 @@ func TestWarnings(t *testing.T) {
 				}},
 			},
 			expected: []string{`spec.volumes[0].glusterfs: deprecated in v1.25, non-functional in v1.26+`},
+		}, {
+			name: "CephFS",
+			template: &api.PodTemplateSpec{Spec: api.PodSpec{
+				Volumes: []api.Volume{
+					{Name: "s", VolumeSource: api.VolumeSource{CephFS: &api.CephFSVolumeSource{}}},
+				}},
+			},
+			expected: []string{`spec.volumes[0].cephfs: deprecated in v1.28, non-functional in v1.31+`},
 		},
+
 		{
 			name: "duplicate hostAlias",
 			template: &api.PodTemplateSpec{Spec: api.PodSpec{


### PR DESCRIPTION
Based on https://groups.google.com/a/kubernetes.io/g/dev/c/g8rwL-qnQhk , the consensus was to start the deprecation in v1.28.

This commit start the deprecation process of CephFS plugin from in-tree drivers.


/kind cleanup

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
ACTION REQUIRED:  
CephFS volume plugin ( `kubernetes.io/cephfs`) has been deprecated in this release and will be removed in a subsequent release. Alternative is to use CephFS CSI driver (https://github.com/ceph/ceph-csi/) in your Kubernetes Cluster.
```

