### PR TITLE
Promote e2e test for PodEphemeralcontainers endpoints + 2 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1950,6 +1950,15 @@
     visible at runtime in the container.
   release: v1.9
   file: test/e2e/common/node/downwardapi.go
+- testname: Ephemeral Container, update ephemeral containers
+  codename: '[sig-node] Ephemeral Containers [NodeConformance] should update the ephemeral
+    containers in an existing pod [Conformance]'
+  description: Adding an ephemeral container to pod.spec MUST result in the container
+    running. There MUST now be only one ephermal container found. Updating the pod
+    with another ephemeral container MUST succeed. There MUST now be two ephermal
+    containers found.
+  release: v1.28
+  file: test/e2e/common/node/ephemeral_containers.go
 - testname: Ephemeral Container Creation
   codename: '[sig-node] Ephemeral Containers [NodeConformance] will start an ephemeral
     container in an existing pod [Conformance]'

--- a/test/e2e/common/node/ephemeral_containers.go
+++ b/test/e2e/common/node/ephemeral_containers.go
@@ -87,7 +87,15 @@ var _ = SIGDescribe("Ephemeral Containers [NodeConformance]", func() {
 		gomega.Expect(log).To(gomega.ContainSubstring("polo"))
 	})
 
-	ginkgo.It("should update the ephemeral containers in an existing pod", func(ctx context.Context) {
+	/*
+		Release: v1.28
+		Testname: Ephemeral Container, update ephemeral containers
+		Description: Adding an ephemeral container to pod.spec MUST result in the container
+		running. There MUST now be only one ephermal container found. Updating the pod with
+		another ephemeral container MUST succeed. There MUST now be two ephermal containers
+		found.
+	*/
+	framework.ConformanceIt("should update the ephemeral containers in an existing pod", func(ctx context.Context) {
 		ginkgo.By("creating a target pod")
 		pod := podClient.CreateSync(ctx, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Name: "ephemeral-containers-target-pod"},


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- readCoreV1NamespacedPodEphemeralcontainers
- replaceCoreV1NamespacedPodEphemeralcontainers

**Which issue(s) this PR fixes:**
Fixes #117894

**Testgrid Link:**
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.update.the.ephemeral.containers.in.an.existing.pod)


**Special notes for your reviewer:**
Adds +2 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance