### PR TITLE
Record failed plugins in Reserver Plugin

### DIFF
--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -1265,6 +1265,11 @@ func (f *frameworkImpl) RunReservePluginsReserve(ctx context.Context, state *fra
 		ctx := klog.NewContext(ctx, logger)
 		status = f.runReservePluginReserve(ctx, pl, state, pod, nodeName)
 		if !status.IsSuccess() {
+			if status.IsUnschedulable() {
+				logger.V(4).Info("Pod rejected by plugin", "pod", klog.KObj(pod), "plugin", pl.Name(), "status", status.Message())
+				status.SetFailedPlugin(pl.Name())
+				return status
+			}
 			err := status.AsError()
 			logger.Error(err, "Plugin failed", "plugin", pl.Name(), "pod", klog.KObj(pod))
 			return framework.AsStatus(fmt.Errorf("running Reserve plugin %q: %w", pl.Name(), err))

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -2422,7 +2422,7 @@ func TestReservePlugins(t *testing.T) {
 					inj:  injectedResult{ReserveStatus: int(framework.Unschedulable)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(`running Reserve plugin "TestPlugin": %w`, errInjectedStatus)),
+			wantStatus: framework.NewStatus(framework.Unschedulable, injectReason).WithFailedPlugin("TestPlugin"),
 		},
 		{
 			name: "ErrorReservePlugin",
@@ -2442,7 +2442,7 @@ func TestReservePlugins(t *testing.T) {
 					inj:  injectedResult{ReserveStatus: int(framework.UnschedulableAndUnresolvable)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(`running Reserve plugin "TestPlugin": %w`, errInjectedStatus)),
+			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, injectReason).WithFailedPlugin("TestPlugin"),
 		},
 		{
 			name: "SuccessSuccessReservePlugins",
@@ -2512,7 +2512,7 @@ func TestReservePlugins(t *testing.T) {
 					inj:  injectedResult{ReserveStatus: int(framework.Success)},
 				},
 			},
-			wantStatus: framework.AsStatus(fmt.Errorf(`running Reserve plugin "TestPlugin": %w`, errInjectedStatus)),
+			wantStatus: framework.NewStatus(framework.Unschedulable, injectReason).WithFailedPlugin("TestPlugin"),
 		},
 	}
 

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -1458,6 +1458,17 @@ func TestFitError_Error(t *testing.T) {
 			},
 			wantReasonMsg: "0/1 nodes are available: 1 Node failed Permit plugin Permit-1.",
 		},
+		{
+			name:        "failed to Reserve on node",
+			numAllNodes: 1,
+			diagnosis: Diagnosis{
+				NodeToStatusMap: NodeToStatusMap{
+					// There should be only one node here.
+					"node1": NewStatus(Unschedulable, "Node failed Reserve plugin Reserve-1"),
+				},
+			},
+			wantReasonMsg: "0/1 nodes are available: 1 Node failed Reserve plugin Reserve-1.",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -195,6 +195,17 @@ func (sched *Scheduler) schedulingCycle(
 			logger.Error(forgetErr, "Scheduler cache ForgetPod failed")
 		}
 
+		if sts.IsUnschedulable() {
+			fitErr := &framework.FitError{
+				NumAllNodes: 1,
+				Pod:         pod,
+				Diagnosis: framework.Diagnosis{
+					NodeToStatusMap:      framework.NodeToStatusMap{scheduleResult.SuggestedHost: sts},
+					UnschedulablePlugins: sets.New(sts.FailedPlugin()),
+				},
+			}
+			return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, framework.NewStatus(sts.Code()).WithError(fitErr)
+		}
 		return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, sts
 	}
 

