### PR TITLE
Remove Ephemeral Containers form pending_eligible_endpoints.yaml

### DIFF
--- a/test/conformance/testdata/pending_eligible_endpoints.yaml
+++ b/test/conformance/testdata/pending_eligible_endpoints.yaml
@@ -31,7 +31,6 @@
 - listStorageV1VolumeAttachment
 - patchCoreV1NamespacedPersistentVolumeClaim
 - patchCoreV1NamespacedPersistentVolumeClaimStatus
-- patchCoreV1NamespacedPodEphemeralcontainers
 - patchCoreV1PersistentVolume
 - patchCoreV1PersistentVolumeStatus
 - patchNetworkingV1NamespacedNetworkPolicyStatus
@@ -42,7 +41,6 @@
 - patchStorageV1VolumeAttachmentStatus
 - readCoreV1NamespacedPersistentVolumeClaim
 - readCoreV1NamespacedPersistentVolumeClaimStatus
-- readCoreV1NamespacedPodEphemeralcontainers
 - readCoreV1NodeStatus
 - readCoreV1PersistentVolume
 - readCoreV1PersistentVolumeStatus


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
PR #117895 tested the 2 Ephemeral Container endpoints.
The test have been flake free for 14 days and was promoted in #118304 which allow the endpoint to be removed from the pending_eligible_endpoints.yaml

**Which PR depend on the merge of:**
#118304  - Merged!



**Special notes for your reviewer:**
Adds +2 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance