### PR TITLE
Automated cherry pick of #118177: Fix the git-repo test error caused by the correct use of loop

### DIFF
--- a/pkg/volume/git_repo/git_repo_test.go
+++ b/pkg/volume/git_repo/git_repo_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -390,10 +391,20 @@ func doTestSetUp(scenario struct {
 	var fakeOutputs []fakeexec.FakeAction
 	var fcmd fakeexec.FakeCmd
 	for _, expected := range expecteds {
+		expected := expected
 		if expected.cmd[1] == "clone" {
+			// Calculate the subdirectory clone would create (if any)
+			// git clone -- https://github.com/kubernetes/kubernetes.git target_dir --> target_dir
+			// git clone -- https://github.com/kubernetes/kubernetes.git            --> kubernetes
+			// git clone -- https://github.com/kubernetes/kubernetes.git .          --> .
+			// git clone -- https://github.com/kubernetes/kubernetes.git ./.        --> .
+			cloneSubdir := path.Base(expected.cmd[len(expected.cmd)-1])
+			if cloneSubdir == "kubernetes.git" {
+				cloneSubdir = "kubernetes"
+			}
 			fakeOutputs = append(fakeOutputs, func() ([]byte, []byte, error) {
 				// git clone, it creates new dir/files
-				os.MkdirAll(filepath.Join(fcmd.Dirs[0], expected.dir), 0750)
+				os.MkdirAll(filepath.Join(fcmd.Dirs[0], expected.dir, cloneSubdir), 0750)
 				return []byte{}, nil, nil
 			})
 		} else {
@@ -422,7 +433,10 @@ func doTestSetUp(scenario struct {
 	g := mounter.(*gitRepoVolumeMounter)
 	g.exec = fake
 
-	g.SetUp(volume.MounterArgs{})
+	err := g.SetUp(volume.MounterArgs{})
+	if err != nil {
+		allErrs = append(allErrs, err)
+	}
 
 	if fake.CommandCalls != len(expecteds) {
 		allErrs = append(allErrs,


### PR DESCRIPTION
Cherry pick of #118177 on release-1.27.

#118177: Fix the git-repo test error caused by the correct use of loop

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```