--- a/test/integration/scheduler/rescheduling_test.go
+++ b/test/integration/scheduler/rescheduling_test.go
@@ -31,6 +31,50 @@ import (
 
 var _ framework.PermitPlugin = &PermitPlugin{}
 var _ framework.EnqueueExtensions = &PermitPlugin{}
+var _ framework.ReservePlugin = &ReservePlugin{}
+var _ framework.EnqueueExtensions = &ReservePlugin{}
+
+type ReservePlugin struct {
+	name               string
+	statusCode         framework.Code
+	numReserveCalled   int
+	numUnreserveCalled int
+}
+
+func (rp *ReservePlugin) Name() string {
+	return rp.name
+}
+
+func (rp *ReservePlugin) Reserve(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) *framework.Status {
+	rp.numReserveCalled += 1
+
+	if rp.statusCode == framework.Error {
+		return framework.NewStatus(framework.Error, "failed to reserve")
+	}
+
+	if rp.statusCode == framework.Unschedulable {
+		if rp.numReserveCalled <= 1 {
+			return framework.NewStatus(framework.Unschedulable, "reject to reserve")
+		}
+	}
+
+	return nil
+}
+
+func (rp *ReservePlugin) Unreserve(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) {
+	rp.numUnreserveCalled += 1
+}
+
+func (rp *ReservePlugin) EventsToRegister() []framework.ClusterEventWithHint {
+	return []framework.ClusterEventWithHint{
+		{
+			Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add},
+			QueueingHintFn: func(pod *v1.Pod, oldObj, newObj interface{}) framework.QueueingHint {
+				return framework.QueueImmediately
+			},
+		},
+	}
+}
 
 type PermitPlugin struct {
 	name            string
@@ -110,6 +154,41 @@ func TestReScheduling(t *testing.T) {
 			name: "Rescheduling pod failed by Permit Plugin",
 			plugins: []framework.Plugin{
 				&PermitPlugin{name: "permit", statusCode: framework.Error},
+			},
+			action: func() error {
+				_, err := createNode(testContext.ClientSet, st.MakeNode().Name("fake-node").Obj())
+				return err
+			},
+			wantFirstSchedulingError: true,
+			wantError:                true,
+		},
+		{
+			name: "Rescheduling pod rejected by Reserve Plugin",
+			plugins: []framework.Plugin{
+				&ReservePlugin{name: "reserve", statusCode: framework.Unschedulable},
+			},
+			action: func() error {
+				_, err := createNode(testContext.ClientSet, st.MakeNode().Name("fake-node").Obj())
+				return err
+			},
+			wantScheduled: true,
+		},
+		{
+			name: "Rescheduling pod rejected by Reserve Plugin with unrelated event",
+			plugins: []framework.Plugin{
+				&ReservePlugin{name: "reserve", statusCode: framework.Unschedulable},
+			},
+			action: func() error {
+				_, err := createPausePod(testContext.ClientSet,
+					initPausePod(&testutils.PausePodConfig{Name: "test-pod-2", Namespace: testContext.NS.Name}))
+				return err
+			},
+			wantScheduled: false,
+		},
+		{
+			name: "Rescheduling pod failed by Reserve Plugin",
+			plugins: []framework.Plugin{
+				&ReservePlugin{name: "reserve", statusCode: framework.Error},
 			},
 			action: func() error {
 				_, err := createNode(testContext.ClientSet, st.MakeNode().Name("fake-node").Obj())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/sig scheduling

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

It's still useful to record failed plugins when running reserve plugins, e.g. in DRA plugin, when resource driver hasn't allocated the resource(inside `Reserve()`  function) yet, it will return unschedulable status.
https://github.com/kubernetes/kubernetes/blob/4c40d749006a8895f6718f2b624a3dbe975988ab/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go#L673-L691

Then when watching node update events for rescheduling, it will be more efficient by recording the unschedulable plugins, or we'll move pods to active or backoff queue anyway.

https://github.com/kubernetes/kubernetes/blob/4c40d749006a8895f6718f2b624a3dbe975988ab/pkg/scheduler/internal/queue/scheduling_queue.go#L771-L780


cc @Huang-Wei @pohly 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
