### PR TITLE
Revert "kubeadm: add --feature-gates flag for kubeadm upgrade node"

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -33,7 +33,6 @@ import (
 	phases "k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/upgrade/node"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 )
 
@@ -48,7 +47,6 @@ type nodeOptions struct {
 	dryRun                bool
 	patchesDir            string
 	ignorePreflightErrors []string
-	featureGatesString    string
 }
 
 // compile-time assert that the local data object satisfies the phases data interface.
@@ -87,7 +85,6 @@ func newCmdNode(out io.Writer) *cobra.Command {
 	// flags could be eventually inherited by the sub-commands automatically generated for phases
 	addUpgradeNodeFlags(cmd.Flags(), nodeOptions)
 	options.AddPatchesFlag(cmd.Flags(), &nodeOptions.patchesDir)
-	options.AddFeatureGatesStringFlag(cmd.Flags(), &nodeOptions.featureGatesString)
 
 	// initialize the workflow runner with the list of phases
 	nodeRunner.AppendPhase(phases.NewPreflightPhase())
@@ -162,15 +159,6 @@ func newNodeData(cmd *cobra.Command, args []string, options *nodeOptions, out io
 	}
 	// Also set the union of pre-flight errors to JoinConfiguration, to provide a consistent view of the runtime configuration:
 	cfg.NodeRegistration.IgnorePreflightErrors = sets.List(ignorePreflightErrorsSet)
-
-	// If features gates are passed to the command line, use it (otherwise use featureGates from configuration)
-	if options.featureGatesString != "" {
-		cfg.FeatureGates, err = features.NewFeatureGate(&features.InitFeatureGates, options.featureGatesString)
-		if err != nil {
-			return nil, errors.Wrap(err, "[upgrade/config] FATAL")
-		}
-	}
-
 	return &nodeData{
 		etcdUpgrade:           options.etcdUpgrade,
 		renewCerts:            options.renewCerts,


### PR DESCRIPTION
Reverts kubernetes/kubernetes#118316

> clusterconfiguration says it is a cluster-wide configuration that should not be overwritten.

- #118316 will make it node-specific FG.

```release-note
None
```

/cc @SataQiu 