### PR TITLE
Add merge map key validation to StorageVersions

### DIFF
--- a/pkg/apis/apiserverinternal/validation/validation.go
+++ b/pkg/apis/apiserverinternal/validation/validation.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/apiserverinternal"
@@ -67,7 +68,13 @@ func ValidateStorageVersionStatusUpdate(sv, oldSV *apiserverinternal.StorageVers
 
 func validateStorageVersionStatus(ss apiserverinternal.StorageVersionStatus, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
+	allAPIServerIDs := sets.New[string]()
 	for i, ssv := range ss.StorageVersions {
+		if allAPIServerIDs.Has(ssv.APIServerID) {
+			allErrs = append(allErrs, field.Duplicate(fldPath.Child("storageVersions").Index(i).Child("apiServerID"), ssv.APIServerID))
+		} else {
+			allAPIServerIDs.Insert(ssv.APIServerID)
+		}
 		allErrs = append(allErrs, validateServerStorageVersion(ssv, fldPath.Child("storageVersions").Index(i))...)
 	}
 	if err := validateCommonVersion(ss, fldPath); err != nil {

--- a/pkg/apis/apiserverinternal/validation/validation_test.go
+++ b/pkg/apis/apiserverinternal/validation/validation_test.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/apiserverinternal"
+	"k8s.io/utils/pointer"
 )
 
 func TestValidateServerStorageVersion(t *testing.T) {
@@ -109,6 +110,59 @@ func TestValidateServerStorageVersion(t *testing.T) {
 
 	for _, tc := range cases {
 		err := validateServerStorageVersion(tc.ssv, field.NewPath("")).ToAggregate()
+		if err == nil && len(tc.expectedErr) == 0 {
+			continue
+		}
+		if err != nil && len(tc.expectedErr) == 0 {
+			t.Errorf("unexpected error %v", err)
+			continue
+		}
+		if err == nil && len(tc.expectedErr) != 0 {
+			t.Errorf("unexpected empty error")
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.expectedErr) {
+			t.Errorf("expected error to contain %s, got %s", tc.expectedErr, err)
+		}
+	}
+}
+
+func TestValidateStorageVersionStatus(t *testing.T) {
+	cases := []struct {
+		svs         apiserverinternal.StorageVersionStatus
+		expectedErr string
+	}{{
+		svs: apiserverinternal.StorageVersionStatus{
+			StorageVersions: []apiserverinternal.ServerStorageVersion{{
+				APIServerID:       "1",
+				EncodingVersion:   "v1alpha1",
+				DecodableVersions: []string{"v1alpha1", "v1"},
+			}, {
+				APIServerID:       "2",
+				EncodingVersion:   "v1alpha1",
+				DecodableVersions: []string{"v1alpha1", "v1"},
+			}},
+			CommonEncodingVersion: pointer.String("v1alpha1"),
+		},
+		expectedErr: "",
+	}, {
+		svs: apiserverinternal.StorageVersionStatus{
+			StorageVersions: []apiserverinternal.ServerStorageVersion{{
+				APIServerID:       "1",
+				EncodingVersion:   "v1alpha1",
+				DecodableVersions: []string{"v1alpha1", "v1"},
+			}, {
+				APIServerID:       "1",
+				EncodingVersion:   "v1beta1",
+				DecodableVersions: []string{"v1alpha1", "v1"},
+			}},
+			CommonEncodingVersion: pointer.String("v1alpha1"),
+		},
+		expectedErr: "storageVersions[1].apiServerID: Duplicate value: \"1\"",
+	}}
+
+	for _, tc := range cases {
+		err := validateStorageVersionStatus(tc.svs, field.NewPath("")).ToAggregate()
 		if err == nil && len(tc.expectedErr) == 0 {
 			continue
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Discovered by https://github.com/kubernetes-sigs/structured-merge-diff/issues/234

apiserverinternal.StorageVersion's Status.StorageVersions list is marked with [`listMapKey=apiServerID`](https://github.com/kubernetes/kubernetes/blob/5a5ebfd88b2899f2116dc858100832f30ac33cf3/staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go#L50), but is missing the corresponding validation to ensure the map key is unique.

Because this is an Alpha API and for a status field of an internal API type, this PR simply adds the validation.

```release-note
NONE
```
