### PR TITLE
stop serving (possibly wrong) information on the deprecated componentstatus API

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -211,6 +211,15 @@ const (
 	// Disable any functionality in kube-apiserver, kube-controller-manager and kubelet related to the `--cloud-provider` component flag.
 	DisableCloudProviders featuregate.Feature = "DisableCloudProviders"
 
+	// owner: @aojea
+	// deprecated: v1.28
+	//
+	// Disable the componentstatus API probes, the API was deprecated in 1.19
+	// for different reasons explained in https://github.com/kubernetes/kubernetes/pull/93570
+	// Enabling the feature gate stops the apiserver to try to probe any of the components
+	// of the cluster.
+	DisableComponentStatusProbes featuregate.Feature = "DisableComponentStatusProbes"
+
 	// owner: @andrewsykim
 	// alpha: v1.23
 	//
@@ -895,6 +904,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	DefaultHostNetworkHostPortsInPodTemplates: {Default: false, PreRelease: featuregate.Deprecated},
 
 	DisableCloudProviders: {Default: false, PreRelease: featuregate.Alpha},
+
+	DisableComponentStatusProbes: {Default: false, PreRelease: featuregate.Deprecated},
 
 	DisableKubeletCloudCredentialProviders: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -417,6 +417,12 @@ type componentStatusStorage struct {
 }
 
 func (s componentStatusStorage) serversToValidate() map[string]*componentstatus.Server {
+	if utilfeature.DefaultFeatureGate.Enabled(features.DisableComponentStatusProbes) {
+		// This API was deprecated in 1.19 for the reasons explained in
+		// https://github.com/kubernetes/kubernetes/pull/93570
+		return map[string]*componentstatus.Server{}
+	}
+
 	// this is fragile, which assumes that the default port is being used
 	// TODO: switch to secure port until these components remove the ability to serve insecurely.
 	serversToValidate := map[string]*componentstatus.Server{


### PR DESCRIPTION
The API was deprecated in 1.19 and it makes a lot of assumptions that may lead to wrong information, we should keep the endpoint for backwards compatibility but is better to not return any information that possible wrong information.


#### What type of PR is this?

/kind deprecation


```release-note
The componentstatus API that was deprecated in 1.19 will no longer return any value to avoid to pass wrong information to the users.
```
