### PR TITLE
kube-proxy local traffic detector single-vs-dual-stack cleanup

### DIFF
--- a/cmd/kube-proxy/app/server_others_test.go
+++ b/cmd/kube-proxy/app/server_others_test.go
@@ -109,6 +109,7 @@ func Test_platformApplyDefaults(t *testing.T) {
 
 func Test_getLocalDetector(t *testing.T) {
 	cases := []struct {
+		name         string
 		mode         proxyconfigapi.LocalMode
 		config       *proxyconfigapi.KubeProxyConfiguration
 		ipt          utiliptables.Interface
@@ -118,6 +119,7 @@ func Test_getLocalDetector(t *testing.T) {
 	}{
 		// LocalModeClusterCIDR
 		{
+			name:        "LocalModeClusterCIDR, IPv4 cluster",
 			mode:        proxyconfigapi.LocalModeClusterCIDR,
 			config:      &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "10.0.0.0/14"},
 			ipt:         utiliptablestest.NewFake(),
@@ -125,6 +127,7 @@ func Test_getLocalDetector(t *testing.T) {
 			errExpected: false,
 		},
 		{
+			name:        "LocalModeClusterCIDR, IPv6 cluster",
 			mode:        proxyconfigapi.LocalModeClusterCIDR,
 			config:      &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "2002::1234:abcd:ffff:c0a8:101/64"},
 			ipt:         utiliptablestest.NewIPv6Fake(),
@@ -132,6 +135,7 @@ func Test_getLocalDetector(t *testing.T) {
 			errExpected: false,
 		},
 		{
+			name:        "LocalModeClusterCIDR, IPv6 cluster with IPv6 config",
 			mode:        proxyconfigapi.LocalModeClusterCIDR,
 			config:      &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "10.0.0.0/14"},
 			ipt:         utiliptablestest.NewIPv6Fake(),
@@ -139,6 +143,7 @@ func Test_getLocalDetector(t *testing.T) {
 			errExpected: true,
 		},
 		{
+			name:        "LocalModeClusterCIDR, IPv4 cluster with IPv6 config",
 			mode:        proxyconfigapi.LocalModeClusterCIDR,
 			config:      &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "2002::1234:abcd:ffff:c0a8:101/64"},
 			ipt:         utiliptablestest.NewFake(),
@@ -146,6 +151,7 @@ func Test_getLocalDetector(t *testing.T) {
 			errExpected: true,
 		},
 		{
+			name:        "LocalModeClusterCIDR, no ClusterCIDR",
 			mode:        proxyconfigapi.LocalModeClusterCIDR,
 			config:      &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: ""},
 			ipt:         utiliptablestest.NewFake(),
@@ -154,6 +160,7 @@ func Test_getLocalDetector(t *testing.T) {
 		},
 		// LocalModeNodeCIDR
 		{
+			name:         "LocalModeNodeCIDR, IPv4 cluster",
 			mode:         proxyconfigapi.LocalModeNodeCIDR,
 			config:       &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "10.0.0.0/14"},
 			ipt:          utiliptablestest.NewFake(),
@@ -162,6 +169,7 @@ func Test_getLocalDetector(t *testing.T) {
 			errExpected:  false,
 		},
 		{
+			name:         "LocalModeNodeCIDR, IPv6 cluster",
 			mode:         proxyconfigapi.LocalModeNodeCIDR,
 			config:       &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "2002::1234:abcd:ffff:c0a8:101/64"},
 			ipt:          utiliptablestest.NewIPv6Fake(),
@@ -170,6 +178,7 @@ func Test_getLocalDetector(t *testing.T) {
 			errExpected:  false,
 		},
 		{
+			name:         "LocalModeNodeCIDR, IPv6 cluster with IPv4 config",
 			mode:         proxyconfigapi.LocalModeNodeCIDR,
 			config:       &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "10.0.0.0/14"},
 			ipt:          utiliptablestest.NewIPv6Fake(),
@@ -178,6 +187,7 @@ func Test_getLocalDetector(t *testing.T) {
 			errExpected:  true,
 		},
 		{
+			name:         "LocalModeNodeCIDR, IPv4 cluster with IPv6 config",
 			mode:         proxyconfigapi.LocalModeNodeCIDR,
 			config:       &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "2002::1234:abcd:ffff:c0a8:101/64"},
 			ipt:          utiliptablestest.NewFake(),
@@ -186,6 +196,7 @@ func Test_getLocalDetector(t *testing.T) {
 			errExpected:  true,
 		},
 		{
+			name:         "LocalModeNodeCIDR, no PodCIDRs",
 			mode:         proxyconfigapi.LocalModeNodeCIDR,
 			config:       &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: ""},
 			ipt:          utiliptablestest.NewFake(),
@@ -195,6 +206,7 @@ func Test_getLocalDetector(t *testing.T) {
 		},
 		// unknown mode
 		{
+			name:        "unknown LocalMode",
 			mode:        proxyconfigapi.LocalMode("abcd"),
 			config:      &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "10.0.0.0/14"},
 			ipt:         utiliptablestest.NewFake(),
@@ -203,6 +215,7 @@ func Test_getLocalDetector(t *testing.T) {
 		},
 		// LocalModeBridgeInterface
 		{
+			name: "LocalModeBrideInterface",
 			mode: proxyconfigapi.LocalModeBridgeInterface,
 			config: &proxyconfigapi.KubeProxyConfiguration{
 				DetectLocal: proxyconfigapi.DetectLocalConfiguration{BridgeInterface: "eth"},
@@ -211,6 +224,7 @@ func Test_getLocalDetector(t *testing.T) {
 			errExpected: false,
 		},
 		{
+			name: "LocalModeBridgeInterface, strange bridge name",
 			mode: proxyconfigapi.LocalModeBridgeInterface,
 			config: &proxyconfigapi.KubeProxyConfiguration{
 				DetectLocal: proxyconfigapi.DetectLocalConfiguration{BridgeInterface: "1234567890123456789"},
@@ -220,6 +234,7 @@ func Test_getLocalDetector(t *testing.T) {
 		},
 		// LocalModeInterfaceNamePrefix
 		{
+			name: "LocalModeInterfaceNamePrefix",
 			mode: proxyconfigapi.LocalModeInterfaceNamePrefix,
 			config: &proxyconfigapi.KubeProxyConfiguration{
 				DetectLocal: proxyconfigapi.DetectLocalConfiguration{InterfaceNamePrefix: "eth"},
@@ -228,6 +243,7 @@ func Test_getLocalDetector(t *testing.T) {
 			errExpected: false,
 		},
 		{
+			name: "LocalModeInterfaceNamePrefix, strange interface name",
 			mode: proxyconfigapi.LocalModeInterfaceNamePrefix,
 			config: &proxyconfigapi.KubeProxyConfiguration{
 				DetectLocal: proxyconfigapi.DetectLocalConfiguration{InterfaceNamePrefix: "1234567890123456789"},
@@ -236,26 +252,29 @@ func Test_getLocalDetector(t *testing.T) {
 			errExpected: false,
 		},
 	}
-	for i, c := range cases {
-		r, err := getLocalDetector(c.mode, c.config, c.ipt, c.nodePodCIDRs)
-		if c.errExpected {
-			if err == nil {
-				t.Errorf("Case[%d] Expected error, but succeeded with %v", i, r)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r, err := getLocalDetector(c.mode, c.config, c.ipt, c.nodePodCIDRs)
+			if c.errExpected {
+				if err == nil {
+					t.Errorf("Expected error, but succeeded with %v", r)
+				}
+				return
 			}
-			continue
-		}
-		if err != nil {
-			t.Errorf("Case[%d] Error resolving detect-local: %v", i, err)
-			continue
-		}
-		if !reflect.DeepEqual(r, c.expected) {
-			t.Errorf("Case[%d] Unexpected detect-local implementation, expected: %q, got: %q", i, c.expected, r)
-		}
+			if err != nil {
+				t.Errorf("Error resolving detect-local: %v", err)
+				return
+			}
+			if !reflect.DeepEqual(r, c.expected) {
+				t.Errorf("Unexpected detect-local implementation, expected: %q, got: %q", c.expected, r)
+			}
+		})
 	}
 }
 
 func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 	cases := []struct {
+		name         string
 		mode         proxyconfigapi.LocalMode
 		config       *proxyconfigapi.KubeProxyConfiguration
 		ipt          [2]utiliptables.Interface
@@ -265,6 +284,7 @@ func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 	}{
 		// LocalModeClusterCIDR
 		{
+			name:   "LocalModeClusterCIDR, dual-stack IPv4-primary cluster",
 			mode:   proxyconfigapi.LocalModeClusterCIDR,
 			config: &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "10.0.0.0/14,2002::1234:abcd:ffff:c0a8:101/64"},
 			ipt:    [2]utiliptables.Interface{utiliptablestest.NewFake(), utiliptablestest.NewIPv6Fake()},
@@ -274,6 +294,7 @@ func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 			errExpected: false,
 		},
 		{
+			name:   "LocalModeClusterCIDR, dual-stack IPv6-primary cluster",
 			mode:   proxyconfigapi.LocalModeClusterCIDR,
 			config: &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "2002::1234:abcd:ffff:c0a8:101/64,10.0.0.0/14"},
 			ipt:    [2]utiliptables.Interface{utiliptablestest.NewFake(), utiliptablestest.NewIPv6Fake()},
@@ -283,6 +304,7 @@ func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 			errExpected: false,
 		},
 		{
+			name:   "LocalModeClusterCIDR, single-stack IPv4 cluster",
 			mode:   proxyconfigapi.LocalModeClusterCIDR,
 			config: &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "10.0.0.0/14"},
 			ipt:    [2]utiliptables.Interface{utiliptablestest.NewFake(), utiliptablestest.NewIPv6Fake()},
@@ -292,6 +314,7 @@ func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 			errExpected: false,
 		},
 		{
+			name:   "LocalModeClusterCIDR, single-stack IPv6 cluster",
 			mode:   proxyconfigapi.LocalModeClusterCIDR,
 			config: &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "2002::1234:abcd:ffff:c0a8:101/64"},
 			ipt:    [2]utiliptables.Interface{utiliptablestest.NewFake(), utiliptablestest.NewIPv6Fake()},
@@ -301,6 +324,7 @@ func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 			errExpected: false,
 		},
 		{
+			name:        "LocalModeClusterCIDR, no ClusterCIDR",
 			mode:        proxyconfigapi.LocalModeClusterCIDR,
 			config:      &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: ""},
 			ipt:         [2]utiliptables.Interface{utiliptablestest.NewFake(), utiliptablestest.NewIPv6Fake()},
@@ -309,6 +333,7 @@ func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 		},
 		// LocalModeNodeCIDR
 		{
+			name:   "LocalModeNodeCIDR, dual-stack IPv4-primary cluster",
 			mode:   proxyconfigapi.LocalModeNodeCIDR,
 			config: &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "10.0.0.0/14,2002::1234:abcd:ffff:c0a8:101/64"},
 			ipt:    [2]utiliptables.Interface{utiliptablestest.NewFake(), utiliptablestest.NewIPv6Fake()},
@@ -319,6 +344,7 @@ func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 			errExpected:  false,
 		},
 		{
+			name:   "LocalModeNodeCIDR, dual-stack IPv6-primary cluster",
 			mode:   proxyconfigapi.LocalModeNodeCIDR,
 			config: &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "2002::1234:abcd:ffff:c0a8:101/64,10.0.0.0/14"},
 			ipt:    [2]utiliptables.Interface{utiliptablestest.NewFake(), utiliptablestest.NewIPv6Fake()},
@@ -329,6 +355,7 @@ func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 			errExpected:  false,
 		},
 		{
+			name:   "LocalModeNodeCIDR, single-stack IPv4 cluster",
 			mode:   proxyconfigapi.LocalModeNodeCIDR,
 			config: &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "10.0.0.0/14"},
 			ipt:    [2]utiliptables.Interface{utiliptablestest.NewFake(), utiliptablestest.NewIPv6Fake()},
@@ -339,6 +366,7 @@ func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 			errExpected:  false,
 		},
 		{
+			name:   "LocalModeNodeCIDR, single-stack IPv6 cluster",
 			mode:   proxyconfigapi.LocalModeNodeCIDR,
 			config: &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: "2002::1234:abcd:ffff:c0a8:101/64"},
 			ipt:    [2]utiliptables.Interface{utiliptablestest.NewFake(), utiliptablestest.NewIPv6Fake()},
@@ -349,6 +377,7 @@ func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 			errExpected:  false,
 		},
 		{
+			name:         "LocalModeNodeCIDR, no PodCIDRs",
 			mode:         proxyconfigapi.LocalModeNodeCIDR,
 			config:       &proxyconfigapi.KubeProxyConfiguration{ClusterCIDR: ""},
 			ipt:          [2]utiliptables.Interface{utiliptablestest.NewFake(), utiliptablestest.NewIPv6Fake()},
@@ -358,6 +387,7 @@ func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 		},
 		// LocalModeBridgeInterface
 		{
+			name: "LocalModeBridgeInterface",
 			mode: proxyconfigapi.LocalModeBridgeInterface,
 			config: &proxyconfigapi.KubeProxyConfiguration{
 				DetectLocal: proxyconfigapi.DetectLocalConfiguration{BridgeInterface: "eth"},
@@ -369,6 +399,7 @@ func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 		},
 		// LocalModeInterfaceNamePrefix
 		{
+			name: "LocalModeInterfaceNamePrefix",
 			mode: proxyconfigapi.LocalModeInterfaceNamePrefix,
 			config: &proxyconfigapi.KubeProxyConfiguration{
 				DetectLocal: proxyconfigapi.DetectLocalConfiguration{InterfaceNamePrefix: "veth"},
@@ -379,21 +410,23 @@ func Test_getDualStackLocalDetectorTuple(t *testing.T) {
 			errExpected: false,
 		},
 	}
-	for i, c := range cases {
-		r, err := getDualStackLocalDetectorTuple(c.mode, c.config, c.ipt, c.nodePodCIDRs)
-		if c.errExpected {
-			if err == nil {
-				t.Errorf("Case[%d] expected error, but succeeded with %q", i, r)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r, err := getDualStackLocalDetectorTuple(c.mode, c.config, c.ipt, c.nodePodCIDRs)
+			if c.errExpected {
+				if err == nil {
+					t.Errorf("Expected error, but succeeded with %q", r)
+				}
+				return
 			}
-			continue
-		}
-		if err != nil {
-			t.Errorf("Case[%d] Error resolving detect-local: %v", i, err)
-			continue
-		}
-		if !reflect.DeepEqual(r, c.expected) {
-			t.Errorf("Case[%d] Unexpected detect-local implementation, expected: %q, got: %q", i, c.expected, r)
-		}
+			if err != nil {
+				t.Errorf("Error resolving detect-local: %v", err)
+				return
+			}
+			if !reflect.DeepEqual(r, c.expected) {
+				t.Errorf("Unexpected detect-local implementation, expected: %q, got: %q", c.expected, r)
+			}
+		})
 	}
 }
 

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -291,7 +291,7 @@ func NewFakeProxier(ipt utiliptables.Interface) *Proxier {
 		ipfamily = v1.IPv6Protocol
 		podCIDR = "fd00::/64"
 	}
-	detectLocal, _ := proxyutiliptables.NewDetectLocalByCIDR(podCIDR, ipt)
+	detectLocal, _ := proxyutiliptables.NewDetectLocalByCIDR(podCIDR)
 
 	networkInterfacer := proxyutiltest.NewFakeNetwork()
 	itf := net.Interface{Index: 0, MTU: 0, Name: "lo", HardwareAddr: nil, Flags: 0}

--- a/pkg/proxy/util/iptables/traffic.go
+++ b/pkg/proxy/util/iptables/traffic.go
@@ -19,7 +19,6 @@ package iptables
 import (
 	"fmt"
 
-	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 	netutils "k8s.io/utils/net"
 )
 
@@ -62,10 +61,7 @@ type detectLocalByCIDR struct {
 
 // NewDetectLocalByCIDR implements the LocalTrafficDetector interface using a CIDR. This can be used when a single CIDR
 // range can be used to capture the notion of local traffic.
-func NewDetectLocalByCIDR(cidr string, ipt utiliptables.Interface) (LocalTrafficDetector, error) {
-	if netutils.IsIPv6CIDRString(cidr) != ipt.IsIPv6() {
-		return nil, fmt.Errorf("CIDR %s has incorrect IP version: expect isIPv6=%t", cidr, ipt.IsIPv6())
-	}
+func NewDetectLocalByCIDR(cidr string) (LocalTrafficDetector, error) {
 	_, _, err := netutils.ParseCIDRSloppy(cidr)
 	if err != nil {
 		return nil, err

--- a/pkg/proxy/util/iptables/traffic_test.go
+++ b/pkg/proxy/util/iptables/traffic_test.go
@@ -19,9 +19,6 @@ package iptables
 import (
 	"reflect"
 	"testing"
-
-	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
-	iptablestest "k8s.io/kubernetes/pkg/util/iptables/testing"
 )
 
 func TestNoOpLocalDetector(t *testing.T) {
@@ -44,52 +41,35 @@ func TestNoOpLocalDetector(t *testing.T) {
 func TestNewDetectLocalByCIDR(t *testing.T) {
 	cases := []struct {
 		cidr        string
-		ipt         utiliptables.Interface
 		errExpected bool
 	}{
 		{
 			cidr:        "10.0.0.0/14",
-			ipt:         iptablestest.NewFake(),
 			errExpected: false,
 		},
 		{
 			cidr:        "2002::1234:abcd:ffff:c0a8:101/64",
-			ipt:         iptablestest.NewIPv6Fake(),
 			errExpected: false,
-		},
-		{
-			cidr:        "10.0.0.0/14",
-			ipt:         iptablestest.NewIPv6Fake(),
-			errExpected: true,
-		},
-		{
-			cidr:        "2002::1234:abcd:ffff:c0a8:101/64",
-			ipt:         iptablestest.NewFake(),
-			errExpected: true,
 		},
 		{
 			cidr:        "10.0.0.0",
-			ipt:         iptablestest.NewFake(),
 			errExpected: true,
 		},
 		{
 			cidr:        "2002::1234:abcd:ffff:c0a8:101",
-			ipt:         iptablestest.NewIPv6Fake(),
 			errExpected: true,
 		},
 		{
 			cidr:        "",
-			ipt:         iptablestest.NewFake(),
 			errExpected: true,
 		},
 		{
 			cidr:        "",
-			ipt:         iptablestest.NewIPv6Fake(),
 			errExpected: true,
 		},
 	}
 	for i, c := range cases {
-		r, err := NewDetectLocalByCIDR(c.cidr, c.ipt)
+		r, err := NewDetectLocalByCIDR(c.cidr)
 		if c.errExpected {
 			if err == nil {
 				t.Errorf("Case[%d] expected error, but succeeded with: %q", i, r)
@@ -105,25 +85,22 @@ func TestNewDetectLocalByCIDR(t *testing.T) {
 func TestDetectLocalByCIDR(t *testing.T) {
 	cases := []struct {
 		cidr                     string
-		ipt                      utiliptables.Interface
 		expectedIfLocalOutput    []string
 		expectedIfNotLocalOutput []string
 	}{
 		{
 			cidr:                     "10.0.0.0/14",
-			ipt:                      iptablestest.NewFake(),
 			expectedIfLocalOutput:    []string{"-s", "10.0.0.0/14"},
 			expectedIfNotLocalOutput: []string{"!", "-s", "10.0.0.0/14"},
 		},
 		{
 			cidr:                     "2002::1234:abcd:ffff:c0a8:101/64",
-			ipt:                      iptablestest.NewIPv6Fake(),
 			expectedIfLocalOutput:    []string{"-s", "2002::1234:abcd:ffff:c0a8:101/64"},
 			expectedIfNotLocalOutput: []string{"!", "-s", "2002::1234:abcd:ffff:c0a8:101/64"},
 		},
 	}
 	for _, c := range cases {
-		localDetector, err := NewDetectLocalByCIDR(c.cidr, c.ipt)
+		localDetector, err := NewDetectLocalByCIDR(c.cidr)
 		if err != nil {
 			t.Errorf("Error initializing localDetector: %v", err)
 			continue


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig network

#### What this PR does / why we need it:

    Previously the single-stack and dual-stack modes of kube-proxy had
    completely separate LocalDetector-creation code paths, with different
    error-handling behavior (where the single-stack mode only looked at
    the legacy single-stack config fields and errored out if they had the
    wrong family, while the dual-stack mode looked at the dual-stack
    config fields, allowed them to be in either order, and fell back to
    no-op when no config was available for a family).
    
    Given that the "dual-stack" mode is kube-proxy's normal mode, and
    "single-stack" mode is mostly just a hack to avoid printing error
    messages when IPv6 is disabled in the kernel, it doesn't make sense
    for errors to be handled differently in the two modes. So make the
    single-stack mode work the same way as the dual-stack mode.

from #117436. (Making the dual-stack local detector constructor be just "call the single-stack local detector constructor for IPv4 then call the single-stack local detector constructor for IPv6" is a pre-req for refactoring the single-vs-dual-stack mode split out into shared code.)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
