### PR TITLE
chore: io/ioutil deprecated

### DIFF
--- a/pkg/auth/authorizer/abac/abac_test.go
+++ b/pkg/auth/authorizer/abac/abac_test.go
@@ -18,7 +18,7 @@ package abac
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"testing"
@@ -817,14 +817,14 @@ func TestSubjectMatches(t *testing.T) {
 }
 
 func newWithContents(t *testing.T, contents string) (PolicyList, error) {
-	f, err := ioutil.TempFile("", "abac_test")
+	f, err := os.CreateTemp("", "abac_test")
 	if err != nil {
 		t.Fatalf("unexpected error creating policyfile: %v", err)
 	}
 	f.Close()
 	defer os.Remove(f.Name())
 
-	if err := ioutil.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
 		t.Fatalf("unexpected error writing policyfile: %v", err)
 	}
 

--- a/pkg/client/tests/remotecommand_test.go
+++ b/pkg/client/tests/remotecommand_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -336,7 +335,7 @@ func TestDial(t *testing.T) {
 		conn:          &fakeConnection{},
 		resp: &http.Response{
 			StatusCode: http.StatusSwitchingProtocols,
-			Body:       ioutil.NopCloser(&bytes.Buffer{}),
+			Body:       io.NopCloser(&bytes.Buffer{}),
 		},
 	}
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: upgrader}, "POST", &url.URL{Host: "something.com", Scheme: "https"})

--- a/pkg/controller/certificates/signer/signer_test.go
+++ b/pkg/controller/certificates/signer/signer_test.go
@@ -23,7 +23,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"io/ioutil"
+	"os"
 	"math/rand"
 	"testing"
 	"time"
@@ -49,7 +49,7 @@ func TestSigner(t *testing.T) {
 		t.Fatalf("failed to create signer: %v", err)
 	}
 
-	csrb, err := ioutil.ReadFile("./testdata/kubelet.csr")
+	csrb, err := os.ReadFile("./testdata/kubelet.csr")
 	if err != nil {
 		t.Fatalf("failed to read CSR: %v", err)
 	}

--- a/pkg/volume/configmap/configmap_test.go
+++ b/pkg/volume/configmap/configmap_test.go
@@ -292,7 +292,7 @@ func TestMakePayload(t *testing.T) {
 }
 
 func newTestHost(t *testing.T, clientset clientset.Interface) (string, volume.VolumeHost) {
-	tempDir, err := ioutil.TempDir("", "configmap_volume_test.")
+	tempDir, err := os.MkdirTemp("", "configmap_volume_test.")
 	if err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
 	}
