### PR TITLE
WIP: apiextensions: lazy validator instantiated on first write

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/kube-openapi/pkg/validation/validate"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -101,8 +102,8 @@ func newStorage(t *testing.T) (customresource.CustomResourceStorage, *etcd3testi
 			typer,
 			true,
 			kind,
-			nil,
-			nil,
+			func() (*validate.SchemaValidator, error) { return nil, nil },
+			func() (*validate.SchemaValidator, error) { return nil, nil },
 			nil,
 			status,
 			scale,

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
@@ -176,12 +176,7 @@ func (s *specAggregator) buildOpenAPISpec() (specToReturn *spec.Swagger, err err
 		if specInfo.spec == nil {
 			continue
 		}
-		// Copy the spec before removing the defaults.
-		localSpec := *specInfo.spec
-		localSpecInfo := *specInfo
-		localSpecInfo.spec = &localSpec
-		localSpecInfo.spec.Definitions = handler.PruneDefaults(specInfo.spec.Definitions)
-		specs = append(specs, localSpecInfo)
+		specs = append(specs, *specInfo)
 	}
 	if len(specs) == 0 {
 		return &spec.Swagger{}, nil
@@ -292,9 +287,13 @@ func (s *specAggregator) UpdateAPIServiceSpec(apiServiceName string, spec *spec.
 		spec = aggregator.FilterSpecByPathsWithoutSideEffects(spec, []string{"/apis/"})
 	}
 
+	// Prune defaults from the spec as we don't want to publish them.
+	specCopy := *spec
+	specCopy.Definitions = handler.PruneDefaults(specInfo.spec.Definitions)
+
 	return s.tryUpdatingServiceSpecs(&openAPISpecInfo{
 		apiService: specInfo.apiService,
-		spec:       spec,
+		spec:       &specCopy,
 		handler:    specInfo.handler,
 		etag:       etag,
 	})
@@ -334,7 +333,7 @@ func (s *specAggregator) RemoveAPIServiceSpec(apiServiceName string) error {
 	return s.tryDeleteServiceSpecs(apiServiceName)
 }
 
-// GetAPIServiceSpec returns api service spec info
+// GetAPIServiceInfo returns api service spec info
 func (s *specAggregator) GetAPIServiceInfo(apiServiceName string) (handler http.Handler, etag string, exists bool) {
 	s.rwMutex.RLock()
 	defer s.rwMutex.RUnlock()


### PR DESCRIPTION
This avoids a conversion of the structural schema to go-openapi, and keeping the later in addition in memory. For many CRDs with large schemas where a lot are unused, this PR leads to substantial memory reduction.

/kind cleanup

```release-note
Save memory with many large unused CRDs by instantiating validation machinery on-demand.
```