### PR TITLE
chore: assigning the result of this type assertion to a variable (swi…

### DIFF
--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -868,9 +868,9 @@ func runMultisyncTests(t *testing.T, ctx context.Context, tests []controllerTest
 			time.Sleep(600 * time.Millisecond)
 
 			// There were some changes, process them
-			switch obj.(type) {
+			switch obj := obj.(type) {
 			case *v1.PersistentVolumeClaim:
-				claim := obj.(*v1.PersistentVolumeClaim)
+				claim := obj
 				// Simulate "claim updated" event
 				ctrl.claims.Update(claim)
 				err = ctrl.syncClaim(context.TODO(), claim)
@@ -887,7 +887,7 @@ func runMultisyncTests(t *testing.T, ctx context.Context, tests []controllerTest
 				// Process generated changes
 				continue
 			case *v1.PersistentVolume:
-				volume := obj.(*v1.PersistentVolume)
+				volume := obj
 				// Simulate "volume updated" event
 				ctrl.volumes.store.Update(volume)
 				err = ctrl.syncVolume(context.TODO(), volume)

--- a/pkg/controller/volume/persistentvolume/testing/testing.go
+++ b/pkg/controller/volume/persistentvolume/testing/testing.go
@@ -397,12 +397,12 @@ func (r *VolumeReactor) PopChange(ctx context.Context) interface{} {
 	// For debugging purposes, print the queue
 	logger := klog.FromContext(ctx)
 	for _, obj := range r.changedObjects {
-		switch obj.(type) {
+		switch obj := obj.(type) {
 		case *v1.PersistentVolume:
-			vol, _ := obj.(*v1.PersistentVolume)
+			vol := obj
 			logger.V(4).Info("Reactor queue", "volumeName", vol.Name)
 		case *v1.PersistentVolumeClaim:
-			claim, _ := obj.(*v1.PersistentVolumeClaim)
+			claim := obj
 			logger.V(4).Info("Reactor queue", "PVC", klog.KObj(claim))
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
assigning the result of this type assertion to a variable (switch obj := obj.(type)) could eliminate type assertions in switch cases (S1034)
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
