### PR TITLE
chore: should use buf.String() instead of string(buf.Bytes())

### DIFF
--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -1698,7 +1698,7 @@ func TestMasqueradeRule(t *testing.T) {
 
 		buf := bytes.NewBuffer(nil)
 		_ = ipt.SaveInto(utiliptables.TableNAT, buf)
-		natRules := strings.Split(string(buf.Bytes()), "\n")
+		natRules := strings.Split(buf.String(), "\n")
 		var hasMasqueradeJump, hasMasqRandomFully bool
 		for _, line := range natRules {
 			rule, _ := iptablestest.ParseRule(line, false)
@@ -3890,7 +3890,7 @@ func getRules(ipt *iptablestest.FakeIPTables, chain utiliptables.Chain) []*iptab
 	buf := bytes.NewBuffer(nil)
 	_ = ipt.SaveInto(utiliptables.TableNAT, buf)
 	_ = ipt.SaveInto(utiliptables.TableFilter, buf)
-	lines := strings.Split(string(buf.Bytes()), "\n")
+	lines := strings.Split(buf.String(), "\n")
 	for _, l := range lines {
 		if !strings.HasPrefix(l, "-A ") {
 			continue


### PR DESCRIPTION
[pkg/proxy/ipvs/proxier_test.go:1701:29](https://github.com/kubernetes/kubernetes/blob/bb878608686a6276cefec3f51bee5d79b0c8c393/pkg/proxy/ipvs/proxier_test.go#LL1701C2-L1701C2): should use buf.String() instead of string(buf.Bytes()) (S1030)
[pkg/proxy/ipvs/proxier_test.go:3893:25](https://github.com/kubernetes/kubernetes/blob/bb878608686a6276cefec3f51bee5d79b0c8c393/pkg/proxy/ipvs/proxier_test.go#L3893): should use buf.String() instead of string(buf.Bytes()) (S1030)