### PR TITLE
chore: code optimization

### DIFF
--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -636,10 +636,7 @@ func patchAllocatedValues(after After, before Before) {
 }
 
 func needsClusterIP(svc *api.Service) bool {
-	if svc.Spec.Type == api.ServiceTypeExternalName {
-		return false
-	}
-	return true
+	return svc.Spec.Type != api.ServiceTypeExternalName
 }
 
 func needsNodePort(svc *api.Service) bool {

--- a/pkg/registry/core/service/storage/storage_test.go
+++ b/pkg/registry/core/service/storage/storage_test.go
@@ -90,7 +90,7 @@ func newStorageWithPods(t *testing.T, ipFamilies []api.IPFamily, pods []api.Pod,
 	if err != nil {
 		t.Fatalf("unexpected error from REST storage: %v", err)
 	}
-	if pods != nil && len(pods) > 0 {
+	if len(pods) > 0 {
 		ctx := genericapirequest.NewDefaultContext()
 		for ix := range pods {
 			key, _ := podStorage.Pod.KeyFunc(ctx, pods[ix].Name)
@@ -108,7 +108,7 @@ func newStorageWithPods(t *testing.T, ipFamilies []api.IPFamily, pods []api.Pod,
 	if err != nil {
 		t.Fatalf("unexpected error from REST storage: %v", err)
 	}
-	if endpoints != nil && len(endpoints) > 0 {
+	if len(endpoints) > 0 {
 		ctx := genericapirequest.NewDefaultContext()
 		for ix := range endpoints {
 			key, _ := endpointsStorage.KeyFunc(ctx, endpoints[ix].Name)

--- a/pkg/registry/core/service/strategy.go
+++ b/pkg/registry/core/service/strategy.go
@@ -263,10 +263,7 @@ func dropTypeDependentFields(newSvc *api.Service, oldSvc *api.Service) {
 }
 
 func needsClusterIP(svc *api.Service) bool {
-	if svc.Spec.Type == api.ServiceTypeExternalName {
-		return false
-	}
-	return true
+	return svc.Spec.Type != api.ServiceTypeExternalName
 }
 
 func sameClusterIPs(oldSvc, newSvc *api.Service) bool {


### PR DESCRIPTION
pkg/registry/core/service/storage/storage.go:639:2: should use 'return svc.Spec.Type != api.ServiceTypeExternalName' instead of 'if svc.Spec.Type == api.ServiceTypeExternalName { return false }; return true' (S1008)
pkg/registry/core/service/storage/storage_test.go:93:5: should omit nil check; len() for []k8s.io/kubernetes/pkg/apis/core.Pod is defined as zero (S1009)
pkg/registry/core/service/storage/storage_test.go:111:5: should omit nil check; len() for []*k8s.io/kubernetes/pkg/apis/core.Endpoints is defined as zero (S1009)
pkg/registry/core/service/strategy.go:266:2: should use 'return svc.Spec.Type != api.ServiceTypeExternalName' instead of 'if svc.Spec.Type == api.ServiceTypeExternalName { return false }; return true' (S1008)