### PR TITLE
[bug] Update DefaultObjectDescriber to handle interface params

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -5030,8 +5030,12 @@ func (fn typeFunc) Matches(types []reflect.Type) bool {
 // Describe invokes the nested function with the exact number of arguments.
 func (fn typeFunc) Describe(exact interface{}, extra ...interface{}) (string, error) {
 	values := []reflect.Value{reflect.ValueOf(exact)}
-	for _, obj := range extra {
-		values = append(values, reflect.ValueOf(obj))
+	for i, obj := range extra {
+		if obj != nil {
+			values = append(values, reflect.ValueOf(obj))
+		} else {
+			values = append(values, reflect.New(fn.Extra[i]).Elem())
+		}
 	}
 	out := fn.Fn.Call(values)
 	s := out[0].Interface().(string)

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -1283,6 +1283,19 @@ func TestDefaultDescribers(t *testing.T) {
 	if !strings.Contains(out, "foo") {
 		t.Errorf("unexpected output: %s", out)
 	}
+
+	var ssReplicas int32
+	ss := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+		Spec:       appsv1.StatefulSetSpec{Replicas: &ssReplicas},
+	}
+	out, err = DefaultObjectDescriber.DescribeObject(ss)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "foo") {
+		t.Errorf("unexpected output: %s", out)
+	}
 }
 
 func TestGetPodsTotalRequests(t *testing.T) {

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -1254,7 +1254,7 @@ func TestDefaultDescribers(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(out, "foo") {
-		t.Errorf("unexpected output: %s", out)
+		t.Errorf("missing Pod `foo` in output: %s", out)
 	}
 
 	out, err = DefaultObjectDescriber.DescribeObject(&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
@@ -1262,18 +1262,18 @@ func TestDefaultDescribers(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(out, "foo") {
-		t.Errorf("unexpected output: %s", out)
+		t.Errorf("missing Service `foo` in output: %s", out)
 	}
 
 	out, err = DefaultObjectDescriber.DescribeObject(&corev1.ReplicationController{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-		Spec:       corev1.ReplicationControllerSpec{Replicas: utilpointer.Int32Ptr(1)},
+		Spec:       corev1.ReplicationControllerSpec{Replicas: utilpointer.Int32(1)},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(out, "foo") {
-		t.Errorf("unexpected output: %s", out)
+		t.Errorf("missing Replication Controller `foo` in output: %s", out)
 	}
 
 	out, err = DefaultObjectDescriber.DescribeObject(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
@@ -1281,20 +1281,18 @@ func TestDefaultDescribers(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(out, "foo") {
-		t.Errorf("unexpected output: %s", out)
+		t.Errorf("missing Node `foo` output: %s", out)
 	}
 
-	var ssReplicas int32
-	ss := &appsv1.StatefulSet{
+	out, err = DefaultObjectDescriber.DescribeObject(&appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-		Spec:       appsv1.StatefulSetSpec{Replicas: &ssReplicas},
-	}
-	out, err = DefaultObjectDescriber.DescribeObject(ss)
+		Spec:       appsv1.StatefulSetSpec{Replicas: utilpointer.Int32(1)},
+	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(out, "foo") {
-		t.Errorf("unexpected output: %s", out)
+		t.Errorf("missing StatefulSet `foo` in output: %s", out)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `DefaultObjectDescriber` lets one call Describe on inmemory objects.
It uses reflection to pick the current func based on the params passed in,
however the reflection setup doesn't handle interface params correctly.

`DescribeObject` fills in the extra params if the `DefaultObjectDescriber`
is called with only one param but we match a Describer that expects more
than one param. However for params that are of type interface, it ends up
passing down a nil which turns into a zero value Argument.

The added test case exhibits this behavior and panics as follows:
<details><summary>Test Output</summary><p>

```
--- FAIL: TestDefaultDescribers (0.00s)                                                                                                                                                               panic: reflect: Call using zero Value argument [recovered]
        panic: reflect: Call using zero Value argument

goroutine 200 [running]:
testing.tRunner.func1.2({0x226a360, 0xc000621210})
        /opt/px_dev/tools/golang/src/testing/testing.go:1526 +0x24e
testing.tRunner.func1()
        /opt/px_dev/tools/golang/src/testing/testing.go:1529 +0x39f
panic({0x226a360, 0xc000621210})
        /opt/px_dev/tools/golang/src/runtime/panic.go:884 +0x213
reflect.Value.call({0x23b1100?, 0x2699100?, 0xd31036?}, {0x25956c4, 0x4}, {0xc000646480, 0x7, 0x8?})
        /opt/px_dev/tools/golang/src/reflect/value.go:437 +0x1aee
reflect.Value.Call({0x23b1100?, 0x2699100?, 0xc000476340?}, {0xc000646480?, 0x2591600?, 0x2265c20?})
        /opt/px_dev/tools/golang/src/reflect/value.go:370 +0xbc
k8s.io/kubectl/pkg/describe.typeFunc.Describe({{0xc0006c8390, 0x6, 0x6}, {0x23b1100, 0x2699100, 0x13}}, {0x2560960?, 0xc00065c000?}, {0xc00064e080, 0x6, ...})
        /home/vihang/go/src/kubernetes/staging/src/k8s.io/kubectl/pkg/describe/describe.go:5036 +0x2cf
k8s.io/kubectl/pkg/describe.(*Describers).DescribeObject(0xc00065a000?, {0x2560960, 0xc00065c000}, {0x0?, 0x0, 0x0})
        /home/vihang/go/src/kubernetes/staging/src/k8s.io/kubectl/pkg/describe/describe.go:4942 +0x8d1
k8s.io/kubectl/pkg/describe.TestDefaultDescribers(0xc00061eb60)
        /home/vihang/go/src/kubernetes/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go:1287 +0x4a5
testing.tRunner(0xc00061eb60, 0x2698eb0)
        /opt/px_dev/tools/golang/src/testing/testing.go:1576 +0x10b
created by testing.(*T).Run
        /opt/px_dev/tools/golang/src/testing/testing.go:1629 +0x3ea
FAIL    k8s.io/kubectl/pkg/describe     0.040s
```

</p></details>

The included patch to the `Describe` invoker handles this case.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

For a minimal repro of the panic, see https://go.dev/play/p/Vmpn7vVf7XH

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
