### PR TITLE
chore: should use raw string () with regexp.MustCompile to avoid havi…

### DIFF
--- a/pkg/volume/util/device_util_linux_test.go
+++ b/pkg/volume/util/device_util_linux_test.go
@@ -31,11 +31,11 @@ import (
 type mockOsIOHandler struct{}
 
 func (handler *mockOsIOHandler) ReadFile(filename string) ([]byte, error) {
-	portPattern := regexp.MustCompile("^/sys/class/iscsi_host/(host\\d)/device/session\\d/connection\\d:0/iscsi_connection/connection\\d:0/(?:persistent_)?port$")
+	portPattern := regexp.MustCompile(`^/sys/class/iscsi_host/(host\d)/device/session\d/connection\d:0/iscsi_connection/connection\d:0/(?:persistent_)?port$`)
 	if portPattern.MatchString(filename) {
 		return []byte("3260"), nil
 	}
-	addressPattern := regexp.MustCompile("^/sys/class/iscsi_host/(host\\d)/device/session\\d/connection\\d:0/iscsi_connection/connection\\d:0/(?:persistent_)?address$")
+	addressPattern := regexp.MustCompile(`^/sys/class/iscsi_host/(host\d)/device/session\d/connection\d:0/iscsi_connection/connection\d:0/(?:persistent_)?address$`)
 	matches := addressPattern.FindStringSubmatch(filename)
 	if nil != matches {
 		switch matches[1] {
@@ -45,7 +45,7 @@ func (handler *mockOsIOHandler) ReadFile(filename string) ([]byte, error) {
 			return []byte("10.0.0.2"), nil
 		}
 	}
-	targetNamePattern := regexp.MustCompile("^/sys/class/iscsi_host/(host\\d)/device/session\\d/iscsi_session/session\\d/targetname$")
+	targetNamePattern := regexp.MustCompile(`^/sys/class/iscsi_host/(host\d)/device/session\d/iscsi_session/session\d/targetname$`)
 	matches = targetNamePattern.FindStringSubmatch(filename)
 	if nil != matches {
 		switch matches[1] {

--- a/test/conformance/walk.go
+++ b/test/conformance/walk.go
@@ -266,17 +266,17 @@ func commentToConformanceData(comment string) *ConformanceData {
 		if len(line) == 0 {
 			continue
 		}
-		if sline := regexp.MustCompile("^Testname\\s*:\\s*").Split(line, -1); len(sline) == 2 {
+		if sline := regexp.MustCompile(`^Testname\s*:\s*`).Split(line, -1); len(sline) == 2 {
 			curLine = "Testname"
 			cd.TestName = sline[1]
 			continue
 		}
-		if sline := regexp.MustCompile("^Release\\s*:\\s*").Split(line, -1); len(sline) == 2 {
+		if sline := regexp.MustCompile(`^Release\s*:\s*`).Split(line, -1); len(sline) == 2 {
 			curLine = "Release"
 			cd.Release = sline[1]
 			continue
 		}
-		if sline := regexp.MustCompile("^Description\\s*:\\s*").Split(line, -1); len(sline) == 2 {
+		if sline := regexp.MustCompile(`^Description\s*:\s*`).Split(line, -1); len(sline) == 2 {
 			curLine = "Description"
 			descLines = append(descLines, sline[1])
 			continue

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -1844,7 +1844,7 @@ type scaleUpStatus struct {
 // Try to get timestamp from status.
 // Status configmap is not parsing-friendly, so evil regexpery follows.
 func getStatusTimestamp(status string) (time.Time, error) {
-	timestampMatcher, err := regexp.Compile("Cluster-autoscaler status at \\s*([0-9\\-]+ [0-9]+:[0-9]+:[0-9]+\\.[0-9]+ \\+[0-9]+ [A-Za-z]+)")
+	timestampMatcher, err := regexp.Compile(`Cluster-autoscaler status at \s*([0-9\-]+ [0-9]+:[0-9]+:[0-9]+\.[0-9]+ \+[0-9]+ [A-Za-z]+)`)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -1878,7 +1878,7 @@ func getScaleUpStatus(ctx context.Context, c clientset.Interface) (*scaleUpStatu
 		return nil, err
 	}
 
-	matcher, err := regexp.Compile("s*ScaleUp:\\s*([A-Za-z]+)\\s*\\(ready=([0-9]+)\\s*cloudProviderTarget=([0-9]+)\\s*\\)")
+	matcher, err := regexp.Compile(`s*ScaleUp:\s*([A-Za-z]+)\s*\(ready=([0-9]+)\s*cloudProviderTarget=([0-9]+)\s*\)`)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -1844,10 +1844,7 @@ type scaleUpStatus struct {
 // Try to get timestamp from status.
 // Status configmap is not parsing-friendly, so evil regexpery follows.
 func getStatusTimestamp(status string) (time.Time, error) {
-	timestampMatcher, err := regexp.Compile(`Cluster-autoscaler status at \s*([0-9\-]+ [0-9]+:[0-9]+:[0-9]+\.[0-9]+ \+[0-9]+ [A-Za-z]+)`)
-	if err != nil {
-		return time.Time{}, err
-	}
+	timestampMatcher := regexp.MustCompile(`Cluster-autoscaler status at \s*([0-9\-]+ [0-9]+:[0-9]+:[0-9]+\.[0-9]+ \+[0-9]+ [A-Za-z]+)`)
 
 	timestampMatch := timestampMatcher.FindStringSubmatch(status)
 	if len(timestampMatch) < 2 {
@@ -1878,10 +1875,7 @@ func getScaleUpStatus(ctx context.Context, c clientset.Interface) (*scaleUpStatu
 		return nil, err
 	}
 
-	matcher, err := regexp.Compile(`s*ScaleUp:\s*([A-Za-z]+)\s*\(ready=([0-9]+)\s*cloudProviderTarget=([0-9]+)\s*\)`)
-	if err != nil {
-		return nil, err
-	}
+	matcher := regexp.MustCompile(`s*ScaleUp:\s*([A-Za-z]+)\s*\(ready=([0-9]+)\s*cloudProviderTarget=([0-9]+)\s*\)`)
 	matches := matcher.FindAllStringSubmatch(status, -1)
 	if len(matches) < 1 {
 		return nil, fmt.Errorf("Failed to parse CA status configmap, raw status: %v", status)

--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -59,7 +59,7 @@ const (
 
 // TODO support other ports besides 80
 var (
-	portForwardRegexp = regexp.MustCompile("Forwarding from (127.0.0.1|\\[::1\\]):([0-9]+) -> 80")
+	portForwardRegexp = regexp.MustCompile(`Forwarding from (127.0.0.1|\[::1\]):([0-9]+) -> 80`)
 )
 
 func pfPod(expectedClientData, chunks, chunkSize, chunkIntervalMillis string, bindAddress string) *v1.Pod {

--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -194,7 +194,7 @@ func newWorkspaceDir() string {
 // Kubelet) so that they can be matched to each other.
 func GetTimestampFromWorkspaceDir(dir string) string {
 	dirTimestamp := strings.TrimPrefix(filepath.Base(dir), workspaceDirPrefix)
-	re := regexp.MustCompile("^\\d{8}T\\d{6}$")
+	re := regexp.MustCompile(`^\d{8}T\d{6}$`)
 	if re.MatchString(dirTimestamp) {
 		return dirTimestamp
 	}

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -357,7 +357,7 @@ func findKubeletServiceName(running bool) string {
 	}
 	stdout, err := exec.Command("sudo", cmdLine...).CombinedOutput()
 	framework.ExpectNoError(err)
-	regex := regexp.MustCompile("(kubelet-\\w+)")
+	regex := regexp.MustCompile(`(kubelet-\w+)`)
 	matches := regex.FindStringSubmatch(string(stdout))
 	gomega.Expect(matches).ToNot(gomega.BeEmpty(), "Found more than one kubelet service running: %q", stdout)
 	kubeletServiceName := matches[0]


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None