### PR TITLE
Add support for Go error unwrapping

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/errors/errors.go
@@ -30,8 +30,9 @@ type MessageCountMap map[string]int
 // necessarily have singular semantic meaning.
 // The aggregate can be used with `errors.Is()` to check for the occurrence of
 // a specific error type.
-// Errors.As() is not supported, because the caller presumably cares about a
-// specific error of potentially multiple that match the given type.
+// It can also be used with `errors.As()` but that doesn't allow multiple
+// errors of the given type to be distinguished. `Unwrap()` should be used if
+// specific errors need to be extracted.
 type Aggregate interface {
 	error
 	Errors() []error
@@ -121,6 +122,11 @@ func (agg aggregate) visit(f func(err error) bool) bool {
 	}
 
 	return false
+}
+
+// Unwrap is part of the error interface.
+func (agg aggregate) Unwrap() []error {
+	return agg.Errors()
 }
 
 // Errors is part of the Aggregate interface.

--- a/staging/src/k8s.io/apimachinery/pkg/util/errors/errors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/errors/errors_test.go
@@ -432,6 +432,54 @@ func TestAggregateGoroutines(t *testing.T) {
 	}
 }
 
+type firstTestError struct{}
+
+func (e firstTestError) Error() string {
+	return "first test error"
+}
+
+type secondTestError struct{}
+
+func (e secondTestError) Error() string {
+	return "second test error"
+}
+
+type thirdTestError struct{}
+
+func (e thirdTestError) Error() string {
+	return "third test error"
+}
+
+func TestGoUnwrapping(t *testing.T) {
+	testErrors := []error{
+		firstTestError{},
+		secondTestError{},
+	}
+	agg := NewAggregate(testErrors)
+
+	if !errors.Is(agg, firstTestError{}) {
+		t.Errorf("Expected %v to be a firstTestError", agg)
+	}
+
+	if !errors.Is(agg, secondTestError{}) {
+		t.Errorf("Expected %v to be a secondTestError", agg)
+	}
+
+	if errors.Is(agg, thirdTestError{}) {
+		t.Errorf("Did not expect %v to be a thirdTestError", agg)
+	}
+
+	var firstError firstTestError
+	if !errors.As(agg, &firstError) {
+		t.Errorf("Unable to extract firstTestError from %v", agg)
+	}
+
+	var secondError secondTestError
+	if !errors.As(agg, &secondError) {
+		t.Errorf("Unable to extract secondTestError from %v", agg)
+	}
+}
+
 type alwaysMatchingError struct{}
 
 func (_ alwaysMatchingError) Error() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Go 1.20 added support for wrapping multiple errors. `Aggregate` errors can be used transparently with `errors.Is` and `errors.As` if they implement an `Unwrap()` method returning an `[]error` slice.

This adds support for `Unwrap()` to `Aggregate`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added support for Go 1.20 aggregate errors to `k8s.io/apimachinery/pkg/util/errors` aggregate errors: the latter can now be used transparently with `errors.As()` in addition to `errors.Is()`. An aggregate error `Is()` any of the errors it contains, and the contained errors can be extracted with `errors.As()` (but this only returns the first match for a given type). Errors can be extracted using Go `Unwrap()` as well as the `Aggregate`-specific `Errors()`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
