### PR TITLE
Automated cherry pick of #118156: update webhook test to go 1.21

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
@@ -47,7 +47,7 @@ import (
 )
 
 const (
-	errBadCertificate    = "Get .*: remote error: tls: bad certificate"
+	errBadCertificate    = "Get .*: remote error: tls: (bad certificate|unknown certificate authority)"
 	errNoConfiguration   = "invalid configuration: no configuration has been provided"
 	errMissingCertPath   = "invalid configuration: unable to read %s %s for %s due to open %s: .*"
 	errSignedByUnknownCA = "Get .*: x509: .*(unknown authority|not standards compliant|not trusted)"


### PR DESCRIPTION
Cherry pick of #118156 on release-1.25.

#118156: update webhook test to go 1.21

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```