### PR TITLE
bump distroless-iptables to v0.2.5

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -96,7 +96,7 @@ readonly KUBE_RSYNC_PORT="${KUBE_RSYNC_PORT:-}"
 readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_distroless_iptables_version=v0.2.4
+readonly __default_distroless_iptables_version=v0.2.5
 readonly __default_go_runner_version=v2.3.1-go1.20.5-bullseye.0
 readonly __default_setcap_version=bullseye-v1.4.2
 

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -139,7 +139,7 @@ dependencies:
       match: BASE_IMAGE_VERSION\?=
 
   - name: "registry.k8s.io/distroless-iptables: dependents"
-    version: v0.2.4
+    version: v0.2.5
     refPaths:
     - path: build/common.sh
       match: __default_distroless_iptables_version=

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -241,7 +241,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.29-4"}
 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.3"}
-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.2.4"}
+	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.2.5"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.9-0"}
 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}
 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-4"}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

* Updates distoless-iptables to use the new released image `registry.k8s.io/build-image/distroless-iptables:v0.2.5` which uses Go 1.20.5

#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes/release/issues/3099

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Updated distroless I-tables to use registry.k8s.io/build-image/distroless-iptables:v0.2.5
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @saschagrunert @cpanato @dims 
/cc @kubernetes/release-engineering 