### PR TITLE
chore: should use for {} instead of for true {} (S1006)

### DIFF
--- a/pkg/volume/fc/fc_util.go
+++ b/pkg/volume/fc/fc_util.go
@@ -215,7 +215,7 @@ func searchDisk(b fcDiskMounter) (string, error) {
 	// two-phase search:
 	// first phase, search existing device path, if a multipath dm is found, exit loop
 	// otherwise, in second phase, rescan scsi bus and search again, return with any findings
-	for true {
+	for {
 		for _, diskID := range diskIDs {
 			if len(wwns) != 0 {
 				disk, dm = findDisk(diskID, lun, io, b.deviceUtil)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
should use for {} instead of for true {} (S1006)

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
