### PR TITLE
Add CAP_NET_RAW to netadmin debugging profile

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -310,7 +310,7 @@ func TestGenerateDebugContainer(t *testing.T) {
 					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 					SecurityContext: &corev1.SecurityContext{
 						Capabilities: &corev1.Capabilities{
-							Add: []corev1.Capability{"NET_ADMIN"},
+							Add: []corev1.Capability{"NET_ADMIN", "NET_RAW"},
 						},
 					},
 				},
@@ -1323,11 +1323,12 @@ func TestGeneratePodCopyWithDebugContainer(t *testing.T) {
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
-									Add: []corev1.Capability{"NET_ADMIN"},
+									Add: []corev1.Capability{"NET_ADMIN", "NET_RAW"},
 								},
 							},
 						},
 					},
+					ShareProcessNamespace: pointer.Bool(true),
 				},
 			},
 		},
@@ -1694,9 +1695,8 @@ func TestGenerateNodeDebugPod(t *testing.T) {
 							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 							VolumeMounts:             nil,
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.Bool(true),
 								Capabilities: &corev1.Capabilities{
-									Add: []corev1.Capability{"NET_ADMIN"},
+									Add: []corev1.Capability{"NET_ADMIN", "NET_RAW"},
 								},
 							},
 						},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles_test.go
@@ -495,7 +495,7 @@ func TestNetAdminProfile(t *testing.T) {
 							Name: "dbg", Image: "dbgimage",
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
-									Add: []corev1.Capability{"NET_ADMIN"},
+									Add: []corev1.Capability{"NET_ADMIN", "NET_RAW"},
 								},
 							},
 						},
@@ -526,6 +526,7 @@ func TestNetAdminProfile(t *testing.T) {
 			expectPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
 				Spec: corev1.PodSpec{
+					ShareProcessNamespace: pointer.Bool(true),
 					Containers: []corev1.Container{
 						{Name: "app", Image: "appimage"},
 						{
@@ -533,7 +534,7 @@ func TestNetAdminProfile(t *testing.T) {
 							Image: "dbgimage",
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
-									Add: []corev1.Capability{"NET_ADMIN"},
+									Add: []corev1.Capability{"NET_ADMIN", "NET_RAW"},
 								},
 							},
 						},
@@ -572,6 +573,7 @@ func TestNetAdminProfile(t *testing.T) {
 			expectPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
 				Spec: corev1.PodSpec{
+					ShareProcessNamespace: pointer.Bool(true),
 					Containers: []corev1.Container{
 						{Name: "app", Image: "appimage"},
 						{
@@ -579,7 +581,7 @@ func TestNetAdminProfile(t *testing.T) {
 							Image: "dbgimage",
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
-									Add: []corev1.Capability{"SYS_PTRACE", "NET_ADMIN"},
+									Add: []corev1.Capability{"SYS_PTRACE", "NET_ADMIN", "NET_RAW"},
 								},
 							},
 						},
@@ -610,9 +612,8 @@ func TestNetAdminProfile(t *testing.T) {
 							Name:  "dbg",
 							Image: "dbgimage",
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.BoolPtr(true),
 								Capabilities: &corev1.Capabilities{
-									Add: []corev1.Capability{"NET_ADMIN"},
+									Add: []corev1.Capability{"NET_ADMIN", "NET_RAW"},
 								},
 							},
 						},
@@ -630,7 +631,6 @@ func TestNetAdminProfile(t *testing.T) {
 							Name:  "dbg",
 							Image: "dbgimage",
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.BoolPtr(true),
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{"SYS_PTRACE"},
 								},
@@ -652,9 +652,8 @@ func TestNetAdminProfile(t *testing.T) {
 							Name:  "dbg",
 							Image: "dbgimage",
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.BoolPtr(true),
 								Capabilities: &corev1.Capabilities{
-									Add: []corev1.Capability{"SYS_PTRACE", "NET_ADMIN"},
+									Add: []corev1.Capability{"SYS_PTRACE", "NET_ADMIN", "NET_RAW"},
 								},
 							},
 						},

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -1029,12 +1029,14 @@ runTests() {
     record_command run_kubectl_debug_general_tests
     record_command run_kubectl_debug_baseline_tests
     record_command run_kubectl_debug_restricted_tests
+    record_command run_kubectl_debug_netadmin_tests
   fi
   if kube::test::if_supports_resource "${nodes}" ; then
     record_command run_kubectl_debug_node_tests
     record_command run_kubectl_debug_general_node_tests
     record_command run_kubectl_debug_baseline_node_tests
     record_command run_kubectl_debug_restricted_node_tests
+    record_command run_kubectl_debug_netadmin_node_tests
   fi
 
   cleanup_tests


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

[netadmin profile](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug#profile-netadmin) adds only `CAP_NET_ADMIN` to `EphemeralContainer` and `DebuggingContainer`.
(In case of debugging Node, debugging Pod will be added `privileged` and `CAP_NET_ADMIN`.)

As disscussed [here](https://github.com/kubernetes/enhancements/issues/1441#issuecomment-1484869020), I add `CAP_NET_RAW` to `netadmin` profile and remove privileged when debug Node in this PR.

#### Which issue(s) this PR fixes:

Fixes: #118962 https://github.com/kubernetes/enhancements/issues/1441#issuecomment-1483047759
Related:  #115712 https://github.com/kubernetes/kubectl/issues/1108
KEP Update: https://github.com/kubernetes/enhancements/pull/4160

#### Special notes for your reviewer:

In this PR:
I add `CAP_NET_RAW` to `netadmin` profile in each case of EphemeralContainer, Pod Copy and Node.
Especially in case of Node, since `privileged` is added, it seems that the `CAP_NET_ADMIN` currently added and `CAP_NET_RAW` to be newly added this time overlap.(Should `privileged` be added `netadmin`? It added  #115712)

#### Does this PR introduce a user-facing change?

```release-note
Add CAP_NET_RAW to netadmin debug profile and remove privileges when debugging nodes
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug#profile-netadmin
```
