### PR TITLE
kube-proxy avoid race condition using LocalModeNodeCIDR

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -522,6 +522,8 @@ type ProxyServer struct {
 	Hostname      string
 	NodeIP        net.IP
 
+	podCIDRs []string // only used for LocalModeNodeCIDR
+
 	Proxier proxy.Provider
 }
 
@@ -754,7 +756,7 @@ func (s *ProxyServer) Run() error {
 	nodeConfig := config.NewNodeConfig(currentNodeInformerFactory.Core().V1().Nodes(), s.Config.ConfigSyncPeriod.Duration)
 	// https://issues.k8s.io/111321
 	if s.Config.DetectLocalMode == kubeproxyconfig.LocalModeNodeCIDR {
-		nodeConfig.RegisterEventHandler(&proxy.NodePodCIDRHandler{})
+		nodeConfig.RegisterEventHandler(proxy.NewNodePodCIDRHandler(s.podCIDRs))
 	}
 	nodeConfig.RegisterEventHandler(s.Proxier)
 

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -88,6 +88,7 @@ func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguratio
 		if err != nil {
 			return nil, err
 		}
+		s.podCIDRs = nodeInfo.Spec.PodCIDRs
 		klog.InfoS("NodeInfo", "podCIDR", nodeInfo.Spec.PodCIDR, "podCIDRs", nodeInfo.Spec.PodCIDRs)
 	}
 

--- a/pkg/proxy/node.go
+++ b/pkg/proxy/node.go
@@ -33,6 +33,12 @@ type NodePodCIDRHandler struct {
 	podCIDRs []string
 }
 
+func NewNodePodCIDRHandler(podCIDRs []string) *NodePodCIDRHandler {
+	return &NodePodCIDRHandler{
+		podCIDRs: podCIDRs,
+	}
+}
+
 var _ config.NodeHandler = &NodePodCIDRHandler{}
 
 // OnNodeAdd is a handler for Node creates.

--- a/pkg/proxy/node_test.go
+++ b/pkg/proxy/node_test.go
@@ -38,6 +38,11 @@ func TestNodePodCIDRHandlerAdd(t *testing.T) {
 			newNodePodCIDRs: []string{"192.168.1.0/24", "fd00:1:2:3::/64"},
 		},
 		{
+			name:            "already initialized and same node",
+			oldNodePodCIDRs: []string{"10.0.0.0/24", "fd00:3:2:1::/64"},
+			newNodePodCIDRs: []string{"10.0.0.0/24", "fd00:3:2:1::/64"},
+		},
+		{
 			name:            "already initialized and different node",
 			oldNodePodCIDRs: []string{"192.168.1.0/24", "fd00:1:2:3::/64"},
 			newNodePodCIDRs: []string{"10.0.0.0/24", "fd00:3:2:1::/64"},


### PR DESCRIPTION
Since kube-proxy in LocalModeNodeCIDR needs to obtain the PodCIDR assigned to the node it watches for the Node object.

However, kube-proxy startup process requires to have these watches in different places, that opens the possibility of having a race condition if the same node is recreated and a different PodCIDR is assigned.

Initializing the second watch with the value obtained in the first one allows us to detect this situation.
Fixes https://github.com/kubernetes/kubernetes/issues/111321

/kind bug

```release-note
fix a race condition in kube-proxy when using LocalModeNodeCIDR to avoid dropping Services traffic if the object node is recreated when kube-proxy is starting
```
