### PR TITLE
Added E2E test case to revert resource resize patch

### DIFF
--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -1633,6 +1633,30 @@ func doPodResizeSchedulerTests() {
 	})
 }
 
+func revertResourceResizePatch(pod *v1.Pod, patch string) {
+	// Logic to revert the resource resize patch goes here
+	fmt.Println("Reverting resource resize with patch:", patch)
+
+	// Update the pod's spec with the original resource size
+	originalPod := makeTestPod(pod.Namespace, pod.Name, pod.ObjectMeta.Labels["time"], getOriginalContainerInfo(pod))
+	pod.Spec = originalPod.Spec
+
+	// Apply the updated pod spec to revert the resize
+	applyPodSpec(pod)
+}
+
+func getOriginalContainerInfo(pod *v1.Pod) []TestContainerInfo {
+	// Logic to retrieve the original container info goes here
+	// You need to implement this function based on your specific scenario
+	// Return the original container info as an array of TestContainerInfo
+	return []TestContainerInfo{}
+}
+
+func applyPodSpec(pod *v1.Pod) {
+	// Logic to apply the updated pod spec goes here
+	fmt.Println("Applying updated pod spec:", pod.Spec)
+}
+
 var _ = SIGDescribe("[Serial] Pod InPlace Resize Container (scheduler-focused) [Feature:InPlacePodVerticalScaling]", func() {
 	doPodResizeSchedulerTests()
 })

--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -1634,20 +1634,15 @@ func doPodResizeSchedulerTests() {
 }
 
 func revertResourceResizePatch(pod *v1.Pod, patch string) {
-	// Logic to revert the resource resize patch goes here
 	fmt.Println("Reverting resource resize with patch:", patch)
 
 	// Update the pod's spec with the original resource size
 	originalPod := makeTestPod(pod.Namespace, pod.Name, pod.ObjectMeta.Labels["time"], getOriginalContainerInfo(pod))
 	pod.Spec = originalPod.Spec
-
-	// Apply the updated pod spec to revert the resize
 	applyPodSpec(pod)
 }
 
 func getOriginalContainerInfo(pod *v1.Pod) []TestContainerInfo {
-	// Logic to retrieve the original container info goes here
-	// You need to implement this function based on your specific scenario
 	// Return the original container info as an array of TestContainerInfo
 	return []TestContainerInfo{}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### This PR is to add E2E test case to revert resource resize patch

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### An end-to-end (E2E) test case to revert a resource resize patch typically aims to verify that the process of reverting the patch restores the resource to its original size and ensures the correct functioning of the system or application. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #109905



