### PR TITLE
Make CA valid 1 hour in the past

### DIFF
--- a/staging/src/k8s.io/client-go/util/cert/cert.go
+++ b/staging/src/k8s.io/client-go/util/cert/cert.go
@@ -71,7 +71,7 @@ func NewSelfSignedCACert(cfg Config, key crypto.Signer) (*x509.Certificate, erro
 			Organization: cfg.Organization,
 		},
 		DNSNames:              []string{cfg.CommonName},
-		NotBefore:             now.UTC(),
+		NotBefore:             now.Add(-time.Hour).UTC(), // valid an hour earlier to avoid flakes
 		NotAfter:              now.Add(duration365d * 10).UTC(),
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
When running kubeadm / installing k8s early during boot, the CA certificate can be generated before time is synchronised and time is jumped backward.
Make notBefore 1 hour in the past to accept small clock jump.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
