### PR TITLE
DRA: report NodePrepareResource errors

### DIFF
--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -74,6 +74,7 @@ const (
 	FailedCreatePodSandBox               = "FailedCreatePodSandBox"
 	FailedStatusPodSandBox               = "FailedPodSandBoxStatus"
 	FailedMountOnFilesystemMismatch      = "FailedMountOnFilesystemMismatch"
+	FailedPrepareDynamicResources        = "FailedPrepareDynamicResources"
 )
 
 // Image manager event reason list


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Log an error and submit an event when NodePrepareResource fails.

#### Which issue(s) this PR fixes:

Fixes #118468

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Dynamic Resource Allocation: log a error and submit an event when Kubelet fails to prepare dynamic resources
```

/sig node