### PR TITLE
PoC using generics for service/endpoint info

### DIFF
--- a/pkg/proxy/conntrack/cleanup_test.go
+++ b/pkg/proxy/conntrack/cleanup_test.go
@@ -50,7 +50,7 @@ func TestCleanStaleEntries(t *testing.T) {
 	// provide our own implementation of that interface, or else use a
 	// proxy.ServiceChangeTracker to construct them and fill in the map for us.
 
-	sct := proxy.NewServiceChangeTracker(nil, v1.IPv4Protocol, nil, nil)
+	sct := proxy.NewServiceChangeTracker(proxy.NewBaseServicePortInfo, v1.IPv4Protocol, nil, nil)
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cleanup-test",
@@ -83,7 +83,7 @@ func TestCleanStaleEntries(t *testing.T) {
 	}
 	sct.Update(nil, svc)
 
-	svcPortMap := make(proxy.ServicePortMap)
+	svcPortMap := make(proxy.ServicePortMap[*proxy.BaseServicePortInfo])
 	_ = svcPortMap.Update(sct)
 
 	// (At this point we are done with sct, and in particular, we don't use sct to

--- a/pkg/proxy/endpointschangetracker_test.go
+++ b/pkg/proxy/endpointschangetracker_test.go
@@ -44,25 +44,25 @@ func (proxier *FakeProxier) deleteEndpointSlice(slice *discovery.EndpointSlice) 
 
 func TestGetLocalEndpointIPs(t *testing.T) {
 	testCases := []struct {
-		endpointsMap EndpointsMap
+		endpointsMap EndpointsMap[*BaseEndpointInfo]
 		expected     map[types.NamespacedName]sets.Set[string]
 	}{{
 		// Case[0]: nothing
-		endpointsMap: EndpointsMap{},
+		endpointsMap: EndpointsMap[*BaseEndpointInfo]{},
 		expected:     map[types.NamespacedName]sets.Set[string]{},
 	}, {
 		// Case[1]: unnamed port
-		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", "", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
+		endpointsMap: EndpointsMap[*BaseEndpointInfo]{
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
 			},
 		},
 		expected: map[types.NamespacedName]sets.Set[string]{},
 	}, {
 		// Case[2]: unnamed port local
-		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", "", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: true, ready: true, serving: true, terminating: false},
+		endpointsMap: EndpointsMap[*BaseEndpointInfo]{
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
 		expected: map[types.NamespacedName]sets.Set[string]{
@@ -70,14 +70,14 @@ func TestGetLocalEndpointIPs(t *testing.T) {
 		},
 	}, {
 		// Case[3]: named local and non-local ports for the same IP.
-		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
-				&BaseEndpointInfo{ip: "1.1.1.2", port: 11, endpoint: "1.1.1.2:11", isLocal: true, ready: true, serving: true, terminating: false},
+		endpointsMap: EndpointsMap[*BaseEndpointInfo]{
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
+				{ip: "1.1.1.2", port: 11, endpoint: "1.1.1.2:11", isLocal: true, ready: true, serving: true, terminating: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "1.1.1.1", port: 12, endpoint: "1.1.1.1:12", isLocal: false, ready: true, serving: true, terminating: false},
-				&BaseEndpointInfo{ip: "1.1.1.2", port: 12, endpoint: "1.1.1.2:12", isLocal: true, ready: true, serving: true, terminating: false},
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "1.1.1.1", port: 12, endpoint: "1.1.1.1:12", isLocal: false, ready: true, serving: true, terminating: false},
+				{ip: "1.1.1.2", port: 12, endpoint: "1.1.1.2:12", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
 		expected: map[types.NamespacedName]sets.Set[string]{
@@ -85,23 +85,23 @@ func TestGetLocalEndpointIPs(t *testing.T) {
 		},
 	}, {
 		// Case[4]: named local and non-local ports for different IPs.
-		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
+		endpointsMap: EndpointsMap[*BaseEndpointInfo]{
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
 			},
-			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "2.2.2.2", port: 22, endpoint: "2.2.2.2:22", isLocal: true, ready: true, serving: true, terminating: false},
-				&BaseEndpointInfo{ip: "2.2.2.22", port: 22, endpoint: "2.2.2.22:22", isLocal: true, ready: true, serving: true, terminating: false},
+			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "2.2.2.2", port: 22, endpoint: "2.2.2.2:22", isLocal: true, ready: true, serving: true, terminating: false},
+				{ip: "2.2.2.22", port: 22, endpoint: "2.2.2.22:22", isLocal: true, ready: true, serving: true, terminating: false},
 			},
-			makeServicePortName("ns2", "ep2", "p23", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "2.2.2.3", port: 23, endpoint: "2.2.2.3:23", isLocal: true, ready: true, serving: true, terminating: false},
+			makeServicePortName("ns2", "ep2", "p23", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "2.2.2.3", port: 23, endpoint: "2.2.2.3:23", isLocal: true, ready: true, serving: true, terminating: false},
 			},
-			makeServicePortName("ns4", "ep4", "p44", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "4.4.4.4", port: 44, endpoint: "4.4.4.4:44", isLocal: true, ready: true, serving: true, terminating: false},
-				&BaseEndpointInfo{ip: "4.4.4.5", port: 44, endpoint: "4.4.4.5:44", isLocal: false, ready: true, serving: true, terminating: false},
+			makeServicePortName("ns4", "ep4", "p44", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "4.4.4.4", port: 44, endpoint: "4.4.4.4:44", isLocal: true, ready: true, serving: true, terminating: false},
+				{ip: "4.4.4.5", port: 44, endpoint: "4.4.4.5:44", isLocal: false, ready: true, serving: true, terminating: false},
 			},
-			makeServicePortName("ns4", "ep4", "p45", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "4.4.4.6", port: 45, endpoint: "4.4.4.6:45", isLocal: true, ready: true, serving: true, terminating: false},
+			makeServicePortName("ns4", "ep4", "p45", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "4.4.4.6", port: 45, endpoint: "4.4.4.6:45", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
 		expected: map[types.NamespacedName]sets.Set[string]{
@@ -110,23 +110,23 @@ func TestGetLocalEndpointIPs(t *testing.T) {
 		},
 	}, {
 		// Case[5]: named local and non-local ports for different IPs, some not ready.
-		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
+		endpointsMap: EndpointsMap[*BaseEndpointInfo]{
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: true, serving: true, terminating: false},
 			},
-			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "2.2.2.2", port: 22, endpoint: "2.2.2.2:22", isLocal: true, ready: true, serving: true, terminating: false},
-				&BaseEndpointInfo{ip: "2.2.2.22", port: 22, endpoint: "2.2.2.22:22", isLocal: true, ready: true, serving: true, terminating: false},
+			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "2.2.2.2", port: 22, endpoint: "2.2.2.2:22", isLocal: true, ready: true, serving: true, terminating: false},
+				{ip: "2.2.2.22", port: 22, endpoint: "2.2.2.22:22", isLocal: true, ready: true, serving: true, terminating: false},
 			},
