### PR TITLE
chore: os.SEEK_END os.SEEK_SET and use b.Logf(...) instead of b.Log(f…

### DIFF
--- a/test/integration/logs/benchmark/benchmark_test.go
+++ b/test/integration/logs/benchmark/benchmark_test.go
@@ -18,7 +18,6 @@ package benchmark
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -119,7 +118,7 @@ func BenchmarkEncoding(b *testing.B) {
 				test(b, "json", prints)
 			})
 
-			b.Log(fmt.Sprintf("%s: file sizes: %v\n", path, fileSizes))
+			b.Logf("%s: file sizes: %v\n", path, fileSizes)
 		})
 		return nil
 	}); err != nil {
@@ -287,11 +286,11 @@ func generateOutput(b *testing.B, config loadGeneratorConfig, files ...*os.File)
 	b.Logf("Wrote %d log entries in %s -> %.1f/s", total, duration, float64(total)/duration.Seconds())
 	for i, file := range files {
 		if file != nil {
-			pos, err := file.Seek(0, os.SEEK_END)
+			pos, err := file.Seek(0, io.SeekEnd)
 			if err != nil {
 				b.Fatal(err)
 			}
-			if _, err := file.Seek(0, os.SEEK_SET); err != nil {
+			if _, err := file.Seek(0, io.SeekStart); err != nil {
 				b.Fatal(err)
 			}
 			max := 50


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
should use b.Logf(...) instead of b.Log(fmt.Sprintf(...)) (S1038)
os.SEEK_END has been deprecated since Go 1.7: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
os.SEEK_SET has been deprecated since Go 1.7: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019)
#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE