### PR TITLE
chore: code optimization

### DIFF
--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -182,12 +182,7 @@ func (c *Controller) removeFinalizer(ctx context.Context, pv *v1.PersistentVolum
 func (c *Controller) isBeingUsed(pv *v1.PersistentVolume) bool {
 	// check if PV is being bound to a PVC by its status
 	// the status will be updated by PV controller
-	if pv.Status.Phase == v1.VolumeBound {
-		// the PV is being used now
-		return true
-	}
-
-	return false
+	return pv.Status.Phase == v1.VolumeBound// the PV is being used now if return true
 }
 
 // pvAddedUpdated reacts to pv added/updated events


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
should use 'return pv.Status.Phase == v1.VolumeBound' instead of 'if pv.Status.Phase == v1.VolumeBound { return true }; return false' (S1008)
#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```

```
