### PR TITLE
integration: remove special verbosity for garbagecollector and graph_builder

### DIFF
--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -41,7 +41,7 @@ KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout=600s}
 LOG_LEVEL=${LOG_LEVEL:-2}
 KUBE_TEST_ARGS=${KUBE_TEST_ARGS:-}
 # Default glog module settings.
-KUBE_TEST_VMODULE=${KUBE_TEST_VMODULE:-"garbagecollector*=6,graph_builder*=6"}
+KUBE_TEST_VMODULE=${KUBE_TEST_VMODULE:-""}
 
 kube::test::find_integration_test_dirs() {
   (


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

These defaults cause performance overhead:
- Enabling -vmodule slows down all log calls because checking verbosity cannot take a simpler fast path.
- The amount of log output is much higher for those files.

The amount of log data also caused test output to get truncated, removing the actual test failure explanation.

#### Special notes for your reviewer:

The setting for garbagecollector was added 7 years ago in 9ac91e5172fb for "debugging gc".  graph_builder was added 6 years ago in a98801c100d27 when restoring the -vmodule parameter after some temporary removal, without an explanation.

It seems safe to assume that the garbage collector has been debugged sufficiently...

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
