### PR TITLE
Lookup ENABLE_CLIENT_GO_WATCH_LIST_ALPHA in NewReflectorWithOptions

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -18,7 +18,6 @@ package cache
 
 import (
 	"errors"
-	"os"
 	"sync"
 	"time"
 
@@ -147,9 +146,6 @@ func (c *controller) Run(stopCh <-chan struct{}) {
 	r.WatchListPageSize = c.config.WatchListPageSize
 	if c.config.WatchErrorHandler != nil {
 		r.watchErrorHandler = c.config.WatchErrorHandler
-	}
-	if s := os.Getenv("ENABLE_CLIENT_GO_WATCH_LIST_ALPHA"); len(s) > 0 {
-		r.UseWatchList = true
 	}
 
 	c.reflectorMutex.Lock()

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -237,6 +238,10 @@ func NewReflectorWithOptions(lw ListerWatcher, expectedType interface{}, store S
 
 	if r.expectedGVK == nil {
 		r.expectedGVK = getExpectedGVKFromObject(expectedType)
+	}
+
+	if s := os.Getenv("ENABLE_CLIENT_GO_WATCH_LIST_ALPHA"); len(s) > 0 {
+		r.UseWatchList = true
 	}
 
 	return r


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
We should change follow codes to NewReflectorWithOptions. 
```
if s := os.Getenv("ENABLE_CLIENT_GO_WATCH_LIST_ALPHA"); len(s) > 0 {
		r.UseWatchList = true
}
```

Current set in https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/cache/controller.go#L151. If other do not use controller, it's not work when set `ENABLE_CLIENT_GO_WATCH_LIST_ALPHA=true`. 

#### we can see follow case `request of kubelet  when restart`
Pods resource still ListWatch when set `ENABLE_CLIENT_GO_WATCH_LIST_ALPHA=true`， you can see https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/config/apiserver.go#L66
```
I0524 12:53:17.548782       1 httplog.go:132] "HTTP" verb="WATCH" URI="/apis/node.k8s.io/v1/runtimeclasses?allowWatchBookmarks=true&resourceVersion=541776794&timeout=5m2s&timeoutSeconds=302&watch=true" latency="3m2.776282077s" userAgent="kubelet/v1.27.0 (linux/amd64) kubernetes/b8e3718" audit-ID="978592e0-f6c1-4895-b498-06d2153a1134" srcIP="x.x.x.x:x" apf_pl="system" apf_fs="system-nodes" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_init_latency="212.878µs" apf_execution_time="213.777µs" resp=200
I0524 12:53:17.548803       1 httplog.go:132] "HTTP" verb="WATCH" URI="/api/v1/nodes?allowWatchBookmarks=true&fieldSelector=metadata.name%3Dnode-1&resourceVersion=541708492&timeout=7m10s&timeoutSeconds=430&watch=true" latency="5m48.788466921s" userAgent="kubelet/v1.27.0 (linux/amd64) kubernetes/b8e3718" audit-ID="ac1a48b5-a030-4e8d-bce5-703f6b50fd59" srcIP="x.x.x.x:x" apf_pl="node-high" apf_fs="system-node-high" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_init_latency="323.669µs" apf_execution_time="325.137µs" resp=200
I0524 12:53:17.548792       1 httplog.go:132] "HTTP" verb="WATCH" URI="/api/v1/services?allowWatchBookmarks=true&resourceVersion=541487296&timeout=7m53s&timeoutSeconds=473&watch=true" latency="6m26.790128209s" userAgent="kubelet/v1.27.0 (linux/amd64) kubernetes/b8e3718" audit-ID="f3bd04d4-0687-42ef-a392-3e7b7a87db12" srcIP="x.x.x.x:x" apf_pl="system" apf_fs="system-nodes" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_init_latency="171.517µs" apf_execution_time="173.588µs" resp=200
I0524 12:53:17.548810       1 httplog.go:132] "HTTP" verb="WATCH" URI="/api/v1/pods?allowWatchBookmarks=true&fieldSelector=spec.nodeName%3Dnode-1&resourceVersion=541596718&timeoutSeconds=571&watch=true" latency="6m32.78753062s" userAgent="kubelet/v1.27.0 (linux/amd64) kubernetes/b8e3718" audit-ID="10b84bc5-0ae1-450a-9771-aa0c5554a3d9" srcIP="x.x.x.x:x" apf_pl="system" apf_fs="system-nodes" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_init_latency="243.261µs" apf_execution_time="244.065µs" resp=200
I0524 12:53:17.548831       1 httplog.go:132] "HTTP" verb="WATCH" URI="/apis/storage.k8s.io/v1/csidrivers?allowWatchBookmarks=true&resourceVersion=541601628&timeout=9m51s&timeoutSeconds=591&watch=true" latency="5m36.787954314s" userAgent="kubelet/v1.27.0 (linux/amd64) kubernetes/b8e3718" audit-ID="d157ef07-2730-47e1-bc0a-4bd8f2f77338" srcIP="x.x.x.x:x" apf_pl="system" apf_fs="system-nodes" apf_iseats=1 apf_fseats=0 apf_additionalLatency="0s" apf_init_latency="238.001µs" apf_execution_time="239.784µs" resp=200
I0524 12:53:18.630986       1 httplog.go:132] "HTTP" verb="LIST" URI="/api/v1/pods?fieldSelector=spec.nodeName%3Dnode-1&limit=500&resourceVersion=0" latency="1.204271ms" userAgent="kubelet/v1.27.0 (linux/amd64) kubernetes/b8e3718" audit-ID="0a0005c4-cbd9-4d3d-839e-523166a83e30" srcIP="x.x.x.x:x" apf_pl="system" apf_fs="system-nodes" apf_iseats=10 apf_fseats=0 apf_additionalLatency="0s" apf_execution_time="482.124µs" resp=200
```




#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
