### PR TITLE
Fixed a typo that caused hostutil_windows.go to not implement the HostUtils interface

### DIFF
--- a/pkg/volume/util/hostutil/hostutil_windows.go
+++ b/pkg/volume/util/hostutil/hostutil_windows.go
@@ -88,7 +88,7 @@ func (hu *HostUtil) MakeRShared(path string) error {
 }
 
 // GetFileType checks for sockets/block/character devices
-func (hu *(HostUtil)) GetFileType(pathname string) (FileType, error) {
+func (hu *HostUtil) GetFileType(pathname string) (FileType, error) {
 	return getFileType(pathname)
 }
 


### PR DESCRIPTION
Fixed a typo that caused hostutil_windows.go to not implement the HostUtils interface

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

There is a typo that caused hostutil_windows.go to not implement the HostUtils interface

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
