### PR TITLE
Automated cherry pick of #112944: Switch to assert.ErrorEquals from assert.Equal to check error

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_blobDiskController_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_blobDiskController_test.go
@@ -88,7 +88,7 @@ func TestCreateVolume(t *testing.T) {
 	diskName, diskURI, requestGB, err := b.CreateVolume("testBlob", "testsa", "type", b.common.location, 10)
 	expectedErr := fmt.Errorf("could not get storage key for storage account testsa: could not get storage key for "+
 		"storage account testsa: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: %w", error(nil))
-	assert.Equal(t, expectedErr, err)
+	assert.EqualError(t, err, expectedErr.Error())
 	assert.Empty(t, diskName)
 	assert.Empty(t, diskURI)
 	assert.Zero(t, requestGB)
@@ -124,10 +124,10 @@ func TestDeleteVolume(t *testing.T) {
 	diskURL := "https://foo.blob./vhds/bar.vhd"
 	err := b.DeleteVolume(diskURL)
 	expectedErr := fmt.Errorf("no key for storage account foo, err Retriable: false, RetryAfter: 0s, HTTPStatusCode: 500, RawError: %w", error(nil))
-	assert.Equal(t, expectedErr, err)
+	assert.EqualError(t, err, expectedErr.Error())
 
 	err = b.DeleteVolume(diskURL)
-	assert.Equal(t, expectedErr, err)
+	assert.EqualError(t, err, expectedErr.Error())
 
 	mockSAClient.EXPECT().ListKeys(gomock.Any(), b.common.resourceGroup, "foo").Return(storage.AccountListKeysResult{
 		Keys: &[]storage.AccountKey{


### PR DESCRIPTION
Cherry pick of #112944 on release-1.24.

#112944: Switch to assert.ErrorEquals from assert.Equal to check error

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```