### PR TITLE
Updates chairs, tech leads for sig cloud provider

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/OWNERS
+++ b/staging/src/k8s.io/legacy-cloud-providers/OWNERS
@@ -4,8 +4,10 @@
 options:
   no_parent_owners: true
 approvers:
-  - andrewsykim # SIG Cloud Provider lead, for approving bug fixes only
-  - nckturner # SIG Cloud Provider lead, for approving bug fixes only
+  - bridgetkromhout # SIG Cloud Provider chair, for approving bug fixes only
+  - elmiko # SIG Cloud Provider chair, for approving bug fixes only
+  - andrewsykim # SIG Cloud Provider TL, for approving bug fixes only
+  - nckturner # SIG Cloud Provider TL, for approving bug fixes only
   - cheftako # SIG Cloud Provider TL, for approving bug fixes only
   - dims # For code organization / dependency updates only
   - liggitt # For code organization / dependency updates only


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add @bridgetkromhout and @elmiko to the legacy cloud providers owners files as chairs and move current chairs to tech leads, to reflect the [SIG Cloud Provider: Leadership Change](https://github.com/kubernetes/community/issues/7340).


#### Special notes for your reviewer:

/cc @cheftako @andrewsykim @nckturner 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

