### PR TITLE
TopologyAwareHints: Take lock in HasPopulatedHints

### DIFF
--- a/staging/src/k8s.io/endpointslice/topologycache/topologycache.go
+++ b/staging/src/k8s.io/endpointslice/topologycache/topologycache.go
@@ -153,8 +153,10 @@ func (t *TopologyCache) AddHints(logger klog.Logger, si *SliceInfo) ([]*discover
 		return slicesToCreate, slicesToUpdate, events
 	}
 
-	hintsEnabled := t.hintsPopulatedByService.Has(si.ServiceKey)
-	t.SetHints(si.ServiceKey, si.AddressType, allocatedHintsByZone)
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	hintsEnabled := t.hasPopulatedHintsLocked(si.ServiceKey)
+	t.setHintsLocked(si.ServiceKey, si.AddressType, allocatedHintsByZone)
 
 	// if hints were not enabled before, we publish an event to indicate we enabled them.
 	if !hintsEnabled {
@@ -174,6 +176,10 @@ func (t *TopologyCache) SetHints(serviceKey string, addrType discovery.AddressTy
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
+	t.setHintsLocked(serviceKey, addrType, allocatedHintsByZone)
+}
+
+func (t *TopologyCache) setHintsLocked(serviceKey string, addrType discovery.AddressType, allocatedHintsByZone EndpointZoneInfo) {
 	_, ok := t.endpointsByService[serviceKey]
 	if !ok {
 		t.endpointsByService[serviceKey] = map[discovery.AddressType]EndpointZoneInfo{}
@@ -262,6 +268,13 @@ func (t *TopologyCache) SetNodes(logger klog.Logger, nodes []*v1.Node) {
 
 // HasPopulatedHints checks whether there are populated hints for a given service in the cache.
 func (t *TopologyCache) HasPopulatedHints(serviceKey string) bool {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.hasPopulatedHintsLocked(serviceKey)
+}
+
+func (t *TopologyCache) hasPopulatedHintsLocked(serviceKey string) bool {
 	return t.hintsPopulatedByService.Has(serviceKey)
 }
 

--- a/staging/src/k8s.io/endpointslice/topologycache/topologycache_test.go
+++ b/staging/src/k8s.io/endpointslice/topologycache/topologycache_test.go
@@ -690,6 +690,9 @@ func TestTopologyCacheRace(t *testing.T) {
 	go func() {
 		cache.AddHints(logger, sliceInfo)
 	}()
+	go func() {
+		cache.HasPopulatedHints(sliceInfo.ServiceKey)
+	}()
 }
 
 // Test Helpers


### PR DESCRIPTION
-------

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Prevent potential concurrent map access by taking a lock before reading the topology cache's `hintsPopulatedByService` map.

* `staging/src/k8s.io/endpointslice/topologycache/topologycache.go` (`setHintsLocked`, `hasPopulatedHintsLocked`): New helper functions.  These are the same as the existing `SetHints` and `HasPopulatedHints` methods except that these helpers assume that a lock is already held.
(`SetHints`): Use `setHintsLocked`.
(`HasPopulatedHints`): Take a lock and use `hasPopulatedHintsLocked`.
(`AddHints`): Take a lock and use `setHintsLocked` and `hasPopulatedHintsLocked`.
* `staging/src/k8s.io/endpointslice/topologycache/topologycache_test.go` (`TestTopologyCacheRace`): Add a goroutine that calls `HasPopulatedHints`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #118188.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix a concurrent map access in TopologyCache's `HasPopulatedHints` method.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```