### PR TITLE
Allow wrapped errors for client-go's `discovery.IsGroupDiscoveryFailedError` API

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -419,8 +419,8 @@ func (e *ErrGroupDiscoveryFailed) Error() string {
 // IsGroupDiscoveryFailedError returns true if the provided error indicates the server was unable to discover
 // a complete list of APIs for the client to use.
 func IsGroupDiscoveryFailedError(err error) bool {
-	_, ok := err.(*ErrGroupDiscoveryFailed)
-	return err != nil && ok
+	as := &ErrGroupDiscoveryFailed{}
+	return goerrors.As(err, &as)
 }
 
 // GroupDiscoveryFailedErrorGroups returns true if the error is an ErrGroupDiscoveryFailed error,


### PR DESCRIPTION



#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:


The current API does not work when wrapping errors via `fmt.Errorf("…: %w")`, which is now supposed by using the `errors.As` API.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow wrapped (`%w`) errors for client-go's `discovery.IsGroupDiscoveryFailedError` API.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
