### PR TITLE
Implement Alpha state for KEP #2340

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -208,6 +208,13 @@ const (
 	//
 	// Allow the API server to stream individual items instead of chunking
 	WatchList featuregate.Feature = "WatchList"
+
+	// owner: @serathius
+	// kep: http://kep.k8s.io/2340
+	// alpha: v1.28
+	//
+	// Allow the API server to serve consistent lists from cache
+	ConsistentListFromCache featuregate.Feature = "ConsistentListFromCache"
 )
 
 func init() {
@@ -264,4 +271,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	InPlacePodVerticalScaling: {Default: false, PreRelease: featuregate.Alpha},
 
 	WatchList: {Default: false, PreRelease: featuregate.Alpha},
+
+	ConsistentListFromCache: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -31,9 +31,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/apis/example"
 	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
+	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/clock"
 )
 
@@ -145,6 +148,13 @@ func TestPreconditionalDeleteWithSuggestion(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
+	ctx, cacher, server, terminate := testSetupWithEtcdServer(t)
+	t.Cleanup(terminate)
+	storagetesting.RunTestList(ctx, t, cacher, compactStorage(cacher, server.V3Client), true)
+}
+
+func TestListWithListFromCache(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConsistentListFromCache, true)()
 	ctx, cacher, server, terminate := testSetupWithEtcdServer(t)
 	t.Cleanup(terminate)
 	storagetesting.RunTestList(ctx, t, cacher, compactStorage(cacher, server.V3Client), true)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -34,8 +34,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/cache"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
 )
@@ -516,6 +519,33 @@ func TestWaitUntilFreshAndList(t *testing.T) {
 	}
 }
 
+func TestWaitUntilFreshAndListFromCache(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConsistentListFromCache, true)()
+	ctx := context.Background()
+	store := newTestWatchCache(3, &cache.Indexers{})
+	defer store.Stop()
+	// In background, update the store.
+	go func() {
+		store.Add(makeTestPod("pod1", 2))
+		store.bookmarkRevision <- 3
+	}()
+
+	// list from future revision. Requires watch cache to request bookmark to get it.
+	list, resourceVersion, indexUsed, err := store.WaitUntilFreshAndList(ctx, 3, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resourceVersion != 3 {
+		t.Errorf("unexpected resourceVersion: %v, expected: 6", resourceVersion)
+	}
+	if len(list) != 1 {
+		t.Errorf("unexpected list returned: %#v", list)
+	}
+	if indexUsed != "" {
+		t.Errorf("Used index %q but expected none to be used", indexUsed)
+	}
+}
+
 func TestWaitUntilFreshAndGet(t *testing.T) {
 	ctx := context.Background()
 	store := newTestWatchCache(3, &cache.Indexers{})
@@ -544,31 +574,51 @@ func TestWaitUntilFreshAndGet(t *testing.T) {
 }
 
 func TestWaitUntilFreshAndListTimeout(t *testing.T) {
-	ctx := context.Background()
-	store := newTestWatchCache(3, &cache.Indexers{})
-	defer store.Stop()
-	fc := store.clock.(*testingclock.FakeClock)
-
-	// In background, step clock after the below call starts the timer.
-	go func() {
-		for !fc.HasWaiters() {
-			time.Sleep(time.Millisecond)
-		}
-		fc.Step(blockTimeout)
-
-		// Add an object to make sure the test would
-		// eventually fail instead of just waiting
-		// forever.
-		time.Sleep(30 * time.Second)
-		store.Add(makeTestPod("bar", 5))
-	}()
-
-	_, _, _, err := store.WaitUntilFreshAndList(ctx, 5, nil)
-	if !errors.IsTimeout(err) {
-		t.Errorf("expected timeout error but got: %v", err)
+	tcs := []struct {
+		name                    string
+		ConsistentListFromCache bool
+	}{
+		{
+			name:                    "FromStorage",
+			ConsistentListFromCache: false,
+		},
+		{
+			name:                    "FromCache",
+			ConsistentListFromCache: true,
+		},
 	}
-	if !storage.IsTooLargeResourceVersion(err) {
-		t.Errorf("expected 'Too large resource version' cause in error but got: %v", err)
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConsistentListFromCache, tc.ConsistentListFromCache)()
+			ctx := context.Background()
+			store := newTestWatchCache(3, &cache.Indexers{})
+			defer store.Stop()
+			fc := store.clock.(*testingclock.FakeClock)
+
+			// In background, step clock after the below call starts the timer.
+			go func() {
+				for !fc.HasWaiters() {
+					time.Sleep(time.Millisecond)
+				}
+				store.Add(makeTestPod("foo", 2))
+				store.bookmarkRevision <- 3
+				fc.Step(blockTimeout)
+
+				// Add an object to make sure the test would
+				// eventually fail instead of just waiting
+				// forever.
+				time.Sleep(30 * time.Second)
+				store.Add(makeTestPod("bar", 4))
+			}()
+
+			_, _, _, err := store.WaitUntilFreshAndList(ctx, 4, nil)
+			if !errors.IsTimeout(err) {
+				t.Errorf("expected timeout error but got: %v", err)
+			}
+			if !storage.IsTooLargeResourceVersion(err) {
+				t.Errorf("expected 'Too large resource version' cause in error but got: %v", err)
+			}
+		})
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
@@ -149,9 +149,10 @@ func shouldListFromStorage(query url.Values, opts *metav1.ListOptions) bool {
 	resourceVersion := opts.ResourceVersion
 	match := opts.ResourceVersionMatch
 	pagingEnabled := utilfeature.DefaultFeatureGate.Enabled(features.APIListChunking)
+	consistentListFromCacheEnabled := utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache)
 
-	// Serve consistent reads from storage
-	consistentReadFromStorage := resourceVersion == ""
+	// Serve consistent reads from storage if ConsistentListFromCache is disabled
+	consistentReadFromStorage := resourceVersion == "" && !consistentListFromCacheEnabled
 	// Watch cache doesn't support continuations, so serve them from etcd.
 	hasContinuation := pagingEnabled && len(opts.Continue) > 0
 	// Serve paginated requests about revision "0" from watch cache to avoid overwhelming etcd.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Implements https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2340-Consistent-reads-from-cache

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Add ConsistentListFromCache feature gate that allows apiserver to serve consistent lists from cache
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Please use the following format for linking documentation:
- https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2340-Consistent-reads-from-cache