-			makeServicePortName("ns2", "ep2", "p23", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "2.2.2.3", port: 23, endpoint: "2.2.2.3:23", isLocal: true, ready: false, serving: true, terminating: true},
+			makeServicePortName("ns2", "ep2", "p23", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "2.2.2.3", port: 23, endpoint: "2.2.2.3:23", isLocal: true, ready: false, serving: true, terminating: true},
 			},
-			makeServicePortName("ns4", "ep4", "p44", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "4.4.4.4", port: 44, endpoint: "4.4.4.4:44", isLocal: true, ready: true, serving: true, terminating: false},
-				&BaseEndpointInfo{ip: "4.4.4.5", port: 44, endpoint: "4.4.4.5:44", isLocal: false, ready: true, serving: true, terminating: false},
+			makeServicePortName("ns4", "ep4", "p44", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "4.4.4.4", port: 44, endpoint: "4.4.4.4:44", isLocal: true, ready: true, serving: true, terminating: false},
+				{ip: "4.4.4.5", port: 44, endpoint: "4.4.4.5:44", isLocal: false, ready: true, serving: true, terminating: false},
 			},
-			makeServicePortName("ns4", "ep4", "p45", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "4.4.4.6", port: 45, endpoint: "4.4.4.6:45", isLocal: true, ready: true, serving: true, terminating: false},
+			makeServicePortName("ns4", "ep4", "p45", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "4.4.4.6", port: 45, endpoint: "4.4.4.6:45", isLocal: true, ready: true, serving: true, terminating: false},
 			},
 		},
 		expected: map[types.NamespacedName]sets.Set[string]{
@@ -135,23 +135,23 @@ func TestGetLocalEndpointIPs(t *testing.T) {
 		},
 	}, {
 		// Case[6]: all endpoints are terminating,, so getLocalReadyEndpointIPs should return 0 ready endpoints
-		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: false, serving: true, terminating: true},
+		endpointsMap: EndpointsMap[*BaseEndpointInfo]{
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "1.1.1.1", port: 11, endpoint: "1.1.1.1:11", isLocal: false, ready: false, serving: true, terminating: true},
 			},
-			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "2.2.2.2", port: 22, endpoint: "2.2.2.2:22", isLocal: true, ready: false, serving: true, terminating: true},
-				&BaseEndpointInfo{ip: "2.2.2.22", port: 22, endpoint: "2.2.2.22:22", isLocal: true, ready: false, serving: true, terminating: true},
+			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "2.2.2.2", port: 22, endpoint: "2.2.2.2:22", isLocal: true, ready: false, serving: true, terminating: true},
+				{ip: "2.2.2.22", port: 22, endpoint: "2.2.2.22:22", isLocal: true, ready: false, serving: true, terminating: true},
 			},
-			makeServicePortName("ns2", "ep2", "p23", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "2.2.2.3", port: 23, endpoint: "2.2.2.3:23", isLocal: true, ready: false, serving: true, terminating: true},
+			makeServicePortName("ns2", "ep2", "p23", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "2.2.2.3", port: 23, endpoint: "2.2.2.3:23", isLocal: true, ready: false, serving: true, terminating: true},
 			},
