### PR TITLE
Adding StorageInfoLister to SharedLister

### DIFF
--- a/pkg/scheduler/framework/listers.go
+++ b/pkg/scheduler/framework/listers.go
@@ -18,17 +18,25 @@ package framework
 
 // NodeInfoLister interface represents anything that can list/get NodeInfo objects from node name.
 type NodeInfoLister interface {
-	// Returns the list of NodeInfos.
+	// List returns the list of NodeInfos.
 	List() ([]*NodeInfo, error)
-	// Returns the list of NodeInfos of nodes with pods with affinity terms.
+	// HavePodsWithAffinityList returns the list of NodeInfos of nodes with pods with affinity terms.
 	HavePodsWithAffinityList() ([]*NodeInfo, error)
-	// Returns the list of NodeInfos of nodes with pods with required anti-affinity terms.
+	// HavePodsWithRequiredAntiAffinityList returns the list of NodeInfos of nodes with pods with required anti-affinity terms.
 	HavePodsWithRequiredAntiAffinityList() ([]*NodeInfo, error)
-	// Returns the NodeInfo of the given node name.
+	// Get returns the NodeInfo of the given node name.
 	Get(nodeName string) (*NodeInfo, error)
+}
+
+// StorageInfoLister interface represents anything that handles storage-related operations and resources.
+type StorageInfoLister interface {
+	// IsPVCUsedByPods returns true/false on whether the PVC is used by one or more scheduled pods,
+	// keyed in the format "namespace/name".
+	IsPVCUsedByPods(key string) bool
 }
 
 // SharedLister groups scheduler-specific listers.
 type SharedLister interface {
 	NodeInfos() NodeInfoLister
+	StorageInfos() StorageInfoLister
 }

--- a/pkg/scheduler/internal/cache/snapshot_test.go
+++ b/pkg/scheduler/internal/cache/snapshot_test.go
@@ -21,10 +21,12 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
 const mb int64 = 1024 * 1024
@@ -176,6 +178,53 @@ func TestCreateImageExistenceMap(t *testing.T) {
 			imageMap := createImageExistenceMap(test.nodes)
 			if !reflect.DeepEqual(test.expected, imageMap) {
 				t.Errorf("expected: %#v, got: %#v", test.expected, imageMap)
+			}
+		})
+	}
+}
+
+func TestCreateUsedPVCSet(t *testing.T) {
+	tests := []struct {
+		name     string
+		pods     []*v1.Pod
+		expected sets.String
+	}{
+		{
+			name:     "empty pods list",
+			pods:     []*v1.Pod{},
+			expected: sets.NewString(),
+		},
+		{
+			name: "pods not scheduled",
+			pods: []*v1.Pod{
+				st.MakePod().Name("foo").Namespace("foo").Obj(),
+				st.MakePod().Name("bar").Namespace("bar").Obj(),
+			},
+			expected: sets.NewString(),
+		},
+		{
+			name: "scheduled pods that do not use any PVC",
+			pods: []*v1.Pod{
+				st.MakePod().Name("foo").Namespace("foo").Node("node-1").Obj(),
+				st.MakePod().Name("bar").Namespace("bar").Node("node-2").Obj(),
+			},
+			expected: sets.NewString(),
+		},
+		{
+			name: "scheduled pods that use PVC",
+			pods: []*v1.Pod{
+				st.MakePod().Name("foo").Namespace("foo").Node("node-1").PVC("pvc1").Obj(),
+				st.MakePod().Name("bar").Namespace("bar").Node("node-2").PVC("pvc2").Obj(),
+			},
+			expected: sets.NewString("foo/pvc1", "bar/pvc2"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			usedPVCs := createUsedPVCSet(test.pods)
+			if diff := cmp.Diff(test.expected, usedPVCs); diff != "" {
+				t.Errorf("Unexpected usedPVCs (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
This change creates a StorageInfoLister interface
and have it under scheduler SharedLister.

The initial StorageInfoLister interface has a
IsPVCUsedByPods which returns true/false depending on whether the PVC (keyed by namespace/name) has at least one scheduled pod using it.

In snapshot real implementation, add a usedPVCSet
key by PVC namespace/name which contains all PVCs
that have at least one scheduled pod using it.
During snapshot update, populate this set based on whether the PVCRefCounts map for node(s) have been updated since last snapshot.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Scheduler may crash when there are a lot of pods in cluster

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #118611

#### Special notes for your reviewer:
Cherry-pick from 1.25

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
