### PR TITLE
fix 'pod' in kubelet prober metrics

### DIFF
--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -18,9 +18,7 @@ package prober
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
-	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -28,7 +26,6 @@ import (
 	"k8s.io/component-base/metrics"
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
-	"k8s.io/kubernetes/pkg/apis/apps"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
 )
@@ -115,12 +112,10 @@ func newWorker(
 		w.initialValue = results.Unknown
 	}
 
-	podName := getPodLabelName(w.pod)
-
 	basicMetricLabels := metrics.Labels{
 		"probe_type": w.probeType.String(),
 		"container":  w.container.Name,
-		"pod":        podName,
+		"pod":        w.pod.Name,
 		"namespace":  w.pod.Namespace,
 		"pod_uid":    string(w.pod.UID),
 	}
@@ -128,7 +123,7 @@ func newWorker(
 	proberDurationLabels := metrics.Labels{
 		"probe_type": w.probeType.String(),
 		"container":  w.container.Name,
-		"pod":        podName,
+		"pod":        w.pod.Name,
 		"namespace":  w.pod.Namespace,
 	}
 
@@ -336,16 +331,4 @@ func deepCopyPrometheusLabels(m metrics.Labels) metrics.Labels {
 		ret[k] = v
 	}
 	return ret
-}
-
-func getPodLabelName(pod *v1.Pod) string {
-	podName := pod.Name
-	if pod.GenerateName != "" {
-		podNameSlice := strings.Split(pod.Name, "-")
-		podName = strings.Join(podNameSlice[:len(podNameSlice)-1], "-")
-		if label, ok := pod.GetLabels()[apps.DefaultDeploymentUniqueLabelKey]; ok {
-			podName = strings.ReplaceAll(podName, fmt.Sprintf("-%s", label), "")
-		}
-	}
-	return podName
 }

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/kubernetes/pkg/apis/apps"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/pkg/kubelet/status"
@@ -492,51 +491,4 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 	msg = "Started, probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
-}
-
-func TestGetPodLabelName(t *testing.T) {
-	testCases := []struct {
-		name   string
-		pod    *v1.Pod
-		result string
-	}{
-		{
-			name: "Static pod",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "kube-controller-manager-k8s-master-21385161-0",
-				},
-			},
-			result: "kube-controller-manager-k8s-master-21385161-0",
-		},
-		{
-			name: "Deployment pod",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:         "coredns-845757d86-ccqpf",
-					GenerateName: "coredns-845757d86-",
-					Labels: map[string]string{
-						apps.DefaultDeploymentUniqueLabelKey: "845757d86",
-					},
-				},
-			},
-			result: "coredns",
-		},
-		{
-			name: "ReplicaSet pod",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:         "kube-proxy-2gmqn",
-					GenerateName: "kube-proxy-",
-				},
-			},
-			result: "kube-proxy",
-		},
-	}
-	for _, test := range testCases {
-		ret := getPodLabelName(test.pod)
-		if ret != test.result {
-			t.Errorf("Expected %s, got %s", test.result, ret)
-		}
-	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind regression
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #115766

#### Special notes for your reviewer:

Kubernetes 1.25 Metric:
```
prober_probe_total{container="app-nginx",namespace="app",
pod="app-nginx",pod_uid="2de634c5-963f-4ffb-9b15-700f3f9b8bf3",
probe_type="Readiness",result="successful"
} 794
```

Kubernetes 1.24 Metric:
```
prober_probe_total{container="app-nginx",namespace="app",
pod="app-nginx-799b74869b-mmhr7",pod_uid="4550420b-6a0c-4d59-a486-f5b3a69ebdf8",
probe_type="Readiness",result="successful"
} 81023
```

This breaking change causes the metrics to not get processed by [datadog core](https://github.com/DataDog/integrations-core/blob/22899496fd0908344f1db0920d55554645b85578/kubelet/datadog_checks/kubelet/probes.py#L94) which relies on actual pod name.

#### Does this PR introduce a user-facing change?
Yes, but it reverts to initial functionality.
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a 1.25 regression to revert kubelet prober metrics `pod` tag to include actual pod name
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @jackfrancis  @SergeyKanzhelev from discussion [here](https://github.com/kubernetes/kubernetes/issues/115766#issuecomment-1446747588)