### PR TITLE
fix using stale binaries in local-up-cluster

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -186,10 +186,10 @@ do
     esac
 done
 
-if [ -z "${GO_OUT:-$(guess_built_binary_path)}" ]; then
+if [ -z "${GO_OUT}" ]; then
     make -C "${KUBE_ROOT}" WHAT="cmd/kubectl cmd/kube-apiserver cmd/kube-controller-manager cmd/cloud-controller-manager cmd/kubelet cmd/kube-proxy cmd/kube-scheduler"
 else
-    echo "skipped the build as we found existing binaries in $(guess_built_binary_path)"
+    echo "skipped the build because GO_OUT was set (${GO_OUT})"
 fi
 
 # Shut down anyway if there's an error.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

After https://github.com/kubernetes/kubernetes/pull/117914 merged, running `local-up-cluster.sh` with the default output directory in your PATH means binaries don't get rebuilt by default. This puts that line back as it was so `local-up-cluster` builds by default

xref https://github.com/kubernetes/kubernetes/commit/1168b1187507d17d60e93520f46ad532711e7c88#r113900716

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @dims