### PR TITLE
apf: refactor bootstrap ensure strategy

### DIFF
--- a/pkg/registry/flowcontrol/ensurer/strategy.go
+++ b/pkg/registry/flowcontrol/ensurer/strategy.go
@@ -116,23 +116,27 @@ type configurationObject interface {
 // NewSuggestedEnsureStrategy returns an EnsureStrategy for suggested config objects
 func NewSuggestedEnsureStrategy() EnsureStrategy {
 	return &strategy{
-		alwaysAutoUpdateSpec: false,
-		name:                 "suggested",
+		alwaysAutoUpdateSpecFn: func(_ wantAndHave) bool {
+			return false
+		},
+		name: "suggested",
 	}
 }
 
 // NewMandatoryEnsureStrategy returns an EnsureStrategy for mandatory config objects
 func NewMandatoryEnsureStrategy() EnsureStrategy {
 	return &strategy{
-		alwaysAutoUpdateSpec: true,
-		name:                 "mandatory",
+		alwaysAutoUpdateSpecFn: func(_ wantAndHave) bool {
+			return true
+		},
+		name: "mandatory",
 	}
 }
 
 // auto-update strategy for the configuration objects
 type strategy struct {
-	alwaysAutoUpdateSpec bool
-	name                 string
+	alwaysAutoUpdateSpecFn func(wantAndHave) bool
+	name                   string
 }
 
 func (s *strategy) Name() string {
@@ -146,7 +150,7 @@ func (s *strategy) ShouldUpdate(wah wantAndHave) (updatable, bool, error) {
 		return nil, false, nil
 	}
 
-	autoUpdateSpec := s.alwaysAutoUpdateSpec
+	autoUpdateSpec := s.alwaysAutoUpdateSpecFn(wah)
 	if !autoUpdateSpec {
 		autoUpdateSpec = shouldUpdateSpec(current)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Currently we don't allow the admin to update the spec of any mandatory flowschema object, any changes made will be stomped by the apf bootstrap controller.

Refactor bootstrap ensure strategy - replace the `alwaysAutoUpdateSpec` bool variable with a  func  that accept an `wantAndHave` interface 
```
func(wh wantAndHave) bool
```

This will allows us to override that spec for mandatory `exempt` prioritylevelconfiguration can be changed by the admin, this will facilitate https://github.com/kubernetes/kubernetes/pull/117703 

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
