### PR TITLE
deprecate RBD plugin from available in-tree drivers.

### DIFF
--- a/pkg/api/persistentvolume/util.go
+++ b/pkg/api/persistentvolume/util.go
@@ -95,6 +95,9 @@ func warningsForPersistentVolumeSpecAndMeta(fieldPath *field.Path, pvSpec *api.P
 	if pvSpec.Glusterfs != nil {
 		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.25, non-functional in v1.26+", fieldPath.Child("spec", "persistentVolumeSource").Child("glusterfs")))
 	}
+	if pvSpec.RBD != nil {
+		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.28, non-functional in v1.31+", fieldPath.Child("spec", "persistentVolumeSource").Child("rbd")))
+	}
 
 	return warnings
 }

--- a/pkg/api/persistentvolume/util_test.go
+++ b/pkg/api/persistentvolume/util_test.go
@@ -275,6 +275,27 @@ func TestWarnings(t *testing.T) {
 				`spec.persistentVolumeSource.glusterfs: deprecated in v1.25, non-functional in v1.26+`,
 			},
 		},
+		{
+			name: "PV RBD deprecation warning",
+			template: &api.PersistentVolume{
+				Spec: api.PersistentVolumeSpec{
+					PersistentVolumeSource: api.PersistentVolumeSource{
+						RBD: &api.RBDPersistentVolumeSource{
+							CephMonitors: nil,
+							RBDImage:     "",
+							FSType:       "",
+							RBDPool:      "",
+							RadosUser:    "",
+							Keyring:      "",
+							SecretRef:    nil,
+							ReadOnly:     false,
+						},
+					},
+				},
+			},
+			expected: []string{
+				`spec.persistentVolumeSource.rbd: deprecated in v1.28, non-functional in v1.31+`},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/api/pod/warnings.go
+++ b/pkg/api/pod/warnings.go
@@ -157,6 +157,9 @@ func warningsForPodSpecAndMeta(fieldPath *field.Path, podSpec *api.PodSpec, meta
 		if v.Glusterfs != nil {
 			warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.25, non-functional in v1.26+", fieldPath.Child("spec", "volumes").Index(i).Child("glusterfs")))
 		}
+		if v.RBD != nil {
+			warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.28, non-functional in v1.31+", fieldPath.Child("spec", "volumes").Index(i).Child("rbd")))
+		}
 		if v.Ephemeral != nil && v.Ephemeral.VolumeClaimTemplate != nil {
 			warnings = append(warnings, pvcutil.GetWarningsForPersistentVolumeClaimSpec(fieldPath.Child("spec", "volumes").Index(i).Child("ephemeral").Child("volumeClaimTemplate").Child("spec"), v.Ephemeral.VolumeClaimTemplate.Spec)...)
 		}

--- a/pkg/api/pod/warnings_test.go
+++ b/pkg/api/pod/warnings_test.go
@@ -225,6 +225,15 @@ func TestWarnings(t *testing.T) {
 		},
 
 		{
+			name: "rbd",
+			template: &api.PodTemplateSpec{Spec: api.PodSpec{
+				Volumes: []api.Volume{
+					{Name: "s", VolumeSource: api.VolumeSource{RBD: &api.RBDVolumeSource{}}},
+				}},
+			},
+			expected: []string{`spec.volumes[0].rbd: deprecated in v1.28, non-functional in v1.31+`},
+		},
+		{
 			name: "duplicate hostAlias",
 			template: &api.PodTemplateSpec{Spec: api.PodSpec{
 				HostAliases: []api.HostAlias{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind deprecation

#### What this PR does / why we need it:

Based on https://groups.google.com/g/kubernetes-sig-storage/c/h5751_B5LQM, the consensus was to start the deprecation in v1.28.

This commit start the deprecation process of RDB plugin from in-tree drivers.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ACTION REQUIRED:
- The in-tree [`rbd`](https://k8s.io/docs/concepts/storage/volumes/#rbd) storage driver has been deprecated in this release and will be removed in a subsequent release. 
  An available alternative is to use the 3rd party [Ceph CSI driver](https://github.com/ceph/ceph-csi/).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/2923-csi-migration-ceph-rbd
```
