### PR TITLE
refactor: simplify RunScorePlugins for readability + performance

### DIFF
--- a/test/integration/scheduler/plugins/plugins_test.go
+++ b/test/integration/scheduler/plugins/plugins_test.go
@@ -808,6 +808,11 @@ func TestPostFilterPlugin(t *testing.T) {
 								{Name: filterPluginName},
 							},
 						},
+						PreScore: configv1.PluginSet{
+							Disabled: []configv1.Plugin{
+								{Name: "*"},
+							},
+						},
 						Score: configv1.PluginSet{
 							Enabled: []configv1.Plugin{
 								{Name: scorePluginName},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Simplify `RunScorePlugins` for readability + performance improvement.
See the benchmark result from [this benchmark test](https://github.com/kubernetes/kubernetes/compare/master...sanposhiho:kubernetes:bench).

```

# master branch

Running tool: /home/gitpod/go/bin/go test -benchmem -run=^$ -bench ^Benchmark_RunScorePlugins$ k8s.io/kubernetes/pkg/scheduler/framework/runtime

goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/pkg/scheduler/framework/runtime
cpu: AMD EPYC 7B13
Benchmark_RunScorePlugins/nodenumber=2/10_score_plugins-16                 36687             33965 ns/op            8616 B/op        194 allocs/op
Benchmark_RunScorePlugins/nodenumber=2/30_score_plugins-16                 19827             66900 ns/op           21162 B/op        459 allocs/op
Benchmark_RunScorePlugins/nodenumber=100/10_score_plugins-16                3812            384578 ns/op          240825 B/op       5610 allocs/op
Benchmark_RunScorePlugins/nodenumber=100/30_score_plugins-16                1423           1263242 ns/op          687209 B/op      15675 allocs/op
PASS
ok      k8s.io/kubernetes/pkg/scheduler/framework/runtime       6.930s

---

# this branch

Running tool: /home/gitpod/go/bin/go test -benchmem -run=^$ -bench ^Benchmark_RunScorePlugins$ k8s.io/kubernetes/pkg/scheduler/framework/runtime

goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/pkg/scheduler/framework/runtime
cpu: AMD EPYC 7B13
Benchmark_RunScorePlugins/nodenumber=2/10_score_plugins-16                 43550             29093 ns/op           10280 B/op        225 allocs/op
Benchmark_RunScorePlugins/nodenumber=2/30_score_plugins-16                 19969             50778 ns/op           27113 B/op        590 allocs/op
Benchmark_RunScorePlugins/nodenumber=100/10_score_plugins-16                4490            288480 ns/op          324646 B/op       6216 allocs/op
Benchmark_RunScorePlugins/nodenumber=100/30_score_plugins-16                1695            739711 ns/op          963506 B/op      18341 allocs/op
PASS    
ok      k8s.io/kubernetes/pkg/scheduler/framework/runtime       5.847s
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
