### PR TITLE
cli: stop using deprecated io/ioutil

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/io_options.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/io_options.go
@@ -18,7 +18,7 @@ package genericclioptions
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
@@ -48,7 +48,7 @@ func NewTestIOStreamsDiscard() genericiooptions.IOStreams {
 	in := &bytes.Buffer{}
 	return IOStreams{
 		In:     in,
-		Out:    ioutil.Discard,
-		ErrOut: ioutil.Discard,
+		Out:    io.Discard,
+		ErrOut: io.Discard,
 	}
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags.go
@@ -18,7 +18,7 @@ package genericclioptions
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -88,7 +88,7 @@ func (f *JSONPathPrintFlags) ToPrinter(templateFormat string) (printers.Resource
 	}
 
 	if templateFormat == "jsonpath-file" {
-		data, err := ioutil.ReadFile(templateValue)
+		data, err := os.ReadFile(templateValue)
 		if err != nil {
 			return nil, fmt.Errorf("error reading --template %s, %v", templateValue, err)
 		}

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags_test.go
@@ -19,7 +19,6 @@ package genericclioptions
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -32,7 +31,7 @@ import (
 func TestPrinterSupportsExpectedJSONPathFormats(t *testing.T) {
 	testObject := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 
-	jsonpathFile, err := ioutil.TempFile("", "printers_jsonpath_flags")
+	jsonpathFile, err := os.CreateTemp("", "printers_jsonpath_flags")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
@@ -18,7 +18,7 @@ package genericclioptions
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -89,7 +89,7 @@ func (f *GoTemplatePrintFlags) ToPrinter(templateFormat string) (printers.Resour
 	}
 
 	if templateFormat == "templatefile" || templateFormat == "go-template-file" {
-		data, err := ioutil.ReadFile(templateValue)
+		data, err := os.ReadFile(templateValue)
 		if err != nil {
 			return nil, fmt.Errorf("error reading --template %s, %v", templateValue, err)
 		}

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags_test.go
@@ -19,7 +19,6 @@ package genericclioptions
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -32,7 +31,7 @@ import (
 func TestPrinterSupportsExpectedTemplateFormats(t *testing.T) {
 	testObject := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 
-	templateFile, err := ioutil.TempFile("", "printers_jsonpath_flags")
+	templateFile, err := os.CreateTemp("", "printers_jsonpath_flags")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strings"
@@ -39,7 +38,7 @@ import (
 )
 
 func objBody(obj runtime.Object) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(corev1Codec, obj))))
+	return io.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(corev1Codec, obj))))
 }
 
 func header() http.Header {
@@ -250,7 +249,7 @@ func TestHelperCreate(t *testing.T) {
 			if tt.Req != nil && !tt.Req(client.Req) {
 				t.Errorf("%d: unexpected request: %#v", i, client.Req)
 			}
-			body, err := ioutil.ReadAll(client.Req.Body)
+			body, err := io.ReadAll(client.Req.Body)
 			if err != nil {
 				t.Fatalf("%d: unexpected error: %#v", i, err)
 			}
@@ -711,7 +710,7 @@ func TestHelperReplace(t *testing.T) {
 			if tt.Req != nil && (client.Req == nil || !tt.Req(tt.ExpectPath, client.Req)) {
 				t.Fatalf("unexpected request: %#v", client.Req)
 			}
-			body, err := ioutil.ReadAll(client.Req.Body)
+			body, err := io.ReadAll(client.Req.Body)
 			if err != nil {
 				t.Fatalf("unexpected error: %#v", err)
 			}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,7 +74,7 @@ func TestVisitorHttpGet(t *testing.T) {
 			httpRetries: func(url string) (int, string, io.ReadCloser, error) {
 				assert.Equal(t, "hello", url)
 				i++
-				return 501, "Status", ioutil.NopCloser(new(bytes.Buffer)), nil
+				return 501, "Status", io.NopCloser(new(bytes.Buffer)), nil
 			},
 			args: httpArgs{
 				duration: 0,
@@ -89,7 +88,7 @@ func TestVisitorHttpGet(t *testing.T) {
 			httpRetries: func(url string) (int, string, io.ReadCloser, error) {
 				assert.Equal(t, "hello", url)
 				i++
-				return 300, "Status", ioutil.NopCloser(new(bytes.Buffer)), nil
+				return 300, "Status", io.NopCloser(new(bytes.Buffer)), nil
 
 			},
 			args: httpArgs{
@@ -104,7 +103,7 @@ func TestVisitorHttpGet(t *testing.T) {
 			httpRetries: func(url string) (int, string, io.ReadCloser, error) {
 				assert.Equal(t, "hello", url)
 				i++
-				return 501, "Status", ioutil.NopCloser(new(bytes.Buffer)), nil
+				return 501, "Status", io.NopCloser(new(bytes.Buffer)), nil
 
 			},
 			args: httpArgs{
@@ -117,7 +116,7 @@ func TestVisitorHttpGet(t *testing.T) {
 		{
 			name: "Test attempts less than 1 results in an error",
 			httpRetries: func(url string) (int, string, io.ReadCloser, error) {
-				return 200, "Status", ioutil.NopCloser(new(bytes.Buffer)), nil
+				return 200, "Status", io.NopCloser(new(bytes.Buffer)), nil
 
 			},
 			args: httpArgs{
@@ -133,9 +132,9 @@ func TestVisitorHttpGet(t *testing.T) {
 				assert.Equal(t, "hello", url)
 				i++
 				if i > 1 {
-					return 200, "Status", ioutil.NopCloser(new(bytes.Buffer)), nil
+					return 200, "Status", io.NopCloser(new(bytes.Buffer)), nil
 				}
-				return 501, "Status", ioutil.NopCloser(new(bytes.Buffer)), nil
+				return 501, "Status", io.NopCloser(new(bytes.Buffer)), nil
 
 			},
 			args: httpArgs{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This replaces deprecated ioutil variables and functions as follows:

* ioutil.Discard -> io.Discard
* ioutil.NopCloser -> io.NopCloser
* ioutil.ReadAll -> io.ReadAll
* ioutil.ReadFile -> os.ReadFile
* ioutil.TempFile -> os.CreateTemp

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
