### PR TITLE
AllowCreateOnUpdate should use resource's settings

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -557,7 +557,7 @@ func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObj
 	out := e.NewFunc()
 	// deleteObj is only used in case a deletion is carried out
 	var deleteObj runtime.Object
-	err = e.Storage.GuaranteedUpdate(ctx, key, out, true, storagePreconditions, func(existing runtime.Object, res storage.ResponseMeta) (runtime.Object, *uint64, error) {
+	err = e.Storage.GuaranteedUpdate(ctx, key, out, e.UpdateStrategy.AllowCreateOnUpdate(), storagePreconditions, func(existing runtime.Object, res storage.ResponseMeta) (runtime.Object, *uint64, error) {
 		existingResourceVersion, err := e.Storage.Versioner().ObjectResourceVersion(existing)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Updated request of resource support feature `AllowCreateOnUpdate` which contain `lease`, `endpoint` and `event`. The `AllowCreateOnUpdate` defines in resource's implement such as pods https://github.com/kubernetes/kubernetes/blob/badcf9ab46e7f3eaa7159436e6d7a66cfa6cbc79/pkg/registry/core/pod/strategy.go#L136

In above function, pods should not support `AllowCreateOnUpdate`.  But when update pods，apiserver get a 409 status code such as. 
```
 {
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {
    
  },
  "status": "Failure",
  "message": "Operation cannot be fulfilled on pods \"allowcreateonupdate-pod\": StorageError: invalid object, Code: 4, Key: /registry/pods/default/allowcreateonupdate-pod, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: fdd171c8-f548-11ed-89d0-525400cecf17, UID in object meta: ",
  "reason": "Conflict",
  "details": {
    "name": "allowcreateonupdate-pod",
    "kind": "pods"
  },
  "code": 409
```

The reason is `AllowCreateOnUpdate` settings to true rather than `e.UpdateStrategy.AllowCreateOnUpdate()`. It's should be fixed.
https://github.com/kubernetes/kubernetes/blob/badcf9ab46e7f3eaa7159436e6d7a66cfa6cbc79/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go#L560


## Before: 
```
curl -v -XPUT  -H "Content-Type: application/json" --data "@/home/dev/test-pod.json" 'localhost:8001/api/v1/namespaces/default/pods/allowcreateonupdate-pod'  
* About to connect() to localhost port 8001 (#0)
*   Trying ::1...
* Connection refused
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8001 (#0)
> PUT /api/v1/namespaces/default/pods/allowcreateonupdate-pod HTTP/1.1
> User-Agent: curl/7.29.0
> Host: localhost:8001
> Accept: */*
> Content-Type: application/json
> Content-Length: 11346
> Expect: 100-continue
> 
< HTTP/1.1 100 Continue
< HTTP/1.1 409 Conflict
< Audit-Id: 3257a935-22c8-4df2-92eb-463216591d33
< Content-Length: 526
< Content-Type: application/json
< Date: Sun, 21 May 2023 13:15:36 GMT
* HTTP error before end of send, stop sending
< 
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {
    
  },
  "status": "Failure",
  "message": "Operation cannot be fulfilled on pods \"allowcreateonupdate-pod\": StorageError: invalid object, Code: 4, Key: /registry/pods/default/allowcreateonupdate-pod, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: fdd171c8-f548-11ed-89d0-525400cecf17, UID in object meta: ",
  "reason": "Conflict",
  "details": {
    "name": "allowcreateonupdate-pod",
    "kind": "pods"
  },
  "code": 409
* Closing connection 0
```

## After: 
```
curl -v -XPUT  -H "Content-Type: application/json" --data "@/home/dev/test-pod.json" 'localhost:8001/api/v1/namespaces/default/pods/allowcreateonupdate-pod'  
* About to connect() to localhost port 8001 (#0)
*   Trying ::1...
* Connection refused
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8001 (#0)
> PUT /api/v1/namespaces/default/pods/allowcreateonupdate-pod HTTP/1.1
> User-Agent: curl/7.29.0
> Host: localhost:8001
> Accept: */*
> Content-Type: application/json
> Content-Length: 11346
> Expect: 100-continue
> 
< HTTP/1.1 100 Continue
< HTTP/1.1 404 Not Found
< Audit-Id: 07ed6cf6-3368-4205-bf37-38a7fd871b1d
< Content-Length: 269
< Content-Type: application/json
< Date: Sun, 21 May 2023 13:14:13 GMT
* HTTP error before end of send, stop sending
< 
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {
    
  },
  "status": "Failure",
  "message": "pods \"allowcreateonupdate-pod\" not found",
  "reason": "NotFound",
  "details": {
    "name": "allowcreateonupdate-pod",
    "kind": "pods"
  },
  "code": 404
* Closing connection 0
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
