### PR TITLE
Replace os.Setenv with testing.T.Setenv in tests

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -149,7 +149,7 @@ func TestToleratingMissingFiles(t *testing.T) {
 
 func TestWarningMissingFiles(t *testing.T) {
 	envVarValue := "bogus"
-	os.Setenv(RecommendedConfigPathEnvVar, envVarValue)
+	t.Setenv(RecommendedConfigPathEnvVar, envVarValue)
 	loadingRules := NewDefaultClientConfigLoadingRules()
 
 	buffer := &bytes.Buffer{}
@@ -174,7 +174,7 @@ func TestWarningMissingFiles(t *testing.T) {
 
 func TestNoWarningMissingFiles(t *testing.T) {
 	envVarValue := "bogus"
-	os.Setenv(RecommendedConfigPathEnvVar, envVarValue)
+	t.Setenv(RecommendedConfigPathEnvVar, envVarValue)
 	loadingRules := NewDefaultClientConfigLoadingRules()
 
 	buffer := &bytes.Buffer{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This replaces `os.Setenv` with `testing.T.Setenv` for its automatic cleanup and protection against accidental use in parallel tests.

#### Special notes for your reviewer:

Follow-up to #117233 which was in flight during #117422.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
