### PR TITLE
Automated cherry pick of #117169: supported version of etcd 3.5.7-0 for Kubernetes v1.27.0-rc.0

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -481,6 +481,7 @@ var (
 		24: "3.5.7-0",
 		25: "3.5.7-0",
 		26: "3.5.7-0",
+		27: "3.5.7-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows


### PR DESCRIPTION
Cherry pick of #117169 on release-1.27.

#117169: supported version of etcd 3.5.7-0 for Kubernetes v1.27.0-rc.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: fix etc version support for Kubernetes v1.27
```

Fix: kubernetes/kubeadm#2882