### PR TITLE
eviction e2e: print log for failed verifyEvictionOrdering

### DIFF
--- a/test/e2e_node/eviction_test.go
+++ b/test/e2e_node/eviction_test.go
@@ -584,7 +584,11 @@ func runEvictionTest(f *framework.Framework, pressureTimeout time.Duration, expe
 				}
 				logKubeletLatencyMetrics(ctx, kubeletmetrics.EvictionStatsAgeKey)
 				logFunc(ctx)
-				return verifyEvictionOrdering(ctx, f, testSpecs)
+				err := verifyEvictionOrdering(ctx, f, testSpecs)
+				if err != nil {
+					framework.Logf("Verify eviction ordering failed: %s", err)
+				}
+				return err
 			}, pressureTimeout, evictionPollInterval).Should(gomega.Succeed())
 
 			ginkgo.By("checking for the expected pod conditions for evicted pods")
@@ -613,7 +617,11 @@ func runEvictionTest(f *framework.Framework, pressureTimeout time.Duration, expe
 				}
 				logFunc(ctx)
 				logKubeletLatencyMetrics(ctx, kubeletmetrics.EvictionStatsAgeKey)
-				return verifyEvictionOrdering(ctx, f, testSpecs)
+				err := verifyEvictionOrdering(ctx, f, testSpecs)
+				if err != nil {
+					framework.Logf("Verify eviction ordering failed: %s", err)
+				}
+				return err
 			}, postTestConditionMonitoringPeriod, evictionPollInterval).Should(gomega.Succeed())
 
 			ginkgo.By("checking for correctly formatted eviction events")


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

xref #

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-crio-cgroupv1-node-e2e-eviction/1666633096746766336

#### Special notes for your reviewer:

```release-note
None
```

According to current log, the test should pass. Need log like `lastErr` to know what failed inside verifyEvictionOrdering.
```
STEP: checking eviction ordering and ensuring important pods don't fail - test/e2e_node/eviction_test.go:703 @ 06/08/23 03:40:33.919
Jun  8 03:40:35.931: INFO: imageFsInfo.CapacityBytes: 20869787648, imageFsInfo.AvailableBytes: 15600832512
Jun  8 03:40:35.931: INFO: rootFsInfo.CapacityBytes: 20869787648, rootFsInfo.AvailableBytes: 15600832512
Jun  8 03:40:35.931: INFO: Pod: emptydir-memory-over-container-sizelimit-pod
Jun  8 03:40:35.931: INFO: --- summary Container: emptydir-memory-over-container-sizelimit-container UsedBytes: 0
Jun  8 03:40:35.931: INFO: --- summary Volume: test-volume UsedBytes: 209715200
Jun  8 03:40:35.931: INFO: Pod: emptydir-memory-innocent-pod
Jun  8 03:40:35.931: INFO: --- summary Container: emptydir-memory-innocent-container UsedBytes: 0
Jun  8 03:40:35.931: INFO: --- summary Volume: test-volume UsedBytes: 83886080
Jun  8 03:40:35.944: INFO: Kubelet Metrics: []
Jun  8 03:40:35.948: INFO: fetching pod emptydir-memory-innocent-pod; phase= Running
Jun  8 03:40:35.948: INFO: fetching pod emptydir-memory-over-container-sizelimit-pod; phase= Running
Jun  8 03:40:35.948: INFO: fetching pod emptydir-memory-over-volume-sizelimit-pod; phase= Failed
STEP: checking eviction ordering and ensuring important pods don't fail - test/e2e_node/eviction_test.go:703 @ 06/08/23 03:40:35.948
[TIMEDOUT] A suite timeout occurred
In [It] at: test/e2e_node/eviction_test.go:566 @ 06/08/23 03:40:36.958

This is the Progress Report generated when the suite timeout occurred:
  [sig-node] LocalStorageCapacityIsolationMemoryBackedVolumeEviction [Slow] [Serial] [Disruptive] [Feature:LocalStorageCapacityIsolation][NodeFeature:Eviction] when we run containers that should cause evictions due to pod local storage violations  should eventually evict all of the correct pods (Spec Runtime: 2m37.953s)
    test/e2e_node/eviction_test.go:566
    In [It] (Node Runtime: 1m58.739s)
      test/e2e_node/eviction_test.go:566
      At [By Step] checking eviction ordering and ensuring important pods don't fail (Step Runtime: 1.01s)
        test/e2e_node/eviction_test.go:703

      Spec Goroutine
      goroutine 8119 [select]
        k8s.io/kubernetes/vendor/github.com/onsi/gomega/internal.(*AsyncAssertion).match(0xc0015f2540, {0x5e5dc40?, 0x8c51098}, 0x1, {0x0, 0x0, 0x0})
          vendor/github.com/onsi/gomega/internal/async_assertion.go:538
        k8s.io/kubernetes/vendor/github.com/onsi/gomega/internal.(*AsyncAssertion).Should(0xc0015f2540, {0x5e5dc40, 0x8c51098}, {0x0, 0x0, 0x0})
          vendor/github.com/onsi/gomega/internal/async_assertion.go:145
      > k8s.io/kubernetes/test/e2e_node.runEvictionTest.func1.2({0x7fe43a8170c0?, 0xc001c154a0})
          test/e2e_node/eviction_test.go:617
        k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func2({0x5e7d928?, 0xc001c154a0})
          vendor/github.com/onsi/ginkgo/v2/internal/node.go:456

```
