### PR TITLE
move an apiserver helper function out of pkg/proxy

### DIFF
--- a/pkg/proxy/util/utils.go
+++ b/pkg/proxy/util/utils.go
@@ -227,7 +227,7 @@ func MapIPsByIPFamily(ipStrings []string) map[v1.IPFamily][]string {
 	ipFamilyMap := map[v1.IPFamily][]string{}
 	for _, ip := range ipStrings {
 		// Handle only the valid IPs
-		if ipFamily, err := getIPFamilyFromIP(ip); err == nil {
+		if ipFamily := getIPFamilyFromIP(ip); ipFamily != "" {
 			ipFamilyMap[ipFamily] = append(ipFamilyMap[ipFamily], ip)
 		} else {
 			// this function is called in multiple places. All of which
@@ -249,7 +249,7 @@ func MapCIDRsByIPFamily(cidrStrings []string) map[v1.IPFamily][]string {
 	ipFamilyMap := map[v1.IPFamily][]string{}
 	for _, cidr := range cidrStrings {
 		// Handle only the valid CIDRs
-		if ipFamily, err := getIPFamilyFromCIDR(cidr); err == nil {
+		if ipFamily := getIPFamilyFromCIDR(cidr); ipFamily != "" {
 			ipFamilyMap[ipFamily] = append(ipFamilyMap[ipFamily], cidr)
 		} else {
 			klog.ErrorS(nil, "Skipping invalid CIDR", "cidr", cidr)
@@ -258,27 +258,29 @@ func MapCIDRsByIPFamily(cidrStrings []string) map[v1.IPFamily][]string {
 	return ipFamilyMap
 }
 
-func getIPFamilyFromIP(ipStr string) (v1.IPFamily, error) {
+// Returns the IP family of ipStr, or "" if ipStr can't be parsed as an IP
+func getIPFamilyFromIP(ipStr string) v1.IPFamily {
 	netIP := netutils.ParseIPSloppy(ipStr)
 	if netIP == nil {
-		return "", ErrAddressNotAllowed
+		return ""
 	}
 
 	if netutils.IsIPv6(netIP) {
-		return v1.IPv6Protocol, nil
+		return v1.IPv6Protocol
 	}
-	return v1.IPv4Protocol, nil
+	return v1.IPv4Protocol
 }
 
-func getIPFamilyFromCIDR(cidrStr string) (v1.IPFamily, error) {
+// Returns the IP family of cidrStr, or "" if cidrStr can't be parsed as a CIDR
+func getIPFamilyFromCIDR(cidrStr string) v1.IPFamily {
 	_, netCIDR, err := netutils.ParseCIDRSloppy(cidrStr)
 	if err != nil {
-		return "", ErrAddressNotAllowed
+		return ""
 	}
 	if netutils.IsIPv6CIDR(netCIDR) {
-		return v1.IPv6Protocol, nil
+		return v1.IPv6Protocol
 	}
-	return v1.IPv4Protocol, nil
+	return v1.IPv4Protocol
 }
 
 // OtherIPFamily returns the other ip family

--- a/pkg/proxy/util/utils.go
+++ b/pkg/proxy/util/utils.go
@@ -19,7 +19,6 @@ package util
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -43,14 +42,6 @@ const (
 
 	// IPv6ZeroCIDR is the CIDR block for the whole IPv6 address space
 	IPv6ZeroCIDR = "::/0"
-)
-
-var (
-	// ErrAddressNotAllowed indicates the address is not allowed
-	ErrAddressNotAllowed = errors.New("address not allowed")
-
-	// ErrNoAddresses indicates there are no addresses for the hostname
-	ErrNoAddresses = errors.New("no addresses for hostname")
 )
 
 // isValidEndpoint checks that the given host / port pair are valid endpoint
@@ -95,44 +86,9 @@ func IsLoopBack(ip string) bool {
 	return false
 }
 
-// IsProxyableIP checks if a given IP address is permitted to be proxied
-func IsProxyableIP(ip string) error {
-	netIP := netutils.ParseIPSloppy(ip)
-	if netIP == nil {
-		return ErrAddressNotAllowed
-	}
-	return isProxyableIP(netIP)
-}
-
-func isProxyableIP(ip net.IP) error {
-	if !ip.IsGlobalUnicast() {
-		return ErrAddressNotAllowed
-	}
-	return nil
-}
-
 // Resolver is an interface for net.Resolver
 type Resolver interface {
 	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
-}
-
-// IsProxyableHostname checks if the IP addresses for a given hostname are permitted to be proxied
-func IsProxyableHostname(ctx context.Context, resolv Resolver, hostname string) error {
-	resp, err := resolv.LookupIPAddr(ctx, hostname)
-	if err != nil {
-		return err
-	}
-
-	if len(resp) == 0 {
-		return ErrNoAddresses
-	}
-
-	for _, host := range resp {
-		if err := isProxyableIP(host.IP); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // GetLocalAddrs returns a list of all network addresses on the local system

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -47,7 +47,7 @@ import (
 	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/client"
-	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
+	netutils "k8s.io/utils/net"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
 )
 
@@ -398,8 +398,8 @@ func ResourceLocation(ctx context.Context, getter ResourceGetter, rt http.RoundT
 		}
 	}
 	podIP := getPodIP(pod)
-	if err := proxyutil.IsProxyableIP(podIP); err != nil {
-		return nil, nil, errors.NewBadRequest(err.Error())
+	if ip := netutils.ParseIPSloppy(podIP); ip == nil || !ip.IsGlobalUnicast() {
+		return nil, nil, errors.NewBadRequest("address not allowed")
 	}
 
 	loc := &url.URL{


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`pkg/proxy/util` contains the functions `IsProxyableIP` and `IsProxyableHostname`, but they don't belong there because `pkg/proxy/util` is "utility functions for kube-proxy" not "utility functions that involve the concept of 'proxying' in any sense".

I moved them to `k8s.io/apimachinery/pkg/util/net` but maybe there's a better place. (The only callers of the functions are in `pkg/registry/core/node/strategy.go` and `pkg/registry/core/pod/strategy.go`.)

(Related cleanup: #118120)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
