### PR TITLE
Add check for kubelet is running in the initial use namespace

### DIFF
--- a/cmd/kubelet/app/server_others.go
+++ b/cmd/kubelet/app/server_others.go
@@ -38,12 +38,20 @@ func checkPermissions() error {
 
 // checkInitialUserNamespace checks if kubelet is running in the initial user namespace.
 // http://man7.org/linux/man-pages/man7/user_namespaces.7.html
+// 
+// The initial user namespace is the namespace from which all other namespaces are derived.
+// Running in the initial user namespace ensures that
+// the process has the same view of users and groups as the host system.
+// The function reads the /proc/self/uid_map file, which describes the UID map for the current process.
+// The initial user namespace has a uid_map of "0 0 4294967295".
 func checkInitialUserNamespace() error {
 	uidMap, err := os.ReadFile("/proc/self/uid_map")
 	if err != nil {
 		return err
 	}
 
+  // When running in the initial user namespace, the `/proc/self/uid_map` file content looks like:
+  // 0          0 4294967295
 	if strings.TrimSpace(string(uidMap)) != "0\t0\t4294967295" {
 		return fmt.Errorf("kubelet is not running in the initial user namespace")
 	}

--- a/cmd/kubelet/app/server_others.go
+++ b/cmd/kubelet/app/server_others.go
@@ -22,6 +22,7 @@ package app
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 func checkPermissions() error {
@@ -38,7 +39,7 @@ func checkPermissions() error {
 
 // checkInitialUserNamespace checks if kubelet is running in the initial user namespace.
 // http://man7.org/linux/man-pages/man7/user_namespaces.7.html
-// 
+//
 // The initial user namespace is the namespace from which all other namespaces are derived.
 // Running in the initial user namespace ensures that
 // the process has the same view of users and groups as the host system.
@@ -47,11 +48,11 @@ func checkPermissions() error {
 func checkInitialUserNamespace() error {
 	uidMap, err := os.ReadFile("/proc/self/uid_map")
 	if err != nil {
-    return fmt.Errorf("error reading /proc/self/uid_map: %w", err)
+		return fmt.Errorf("failed to read /proc/self/uid_map: %w", err)
 	}
 
-  // When running in the initial user namespace, the `/proc/self/uid_map` file content looks like:
-  // 0          0 4294967295
+	// When running in the initial user namespace, the `/proc/self/uid_map` file content looks like:
+	// 0          0 4294967295
 	if strings.TrimSpace(string(uidMap)) != "0\t0\t4294967295" {
 		return fmt.Errorf("kubelet is not running in the initial user namespace")
 	}

--- a/cmd/kubelet/app/server_others.go
+++ b/cmd/kubelet/app/server_others.go
@@ -39,7 +39,7 @@ func checkPermissions() error {
 // checkInitialUserNamespace checks if kubelet is running in the initial user namespace.
 // http://man7.org/linux/man-pages/man7/user_namespaces.7.html
 func checkInitialUserNamespace() error {
-	uidMap, err := ioutil.ReadFile("/proc/self/uid_map")
+	uidMap, err := os.ReadFile("/proc/self/uid_map")
 	if err != nil {
 		return err
 	}

--- a/cmd/kubelet/app/server_others.go
+++ b/cmd/kubelet/app/server_others.go
@@ -47,7 +47,7 @@ func checkPermissions() error {
 func checkInitialUserNamespace() error {
 	uidMap, err := os.ReadFile("/proc/self/uid_map")
 	if err != nil {
-		return err
+    return fmt.Errorf("error reading /proc/self/uid_map: %w", err)
 	}
 
   // When running in the initial user namespace, the `/proc/self/uid_map` file content looks like:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

##### What this PR does
The new function `checkInitialUserNamespace()` checks if the `Kubelet` process is running in the initial user namespace.
The check is performed by reading the /proc/self/uid_map file, which describes the UID map for the current process, and comparing its contents to the expected UID map of the initial user namespace, which is "0 0 4294967295".

##### Why we need it
The reason why I think it's important for the `Kubelet` to run in the initial user namespace is because it ensures that the `Kubelet` has the same view of users and groups as the host system.
This is vital for maintaining the security and integrity of the system, as it prevents processes running within the `Kubelet` from potentially gaining unauthorized access to system resources by manipulating their perceived user or group identities.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
