### PR TITLE
deprecate RBD plugin from available in-tree drivers

### DIFF
--- a/pkg/api/persistentvolume/util.go
+++ b/pkg/api/persistentvolume/util.go
@@ -81,16 +81,16 @@ func warningsForPersistentVolumeSpecAndMeta(fieldPath *field.Path, pvSpec *api.P
 	}
 	// If we are on deprecated volume plugin
 	if pvSpec.CephFS != nil {
-		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.28, non-functional in v1.31+", fieldPath.Child("spec", "persistentVolumeSource").Child("cephfs")))
+		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.28, non-functional in v1.31+", fieldPath.Child("spec", "cephfs")))
 	}
 	if pvSpec.PhotonPersistentDisk != nil {
-		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.11, non-functional in v1.16+", fieldPath.Child("spec", "persistentVolumeSource").Child("photonPersistentDisk")))
+		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.11, non-functional in v1.16+", fieldPath.Child("spec", "photonPersistentDisk")))
 	}
 	if pvSpec.ScaleIO != nil {
-		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.16, non-functional in v1.22+", fieldPath.Child("spec", "persistentVolumeSource").Child("scaleIO")))
+		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.16, non-functional in v1.22+", fieldPath.Child("spec", "scaleIO")))
 	}
 	if pvSpec.StorageOS != nil {
-		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.22, non-functional in v1.25+", fieldPath.Child("spec", "persistentVolumeSource").Child("storageOS")))
+		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.22, non-functional in v1.25+", fieldPath.Child("spec", "storageOS")))
 	}
 	if pvSpec.Glusterfs != nil {
 		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.25, non-functional in v1.26+", fieldPath.Child("spec", "glusterfs")))

--- a/pkg/api/persistentvolume/util.go
+++ b/pkg/api/persistentvolume/util.go
@@ -93,8 +93,10 @@ func warningsForPersistentVolumeSpecAndMeta(fieldPath *field.Path, pvSpec *api.P
 		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.22, non-functional in v1.25+", fieldPath.Child("spec", "persistentVolumeSource").Child("storageOS")))
 	}
 	if pvSpec.Glusterfs != nil {
-		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.25, non-functional in v1.26+", fieldPath.Child("spec", "persistentVolumeSource").Child("glusterfs")))
+		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.25, non-functional in v1.26+", fieldPath.Child("spec", "glusterfs")))
 	}
-
+	if pvSpec.RBD != nil {
+		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.28, non-functional in v1.31+", fieldPath.Child("spec", "rbd")))
+	}
 	return warnings
 }

--- a/pkg/api/persistentvolume/util_test.go
+++ b/pkg/api/persistentvolume/util_test.go
@@ -193,7 +193,7 @@ func TestWarnings(t *testing.T) {
 				},
 			},
 			expected: []string{
-				`spec.persistentVolumeSource.cephfs: deprecated in v1.28, non-functional in v1.31+`,
+				`spec.cephfs: deprecated in v1.28, non-functional in v1.31+`,
 			},
 		},
 		{
@@ -209,7 +209,7 @@ func TestWarnings(t *testing.T) {
 				},
 			},
 			expected: []string{
-				`spec.persistentVolumeSource.photonPersistentDisk: deprecated in v1.11, non-functional in v1.16+`,
+				`spec.photonPersistentDisk: deprecated in v1.11, non-functional in v1.16+`,
 			},
 		},
 		{
@@ -254,10 +254,9 @@ func TestWarnings(t *testing.T) {
 				},
 			},
 			expected: []string{
-				`spec.persistentVolumeSource.scaleIO: deprecated in v1.16, non-functional in v1.22+`,
+				`spec.scaleIO: deprecated in v1.16, non-functional in v1.22+`,
 			},
 		},
-
 		{
 			name: "PV StorageOS deprecation warning",
 			template: &api.PersistentVolume{
@@ -274,10 +273,9 @@ func TestWarnings(t *testing.T) {
 				},
 			},
 			expected: []string{
-				`spec.persistentVolumeSource.storageOS: deprecated in v1.22, non-functional in v1.25+`,
+				`spec.storageOS: deprecated in v1.22, non-functional in v1.25+`,
 			},
 		},
-
 		{
 			name: "PV GlusterFS deprecation warning",
 			template: &api.PersistentVolume{
@@ -293,7 +291,7 @@ func TestWarnings(t *testing.T) {
 				},
 			},
 			expected: []string{
-				`spec.persistentVolumeSource.glusterfs: deprecated in v1.25, non-functional in v1.26+`,
+				`spec.glusterfs: deprecated in v1.25, non-functional in v1.26+`,
 			},
 		},
 	}

--- a/pkg/api/persistentvolume/util_test.go
+++ b/pkg/api/persistentvolume/util_test.go
@@ -213,6 +213,27 @@ func TestWarnings(t *testing.T) {
 			},
 		},
 		{
+			name: "PV RBD deprecation warning",
+			template: &api.PersistentVolume{
+				Spec: api.PersistentVolumeSpec{
+					PersistentVolumeSource: api.PersistentVolumeSource{
+						RBD: &api.RBDPersistentVolumeSource{
+							CephMonitors: nil,
+							RBDImage:     "",
+							FSType:       "",
+							RBDPool:      "",
+							RadosUser:    "",
+							Keyring:      "",
+							SecretRef:    nil,
+							ReadOnly:     false,
+						},
+					},
+				},
+			},
+			expected: []string{
+				`spec.rbd: deprecated in v1.28, non-functional in v1.31+`},
+		},
+		{
 			name: "PV ScaleIO deprecation warning",
 			template: &api.PersistentVolume{
 				Spec: api.PersistentVolumeSpec{

--- a/pkg/api/pod/warnings.go
+++ b/pkg/api/pod/warnings.go
@@ -163,6 +163,9 @@ func warningsForPodSpecAndMeta(fieldPath *field.Path, podSpec *api.PodSpec, meta
 		if v.CephFS != nil {
 			warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.28, non-functional in v1.31+", fieldPath.Child("spec", "volumes").Index(i).Child("cephfs")))
 		}
+		if v.RBD != nil {
+			warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.28, non-functional in v1.31+", fieldPath.Child("spec", "volumes").Index(i).Child("rbd")))
+		}
 	}
 
 	// duplicate hostAliases (#91670, #58477)

--- a/pkg/api/pod/warnings_test.go
+++ b/pkg/api/pod/warnings_test.go
@@ -225,6 +225,15 @@ func TestWarnings(t *testing.T) {
 		},
 
 		{
+			name: "rbd",
+			template: &api.PodTemplateSpec{Spec: api.PodSpec{
+				Volumes: []api.Volume{
+					{Name: "s", VolumeSource: api.VolumeSource{RBD: &api.RBDVolumeSource{}}},
+				}},
+			},
+			expected: []string{`spec.volumes[0].rbd: deprecated in v1.28, non-functional in v1.31+`},
+		},
+		{
 			name: "duplicate hostAlias",
 			template: &api.PodTemplateSpec{Spec: api.PodSpec{
 				HostAliases: []api.HostAlias{


### PR DESCRIPTION
Based on
https://groups.google.com/g/kubernetes-sig-storage/c/h5751_B5LQM, the consensus was to start the deprecation in v1.28.

This commit start the deprecation process of RBD plugin from in-tree drivers.


/kind deprecation


```release-note
ACTION REQUIRED:
RBD volume plugin ( `kubernetes.io/rbd`) has been deprecated in this release and will be removed in a subsequent release. Alternative is to use RBD CSI driver (https://github.com/ceph/ceph-csi/) in your Kubernetes Cluster.
```


```docs

```
