### PR TITLE
Handle eventually-consistent EC2 PrivateDnsName

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -280,6 +280,14 @@ const (
 	volumeCreateBackoffFactor = 1.2
 	volumeCreateBackoffSteps  = 10
 
+	// acquireNodeName* is configuration of exponential backoff for acquiring this instance's
+	// node name (currently the EC2 PrivateDnsName) during cloud provider initialization.
+	// This value is eventually-consistent.
+	// The current config will make its final attempt after ~130 seconds.
+	acquireNodeNameInitialDelay  = 5 * time.Second
+	acquireNodeNameBackoffFactor = 1.25
+	acquireNodeNameBackoffSteps  = 10
+
 	// Number of node names that can be added to a filter. The AWS limit is 200
 	// but we are using a lower limit on purpose
 	filterNodeLimit = 150
@@ -2379,11 +2387,29 @@ func (c *Cloud) buildSelfAWSInstance() (*awsInstance, error) {
 	// information from the instance returned by the EC2 API - it is a
 	// single API call to get all the information, and it means we don't
 	// have two code paths.
-	instance, err := c.getInstanceByID(instanceID)
-	if err != nil {
-		return nil, fmt.Errorf("error finding instance %s: %q", instanceID, err)
+	// The PrivateDnsName is eventually-consistent, and we can't complete
+	// initialization until we acquire it.
+	backoff := wait.Backoff{
+		Duration: acquireNodeNameInitialDelay,
+		Factor:   acquireNodeNameBackoffFactor,
+		Steps:    acquireNodeNameBackoffSteps,
 	}
-	return newAWSInstance(c.ec2, instance), nil
+	var awsInstance *awsInstance
+	err = wait.ExponentialBackoff(backoff, func() (done bool, err error) {
+		instance, err := c.getInstanceByID(instanceID)
+		if err != nil {
+			return true, fmt.Errorf("error finding instance %s: %q", instanceID, err)
+		}
+		awsInstance = newAWSInstance(c.ec2, instance)
+		if awsInstance.nodeName != "" {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire node name for instance %s: %q", instanceID, err)
+	}
+	return awsInstance, nil
 }
 
 // wrapAttachError wraps the error returned by an AttachVolume request with


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR adds retries (exponential backoff) when the `PrivateDnsName` returned by `EC2.DescribeInstances` is empty. The `PrivateDnsName` is utilized as kubelet's `Node` name, and without it, the kubelet will be unable to register with the API server. The `kubelet` currently makes a single attempt to acquire this value, and if it is not available, the kubelet will continually fail to register with the API server:
```
kubelet_node_status.go:92] "Unable to register node with API server" err="nodes \"Unknown\" is forbidden: node \"ip-x-x-x-x.ec2.internal\" is not allowed to modify node \"\"" node=""
```

In a very small percentage of cases, the `PrivateDnsName` may be empty for a short period of time after the instance transitions to `running` state. This field therefore needs to be treated as eventually-consistent.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

I know the legacy cloud providers are removed in 1.27+, and changes to this package are and have been discouraged for some time. However, this issue represents a terminal failure in node launch, from which `kubelet` currently cannot recover. Additionally, the underlying issue is fairly obfuscated; this PR properly treats an empty `PrivateDnsName` as an error. We (EKS) will support Kubernetes 1.26 until at least [June 2024](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar), and I'd like to cherrypick this to 1.25 and 1.24 as well.

#### Does this PR introduce a user-facing change?
```release-note
Initialization of the legacy AWS cloud provider will wait for the instance's `PrivateDnsName` to be non-empty; and will fail if the `PrivateDnsName` is empty after a retry period.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