@@ -703,7 +703,7 @@ func doTestConfigMapDataInVolume(volumePath string, configMap v1.ConfigMap, t *t
 		if _, err := os.Stat(configMapDataHostPath); err != nil {
 			t.Fatalf("SetUp() failed, couldn't find configMap data on disk: %v", configMapDataHostPath)
 		} else {
-			actualValue, err := ioutil.ReadFile(configMapDataHostPath)
+			actualValue, err := os.ReadFile(configMapDataHostPath)
 			if err != nil {
 				t.Fatalf("Couldn't read configMap data from: %v", configMapDataHostPath)
 			}

--- a/pkg/volume/downwardapi/downwardapi_test.go
+++ b/pkg/volume/downwardapi/downwardapi_test.go
@@ -18,7 +18,6 @@ package downwardapi
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -320,7 +319,7 @@ type stepName struct {
 func (step stepName) getName() string { return step.name }
 
 func doVerifyLinesInFile(t *testing.T, volumePath, filename string, expected string) {
-	data, err := ioutil.ReadFile(filepath.Join(volumePath, filename))
+	data, err := os.ReadFile(filepath.Join(volumePath, filename))
 	if err != nil {
 		t.Errorf(err.Error())
 		return

--- a/pkg/volume/fc/fc_util.go
+++ b/pkg/volume/fc/fc_util.go
@@ -57,7 +57,7 @@ func (handler *osIOHandler) EvalSymlinks(path string) (string, error) {
 	return filepath.EvalSymlinks(path)
 }
 func (handler *osIOHandler) WriteFile(filename string, data []byte, perm os.FileMode) error {
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 }
 
 // given a wwn and lun, find the device and associated devicemapper parent

--- a/pkg/volume/iscsi/iscsi_util_test.go
+++ b/pkg/volume/iscsi/iscsi_util_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package iscsi
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -442,7 +441,7 @@ func TestGetVolCount(t *testing.T) {
 }
 
 func createFakePluginDirs() (string, error) {
-	dir, err := ioutil.TempDir("", "refcounter")
+	dir, err := os.MkdirTemp("", "refcounter")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -88,7 +88,7 @@ func getRbdDevFromImageAndPool(pool string, image string) (string, bool) {
 			name := f.Name()
 			// First match pool, then match name.
 			poolFile := filepath.Join(sysPath, name, "pool")
-			poolBytes, err := ioutil.ReadFile(poolFile)
+			poolBytes, err := os.ReadFile(poolFile)
 			if err != nil {
 				klog.V(4).Infof("error reading %s: %v", poolFile, err)
 				continue
@@ -98,7 +98,7 @@ func getRbdDevFromImageAndPool(pool string, image string) (string, bool) {
 				continue
 			}
 			imgFile := filepath.Join(sysPath, name, "name")
-			imgBytes, err := ioutil.ReadFile(imgFile)
+			imgBytes, err := os.ReadFile(imgFile)
 			if err != nil {
 				klog.V(4).Infof("error reading %s: %v", imgFile, err)
 				continue
@@ -129,7 +129,7 @@ func getMaxNbds() (int, error) {
 
 	klog.V(4).Infof("found nbds max parameters file at %s", maxNbdsPath)
 
-	maxNbdBytes, err := ioutil.ReadFile(maxNbdsPath)
+	maxNbdBytes, err := os.ReadFile(maxNbdsPath)
 	if err != nil {
 		return 0, fmt.Errorf("rbd-nbd: failed to read max_nbds from %s err: %q", maxNbdsPath, err)
 	}
@@ -167,13 +167,13 @@ func getNbdDevFromImageAndPool(pool string, image string) (string, bool) {
 			klog.V(4).Infof("error reading nbd info directory %s: %v", nbdPath, err)
 			continue
 		}
-		pidBytes, err := ioutil.ReadFile(filepath.Join(nbdPath, "pid"))
+		pidBytes, err := os.ReadFile(filepath.Join(nbdPath, "pid"))
 		if err != nil {
 			klog.V(5).Infof("did not find valid pid file in dir %s: %v", nbdPath, err)
 			continue
 		}
 		cmdlineFileName := filepath.Join("/proc", strings.TrimSpace(string(pidBytes)), "cmdline")
-		rawCmdline, err := ioutil.ReadFile(cmdlineFileName)
+		rawCmdline, err := os.ReadFile(cmdlineFileName)
 		if err != nil {
 			klog.V(4).Infof("failed to read cmdline file %s: %v", cmdlineFileName, err)
 			continue

--- a/pkg/volume/secret/secret_test.go
+++ b/pkg/volume/secret/secret_test.go
@@ -263,7 +263,7 @@ func TestMakePayload(t *testing.T) {
 }
 
 func newTestHost(t *testing.T, clientset clientset.Interface) (string, volume.VolumeHost) {
-	tempDir, err := ioutil.TempDir("", "secret_volume_test.")
+	tempDir, err := os.MkdirTemp("", "secret_volume_test.")
 	if err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
 	}
@@ -670,7 +670,7 @@ func doTestSecretDataInVolume(volumePath string, secret v1.Secret, t *testing.T)
 		if _, err := os.Stat(secretDataHostPath); err != nil {
 			t.Fatalf("SetUp() failed, couldn't find secret data on disk: %v", secretDataHostPath)
 		} else {
-			actualSecretBytes, err := ioutil.ReadFile(secretDataHostPath)
+			actualSecretBytes, err := os.ReadFile(secretDataHostPath)
 			if err != nil {
 				t.Fatalf("Couldn't read secret data from: %v", secretDataHostPath)
 			}

--- a/pkg/volume/util/subpath/subpath_linux.go
+++ b/pkg/volume/util/subpath/subpath_linux.go
@@ -148,7 +148,7 @@ func prepareSubpathTarget(mounter mount.Interface, subpath Subpath) (bool, strin
 		// A file is enough for all possible targets (symlink, device, pipe,
 		// socket, ...), bind-mounting them into a file correctly changes type
 		// of the target file.
-		if err = ioutil.WriteFile(bindPathTarget, []byte{}, 0640); err != nil {
+		if err = os.WriteFile(bindPathTarget, []byte{}, 0640); err != nil {
 			return false, "", fmt.Errorf("error creating file %s: %s", bindPathTarget, err)
 		}
 	}

--- a/pkg/volume/util/subpath/subpath_linux_test.go
+++ b/pkg/volume/util/subpath/subpath_linux_test.go
@@ -196,7 +196,7 @@ func TestSafeMakeDir(t *testing.T) {
 		{
 			"non-directory",
 			func(base string) error {
-				return ioutil.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
+				return os.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
 			},
 			"test/directory",
 			"",
@@ -206,7 +206,7 @@ func TestSafeMakeDir(t *testing.T) {
 		{
 			"non-directory-final",
 			func(base string) error {
-				return ioutil.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
+				return os.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
 			},
 			"test",
 			"",
@@ -257,7 +257,7 @@ func TestSafeMakeDir(t *testing.T) {
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
-			base, err := ioutil.TempDir("", "safe-make-dir-"+test.name+"-")
+			base, err := os.MkdirTemp("", "safe-make-dir-"+test.name+"-")
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
@@ -367,7 +367,7 @@ func TestRemoveEmptyDirs(t *testing.T) {
 				if err := os.MkdirAll(filepath.Join(base, "a/b"), defaultPerm); err != nil {
 					return err
 				}
-				return ioutil.WriteFile(filepath.Join(base, "a/b", "c"), []byte{}, defaultPerm)
+				return os.WriteFile(filepath.Join(base, "a/b", "c"), []byte{}, defaultPerm)
 			},
 			validate: func(base string) error {
 				if err := validateDirExists(filepath.Join(base, "a/b")); err != nil {
@@ -383,7 +383,7 @@ func TestRemoveEmptyDirs(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "remove-empty-dirs-"+test.name+"-")
+		base, err := os.MkdirTemp("", "remove-empty-dirs-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -449,7 +449,7 @@ func TestCleanSubPaths(t *testing.T) {
 				if err := os.MkdirAll(path, defaultPerm); err != nil {
 					return nil, err
 				}
-				return nil, ioutil.WriteFile(filepath.Join(path, "0"), []byte{}, defaultPerm)
+				return nil, os.WriteFile(filepath.Join(path, "0"), []byte{}, defaultPerm)
 			},
 			validate: func(base string) error {
 				return validateDirNotExists(filepath.Join(base, containerSubPathDirectoryName))
@@ -463,7 +463,7 @@ func TestCleanSubPaths(t *testing.T) {
 				if err := os.MkdirAll(path, defaultPerm); err != nil {
 					return nil, err
 				}
-				return nil, ioutil.WriteFile(filepath.Join(path, "container1"), []byte{}, defaultPerm)
+				return nil, os.WriteFile(filepath.Join(path, "container1"), []byte{}, defaultPerm)
 			},
 			validate: func(base string) error {
 				return validateDirExists(filepath.Join(base, containerSubPathDirectoryName, testVol))
@@ -477,7 +477,7 @@ func TestCleanSubPaths(t *testing.T) {
 				if err := os.MkdirAll(filepath.Join(path, "container1"), defaultPerm); err != nil {
 					return nil, err
 				}
-				return nil, ioutil.WriteFile(filepath.Join(path, "container2"), []byte{}, defaultPerm)
+				return nil, os.WriteFile(filepath.Join(path, "container2"), []byte{}, defaultPerm)
 			},
 			validate: func(base string) error {
 				path := filepath.Join(base, containerSubPathDirectoryName, testVol)
@@ -560,7 +560,7 @@ func TestCleanSubPaths(t *testing.T) {
 				}
 
 				file0 := filepath.Join(containerPath, "0")
-				if err := ioutil.WriteFile(file0, []byte{}, defaultPerm); err != nil {
+				if err := os.WriteFile(file0, []byte{}, defaultPerm); err != nil {
 					return nil, err
 				}
 
@@ -575,7 +575,7 @@ func TestCleanSubPaths(t *testing.T) {
 				}
 
 				file3 := filepath.Join(containerPath, "3")
-				if err := ioutil.WriteFile(file3, []byte{}, defaultPerm); err != nil {
+				if err := os.WriteFile(file3, []byte{}, defaultPerm); err != nil {
 					return nil, err
 				}
 
@@ -613,7 +613,7 @@ func TestCleanSubPaths(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "clean-subpaths-"+test.name+"-")
+		base, err := os.MkdirTemp("", "clean-subpaths-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -701,7 +701,7 @@ func TestBindSubPath(t *testing.T) {
 				if err := os.MkdirAll(volpath, defaultPerm); err != nil {
 					return nil, "", "", err
 				}
-				return nil, volpath, subpath, ioutil.WriteFile(subpath, []byte{}, defaultPerm)
+				return nil, volpath, subpath, os.WriteFile(subpath, []byte{}, defaultPerm)
 			},
 			expectError: false,
 		},
@@ -750,7 +750,7 @@ func TestBindSubPath(t *testing.T) {
 					return nil, "", "", err
 				}
 				// touch file outside
-				if err := ioutil.WriteFile(child, []byte{}, defaultPerm); err != nil {
+				if err := os.WriteFile(child, []byte{}, defaultPerm); err != nil {
 					return nil, "", "", err
 				}
 
@@ -785,7 +785,7 @@ func TestBindSubPath(t *testing.T) {
 					return nil, "", "", err
 				}
 				// touch file outside
-				if err := ioutil.WriteFile(child, []byte{}, defaultPerm); err != nil {
+				if err := os.WriteFile(child, []byte{}, defaultPerm); err != nil {
 					return nil, "", "", err
 				}
 
@@ -870,7 +870,7 @@ func TestBindSubPath(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "bind-subpath-"+test.name+"-")
+		base, err := os.MkdirTempr("", "bind-subpath-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -984,7 +984,7 @@ func TestSubpath_PrepareSafeSubpath(t *testing.T) {
 	}
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "bind-subpath-"+test.name+"-")
+		base, err := os.MkdirTemp("", "bind-subpath-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -1142,7 +1142,7 @@ func TestSafeOpen(t *testing.T) {
 		{
 			"non-directory",
 			func(base string) error {
-				return ioutil.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
+				return os.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
 			},
 			"test/directory",
 			true,
@@ -1150,7 +1150,7 @@ func TestSafeOpen(t *testing.T) {
 		{
 			"non-directory-final",
 			func(base string) error {
-				return ioutil.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
+				return os.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
 			},
 			"test",
 			false,
@@ -1218,7 +1218,7 @@ func TestSafeOpen(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "safe-open-"+test.name+"-")
+		base, err := os.MkdirTemp("", "safe-open-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -1365,7 +1365,7 @@ func TestFindExistingPrefix(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "find-prefix-"+test.name+"-")
+		base, err := os.MkdirTemp("", "find-prefix-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}

--- a/plugin/pkg/admission/eventratelimit/config.go
+++ b/plugin/pkg/admission/eventratelimit/config.go
@@ -19,7 +19,6 @@ package eventratelimit
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -50,7 +49,7 @@ func LoadConfiguration(config io.Reader) (*eventratelimitapi.Configuration, erro
 		return internalConfig, nil
 	}
 	// we have a config so parse it.
-	data, err := ioutil.ReadAll(config)
+	data, err := io.ReadAll(config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/admission/podtolerationrestriction/config.go
+++ b/plugin/pkg/admission/podtolerationrestriction/config.go
@@ -19,7 +19,6 @@ package podtolerationrestriction
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -51,7 +50,7 @@ func loadConfiguration(config io.Reader) (*internalapi.Configuration, error) {
 		return internalConfig, nil
 	}
 	// we have a config so parse it.
-	data, err := ioutil.ReadAll(config)
+	data, err := io.ReadAll(config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/admission/security/podsecurity/admission_test.go
+++ b/plugin/pkg/admission/security/podsecurity/admission_test.go
@@ -19,7 +19,7 @@ package podsecurity
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -116,7 +116,7 @@ func BenchmarkVerifyPod(b *testing.B) {
 
 	corePod := &core.Pod{}
 	v1Pod := &corev1.Pod{}
-	data, err := ioutil.ReadFile("testdata/pod_restricted.yaml")
+	data, err := os.ReadFile("testdata/pod_restricted.yaml")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -205,7 +205,7 @@ func BenchmarkVerifyNamespace(b *testing.B) {
 	}
 
 	v1Pod := &corev1.Pod{}
-	data, err := ioutil.ReadFile("testdata/pod_baseline.yaml")
+	data, err := os.ReadFile("testdata/pod_baseline.yaml")
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
fix  "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)