### PR TITLE
WIP: kubelet: optional wait for device registration

### DIFF
--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -127,6 +127,10 @@ type ContainerManager interface {
 	// might need to unprepare resources.
 	PodMightNeedToUnprepareResources(UID types.UID) bool
 
+	// AreAllDeviceResourcesReady returns bool when the container manager have up to date information about
+	// the device plugins. Note this doesn't mean devices are healthy, but just that they reported their status.
+	AreAllDeviceResourcesReady() bool
+
 	// Implements the PodResources Provider API
 	podresources.CPUsProvider
 	podresources.DevicesProvider

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -1041,3 +1041,19 @@ func (cm *containerManagerImpl) UnprepareDynamicResources(pod *v1.Pod) error {
 func (cm *containerManagerImpl) PodMightNeedToUnprepareResources(UID types.UID) bool {
 	return cm.draManager.PodMightNeedToUnprepareResources(UID)
 }
+
+func (cm *containerManagerImpl) AreAllDeviceResourcesReady() bool {
+	rs, running := cm.deviceManager.GetResourceRegistrationStatus()
+	klog.V(2).InfoS("Checking registration status", "deviceCount", len(rs), "running", running)
+	if !running {
+		return false
+	}
+	for resourceName, registered := range rs {
+		if !registered {
+			klog.V(4).InfoS("Device has not registered yet", "resourceName", resourceName)
+			return false
+		}
+		klog.V(4).InfoS("Device has registered", "resourceName", resourceName)
+	}
+	return true
+}

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -181,6 +181,10 @@ func (cm *containerManagerStub) PodMightNeedToUnprepareResources(UID types.UID) 
 	return false
 }
 
+func (cm *containerManagerStub) AreAllDeviceResourcesReady() bool {
+	return true
+}
+
 func NewStubContainerManager() ContainerManager {
 	return &containerManagerStub{shouldResetExtendedResourceCapacity: false}
 }

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -268,3 +268,19 @@ func (cm *containerManagerImpl) UnprepareDynamicResources(*v1.Pod) error {
 func (cm *containerManagerImpl) PodMightNeedToUnprepareResources(UID types.UID) bool {
 	return false
 }
+
+func (cm *containerManagerImpl) AreAllDeviceResourcesReady() bool {
+	rs, running := cm.deviceManager.GetResourceRegistrationStatus()
+	klog.V(2).InfoS("Checking registration status", "deviceCount", len(rs), "running", running)
+	if !running {
+		return false
+	}
+	for resourceName, registered := range rs {
+		if !registered {
+			klog.V(4).InfoS("Device has not registered yet", "resourceName", resourceName)
+			return false
+		}
+		klog.V(4).InfoS("Device has registered", "resourceName", resourceName)
+	}
+	return true
+}

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -79,6 +79,10 @@ type Manager interface {
 
 	// UpdateAllocatedDevices frees any Devices that are bound to terminated pods.
 	UpdateAllocatedDevices()
+
+	// GetResourcRegistrationStatus() returns a map resourceName->ready reporting the resource readiness status
+	// and a boolean reporting if the server is running yet or not
+	GetResourceRegistrationStatus() (map[string]bool, bool)
 }
 
 // DeviceRunContainerOptions contains the combined container runtime settings to consume its allocated devices.

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -41,6 +41,7 @@ type FakeContainerManager struct {
 	CalledFunctions                     []string
 	PodContainerManager                 *FakePodContainerManager
 	shouldResetExtendedResourceCapacity bool
+	areAllDeviceResourcesReady          bool
 }
 
 var _ ContainerManager = &FakeContainerManager{}
@@ -252,4 +253,11 @@ func (cm *FakeContainerManager) UnprepareDynamicResources(*v1.Pod) error {
 
 func (cm *FakeContainerManager) PodMightNeedToUnprepareResources(UID types.UID) bool {
 	return false
+}
+
+func (cm *FakeContainerManager) AreAllDeviceResourcesReady() bool {
+	cm.Lock()
+	defer cm.Unlock()
+	cm.CalledFunctions = append(cm.CalledFunctions, "AreAllDeviceResourcesReady")
+	return cm.areAllDeviceResourcesReady
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:
PoC to a possible resolution for #118559 

The device manager is invoked as part of pod admission and it performs allocation. Up until the device plugins register themselves, the device manager cannot indeed provide authoritative answers about device availability. Any answer is essentially wrong at this stage. The idea is to add a wait on restart to let device plugins reconnect to the kubelet, so the admission can be done with up to date information

#### Which issue(s) this PR fixes:
Fixes DEPENDS_ON_DESIGN_REVIEW

#### Special notes for your reviewer:
POC to illustrate the concept

#### Does this PR introduce a user-facing change?
```release-note
Add a wait on startup to let the device plugins reconnect to the kubelet
```