### PR TITLE
Promote test for StorageV1CSIDriver Endpoints + 3 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2565,6 +2565,15 @@
     pod.
   release: v1.19
   file: test/e2e/scheduling/preemption.go
+- testname: CSIDriver, lifecycle
+  codename: '[sig-storage] CSIInlineVolumes should run through the lifecycle of a
+    CSIDriver [Conformance]'
+  description: Creating two CSIDrivers MUST succeed. Patching a CSIDriver MUST succeed
+    with its new label found. Updating a CSIDriver MUST succeed with its new label
+    found. Two CSIDrivers MUST be found when listed. Deleting the first CSIDriver
+    MUST succeed. Deleting the second CSIDriver via deleteCollection MUST succeed.
+  release: v1.28
+  file: test/e2e/storage/csi_inline.go
 - testname: CSIInlineVolumes should support Pods with inline volumes
   codename: '[sig-storage] CSIInlineVolumes should support CSIVolumeSource in Pod
     API [Conformance]'

--- a/test/e2e/storage/csi_inline.go
+++ b/test/e2e/storage/csi_inline.go
@@ -230,7 +230,16 @@ var _ = utils.SIGDescribe("CSIInlineVolumes", func() {
 		}
 	})
 
-	ginkgo.It("should run through the lifecycle of a CSIDriver", func(ctx context.Context) {
+	/*
+		Release: v1.28
+		Testname: CSIDriver, lifecycle
+		Description: Creating two CSIDrivers MUST succeed. Patching a CSIDriver MUST
+		succeed with its new label found. Updating a CSIDriver MUST succeed with its
+		new label found. Two CSIDrivers MUST be found when listed. Deleting the first
+		CSIDriver MUST succeed. Deleting the second CSIDriver via deleteCollection
+		MUST succeed.
+	*/
+	framework.ConformanceIt("should run through the lifecycle of a CSIDriver", func(ctx context.Context) {
 		// Create client
 		client := f.ClientSet.StorageV1().CSIDrivers()
 		defaultFSGroupPolicy := storagev1.ReadWriteOnceWithFSTypeFSGroupPolicy


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- deleteStorageV1CollectionCSIDriver
- patchStorageV1CSIDriver
- replaceStorageV1CSIDriver    

**Which issue(s) this PR fixes:**
Fixes #118098

**Testgrid Link:**
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.run.through.the.lifecycle.of.a.CSIDriver)


**Special notes for your reviewer:**
This test cover all 7 StorageV1CSIDriver Endpoints. Once the test have been promoted to conformance and proven stable the [current test for create, read, list & delete](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/csi_inline.go#L46) could be removed to reduce the test load.
Adds +3 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance