### PR TITLE
kube-proxy detect nodePodCIDR changes in LocalModeNodeCIDR

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -754,7 +754,7 @@ func (s *ProxyServer) Run() error {
 	nodeConfig := config.NewNodeConfig(currentNodeInformerFactory.Core().V1().Nodes(), s.Config.ConfigSyncPeriod.Duration)
 	// https://issues.k8s.io/111321
 	if s.Config.DetectLocalMode == kubeproxyconfig.LocalModeNodeCIDR {
-		nodeConfig.RegisterEventHandler(&proxy.NodePodCIDRHandler{})
+		nodeConfig.RegisterEventHandler(proxy.NewNodePodCIDRHandler(s.NodeRef.UID))
 	}
 	nodeConfig.RegisterEventHandler(s.Proxier)
 

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -88,7 +88,8 @@ func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguratio
 		if err != nil {
 			return nil, err
 		}
-		klog.InfoS("NodeInfo", "podCIDR", nodeInfo.Spec.PodCIDR, "podCIDRs", nodeInfo.Spec.PodCIDRs)
+		s.NodeRef.UID = nodeInfo.GetUID()
+		klog.InfoS("NodeInfo", "podCIDR", nodeInfo.Spec.PodCIDR, "podCIDRs", nodeInfo.Spec.PodCIDRs, "UID", nodeInfo.GetUID())
 	}
 
 	primaryFamily := v1.IPv4Protocol


### PR DESCRIPTION
kube-proxy, when using the local detector NodePodCIDR depends on the value of the node.Spec.PodCIDR to route traffic correctly.

There are some environments where kube-proxy can run as a standalone binary or a pod static pod, where the node object can change and hence the PodCIDR assigned value. If this happens, then kube-proxy need to restart to acquire the right value to work correctly.

Since the logic that detects the PodCIDR happens before the node event handler is initialised, there can be a window where the node changes and the event handler is not able to detect the problem. To keep the logic in sync we can use the node UID to assert that both the event handler and the local detector are processing the same object.

The main problem we have is that the startup logic is complex and we create the local detectors before the informers are initialised https://github.com/kubernetes/kubernetes/issues/111321#issuecomment-1568345649
We need to backport this change since is hitting users in production, I think that this is the simplest alternative, some others alternatives I considered:
1. add a new `podCIDR []string` field to the `ProxyServer` object and use it to initialize the nodePodCIDR handler
2. moving the informers creation before `createProxier` and use the informer lister instead of `waitForPodCIDR`


/kind bug
Fixes #111321


```release-note
fix a race condition in kube-proxy when using LocalModeNodeCIDR to avoid dropping Services traffic if the object node is recreated when kube-proxy is starting
```

/sig network
/priority important-soon
/assign @thockin @danwinship 
