### PR TITLE
Add hostIP to merge key for containers and ephemeralContainer ports

### DIFF
--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -1143,7 +1143,8 @@
             "type": "array",
             "x-kubernetes-list-map-keys": [
               "containerPort",
-              "protocol"
+              "protocol",
+              "hostIP"
             ],
             "x-kubernetes-list-type": "map",
             "x-kubernetes-patch-merge-key": "containerPort",
@@ -1993,7 +1994,8 @@
             "type": "array",
             "x-kubernetes-list-map-keys": [
               "containerPort",
-              "protocol"
+              "protocol",
+              "hostIP"
             ],
             "x-kubernetes-list-type": "map",
             "x-kubernetes-patch-merge-key": "containerPort",

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -1766,7 +1766,8 @@
             "type": "array",
             "x-kubernetes-list-map-keys": [
               "containerPort",
-              "protocol"
+              "protocol",
+              "hostIP"
             ],
             "x-kubernetes-list-type": "map",
             "x-kubernetes-patch-merge-key": "containerPort",
@@ -2200,7 +2201,8 @@
             "type": "array",
             "x-kubernetes-list-map-keys": [
               "containerPort",
-              "protocol"
+              "protocol",
+              "hostIP"
             ],
             "x-kubernetes-list-type": "map",
             "x-kubernetes-patch-merge-key": "containerPort",

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -1057,7 +1057,8 @@
             "type": "array",
             "x-kubernetes-list-map-keys": [
               "containerPort",
-              "protocol"
+              "protocol",
+              "hostIP"
             ],
             "x-kubernetes-list-type": "map",
             "x-kubernetes-patch-merge-key": "containerPort",
@@ -1491,7 +1492,8 @@
             "type": "array",
             "x-kubernetes-list-map-keys": [
               "containerPort",
-              "protocol"
+              "protocol",
+              "hostIP"
             ],
             "x-kubernetes-list-type": "map",
             "x-kubernetes-patch-merge-key": "containerPort",

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -17629,6 +17629,7 @@ func schema_k8sio_api_core_v1_Container(ref common.ReferenceCallback) common.Ope
 								"x-kubernetes-list-map-keys": []interface{}{
 									"containerPort",
 									"protocol",
+									"hostIP",
 								},
 								"x-kubernetes-list-type":       "map",
 								"x-kubernetes-patch-merge-key": "containerPort",
@@ -18790,6 +18791,7 @@ func schema_k8sio_api_core_v1_EphemeralContainer(ref common.ReferenceCallback) c
 								"x-kubernetes-list-map-keys": []interface{}{
 									"containerPort",
 									"protocol",
+									"hostIP",
 								},
 								"x-kubernetes-list-type":       "map",
 								"x-kubernetes-patch-merge-key": "containerPort",
@@ -19064,6 +19066,7 @@ func schema_k8sio_api_core_v1_EphemeralContainerCommon(ref common.ReferenceCallb
 								"x-kubernetes-list-map-keys": []interface{}{
 									"containerPort",
 									"protocol",
+									"hostIP",
 								},
 								"x-kubernetes-list-type":       "map",
 								"x-kubernetes-patch-merge-key": "containerPort",

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -699,6 +699,7 @@ message Container {
   // +listType=map
   // +listMapKey=containerPort
   // +listMapKey=protocol
+  // +listMapKey=hostIP
   repeated ContainerPort ports = 6;
 
   // List of sources to populate environment variables in the container.
@@ -1357,6 +1358,7 @@ message EphemeralContainerCommon {
   // +listType=map
   // +listMapKey=containerPort
   // +listMapKey=protocol
+  // +listMapKey=hostIP
   repeated ContainerPort ports = 6;
 
   // List of sources to populate environment variables in the container.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2421,6 +2421,7 @@ type Container struct {
 	// +listType=map
 	// +listMapKey=containerPort
 	// +listMapKey=protocol
+	// +listMapKey=hostIP
 	Ports []ContainerPort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"containerPort" protobuf:"bytes,6,rep,name=ports"`
 	// List of sources to populate environment variables in the container.
 	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys
@@ -3952,6 +3953,7 @@ type EphemeralContainerCommon struct {
 	// +listType=map
 	// +listMapKey=containerPort
 	// +listMapKey=protocol
+	// +listMapKey=hostIP
 	Ports []ContainerPort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"containerPort" protobuf:"bytes,6,rep,name=ports"`
 	// List of sources to populate environment variables in the container.
 	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -4293,6 +4293,7 @@ var schemaYAML = typed.YAMLObject(`types:
           keys:
           - containerPort
           - protocol
+          - hostIP
     - name: readinessProbe
       type:
         namedType: io.k8s.api.core.v1.Probe
@@ -4710,6 +4711,7 @@ var schemaYAML = typed.YAMLObject(`types:
           keys:
           - containerPort
           - protocol
+          - hostIP
     - name: readinessProbe
       type:
         namedType: io.k8s.api.core.v1.Probe


### PR DESCRIPTION
#### What type of PR is this?

Add hostIP to merge keys for server side apply operations involving container or ephemeralContainer ports to align merge keys with [validation](https://github.com/kubernetes/kubernetes/blob/5a5ebfd88b2899f2116dc858100832f30ac33cf3/pkg/apis/core/validation/validation.go#L2908-L2913).

/kind bug

#### Special notes for your reviewer:

| Field | validation | old merge keys | new merge keys |
| ------  | --------------- | ---------------------- | ----------------------- |
| Container.Ports                                      | name (if present) & {hostPort, protocol, hostIP} | containerPort, protocol | hostPort, protocol, hostIP |
| EphemeralContainerCommon.Ports | name (if present) & {hostPort, protocol, hostIP} | containerPort, protocol | hostPort, protocol, hostIP |
| ServiceSpec.Ports                                  | name (name is required if multiple ports exist)  | port, protocol | name |

InitContainers already has `hostIP` correctly included in the set of merge keys and does not need to be updated.

The re-keying of a type requires special review for all the possible skew cases.

#### Does this PR introduce a user-facing change?

```release-note
Fix handling of server side apply operations involving container or ephemeralContainer ports with identical port number and protocol to succeed so long as hostIP differs.
```

/sig api-machinery