### PR TITLE
chore: should use output.String() instead of string(output.Bytes())

### DIFF
--- a/cmd/prune-junit-xml/prunexml_test.go
+++ b/cmd/prune-junit-xml/prunexml_test.go
@@ -63,5 +63,5 @@ func TestPruneXML(t *testing.T) {
 	writer := bufio.NewWriter(&output)
 	_ = streamXML(writer, suites)
 	_ = writer.Flush()
-	assert.Equal(t, outputXML, string(output.Bytes()), "xml was not pruned correctly")
+	assert.Equal(t, outputXML, output.String(), "xml was not pruned correctly")
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
should use output.String() instead of string(output.Bytes()) (S1030)
Fixes #

#### Special notes for your reviewer:
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
