### PR TITLE
kubeadm: add command-line integration test to ensure that the supported etcd version is always available for the stable Kubernetes version

### DIFF
--- a/cmd/kubeadm/test/cmd/config_test.go
+++ b/cmd/kubeadm/test/cmd/config_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeadm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCmdConfigImagesList(t *testing.T) {
+	var tests = []struct {
+		name     string
+		args     string
+		expected bool
+	}{
+		{
+			name:     "valid: latest stable Kubernetes version should not throw the warning that a supported etcd version cannot be found",
+			args:     "--kubernetes-version=stable-1",
+			expected: false,
+		},
+	}
+
+	kubeadmPath := getKubeadmPath()
+	for _, rt := range tests {
+		t.Run(rt.name, func(t *testing.T) {
+			_, stderr, _, err := RunCmd(kubeadmPath, "config", "images", "list", "--v=1", rt.args)
+			if err != nil {
+				t.Fatalf("failed to run 'kubeadm config images list --v=1 %s', err: %v", rt.args, err)
+			}
+			actual := strings.Contains(stderr, "could not find officially supported version of etcd")
+			if actual != rt.expected {
+				t.Errorf(
+					"failed CmdConfigImagesList running 'kubeadm config images list --v=1 %s' with stderr output:\n%v\n\t  expected: %t\n\t  actual: %t\n\n"+
+						"FYI: This usually indicates that the 'SupportedEtcdVersion' map defined in 'cmd/kubeadm/app/constants/constants.go' needs to be updated.\n",
+					rt.args,
+					stderr,
+					rt.expected,
+					actual,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubeadm: add command-line integration test to ensure that the supported etcd version is always available for the stable Kubernetes version

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref kubernetes/kubeadm#2882

#### Special notes for your reviewer:
Use `make test-cmd WHAT=kubeadm` to run the integration test.
test-infra job defined at https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-testing/integration.yaml

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