-			makeServicePortName("ns4", "ep4", "p44", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "4.4.4.4", port: 44, endpoint: "4.4.4.4:44", isLocal: true, ready: false, serving: true, terminating: true},
-				&BaseEndpointInfo{ip: "4.4.4.5", port: 44, endpoint: "4.4.4.5:44", isLocal: false, ready: false, serving: true, terminating: true},
+			makeServicePortName("ns4", "ep4", "p44", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "4.4.4.4", port: 44, endpoint: "4.4.4.4:44", isLocal: true, ready: false, serving: true, terminating: true},
+				{ip: "4.4.4.5", port: 44, endpoint: "4.4.4.5:44", isLocal: false, ready: false, serving: true, terminating: true},
 			},
-			makeServicePortName("ns4", "ep4", "p45", v1.ProtocolTCP): []Endpoint{
-				&BaseEndpointInfo{ip: "4.4.4.6", port: 45, endpoint: "4.4.4.6:45", isLocal: true, ready: false, serving: true, terminating: true},
+			makeServicePortName("ns4", "ep4", "p45", v1.ProtocolTCP): []*BaseEndpointInfo{
+				{ip: "4.4.4.6", port: 45, endpoint: "4.4.4.6:45", isLocal: true, ready: false, serving: true, terminating: true},
 			},
 		},
 		expected: make(map[types.NamespacedName]sets.Set[string], 0),
