### PR TITLE
logging the metrics of reqeust/error counts and latency when request extension apiserver

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -99,10 +99,11 @@ func proxyError(w http.ResponseWriter, req *http.Request, error string, code int
 
 func (r *proxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	httpStatus := http.StatusOK
+	serviceName := ""
 	extensionApiserverStart := time.Now()
 	ctx := req.Context()
 	defer func() {
-		recordExtensionApiserverMetrics(ctx, httpStatus, extensionApiserverStart)
+		recordExtensionApiserverMetrics(ctx, httpStatus, extensionApiserverStart, serviceName)
 	}()
 	value := r.handlingInfo.Load()
 	if value == nil {
@@ -110,6 +111,7 @@ func (r *proxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	handlingInfo := value.(proxyHandlingInfo)
+	serviceName = handlingInfo.serviceName
 	if handlingInfo.local {
 		if r.localDelegate == nil {
 			http.Error(w, "", http.StatusNotFound)

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
@@ -1128,7 +1128,7 @@ func TestRecordExtApiserverMetricsMetrics(t *testing.T) {
 			want: `
 			# HELP extension_apiserver_request_total [ALPHA] Counter of extension apiserver request broken down by result. It can be either '200', '404', '503' or '500'.
 			# TYPE extension_apiserver_request_total counter
-			extension_apiserver_request_total{code="200"} 1
+			extension_apiserver_request_total{code="200", resource="testResource"} 1
 				`,
 		},
 		{
@@ -1137,7 +1137,7 @@ func TestRecordExtApiserverMetricsMetrics(t *testing.T) {
 			want: `
 			# HELP extension_apiserver_request_total [ALPHA] Counter of extension apiserver request broken down by result. It can be either '200', '404', '503' or '500'.
 			# TYPE extension_apiserver_request_total counter
-			extension_apiserver_request_total{code="404"} 1
+			extension_apiserver_request_total{code="404", resource="testResource"} 1
 				`,
 		},
 		{
@@ -1146,7 +1146,7 @@ func TestRecordExtApiserverMetricsMetrics(t *testing.T) {
 			want: `
 			# HELP extension_apiserver_request_total [ALPHA] Counter of extension apiserver request broken down by result. It can be either '200', '404', '503' or '500'.
 			# TYPE extension_apiserver_request_total counter
-			extension_apiserver_request_total{code="503"} 1
+			extension_apiserver_request_total{code="503", resource="testResource"} 1
 				`,
 		},
 		{
@@ -1155,7 +1155,7 @@ func TestRecordExtApiserverMetricsMetrics(t *testing.T) {
 			want: `
 			# HELP extension_apiserver_request_total [ALPHA] Counter of extension apiserver request broken down by result. It can be either '200', '404', '503' or '500'.
 			# TYPE extension_apiserver_request_total counter
-            extension_apiserver_request_total{code="500"} 1
+            extension_apiserver_request_total{code="500", resource="testResource"} 1
 				`,
 		},
 	}
@@ -1170,7 +1170,7 @@ func TestRecordExtApiserverMetricsMetrics(t *testing.T) {
 			aggregationStart := time.Now()
 			ctx := context.TODO()
 			time.Sleep(time.Duration(random.Intn(100)) * time.Millisecond)
-			recordExtensionApiserverMetrics(ctx, tt.err, aggregationStart)
+			recordExtensionApiserverMetrics(ctx, tt.err, aggregationStart, "testResource")
 			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tt.want), metrics...); err != nil {
 				t.Fatal(err)
 			}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
@@ -1114,7 +1114,7 @@ func clientCaCrt() []byte { return readTestFile("client-ca.pem") }
 
 func TestRecordExtApiserverMetricsMetrics(t *testing.T) {
 	metrics := []string{
-		"extension_apiserver_requests_total",
+		"extension_apiserver_request_total",
 	}
 
 	testCases := []struct {
@@ -1126,36 +1126,36 @@ func TestRecordExtApiserverMetricsMetrics(t *testing.T) {
 			desc: "OK",
 			err:  200,
 			want: `
-			# HELP extension_apiserver_requests_total [ALPHA] Counter of extension apiserver request broken down by result. It can be either 'OK', 'Not Found', 'Service Unavailable' or 'Internal Server Error'.
-			# TYPE extension_apiserver_requests_total counter
-			extension_apiserver_requests_total{result="OK"} 1
+			# HELP extension_apiserver_request_total [ALPHA] Counter of extension apiserver request broken down by result. It can be either '200', '404', '503' or '500'.
+			# TYPE extension_apiserver_request_total counter
+			extension_apiserver_request_total{code="200"} 1
 				`,
 		},
 		{
 			desc: "Not Found",
 			err:  404,
 			want: `
-			# HELP extension_apiserver_requests_total [ALPHA] Counter of extension apiserver request broken down by result. It can be either 'OK', 'Not Found', 'Service Unavailable' or 'Internal Server Error'.
-			# TYPE extension_apiserver_requests_total counter
-			extension_apiserver_requests_total{result="Not Found"} 1
+			# HELP extension_apiserver_request_total [ALPHA] Counter of extension apiserver request broken down by result. It can be either '200', '404', '503' or '500'.
+			# TYPE extension_apiserver_request_total counter
+			extension_apiserver_request_total{code="404"} 1
 				`,
 		},
 		{
 			desc: "Service Unavailable",
 			err:  503,
 			want: `
-			# HELP extension_apiserver_requests_total [ALPHA] Counter of extension apiserver request broken down by result. It can be either 'OK', 'Not Found', 'Service Unavailable' or 'Internal Server Error'.
-			# TYPE extension_apiserver_requests_total counter
-			extension_apiserver_requests_total{result="Service Unavailable"} 1
+			# HELP extension_apiserver_request_total [ALPHA] Counter of extension apiserver request broken down by result. It can be either '200', '404', '503' or '500'.
+			# TYPE extension_apiserver_request_total counter
+			extension_apiserver_request_total{code="503"} 1
 				`,
 		},
 		{
 			desc: "Internal Server Error",
 			err:  500,
 			want: `
-			# HELP extension_apiserver_requests_total [ALPHA] Counter of extension apiserver request broken down by result. It can be either 'OK', 'Not Found', 'Service Unavailable' or 'Internal Server Error'.
-			# TYPE extension_apiserver_requests_total counter
-            extension_apiserver_requests_total{result="Internal Server Error"} 1
+			# HELP extension_apiserver_request_total [ALPHA] Counter of extension apiserver request broken down by result. It can be either '200', '404', '503' or '500'.
+			# TYPE extension_apiserver_request_total counter
+            extension_apiserver_request_total{code="500"} 1
 				`,
 		},
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
@@ -60,7 +60,7 @@ var (
 			Help:           "Counter of extension apiserver request broken down by result. It can be either '200', '404', '503' or '500'.",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"code"},
+		[]string{"resource", "code"},
 	)
 
 	extensionApiserverLatency = metrics.NewHistogramVec(
@@ -71,7 +71,7 @@ var (
 			Buckets:        []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"code"},
+		[]string{"resource", "code"},
 	)
 )
 
@@ -82,8 +82,8 @@ func init() {
 	legacyregistry.MustRegister(extensionApiserverLatency)
 }
 
-func recordExtensionApiserverMetrics(ctx context.Context, httpStatus int, extensionApiserverStart time.Time) {
+func recordExtensionApiserverMetrics(ctx context.Context, httpStatus int, extensionApiserverStart time.Time, resource string) {
 	extensionApiserverFinish := time.Now()
-	extensionApiserverRequestCounter.WithContext(ctx).WithLabelValues(strconv.Itoa(httpStatus)).Inc()
-	extensionApiserverLatency.WithContext(ctx).WithLabelValues(strconv.Itoa(httpStatus)).Observe(extensionApiserverFinish.Sub(extensionApiserverStart).Seconds())
+	extensionApiserverRequestCounter.WithContext(ctx).WithLabelValues(resource, strconv.Itoa(httpStatus)).Inc()
+	extensionApiserverLatency.WithContext(ctx).WithLabelValues(resource, strconv.Itoa(httpStatus)).Observe(extensionApiserverFinish.Sub(extensionApiserverStart).Seconds())
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
@@ -18,7 +18,7 @@ package apiserver
 
 import (
 	"context"
-	"net/http"
+	"strconv"
 	"time"
 
 	"k8s.io/component-base/metrics"
@@ -56,11 +56,11 @@ var (
 	extensionApiserverRequestCounter = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      ExtensionApiserver,
-			Name:           "requests_total",
-			Help:           "Counter of extension apiserver request broken down by result. It can be either 'OK', 'Not Found', 'Service Unavailable' or 'Internal Server Error'.",
+			Name:           "request_total",
+			Help:           "Counter of extension apiserver request broken down by result. It can be either '200', '404', '503' or '500'.",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"result"},
+		[]string{"code"},
 	)
 
 	extensionApiserverLatency = metrics.NewHistogramVec(
@@ -71,7 +71,7 @@ var (
 			Buckets:        []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"result"},
+		[]string{"code"},
 	)
 )
 
@@ -84,6 +84,6 @@ func init() {
 
 func recordExtensionApiserverMetrics(ctx context.Context, httpStatus int, extensionApiserverStart time.Time) {
 	extensionApiserverFinish := time.Now()
-	extensionApiserverRequestCounter.WithContext(ctx).WithLabelValues(http.StatusText(httpStatus)).Inc()
-	extensionApiserverLatency.WithContext(ctx).WithLabelValues(http.StatusText(httpStatus)).Observe(extensionApiserverFinish.Sub(extensionApiserverStart).Seconds())
+	extensionApiserverRequestCounter.WithContext(ctx).WithLabelValues(strconv.Itoa(httpStatus)).Inc()
+	extensionApiserverLatency.WithContext(ctx).WithLabelValues(strconv.Itoa(httpStatus)).Observe(extensionApiserverFinish.Sub(extensionApiserverStart).Seconds())
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
@@ -64,7 +64,7 @@ var (
 		&metrics.HistogramOpts{
 			Name:           "extension_apiserver_request_duration_seconds",
 			Help:           "extension apiserver request duration in seconds broken out by result.",
-			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
+			Buckets:        []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"result"},

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/component-base/metrics/legacyregistry"
 )
 
+const ExtensionApiserver string = "extension_apiserver"
+
 var x509MissingSANCounter = metrics.NewCounter(
 	&metrics.CounterOpts{
 		Subsystem: "kube_aggregator",
@@ -53,7 +55,8 @@ var x509InsecureSHA1Counter = metrics.NewCounter(
 var (
 	extensionApiserverRequestCounter = metrics.NewCounterVec(
 		&metrics.CounterOpts{
-			Name:           "extension_apiserver_requests_total",
+			Subsystem:      ExtensionApiserver,
+			Name:           "requests_total",
 			Help:           "Counter of extension apiserver request broken down by result. It can be either 'OK', 'Not Found', 'Service Unavailable' or 'Internal Server Error'.",
 			StabilityLevel: metrics.ALPHA,
 		},
@@ -62,8 +65,9 @@ var (
 
 	extensionApiserverLatency = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
-			Name:           "extension_apiserver_request_duration_seconds",
-			Help:           "extension apiserver request duration in seconds broken out by result.",
+			Subsystem:      ExtensionApiserver,
+			Name:           "request_duration_seconds",
+			Help:           "Extension apiserver request duration in seconds broken out by result.",
 			Buckets:        []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
 			StabilityLevel: metrics.ALPHA,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
logging the metrics of reqeust/error counts and latency when request extension apiserver

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #117167 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver adds two new metrics `extension_apiserver_attempts_total` and `extension_apiserver_duration_seconds` that allow users to monitor requests to extension apiserver, split by result.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
