### PR TITLE
DRA: E2E Node: test GRPC timeout

### DIFF
--- a/test/e2e/dra/test-driver/app/gomega.go
+++ b/test/e2e/dra/test-driver/app/gomega.go
@@ -17,6 +17,8 @@ limitations under the License.
 package app
 
 import (
+	"strings"
+
 	"github.com/onsi/gomega/gcustom"
 )
 
@@ -30,3 +32,13 @@ var BeRegistered = gcustom.MakeMatcher(func(actualCalls []GRPCCall) (bool, error
 	}
 	return false, nil
 }).WithMessage("contain successful NotifyRegistrationStatus call")
+
+// NodePrepareResouceCalled checks that NodePrepareResource API has been called
+var NodePrepareResourceCalled = gcustom.MakeMatcher(func(actualCalls []GRPCCall) (bool, error) {
+	for _, call := range actualCalls {
+		if strings.HasSuffix(call.FullMethod, "/NodePrepareResource") && call.Err == nil {
+			return true, nil
+		}
+	}
+	return false, nil
+}).WithMessage("contain NodePrepareResource call")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Test GRPC timeout by slowing down NodePrepareResource call on the test plugin side.

#### Special notes for your reviewer:

This test case was implemented when trying to reproduce https://github.com/kubernetes/kubernetes/issues/117146

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
