### PR TITLE
auth: stop using deprecated io/ioutil

### DIFF
--- a/pkg/auth/authorizer/abac/abac_test.go
+++ b/pkg/auth/authorizer/abac/abac_test.go
@@ -18,7 +18,6 @@ package abac
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -818,14 +817,14 @@ func TestSubjectMatches(t *testing.T) {
 }
 
 func newWithContents(t *testing.T, contents string) (PolicyList, error) {
-	f, err := ioutil.TempFile("", "abac_test")
+	f, err := os.CreateTemp("", "abac_test")
 	if err != nil {
 		t.Fatalf("unexpected error creating policyfile: %v", err)
 	}
 	f.Close()
 	defer os.Remove(f.Name())
 
-	if err := ioutil.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
 		t.Fatalf("unexpected error writing policyfile: %v", err)
 	}
 

--- a/pkg/controller/certificates/signer/signer_test.go
+++ b/pkg/controller/certificates/signer/signer_test.go
@@ -23,8 +23,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -49,7 +49,7 @@ func TestSigner(t *testing.T) {
 		t.Fatalf("failed to create signer: %v", err)
 	}
 
-	csrb, err := ioutil.ReadFile("./testdata/kubelet.csr")
+	csrb, err := os.ReadFile("./testdata/kubelet.csr")
 	if err != nil {
 		t.Fatalf("failed to read CSR: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/reader.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/reader.go
@@ -18,7 +18,7 @@ package policy
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -47,7 +47,7 @@ func LoadPolicyFromFile(filePath string) (*auditinternal.Policy, error) {
 	if filePath == "" {
 		return nil, fmt.Errorf("file path not specified")
 	}
-	policyDef, err := ioutil.ReadFile(filePath)
+	policyDef, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file path %q: %+v", filePath, err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/reader_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/reader_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package policy
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -158,7 +157,7 @@ kind: Policy`,
 }
 
 func writePolicy(t *testing.T, policy string) (string, error) {
-	f, err := ioutil.TempFile("", "policy.yaml")
+	f, err := os.CreateTemp("", "policy.yaml")
 	require.NoError(t, err)
 
 	_, err = f.WriteString(policy)

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/tokenfile_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/tokenfile_test.go
@@ -18,7 +18,6 @@ package tokenfile
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -137,14 +136,14 @@ func TestEmptyTokenTokenFile(t *testing.T) {
 }
 
 func newWithContents(t *testing.T, contents string) (auth *TokenAuthenticator, err error) {
-	f, err := ioutil.TempFile("", "tokenfile_test")
+	f, err := os.CreateTemp("", "tokenfile_test")
 	if err != nil {
 		t.Fatalf("unexpected error creating tokenfile: %v", err)
 	}
 	f.Close()
 	defer os.Remove(f.Name())
 
-	if err := ioutil.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
 		t.Fatalf("unexpected error writing tokenfile: %v", err)
 	}
 

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook_test.go
@@ -20,7 +20,6 @@ import (
 	stdjson "encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -65,7 +64,7 @@ type testWebhookHandler struct {
 
 func (t *testWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := func() error {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			return fmt.Errorf("read webhook request body: %v", err)
 		}
@@ -96,7 +95,7 @@ func newWebhook(t *testing.T, endpoint string, groupVersion schema.GroupVersion)
 			{Cluster: v1.Cluster{Server: endpoint, InsecureSkipTLSVerify: true}},
 		},
 	}
-	f, err := ioutil.TempFile("", "k8s_audit_webhook_test_")
+	f, err := os.CreateTemp("", "k8s_audit_webhook_test_")
 	require.NoError(t, err, "creating temp file")
 
 	defer func() {

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -33,7 +33,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -993,7 +993,7 @@ func getClaimJWT(ctx context.Context, client *http.Client, url, accessToken stri
 	if response.StatusCode < http.StatusOK || response.StatusCode > http.StatusIMUsed {
 		return "", fmt.Errorf("error while getting distributed claim JWT: %v", response.Status)
 	}
-	responseBytes, err := ioutil.ReadAll(response.Body)
+	responseBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", fmt.Errorf("could not decode distributed claim response")
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1_test.go
@@ -22,7 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -89,7 +89,7 @@ func NewV1TestServer(s V1Service, cert, key, caCert []byte) (*httptest.Server, e
 		}
 
 		var review authenticationv1.TokenReview
-		bodyData, _ := ioutil.ReadAll(r.Body)
+		bodyData, _ := io.ReadAll(r.Body)
 		if err := json.Unmarshal(bodyData, &review); err != nil {
 			http.Error(w, fmt.Sprintf("failed to decode body: %v", err), http.StatusBadRequest)
 			return
@@ -180,7 +180,7 @@ func (m *mockV1Service) HTTPStatusCode() int { return m.statusCode }
 // newV1TokenAuthenticator creates a temporary kubeconfig file from the provided
 // arguments and attempts to load a new WebhookTokenAuthenticator from it.
 func newV1TokenAuthenticator(serverURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration, implicitAuds authenticator.Audiences, metrics AuthenticatorMetrics) (authenticator.Token, error) {
-	tempfile, err := ioutil.TempFile("", "")
+	tempfile, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1beta1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1beta1_test.go
@@ -22,7 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -83,7 +83,7 @@ func NewV1beta1TestServer(s V1beta1Service, cert, key, caCert []byte) (*httptest
 		}
 
 		var review authenticationv1beta1.TokenReview
-		bodyData, _ := ioutil.ReadAll(r.Body)
+		bodyData, _ := io.ReadAll(r.Body)
 		if err := json.Unmarshal(bodyData, &review); err != nil {
 			http.Error(w, fmt.Sprintf("failed to decode body: %v", err), http.StatusBadRequest)
 			return
@@ -174,7 +174,7 @@ func (m *mockV1beta1Service) HTTPStatusCode() int { return m.statusCode }
 // newV1beta1TokenAuthenticator creates a temporary kubeconfig file from the provided
 // arguments and attempts to load a new WebhookTokenAuthenticator from it.
 func newV1beta1TokenAuthenticator(serverURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration, implicitAuds authenticator.Audiences) (authenticator.Token, error) {
-	tempfile, err := ioutil.TempFile("", "")
+	tempfile, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1_test.go
@@ -22,7 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -65,7 +65,7 @@ var testRetryBackoff = wait.Backoff{
 }
 
 func TestV1NewFromConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func TestV1NewFromConfig(t *testing.T) {
 		{data.Key, clientKey},
 	}
 	for _, file := range files {
-		if err := ioutil.WriteFile(file.name, file.data, 0400); err != nil {
+		if err := os.WriteFile(file.name, file.data, 0400); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -193,7 +193,7 @@ current-context: default
 	for _, tt := range tests {
 		// Use a closure so defer statements trigger between loop iterations.
 		err := func() error {
-			tempfile, err := ioutil.TempFile("", "")
+			tempfile, err := os.CreateTemp("", "")
 			if err != nil {
 				return err
 			}
@@ -267,7 +267,7 @@ func NewV1TestServer(s V1Service, cert, key, caCert []byte) (*httptest.Server, e
 		}
 
 		var review authorizationv1.SubjectAccessReview
-		bodyData, _ := ioutil.ReadAll(r.Body)
+		bodyData, _ := io.ReadAll(r.Body)
 		if err := json.Unmarshal(bodyData, &review); err != nil {
 			http.Error(w, fmt.Sprintf("failed to decode body: %v", err), http.StatusBadRequest)
 			return
@@ -337,7 +337,7 @@ func (m *mockV1Service) HTTPStatusCode() int { return m.statusCode }
 // newV1Authorizer creates a temporary kubeconfig file from the provided arguments and attempts to load
 // a new WebhookAuthorizer from it.
 func newV1Authorizer(callbackURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration, metrics metrics.AuthorizerMetrics, compiler authorizationcel.Compiler, expressions []apiserver.WebhookMatchCondition, authzName string) (*WebhookAuthorizer, error) {
-	tempfile, err := ioutil.TempFile("", "")
+	tempfile, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1beta1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1beta1_test.go
@@ -22,7 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -47,7 +47,7 @@ import (
 )
 
 func TestV1beta1NewFromConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestV1beta1NewFromConfig(t *testing.T) {
 		{data.Key, clientKey},
 	}
 	for _, file := range files {
-		if err := ioutil.WriteFile(file.name, file.data, 0400); err != nil {
+		if err := os.WriteFile(file.name, file.data, 0400); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -175,7 +175,7 @@ current-context: default
 	for _, tt := range tests {
 		// Use a closure so defer statements trigger between loop iterations.
 		err := func() error {
-			tempfile, err := ioutil.TempFile("", "")
+			tempfile, err := os.CreateTemp("", "")
 			if err != nil {
 				return err
 			}
@@ -249,7 +249,7 @@ func NewV1beta1TestServer(s V1beta1Service, cert, key, caCert []byte) (*httptest
 		}
 
 		var review authorizationv1beta1.SubjectAccessReview
-		bodyData, _ := ioutil.ReadAll(r.Body)
+		bodyData, _ := io.ReadAll(r.Body)
 		if err := json.Unmarshal(bodyData, &review); err != nil {
 			http.Error(w, fmt.Sprintf("failed to decode body: %v", err), http.StatusBadRequest)
 			return
@@ -312,7 +312,7 @@ func (m *mockV1beta1Service) HTTPStatusCode() int { return m.statusCode }
 // newV1beta1Authorizer creates a temporary kubeconfig file from the provided arguments and attempts to load
 // a new WebhookAuthorizer from it.
 func newV1beta1Authorizer(callbackURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration) (*WebhookAuthorizer, error) {
-	tempfile, err := ioutil.TempFile("", "")
+	tempfile, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/pod-security-admission/admission/api/load/load_test.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/api/load/load_test.go
@@ -18,7 +18,7 @@ package load
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -40,14 +40,14 @@ var defaultConfig = &api.PodSecurityConfiguration{
 
 func writeTempFile(t *testing.T, content string) string {
 	t.Helper()
-	file, err := ioutil.TempFile("", "podsecurityconfig")
+	file, err := os.CreateTemp("", "podsecurityconfig")
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
 		utiltesting.CloseAndRemove(t, file)
 	})
-	if err := ioutil.WriteFile(file.Name(), []byte(content), 0600); err != nil {
+	if err := os.WriteFile(file.Name(), []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
 	return file.Name()

--- a/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
+++ b/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -182,7 +181,7 @@ func (s *Server) HandleValidate(w http.ResponseWriter, r *http.Request) {
 
 	defer r.Body.Close()
 	limitedReader := &io.LimitedReader{R: r.Body, N: maxRequestSize}
-	if body, err = ioutil.ReadAll(limitedReader); err != nil {
+	if body, err = io.ReadAll(limitedReader); err != nil {
 		logger.Error(err, "unable to read the body from the incoming request")
 		http.Error(w, "unable to read the body from the incoming request", http.StatusBadRequest)
 		return

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_test.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_test.go
@@ -18,7 +18,6 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -137,7 +136,7 @@ func testFixtureFile(t *testing.T, dir, name string, pod *corev1.Pod) string {
 	pod = pod.DeepCopy()
 	pod.Name = name
 
-	expectedYAML, _ := ioutil.ReadFile(filename)
+	expectedYAML, _ := os.ReadFile(filename)
 
 	jsonData, err := runtime.Encode(scheme.Codecs.LegacyCodec(corev1.SchemeGroupVersion), pod)
 	if err != nil {
@@ -160,7 +159,7 @@ func testFixtureFile(t *testing.T, dir, name string, pod *corev1.Pod) string {
 			if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
 				t.Fatal(err)
 			}
-			if err := ioutil.WriteFile(filename, []byte(yamlData), os.FileMode(0755)); err == nil {
+			if err := os.WriteFile(filename, []byte(yamlData), os.FileMode(0755)); err == nil {
 				t.Logf("Updated data in %s", filename)
 				t.Logf("Verify the diff, commit changes, and rerun the tests")
 			} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This replaces deprecated ioutil functions as follows:

* ioutil.ReadAll -> io.ReadAll
* ioutil.ReadFile -> os.ReadFile
* ioutil.TempDir -> os.MkdirTemp
* ioutil.TempFile -> os.CreateTemp
* ioutil.WriteFile -> os.WriteFile

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
