### PR TITLE
Fix pod probe sampling start time upon kubelet restarts

### DIFF
--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -192,12 +192,15 @@ func (w *worker) run() {
 		}
 	}
 
-	// Execute the probe once, even before InitialDelaySeconds have passed. This is done in order
-	// to initialize the results manager with the initial value of the probe.
+	// Let the worker enter doProbe once, even before InitialDelaySeconds have passed.
+	// This is done in order to initialize the results manager with the initial value of the probe.
 	beforeProbeExecution := time.Now()
 	w.doProbe(ctx)
 
-	// Wait for the remaining time of InitialDelaySeconds.
+	// Wait for the remaining time of InitialDelaySeconds. The wait is performed here, even though
+	// doProbe checks InitialDelaySeconds, in order to make sure the first probe will start
+	// at the right time (after InitialDelaySeconds passed). From there, doProbe will execute
+	// every PeriodDurationSeconds.
 	initialDelay := time.Duration(w.spec.InitialDelaySeconds)*time.Second - time.Since(beforeProbeExecution)
 	if stopped := waitUntilStopTriggerOrTimeout(time.After(initialDelay)); stopped {
 		return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
-->

#### What this PR does / why we need it:
```release-note
1. As mentioned at #118396, pods with high periodSeconds duration at the readiness probe will not be ready
for a long time if scheduled on new provisioned nodes. Having a predefined max duration wait time for the
probing workers can solve the issue.
2. I've also noticed that when having an initialDelay > 0, the first probe call (not doProbe) will happen
only after periodSeconds has elapsed, instead of initialDelay. Meaning the timing of the run() function
is slightly off.
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/118396

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
<!--
