### PR TITLE
Automated cherry pick of #118150: kubeadm: remove function pointer comparison in phase test

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/workflow/runner_test.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/runner_test.go
@@ -401,14 +401,8 @@ func TestBindToCommandArgRequirements(t *testing.T) {
 					continue
 				}
 
-				// Ensure it is the expected function
-				if reflect.ValueOf(cCmd.Args).Pointer() != reflect.ValueOf(args.args).Pointer() {
-					t.Error("The function pointers where not equal.")
-				}
-
 				// Test passing argument set
 				err := cCmd.Args(cCmd, args.pass)
-
 				if err != nil {
 					t.Errorf("command %s should validate the args: %v\n %v", cCmd.Name(), args.pass, err)
 				}


### PR DESCRIPTION
Cherry pick of #118150 on release-1.25.

#118150: kubeadm: remove function pointer comparison in phase test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```