### PR TITLE
Automated cherry pick of #118256: e2e framework retry on Service unavailable errors

### DIFF
--- a/test/e2e/framework/get.go
+++ b/test/e2e/framework/get.go
@@ -100,7 +100,10 @@ func ShouldRetry(err error) (retry bool, retryAfter time.Duration) {
 	}
 
 	// these errors indicate a transient error that should be retried.
-	if apierrors.IsTimeout(err) || apierrors.IsTooManyRequests(err) || errors.As(err, &transientError{}) {
+	if apierrors.IsTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		errors.As(err, &transientError{}) {
 		return true, 0
 	}
 


### PR DESCRIPTION
Cherry pick of #118256 on release-1.27.

#118256: e2e framework retry on Service unavailable errors

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```