### PR TITLE
Fixed a typo that caused hostutil_windows.go to not implement the HostUtils interface

### DIFF
--- a/pkg/volume/util/hostutil/hostutil_windows.go
+++ b/pkg/volume/util/hostutil/hostutil_windows.go
@@ -88,7 +88,7 @@ func (hu *HostUtil) MakeRShared(path string) error {
 }
 
 // GetFileType checks for sockets/block/character devices
-func (hu *(HostUtil)) GetFileType(pathname string) (FileType, error) {
+func (hu *HostUtil) GetFileType(pathname string) (FileType, error) {
 	return getFileType(pathname)
 }
 


### PR DESCRIPTION
Fixed a typo that caused hostutil_windows.go to not implement the HostUtils interface

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixed a typo that caused hostutil_windows.go to not implement the HostUtils interface

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
