### PR TITLE
chore: io/ioutil deprecated

### DIFF
--- a/plugin/pkg/admission/eventratelimit/config.go
+++ b/plugin/pkg/admission/eventratelimit/config.go
@@ -19,7 +19,6 @@ package eventratelimit
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -50,7 +49,7 @@ func LoadConfiguration(config io.Reader) (*eventratelimitapi.Configuration, erro
 		return internalConfig, nil
 	}
 	// we have a config so parse it.
-	data, err := ioutil.ReadAll(config)
+	data, err := io.ReadAll(config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/admission/podtolerationrestriction/config.go
+++ b/plugin/pkg/admission/podtolerationrestriction/config.go
@@ -19,7 +19,6 @@ package podtolerationrestriction
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -51,7 +50,7 @@ func loadConfiguration(config io.Reader) (*internalapi.Configuration, error) {
 		return internalConfig, nil
 	}
 	// we have a config so parse it.
-	data, err := ioutil.ReadAll(config)
+	data, err := io.ReadAll(config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/admission/security/podsecurity/admission_test.go
+++ b/plugin/pkg/admission/security/podsecurity/admission_test.go
@@ -19,7 +19,7 @@ package podsecurity
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -116,7 +116,7 @@ func BenchmarkVerifyPod(b *testing.B) {
 
 	corePod := &core.Pod{}
 	v1Pod := &corev1.Pod{}
-	data, err := ioutil.ReadFile("testdata/pod_restricted.yaml")
+	data, err := os.ReadFile("testdata/pod_restricted.yaml")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -205,7 +205,7 @@ func BenchmarkVerifyNamespace(b *testing.B) {
 	}
 
 	v1Pod := &corev1.Pod{}
-	data, err := ioutil.ReadFile("testdata/pod_baseline.yaml")
+	data, err := os.ReadFile("testdata/pod_baseline.yaml")
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
https://github.com/kubernetes/kubernetes/pull/118370 split plugin/pkg/admission/
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: