### PR TITLE
DRA Node E2E: remove NodeFeature label

### DIFF
--- a/test/e2e_node/dra_test.go
+++ b/test/e2e_node/dra_test.go
@@ -59,7 +59,7 @@ const (
 	podInPendingStateTimeout  = time.Second * 60 // how long to wait for a pod to stay in pending state
 )
 
-var _ = ginkgo.Describe("[sig-node] DRA [Feature:DynamicResourceAllocation][NodeFeature:DynamicResourceAllocation]", func() {
+var _ = ginkgo.Describe("[sig-node] DRA [Feature:DynamicResourceAllocation]", func() {
 	f := framework.NewDefaultFramework("dra-node")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Removed NodeFeature:DynamicResourceAllocation label from the tests to fix `cos-cgroupv1/v2-containerd-node-e2e-serial` CI jobs.

It turned out that labeling DRA Node tests as `NodeFeature` was a mistake. Re-labeling with `NodeAlphaFeature` would not work either. It would fail certain `containerd` jobs as DRA requires `containerd` >= 1.7

#### Which issue(s) this PR fixes:
Fixes #118660

#### Special notes for your reviewer:

Correspondent test-infra PR updating ginkgo focus for DRA Node job: https://github.com/kubernetes/test-infra/pull/29811

#### Does this PR introduce a user-facing change?
```release-note
NONE
```