### PR TITLE
fix Cronjob status.lastSuccessfulTime not populated by a manually triggered job

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
@@ -261,17 +261,10 @@ func (o *CreateJobOptions) createJobFromCronJob(cronJob *batchv1.CronJob) *batch
 		// this is ok because we know exactly how we want to be serialized
 		TypeMeta: metav1.TypeMeta{APIVersion: batchv1.SchemeGroupVersion.String(), Kind: "Job"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        o.Name,
-			Annotations: annotations,
-			Labels:      cronJob.Spec.JobTemplate.Labels,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: batchv1.SchemeGroupVersion.String(),
-					Kind:       "CronJob",
-					Name:       cronJob.GetName(),
-					UID:        cronJob.GetUID(),
-				},
-			},
+			Name:            o.Name,
+			Annotations:     annotations,
+			Labels:          cronJob.Spec.JobTemplate.Labels,
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(cronJob, batchv1.SchemeGroupVersion.WithKind("CronJob"))},
 		},
 		Spec: cronJob.Spec.JobTemplate.Spec,
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
@@ -161,16 +161,9 @@ func TestCreateJobFromCronJob(t *testing.T) {
 			expected: &batchv1.Job{
 				TypeMeta: metav1.TypeMeta{APIVersion: batchv1.SchemeGroupVersion.String(), Kind: "Job"},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        jobName,
-					Annotations: map[string]string{"cronjob.kubernetes.io/instantiate": "manual"},
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion: batchv1.SchemeGroupVersion.String(),
-							Kind:       "CronJob",
-							Name:       cronJob.GetName(),
-							UID:        cronJob.GetUID(),
-						},
-					},
+					Name:            jobName,
+					Annotations:     map[string]string{"cronjob.kubernetes.io/instantiate": "manual"},
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(cronJob, batchv1.SchemeGroupVersion.WithKind("CronJob"))},
 				},
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

```
// cronjob status when job fail 

(⎈|kind-kind:default)➜  ~ kubectl get cronjob -o jsonpath='{.items[*].status}' | jq
{
  "lastScheduleTime": "2023-06-07T15:27:00Z",
  "lastSuccessfulTime": "2023-06-07T15:25:07Z"
}

// cronjob status when a manually triggered job complete before next scheduled time is reach

(⎈|kind-kind:default)➜  ~ kubectl get cronjob -o jsonpath='{.items[*].status}' | jq
{
  "lastScheduleTime": "2023-06-07T15:27:00Z",
  "lastSuccessfulTime": "2023-06-07T15:27:39Z"
}
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #118276 

#### Special notes for your reviewer:

https://github.com/kubernetes/kubernetes/blob/8d78d5e19cc80c860faa7cb32e31e9cb0a31e9e5/pkg/controller/cronjob/cronjob_controllerv2.go#L252-L270


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix Cronjob status.lastSuccessfulTime not populated by a manually triggered job
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
