### PR TITLE
Automated cherry pick of #118460: Make etcd component status consistent with health probes

### DIFF
--- a/pkg/registry/core/componentstatus/rest.go
+++ b/pkg/registry/core/componentstatus/rest.go
@@ -38,12 +38,12 @@ import (
 )
 
 type REST struct {
-	GetServersToValidate func() map[string]*Server
+	GetServersToValidate func() map[string]Server
 	rest.TableConvertor
 }
 
 // NewStorage returns a new REST.
-func NewStorage(serverRetriever func() map[string]*Server) *REST {
+func NewStorage(serverRetriever func() map[string]Server) *REST {
 	return &REST{
 		GetServersToValidate: serverRetriever,
 		TableConvertor:       printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
@@ -83,7 +83,7 @@ func (rs *REST) List(ctx context.Context, options *metainternalversion.ListOptio
 	wait.Add(len(servers))
 	statuses := make(chan api.ComponentStatus, len(servers))
 	for k, v := range servers {
-		go func(name string, server *Server) {
+		go func(name string, server Server) {
 			defer wait.Done()
 			status := rs.getComponentStatus(name, server)
 			statuses <- *status
@@ -153,7 +153,7 @@ func ToConditionStatus(s probe.Result) api.ConditionStatus {
 	}
 }
 
-func (rs *REST) getComponentStatus(name string, server *Server) *api.ComponentStatus {
+func (rs *REST) getComponentStatus(name string, server Server) *api.ComponentStatus {
 	status, msg, err := server.DoServerCheck()
 	errorMsg := ""
 	if err != nil {

--- a/pkg/registry/core/componentstatus/rest_test.go
+++ b/pkg/registry/core/componentstatus/rest_test.go
@@ -59,9 +59,9 @@ func NewTestREST(resp testResponse) *REST {
 		err:    resp.err,
 	}
 	return &REST{
-		GetServersToValidate: func() map[string]*Server {
-			return map[string]*Server{
-				"test1": {Addr: "testserver1", Port: 8000, Path: "/healthz", Prober: prober},
+		GetServersToValidate: func() map[string]Server {
+			return map[string]Server{
+				"test1": &HttpServer{Addr: "testserver1", Port: 8000, Path: "/healthz", Prober: prober},
 			}
 		},
 	}

--- a/pkg/registry/core/componentstatus/validator.go
+++ b/pkg/registry/core/componentstatus/validator.go
@@ -17,12 +17,15 @@ limitations under the License.
 package componentstatus
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"sync"
 	"time"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
+	"k8s.io/apiserver/pkg/storage/storagebackend/factory"
 	"k8s.io/kubernetes/pkg/probe"
 	httpprober "k8s.io/kubernetes/pkg/probe/http"
 )
@@ -33,7 +36,11 @@ const (
 
 type ValidatorFn func([]byte) error
 
-type Server struct {
+type Server interface {
+	DoServerCheck() (probe.Result, string, error)
+}
+
+type HttpServer struct {
 	Addr        string
 	Port        int
 	Path        string
@@ -57,7 +64,7 @@ type ServerStatus struct {
 	Err string `json:"err,omitempty"`
 }
 
-func (server *Server) DoServerCheck() (probe.Result, string, error) {
+func (server *HttpServer) DoServerCheck() (probe.Result, string, error) {
 	// setup the prober
 	server.Once.Do(func() {
 		if server.Prober != nil {
@@ -91,4 +98,24 @@ func (server *Server) DoServerCheck() (probe.Result, string, error) {
 		}
 	}
 	return result, data, nil
+}
+
+type EtcdServer struct {
+	storagebackend.Config
+}
+
+func (server *EtcdServer) DoServerCheck() (probe.Result, string, error) {
+	prober, err := factory.CreateProber(server.Config)
+	if err != nil {
+		return probe.Failure, "", err
+	}
+	defer prober.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), probeTimeOut)
+	defer cancel()
+	err = prober.Probe(ctx)
+	if err != nil {
+		return probe.Failure, "", err
+	}
+	return probe.Success, "", err
 }

--- a/pkg/registry/core/componentstatus/validator_test.go
+++ b/pkg/registry/core/componentstatus/validator_test.go
@@ -49,7 +49,7 @@ func TestValidate(t *testing.T) {
 		{probe.Success, "foo", nil, probe.Success, "foo", false, nil},
 	}
 
-	s := Server{Addr: "foo.com", Port: 8080, Path: "/healthz"}
+	s := HttpServer{Addr: "foo.com", Port: 8080, Path: "/healthz"}
 
 	for _, test := range tests {
 		fakeProber := &fakeHttpProber{

--- a/pkg/registry/core/rest/storage_core_test.go
+++ b/pkg/registry/core/rest/storage_core_test.go
@@ -51,3 +51,7 @@ func (f fakeStorageFactory) ResourcePrefix(groupResource schema.GroupResource) s
 func (f fakeStorageFactory) Backends() []storage.Backend {
 	return []storage.Backend{{Server: "etcd-0"}}
 }
+
+func (f fakeStorageFactory) Configs() []storagebackend.Config {
+	return []storagebackend.Config{{Transport: storagebackend.TransportConfig{ServerList: []string{"etcd-0"}}}}
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -444,6 +444,10 @@ func (s *SimpleStorageFactory) ResourcePrefix(resource schema.GroupResource) str
 	return resource.Group + "/" + resource.Resource
 }
 
+func (s *SimpleStorageFactory) Configs() []storagebackend.Config {
+	return serverstorage.Configs(s.StorageConfig)
+}
+
 func (s *SimpleStorageFactory) Backends() []serverstorage.Backend {
 	// nothing should ever call this method but we still provide a functional implementation
 	return serverstorage.Backends(s.StorageConfig)
@@ -472,6 +476,10 @@ func (t *transformerStorageFactory) NewConfig(resource schema.GroupResource) (*s
 
 func (t *transformerStorageFactory) ResourcePrefix(resource schema.GroupResource) string {
 	return t.delegate.ResourcePrefix(resource)
+}
+
+func (t *transformerStorageFactory) Configs() []storagebackend.Config {
+	return t.delegate.Configs()
 }
 
 func (t *transformerStorageFactory) Backends() []serverstorage.Backend {

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
@@ -22,14 +22,13 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"k8s.io/klog/v2"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog/v2"
 )
 
 // Backend describes the storage servers, the information here should be enough
@@ -52,8 +51,12 @@ type StorageFactory interface {
 	// centralized control over the shape of etcd directories
 	ResourcePrefix(groupResource schema.GroupResource) string
 
+	// Configs gets configurations for all of registered storage destinations.
+	Configs() []storagebackend.Config
+
 	// Backends gets all backends for all registered storage destinations.
 	// Used for getting all instances for health validations.
+	// Deprecated: Use Configs instead
 	Backends() []Backend
 }
 
@@ -276,14 +279,52 @@ func (s *DefaultStorageFactory) NewConfig(groupResource schema.GroupResource) (*
 	return storageConfig.ForResource(groupResource), nil
 }
 
-// Backends returns all backends for all registered storage destinations.
-// Used for getting all instances for health validations.
+// Configs implements StorageFactory.
+func (s *DefaultStorageFactory) Configs() []storagebackend.Config {
+	return configs(s.StorageConfig, s.Overrides)
+}
+
+// Configs gets configurations for all of registered storage destinations.
+func Configs(storageConfig storagebackend.Config) []storagebackend.Config {
+	return configs(storageConfig, nil)
+}
+
+// Returns all storage configurations including those for group resource overrides
+func configs(storageConfig storagebackend.Config, grOverrides map[schema.GroupResource]groupResourceOverrides) []storagebackend.Config {
+	locations := sets.NewString()
+	configs := []storagebackend.Config{}
+	for _, loc := range storageConfig.Transport.ServerList {
+		// copy
+		newConfig := storageConfig
+		newConfig.Transport.ServerList = []string{loc}
+		configs = append(configs, newConfig)
+		locations.Insert(loc)
+	}
+
+	for _, override := range grOverrides {
+		for _, loc := range override.etcdLocation {
+			if locations.Has(loc) {
+				continue
+			}
+			// copy
+			newConfig := storageConfig
+			override.Apply(&newConfig, &StorageCodecConfig{})
+			newConfig.Transport.ServerList = []string{loc}
+			configs = append(configs, newConfig)
+			locations.Insert(loc)
+		}
+	}
+	return configs
+}
+
+// Backends implements StorageFactory.
 func (s *DefaultStorageFactory) Backends() []Backend {
 	return backends(s.StorageConfig, s.Overrides)
 }
 
 // Backends returns all backends for all registered storage destinations.
 // Used for getting all instances for health validations.
+// Deprecated: Validate health by passing storagebackend.Config directly to storagefactory.CreateProber.
 func Backends(storageConfig storagebackend.Config) []Backend {
 	return backends(storageConfig, nil)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory_test.go
@@ -185,3 +185,59 @@ func TestUpdateEtcdOverrides(t *testing.T) {
 
 	}
 }
+
+func TestConfigs(t *testing.T) {
+	exampleinstall.Install(scheme)
+	defaultEtcdLocations := []string{"http://127.0.0.1", "http://127.0.0.2"}
+
+	testCases := []struct {
+		resource    schema.GroupResource
+		servers     []string
+		wantConfigs []storagebackend.Config
+	}{
+		{
+			wantConfigs: []storagebackend.Config{
+				{Transport: storagebackend.TransportConfig{ServerList: []string{"http://127.0.0.1"}}, Prefix: "/registry", Paging: true},
+				{Transport: storagebackend.TransportConfig{ServerList: []string{"http://127.0.0.2"}}, Prefix: "/registry", Paging: true},
+			},
+		},
+		{
+			resource: schema.GroupResource{Group: example.GroupName, Resource: "resource"},
+			servers:  []string{"http://127.0.0.1:10000"},
+			wantConfigs: []storagebackend.Config{
+				{Transport: storagebackend.TransportConfig{ServerList: []string{"http://127.0.0.1"}}, Prefix: "/registry", Paging: true},
+				{Transport: storagebackend.TransportConfig{ServerList: []string{"http://127.0.0.2"}}, Prefix: "/registry", Paging: true},
+				{Transport: storagebackend.TransportConfig{ServerList: []string{"http://127.0.0.1:10000"}}, Prefix: "/registry", Paging: true},
+			},
+		},
+		{
+			resource: schema.GroupResource{Group: example.GroupName, Resource: "resource"},
+			servers:  []string{"http://127.0.0.1:10000", "https://127.0.0.1", "http://127.0.0.2"},
+			wantConfigs: []storagebackend.Config{
+				{Transport: storagebackend.TransportConfig{ServerList: []string{"http://127.0.0.1"}}, Prefix: "/registry", Paging: true},
+				{Transport: storagebackend.TransportConfig{ServerList: []string{"http://127.0.0.2"}}, Prefix: "/registry", Paging: true},
+				{Transport: storagebackend.TransportConfig{ServerList: []string{"http://127.0.0.1:10000"}}, Prefix: "/registry", Paging: true},
+				{Transport: storagebackend.TransportConfig{ServerList: []string{"https://127.0.0.1"}}, Prefix: "/registry", Paging: true},
+			},
+		},
+	}
+
+	for i, test := range testCases {
+		defaultConfig := storagebackend.Config{
+			Prefix: "/registry",
+			Transport: storagebackend.TransportConfig{
+				ServerList: defaultEtcdLocations,
+			},
+		}
+		storageFactory := NewDefaultStorageFactory(defaultConfig, "", codecs, NewDefaultResourceEncodingConfig(scheme), NewResourceConfig(), nil)
+		if len(test.servers) > 0 {
+			storageFactory.SetEtcdLocation(test.resource, test.servers)
+		}
+
+		got := storageFactory.Configs()
+		if !reflect.DeepEqual(test.wantConfigs, got) {
+			t.Errorf("%d: expected %v, got %v", i, test.wantConfigs, got)
+			continue
+		}
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/healthcheck.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/healthcheck.go
@@ -28,6 +28,7 @@ type etcdHealth struct {
 }
 
 // EtcdHealthCheck decodes data returned from etcd /healthz handler.
+// Deprecated: Validate health by passing storagebackend.Config directly to storagefactory.CreateProber.
 func EtcdHealthCheck(data []byte) error {
 	obj := etcdHealth{}
 	if err := json.Unmarshal(data, &obj); err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory.go
@@ -17,6 +17,7 @@ limitations under the License.
 package factory
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,4 +61,21 @@ func CreateReadyCheck(c storagebackend.Config, stopCh <-chan struct{}) (func() e
 	default:
 		return nil, fmt.Errorf("unknown storage type: %s", c.Type)
 	}
+}
+
+func CreateProber(c storagebackend.Config) (Prober, error) {
+	switch c.Type {
+	case storagebackend.StorageTypeETCD2:
+		return nil, fmt.Errorf("%s is no longer a supported storage backend", c.Type)
+	case storagebackend.StorageTypeUnset, storagebackend.StorageTypeETCD3:
+		return newETCD3Prober(c)
+	default:
+		return nil, fmt.Errorf("unknown storage type: %s", c.Type)
+	}
+}
+
+// Prober is an interface that defines the Probe function for doing etcd readiness/liveness checks.
+type Prober interface {
+	Probe(ctx context.Context) error
+	Close() error
 }


### PR DESCRIPTION
Cherry pick of #118460 on release-1.27.

#118460: Make etcd component status consistent with health probes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix component status calling etcd health endpoint over http which exposed kubernetes to the risk of complete watch starvation and is inconsistent with other etcd probing done by kube-apiserver.
```