### PR TITLE
Automated cherry pick of #118200: e2e: apply timeout for CSI Storage Capacity test only to node

### DIFF
--- a/test/e2e/storage/csi_mock/csi_storage_capacity.go
+++ b/test/e2e/storage/csi_mock/csi_storage_capacity.go
@@ -320,7 +320,7 @@ var _ = utils.SIGDescribe("CSI Mock volume storage capacity", func() {
 		}
 		for _, t := range tests {
 			test := t
-			ginkgo.It(t.name, ginkgo.SpecTimeout(f.Timeouts.PodStart), func(ctx context.Context) {
+			ginkgo.It(t.name, ginkgo.NodeTimeout(f.Timeouts.PodStart), func(ctx context.Context) {
 				scName := "mock-csi-storage-capacity-" + f.UniqueName
 				m.init(ctx, testParameters{
 					registerDriver:  true,


### PR DESCRIPTION
Cherry pick of #118200 on release-1.27.

#118200: e2e: apply timeout for CSI Storage Capacity test only to node

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```