### PR TITLE
Automated cherry pick of #118515: kube-proxy avoid race condition using LocalModeNodeCIDR

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -554,6 +554,7 @@ type ProxyServer struct {
 	ConfigSyncPeriod       time.Duration
 	HealthzServer          healthcheck.ProxierHealthUpdater
 	localDetectorMode      kubeproxyconfig.LocalMode
+	podCIDRs               []string // only used for LocalModeNodeCIDR
 }
 
 // createClients creates a kube client and an event client from the given config and masterOverride.
@@ -779,7 +780,7 @@ func (s *ProxyServer) Run() error {
 	nodeConfig := config.NewNodeConfig(currentNodeInformerFactory.Core().V1().Nodes(), s.ConfigSyncPeriod)
 	// https://issues.k8s.io/111321
 	if s.localDetectorMode == kubeproxyconfig.LocalModeNodeCIDR {
-		nodeConfig.RegisterEventHandler(&proxy.NodePodCIDRHandler{})
+		nodeConfig.RegisterEventHandler(proxy.NewNodePodCIDRHandler(s.podCIDRs))
 	}
 	nodeConfig.RegisterEventHandler(s.Proxier)
 

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -163,12 +163,14 @@ func newProxyServer(
 	}
 
 	var nodeInfo *v1.Node
+	podCIDRs := []string{}
 	if detectLocalMode == proxyconfigapi.LocalModeNodeCIDR {
 		klog.InfoS("Watching for node, awaiting podCIDR allocation", "hostname", hostname)
 		nodeInfo, err = waitForPodCIDR(client, hostname)
 		if err != nil {
 			return nil, err
 		}
+		podCIDRs = nodeInfo.Spec.PodCIDRs
 		klog.InfoS("NodeInfo", "PodCIDR", nodeInfo.Spec.PodCIDR, "PodCIDRs", nodeInfo.Spec.PodCIDRs)
 	}
 
@@ -388,6 +390,7 @@ func newProxyServer(
 		HealthzServer:          healthzServer,
 		UseEndpointSlices:      useEndpointSlices,
 		localDetectorMode:      detectLocalMode,
+		podCIDRs:               podCIDRs,
 	}, nil
 }
 

--- a/pkg/proxy/node.go
+++ b/pkg/proxy/node.go
@@ -33,6 +33,12 @@ type NodePodCIDRHandler struct {
 	podCIDRs []string
 }
 
+func NewNodePodCIDRHandler(podCIDRs []string) *NodePodCIDRHandler {
+	return &NodePodCIDRHandler{
+		podCIDRs: podCIDRs,
+	}
+}
+
 var _ config.NodeHandler = &NodePodCIDRHandler{}
 
 // OnNodeAdd is a handler for Node creates.

--- a/pkg/proxy/node_test.go
+++ b/pkg/proxy/node_test.go
@@ -38,6 +38,11 @@ func TestNodePodCIDRHandlerAdd(t *testing.T) {
 			newNodePodCIDRs: []string{"192.168.1.0/24", "fd00:1:2:3::/64"},
 		},
 		{
+			name:            "already initialized and same node",
+			oldNodePodCIDRs: []string{"10.0.0.0/24", "fd00:3:2:1::/64"},
+			newNodePodCIDRs: []string{"10.0.0.0/24", "fd00:3:2:1::/64"},
+		},
+		{
 			name:            "already initialized and different node",
 			oldNodePodCIDRs: []string{"192.168.1.0/24", "fd00:1:2:3::/64"},
 			newNodePodCIDRs: []string{"10.0.0.0/24", "fd00:3:2:1::/64"},


### PR DESCRIPTION
Cherry pick of #118515 on release-1.25.

#118515: kube-proxy avoid race condition using LocalModeNodeCIDR

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```