### PR TITLE
Return deprecation warning for storageOS,PhotonPD,ScaleIO..etc

### DIFF
--- a/pkg/api/persistentvolume/util.go
+++ b/pkg/api/persistentvolume/util.go
@@ -83,6 +83,18 @@ func warningsForPersistentVolumeSpecAndMeta(fieldPath *field.Path, pvSpec *api.P
 	if pvSpec.CephFS != nil {
 		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.28, non-functional in v1.31+", fieldPath.Child("spec", "persistentVolumeSource").Child("cephfs")))
 	}
+	if pvSpec.PhotonPersistentDisk != nil {
+		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.11, non-functional in v1.16+", fieldPath.Child("spec", "persistentVolumeSource").Child("photonPersistentDisk")))
+	}
+	if pvSpec.ScaleIO != nil {
+		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.16, non-functional in v1.22+", fieldPath.Child("spec", "persistentVolumeSource").Child("scaleIO")))
+	}
+	if pvSpec.StorageOS != nil {
+		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.22, non-functional in v1.25+", fieldPath.Child("spec", "persistentVolumeSource").Child("storageOS")))
+	}
+	if pvSpec.Glusterfs != nil {
+		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.25, non-functional in v1.26+", fieldPath.Child("spec", "persistentVolumeSource").Child("glusterfs")))
+	}
 
 	return warnings
 }

--- a/pkg/api/persistentvolume/util_test.go
+++ b/pkg/api/persistentvolume/util_test.go
@@ -196,6 +196,85 @@ func TestWarnings(t *testing.T) {
 				`spec.persistentVolumeSource.cephfs: deprecated in v1.28, non-functional in v1.31+`,
 			},
 		},
+		{
+			name: "PV PhotonPersistentDisk deprecation warning",
+			template: &api.PersistentVolume{
+				Spec: api.PersistentVolumeSpec{
+					PersistentVolumeSource: api.PersistentVolumeSource{
+						PhotonPersistentDisk: &api.PhotonPersistentDiskVolumeSource{
+							PdID:   "",
+							FSType: "",
+						},
+					},
+				},
+			},
+			expected: []string{
+				`spec.persistentVolumeSource.photonPersistentDisk: deprecated in v1.11, non-functional in v1.16+`,
+			},
+		},
+		{
+			name: "PV ScaleIO deprecation warning",
+			template: &api.PersistentVolume{
+				Spec: api.PersistentVolumeSpec{
+					PersistentVolumeSource: api.PersistentVolumeSource{
+						ScaleIO: &api.ScaleIOPersistentVolumeSource{
+							Gateway:          "",
+							System:           "",
+							SecretRef:        nil,
+							SSLEnabled:       false,
+							ProtectionDomain: "",
+							StoragePool:      "",
+							StorageMode:      "",
+							VolumeName:       "",
+							FSType:           "",
+							ReadOnly:         false,
+						},
+					},
+				},
+			},
+			expected: []string{
+				`spec.persistentVolumeSource.scaleIO: deprecated in v1.16, non-functional in v1.22+`,
+			},
+		},
+
+		{
+			name: "PV StorageOS deprecation warning",
+			template: &api.PersistentVolume{
+				Spec: api.PersistentVolumeSpec{
+					PersistentVolumeSource: api.PersistentVolumeSource{
+						StorageOS: &api.StorageOSPersistentVolumeSource{
+							VolumeName:      "",
+							VolumeNamespace: "",
+							FSType:          "",
+							ReadOnly:        false,
+							SecretRef:       nil,
+						},
+					},
+				},
+			},
+			expected: []string{
+				`spec.persistentVolumeSource.storageOS: deprecated in v1.22, non-functional in v1.25+`,
+			},
+		},
+
+		{
+			name: "PV GlusterFS deprecation warning",
+			template: &api.PersistentVolume{
+				Spec: api.PersistentVolumeSpec{
+					PersistentVolumeSource: api.PersistentVolumeSource{
+						Glusterfs: &api.GlusterfsPersistentVolumeSource{
+							EndpointsName:      "",
+							Path:               "",
+							ReadOnly:           false,
+							EndpointsNamespace: nil,
+						},
+					},
+				},
+			},
+			expected: []string{
+				`spec.persistentVolumeSource.glusterfs: deprecated in v1.25, non-functional in v1.26+`,
+			},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
/kind bug

```release-note
NONE
```

Additional Note for reviewer:

May be we missed out to add these deprecation warnings in pvspec path while deprecating. This was a learning while addressing comment from @jsafrane ( Thx) https://github.com/kubernetes/kubernetes/pull/118143#discussion_r1213394194