@@ -1334,7 +1334,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 
 	testCases := map[string]struct {
 		startingSlices         []*discovery.EndpointSlice
-		endpointsChangeTracker *EndpointsChangeTracker
+		endpointsChangeTracker *EndpointsChangeTracker[*BaseEndpointInfo]
 		namespacedName         types.NamespacedName
 		paramEndpointSlice     *discovery.EndpointSlice
 		paramRemoveSlice       bool
@@ -1344,7 +1344,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 		// test starting from an empty state
 		"add a simple slice that doesn't already exist": {
 			startingSlices:         []*discovery.EndpointSlice{},
-			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", NewBaseEndpointInfo, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       false,
@@ -1367,7 +1367,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			startingSlices: []*discovery.EndpointSlice{
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
-			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", NewBaseEndpointInfo, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       false,
@@ -1379,7 +1379,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			startingSlices: []*discovery.EndpointSlice{
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
-			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", NewBaseEndpointInfo, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			paramEndpointSlice:     fqdnSlice,
 			paramRemoveSlice:       false,
@@ -1392,7 +1392,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
-			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", NewBaseEndpointInfo, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       false,
@@ -1424,7 +1424,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
-			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", NewBaseEndpointInfo, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			paramEndpointSlice:     generateEndpointSliceWithOffset("svc1", "ns1", 3, 1, 5, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80)}),
 			paramRemoveSlice:       false,
@@ -1454,7 +1454,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
-			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", NewBaseEndpointInfo, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       true,
@@ -1476,7 +1476,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
-			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", NewBaseEndpointInfo, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 3, 5, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       true,
@@ -1488,7 +1488,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			startingSlices: []*discovery.EndpointSlice{
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
-			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", NewBaseEndpointInfo, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 1, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       false,
@@ -1511,7 +1511,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			startingSlices: []*discovery.EndpointSlice{
 				generateEndpointSlice("svc1", "ns1", 1, 2, 1, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
-			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", NewBaseEndpointInfo, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 2, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       false,
@@ -1533,7 +1533,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 3, 2, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 				generateEndpointSlice("svc1", "ns1", 2, 2, 2, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
-			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", NewBaseEndpointInfo, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 3, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       false,
@@ -1561,7 +1561,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 3, 2, 2, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 				generateEndpointSlice("svc1", "ns1", 2, 2, 2, 2, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
-			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", NewBaseEndpointInfo, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 3, 2, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       false,
@@ -1614,27 +1614,27 @@ func TestCheckoutChanges(t *testing.T) {
 	svcPortName1 := ServicePortName{types.NamespacedName{Namespace: "ns1", Name: "svc1"}, "port-1", v1.ProtocolTCP}
 
 	testCases := map[string]struct {
-		endpointsChangeTracker *EndpointsChangeTracker
-		expectedChanges        []*endpointsChange
-		items                  map[types.NamespacedName]*endpointsChange
+		endpointsChangeTracker *EndpointsChangeTracker[*BaseEndpointInfo]
+		expectedChanges        []*endpointsChange[*BaseEndpointInfo]
+		items                  map[types.NamespacedName]*endpointsChange[*BaseEndpointInfo]
 		appliedSlices          []*discovery.EndpointSlice
 		pendingSlices          []*discovery.EndpointSlice
 	}{
 		"empty slices": {
-			endpointsChangeTracker: NewEndpointsChangeTracker("", nil, v1.IPv4Protocol, nil, nil),
-			expectedChanges:        []*endpointsChange{},
+			endpointsChangeTracker: NewEndpointsChangeTracker("", NewBaseEndpointInfo, v1.IPv4Protocol, nil, nil),
+			expectedChanges:        []*endpointsChange[*BaseEndpointInfo]{},
 			appliedSlices:          []*discovery.EndpointSlice{},
 			pendingSlices:          []*discovery.EndpointSlice{},
 		},
 		"adding initial slice": {
-			endpointsChangeTracker: NewEndpointsChangeTracker("", nil, v1.IPv4Protocol, nil, nil),
-			expectedChanges: []*endpointsChange{{
-				previous: EndpointsMap{},
-				current: EndpointsMap{
-					svcPortName0: []Endpoint{
-						&BaseEndpointInfo{ip: "10.0.1.1", port: 80, endpoint: "10.0.1.1:80", ready: true, serving: true, terminating: false},
-						&BaseEndpointInfo{ip: "10.0.1.2", port: 80, endpoint: "10.0.1.2:80", ready: false, serving: true, terminating: true},
-						&BaseEndpointInfo{ip: "10.0.1.3", port: 80, endpoint: "10.0.1.3:80", ready: false, serving: false, terminating: false},
+			endpointsChangeTracker: NewEndpointsChangeTracker("", NewBaseEndpointInfo, v1.IPv4Protocol, nil, nil),
+			expectedChanges: []*endpointsChange[*BaseEndpointInfo]{{
+				previous: EndpointsMap[*BaseEndpointInfo]{},
+				current: EndpointsMap[*BaseEndpointInfo]{
+					svcPortName0: []*BaseEndpointInfo{
+						{ip: "10.0.1.1", port: 80, endpoint: "10.0.1.1:80", ready: true, serving: true, terminating: false},
+						{ip: "10.0.1.2", port: 80, endpoint: "10.0.1.2:80", ready: false, serving: true, terminating: true},
+						{ip: "10.0.1.3", port: 80, endpoint: "10.0.1.3:80", ready: false, serving: false, terminating: false},
 					},
 				},
 			}},
@@ -1644,25 +1644,25 @@ func TestCheckoutChanges(t *testing.T) {
 			},
 		},
 		"removing port in update": {
-			endpointsChangeTracker: NewEndpointsChangeTracker("", nil, v1.IPv4Protocol, nil, nil),
-			expectedChanges: []*endpointsChange{{
-				previous: EndpointsMap{
-					svcPortName0: []Endpoint{
-						&BaseEndpointInfo{ip: "10.0.1.1", port: 80, endpoint: "10.0.1.1:80", ready: true, serving: true, terminating: false},
-						&BaseEndpointInfo{ip: "10.0.1.2", port: 80, endpoint: "10.0.1.2:80", ready: true, serving: true, terminating: false},
-						&BaseEndpointInfo{ip: "10.0.1.3", port: 80, endpoint: "10.0.1.3:80", ready: false, serving: false, terminating: false},
+			endpointsChangeTracker: NewEndpointsChangeTracker("", NewBaseEndpointInfo, v1.IPv4Protocol, nil, nil),
+			expectedChanges: []*endpointsChange[*BaseEndpointInfo]{{
+				previous: EndpointsMap[*BaseEndpointInfo]{
+					svcPortName0: []*BaseEndpointInfo{
+						{ip: "10.0.1.1", port: 80, endpoint: "10.0.1.1:80", ready: true, serving: true, terminating: false},
+						{ip: "10.0.1.2", port: 80, endpoint: "10.0.1.2:80", ready: true, serving: true, terminating: false},
+						{ip: "10.0.1.3", port: 80, endpoint: "10.0.1.3:80", ready: false, serving: false, terminating: false},
 					},
-					svcPortName1: []Endpoint{
-						&BaseEndpointInfo{ip: "10.0.1.1", port: 443, endpoint: "10.0.1.1:443", ready: true, serving: true, terminating: false},
-						&BaseEndpointInfo{ip: "10.0.1.2", port: 443, endpoint: "10.0.1.2:443", ready: true, serving: true, terminating: false},
-						&BaseEndpointInfo{ip: "10.0.1.3", port: 443, endpoint: "10.0.1.3:443", ready: false, serving: false, terminating: false},
+					svcPortName1: []*BaseEndpointInfo{
+						{ip: "10.0.1.1", port: 443, endpoint: "10.0.1.1:443", ready: true, serving: true, terminating: false},
+						{ip: "10.0.1.2", port: 443, endpoint: "10.0.1.2:443", ready: true, serving: true, terminating: false},
+						{ip: "10.0.1.3", port: 443, endpoint: "10.0.1.3:443", ready: false, serving: false, terminating: false},
 					},
 				},
-				current: EndpointsMap{
-					svcPortName0: []Endpoint{
-						&BaseEndpointInfo{ip: "10.0.1.1", port: 80, endpoint: "10.0.1.1:80", ready: true, serving: true, terminating: false},
-						&BaseEndpointInfo{ip: "10.0.1.2", port: 80, endpoint: "10.0.1.2:80", ready: true, serving: true, terminating: false},
-						&BaseEndpointInfo{ip: "10.0.1.3", port: 80, endpoint: "10.0.1.3:80", ready: false, serving: false, terminating: false},
+				current: EndpointsMap[*BaseEndpointInfo]{
+					svcPortName0: []*BaseEndpointInfo{
+						{ip: "10.0.1.1", port: 80, endpoint: "10.0.1.1:80", ready: true, serving: true, terminating: false},
+						{ip: "10.0.1.2", port: 80, endpoint: "10.0.1.2:80", ready: true, serving: true, terminating: false},
+						{ip: "10.0.1.3", port: 80, endpoint: "10.0.1.3:80", ready: false, serving: false, terminating: false},
 					},
 				},
 			}},
@@ -1709,7 +1709,7 @@ func TestCheckoutChanges(t *testing.T) {
 
 // Test helpers
 
-func compareEndpointsMapsStr(t *testing.T, newMap EndpointsMap, expected map[ServicePortName][]*BaseEndpointInfo) {
+func compareEndpointsMapsStr(t *testing.T, newMap EndpointsMap[*BaseEndpointInfo], expected map[ServicePortName][]*BaseEndpointInfo) {
 	t.Helper()
 	if len(newMap) != len(expected) {
 		t.Fatalf("expected %d results, got %d: %v", len(expected), len(newMap), newMap)
@@ -1723,10 +1723,7 @@ func compareEndpointsMapsStr(t *testing.T, newMap EndpointsMap, expected map[Ser
 			t.Fatalf("expected %d endpoints for %v, got %d", len(expected[x]), x, len(newMap[x]))
 		} else {
 			for i := range expected[x] {
-				newEp, ok := newMap[x][i].(*BaseEndpointInfo)
-				if !ok {
-					t.Fatalf("Failed to cast endpointInfo")
-				}
+				newEp := newMap[x][i]
 				if !endpointEqual(newEp, expected[x][i]) {
 					t.Fatalf("expected new[%v][%d] to be %v, got %v"+
 						"(IsLocal expected %v, got %v) (Ready expected %v, got %v) (Serving expected %v, got %v) (Terminating expected %v got %v)",
@@ -1738,7 +1735,7 @@ func compareEndpointsMapsStr(t *testing.T, newMap EndpointsMap, expected map[Ser
 	}
 }
 
-func initializeCache(endpointSliceCache *EndpointSliceCache, endpointSlices []*discovery.EndpointSlice) {
+func initializeCache[E Endpoint](endpointSliceCache *EndpointSliceCache[E], endpointSlices []*discovery.EndpointSlice) {
 	for _, endpointSlice := range endpointSlices {
 		endpointSliceCache.updatePending(endpointSlice, false)
 	}

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -113,9 +113,9 @@ func NewFakeProxier(ipt utiliptables.Interface) *Proxier {
 	networkInterfacer.AddInterfaceAddr(&itf1, addrs1)
 
 	p := &Proxier{
-		svcPortMap:               make(proxy.ServicePortMap),
+		svcPortMap:               make(proxy.ServicePortMap[*servicePortInfo]),
 		serviceChanges:           proxy.NewServiceChangeTracker(newServiceInfo, ipfamily, nil, nil),
-		endpointsMap:             make(proxy.EndpointsMap),
+		endpointsMap:             make(proxy.EndpointsMap[*endpointInfo]),
 		endpointsChanges:         proxy.NewEndpointsChangeTracker(testHostname, newEndpointInfo, ipfamily, nil, nil),
 		needFullSync:             true,
 		iptables:                 ipt,
@@ -3179,7 +3179,7 @@ type endpointExpectation struct {
 	isLocal  bool
 }
 
-func checkEndpointExpectations(t *testing.T, tci int, newMap proxy.EndpointsMap, expected map[proxy.ServicePortName][]endpointExpectation) {
+func checkEndpointExpectations(t *testing.T, tci int, newMap proxy.EndpointsMap[*endpointInfo], expected map[proxy.ServicePortName][]endpointExpectation) {
 	if len(newMap) != len(expected) {
 		t.Errorf("[%d] expected %d results, got %d: %v", tci, len(expected), len(newMap), newMap)
 	}

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -136,10 +136,10 @@ func NewFakeProxier(ipt utiliptables.Interface, ipvs utilipvs.Interface, ipset u
 		ipsetList[is.name] = NewIPSet(ipset, is.name, is.setType, false, is.comment)
 	}
 	p := &Proxier{
-		svcPortMap:            make(proxy.ServicePortMap),
+		svcPortMap:            make(proxy.ServicePortMap[*servicePortInfo]),
 		serviceChanges:        proxy.NewServiceChangeTracker(newServiceInfo, ipFamily, nil, nil),
-		endpointsMap:          make(proxy.EndpointsMap),
-		endpointsChanges:      proxy.NewEndpointsChangeTracker(testHostname, nil, ipFamily, nil, nil),
+		endpointsMap:          make(proxy.EndpointsMap[*proxy.BaseEndpointInfo]),
+		endpointsChanges:      proxy.NewEndpointsChangeTracker(testHostname, proxy.NewBaseEndpointInfo, ipFamily, nil, nil),
 		excludeCIDRs:          excludeCIDRs,
 		iptables:              ipt,
 		ipvs:                  ipvs,
@@ -3615,7 +3615,7 @@ type endpointExpectation struct {
 	isLocal  bool
 }
 
-func checkEndpointExpectations(t *testing.T, tci int, newMap proxy.EndpointsMap, expected map[proxy.ServicePortName][]endpointExpectation) {
+func checkEndpointExpectations(t *testing.T, tci int, newMap proxy.EndpointsMap[*proxy.BaseEndpointInfo], expected map[proxy.ServicePortName][]endpointExpectation) {
 	if len(newMap) != len(expected) {
 		t.Errorf("[%d] expected %d results, got %d: %v", tci, len(expected), len(newMap), newMap)
 	}

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -114,9 +114,9 @@ func NewFakeProxier(ipFamily v1.IPFamily) (*knftables.Fake, *Proxier) {
 	}
 	p := &Proxier{
 		ipFamily:            ipFamily,
-		svcPortMap:          make(proxy.ServicePortMap),
+		svcPortMap:          make(proxy.ServicePortMap[*servicePortInfo]),
 		serviceChanges:      proxy.NewServiceChangeTracker(newServiceInfo, ipFamily, nil, nil),
-		endpointsMap:        make(proxy.EndpointsMap),
+		endpointsMap:        make(proxy.EndpointsMap[*endpointInfo]),
 		endpointsChanges:    proxy.NewEndpointsChangeTracker(testHostname, newEndpointInfo, ipFamily, nil, nil),
 		nftables:            nft,
 		masqueradeMark:      "0x4000",
@@ -1611,7 +1611,7 @@ type endpointExpectation struct {
 	isLocal  bool
 }
 
-func checkEndpointExpectations(t *testing.T, tci int, newMap proxy.EndpointsMap, expected map[proxy.ServicePortName][]endpointExpectation) {
+func checkEndpointExpectations(t *testing.T, tci int, newMap proxy.EndpointsMap[*endpointInfo], expected map[proxy.ServicePortName][]endpointExpectation) {
 	if len(newMap) != len(expected) {
 		t.Errorf("[%d] expected %d results, got %d: %v", tci, len(expected), len(newMap), newMap)
 	}

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -102,8 +102,8 @@ func NewFakeProxier(syncPeriod time.Duration, minSyncPeriod time.Duration, hostn
 	hnsNetwork := newHnsNetwork(hnsNetworkInfo)
 	hcnMock := fakehcn.NewHcnMock(hnsNetwork)
 	proxier := &Proxier{
-		svcPortMap:          make(proxy.ServicePortMap),
-		endpointsMap:        make(proxy.EndpointsMap),
+		svcPortMap:          make(proxy.ServicePortMap[*serviceInfo]),
+		endpointsMap:        make(proxy.EndpointsMap[*endpointInfo]),
 		hostname:            testHostName,
 		nodeIP:              nodeIP,
 		serviceHealthServer: healthcheck.NewFakeServiceHealthServer(),
@@ -167,18 +167,13 @@ func TestCreateServiceVip(t *testing.T) {
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 
-	svc := proxier.svcPortMap[svcPortName]
-	svcInfo, ok := svc.(*serviceInfo)
-	if !ok {
-		t.Errorf("Failed to cast serviceInfo %q", svcPortName.String())
+	svcInfo := proxier.svcPortMap[svcPortName]
 
-	} else {
-		if svcInfo.remoteEndpoint == nil {
-			t.Error()
-		}
-		if svcInfo.remoteEndpoint.ip != svcIP {
-			t.Error()
-		}
+	if svcInfo.remoteEndpoint == nil {
+		t.Error()
+	}
+	if svcInfo.remoteEndpoint.ip != svcIP {
+		t.Error()
 	}
 }
 
@@ -227,15 +222,9 @@ func TestCreateRemoteEndpointOverlay(t *testing.T) {
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 
-	ep := proxier.endpointsMap[svcPortName][0]
-	epInfo, ok := ep.(*endpointInfo)
-	if !ok {
-		t.Errorf("Failed to cast endpointInfo %q", svcPortName.String())
-
-	} else {
-		if epInfo.hnsID != "EPID-3" {
-			t.Errorf("%v does not match %v", epInfo.hnsID, endpointGuid1)
-		}
+	epInfo := proxier.endpointsMap[svcPortName][0]
+	if epInfo.hnsID != "EPID-3" {
+		t.Errorf("%v does not match %v", epInfo.hnsID, endpointGuid1)
 	}
 
 	if *proxier.endPointsRefCount["EPID-3"] <= 0 {
@@ -290,15 +279,10 @@ func TestCreateRemoteEndpointL2Bridge(t *testing.T) {
 	)
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
-	ep := proxier.endpointsMap[svcPortName][0]
-	epInfo, ok := ep.(*endpointInfo)
-	if !ok {
-		t.Errorf("Failed to cast endpointInfo %q", svcPortName.String())
+	epInfo := proxier.endpointsMap[svcPortName][0]
 
-	} else {
-		if epInfo.hnsID != endpointGuid1 {
-			t.Errorf("%v does not match %v", epInfo.hnsID, endpointGuid1)
-		}
+	if epInfo.hnsID != endpointGuid1 {
+		t.Errorf("%v does not match %v", epInfo.hnsID, endpointGuid1)
 	}
 
 	if *proxier.endPointsRefCount[endpointGuid1] <= 0 {
@@ -382,15 +366,10 @@ func TestSharedRemoteEndpointDelete(t *testing.T) {
 	)
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
-	ep := proxier.endpointsMap[svcPortName1][0]
-	epInfo, ok := ep.(*endpointInfo)
-	if !ok {
-		t.Errorf("Failed to cast endpointInfo %q", svcPortName1.String())
+	epInfo := proxier.endpointsMap[svcPortName1][0]
 
-	} else {
-		if epInfo.hnsID != endpointGuid1 {
-			t.Errorf("%v does not match %v", epInfo.hnsID, endpointGuid1)
-		}
+	if epInfo.hnsID != endpointGuid1 {
+		t.Errorf("%v does not match %v", epInfo.hnsID, endpointGuid1)
 	}
 
 	if *proxier.endPointsRefCount[endpointGuid1] != 2 {
@@ -432,15 +411,10 @@ func TestSharedRemoteEndpointDelete(t *testing.T) {
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 
-	ep = proxier.endpointsMap[svcPortName1][0]
-	epInfo, ok = ep.(*endpointInfo)
-	if !ok {
-		t.Errorf("Failed to cast endpointInfo %q", svcPortName1.String())
+	epInfo = proxier.endpointsMap[svcPortName1][0]
 
-	} else {
-		if epInfo.hnsID != endpointGuid1 {
-			t.Errorf("%v does not match %v", epInfo.hnsID, endpointGuid1)
-		}
+	if epInfo.hnsID != endpointGuid1 {
+		t.Errorf("%v does not match %v", epInfo.hnsID, endpointGuid1)
 	}
 
 	if *epInfo.refCount != 1 {
@@ -526,15 +500,10 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
-	ep := proxier.endpointsMap[svcPortName1][0]
-	epInfo, ok := ep.(*endpointInfo)
-	if !ok {
-		t.Errorf("Failed to cast endpointInfo %q", svcPortName1.String())
+	epInfo := proxier.endpointsMap[svcPortName1][0]
 
-	} else {
-		if epInfo.hnsID != endpointGuid1 {
-			t.Errorf("%v does not match %v", epInfo.hnsID, endpointGuid1)
-		}
+	if epInfo.hnsID != endpointGuid1 {
+		t.Errorf("%v does not match %v", epInfo.hnsID, endpointGuid1)
 	}
 
 	if *proxier.endPointsRefCount[endpointGuid1] != 2 {
@@ -605,16 +574,10 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 
-	ep = proxier.endpointsMap[svcPortName1][0]
-	epInfo, ok = ep.(*endpointInfo)
+	epInfo = proxier.endpointsMap[svcPortName1][0]
 
-	if !ok {
-		t.Errorf("Failed to cast endpointInfo %q", svcPortName1.String())
-
-	} else {
-		if epInfo.hnsID != endpointGuid1 {
-			t.Errorf("%v does not match %v", epInfo.hnsID, endpointGuid1)
-		}
+	if epInfo.hnsID != endpointGuid1 {
+		t.Errorf("%v does not match %v", epInfo.hnsID, endpointGuid1)
 	}
 
 	if *epInfo.refCount != 2 {
@@ -670,15 +633,10 @@ func TestCreateLoadBalancer(t *testing.T) {
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 
-	svc := proxier.svcPortMap[svcPortName]
-	svcInfo, ok := svc.(*serviceInfo)
-	if !ok {
-		t.Errorf("Failed to cast serviceInfo %q", svcPortName.String())
+	svcInfo := proxier.svcPortMap[svcPortName]
 
-	} else {
-		if svcInfo.hnsID != loadbalancerGuid1 {
-			t.Errorf("%v does not match %v", svcInfo.hnsID, loadbalancerGuid1)
-		}
+	if svcInfo.hnsID != loadbalancerGuid1 {
+		t.Errorf("%v does not match %v", svcInfo.hnsID, loadbalancerGuid1)
 	}
 }
 
@@ -737,23 +695,18 @@ func TestCreateDsrLoadBalancer(t *testing.T) {
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 
-	svc := proxier.svcPortMap[svcPortName]
-	svcInfo, ok := svc.(*serviceInfo)
-	if !ok {
-		t.Errorf("Failed to cast serviceInfo %q", svcPortName.String())
+	svcInfo := proxier.svcPortMap[svcPortName]
 
-	} else {
-		if svcInfo.hnsID != loadbalancerGuid1 {
-			t.Errorf("%v does not match %v", svcInfo.hnsID, loadbalancerGuid1)
-		}
-		if svcInfo.localTrafficDSR != true {
-			t.Errorf("Failed to create DSR loadbalancer with local traffic policy")
-		}
-		if len(svcInfo.loadBalancerIngressIPs) == 0 {
-			t.Errorf("svcInfo does not have any loadBalancerIngressIPs, %+v", svcInfo)
-		} else if svcInfo.loadBalancerIngressIPs[0].healthCheckHnsID != "LBID-4" {
-			t.Errorf("The Hns Loadbalancer HealthCheck Id %v does not match %v. ServicePortName %q", svcInfo.loadBalancerIngressIPs[0].healthCheckHnsID, loadbalancerGuid1, svcPortName.String())
-		}
+	if svcInfo.hnsID != loadbalancerGuid1 {
+		t.Errorf("%v does not match %v", svcInfo.hnsID, loadbalancerGuid1)
+	}
+	if svcInfo.localTrafficDSR != true {
+		t.Errorf("Failed to create DSR loadbalancer with local traffic policy")
+	}
+	if len(svcInfo.loadBalancerIngressIPs) == 0 {
+		t.Errorf("svcInfo does not have any loadBalancerIngressIPs, %+v", svcInfo)
+	} else if svcInfo.loadBalancerIngressIPs[0].healthCheckHnsID != "LBID-4" {
+		t.Errorf("The Hns Loadbalancer HealthCheck Id %v does not match %v. ServicePortName %q", svcInfo.loadBalancerIngressIPs[0].healthCheckHnsID, loadbalancerGuid1, svcPortName.String())
 	}
 }
 
@@ -812,31 +765,16 @@ func TestClusterIPLBInCreateDsrLoadBalancer(t *testing.T) {
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 
-	svc := proxier.svcPortMap[svcPortName]
-	svcInfo, ok := svc.(*serviceInfo)
-	if !ok {
-		t.Errorf("Failed to cast serviceInfo %q", svcPortName.String())
+	svcInfo := proxier.svcPortMap[svcPortName]
 
-	} else {
-		// Checking ClusterIP Loadbalancer is created
-		if svcInfo.hnsID != loadbalancerGuid1 {
-			t.Errorf("%v does not match %v", svcInfo.hnsID, loadbalancerGuid1)
-		}
-		// Verifying NodePort Loadbalancer is not created
-		if svcInfo.nodePorthnsID != "" {
-			t.Errorf("NodePortHnsID %v is not empty.", svcInfo.nodePorthnsID)
-		}
-		// Verifying ExternalIP Loadbalancer is not created
-		for _, externalIP := range svcInfo.externalIPs {
-			if externalIP.hnsID != "" {
-				t.Errorf("ExternalLBID %v is not empty.", externalIP.hnsID)
-			}
-		}
-		// Verifying IngressIP Loadbalancer is not created
-		for _, ingressIP := range svcInfo.loadBalancerIngressIPs {
-			if ingressIP.hnsID != "" {
-				t.Errorf("IngressLBID %v is not empty.", ingressIP.hnsID)
-			}
+	// Checking ClusterIP Loadbalancer is created
+	if svcInfo.hnsID != loadbalancerGuid1 {
+		t.Errorf("%v does not match %v", svcInfo.hnsID, loadbalancerGuid1)
+	}
+	// Verifying IngressIP Loadbalancer is not created
+	for _, ingressIP := range svcInfo.loadBalancerIngressIPs {
+		if ingressIP.hnsID != "" {
+			t.Errorf("IngressLBID %v is not empty.", ingressIP.hnsID)
 		}
 	}
 }
@@ -890,26 +828,15 @@ func TestEndpointSlice(t *testing.T) {
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 
-	svc := proxier.svcPortMap[svcPortName]
-	svcInfo, ok := svc.(*serviceInfo)
-	if !ok {
-		t.Errorf("Failed to cast serviceInfo %q", svcPortName.String())
+	svcInfo := proxier.svcPortMap[svcPortName]
 
-	} else {
-		if svcInfo.hnsID != loadbalancerGuid1 {
-			t.Errorf("The Hns Loadbalancer Id %v does not match %v. ServicePortName %q", svcInfo.hnsID, loadbalancerGuid1, svcPortName.String())
-		}
+	if svcInfo.hnsID != loadbalancerGuid1 {
+		t.Errorf("The Hns Loadbalancer Id %v does not match %v. ServicePortName %q", svcInfo.hnsID, loadbalancerGuid1, svcPortName.String())
 	}
 
-	ep := proxier.endpointsMap[svcPortName][0]
-	epInfo, ok := ep.(*endpointInfo)
-	if !ok {
-		t.Errorf("Failed to cast endpointInfo %q", svcPortName.String())
-
-	} else {
-		if epInfo.hnsID != "EPID-3" {
-			t.Errorf("Hns EndpointId %v does not match %v. ServicePortName %q", epInfo.hnsID, endpointGuid1, svcPortName.String())
-		}
+	epInfo := proxier.endpointsMap[svcPortName][0]
+	if epInfo.hnsID != "EPID-3" {
+		t.Errorf("Hns EndpointId %v does not match %v. ServicePortName %q", epInfo.hnsID, endpointGuid1, svcPortName.String())
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig network
/priority backlog
/hold

#### What this PR does / why we need it:
The proxy backends have a lot of pointless typecasting, and this gets rid of it:

```
                // Generate the per-endpoint chains.
-               for _, ep := range allLocallyReachableEndpoints {
-                       epInfo, ok := ep.(*endpointsInfo)
-                       if !ok {
-                               klog.ErrorS(nil, "Failed to cast endpointsInfo", "endpointsInfo", ep)
-                               continue
-                       }
-
+               for _, epInfo := range allLocallyReachableEndpoints {
                        endpointChain := epInfo.ChainName
```

But I'm not sure if the changes in `pkg/proxy/*.go` are too ugly/big to be worth the improvements in `pkg/proxy/{iptables,ipvs,winkernel}/proxier.go`? (Also, this will make linux kube-proxy slightly bigger since it will end up with two (and eventually three) implementations of much of `pkg/proxy`.)

Note that for iptables and ipvs (and presumably nftables) we could get rid of the backend-specific service/endpoint types by just adding a `BackendData map[string]string` to the generic types. But that wouldn't work for winkernel, which does much more complicated things with those types...

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @thockin @aojea
