### PR TITLE
kubeadm: warning only for deprecated FG

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -205,7 +205,6 @@ func enforceRequirements(flags *applyPlanFlags, args []string, dryRun bool, upgr
 		for _, m := range msg {
 			printer.Printf("[upgrade/config] %s\n", m)
 		}
-		return nil, nil, nil, errors.New("[upgrade/config] FATAL. Unable to upgrade a cluster using deprecated feature-gate flags. Please see the release notes")
 	}
 
 	// If the user told us to print this information out; do it!

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/featuregate"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -148,7 +149,7 @@ func NewFeatureGate(f *FeatureList, value string) (map[string]bool, error) {
 		}
 
 		if featureSpec.PreRelease == featuregate.Deprecated {
-			return nil, errors.Errorf("feature-gate key is deprecated: %s", k)
+			klog.Warningf("Setting deprecated feature gate %s=%t. It will be removed in a future release.", k, v)
 		}
 
 		boolValue, err := strconv.ParseBool(v)

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -91,9 +91,9 @@ func Enabled(featureList map[string]bool, featureName string) bool {
 // Supports indicates whether a feature name is supported on the given
 // feature set
 func Supports(featureList FeatureList, featureName string) bool {
-	for k, v := range featureList {
+	for k := range featureList {
 		if featureName == k {
-			return v.PreRelease != featuregate.Deprecated
+			return true
 		}
 	}
 	return false

--- a/cmd/kubeadm/app/features/features_test.go
+++ b/cmd/kubeadm/app/features/features_test.go
@@ -92,8 +92,9 @@ func TestNewFeatureGate(t *testing.T) {
 			expectedError: true,
 		},
 		{ //deprecated feature-gate key
-			value:         "deprecated=true",
-			expectedError: true,
+			value:                "deprecated=true",
+			expectedError:        false,
+			expectedFeaturesGate: map[string]bool{"deprecated": true},
 		},
 		{ //one feature
 			value:                "feature1=true",


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
- needed by https://github.com/kubernetes/kubernetes/pull/116570

#### Which issue(s) this PR fixes:

See https://github.com/kubernetes/kubeadm/issues/2346#issuecomment-1563079336
#### Special notes for your reviewer:

> BTW, there is no warning message for the GAed FG in kubeadm
#### Does this PR introduce a user-facing change?

```release-note
kubeadm: throw warnings instead of errors for deprecated feature gates
```

/cc @SataQiu  @neolit123 
