### PR TITLE
Fix SELinux contexts used in e2e tests

### DIFF
--- a/test/e2e/storage/csi_mock/csi_selinux_mount.go
+++ b/test/e2e/storage/csi_mock/csi_selinux_mount.go
@@ -49,15 +49,15 @@ var _ = utils.SIGDescribe("CSI Mock selinux on mount", func() {
 		// Make sure all options are set so system specific defaults are not used.
 		seLinuxOpts1 := v1.SELinuxOptions{
 			User:  "system_u",
-			Role:  "object_r",
-			Type:  "container_file_t",
+			Role:  "system_r",
+			Type:  "container_t",
 			Level: "s0:c0,c1",
 		}
 		seLinuxMountOption1 := "context=\"system_u:object_r:container_file_t:s0:c0,c1\""
 		seLinuxOpts2 := v1.SELinuxOptions{
 			User:  "system_u",
-			Role:  "object_r",
-			Type:  "container_file_t",
+			Role:  "system_r",
+			Type:  "container_t",
 			Level: "s0:c98,c99",
 		}
 		seLinuxMountOption2 := "context=\"system_u:object_r:container_file_t:s0:c98,c99\""
@@ -267,14 +267,14 @@ var _ = utils.SIGDescribe("CSI Mock selinux on mount metrics", func() {
 		// Make sure all options are set so system specific defaults are not used.
 		seLinuxOpts1 := v1.SELinuxOptions{
 			User:  "system_u",
-			Role:  "object_r",
-			Type:  "container_file_t",
+			Role:  "system_r",
+			Type:  "container_t",
 			Level: "s0:c0,c1",
 		}
 		seLinuxOpts2 := v1.SELinuxOptions{
 			User:  "system_u",
-			Role:  "object_r",
-			Type:  "container_file_t",
+			Role:  "system_r",
+			Type:  "container_t",
 			Level: "s0:c98,c99",
 		}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind failing-test

#### What this PR does / why we need it:
SELinux tests fail on RHEL 9. While the expected label on a file is correct in the tests, `system_u:object_r:container_file_t:s0:c0,c1`, a container must run as `system_u:system_r:container_t:s0:c0,c1`, otherwise CRI-O / SELinux denies creating such a container.

containerd + RHEL8 does not mind container with object_r, all tests pass there: https://testgrid.k8s.io/google-aws#kops-aws-selinux

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
