### PR TITLE
fix eviction failing test for nil feature gates assignment

### DIFF
--- a/test/e2e_node/eviction_test.go
+++ b/test/e2e_node/eviction_test.go
@@ -257,6 +257,9 @@ var _ = SIGDescribe("LocalStorageCapacityIsolationMemoryBackedVolumeEviction [Sl
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			// setting a threshold to 0% disables; non-empty map overrides default value (necessary due to omitempty)
 			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalMemoryAvailable): "0%"}
+			if initialConfig.FeatureGates == nil {
+				initialConfig.FeatureGates = make(map[string]bool)
+			}
 			initialConfig.FeatureGates["SizeMemoryBackedVolumes"] = false
 		})
 


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
/kind flake

#### What this PR does / why we need it:

https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cgroupv1-node-e2e-eviction

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-crio-cgroupv1-node-e2e-eviction/1665953106753490944

```
> Enter [BeforeEach] when we run containers that should cause evictions due to pod local storage violations - test/e2e_node/util.go:179 @ 06/06/23 06:02:02.272
[PANICKED] Test Panicked
In [BeforeEach] at: /usr/local/go/src/runtime/map_faststr.go:205 @ 06/06/23 06:02:02.28

assignment to entry in nil map

Full Stack Trace
  k8s.io/kubernetes/test/e2e_node.glob..func23.1.1({0xc000ec4100?, 0xc000ec5180?}, 0xc000ec5180)
  	test/e2e_node/eviction_test.go:260 +0xc9
  k8s.io/kubernetes/test/e2e_node.tempSetCurrentKubeletConfig.func1({0x7f00220b92d8, 0xc00171e180})
  	test/e2e_node/util.go:185 +0xf3
```

#### Which issue(s) this PR fixes:

Fixes None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
