### PR TITLE
scheduler-perf: inject "benchmark" as name into JSON result filename

### DIFF
--- a/test/integration/scheduler_perf/README.md
+++ b/test/integration/scheduler_perf/README.md
@@ -48,7 +48,7 @@ as "fast":
 make test-integration WHAT=./test/integration/scheduler_perf ETCD_LOGLEVEL=warn KUBE_TEST_VMODULE="''" KUBE_TEST_ARGS="-run=^$$ -benchtime=1ns -bench=BenchmarkPerfScheduling -perf-scheduling-label-filter=performance,-fast"
 ```
 
-Once the benchmark is finished, JSON file with metrics is available in the current directory (test/integration/scheduler_perf). Look for `BenchmarkPerfScheduling_YYYY-MM-DDTHH:MM:SSZ.json`.
+Once the benchmark is finished, JSON file with metrics is available in the current directory (test/integration/scheduler_perf). Look for `BenchmarkPerfScheduling_benchmark_YYYY-MM-DDTHH:MM:SSZ.json`.
 You can use `-data-items-dir` to generate the metrics file elsewhere.
 
 In case you want to run a specific test in the suite, you can specify the test through `-bench` flag:

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -724,7 +724,7 @@ func BenchmarkPerfScheduling(b *testing.B) {
 			}
 		})
 	}
-	if err := dataItems2JSONFile(dataItems, b.Name()); err != nil {
+	if err := dataItems2JSONFile(dataItems, b.Name()+"_benchmark"); err != nil {
 		b.Fatalf("unable to write measured data %+v: %v", dataItems, err)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

This is required because an empty name is no longer supported: the perf-dashboard is run with --allow-parsers-matching-all-tests=false which causes perfdash to skip current configuration for BenchmarkPerfResults as it does not have name
set (https://github.com/kubernetes/perf-tests/blob/4674704f45e5d9785741b0399426cbfced37a648/perfdash/metrics-downloader.go#L165-L167).

#### Special notes for your reviewer:

The perf-dash config needs to be updated accordingly, see https://github.com/kubernetes/perf-tests/pull/2266.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @sanposhiho @kerthcet 