### PR TITLE
Add FieldManager to client-go fake

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -23,18 +23,20 @@ import (
 	crv1 "k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1"
 	fakecrv1 "k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
 )
 
-// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// NewSimpleClientsetWithFieldmanager returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewSimpleClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+// It also takes the fieldmanager that can be used to track field ownership and use server-side apply.
+func NewSimpleClientsetWithFieldManager(fieldManager *managedfields.FieldManager, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTrackerWithFieldManager(scheme, codecs.UniversalDecoder(), fieldManager)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)
@@ -57,13 +59,22 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+	return NewSimpleClientsetWithFieldManager(nil, objects...)
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
-	tracker   testing.ObjectTracker
+	discovery    *fakediscovery.FakeDiscovery
+	tracker      testing.ObjectTracker
+	fieldManager *managedfields.FieldManager
 }
 
 func (c *Clientset) Discovery() discovery.DiscoveryInterface {

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/fake/fake_example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/fake/fake_example.go
@@ -140,12 +140,18 @@ func (c *FakeExamples) Apply(ctx context.Context, example *crv1.ExampleApplyConf
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := example.Name
 	if name == nil {
 		return nil, fmt.Errorf("example.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(examplesResource, c.ns, *name, types.ApplyPatchType, data), &v1.Example{})
+		Invokes(testing.NewApplySubresourceAction(examplesResource, c.ns, *name, data, manager, opts.Force), &v1.Example{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/clientset_generated.go
@@ -25,18 +25,20 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	fakeapiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
 )
 
-// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// NewSimpleClientsetWithFieldmanager returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewSimpleClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+// It also takes the fieldmanager that can be used to track field ownership and use server-side apply.
+func NewSimpleClientsetWithFieldManager(fieldManager *managedfields.FieldManager, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTrackerWithFieldManager(scheme, codecs.UniversalDecoder(), fieldManager)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)
@@ -59,13 +61,22 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+	return NewSimpleClientsetWithFieldManager(nil, objects...)
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
-	tracker   testing.ObjectTracker
+	discovery    *fakediscovery.FakeDiscovery
+	tracker      testing.ObjectTracker
+	fieldManager *managedfields.FieldManager
 }
 
 func (c *Clientset) Discovery() discovery.DiscoveryInterface {

--- a/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
@@ -20,6 +20,7 @@ package fake
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -129,12 +130,13 @@ import (
 	"k8s.io/client-go/testing"
 )
 
-// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// NewSimpleClientsetWithFieldmanager returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewSimpleClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+// It also takes the fieldmanager that can be used to track field ownership and use server-side apply.
+func NewSimpleClientsetWithFieldManager(fieldManager *managedfields.FieldManager, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTrackerWithFieldManager(scheme, codecs.UniversalDecoder(), fieldManager)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)
@@ -157,13 +159,22 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+	return NewSimpleClientsetWithFieldManager(nil, objects...)
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
-	tracker   testing.ObjectTracker
+	discovery    *fakediscovery.FakeDiscovery
+	tracker      testing.ObjectTracker
+	fieldManager *managedfields.FieldManager
 }
 
 func (c *Clientset) Discovery() discovery.DiscoveryInterface {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/fake/fake_mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/fake/fake_mutatingwebhookconfiguration.go
@@ -132,12 +132,18 @@ func (c *FakeMutatingWebhookConfigurations) Apply(ctx context.Context, mutatingW
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := mutatingWebhookConfiguration.Name
 	if name == nil {
 		return nil, fmt.Errorf("mutatingWebhookConfiguration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(mutatingwebhookconfigurationsResource, *name, types.ApplyPatchType, data), &v1.MutatingWebhookConfiguration{})
+		Invokes(testing.NewRootApplySubresourceAction(mutatingwebhookconfigurationsResource, *name, data, manager, opts.Force), &v1.MutatingWebhookConfiguration{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/fake/fake_validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/fake/fake_validatingwebhookconfiguration.go
@@ -132,12 +132,18 @@ func (c *FakeValidatingWebhookConfigurations) Apply(ctx context.Context, validat
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := validatingWebhookConfiguration.Name
 	if name == nil {
 		return nil, fmt.Errorf("validatingWebhookConfiguration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(validatingwebhookconfigurationsResource, *name, types.ApplyPatchType, data), &v1.ValidatingWebhookConfiguration{})
+		Invokes(testing.NewRootApplySubresourceAction(validatingwebhookconfigurationsResource, *name, data, manager, opts.Force), &v1.ValidatingWebhookConfiguration{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/fake_validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/fake_validatingadmissionpolicy.go
@@ -143,12 +143,18 @@ func (c *FakeValidatingAdmissionPolicies) Apply(ctx context.Context, validatingA
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := validatingAdmissionPolicy.Name
 	if name == nil {
 		return nil, fmt.Errorf("validatingAdmissionPolicy.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(validatingadmissionpoliciesResource, *name, types.ApplyPatchType, data), &v1alpha1.ValidatingAdmissionPolicy{})
+		Invokes(testing.NewRootApplySubresourceAction(validatingadmissionpoliciesResource, *name, data, manager, opts.Force), &v1alpha1.ValidatingAdmissionPolicy{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakeValidatingAdmissionPolicies) ApplyStatus(ctx context.Context, valid
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := validatingAdmissionPolicy.Name
 	if name == nil {
 		return nil, fmt.Errorf("validatingAdmissionPolicy.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(validatingadmissionpoliciesResource, *name, types.ApplyPatchType, data, "status"), &v1alpha1.ValidatingAdmissionPolicy{})
+		Invokes(testing.NewRootApplySubresourceAction(validatingadmissionpoliciesResource, *name, data, manager, opts.Force, "status"), &v1alpha1.ValidatingAdmissionPolicy{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/fake_validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/fake_validatingadmissionpolicybinding.go
@@ -132,12 +132,18 @@ func (c *FakeValidatingAdmissionPolicyBindings) Apply(ctx context.Context, valid
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := validatingAdmissionPolicyBinding.Name
 	if name == nil {
 		return nil, fmt.Errorf("validatingAdmissionPolicyBinding.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(validatingadmissionpolicybindingsResource, *name, types.ApplyPatchType, data), &v1alpha1.ValidatingAdmissionPolicyBinding{})
+		Invokes(testing.NewRootApplySubresourceAction(validatingadmissionpolicybindingsResource, *name, data, manager, opts.Force), &v1alpha1.ValidatingAdmissionPolicyBinding{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/fake_mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/fake_mutatingwebhookconfiguration.go
@@ -132,12 +132,18 @@ func (c *FakeMutatingWebhookConfigurations) Apply(ctx context.Context, mutatingW
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := mutatingWebhookConfiguration.Name
 	if name == nil {
 		return nil, fmt.Errorf("mutatingWebhookConfiguration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(mutatingwebhookconfigurationsResource, *name, types.ApplyPatchType, data), &v1beta1.MutatingWebhookConfiguration{})
+		Invokes(testing.NewRootApplySubresourceAction(mutatingwebhookconfigurationsResource, *name, data, manager, opts.Force), &v1beta1.MutatingWebhookConfiguration{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/fake_validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/fake_validatingwebhookconfiguration.go
@@ -132,12 +132,18 @@ func (c *FakeValidatingWebhookConfigurations) Apply(ctx context.Context, validat
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := validatingWebhookConfiguration.Name
 	if name == nil {
 		return nil, fmt.Errorf("validatingWebhookConfiguration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(validatingwebhookconfigurationsResource, *name, types.ApplyPatchType, data), &v1beta1.ValidatingWebhookConfiguration{})
+		Invokes(testing.NewRootApplySubresourceAction(validatingwebhookconfigurationsResource, *name, data, manager, opts.Force), &v1beta1.ValidatingWebhookConfiguration{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/fake/fake_storageversion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/fake/fake_storageversion.go
@@ -143,12 +143,18 @@ func (c *FakeStorageVersions) Apply(ctx context.Context, storageVersion *apiserv
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := storageVersion.Name
 	if name == nil {
 		return nil, fmt.Errorf("storageVersion.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(storageversionsResource, *name, types.ApplyPatchType, data), &v1alpha1.StorageVersion{})
+		Invokes(testing.NewRootApplySubresourceAction(storageversionsResource, *name, data, manager, opts.Force), &v1alpha1.StorageVersion{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakeStorageVersions) ApplyStatus(ctx context.Context, storageVersion *a
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := storageVersion.Name
 	if name == nil {
 		return nil, fmt.Errorf("storageVersion.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(storageversionsResource, *name, types.ApplyPatchType, data, "status"), &v1alpha1.StorageVersion{})
+		Invokes(testing.NewRootApplySubresourceAction(storageversionsResource, *name, data, manager, opts.Force, "status"), &v1alpha1.StorageVersion{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_controllerrevision.go
@@ -140,12 +140,18 @@ func (c *FakeControllerRevisions) Apply(ctx context.Context, controllerRevision 
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := controllerRevision.Name
 	if name == nil {
 		return nil, fmt.Errorf("controllerRevision.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(controllerrevisionsResource, c.ns, *name, types.ApplyPatchType, data), &v1.ControllerRevision{})
+		Invokes(testing.NewApplySubresourceAction(controllerrevisionsResource, c.ns, *name, data, manager, opts.Force), &v1.ControllerRevision{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_daemonset.go
@@ -152,12 +152,18 @@ func (c *FakeDaemonSets) Apply(ctx context.Context, daemonSet *appsv1.DaemonSetA
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := daemonSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("daemonSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(daemonsetsResource, c.ns, *name, types.ApplyPatchType, data), &v1.DaemonSet{})
+		Invokes(testing.NewApplySubresourceAction(daemonsetsResource, c.ns, *name, data, manager, opts.Force), &v1.DaemonSet{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeDaemonSets) ApplyStatus(ctx context.Context, daemonSet *appsv1.Daem
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := daemonSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("daemonSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(daemonsetsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.DaemonSet{})
+		Invokes(testing.NewApplySubresourceAction(daemonsetsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.DaemonSet{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_deployment.go
@@ -154,12 +154,18 @@ func (c *FakeDeployments) Apply(ctx context.Context, deployment *appsv1.Deployme
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := deployment.Name
 	if name == nil {
 		return nil, fmt.Errorf("deployment.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(deploymentsResource, c.ns, *name, types.ApplyPatchType, data), &v1.Deployment{})
+		Invokes(testing.NewApplySubresourceAction(deploymentsResource, c.ns, *name, data, manager, opts.Force), &v1.Deployment{})
 
 	if obj == nil {
 		return nil, err
@@ -177,12 +183,18 @@ func (c *FakeDeployments) ApplyStatus(ctx context.Context, deployment *appsv1.De
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := deployment.Name
 	if name == nil {
 		return nil, fmt.Errorf("deployment.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(deploymentsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.Deployment{})
+		Invokes(testing.NewApplySubresourceAction(deploymentsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.Deployment{})
 
 	if obj == nil {
 		return nil, err
@@ -222,8 +234,14 @@ func (c *FakeDeployments) ApplyScale(ctx context.Context, deploymentName string,
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(deploymentsResource, c.ns, deploymentName, types.ApplyPatchType, data, "status"), &autoscalingv1.Scale{})
+		Invokes(testing.NewApplySubresourceAction(deploymentsResource, c.ns, deploymentName, data, manager, opts.Force, "status"), &autoscalingv1.Scale{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_replicaset.go
@@ -154,12 +154,18 @@ func (c *FakeReplicaSets) Apply(ctx context.Context, replicaSet *appsv1.ReplicaS
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := replicaSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("replicaSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(replicasetsResource, c.ns, *name, types.ApplyPatchType, data), &v1.ReplicaSet{})
+		Invokes(testing.NewApplySubresourceAction(replicasetsResource, c.ns, *name, data, manager, opts.Force), &v1.ReplicaSet{})
 
 	if obj == nil {
 		return nil, err
@@ -177,12 +183,18 @@ func (c *FakeReplicaSets) ApplyStatus(ctx context.Context, replicaSet *appsv1.Re
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := replicaSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("replicaSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(replicasetsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.ReplicaSet{})
+		Invokes(testing.NewApplySubresourceAction(replicasetsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.ReplicaSet{})
 
 	if obj == nil {
 		return nil, err
@@ -222,8 +234,14 @@ func (c *FakeReplicaSets) ApplyScale(ctx context.Context, replicaSetName string,
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(replicasetsResource, c.ns, replicaSetName, types.ApplyPatchType, data, "status"), &autoscalingv1.Scale{})
+		Invokes(testing.NewApplySubresourceAction(replicasetsResource, c.ns, replicaSetName, data, manager, opts.Force, "status"), &autoscalingv1.Scale{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_statefulset.go
@@ -154,12 +154,18 @@ func (c *FakeStatefulSets) Apply(ctx context.Context, statefulSet *appsv1.Statef
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := statefulSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("statefulSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(statefulsetsResource, c.ns, *name, types.ApplyPatchType, data), &v1.StatefulSet{})
+		Invokes(testing.NewApplySubresourceAction(statefulsetsResource, c.ns, *name, data, manager, opts.Force), &v1.StatefulSet{})
 
 	if obj == nil {
 		return nil, err
@@ -177,12 +183,18 @@ func (c *FakeStatefulSets) ApplyStatus(ctx context.Context, statefulSet *appsv1.
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := statefulSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("statefulSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(statefulsetsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.StatefulSet{})
+		Invokes(testing.NewApplySubresourceAction(statefulsetsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.StatefulSet{})
 
 	if obj == nil {
 		return nil, err
@@ -222,8 +234,14 @@ func (c *FakeStatefulSets) ApplyScale(ctx context.Context, statefulSetName strin
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(statefulsetsResource, c.ns, statefulSetName, types.ApplyPatchType, data, "status"), &autoscalingv1.Scale{})
+		Invokes(testing.NewApplySubresourceAction(statefulsetsResource, c.ns, statefulSetName, data, manager, opts.Force, "status"), &autoscalingv1.Scale{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_controllerrevision.go
@@ -140,12 +140,18 @@ func (c *FakeControllerRevisions) Apply(ctx context.Context, controllerRevision 
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := controllerRevision.Name
 	if name == nil {
 		return nil, fmt.Errorf("controllerRevision.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(controllerrevisionsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.ControllerRevision{})
+		Invokes(testing.NewApplySubresourceAction(controllerrevisionsResource, c.ns, *name, data, manager, opts.Force), &v1beta1.ControllerRevision{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_deployment.go
@@ -152,12 +152,18 @@ func (c *FakeDeployments) Apply(ctx context.Context, deployment *appsv1beta1.Dep
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := deployment.Name
 	if name == nil {
 		return nil, fmt.Errorf("deployment.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(deploymentsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.Deployment{})
+		Invokes(testing.NewApplySubresourceAction(deploymentsResource, c.ns, *name, data, manager, opts.Force), &v1beta1.Deployment{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeDeployments) ApplyStatus(ctx context.Context, deployment *appsv1bet
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := deployment.Name
 	if name == nil {
 		return nil, fmt.Errorf("deployment.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(deploymentsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta1.Deployment{})
+		Invokes(testing.NewApplySubresourceAction(deploymentsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1beta1.Deployment{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_statefulset.go
@@ -152,12 +152,18 @@ func (c *FakeStatefulSets) Apply(ctx context.Context, statefulSet *appsv1beta1.S
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := statefulSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("statefulSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(statefulsetsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.StatefulSet{})
+		Invokes(testing.NewApplySubresourceAction(statefulsetsResource, c.ns, *name, data, manager, opts.Force), &v1beta1.StatefulSet{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeStatefulSets) ApplyStatus(ctx context.Context, statefulSet *appsv1b
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := statefulSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("statefulSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(statefulsetsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta1.StatefulSet{})
+		Invokes(testing.NewApplySubresourceAction(statefulsetsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1beta1.StatefulSet{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_controllerrevision.go
@@ -140,12 +140,18 @@ func (c *FakeControllerRevisions) Apply(ctx context.Context, controllerRevision 
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := controllerRevision.Name
 	if name == nil {
 		return nil, fmt.Errorf("controllerRevision.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(controllerrevisionsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta2.ControllerRevision{})
+		Invokes(testing.NewApplySubresourceAction(controllerrevisionsResource, c.ns, *name, data, manager, opts.Force), &v1beta2.ControllerRevision{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_daemonset.go
@@ -152,12 +152,18 @@ func (c *FakeDaemonSets) Apply(ctx context.Context, daemonSet *appsv1beta2.Daemo
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := daemonSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("daemonSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(daemonsetsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta2.DaemonSet{})
+		Invokes(testing.NewApplySubresourceAction(daemonsetsResource, c.ns, *name, data, manager, opts.Force), &v1beta2.DaemonSet{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeDaemonSets) ApplyStatus(ctx context.Context, daemonSet *appsv1beta2
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := daemonSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("daemonSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(daemonsetsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta2.DaemonSet{})
+		Invokes(testing.NewApplySubresourceAction(daemonsetsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1beta2.DaemonSet{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_deployment.go
@@ -152,12 +152,18 @@ func (c *FakeDeployments) Apply(ctx context.Context, deployment *appsv1beta2.Dep
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := deployment.Name
 	if name == nil {
 		return nil, fmt.Errorf("deployment.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(deploymentsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta2.Deployment{})
+		Invokes(testing.NewApplySubresourceAction(deploymentsResource, c.ns, *name, data, manager, opts.Force), &v1beta2.Deployment{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeDeployments) ApplyStatus(ctx context.Context, deployment *appsv1bet
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := deployment.Name
 	if name == nil {
 		return nil, fmt.Errorf("deployment.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(deploymentsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta2.Deployment{})
+		Invokes(testing.NewApplySubresourceAction(deploymentsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1beta2.Deployment{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_replicaset.go
@@ -152,12 +152,18 @@ func (c *FakeReplicaSets) Apply(ctx context.Context, replicaSet *appsv1beta2.Rep
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := replicaSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("replicaSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(replicasetsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta2.ReplicaSet{})
+		Invokes(testing.NewApplySubresourceAction(replicasetsResource, c.ns, *name, data, manager, opts.Force), &v1beta2.ReplicaSet{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeReplicaSets) ApplyStatus(ctx context.Context, replicaSet *appsv1bet
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := replicaSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("replicaSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(replicasetsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta2.ReplicaSet{})
+		Invokes(testing.NewApplySubresourceAction(replicasetsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1beta2.ReplicaSet{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_statefulset.go
@@ -152,12 +152,18 @@ func (c *FakeStatefulSets) Apply(ctx context.Context, statefulSet *appsv1beta2.S
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := statefulSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("statefulSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(statefulsetsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta2.StatefulSet{})
+		Invokes(testing.NewApplySubresourceAction(statefulsetsResource, c.ns, *name, data, manager, opts.Force), &v1beta2.StatefulSet{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeStatefulSets) ApplyStatus(ctx context.Context, statefulSet *appsv1b
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := statefulSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("statefulSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(statefulsetsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta2.StatefulSet{})
+		Invokes(testing.NewApplySubresourceAction(statefulsetsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1beta2.StatefulSet{})
 
 	if obj == nil {
 		return nil, err
@@ -220,8 +232,14 @@ func (c *FakeStatefulSets) ApplyScale(ctx context.Context, statefulSetName strin
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(statefulsetsResource, c.ns, statefulSetName, types.ApplyPatchType, data, "status"), &v1beta2.Scale{})
+		Invokes(testing.NewApplySubresourceAction(statefulsetsResource, c.ns, statefulSetName, data, manager, opts.Force, "status"), &v1beta2.Scale{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
@@ -152,12 +152,18 @@ func (c *FakeHorizontalPodAutoscalers) Apply(ctx context.Context, horizontalPodA
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := horizontalPodAutoscaler.Name
 	if name == nil {
 		return nil, fmt.Errorf("horizontalPodAutoscaler.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(horizontalpodautoscalersResource, c.ns, *name, types.ApplyPatchType, data), &v1.HorizontalPodAutoscaler{})
+		Invokes(testing.NewApplySubresourceAction(horizontalpodautoscalersResource, c.ns, *name, data, manager, opts.Force), &v1.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeHorizontalPodAutoscalers) ApplyStatus(ctx context.Context, horizont
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := horizontalPodAutoscaler.Name
 	if name == nil {
 		return nil, fmt.Errorf("horizontalPodAutoscaler.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(horizontalpodautoscalersResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.HorizontalPodAutoscaler{})
+		Invokes(testing.NewApplySubresourceAction(horizontalpodautoscalersResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2/fake/fake_horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2/fake/fake_horizontalpodautoscaler.go
@@ -152,12 +152,18 @@ func (c *FakeHorizontalPodAutoscalers) Apply(ctx context.Context, horizontalPodA
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := horizontalPodAutoscaler.Name
 	if name == nil {
 		return nil, fmt.Errorf("horizontalPodAutoscaler.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(horizontalpodautoscalersResource, c.ns, *name, types.ApplyPatchType, data), &v2.HorizontalPodAutoscaler{})
+		Invokes(testing.NewApplySubresourceAction(horizontalpodautoscalersResource, c.ns, *name, data, manager, opts.Force), &v2.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeHorizontalPodAutoscalers) ApplyStatus(ctx context.Context, horizont
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := horizontalPodAutoscaler.Name
 	if name == nil {
 		return nil, fmt.Errorf("horizontalPodAutoscaler.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(horizontalpodautoscalersResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v2.HorizontalPodAutoscaler{})
+		Invokes(testing.NewApplySubresourceAction(horizontalpodautoscalersResource, c.ns, *name, data, manager, opts.Force, "status"), &v2.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/fake/fake_horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/fake/fake_horizontalpodautoscaler.go
@@ -152,12 +152,18 @@ func (c *FakeHorizontalPodAutoscalers) Apply(ctx context.Context, horizontalPodA
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := horizontalPodAutoscaler.Name
 	if name == nil {
 		return nil, fmt.Errorf("horizontalPodAutoscaler.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(horizontalpodautoscalersResource, c.ns, *name, types.ApplyPatchType, data), &v2beta1.HorizontalPodAutoscaler{})
+		Invokes(testing.NewApplySubresourceAction(horizontalpodautoscalersResource, c.ns, *name, data, manager, opts.Force), &v2beta1.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeHorizontalPodAutoscalers) ApplyStatus(ctx context.Context, horizont
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := horizontalPodAutoscaler.Name
 	if name == nil {
 		return nil, fmt.Errorf("horizontalPodAutoscaler.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(horizontalpodautoscalersResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v2beta1.HorizontalPodAutoscaler{})
+		Invokes(testing.NewApplySubresourceAction(horizontalpodautoscalersResource, c.ns, *name, data, manager, opts.Force, "status"), &v2beta1.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/fake/fake_horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/fake/fake_horizontalpodautoscaler.go
@@ -152,12 +152,18 @@ func (c *FakeHorizontalPodAutoscalers) Apply(ctx context.Context, horizontalPodA
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := horizontalPodAutoscaler.Name
 	if name == nil {
 		return nil, fmt.Errorf("horizontalPodAutoscaler.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(horizontalpodautoscalersResource, c.ns, *name, types.ApplyPatchType, data), &v2beta2.HorizontalPodAutoscaler{})
+		Invokes(testing.NewApplySubresourceAction(horizontalpodautoscalersResource, c.ns, *name, data, manager, opts.Force), &v2beta2.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeHorizontalPodAutoscalers) ApplyStatus(ctx context.Context, horizont
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := horizontalPodAutoscaler.Name
 	if name == nil {
 		return nil, fmt.Errorf("horizontalPodAutoscaler.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(horizontalpodautoscalersResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v2beta2.HorizontalPodAutoscaler{})
+		Invokes(testing.NewApplySubresourceAction(horizontalpodautoscalersResource, c.ns, *name, data, manager, opts.Force, "status"), &v2beta2.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/fake/fake_cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/fake/fake_cronjob.go
@@ -152,12 +152,18 @@ func (c *FakeCronJobs) Apply(ctx context.Context, cronJob *batchv1.CronJobApplyC
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := cronJob.Name
 	if name == nil {
 		return nil, fmt.Errorf("cronJob.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(cronjobsResource, c.ns, *name, types.ApplyPatchType, data), &v1.CronJob{})
+		Invokes(testing.NewApplySubresourceAction(cronjobsResource, c.ns, *name, data, manager, opts.Force), &v1.CronJob{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeCronJobs) ApplyStatus(ctx context.Context, cronJob *batchv1.CronJob
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := cronJob.Name
 	if name == nil {
 		return nil, fmt.Errorf("cronJob.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(cronjobsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.CronJob{})
+		Invokes(testing.NewApplySubresourceAction(cronjobsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.CronJob{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/fake/fake_job.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/fake/fake_job.go
@@ -152,12 +152,18 @@ func (c *FakeJobs) Apply(ctx context.Context, job *batchv1.JobApplyConfiguration
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := job.Name
 	if name == nil {
 		return nil, fmt.Errorf("job.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(jobsResource, c.ns, *name, types.ApplyPatchType, data), &v1.Job{})
+		Invokes(testing.NewApplySubresourceAction(jobsResource, c.ns, *name, data, manager, opts.Force), &v1.Job{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeJobs) ApplyStatus(ctx context.Context, job *batchv1.JobApplyConfigu
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := job.Name
 	if name == nil {
 		return nil, fmt.Errorf("job.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(jobsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.Job{})
+		Invokes(testing.NewApplySubresourceAction(jobsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.Job{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/fake/fake_cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/fake/fake_cronjob.go
@@ -152,12 +152,18 @@ func (c *FakeCronJobs) Apply(ctx context.Context, cronJob *batchv1beta1.CronJobA
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := cronJob.Name
 	if name == nil {
 		return nil, fmt.Errorf("cronJob.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(cronjobsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.CronJob{})
+		Invokes(testing.NewApplySubresourceAction(cronjobsResource, c.ns, *name, data, manager, opts.Force), &v1beta1.CronJob{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeCronJobs) ApplyStatus(ctx context.Context, cronJob *batchv1beta1.Cr
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := cronJob.Name
 	if name == nil {
 		return nil, fmt.Errorf("cronJob.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(cronjobsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta1.CronJob{})
+		Invokes(testing.NewApplySubresourceAction(cronjobsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1beta1.CronJob{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/fake/fake_certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/fake/fake_certificatesigningrequest.go
@@ -143,12 +143,18 @@ func (c *FakeCertificateSigningRequests) Apply(ctx context.Context, certificateS
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := certificateSigningRequest.Name
 	if name == nil {
 		return nil, fmt.Errorf("certificateSigningRequest.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(certificatesigningrequestsResource, *name, types.ApplyPatchType, data), &v1.CertificateSigningRequest{})
+		Invokes(testing.NewRootApplySubresourceAction(certificatesigningrequestsResource, *name, data, manager, opts.Force), &v1.CertificateSigningRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakeCertificateSigningRequests) ApplyStatus(ctx context.Context, certif
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := certificateSigningRequest.Name
 	if name == nil {
 		return nil, fmt.Errorf("certificateSigningRequest.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(certificatesigningrequestsResource, *name, types.ApplyPatchType, data, "status"), &v1.CertificateSigningRequest{})
+		Invokes(testing.NewRootApplySubresourceAction(certificatesigningrequestsResource, *name, data, manager, opts.Force, "status"), &v1.CertificateSigningRequest{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1alpha1/fake/fake_clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1alpha1/fake/fake_clustertrustbundle.go
@@ -132,12 +132,18 @@ func (c *FakeClusterTrustBundles) Apply(ctx context.Context, clusterTrustBundle 
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := clusterTrustBundle.Name
 	if name == nil {
 		return nil, fmt.Errorf("clusterTrustBundle.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(clustertrustbundlesResource, *name, types.ApplyPatchType, data), &v1alpha1.ClusterTrustBundle{})
+		Invokes(testing.NewRootApplySubresourceAction(clustertrustbundlesResource, *name, data, manager, opts.Force), &v1alpha1.ClusterTrustBundle{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake/fake_certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake/fake_certificatesigningrequest.go
@@ -143,12 +143,18 @@ func (c *FakeCertificateSigningRequests) Apply(ctx context.Context, certificateS
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := certificateSigningRequest.Name
 	if name == nil {
 		return nil, fmt.Errorf("certificateSigningRequest.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(certificatesigningrequestsResource, *name, types.ApplyPatchType, data), &v1beta1.CertificateSigningRequest{})
+		Invokes(testing.NewRootApplySubresourceAction(certificatesigningrequestsResource, *name, data, manager, opts.Force), &v1beta1.CertificateSigningRequest{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakeCertificateSigningRequests) ApplyStatus(ctx context.Context, certif
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := certificateSigningRequest.Name
 	if name == nil {
 		return nil, fmt.Errorf("certificateSigningRequest.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(certificatesigningrequestsResource, *name, types.ApplyPatchType, data, "status"), &v1beta1.CertificateSigningRequest{})
+		Invokes(testing.NewRootApplySubresourceAction(certificatesigningrequestsResource, *name, data, manager, opts.Force, "status"), &v1beta1.CertificateSigningRequest{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/fake/fake_lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/fake/fake_lease.go
@@ -140,12 +140,18 @@ func (c *FakeLeases) Apply(ctx context.Context, lease *coordinationv1.LeaseApply
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := lease.Name
 	if name == nil {
 		return nil, fmt.Errorf("lease.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(leasesResource, c.ns, *name, types.ApplyPatchType, data), &v1.Lease{})
+		Invokes(testing.NewApplySubresourceAction(leasesResource, c.ns, *name, data, manager, opts.Force), &v1.Lease{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/fake/fake_lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/fake/fake_lease.go
@@ -140,12 +140,18 @@ func (c *FakeLeases) Apply(ctx context.Context, lease *coordinationv1beta1.Lease
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := lease.Name
 	if name == nil {
 		return nil, fmt.Errorf("lease.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(leasesResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.Lease{})
+		Invokes(testing.NewApplySubresourceAction(leasesResource, c.ns, *name, data, manager, opts.Force), &v1beta1.Lease{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_componentstatus.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_componentstatus.go
@@ -132,12 +132,18 @@ func (c *FakeComponentStatuses) Apply(ctx context.Context, componentStatus *core
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := componentStatus.Name
 	if name == nil {
 		return nil, fmt.Errorf("componentStatus.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(componentstatusesResource, *name, types.ApplyPatchType, data), &v1.ComponentStatus{})
+		Invokes(testing.NewRootApplySubresourceAction(componentstatusesResource, *name, data, manager, opts.Force), &v1.ComponentStatus{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_configmap.go
@@ -140,12 +140,18 @@ func (c *FakeConfigMaps) Apply(ctx context.Context, configMap *corev1.ConfigMapA
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := configMap.Name
 	if name == nil {
 		return nil, fmt.Errorf("configMap.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(configmapsResource, c.ns, *name, types.ApplyPatchType, data), &v1.ConfigMap{})
+		Invokes(testing.NewApplySubresourceAction(configmapsResource, c.ns, *name, data, manager, opts.Force), &v1.ConfigMap{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_endpoints.go
@@ -140,12 +140,18 @@ func (c *FakeEndpoints) Apply(ctx context.Context, endpoints *corev1.EndpointsAp
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := endpoints.Name
 	if name == nil {
 		return nil, fmt.Errorf("endpoints.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(endpointsResource, c.ns, *name, types.ApplyPatchType, data), &v1.Endpoints{})
+		Invokes(testing.NewApplySubresourceAction(endpointsResource, c.ns, *name, data, manager, opts.Force), &v1.Endpoints{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event.go
@@ -140,12 +140,18 @@ func (c *FakeEvents) Apply(ctx context.Context, event *corev1.EventApplyConfigur
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := event.Name
 	if name == nil {
 		return nil, fmt.Errorf("event.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(eventsResource, c.ns, *name, types.ApplyPatchType, data), &v1.Event{})
+		Invokes(testing.NewApplySubresourceAction(eventsResource, c.ns, *name, data, manager, opts.Force), &v1.Event{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_limitrange.go
@@ -140,12 +140,18 @@ func (c *FakeLimitRanges) Apply(ctx context.Context, limitRange *corev1.LimitRan
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := limitRange.Name
 	if name == nil {
 		return nil, fmt.Errorf("limitRange.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(limitrangesResource, c.ns, *name, types.ApplyPatchType, data), &v1.LimitRange{})
+		Invokes(testing.NewApplySubresourceAction(limitrangesResource, c.ns, *name, data, manager, opts.Force), &v1.LimitRange{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_namespace.go
@@ -135,12 +135,18 @@ func (c *FakeNamespaces) Apply(ctx context.Context, namespace *corev1.NamespaceA
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := namespace.Name
 	if name == nil {
 		return nil, fmt.Errorf("namespace.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(namespacesResource, *name, types.ApplyPatchType, data), &v1.Namespace{})
+		Invokes(testing.NewRootApplySubresourceAction(namespacesResource, *name, data, manager, opts.Force), &v1.Namespace{})
 	if obj == nil {
 		return nil, err
 	}
@@ -157,12 +163,18 @@ func (c *FakeNamespaces) ApplyStatus(ctx context.Context, namespace *corev1.Name
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := namespace.Name
 	if name == nil {
 		return nil, fmt.Errorf("namespace.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(namespacesResource, *name, types.ApplyPatchType, data, "status"), &v1.Namespace{})
+		Invokes(testing.NewRootApplySubresourceAction(namespacesResource, *name, data, manager, opts.Force, "status"), &v1.Namespace{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_node.go
@@ -143,12 +143,18 @@ func (c *FakeNodes) Apply(ctx context.Context, node *corev1.NodeApplyConfigurati
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := node.Name
 	if name == nil {
 		return nil, fmt.Errorf("node.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(nodesResource, *name, types.ApplyPatchType, data), &v1.Node{})
+		Invokes(testing.NewRootApplySubresourceAction(nodesResource, *name, data, manager, opts.Force), &v1.Node{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakeNodes) ApplyStatus(ctx context.Context, node *corev1.NodeApplyConfi
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := node.Name
 	if name == nil {
 		return nil, fmt.Errorf("node.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(nodesResource, *name, types.ApplyPatchType, data, "status"), &v1.Node{})
+		Invokes(testing.NewRootApplySubresourceAction(nodesResource, *name, data, manager, opts.Force, "status"), &v1.Node{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolume.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolume.go
@@ -143,12 +143,18 @@ func (c *FakePersistentVolumes) Apply(ctx context.Context, persistentVolume *cor
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := persistentVolume.Name
 	if name == nil {
 		return nil, fmt.Errorf("persistentVolume.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(persistentvolumesResource, *name, types.ApplyPatchType, data), &v1.PersistentVolume{})
+		Invokes(testing.NewRootApplySubresourceAction(persistentvolumesResource, *name, data, manager, opts.Force), &v1.PersistentVolume{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakePersistentVolumes) ApplyStatus(ctx context.Context, persistentVolum
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := persistentVolume.Name
 	if name == nil {
 		return nil, fmt.Errorf("persistentVolume.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(persistentvolumesResource, *name, types.ApplyPatchType, data, "status"), &v1.PersistentVolume{})
+		Invokes(testing.NewRootApplySubresourceAction(persistentvolumesResource, *name, data, manager, opts.Force, "status"), &v1.PersistentVolume{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolumeclaim.go
@@ -152,12 +152,18 @@ func (c *FakePersistentVolumeClaims) Apply(ctx context.Context, persistentVolume
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := persistentVolumeClaim.Name
 	if name == nil {
 		return nil, fmt.Errorf("persistentVolumeClaim.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(persistentvolumeclaimsResource, c.ns, *name, types.ApplyPatchType, data), &v1.PersistentVolumeClaim{})
+		Invokes(testing.NewApplySubresourceAction(persistentvolumeclaimsResource, c.ns, *name, data, manager, opts.Force), &v1.PersistentVolumeClaim{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakePersistentVolumeClaims) ApplyStatus(ctx context.Context, persistent
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := persistentVolumeClaim.Name
 	if name == nil {
 		return nil, fmt.Errorf("persistentVolumeClaim.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(persistentvolumeclaimsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.PersistentVolumeClaim{})
+		Invokes(testing.NewApplySubresourceAction(persistentvolumeclaimsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.PersistentVolumeClaim{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
@@ -152,12 +152,18 @@ func (c *FakePods) Apply(ctx context.Context, pod *corev1.PodApplyConfiguration,
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := pod.Name
 	if name == nil {
 		return nil, fmt.Errorf("pod.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(podsResource, c.ns, *name, types.ApplyPatchType, data), &v1.Pod{})
+		Invokes(testing.NewApplySubresourceAction(podsResource, c.ns, *name, data, manager, opts.Force), &v1.Pod{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakePods) ApplyStatus(ctx context.Context, pod *corev1.PodApplyConfigur
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := pod.Name
 	if name == nil {
 		return nil, fmt.Errorf("pod.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(podsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.Pod{})
+		Invokes(testing.NewApplySubresourceAction(podsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.Pod{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_podtemplate.go
@@ -140,12 +140,18 @@ func (c *FakePodTemplates) Apply(ctx context.Context, podTemplate *corev1.PodTem
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := podTemplate.Name
 	if name == nil {
 		return nil, fmt.Errorf("podTemplate.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(podtemplatesResource, c.ns, *name, types.ApplyPatchType, data), &v1.PodTemplate{})
+		Invokes(testing.NewApplySubresourceAction(podtemplatesResource, c.ns, *name, data, manager, opts.Force), &v1.PodTemplate{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_replicationcontroller.go
@@ -153,12 +153,18 @@ func (c *FakeReplicationControllers) Apply(ctx context.Context, replicationContr
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := replicationController.Name
 	if name == nil {
 		return nil, fmt.Errorf("replicationController.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(replicationcontrollersResource, c.ns, *name, types.ApplyPatchType, data), &v1.ReplicationController{})
+		Invokes(testing.NewApplySubresourceAction(replicationcontrollersResource, c.ns, *name, data, manager, opts.Force), &v1.ReplicationController{})
 
 	if obj == nil {
 		return nil, err
@@ -176,12 +182,18 @@ func (c *FakeReplicationControllers) ApplyStatus(ctx context.Context, replicatio
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := replicationController.Name
 	if name == nil {
 		return nil, fmt.Errorf("replicationController.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(replicationcontrollersResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.ReplicationController{})
+		Invokes(testing.NewApplySubresourceAction(replicationcontrollersResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.ReplicationController{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_resourcequota.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_resourcequota.go
@@ -152,12 +152,18 @@ func (c *FakeResourceQuotas) Apply(ctx context.Context, resourceQuota *corev1.Re
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := resourceQuota.Name
 	if name == nil {
 		return nil, fmt.Errorf("resourceQuota.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(resourcequotasResource, c.ns, *name, types.ApplyPatchType, data), &v1.ResourceQuota{})
+		Invokes(testing.NewApplySubresourceAction(resourcequotasResource, c.ns, *name, data, manager, opts.Force), &v1.ResourceQuota{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeResourceQuotas) ApplyStatus(ctx context.Context, resourceQuota *cor
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := resourceQuota.Name
 	if name == nil {
 		return nil, fmt.Errorf("resourceQuota.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(resourcequotasResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.ResourceQuota{})
+		Invokes(testing.NewApplySubresourceAction(resourcequotasResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.ResourceQuota{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_secret.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_secret.go
@@ -140,12 +140,18 @@ func (c *FakeSecrets) Apply(ctx context.Context, secret *corev1.SecretApplyConfi
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := secret.Name
 	if name == nil {
 		return nil, fmt.Errorf("secret.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(secretsResource, c.ns, *name, types.ApplyPatchType, data), &v1.Secret{})
+		Invokes(testing.NewApplySubresourceAction(secretsResource, c.ns, *name, data, manager, opts.Force), &v1.Secret{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_service.go
@@ -144,12 +144,18 @@ func (c *FakeServices) Apply(ctx context.Context, service *corev1.ServiceApplyCo
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := service.Name
 	if name == nil {
 		return nil, fmt.Errorf("service.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(servicesResource, c.ns, *name, types.ApplyPatchType, data), &v1.Service{})
+		Invokes(testing.NewApplySubresourceAction(servicesResource, c.ns, *name, data, manager, opts.Force), &v1.Service{})
 
 	if obj == nil {
 		return nil, err
@@ -167,12 +173,18 @@ func (c *FakeServices) ApplyStatus(ctx context.Context, service *corev1.ServiceA
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := service.Name
 	if name == nil {
 		return nil, fmt.Errorf("service.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(servicesResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.Service{})
+		Invokes(testing.NewApplySubresourceAction(servicesResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.Service{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_serviceaccount.go
@@ -141,12 +141,18 @@ func (c *FakeServiceAccounts) Apply(ctx context.Context, serviceAccount *corev1.
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := serviceAccount.Name
 	if name == nil {
 		return nil, fmt.Errorf("serviceAccount.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(serviceaccountsResource, c.ns, *name, types.ApplyPatchType, data), &v1.ServiceAccount{})
+		Invokes(testing.NewApplySubresourceAction(serviceaccountsResource, c.ns, *name, data, manager, opts.Force), &v1.ServiceAccount{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/fake/fake_endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/fake/fake_endpointslice.go
@@ -140,12 +140,18 @@ func (c *FakeEndpointSlices) Apply(ctx context.Context, endpointSlice *discovery
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := endpointSlice.Name
 	if name == nil {
 		return nil, fmt.Errorf("endpointSlice.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(endpointslicesResource, c.ns, *name, types.ApplyPatchType, data), &v1.EndpointSlice{})
+		Invokes(testing.NewApplySubresourceAction(endpointslicesResource, c.ns, *name, data, manager, opts.Force), &v1.EndpointSlice{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/fake/fake_endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/fake/fake_endpointslice.go
@@ -140,12 +140,18 @@ func (c *FakeEndpointSlices) Apply(ctx context.Context, endpointSlice *discovery
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := endpointSlice.Name
 	if name == nil {
 		return nil, fmt.Errorf("endpointSlice.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(endpointslicesResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.EndpointSlice{})
+		Invokes(testing.NewApplySubresourceAction(endpointslicesResource, c.ns, *name, data, manager, opts.Force), &v1beta1.EndpointSlice{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/fake/fake_event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/fake/fake_event.go
@@ -140,12 +140,18 @@ func (c *FakeEvents) Apply(ctx context.Context, event *eventsv1.EventApplyConfig
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := event.Name
 	if name == nil {
 		return nil, fmt.Errorf("event.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(eventsResource, c.ns, *name, types.ApplyPatchType, data), &v1.Event{})
+		Invokes(testing.NewApplySubresourceAction(eventsResource, c.ns, *name, data, manager, opts.Force), &v1.Event{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/fake/fake_event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/fake/fake_event.go
@@ -140,12 +140,18 @@ func (c *FakeEvents) Apply(ctx context.Context, event *eventsv1beta1.EventApplyC
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := event.Name
 	if name == nil {
 		return nil, fmt.Errorf("event.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(eventsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.Event{})
+		Invokes(testing.NewApplySubresourceAction(eventsResource, c.ns, *name, data, manager, opts.Force), &v1beta1.Event{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_daemonset.go
@@ -152,12 +152,18 @@ func (c *FakeDaemonSets) Apply(ctx context.Context, daemonSet *extensionsv1beta1
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := daemonSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("daemonSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(daemonsetsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.DaemonSet{})
+		Invokes(testing.NewApplySubresourceAction(daemonsetsResource, c.ns, *name, data, manager, opts.Force), &v1beta1.DaemonSet{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeDaemonSets) ApplyStatus(ctx context.Context, daemonSet *extensionsv
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := daemonSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("daemonSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(daemonsetsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta1.DaemonSet{})
+		Invokes(testing.NewApplySubresourceAction(daemonsetsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1beta1.DaemonSet{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_deployment.go
@@ -152,12 +152,18 @@ func (c *FakeDeployments) Apply(ctx context.Context, deployment *extensionsv1bet
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := deployment.Name
 	if name == nil {
 		return nil, fmt.Errorf("deployment.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(deploymentsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.Deployment{})
+		Invokes(testing.NewApplySubresourceAction(deploymentsResource, c.ns, *name, data, manager, opts.Force), &v1beta1.Deployment{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeDeployments) ApplyStatus(ctx context.Context, deployment *extension
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := deployment.Name
 	if name == nil {
 		return nil, fmt.Errorf("deployment.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(deploymentsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta1.Deployment{})
+		Invokes(testing.NewApplySubresourceAction(deploymentsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1beta1.Deployment{})
 
 	if obj == nil {
 		return nil, err
@@ -220,8 +232,14 @@ func (c *FakeDeployments) ApplyScale(ctx context.Context, deploymentName string,
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(deploymentsResource, c.ns, deploymentName, types.ApplyPatchType, data, "status"), &v1beta1.Scale{})
+		Invokes(testing.NewApplySubresourceAction(deploymentsResource, c.ns, deploymentName, data, manager, opts.Force, "status"), &v1beta1.Scale{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_ingress.go
@@ -152,12 +152,18 @@ func (c *FakeIngresses) Apply(ctx context.Context, ingress *extensionsv1beta1.In
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := ingress.Name
 	if name == nil {
 		return nil, fmt.Errorf("ingress.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(ingressesResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.Ingress{})
+		Invokes(testing.NewApplySubresourceAction(ingressesResource, c.ns, *name, data, manager, opts.Force), &v1beta1.Ingress{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeIngresses) ApplyStatus(ctx context.Context, ingress *extensionsv1be
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := ingress.Name
 	if name == nil {
 		return nil, fmt.Errorf("ingress.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(ingressesResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta1.Ingress{})
+		Invokes(testing.NewApplySubresourceAction(ingressesResource, c.ns, *name, data, manager, opts.Force, "status"), &v1beta1.Ingress{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_networkpolicy.go
@@ -140,12 +140,18 @@ func (c *FakeNetworkPolicies) Apply(ctx context.Context, networkPolicy *extensio
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := networkPolicy.Name
 	if name == nil {
 		return nil, fmt.Errorf("networkPolicy.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(networkpoliciesResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.NetworkPolicy{})
+		Invokes(testing.NewApplySubresourceAction(networkpoliciesResource, c.ns, *name, data, manager, opts.Force), &v1beta1.NetworkPolicy{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_replicaset.go
@@ -152,12 +152,18 @@ func (c *FakeReplicaSets) Apply(ctx context.Context, replicaSet *extensionsv1bet
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := replicaSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("replicaSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(replicasetsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.ReplicaSet{})
+		Invokes(testing.NewApplySubresourceAction(replicasetsResource, c.ns, *name, data, manager, opts.Force), &v1beta1.ReplicaSet{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeReplicaSets) ApplyStatus(ctx context.Context, replicaSet *extension
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := replicaSet.Name
 	if name == nil {
 		return nil, fmt.Errorf("replicaSet.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(replicasetsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta1.ReplicaSet{})
+		Invokes(testing.NewApplySubresourceAction(replicasetsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1beta1.ReplicaSet{})
 
 	if obj == nil {
 		return nil, err
@@ -220,8 +232,14 @@ func (c *FakeReplicaSets) ApplyScale(ctx context.Context, replicaSetName string,
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(replicasetsResource, c.ns, replicaSetName, types.ApplyPatchType, data, "status"), &v1beta1.Scale{})
+		Invokes(testing.NewApplySubresourceAction(replicasetsResource, c.ns, replicaSetName, data, manager, opts.Force, "status"), &v1beta1.Scale{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/fake/fake_flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/fake/fake_flowschema.go
@@ -143,12 +143,18 @@ func (c *FakeFlowSchemas) Apply(ctx context.Context, flowSchema *flowcontrolv1al
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := flowSchema.Name
 	if name == nil {
 		return nil, fmt.Errorf("flowSchema.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(flowschemasResource, *name, types.ApplyPatchType, data), &v1alpha1.FlowSchema{})
+		Invokes(testing.NewRootApplySubresourceAction(flowschemasResource, *name, data, manager, opts.Force), &v1alpha1.FlowSchema{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakeFlowSchemas) ApplyStatus(ctx context.Context, flowSchema *flowcontr
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := flowSchema.Name
 	if name == nil {
 		return nil, fmt.Errorf("flowSchema.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(flowschemasResource, *name, types.ApplyPatchType, data, "status"), &v1alpha1.FlowSchema{})
+		Invokes(testing.NewRootApplySubresourceAction(flowschemasResource, *name, data, manager, opts.Force, "status"), &v1alpha1.FlowSchema{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/fake/fake_prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/fake/fake_prioritylevelconfiguration.go
@@ -143,12 +143,18 @@ func (c *FakePriorityLevelConfigurations) Apply(ctx context.Context, priorityLev
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := priorityLevelConfiguration.Name
 	if name == nil {
 		return nil, fmt.Errorf("priorityLevelConfiguration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(prioritylevelconfigurationsResource, *name, types.ApplyPatchType, data), &v1alpha1.PriorityLevelConfiguration{})
+		Invokes(testing.NewRootApplySubresourceAction(prioritylevelconfigurationsResource, *name, data, manager, opts.Force), &v1alpha1.PriorityLevelConfiguration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakePriorityLevelConfigurations) ApplyStatus(ctx context.Context, prior
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := priorityLevelConfiguration.Name
 	if name == nil {
 		return nil, fmt.Errorf("priorityLevelConfiguration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(prioritylevelconfigurationsResource, *name, types.ApplyPatchType, data, "status"), &v1alpha1.PriorityLevelConfiguration{})
+		Invokes(testing.NewRootApplySubresourceAction(prioritylevelconfigurationsResource, *name, data, manager, opts.Force, "status"), &v1alpha1.PriorityLevelConfiguration{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/fake_flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/fake_flowschema.go
@@ -143,12 +143,18 @@ func (c *FakeFlowSchemas) Apply(ctx context.Context, flowSchema *flowcontrolv1be
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := flowSchema.Name
 	if name == nil {
 		return nil, fmt.Errorf("flowSchema.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(flowschemasResource, *name, types.ApplyPatchType, data), &v1beta1.FlowSchema{})
+		Invokes(testing.NewRootApplySubresourceAction(flowschemasResource, *name, data, manager, opts.Force), &v1beta1.FlowSchema{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakeFlowSchemas) ApplyStatus(ctx context.Context, flowSchema *flowcontr
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := flowSchema.Name
 	if name == nil {
 		return nil, fmt.Errorf("flowSchema.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(flowschemasResource, *name, types.ApplyPatchType, data, "status"), &v1beta1.FlowSchema{})
+		Invokes(testing.NewRootApplySubresourceAction(flowschemasResource, *name, data, manager, opts.Force, "status"), &v1beta1.FlowSchema{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/fake_prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/fake/fake_prioritylevelconfiguration.go
@@ -143,12 +143,18 @@ func (c *FakePriorityLevelConfigurations) Apply(ctx context.Context, priorityLev
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := priorityLevelConfiguration.Name
 	if name == nil {
 		return nil, fmt.Errorf("priorityLevelConfiguration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(prioritylevelconfigurationsResource, *name, types.ApplyPatchType, data), &v1beta1.PriorityLevelConfiguration{})
+		Invokes(testing.NewRootApplySubresourceAction(prioritylevelconfigurationsResource, *name, data, manager, opts.Force), &v1beta1.PriorityLevelConfiguration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakePriorityLevelConfigurations) ApplyStatus(ctx context.Context, prior
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := priorityLevelConfiguration.Name
 	if name == nil {
 		return nil, fmt.Errorf("priorityLevelConfiguration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(prioritylevelconfigurationsResource, *name, types.ApplyPatchType, data, "status"), &v1beta1.PriorityLevelConfiguration{})
+		Invokes(testing.NewRootApplySubresourceAction(prioritylevelconfigurationsResource, *name, data, manager, opts.Force, "status"), &v1beta1.PriorityLevelConfiguration{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/fake_flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/fake_flowschema.go
@@ -143,12 +143,18 @@ func (c *FakeFlowSchemas) Apply(ctx context.Context, flowSchema *flowcontrolv1be
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := flowSchema.Name
 	if name == nil {
 		return nil, fmt.Errorf("flowSchema.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(flowschemasResource, *name, types.ApplyPatchType, data), &v1beta2.FlowSchema{})
+		Invokes(testing.NewRootApplySubresourceAction(flowschemasResource, *name, data, manager, opts.Force), &v1beta2.FlowSchema{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakeFlowSchemas) ApplyStatus(ctx context.Context, flowSchema *flowcontr
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := flowSchema.Name
 	if name == nil {
 		return nil, fmt.Errorf("flowSchema.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(flowschemasResource, *name, types.ApplyPatchType, data, "status"), &v1beta2.FlowSchema{})
+		Invokes(testing.NewRootApplySubresourceAction(flowschemasResource, *name, data, manager, opts.Force, "status"), &v1beta2.FlowSchema{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/fake_prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/fake/fake_prioritylevelconfiguration.go
@@ -143,12 +143,18 @@ func (c *FakePriorityLevelConfigurations) Apply(ctx context.Context, priorityLev
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := priorityLevelConfiguration.Name
 	if name == nil {
 		return nil, fmt.Errorf("priorityLevelConfiguration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(prioritylevelconfigurationsResource, *name, types.ApplyPatchType, data), &v1beta2.PriorityLevelConfiguration{})
+		Invokes(testing.NewRootApplySubresourceAction(prioritylevelconfigurationsResource, *name, data, manager, opts.Force), &v1beta2.PriorityLevelConfiguration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakePriorityLevelConfigurations) ApplyStatus(ctx context.Context, prior
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := priorityLevelConfiguration.Name
 	if name == nil {
 		return nil, fmt.Errorf("priorityLevelConfiguration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(prioritylevelconfigurationsResource, *name, types.ApplyPatchType, data, "status"), &v1beta2.PriorityLevelConfiguration{})
+		Invokes(testing.NewRootApplySubresourceAction(prioritylevelconfigurationsResource, *name, data, manager, opts.Force, "status"), &v1beta2.PriorityLevelConfiguration{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/fake_flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/fake_flowschema.go
@@ -143,12 +143,18 @@ func (c *FakeFlowSchemas) Apply(ctx context.Context, flowSchema *flowcontrolv1be
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := flowSchema.Name
 	if name == nil {
 		return nil, fmt.Errorf("flowSchema.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(flowschemasResource, *name, types.ApplyPatchType, data), &v1beta3.FlowSchema{})
+		Invokes(testing.NewRootApplySubresourceAction(flowschemasResource, *name, data, manager, opts.Force), &v1beta3.FlowSchema{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakeFlowSchemas) ApplyStatus(ctx context.Context, flowSchema *flowcontr
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := flowSchema.Name
 	if name == nil {
 		return nil, fmt.Errorf("flowSchema.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(flowschemasResource, *name, types.ApplyPatchType, data, "status"), &v1beta3.FlowSchema{})
+		Invokes(testing.NewRootApplySubresourceAction(flowschemasResource, *name, data, manager, opts.Force, "status"), &v1beta3.FlowSchema{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/fake_prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/fake/fake_prioritylevelconfiguration.go
@@ -143,12 +143,18 @@ func (c *FakePriorityLevelConfigurations) Apply(ctx context.Context, priorityLev
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := priorityLevelConfiguration.Name
 	if name == nil {
 		return nil, fmt.Errorf("priorityLevelConfiguration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(prioritylevelconfigurationsResource, *name, types.ApplyPatchType, data), &v1beta3.PriorityLevelConfiguration{})
+		Invokes(testing.NewRootApplySubresourceAction(prioritylevelconfigurationsResource, *name, data, manager, opts.Force), &v1beta3.PriorityLevelConfiguration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakePriorityLevelConfigurations) ApplyStatus(ctx context.Context, prior
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := priorityLevelConfiguration.Name
 	if name == nil {
 		return nil, fmt.Errorf("priorityLevelConfiguration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(prioritylevelconfigurationsResource, *name, types.ApplyPatchType, data, "status"), &v1beta3.PriorityLevelConfiguration{})
+		Invokes(testing.NewRootApplySubresourceAction(prioritylevelconfigurationsResource, *name, data, manager, opts.Force, "status"), &v1beta3.PriorityLevelConfiguration{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_ingress.go
@@ -152,12 +152,18 @@ func (c *FakeIngresses) Apply(ctx context.Context, ingress *networkingv1.Ingress
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := ingress.Name
 	if name == nil {
 		return nil, fmt.Errorf("ingress.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(ingressesResource, c.ns, *name, types.ApplyPatchType, data), &v1.Ingress{})
+		Invokes(testing.NewApplySubresourceAction(ingressesResource, c.ns, *name, data, manager, opts.Force), &v1.Ingress{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeIngresses) ApplyStatus(ctx context.Context, ingress *networkingv1.I
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := ingress.Name
 	if name == nil {
 		return nil, fmt.Errorf("ingress.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(ingressesResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.Ingress{})
+		Invokes(testing.NewApplySubresourceAction(ingressesResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.Ingress{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_ingressclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_ingressclass.go
@@ -132,12 +132,18 @@ func (c *FakeIngressClasses) Apply(ctx context.Context, ingressClass *networking
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := ingressClass.Name
 	if name == nil {
 		return nil, fmt.Errorf("ingressClass.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(ingressclassesResource, *name, types.ApplyPatchType, data), &v1.IngressClass{})
+		Invokes(testing.NewRootApplySubresourceAction(ingressclassesResource, *name, data, manager, opts.Force), &v1.IngressClass{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_networkpolicy.go
@@ -140,12 +140,18 @@ func (c *FakeNetworkPolicies) Apply(ctx context.Context, networkPolicy *networki
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := networkPolicy.Name
 	if name == nil {
 		return nil, fmt.Errorf("networkPolicy.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(networkpoliciesResource, c.ns, *name, types.ApplyPatchType, data), &v1.NetworkPolicy{})
+		Invokes(testing.NewApplySubresourceAction(networkpoliciesResource, c.ns, *name, data, manager, opts.Force), &v1.NetworkPolicy{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1alpha1/fake/fake_clustercidr.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1alpha1/fake/fake_clustercidr.go
@@ -132,12 +132,18 @@ func (c *FakeClusterCIDRs) Apply(ctx context.Context, clusterCIDR *networkingv1a
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := clusterCIDR.Name
 	if name == nil {
 		return nil, fmt.Errorf("clusterCIDR.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(clustercidrsResource, *name, types.ApplyPatchType, data), &v1alpha1.ClusterCIDR{})
+		Invokes(testing.NewRootApplySubresourceAction(clustercidrsResource, *name, data, manager, opts.Force), &v1alpha1.ClusterCIDR{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1alpha1/fake/fake_ipaddress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1alpha1/fake/fake_ipaddress.go
@@ -132,12 +132,18 @@ func (c *FakeIPAddresses) Apply(ctx context.Context, iPAddress *networkingv1alph
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := iPAddress.Name
 	if name == nil {
 		return nil, fmt.Errorf("iPAddress.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(ipaddressesResource, *name, types.ApplyPatchType, data), &v1alpha1.IPAddress{})
+		Invokes(testing.NewRootApplySubresourceAction(ipaddressesResource, *name, data, manager, opts.Force), &v1alpha1.IPAddress{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/fake/fake_ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/fake/fake_ingress.go
@@ -152,12 +152,18 @@ func (c *FakeIngresses) Apply(ctx context.Context, ingress *networkingv1beta1.In
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := ingress.Name
 	if name == nil {
 		return nil, fmt.Errorf("ingress.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(ingressesResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.Ingress{})
+		Invokes(testing.NewApplySubresourceAction(ingressesResource, c.ns, *name, data, manager, opts.Force), &v1beta1.Ingress{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeIngresses) ApplyStatus(ctx context.Context, ingress *networkingv1be
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := ingress.Name
 	if name == nil {
 		return nil, fmt.Errorf("ingress.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(ingressesResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta1.Ingress{})
+		Invokes(testing.NewApplySubresourceAction(ingressesResource, c.ns, *name, data, manager, opts.Force, "status"), &v1beta1.Ingress{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/fake/fake_ingressclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/fake/fake_ingressclass.go
@@ -132,12 +132,18 @@ func (c *FakeIngressClasses) Apply(ctx context.Context, ingressClass *networking
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := ingressClass.Name
 	if name == nil {
 		return nil, fmt.Errorf("ingressClass.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(ingressclassesResource, *name, types.ApplyPatchType, data), &v1beta1.IngressClass{})
+		Invokes(testing.NewRootApplySubresourceAction(ingressclassesResource, *name, data, manager, opts.Force), &v1beta1.IngressClass{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/fake/fake_runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/fake/fake_runtimeclass.go
@@ -132,12 +132,18 @@ func (c *FakeRuntimeClasses) Apply(ctx context.Context, runtimeClass *nodev1.Run
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := runtimeClass.Name
 	if name == nil {
 		return nil, fmt.Errorf("runtimeClass.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(runtimeclassesResource, *name, types.ApplyPatchType, data), &v1.RuntimeClass{})
+		Invokes(testing.NewRootApplySubresourceAction(runtimeclassesResource, *name, data, manager, opts.Force), &v1.RuntimeClass{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/fake/fake_runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/fake/fake_runtimeclass.go
@@ -132,12 +132,18 @@ func (c *FakeRuntimeClasses) Apply(ctx context.Context, runtimeClass *nodev1alph
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := runtimeClass.Name
 	if name == nil {
 		return nil, fmt.Errorf("runtimeClass.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(runtimeclassesResource, *name, types.ApplyPatchType, data), &v1alpha1.RuntimeClass{})
+		Invokes(testing.NewRootApplySubresourceAction(runtimeclassesResource, *name, data, manager, opts.Force), &v1alpha1.RuntimeClass{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/fake/fake_runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/fake/fake_runtimeclass.go
@@ -132,12 +132,18 @@ func (c *FakeRuntimeClasses) Apply(ctx context.Context, runtimeClass *nodev1beta
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := runtimeClass.Name
 	if name == nil {
 		return nil, fmt.Errorf("runtimeClass.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(runtimeclassesResource, *name, types.ApplyPatchType, data), &v1beta1.RuntimeClass{})
+		Invokes(testing.NewRootApplySubresourceAction(runtimeclassesResource, *name, data, manager, opts.Force), &v1beta1.RuntimeClass{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/fake/fake_poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/fake/fake_poddisruptionbudget.go
@@ -152,12 +152,18 @@ func (c *FakePodDisruptionBudgets) Apply(ctx context.Context, podDisruptionBudge
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := podDisruptionBudget.Name
 	if name == nil {
 		return nil, fmt.Errorf("podDisruptionBudget.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(poddisruptionbudgetsResource, c.ns, *name, types.ApplyPatchType, data), &v1.PodDisruptionBudget{})
+		Invokes(testing.NewApplySubresourceAction(poddisruptionbudgetsResource, c.ns, *name, data, manager, opts.Force), &v1.PodDisruptionBudget{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakePodDisruptionBudgets) ApplyStatus(ctx context.Context, podDisruptio
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := podDisruptionBudget.Name
 	if name == nil {
 		return nil, fmt.Errorf("podDisruptionBudget.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(poddisruptionbudgetsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.PodDisruptionBudget{})
+		Invokes(testing.NewApplySubresourceAction(poddisruptionbudgetsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.PodDisruptionBudget{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_poddisruptionbudget.go
@@ -152,12 +152,18 @@ func (c *FakePodDisruptionBudgets) Apply(ctx context.Context, podDisruptionBudge
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := podDisruptionBudget.Name
 	if name == nil {
 		return nil, fmt.Errorf("podDisruptionBudget.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(poddisruptionbudgetsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.PodDisruptionBudget{})
+		Invokes(testing.NewApplySubresourceAction(poddisruptionbudgetsResource, c.ns, *name, data, manager, opts.Force), &v1beta1.PodDisruptionBudget{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakePodDisruptionBudgets) ApplyStatus(ctx context.Context, podDisruptio
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := podDisruptionBudget.Name
 	if name == nil {
 		return nil, fmt.Errorf("podDisruptionBudget.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(poddisruptionbudgetsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta1.PodDisruptionBudget{})
+		Invokes(testing.NewApplySubresourceAction(poddisruptionbudgetsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1beta1.PodDisruptionBudget{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_podsecuritypolicy.go
@@ -132,12 +132,18 @@ func (c *FakePodSecurityPolicies) Apply(ctx context.Context, podSecurityPolicy *
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := podSecurityPolicy.Name
 	if name == nil {
 		return nil, fmt.Errorf("podSecurityPolicy.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(podsecuritypoliciesResource, *name, types.ApplyPatchType, data), &v1beta1.PodSecurityPolicy{})
+		Invokes(testing.NewRootApplySubresourceAction(podsecuritypoliciesResource, *name, data, manager, opts.Force), &v1beta1.PodSecurityPolicy{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_clusterrole.go
@@ -132,12 +132,18 @@ func (c *FakeClusterRoles) Apply(ctx context.Context, clusterRole *rbacv1.Cluste
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := clusterRole.Name
 	if name == nil {
 		return nil, fmt.Errorf("clusterRole.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(clusterrolesResource, *name, types.ApplyPatchType, data), &v1.ClusterRole{})
+		Invokes(testing.NewRootApplySubresourceAction(clusterrolesResource, *name, data, manager, opts.Force), &v1.ClusterRole{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_clusterrolebinding.go
@@ -132,12 +132,18 @@ func (c *FakeClusterRoleBindings) Apply(ctx context.Context, clusterRoleBinding 
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := clusterRoleBinding.Name
 	if name == nil {
 		return nil, fmt.Errorf("clusterRoleBinding.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(clusterrolebindingsResource, *name, types.ApplyPatchType, data), &v1.ClusterRoleBinding{})
+		Invokes(testing.NewRootApplySubresourceAction(clusterrolebindingsResource, *name, data, manager, opts.Force), &v1.ClusterRoleBinding{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_role.go
@@ -140,12 +140,18 @@ func (c *FakeRoles) Apply(ctx context.Context, role *rbacv1.RoleApplyConfigurati
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := role.Name
 	if name == nil {
 		return nil, fmt.Errorf("role.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(rolesResource, c.ns, *name, types.ApplyPatchType, data), &v1.Role{})
+		Invokes(testing.NewApplySubresourceAction(rolesResource, c.ns, *name, data, manager, opts.Force), &v1.Role{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_rolebinding.go
@@ -140,12 +140,18 @@ func (c *FakeRoleBindings) Apply(ctx context.Context, roleBinding *rbacv1.RoleBi
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := roleBinding.Name
 	if name == nil {
 		return nil, fmt.Errorf("roleBinding.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(rolebindingsResource, c.ns, *name, types.ApplyPatchType, data), &v1.RoleBinding{})
+		Invokes(testing.NewApplySubresourceAction(rolebindingsResource, c.ns, *name, data, manager, opts.Force), &v1.RoleBinding{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrole.go
@@ -132,12 +132,18 @@ func (c *FakeClusterRoles) Apply(ctx context.Context, clusterRole *rbacv1alpha1.
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := clusterRole.Name
 	if name == nil {
 		return nil, fmt.Errorf("clusterRole.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(clusterrolesResource, *name, types.ApplyPatchType, data), &v1alpha1.ClusterRole{})
+		Invokes(testing.NewRootApplySubresourceAction(clusterrolesResource, *name, data, manager, opts.Force), &v1alpha1.ClusterRole{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrolebinding.go
@@ -132,12 +132,18 @@ func (c *FakeClusterRoleBindings) Apply(ctx context.Context, clusterRoleBinding 
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := clusterRoleBinding.Name
 	if name == nil {
 		return nil, fmt.Errorf("clusterRoleBinding.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(clusterrolebindingsResource, *name, types.ApplyPatchType, data), &v1alpha1.ClusterRoleBinding{})
+		Invokes(testing.NewRootApplySubresourceAction(clusterrolebindingsResource, *name, data, manager, opts.Force), &v1alpha1.ClusterRoleBinding{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_role.go
@@ -140,12 +140,18 @@ func (c *FakeRoles) Apply(ctx context.Context, role *rbacv1alpha1.RoleApplyConfi
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := role.Name
 	if name == nil {
 		return nil, fmt.Errorf("role.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(rolesResource, c.ns, *name, types.ApplyPatchType, data), &v1alpha1.Role{})
+		Invokes(testing.NewApplySubresourceAction(rolesResource, c.ns, *name, data, manager, opts.Force), &v1alpha1.Role{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_rolebinding.go
@@ -140,12 +140,18 @@ func (c *FakeRoleBindings) Apply(ctx context.Context, roleBinding *rbacv1alpha1.
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := roleBinding.Name
 	if name == nil {
 		return nil, fmt.Errorf("roleBinding.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(rolebindingsResource, c.ns, *name, types.ApplyPatchType, data), &v1alpha1.RoleBinding{})
+		Invokes(testing.NewApplySubresourceAction(rolebindingsResource, c.ns, *name, data, manager, opts.Force), &v1alpha1.RoleBinding{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrole.go
@@ -132,12 +132,18 @@ func (c *FakeClusterRoles) Apply(ctx context.Context, clusterRole *rbacv1beta1.C
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := clusterRole.Name
 	if name == nil {
 		return nil, fmt.Errorf("clusterRole.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(clusterrolesResource, *name, types.ApplyPatchType, data), &v1beta1.ClusterRole{})
+		Invokes(testing.NewRootApplySubresourceAction(clusterrolesResource, *name, data, manager, opts.Force), &v1beta1.ClusterRole{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrolebinding.go
@@ -132,12 +132,18 @@ func (c *FakeClusterRoleBindings) Apply(ctx context.Context, clusterRoleBinding 
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := clusterRoleBinding.Name
 	if name == nil {
 		return nil, fmt.Errorf("clusterRoleBinding.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(clusterrolebindingsResource, *name, types.ApplyPatchType, data), &v1beta1.ClusterRoleBinding{})
+		Invokes(testing.NewRootApplySubresourceAction(clusterrolebindingsResource, *name, data, manager, opts.Force), &v1beta1.ClusterRoleBinding{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_role.go
@@ -140,12 +140,18 @@ func (c *FakeRoles) Apply(ctx context.Context, role *rbacv1beta1.RoleApplyConfig
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := role.Name
 	if name == nil {
 		return nil, fmt.Errorf("role.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(rolesResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.Role{})
+		Invokes(testing.NewApplySubresourceAction(rolesResource, c.ns, *name, data, manager, opts.Force), &v1beta1.Role{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_rolebinding.go
@@ -140,12 +140,18 @@ func (c *FakeRoleBindings) Apply(ctx context.Context, roleBinding *rbacv1beta1.R
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := roleBinding.Name
 	if name == nil {
 		return nil, fmt.Errorf("roleBinding.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(rolebindingsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.RoleBinding{})
+		Invokes(testing.NewApplySubresourceAction(rolebindingsResource, c.ns, *name, data, manager, opts.Force), &v1beta1.RoleBinding{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/fake/fake_podschedulingcontext.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/fake/fake_podschedulingcontext.go
@@ -152,12 +152,18 @@ func (c *FakePodSchedulingContexts) Apply(ctx context.Context, podSchedulingCont
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := podSchedulingContext.Name
 	if name == nil {
 		return nil, fmt.Errorf("podSchedulingContext.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(podschedulingcontextsResource, c.ns, *name, types.ApplyPatchType, data), &v1alpha2.PodSchedulingContext{})
+		Invokes(testing.NewApplySubresourceAction(podschedulingcontextsResource, c.ns, *name, data, manager, opts.Force), &v1alpha2.PodSchedulingContext{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakePodSchedulingContexts) ApplyStatus(ctx context.Context, podScheduli
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := podSchedulingContext.Name
 	if name == nil {
 		return nil, fmt.Errorf("podSchedulingContext.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(podschedulingcontextsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1alpha2.PodSchedulingContext{})
+		Invokes(testing.NewApplySubresourceAction(podschedulingcontextsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1alpha2.PodSchedulingContext{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/fake/fake_resourceclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/fake/fake_resourceclaim.go
@@ -152,12 +152,18 @@ func (c *FakeResourceClaims) Apply(ctx context.Context, resourceClaim *resourcev
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := resourceClaim.Name
 	if name == nil {
 		return nil, fmt.Errorf("resourceClaim.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(resourceclaimsResource, c.ns, *name, types.ApplyPatchType, data), &v1alpha2.ResourceClaim{})
+		Invokes(testing.NewApplySubresourceAction(resourceclaimsResource, c.ns, *name, data, manager, opts.Force), &v1alpha2.ResourceClaim{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeResourceClaims) ApplyStatus(ctx context.Context, resourceClaim *res
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := resourceClaim.Name
 	if name == nil {
 		return nil, fmt.Errorf("resourceClaim.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(resourceclaimsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1alpha2.ResourceClaim{})
+		Invokes(testing.NewApplySubresourceAction(resourceclaimsResource, c.ns, *name, data, manager, opts.Force, "status"), &v1alpha2.ResourceClaim{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/fake/fake_resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/fake/fake_resourceclaimtemplate.go
@@ -140,12 +140,18 @@ func (c *FakeResourceClaimTemplates) Apply(ctx context.Context, resourceClaimTem
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := resourceClaimTemplate.Name
 	if name == nil {
 		return nil, fmt.Errorf("resourceClaimTemplate.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(resourceclaimtemplatesResource, c.ns, *name, types.ApplyPatchType, data), &v1alpha2.ResourceClaimTemplate{})
+		Invokes(testing.NewApplySubresourceAction(resourceclaimtemplatesResource, c.ns, *name, data, manager, opts.Force), &v1alpha2.ResourceClaimTemplate{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/fake/fake_resourceclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/fake/fake_resourceclass.go
@@ -132,12 +132,18 @@ func (c *FakeResourceClasses) Apply(ctx context.Context, resourceClass *resource
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := resourceClass.Name
 	if name == nil {
 		return nil, fmt.Errorf("resourceClass.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(resourceclassesResource, *name, types.ApplyPatchType, data), &v1alpha2.ResourceClass{})
+		Invokes(testing.NewRootApplySubresourceAction(resourceclassesResource, *name, data, manager, opts.Force), &v1alpha2.ResourceClass{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/fake/fake_priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/fake/fake_priorityclass.go
@@ -132,12 +132,18 @@ func (c *FakePriorityClasses) Apply(ctx context.Context, priorityClass *scheduli
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := priorityClass.Name
 	if name == nil {
 		return nil, fmt.Errorf("priorityClass.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(priorityclassesResource, *name, types.ApplyPatchType, data), &v1.PriorityClass{})
+		Invokes(testing.NewRootApplySubresourceAction(priorityclassesResource, *name, data, manager, opts.Force), &v1.PriorityClass{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/fake/fake_priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/fake/fake_priorityclass.go
@@ -132,12 +132,18 @@ func (c *FakePriorityClasses) Apply(ctx context.Context, priorityClass *scheduli
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := priorityClass.Name
 	if name == nil {
 		return nil, fmt.Errorf("priorityClass.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(priorityclassesResource, *name, types.ApplyPatchType, data), &v1alpha1.PriorityClass{})
+		Invokes(testing.NewRootApplySubresourceAction(priorityclassesResource, *name, data, manager, opts.Force), &v1alpha1.PriorityClass{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/fake/fake_priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/fake/fake_priorityclass.go
@@ -132,12 +132,18 @@ func (c *FakePriorityClasses) Apply(ctx context.Context, priorityClass *scheduli
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := priorityClass.Name
 	if name == nil {
 		return nil, fmt.Errorf("priorityClass.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(priorityclassesResource, *name, types.ApplyPatchType, data), &v1beta1.PriorityClass{})
+		Invokes(testing.NewRootApplySubresourceAction(priorityclassesResource, *name, data, manager, opts.Force), &v1beta1.PriorityClass{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_csidriver.go
@@ -132,12 +132,18 @@ func (c *FakeCSIDrivers) Apply(ctx context.Context, cSIDriver *storagev1.CSIDriv
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := cSIDriver.Name
 	if name == nil {
 		return nil, fmt.Errorf("cSIDriver.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(csidriversResource, *name, types.ApplyPatchType, data), &v1.CSIDriver{})
+		Invokes(testing.NewRootApplySubresourceAction(csidriversResource, *name, data, manager, opts.Force), &v1.CSIDriver{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_csinode.go
@@ -132,12 +132,18 @@ func (c *FakeCSINodes) Apply(ctx context.Context, cSINode *storagev1.CSINodeAppl
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := cSINode.Name
 	if name == nil {
 		return nil, fmt.Errorf("cSINode.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(csinodesResource, *name, types.ApplyPatchType, data), &v1.CSINode{})
+		Invokes(testing.NewRootApplySubresourceAction(csinodesResource, *name, data, manager, opts.Force), &v1.CSINode{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_csistoragecapacity.go
@@ -140,12 +140,18 @@ func (c *FakeCSIStorageCapacities) Apply(ctx context.Context, cSIStorageCapacity
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := cSIStorageCapacity.Name
 	if name == nil {
 		return nil, fmt.Errorf("cSIStorageCapacity.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(csistoragecapacitiesResource, c.ns, *name, types.ApplyPatchType, data), &v1.CSIStorageCapacity{})
+		Invokes(testing.NewApplySubresourceAction(csistoragecapacitiesResource, c.ns, *name, data, manager, opts.Force), &v1.CSIStorageCapacity{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storageclass.go
@@ -132,12 +132,18 @@ func (c *FakeStorageClasses) Apply(ctx context.Context, storageClass *storagev1.
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := storageClass.Name
 	if name == nil {
 		return nil, fmt.Errorf("storageClass.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(storageclassesResource, *name, types.ApplyPatchType, data), &v1.StorageClass{})
+		Invokes(testing.NewRootApplySubresourceAction(storageclassesResource, *name, data, manager, opts.Force), &v1.StorageClass{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_volumeattachment.go
@@ -143,12 +143,18 @@ func (c *FakeVolumeAttachments) Apply(ctx context.Context, volumeAttachment *sto
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := volumeAttachment.Name
 	if name == nil {
 		return nil, fmt.Errorf("volumeAttachment.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(volumeattachmentsResource, *name, types.ApplyPatchType, data), &v1.VolumeAttachment{})
+		Invokes(testing.NewRootApplySubresourceAction(volumeattachmentsResource, *name, data, manager, opts.Force), &v1.VolumeAttachment{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakeVolumeAttachments) ApplyStatus(ctx context.Context, volumeAttachmen
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := volumeAttachment.Name
 	if name == nil {
 		return nil, fmt.Errorf("volumeAttachment.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(volumeattachmentsResource, *name, types.ApplyPatchType, data, "status"), &v1.VolumeAttachment{})
+		Invokes(testing.NewRootApplySubresourceAction(volumeattachmentsResource, *name, data, manager, opts.Force, "status"), &v1.VolumeAttachment{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake/fake_csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake/fake_csistoragecapacity.go
@@ -140,12 +140,18 @@ func (c *FakeCSIStorageCapacities) Apply(ctx context.Context, cSIStorageCapacity
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := cSIStorageCapacity.Name
 	if name == nil {
 		return nil, fmt.Errorf("cSIStorageCapacity.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(csistoragecapacitiesResource, c.ns, *name, types.ApplyPatchType, data), &v1alpha1.CSIStorageCapacity{})
+		Invokes(testing.NewApplySubresourceAction(csistoragecapacitiesResource, c.ns, *name, data, manager, opts.Force), &v1alpha1.CSIStorageCapacity{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake/fake_volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake/fake_volumeattachment.go
@@ -143,12 +143,18 @@ func (c *FakeVolumeAttachments) Apply(ctx context.Context, volumeAttachment *sto
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := volumeAttachment.Name
 	if name == nil {
 		return nil, fmt.Errorf("volumeAttachment.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(volumeattachmentsResource, *name, types.ApplyPatchType, data), &v1alpha1.VolumeAttachment{})
+		Invokes(testing.NewRootApplySubresourceAction(volumeattachmentsResource, *name, data, manager, opts.Force), &v1alpha1.VolumeAttachment{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakeVolumeAttachments) ApplyStatus(ctx context.Context, volumeAttachmen
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := volumeAttachment.Name
 	if name == nil {
 		return nil, fmt.Errorf("volumeAttachment.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(volumeattachmentsResource, *name, types.ApplyPatchType, data, "status"), &v1alpha1.VolumeAttachment{})
+		Invokes(testing.NewRootApplySubresourceAction(volumeattachmentsResource, *name, data, manager, opts.Force, "status"), &v1alpha1.VolumeAttachment{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_csidriver.go
@@ -132,12 +132,18 @@ func (c *FakeCSIDrivers) Apply(ctx context.Context, cSIDriver *storagev1beta1.CS
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := cSIDriver.Name
 	if name == nil {
 		return nil, fmt.Errorf("cSIDriver.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(csidriversResource, *name, types.ApplyPatchType, data), &v1beta1.CSIDriver{})
+		Invokes(testing.NewRootApplySubresourceAction(csidriversResource, *name, data, manager, opts.Force), &v1beta1.CSIDriver{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_csinode.go
@@ -132,12 +132,18 @@ func (c *FakeCSINodes) Apply(ctx context.Context, cSINode *storagev1beta1.CSINod
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := cSINode.Name
 	if name == nil {
 		return nil, fmt.Errorf("cSINode.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(csinodesResource, *name, types.ApplyPatchType, data), &v1beta1.CSINode{})
+		Invokes(testing.NewRootApplySubresourceAction(csinodesResource, *name, data, manager, opts.Force), &v1beta1.CSINode{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_csistoragecapacity.go
@@ -140,12 +140,18 @@ func (c *FakeCSIStorageCapacities) Apply(ctx context.Context, cSIStorageCapacity
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := cSIStorageCapacity.Name
 	if name == nil {
 		return nil, fmt.Errorf("cSIStorageCapacity.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(csistoragecapacitiesResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.CSIStorageCapacity{})
+		Invokes(testing.NewApplySubresourceAction(csistoragecapacitiesResource, c.ns, *name, data, manager, opts.Force), &v1beta1.CSIStorageCapacity{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storageclass.go
@@ -132,12 +132,18 @@ func (c *FakeStorageClasses) Apply(ctx context.Context, storageClass *storagev1b
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := storageClass.Name
 	if name == nil {
 		return nil, fmt.Errorf("storageClass.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(storageclassesResource, *name, types.ApplyPatchType, data), &v1beta1.StorageClass{})
+		Invokes(testing.NewRootApplySubresourceAction(storageclassesResource, *name, data, manager, opts.Force), &v1beta1.StorageClass{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_volumeattachment.go
@@ -143,12 +143,18 @@ func (c *FakeVolumeAttachments) Apply(ctx context.Context, volumeAttachment *sto
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := volumeAttachment.Name
 	if name == nil {
 		return nil, fmt.Errorf("volumeAttachment.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(volumeattachmentsResource, *name, types.ApplyPatchType, data), &v1beta1.VolumeAttachment{})
+		Invokes(testing.NewRootApplySubresourceAction(volumeattachmentsResource, *name, data, manager, opts.Force), &v1beta1.VolumeAttachment{})
 	if obj == nil {
 		return nil, err
 	}
@@ -165,12 +171,18 @@ func (c *FakeVolumeAttachments) ApplyStatus(ctx context.Context, volumeAttachmen
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := volumeAttachment.Name
 	if name == nil {
 		return nil, fmt.Errorf("volumeAttachment.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(volumeattachmentsResource, *name, types.ApplyPatchType, data, "status"), &v1beta1.VolumeAttachment{})
+		Invokes(testing.NewRootApplySubresourceAction(volumeattachmentsResource, *name, data, manager, opts.Force, "status"), &v1beta1.VolumeAttachment{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/testing/actions.go
+++ b/staging/src/k8s.io/client-go/testing/actions.go
@@ -201,6 +201,62 @@ func NewPatchSubresourceAction(resource schema.GroupVersionResource, namespace, 
 	return action
 }
 
+func NewRootApplyAction(resource schema.GroupVersionResource, name string, patch []byte, manager string, force bool) ApplyActionImpl {
+	action := ApplyActionImpl{}
+	action.Verb = "patch"
+	action.Resource = resource
+	action.Name = name
+	action.PatchType = types.ApplyPatchType
+	action.Patch = patch
+	action.Manager = manager
+	action.Force = force
+
+	return action
+}
+
+func NewApplyAction(resource schema.GroupVersionResource, namespace string, name string, patch []byte, manager string, force bool) ApplyActionImpl {
+	action := ApplyActionImpl{}
+	action.Verb = "patch"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Name = name
+	action.PatchType = types.ApplyPatchType
+	action.Patch = patch
+	action.Manager = manager
+	action.Force = force
+
+	return action
+}
+
+func NewRootApplySubresourceAction(resource schema.GroupVersionResource, name string, patch []byte, manager string, force bool, subresources ...string) ApplyActionImpl {
+	action := ApplyActionImpl{}
+	action.Verb = "patch"
+	action.Resource = resource
+	action.Subresource = path.Join(subresources...)
+	action.Name = name
+	action.PatchType = types.ApplyPatchType
+	action.Patch = patch
+	action.Manager = manager
+	action.Force = force
+
+	return action
+}
+
+func NewApplySubresourceAction(resource schema.GroupVersionResource, namespace string, name string, patch []byte, manager string, force bool, subresources ...string) ApplyActionImpl {
+	action := ApplyActionImpl{}
+	action.Verb = "patch"
+	action.Resource = resource
+	action.Subresource = path.Join(subresources...)
+	action.Namespace = namespace
+	action.Name = name
+	action.PatchType = types.ApplyPatchType
+	action.Patch = patch
+	action.Manager = manager
+	action.Force = force
+
+	return action
+}
+
 func NewRootUpdateSubresourceAction(resource schema.GroupVersionResource, subresource string, object runtime.Object) UpdateActionImpl {
 	action := UpdateActionImpl{}
 	action.Verb = "update"
@@ -416,6 +472,12 @@ type PatchAction interface {
 	GetPatch() []byte
 }
 
+type ApplyAction interface {
+	PatchAction
+	Force() bool
+	Manager() string
+}
+
 type WatchAction interface {
 	Action
 	GetWatchRestrictions() WatchRestrictions
@@ -589,6 +651,28 @@ func (a PatchActionImpl) DeepCopy() Action {
 		Name:       a.Name,
 		PatchType:  a.PatchType,
 		Patch:      patch,
+	}
+}
+
+type ApplyActionImpl struct {
+	PatchActionImpl
+	Force   bool
+	Manager string
+}
+
+func (a ApplyActionImpl) GetForce() bool {
+	return a.Force
+}
+
+func (a ApplyActionImpl) GetManager() string {
+	return a.Manager
+}
+
+func (a ApplyActionImpl) DeepCopy() Action {
+	return ApplyActionImpl{
+		PatchActionImpl: a.PatchActionImpl.DeepCopy().(PatchActionImpl),
+		Manager:         a.Manager,
+		Force:           a.Force,
 	}
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
@@ -76,6 +76,7 @@ func (g *genClientset) Imports(c *generator.Context) (imports []string) {
 		"k8s.io/client-go/discovery",
 		"fakediscovery \"k8s.io/client-go/discovery/fake\"",
 		"k8s.io/apimachinery/pkg/runtime",
+		"k8s.io/apimachinery/pkg/util/managedfields",
 		"k8s.io/apimachinery/pkg/watch",
 	)
 
@@ -109,12 +110,13 @@ func (g *genClientset) GenerateType(c *generator.Context, t *types.Type, w io.Wr
 
 // This part of code is version-independent, unchanging.
 var common = `
-// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// NewSimpleClientsetWithFieldmanager returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewSimpleClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+// It also takes the fieldmanager that can be used to track field ownership and use server-side apply.
+func NewSimpleClientsetWithFieldManager(fieldManager *managedfields.FieldManager, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTrackerWithFieldManager(scheme, codecs.UniversalDecoder(), fieldManager)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)
@@ -137,6 +139,14 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+	return NewSimpleClientsetWithFieldManager(nil, objects...)
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
@@ -144,6 +154,7 @@ type Clientset struct {
 	testing.Fake
 	discovery *fakediscovery.FakeDiscovery
 	tracker testing.ObjectTracker
+	fieldManager *managedfields.FieldManager
 }
 
 func (c *Clientset) Discovery() discovery.DiscoveryInterface {

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_type.go
@@ -146,6 +146,10 @@ func (g *genFakeForType) GenerateType(c *generator.Context, t *types.Type, w io.
 		"NewPatchAction":                 c.Universe.Function(types.Name{Package: pkgClientGoTesting, Name: "NewPatchAction"}),
 		"NewRootPatchSubresourceAction":  c.Universe.Function(types.Name{Package: pkgClientGoTesting, Name: "NewRootPatchSubresourceAction"}),
 		"NewPatchSubresourceAction":      c.Universe.Function(types.Name{Package: pkgClientGoTesting, Name: "NewPatchSubresourceAction"}),
+		"NewRootApplyAction":             c.Universe.Function(types.Name{Package: pkgClientGoTesting, Name: "NewRootApplyAction"}),
+		"NewApplyAction":                 c.Universe.Function(types.Name{Package: pkgClientGoTesting, Name: "NewApplyAction"}),
+		"NewRootApplySubresourceAction":  c.Universe.Function(types.Name{Package: pkgClientGoTesting, Name: "NewRootApplySubresourceAction"}),
+		"NewApplySubresourceAction":      c.Universe.Function(types.Name{Package: pkgClientGoTesting, Name: "NewApplySubresourceAction"}),
 		"ExtractFromListOptions":         c.Universe.Function(types.Name{Package: pkgClientGoTesting, Name: "ExtractFromListOptions"}),
 	}
 
@@ -509,13 +513,19 @@ func (c *Fake$.type|publicPlural$) Apply(ctx context.Context, $.inputType|privat
 	if err != nil {
 		return nil, err
 	}
-    name := $.inputType|private$.Name
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
+	name := $.inputType|private$.Name
 	if name == nil {
 		return nil, fmt.Errorf("$.inputType|private$.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		$if .namespaced$Invokes($.NewPatchSubresourceAction|raw$($.type|allLowercasePlural$Resource, c.ns, *name, $.ApplyPatchType|raw$, data), &$.resultType|raw${})
-		$else$Invokes($.NewRootPatchSubresourceAction|raw$($.type|allLowercasePlural$Resource, *name, $.ApplyPatchType|raw$, data), &$.resultType|raw${})$end$
+		$if .namespaced$Invokes($.NewApplySubresourceAction|raw$($.type|allLowercasePlural$Resource, c.ns, *name, data, manager, opts.Force), &$.resultType|raw${})
+		$else$Invokes($.NewRootApplySubresourceAction|raw$($.type|allLowercasePlural$Resource, *name, data, manager, opts.Force), &$.resultType|raw${})$end$
 	if obj == nil {
 		return nil, err
 	}
@@ -534,13 +544,19 @@ func (c *Fake$.type|publicPlural$) ApplyStatus(ctx context.Context, $.inputType|
 	if err != nil {
 		return nil, err
 	}
-    name := $.inputType|private$.Name
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
+	name := $.inputType|private$.Name
 	if name == nil {
 		return nil, fmt.Errorf("$.inputType|private$.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		$if .namespaced$Invokes($.NewPatchSubresourceAction|raw$($.type|allLowercasePlural$Resource, c.ns, *name, $.ApplyPatchType|raw$, data, "status"), &$.resultType|raw${})
-		$else$Invokes($.NewRootPatchSubresourceAction|raw$($.type|allLowercasePlural$Resource, *name, $.ApplyPatchType|raw$, data, "status"), &$.resultType|raw${})$end$
+		$if .namespaced$Invokes($.NewApplySubresourceAction|raw$($.type|allLowercasePlural$Resource, c.ns, *name, data, manager, opts.Force, "status"), &$.resultType|raw${})
+		$else$Invokes($.NewRootApplySubresourceAction|raw$($.type|allLowercasePlural$Resource, *name, data, manager, opts.Force, "status"), &$.resultType|raw${})$end$
 	if obj == nil {
 		return nil, err
 	}
@@ -559,9 +575,15 @@ func (c *Fake$.type|publicPlural$) Apply(ctx context.Context, $.type|private$Nam
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	obj, err := c.Fake.
-		$if .namespaced$Invokes($.NewPatchSubresourceAction|raw$($.type|allLowercasePlural$Resource, c.ns, $.type|private$Name, $.ApplyPatchType|raw$, data, "status"), &$.resultType|raw${})
-		$else$Invokes($.NewRootPatchSubresourceAction|raw$($.type|allLowercasePlural$Resource, $.type|private$Name, $.ApplyPatchType|raw$, data, "status"), &$.resultType|raw${})$end$
+		$if .namespaced$Invokes($.NewApplySubresourceAction|raw$($.type|allLowercasePlural$Resource, c.ns, $.type|private$Name, data, manager, opts.Force, "status"), &$.resultType|raw${})
+		$else$Invokes($.NewRootApplySubresourceAction|raw$($.type|allLowercasePlural$Resource, $.type|private$Name, data, manager, opts.Force, "status"), &$.resultType|raw${})$end$
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
@@ -144,12 +144,18 @@ func (c *FakeClusterTestTypes) Apply(ctx context.Context, clusterTestType *examp
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := clusterTestType.Name
 	if name == nil {
 		return nil, fmt.Errorf("clusterTestType.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(clustertesttypesResource, *name, types.ApplyPatchType, data), &v1.ClusterTestType{})
+		Invokes(testing.NewRootApplySubresourceAction(clustertesttypesResource, *name, data, manager, opts.Force), &v1.ClusterTestType{})
 	if obj == nil {
 		return nil, err
 	}
@@ -166,12 +172,18 @@ func (c *FakeClusterTestTypes) ApplyStatus(ctx context.Context, clusterTestType 
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := clusterTestType.Name
 	if name == nil {
 		return nil, fmt.Errorf("clusterTestType.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(clustertesttypesResource, *name, types.ApplyPatchType, data, "status"), &v1.ClusterTestType{})
+		Invokes(testing.NewRootApplySubresourceAction(clustertesttypesResource, *name, data, manager, opts.Force, "status"), &v1.ClusterTestType{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/fake/fake_testtype.go
@@ -152,12 +152,18 @@ func (c *FakeTestTypes) Apply(ctx context.Context, testType *examplev1.TestTypeA
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := testType.Name
 	if name == nil {
 		return nil, fmt.Errorf("testType.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(testtypesResource, c.ns, *name, types.ApplyPatchType, data), &v1.TestType{})
+		Invokes(testing.NewApplySubresourceAction(testtypesResource, c.ns, *name, data, manager, opts.Force), &v1.TestType{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeTestTypes) ApplyStatus(ctx context.Context, testType *examplev1.Tes
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := testType.Name
 	if name == nil {
 		return nil, fmt.Errorf("testType.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(testtypesResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.TestType{})
+		Invokes(testing.NewApplySubresourceAction(testtypesResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.TestType{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/fake/clientset_generated.go
@@ -20,6 +20,7 @@ package fake
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -29,12 +30,13 @@ import (
 	fakeexamplev1 "k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/fake"
 )
 
-// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// NewSimpleClientsetWithFieldmanager returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewSimpleClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+// It also takes the fieldmanager that can be used to track field ownership and use server-side apply.
+func NewSimpleClientsetWithFieldManager(fieldManager *managedfields.FieldManager, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTrackerWithFieldManager(scheme, codecs.UniversalDecoder(), fieldManager)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)
@@ -57,13 +59,22 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+	return NewSimpleClientsetWithFieldManager(nil, objects...)
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
-	tracker   testing.ObjectTracker
+	discovery    *fakediscovery.FakeDiscovery
+	tracker      testing.ObjectTracker
+	fieldManager *managedfields.FieldManager
 }
 
 func (c *Clientset) Discovery() discovery.DiscoveryInterface {

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
@@ -144,12 +144,18 @@ func (c *FakeClusterTestTypes) Apply(ctx context.Context, clusterTestType *examp
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := clusterTestType.Name
 	if name == nil {
 		return nil, fmt.Errorf("clusterTestType.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(clustertesttypesResource, *name, types.ApplyPatchType, data), &v1.ClusterTestType{})
+		Invokes(testing.NewRootApplySubresourceAction(clustertesttypesResource, *name, data, manager, opts.Force), &v1.ClusterTestType{})
 	if obj == nil {
 		return nil, err
 	}
@@ -166,12 +172,18 @@ func (c *FakeClusterTestTypes) ApplyStatus(ctx context.Context, clusterTestType 
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := clusterTestType.Name
 	if name == nil {
 		return nil, fmt.Errorf("clusterTestType.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(clustertesttypesResource, *name, types.ApplyPatchType, data, "status"), &v1.ClusterTestType{})
+		Invokes(testing.NewRootApplySubresourceAction(clustertesttypesResource, *name, data, manager, opts.Force, "status"), &v1.ClusterTestType{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_testtype.go
@@ -152,12 +152,18 @@ func (c *FakeTestTypes) Apply(ctx context.Context, testType *examplev1.TestTypeA
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := testType.Name
 	if name == nil {
 		return nil, fmt.Errorf("testType.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(testtypesResource, c.ns, *name, types.ApplyPatchType, data), &v1.TestType{})
+		Invokes(testing.NewApplySubresourceAction(testtypesResource, c.ns, *name, data, manager, opts.Force), &v1.TestType{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeTestTypes) ApplyStatus(ctx context.Context, testType *examplev1.Tes
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := testType.Name
 	if name == nil {
 		return nil, fmt.Errorf("testType.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(testtypesResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.TestType{})
+		Invokes(testing.NewApplySubresourceAction(testtypesResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.TestType{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/fake/clientset_generated.go
@@ -20,6 +20,7 @@ package fake
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -33,12 +34,13 @@ import (
 	fakethirdexamplev1 "k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/fake"
 )
 
-// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// NewSimpleClientsetWithFieldmanager returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewSimpleClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+// It also takes the fieldmanager that can be used to track field ownership and use server-side apply.
+func NewSimpleClientsetWithFieldManager(fieldManager *managedfields.FieldManager, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTrackerWithFieldManager(scheme, codecs.UniversalDecoder(), fieldManager)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)
@@ -61,13 +63,22 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+	return NewSimpleClientsetWithFieldManager(nil, objects...)
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
-	tracker   testing.ObjectTracker
+	discovery    *fakediscovery.FakeDiscovery
+	tracker      testing.ObjectTracker
+	fieldManager *managedfields.FieldManager
 }
 
 func (c *Clientset) Discovery() discovery.DiscoveryInterface {

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/fake/clientset_generated.go
@@ -20,6 +20,7 @@ package fake
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -31,12 +32,13 @@ import (
 	fakesecondexamplev1 "k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/fake"
 )
 
-// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// NewSimpleClientsetWithFieldmanager returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewSimpleClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+// It also takes the fieldmanager that can be used to track field ownership and use server-side apply.
+func NewSimpleClientsetWithFieldManager(fieldManager *managedfields.FieldManager, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTrackerWithFieldManager(scheme, codecs.UniversalDecoder(), fieldManager)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)
@@ -59,13 +61,22 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+	return NewSimpleClientsetWithFieldManager(nil, objects...)
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
-	tracker   testing.ObjectTracker
+	discovery    *fakediscovery.FakeDiscovery
+	tracker      testing.ObjectTracker
+	fieldManager *managedfields.FieldManager
 }
 
 func (c *Clientset) Discovery() discovery.DiscoveryInterface {

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
@@ -144,12 +144,18 @@ func (c *FakeClusterTestTypes) Apply(ctx context.Context, clusterTestType *examp
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := clusterTestType.Name
 	if name == nil {
 		return nil, fmt.Errorf("clusterTestType.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(clustertesttypesResource, *name, types.ApplyPatchType, data), &v1.ClusterTestType{})
+		Invokes(testing.NewRootApplySubresourceAction(clustertesttypesResource, *name, data, manager, opts.Force), &v1.ClusterTestType{})
 	if obj == nil {
 		return nil, err
 	}
@@ -166,12 +172,18 @@ func (c *FakeClusterTestTypes) ApplyStatus(ctx context.Context, clusterTestType 
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := clusterTestType.Name
 	if name == nil {
 		return nil, fmt.Errorf("clusterTestType.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(clustertesttypesResource, *name, types.ApplyPatchType, data, "status"), &v1.ClusterTestType{})
+		Invokes(testing.NewRootApplySubresourceAction(clustertesttypesResource, *name, data, manager, opts.Force, "status"), &v1.ClusterTestType{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/fake/fake_testtype.go
@@ -152,12 +152,18 @@ func (c *FakeTestTypes) Apply(ctx context.Context, testType *examplev1.TestTypeA
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := testType.Name
 	if name == nil {
 		return nil, fmt.Errorf("testType.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(testtypesResource, c.ns, *name, types.ApplyPatchType, data), &v1.TestType{})
+		Invokes(testing.NewApplySubresourceAction(testtypesResource, c.ns, *name, data, manager, opts.Force), &v1.TestType{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeTestTypes) ApplyStatus(ctx context.Context, testType *examplev1.Tes
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := testType.Name
 	if name == nil {
 		return nil, fmt.Errorf("testType.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(testtypesResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.TestType{})
+		Invokes(testing.NewApplySubresourceAction(testtypesResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.TestType{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/fake/fake_testtype.go
@@ -152,12 +152,18 @@ func (c *FakeTestTypes) Apply(ctx context.Context, testType *example2v1.TestType
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := testType.Name
 	if name == nil {
 		return nil, fmt.Errorf("testType.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(testtypesResource, c.ns, *name, types.ApplyPatchType, data), &v1.TestType{})
+		Invokes(testing.NewApplySubresourceAction(testtypesResource, c.ns, *name, data, manager, opts.Force), &v1.TestType{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeTestTypes) ApplyStatus(ctx context.Context, testType *example2v1.Te
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := testType.Name
 	if name == nil {
 		return nil, fmt.Errorf("testType.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(testtypesResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.TestType{})
+		Invokes(testing.NewApplySubresourceAction(testtypesResource, c.ns, *name, data, manager, opts.Force, "status"), &v1.TestType{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/clientset_generated.go
@@ -20,6 +20,7 @@ package fake
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -31,12 +32,13 @@ import (
 	fakeapiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/fake"
 )
 
-// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// NewSimpleClientsetWithFieldmanager returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewSimpleClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+// It also takes the fieldmanager that can be used to track field ownership and use server-side apply.
+func NewSimpleClientsetWithFieldManager(fieldManager *managedfields.FieldManager, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTrackerWithFieldManager(scheme, codecs.UniversalDecoder(), fieldManager)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)
@@ -59,13 +61,22 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+	return NewSimpleClientsetWithFieldManager(nil, objects...)
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
-	tracker   testing.ObjectTracker
+	discovery    *fakediscovery.FakeDiscovery
+	tracker      testing.ObjectTracker
+	fieldManager *managedfields.FieldManager
 }
 
 func (c *Clientset) Discovery() discovery.DiscoveryInterface {

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -20,6 +20,7 @@ package fake
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -31,12 +32,13 @@ import (
 	fakemetricsv1beta1 "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake"
 )
 
-// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// NewSimpleClientsetWithFieldmanager returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewSimpleClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+// It also takes the fieldmanager that can be used to track field ownership and use server-side apply.
+func NewSimpleClientsetWithFieldManager(fieldManager *managedfields.FieldManager, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTrackerWithFieldManager(scheme, codecs.UniversalDecoder(), fieldManager)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)
@@ -59,13 +61,22 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+	return NewSimpleClientsetWithFieldManager(nil, objects...)
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
-	tracker   testing.ObjectTracker
+	discovery    *fakediscovery.FakeDiscovery
+	tracker      testing.ObjectTracker
+	fieldManager *managedfields.FieldManager
 }
 
 func (c *Clientset) Discovery() discovery.DiscoveryInterface {

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/fake/clientset_generated.go
@@ -20,6 +20,7 @@ package fake
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -31,12 +32,13 @@ import (
 	fakewardlev1beta1 "k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/fake"
 )
 
-// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// NewSimpleClientsetWithFieldmanager returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewSimpleClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+// It also takes the fieldmanager that can be used to track field ownership and use server-side apply.
+func NewSimpleClientsetWithFieldManager(fieldManager *managedfields.FieldManager, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTrackerWithFieldManager(scheme, codecs.UniversalDecoder(), fieldManager)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)
@@ -59,13 +61,22 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+	return NewSimpleClientsetWithFieldManager(nil, objects...)
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
-	tracker   testing.ObjectTracker
+	discovery    *fakediscovery.FakeDiscovery
+	tracker      testing.ObjectTracker
+	fieldManager *managedfields.FieldManager
 }
 
 func (c *Clientset) Discovery() discovery.DiscoveryInterface {

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_fischer.go
@@ -132,12 +132,18 @@ func (c *FakeFischers) Apply(ctx context.Context, fischer *wardlev1alpha1.Fische
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := fischer.Name
 	if name == nil {
 		return nil, fmt.Errorf("fischer.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(fischersResource, *name, types.ApplyPatchType, data), &v1alpha1.Fischer{})
+		Invokes(testing.NewRootApplySubresourceAction(fischersResource, *name, data, manager, opts.Force), &v1alpha1.Fischer{})
 	if obj == nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_flunder.go
@@ -152,12 +152,18 @@ func (c *FakeFlunders) Apply(ctx context.Context, flunder *wardlev1alpha1.Flunde
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := flunder.Name
 	if name == nil {
 		return nil, fmt.Errorf("flunder.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(flundersResource, c.ns, *name, types.ApplyPatchType, data), &v1alpha1.Flunder{})
+		Invokes(testing.NewApplySubresourceAction(flundersResource, c.ns, *name, data, manager, opts.Force), &v1alpha1.Flunder{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeFlunders) ApplyStatus(ctx context.Context, flunder *wardlev1alpha1.
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := flunder.Name
 	if name == nil {
 		return nil, fmt.Errorf("flunder.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(flundersResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1alpha1.Flunder{})
+		Invokes(testing.NewApplySubresourceAction(flundersResource, c.ns, *name, data, manager, opts.Force, "status"), &v1alpha1.Flunder{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/fake/fake_flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/fake/fake_flunder.go
@@ -152,12 +152,18 @@ func (c *FakeFlunders) Apply(ctx context.Context, flunder *wardlev1beta1.Flunder
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := flunder.Name
 	if name == nil {
 		return nil, fmt.Errorf("flunder.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(flundersResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.Flunder{})
+		Invokes(testing.NewApplySubresourceAction(flundersResource, c.ns, *name, data, manager, opts.Force), &v1beta1.Flunder{})
 
 	if obj == nil {
 		return nil, err
@@ -175,12 +181,18 @@ func (c *FakeFlunders) ApplyStatus(ctx context.Context, flunder *wardlev1beta1.F
 	if err != nil {
 		return nil, err
 	}
+
+	manager := "default-test-manager"
+	if m := opts.FieldManager; m != "" {
+		manager = m
+	}
+
 	name := flunder.Name
 	if name == nil {
 		return nil, fmt.Errorf("flunder.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(flundersResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta1.Flunder{})
+		Invokes(testing.NewApplySubresourceAction(flundersResource, c.ns, *name, data, manager, opts.Force, "status"), &v1beta1.Flunder{})
 
 	if obj == nil {
 		return nil, err

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/fake/clientset_generated.go
@@ -20,6 +20,7 @@ package fake
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -29,12 +30,13 @@ import (
 	fakesamplecontrollerv1alpha1 "k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/fake"
 )
 
-// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// NewSimpleClientsetWithFieldmanager returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewSimpleClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+// It also takes the fieldmanager that can be used to track field ownership and use server-side apply.
+func NewSimpleClientsetWithFieldManager(fieldManager *managedfields.FieldManager, objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTrackerWithFieldManager(scheme, codecs.UniversalDecoder(), fieldManager)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)
@@ -57,13 +59,22 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	return cs
 }
 
+// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+	return NewSimpleClientsetWithFieldManager(nil, objects...)
+}
+
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
-	tracker   testing.ObjectTracker
+	discovery    *fakediscovery.FakeDiscovery
+	tracker      testing.ObjectTracker
+	fieldManager *managedfields.FieldManager
 }
 
 func (c *Clientset) Discovery() discovery.DiscoveryInterface {


### PR DESCRIPTION
Allow fieldmanager to be wired inside the client-go fake so that we can test server-side apply with it.

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
TODO: This is a draft, but this will probably close a bunch of issues.
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
