### PR TITLE
Fix ginkgo noColor deprecation warning

### DIFF
--- a/test/conformance/image/go-runner/cmd.go
+++ b/test/conformance/image/go-runner/cmd.go
@@ -42,7 +42,7 @@ func getCmd(env Getenver, w io.Writer) *exec.Cmd {
 	ginkgoArgs = append(ginkgoArgs, []string{
 		"--focus=" + env.Getenv(focusEnvKey),
 		"--skip=" + skip,
-		"--noColor=true",
+		"--no-color=true",
 	}...)
 
 	extraArgs := []string{

--- a/test/conformance/image/go-runner/cmd_test.go
+++ b/test/conformance/image/go-runner/cmd_test.go
@@ -39,7 +39,7 @@ func TestGetCmd(t *testing.T) {
 			expectArgs: []string{
 				"ginkgobin",
 				"--focus=", "--skip=",
-				"--noColor=true", "--timeout=24h", "testbin", "--",
+				"--no-color=true", "--timeout=24h", "testbin", "--",
 				"--disable-log-dump", "--repo-root=/kubernetes",
 				"--provider=", "--report-dir=", "--kubeconfig=",
 			},
@@ -59,7 +59,7 @@ func TestGetCmd(t *testing.T) {
 			expectArgs: []string{
 				"ginkgobin",
 				"--focus=focus", "--skip=skip",
-				"--noColor=true", "--timeout=24h", "testbin", "--",
+				"--no-color=true", "--timeout=24h", "testbin", "--",
 				"--disable-log-dump", "--repo-root=/kubernetes",
 				"--provider=provider", "--report-dir=results", "--kubeconfig=kubeconfig",
 			},
@@ -75,7 +75,7 @@ func TestGetCmd(t *testing.T) {
 			expectArgs: []string{
 				"ginkgobin", "--p",
 				"--focus=", "--skip=\\[Serial\\]",
-				"--noColor=true", "--timeout=24h", "testbin", "--",
+				"--no-color=true", "--timeout=24h", "testbin", "--",
 				"--disable-log-dump", "--repo-root=/kubernetes",
 				"--provider=", "--report-dir=", "--kubeconfig=",
 			},
@@ -91,7 +91,7 @@ func TestGetCmd(t *testing.T) {
 			},
 			expectArgs: []string{
 				"ginkgobin", "--focus=", "--skip=",
-				"--noColor=true", "--ginkgo1", "--ginkgo2", "--timeout=24h",
+				"--no-color=true", "--ginkgo1", "--ginkgo2", "--timeout=24h",
 				"testbin", "--",
 				"--disable-log-dump", "--repo-root=/kubernetes",
 				"--provider=", "--report-dir=", "--kubeconfig=",
@@ -110,7 +110,7 @@ func TestGetCmd(t *testing.T) {
 			},
 			expectArgs: []string{
 				"ginkgobin", "--focus=", "--skip=",
-				"--noColor=true", `--ginkgo='with "quotes" and '`, "--ginkgo2=true$(foo)", "--timeout=24h",
+				"--no-color=true", `--ginkgo='with "quotes" and '`, "--ginkgo2=true$(foo)", "--timeout=24h",
 				"testbin", "--",
 				"--disable-log-dump", "--repo-root=/kubernetes",
 				"--provider=", "--report-dir=", "--kubeconfig=",
@@ -127,7 +127,7 @@ func TestGetCmd(t *testing.T) {
 			},
 			expectArgs: []string{
 				"ginkgobin", "--focus=", "--skip=",
-				"--noColor=true", "--timeout=10h", "testbin", "--",
+				"--no-color=true", "--timeout=10h", "testbin", "--",
 				"--disable-log-dump", "--repo-root=/kubernetes",
 				"--provider=", "--report-dir=", "--kubeconfig=",
 			},

--- a/test/conformance/image/run_e2e.sh
+++ b/test/conformance/image/run_e2e.sh
@@ -67,7 +67,7 @@ esac
 ginkgo_args+=(
     "--focus=${E2E_FOCUS}"
     "--skip=${E2E_SKIP}"
-    "--noColor=true"
+    "--no-color=true"
 )
 
 set -x

--- a/test/e2e/windows/README.md
+++ b/test/e2e/windows/README.md
@@ -11,7 +11,7 @@ export KUBE_TEST_REPO_LIST=$(pwd)/repo_list
 1. Run only sig-windows tests:
 
     ```bash
-    ./e2e.test --provider=local --ginkgo.noColor --ginkgo.focus="\[sig-windows\]|\[Feature:Windows\]" --node-os-distro="windows"
+    ./e2e.test --provider=local --ginkgo.no-color --ginkgo.focus="\[sig-windows\]|\[Feature:Windows\]" --node-os-distro="windows"
     ```
 
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Ginkgo changed the noColor command line arg to be no-color and will issue the following warning:

```text
You're using deprecated Ginkgo functionality:
=============================================
  --noColor is deprecated, use --no-color instead
```

Fix this by changing all occurrences accordingly.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
