### PR TITLE
pkg/util/iptables: use buf.String() instead of string(buf.Bytes())

### DIFF
--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -4660,8 +4660,8 @@ func TestCreateAndLinkKubeChain(t *testing.T) {
 :KUBE-SOURCE-RANGES-FIREWALL - [0:0]
 :KUBE-IPVS-FILTER - [0:0]
 `
-	assert.Equal(t, expectedNATChains, string(fp.natChains.Bytes()))
-	assert.Equal(t, expectedFilterChains, string(fp.filterChains.Bytes()))
+	assert.Equal(t, expectedNATChains, fp.natChains.String())
+	assert.Equal(t, expectedFilterChains, fp.filterChains.String())
 }
 
 // This test ensures that the iptables proxier supports translating Endpoints to

--- a/pkg/proxy/util/utils.go
+++ b/pkg/proxy/util/utils.go
@@ -483,6 +483,11 @@ func (buf *LineBuffer) Bytes() []byte {
 	return buf.b.Bytes()
 }
 
+// String returns the contents of buf as a string
+func (buf *LineBuffer) String() string {
+	return buf.b.String()
+}
+
 // Lines returns the number of lines in buf. Note that more precisely, this returns the
 // number of times Write() or WriteBytes() was called; it assumes that you never wrote
 // any newlines to the buffer yourself.

--- a/pkg/proxy/util/utils_test.go
+++ b/pkg/proxy/util/utils_test.go
@@ -962,7 +962,7 @@ func TestLineBufferWrite(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			testBuffer.Reset()
 			testBuffer.Write(testCase.input...)
-			if want, got := testCase.expected, string(testBuffer.Bytes()); !strings.EqualFold(want, got) {
+			if want, got := testCase.expected, testBuffer.String(); !strings.EqualFold(want, got) {
 				t.Fatalf("write word is %v\n expected: %q, got: %q", testCase.input, want, got)
 			}
 			if testBuffer.Lines() != 1 {
@@ -1005,7 +1005,7 @@ func TestLineBufferWriteBytes(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			testBuffer.Reset()
 			testBuffer.WriteBytes(testCase.bytes)
-			if want, got := testCase.expected, string(testBuffer.Bytes()); !strings.EqualFold(want, got) {
+			if want, got := testCase.expected, testBuffer.String(); !strings.EqualFold(want, got) {
 				t.Fatalf("write bytes is %v\n expected: %s, got: %s", testCase.bytes, want, got)
 			}
 		})

--- a/pkg/util/iptables/testing/fake_test.go
+++ b/pkg/util/iptables/testing/fake_test.go
@@ -49,7 +49,7 @@ func TestFakeIPTables(t *testing.T) {
 		*mangle
 		COMMIT
 		`, "\n"))
-	if string(buf.Bytes()) != expected {
+	if buf.String() != expected {
 		t.Fatalf("bad initial dump. expected:\n%s\n\ngot:\n%s\n", expected, buf.Bytes())
 	}
 
@@ -143,7 +143,7 @@ func TestFakeIPTables(t *testing.T) {
 		*mangle
 		COMMIT
 		`, "\n"))
-	if string(buf.Bytes()) != expected {
+	if buf.String() != expected {
 		t.Fatalf("bad sanity-check dump. expected:\n%s\n\ngot:\n%s\n", expected, buf.Bytes())
 	}
 
@@ -214,7 +214,7 @@ func TestFakeIPTables(t *testing.T) {
 		*mangle
 		COMMIT
 		`, "\n"))
-	if string(buf.Bytes()) != expected {
+	if buf.String() != expected {
 		t.Fatalf("bad post-restore dump. expected:\n%s\n\ngot:\n%s\n", expected, buf.Bytes())
 	}
 
@@ -282,7 +282,7 @@ func TestFakeIPTables(t *testing.T) {
 		*mangle
 		COMMIT
 		`, "\n"))
-	if string(buf.Bytes()) != expected {
+	if buf.String() != expected {
 		t.Fatalf("bad post-second-restore dump. expected:\n%s\n\ngot:\n%s\n", expected, buf.Bytes())
 	}
 
@@ -339,7 +339,7 @@ func TestFakeIPTables(t *testing.T) {
 		*mangle
 		COMMIT
 		`, "\n"))
-	if string(buf.Bytes()) != expected {
+	if buf.String() != expected {
 		t.Fatalf("bad post-restore-all dump. expected:\n%s\n\ngot:\n%s\n", expected, buf.Bytes())
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When dealing with `*bytes.Buffer`, use `buf.String()` instead of `string(buf.Bytes())`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
