### PR TITLE
storage: stop using deprecated io/ioutil

### DIFF
--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -1644,7 +1643,7 @@ func TestAttacherUnmountDevice(t *testing.T) {
 			// Make JSON for this object
 			if tc.jsonFile != "" {
 				dataPath := filepath.Join(dir, volDataFileName)
-				if err := ioutil.WriteFile(dataPath, []byte(tc.jsonFile), 0644); err != nil {
+				if err := os.WriteFile(dataPath, []byte(tc.jsonFile), 0644); err != nil {
 					t.Fatalf("error creating %s: %s", dataPath, err)
 				}
 			}

--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -19,7 +19,6 @@ package csi
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -1065,7 +1064,7 @@ func TestUnmounterTeardown(t *testing.T) {
 }
 
 func TestIsCorruptedDir(t *testing.T) {
-	existingMountPath, err := ioutil.TempDir(os.TempDir(), "blobfuse-csi-mount-test")
+	existingMountPath, err := os.MkdirTemp(os.TempDir(), "blobfuse-csi-mount-test")
 	if err != nil {
 		t.Fatalf("failed to create tmp dir: %v", err)
 	}

--- a/pkg/volume/csi/csi_util_test.go
+++ b/pkg/volume/csi/csi_util_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -143,7 +142,7 @@ func TestSaveVolumeData(t *testing.T) {
 		}
 
 		// validate content
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		if !tc.shouldFail && err != nil {
 			t.Errorf("failed to read data file: %v", err)
 		}

--- a/pkg/volume/csi/fake/fake_client.go
+++ b/pkg/volume/csi/fake/fake_client.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -205,7 +204,7 @@ func (f *NodeClient) NodePublishVolume(ctx context.Context, req *csipb.NodePubli
 	// "Creation of target_path is the responsibility of the SP."
 	// Our plugin depends on it.
 	if req.VolumeCapability.GetBlock() != nil {
-		if err := ioutil.WriteFile(req.TargetPath, []byte{}, 0644); err != nil {
+		if err := os.WriteFile(req.TargetPath, []byte{}, 0644); err != nil {
 			return nil, fmt.Errorf("cannot create target path %s for block file: %s", req.TargetPath, err)
 		}
 	} else {

--- a/pkg/volume/metrics_du_test.go
+++ b/pkg/volume/metrics_du_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package volume_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,7 +59,7 @@ func TestMetricsDuGetCapacity(t *testing.T) {
 	}
 
 	// Write a file and expect Used to increase
-	ioutil.WriteFile(filepath.Join(tmpDir, "f1"), []byte("Hello World"), os.ModeTemporary)
+	os.WriteFile(filepath.Join(tmpDir, "f1"), []byte("Hello World"), os.ModeTemporary)
 	actual, err = metrics.GetMetrics()
 	if err != nil {
 		t.Errorf("Unexpected error when calling GetMetrics %v", err)

--- a/pkg/volume/projected/projected_test.go
+++ b/pkg/volume/projected/projected_test.go
@@ -18,7 +18,6 @@ package projected
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -874,7 +873,7 @@ func TestCollectDataWithServiceAccountToken(t *testing.T) {
 }
 
 func newTestHost(t *testing.T, clientset clientset.Interface) (string, volume.VolumeHost) {
-	tempDir, err := ioutil.TempDir("", "projected_volume_test.")
+	tempDir, err := os.MkdirTemp("", "projected_volume_test.")
 	if err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
 	}
@@ -1139,7 +1138,7 @@ func TestPluginOptional(t *testing.T) {
 	}
 	datadirPath := filepath.Join(volumePath, datadir)
 
-	infos, err := ioutil.ReadDir(volumePath)
+	infos, err := os.ReadDir(volumePath)
 	if err != nil {
 		t.Fatalf("couldn't find volume path, %s", volumePath)
 	}
@@ -1151,7 +1150,7 @@ func TestPluginOptional(t *testing.T) {
 		}
 	}
 
-	infos, err = ioutil.ReadDir(datadirPath)
+	infos, err = os.ReadDir(datadirPath)
 	if err != nil {
 		t.Fatalf("couldn't find volume data path, %s", datadirPath)
 	}
@@ -1292,7 +1291,7 @@ func doTestSecretDataInVolume(volumePath string, secret v1.Secret, t *testing.T)
 		if _, err := os.Stat(secretDataHostPath); err != nil {
 			t.Fatalf("SetUp() failed, couldn't find secret data on disk: %v", secretDataHostPath)
 		} else {
-			actualSecretBytes, err := ioutil.ReadFile(secretDataHostPath)
+			actualSecretBytes, err := os.ReadFile(secretDataHostPath)
 			if err != nil {
 				t.Fatalf("Couldn't read secret data from: %v", secretDataHostPath)
 			}

--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -19,7 +19,6 @@ package util
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -327,7 +326,7 @@ func shouldWriteFile(path string, content []byte) (bool, error) {
 		return true, nil
 	}
 
-	contentOnFs, err := ioutil.ReadFile(path)
+	contentOnFs, err := os.ReadFile(path)
 	if err != nil {
 		return false, err
 	}
@@ -379,7 +378,7 @@ func (w *AtomicWriter) pathsToRemove(payload map[string]FileProjection, oldTsDir
 
 // newTimestampDir creates a new timestamp directory
 func (w *AtomicWriter) newTimestampDir() (string, error) {
-	tsDir, err := ioutil.TempDir(w.targetDir, time.Now().UTC().Format("..2006_01_02_15_04_05."))
+	tsDir, err := os.MkdirTemp(w.targetDir, time.Now().UTC().Format("..2006_01_02_15_04_05."))
 	if err != nil {
 		klog.Errorf("%s: unable to create new temp directory: %v", w.logContext, err)
 		return "", err
@@ -411,11 +410,11 @@ func (w *AtomicWriter) writePayloadToDir(payload map[string]FileProjection, dir 
 			return err
 		}
 
-		if err := ioutil.WriteFile(fullPath, content, mode); err != nil {
+		if err := os.WriteFile(fullPath, content, mode); err != nil {
 			klog.Errorf("%s: unable to write file %s with mode %v: %v", w.logContext, fullPath, mode, err)
 			return err
 		}
-		// Chmod is needed because ioutil.WriteFile() ends up calling
+		// Chmod is needed because os.WriteFile() ends up calling
 		// open(2) to create the file, so the final mode used is "mode &
 		// ~umask". But we want to make sure the specified mode is used
 		// in the file no matter what the umask is.

--- a/pkg/volume/util/atomic_writer_test.go
+++ b/pkg/volume/util/atomic_writer_test.go
@@ -22,7 +22,6 @@ package util
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -766,7 +765,7 @@ func checkVolumeContents(targetDir, tcName string, payload map[string]FileProjec
 			return nil
 		}
 
-		content, err := ioutil.ReadFile(path)
+		content, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
@@ -781,7 +780,7 @@ func checkVolumeContents(targetDir, tcName string, payload map[string]FileProjec
 		return nil
 	}
 
-	d, err := ioutil.ReadDir(targetDir)
+	d, err := os.ReadDir(targetDir)
 	if err != nil {
 		t.Errorf("Unable to read dir %v: %v", targetDir, err)
 		return
@@ -790,7 +789,7 @@ func checkVolumeContents(targetDir, tcName string, payload map[string]FileProjec
 		if strings.HasPrefix(info.Name(), "..") {
 			continue
 		}
-		if info.Mode()&os.ModeSymlink != 0 {
+		if info.Type()&os.ModeSymlink != 0 {
 			p := filepath.Join(targetDir, info.Name())
 			actual, err := os.Readlink(p)
 			if err != nil {

--- a/pkg/volume/util/fs/fs_windows_test.go
+++ b/pkg/volume/util/fs/fs_windows_test.go
@@ -18,7 +18,6 @@ package fs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"testing"
@@ -28,21 +27,21 @@ import (
 
 func TestDiskUsage(t *testing.T) {
 
-	dir1, err := ioutil.TempDir("", "dir_1")
+	dir1, err := os.MkdirTemp("", "dir_1")
 	if err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
 	}
 	defer os.RemoveAll(dir1)
 
-	tmpfile1, err := ioutil.TempFile(dir1, "test")
+	tmpfile1, err := os.CreateTemp(dir1, "test")
 	if _, err = tmpfile1.WriteString("just for testing"); err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
 	}
-	dir2, err := ioutil.TempDir(dir1, "dir_2")
+	dir2, err := os.MkdirTemp(dir1, "dir_2")
 	if err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
 	}
-	tmpfile2, err := ioutil.TempFile(dir2, "test")
+	tmpfile2, err := os.CreateTemp(dir2, "test")
 	if _, err = tmpfile2.WriteString("just for testing"); err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
 	}
@@ -92,7 +91,7 @@ func TestDiskUsage(t *testing.T) {
 }
 
 func TestInfo(t *testing.T) {
-	dir1, err := ioutil.TempDir("", "dir_1")
+	dir1, err := os.MkdirTemp("", "dir_1")
 	if err != nil {
 		t.Fatalf("TestInfo failed: %s", err.Error())
 	}
@@ -107,7 +106,7 @@ func TestInfo(t *testing.T) {
 	validateInfo(t, availablebytes, capacity, usage, inodesTotal, inodeUsage, inodesFree)
 
 	// should pass for file
-	tmpfile1, err := ioutil.TempFile(dir1, "test")
+	tmpfile1, err := os.CreateTemp(dir1, "test")
 	if _, err = tmpfile1.WriteString("just for testing"); err != nil {
 		t.Fatalf("TestInfo failed: %s", err.Error())
 	}

--- a/pkg/volume/util/fsquota/common/quota_common_linux_impl.go
+++ b/pkg/volume/util/fsquota/common/quota_common_linux_impl.go
@@ -22,7 +22,6 @@ package common
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -144,7 +143,7 @@ func doRunXFSQuotaCommand(mountpoint string, mountsFile, command string) (string
 // See https://bugzilla.redhat.com/show_bug.cgi?id=237120 for an example
 // of the problem that could be caused if this were to happen.
 func runXFSQuotaCommand(mountpoint string, command string) (string, error) {
-	tmpMounts, err := ioutil.TempFile("", "mounts")
+	tmpMounts, err := os.CreateTemp("", "mounts")
 	if err != nil {
 		return "", fmt.Errorf("cannot create temporary mount file: %v", err)
 	}

--- a/pkg/volume/util/fsquota/project.go
+++ b/pkg/volume/util/fsquota/project.go
@@ -22,7 +22,6 @@ package fsquota
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -267,7 +266,7 @@ func writeProjectFile(base *os.File, projects []projectType) (string, error) {
 		return "", err
 	}
 	mode := stat.Mode() & os.ModePerm
-	f, err := ioutil.TempFile(filepath.Dir(oname), filepath.Base(oname))
+	f, err := os.CreateTemp(filepath.Dir(oname), filepath.Base(oname))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/volume/util/fsquota/quota_linux_test.go
+++ b/pkg/volume/util/fsquota/quota_linux_test.go
@@ -21,7 +21,6 @@ package fsquota
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -97,7 +96,7 @@ type mountpointTest struct {
 }
 
 func testBackingDev1(testcase backingDevTest) error {
-	tmpfile, err := ioutil.TempFile("", "backingdev")
+	tmpfile, err := os.CreateTemp("", "backingdev")
 	if err != nil {
 		return err
 	}
@@ -502,7 +501,7 @@ var quotaTestCases = []quotaTestCase{
 }
 
 func compareProjectsFiles(t *testing.T, testcase quotaTestCase, projectsFile string, projidFile string, enabled bool) {
-	bytes, err := ioutil.ReadFile(projectsFile)
+	bytes, err := os.ReadFile(projectsFile)
 	if err != nil {
 		t.Error(err.Error())
 	} else {
@@ -515,7 +514,7 @@ func compareProjectsFiles(t *testing.T, testcase quotaTestCase, projectsFile str
 			t.Errorf("Case %v /etc/projects miscompare: expected\n`%s`\ngot\n`%s`\n", testcase.path, p, s)
 		}
 	}
-	bytes, err = ioutil.ReadFile(projidFile)
+	bytes, err = os.ReadFile(projidFile)
 	if err != nil {
 		t.Error(err.Error())
 	} else {
@@ -598,7 +597,7 @@ func runCaseDisabled(t *testing.T, testcase quotaTestCase, seq int) bool {
 
 func testAddRemoveQuotas(t *testing.T, enabled bool) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.LocalStorageCapacityIsolationFSQuotaMonitoring, enabled)()
-	tmpProjectsFile, err := ioutil.TempFile("", "projects")
+	tmpProjectsFile, err := os.CreateTemp("", "projects")
 	if err == nil {
 		_, err = tmpProjectsFile.WriteString(projectsHeader)
 	}
@@ -607,7 +606,7 @@ func testAddRemoveQuotas(t *testing.T, enabled bool) {
 	}
 	projectsFile = tmpProjectsFile.Name()
 	tmpProjectsFile.Close()
-	tmpProjidFile, err := ioutil.TempFile("", "projid")
+	tmpProjidFile, err := os.CreateTemp("", "projid")
 	if err == nil {
 		_, err = tmpProjidFile.WriteString(projidHeader)
 	}

--- a/pkg/volume/util/hostutil/hostutil_linux_test.go
+++ b/pkg/volume/util/hostutil/hostutil_linux_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package hostutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -193,12 +192,12 @@ func TestGetSELinuxSupport(t *testing.T) {
 }
 
 func writeFile(content string) (string, string, error) {
-	tempDir, err := ioutil.TempDir("", "mounter_shared_test")
+	tempDir, err := os.MkdirTemp("", "mounter_shared_test")
 	if err != nil {
 		return "", "", err
 	}
 	filename := filepath.Join(tempDir, "mountinfo")
-	err = ioutil.WriteFile(filename, []byte(content), 0600)
+	err = os.WriteFile(filename, []byte(content), 0600)
 	if err != nil {
 		os.RemoveAll(tempDir)
 		return "", "", err

--- a/pkg/volume/util/io_util.go
+++ b/pkg/volume/util/io_util.go
@@ -38,7 +38,7 @@ func NewIOHandler() IoUtil {
 }
 
 func (handler *osIOHandler) ReadFile(filename string) ([]byte, error) {
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 func (handler *osIOHandler) ReadDir(dirname string) ([]os.FileInfo, error) {
 	return ioutil.ReadDir(dirname)

--- a/pkg/volume/util/nested_volumes_test.go
+++ b/pkg/volume/util/nested_volumes_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -202,7 +201,7 @@ func TestGetNestedMountpoints(t *testing.T) {
 		},
 	}
 	for _, test := range tc {
-		dir, err := ioutil.TempDir("", "TestMakeNestedMountpoints.")
+		dir, err := os.MkdirTemp("", "TestMakeNestedMountpoints.")
 		if err != nil {
 			t.Errorf("Unexpected error trying to create temp directory: %v", err)
 			return

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -19,7 +19,6 @@ package util
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -173,7 +172,7 @@ func LoadPodFromFile(filePath string) (*v1.Pod, error) {
 	if filePath == "" {
 		return nil, fmt.Errorf("file path not specified")
 	}
-	podDef, err := ioutil.ReadFile(filePath)
+	podDef, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file path %s: %+v", filePath, err)
 	}

--- a/pkg/volume/util/util_test.go
+++ b/pkg/volume/util/util_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"runtime"
@@ -93,7 +92,7 @@ spec:
 	}
 
 	for _, test := range tests {
-		tempFile, err := ioutil.TempFile("", "podfile")
+		tempFile, err := os.CreateTemp("", "podfile")
 		defer os.Remove(tempFile.Name())
 		if err != nil {
 			t.Fatalf("cannot create temporary file: %v", err)

--- a/pkg/volume/util/volumepathhandler/volume_path_handler.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler.go
@@ -18,7 +18,6 @@ package volumepathhandler
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -279,12 +278,12 @@ func (v VolumePathHandler) IsDeviceBindMountExist(mapPath string) (bool, error) 
 // GetDeviceBindMountRefs searches bind mounts under global map path
 func (v VolumePathHandler) GetDeviceBindMountRefs(devPath string, mapPath string) ([]string, error) {
 	var refs []string
-	files, err := ioutil.ReadDir(mapPath)
+	files, err := os.ReadDir(mapPath)
 	if err != nil {
 		return nil, err
 	}
 	for _, file := range files {
-		if file.Mode()&os.ModeDevice != os.ModeDevice {
+		if file.Type()&os.ModeDevice != os.ModeDevice {
 			continue
 		}
 		filename := file.Name()

--- a/pkg/volume/util/volumepathhandler/volume_path_handler_linux.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler_linux.go
@@ -22,7 +22,6 @@ package volumepathhandler
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -133,7 +132,7 @@ func getLoopDeviceFromSysfs(path string) (string, error) {
 		backingFile := fmt.Sprintf("%s/loop/backing_file", device)
 
 		// The contents of this file is the absolute path of "path".
-		data, err := ioutil.ReadFile(backingFile)
+		data, err := os.ReadFile(backingFile)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This replaces deprecated ioutil variables and functions as follows:

* ioutil.ReadDir -> os.ReadDir
* ioutil.ReadFile -> os.ReadFile
* ioutil.TempDir -> os.MkdirTemp
* ioutil.TempFile -> os.CreateTemp
* ioutil.WriteFile -> os.WriteFile

The ReadDir conversion involves an API change, the replacement function returns a slice of fs.DirEntry instead of fs.FileInfo. Where appropriate, the surrounding code has been adjusted; mostly, that means using DirEntry.Type() instead of FileInfo.Mode(). Applying this change to the IoUtil interface would mean changing its API, so this is left for later.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
