### PR TITLE
chore: use strings.Contains instead

### DIFF
--- a/test/e2e/framework/providers/gce/util.go
+++ b/test/e2e/framework/providers/gce/util.go
@@ -52,7 +52,7 @@ func RecreateNodes(c clientset.Interface, nodes []v1.Node) error {
 
 	// Find the sole managed instance group name
 	var instanceGroup string
-	if strings.Index(framework.TestContext.CloudConfig.NodeInstanceGroup, ",") >= 0 {
+	if strings.Contains(framework.TestContext.CloudConfig.NodeInstanceGroup, ",") {
 		return fmt.Errorf("Test does not support cluster setup with more than one managed instance group: %s", framework.TestContext.CloudConfig.NodeInstanceGroup)
 	}
 	instanceGroup = framework.TestContext.CloudConfig.NodeInstanceGroup


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
should use strings.Contains(framework.TestContext.CloudConfig.NodeInstanceGroup, ",") instead (S1003)

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
no
#### Does this PR introduce a user-facing change?
NONE
