### PR TITLE
RFC: dra: support skipping NodePrepareResource and NodeUnprepareResource

### DIFF
--- a/pkg/apis/resource/types.go
+++ b/pkg/apis/resource/types.go
@@ -172,6 +172,10 @@ type ResourceHandle struct {
 	// plugin should be invoked to process this ResourceHandle's data once it
 	// lands on a node. This may differ from the DriverName set in
 	// ResourceClaimStatus this ResourceHandle is embedded in.
+	//
+	// The special "nop.k8s.io" constant may be used here. This tells the
+	// kubelet that it does no resource driver is required when starting or
+	// stopping containers that use this resource.
 	DriverName string
 
 	// Data contains the opaque data associated with this ResourceHandle. It is
@@ -189,6 +193,10 @@ type ResourceHandle struct {
 
 // ResourceHandleDataMaxSize represents the maximum size of resourceHandle.data.
 const ResourceHandleDataMaxSize = 16 * 1024
+
+// ResourceHandleNopDriver is the special driver name for
+// ResourceHandle.DriverName that causes the kubelet to skip the resource.
+const ResourceHandleNopDriver = "nop.k8s.io"
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -42412,7 +42412,7 @@ func schema_k8sio_api_resource_v1alpha2_ResourceHandle(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"driverName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DriverName specifies the name of the resource driver whose kubelet plugin should be invoked to process this ResourceHandle's data once it lands on a node. This may differ from the DriverName set in ResourceClaimStatus this ResourceHandle is embedded in.",
+							Description: "DriverName specifies the name of the resource driver whose kubelet plugin should be invoked to process this ResourceHandle's data once it lands on a node. This may differ from the DriverName set in ResourceClaimStatus this ResourceHandle is embedded in.\n\nThe special \"nop.k8s.io\" constant may be used here. This tells the kubelet that it does no resource driver is required when starting or stopping containers that use this resource.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -123,7 +123,11 @@ func (m *ManagerImpl) PrepareResources(pod *v1.Pod) error {
 			// If no DriverName is provided in the resourceHandle, we
 			// use the DriverName from the status
 			pluginName := resourceHandle.DriverName
-			if pluginName == "" {
+			switch pluginName {
+			case resourcev1alpha2.ResourceHandleNopDriver:
+				// Nothing to do.
+				continue
+			case "":
 				pluginName = resourceClaim.Status.DriverName
 			}
 
@@ -260,7 +264,11 @@ func (m *ManagerImpl) UnprepareResources(pod *v1.Pod) error {
 			// If no DriverName is provided in the resourceHandle, we
 			// use the DriverName from the status
 			pluginName := resourceHandle.DriverName
-			if pluginName == "" {
+			switch pluginName {
+			case resourcev1alpha2.ResourceHandleNopDriver:
+				// Nothing to do.
+				continue
+			case "":
 				pluginName = claimInfo.DriverName
 			}
 

--- a/staging/src/k8s.io/api/resource/v1alpha2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1alpha2/generated.proto
@@ -383,6 +383,10 @@ message ResourceHandle {
   // plugin should be invoked to process this ResourceHandle's data once it
   // lands on a node. This may differ from the DriverName set in
   // ResourceClaimStatus this ResourceHandle is embedded in.
+  //
+  // The special "nop.k8s.io" constant may be used here. This tells the
+  // kubelet that it does no resource driver is required when starting or
+  // stopping containers that use this resource.
   optional string driverName = 1;
 
   // Data contains the opaque data associated with this ResourceHandle. It is

--- a/staging/src/k8s.io/api/resource/v1alpha2/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha2/types.go
@@ -177,6 +177,10 @@ type ResourceHandle struct {
 	// plugin should be invoked to process this ResourceHandle's data once it
 	// lands on a node. This may differ from the DriverName set in
 	// ResourceClaimStatus this ResourceHandle is embedded in.
+	//
+	// The special "nop.k8s.io" constant may be used here. This tells the
+	// kubelet that it does no resource driver is required when starting or
+	// stopping containers that use this resource.
 	DriverName string `json:"driverName,omitempty" protobuf:"bytes,1,opt,name=driverName"`
 
 	// Data contains the opaque data associated with this ResourceHandle. It is
@@ -194,6 +198,10 @@ type ResourceHandle struct {
 
 // ResourceHandleDataMaxSize represents the maximum size of resourceHandle.data.
 const ResourceHandleDataMaxSize = 16 * 1024
+
+// ResourceHandleNopDriver is the special driver name for
+// ResourceHandle.DriverName that causes the kubelet to skip the resource.
+const ResourceHandleNopDriver = "nop.k8s.io"
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.26

--- a/staging/src/k8s.io/api/resource/v1alpha2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1alpha2/types_swagger_doc_generated.go
@@ -221,7 +221,7 @@ func (ResourceClassParametersReference) SwaggerDoc() map[string]string {
 
 var map_ResourceHandle = map[string]string{
 	"":           "ResourceHandle holds opaque resource data for processing by a specific kubelet plugin.",
-	"driverName": "DriverName specifies the name of the resource driver whose kubelet plugin should be invoked to process this ResourceHandle's data once it lands on a node. This may differ from the DriverName set in ResourceClaimStatus this ResourceHandle is embedded in.",
+	"driverName": "DriverName specifies the name of the resource driver whose kubelet plugin should be invoked to process this ResourceHandle's data once it lands on a node. This may differ from the DriverName set in ResourceClaimStatus this ResourceHandle is embedded in.\n\nThe special \"nop.k8s.io\" constant may be used here. This tells the kubelet that it does no resource driver is required when starting or stopping containers that use this resource.",
 	"data":       "Data contains the opaque data associated with this ResourceHandle. It is set by the controller component of the resource driver whose name matches the DriverName set in the ResourceClaimStatus this ResourceHandle is embedded in. It is set at allocation time and is intended for processing by the kubelet plugin whose name matches the DriverName set in this ResourceHandle.\n\nThe maximum size of this field is 16KiB. This may get increased in the future, but not reduced.",
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

This enables writing DRA drivers where the part local to a node isn't using CDI and CRI. For example, an NRI plugin might act upon the allocated resource.

#### Special notes for your reviewer:

Using a new special value for the DriverName is simple. However, like any alternative (for example, a separate field) it will cause problems when the kubelet handling the pod does not know about it: then the kubelet will try to find a non-existent "nop.k8s.io" plugin and fail to prepare.

#### Does this PR introduce a user-facing change?
```release-note
DRA: when using the new kubelet on a node, allocated ResourceClaims can skip the local prepare/unprepare operations and thus run without a DRA driver on the node. This enables additional use cases for DRA beyond the traditional injection of resources into the container.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3063
```
