### PR TITLE
chore: use log.Fatalf(...) instead of log.Fatal(fmt.Sprintf(...))

### DIFF
--- a/test/images/agnhost/grpc-health-checking/grpc-health-checking.go
+++ b/test/images/agnhost/grpc-health-checking/grpc-health-checking.go
@@ -122,7 +122,7 @@ func main(cmd *cobra.Command, args []string) {
 	serverAdr := fmt.Sprintf(":%d", port)
 	listenAddr, err := net.Listen("tcp", serverAdr)
 	if err != nil {
-		log.Fatal(fmt.Sprintf("Error while starting the listening service %v", err.Error()))
+		log.Fatalf("Error while starting the listening service %v", err.Error())
 	}
 
 	grpcServer := grpc.NewServer()
@@ -131,7 +131,7 @@ func main(cmd *cobra.Command, args []string) {
 
 	log.Printf("gRPC server starting to listen on %s", serverAdr)
 	if err = grpcServer.Serve(listenAddr); err != nil {
-		log.Fatal(fmt.Sprintf("Error while starting the gRPC server on the %s listen address %v", listenAddr, err.Error()))
+		log.Fatalf("Error while starting the gRPC server on the %s listen address %v", listenAddr, err.Error())
 	}
 
 	select {}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
should use log.Fatalf(...) instead of log.Fatal(fmt.Sprintf(...)) (S1038)
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


