### PR TITLE
chore: unnecessary assignment to the blank identifier

### DIFF
--- a/pkg/controller/bootstrap/bootstrapsigner.go
+++ b/pkg/controller/bootstrap/bootstrapsigner.go
@@ -220,7 +220,7 @@ func (e *Signer) signConfigMap(ctx context.Context) {
 		}
 
 		// Check to see if this signature is changed or new.
-		oldSig, _ := sigs[tokenID]
+		oldSig := sigs[tokenID]
 		if sig != oldSig {
 			needUpdate = true
 		}

--- a/pkg/controller/testutil/test_utils.go
+++ b/pkg/controller/testutil/test_utils.go
@@ -90,10 +90,8 @@ type FakeLegacyHandler struct {
 func (m *FakeNodeHandler) GetUpdatedNodesCopy() []*v1.Node {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	updatedNodesCopy := make([]*v1.Node, len(m.UpdatedNodes), len(m.UpdatedNodes))
-	for i, ptr := range m.UpdatedNodes {
-		updatedNodesCopy[i] = ptr
-	}
+	updatedNodesCopy := make([]*v1.Node, len(m.UpdatedNodes))
+	copy(updatedNodesCopy, m.UpdatedNodes)
 	return updatedNodesCopy
 }
 

--- a/staging/src/k8s.io/endpointslice/reconciler_test.go
+++ b/staging/src/k8s.io/endpointslice/reconciler_test.go
@@ -1959,7 +1959,7 @@ func TestReconcileTopology(t *testing.T) {
 			}
 
 			for zone, expectedNum := range tc.expectedHints {
-				actualNum, _ := actualHints[zone]
+				actualNum := actualHints[zone]
 				if actualNum != expectedNum {
 					t.Errorf("Expected %d hints for %s zone, got %d", expectedNum, zone, actualNum)
 				}


### PR DESCRIPTION
Add one of the following kinds:
/kind cleanup

#### What this PR does / why we need it:
unnecessary assignment to the blank identifier (S1005)
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```