### PR TITLE
Remove csidriver endpoints from pending_eligible_endpoints.yaml

### DIFF
--- a/test/conformance/testdata/pending_eligible_endpoints.yaml
+++ b/test/conformance/testdata/pending_eligible_endpoints.yaml
@@ -11,7 +11,6 @@
 - deleteCoreV1NamespacedPersistentVolumeClaim
 - deleteCoreV1Node
 - deleteCoreV1PersistentVolume
-- deleteStorageV1CollectionCSIDriver
 - deleteStorageV1CollectionCSINode
 - deleteStorageV1CollectionStorageClass
 - deleteStorageV1CollectionVolumeAttachment
@@ -34,7 +33,6 @@
 - patchCoreV1PersistentVolume
 - patchCoreV1PersistentVolumeStatus
 - patchNetworkingV1NamespacedNetworkPolicyStatus
-- patchStorageV1CSIDriver
 - patchStorageV1CSINode
 - patchStorageV1StorageClass
 - patchStorageV1VolumeAttachment
@@ -56,7 +54,6 @@
 - replaceCoreV1PersistentVolume
 - replaceCoreV1PersistentVolumeStatus
 - replaceNetworkingV1NamespacedNetworkPolicyStatus
-- replaceStorageV1CSIDriver
 - replaceStorageV1CSINode
 - replaceStorageV1StorageClass
 - replaceStorageV1VolumeAttachment


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
PR #118099  tested the 3 CSIDriver endpoints.
The test have been flake free for 14 days and was promoted in #118478 which allow the endpoint to be removed from the pending_eligible_endpoints.yaml

**Which PR depend on the merge of:**
#118478 



**Special notes for your reviewer:**
Adds +3 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance