### PR TITLE
DRA Node E2E: remove Serial label

### DIFF
--- a/test/e2e_node/dra_test.go
+++ b/test/e2e_node/dra_test.go
@@ -65,7 +65,7 @@ var _ = ginkgo.Describe("[sig-node] DRA [Feature:DynamicResourceAllocation]", fu
 
 	var kubeletPlugin *testdriver.ExamplePlugin
 
-	ginkgo.Context("Resource Kubelet Plugin [Serial]", func() {
+	ginkgo.Context("Resource Kubelet Plugin", func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			kubeletPlugin = newKubeletPlugin(getNodeName(ctx, f))
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Removed Serial label from the DRA tests to fix
cos-cgroupv1/v*-containerd-node-e2e-serial and other CI jobs that can be triggerd by this label.

#### Which issue(s) this PR fixes:

Fixes #118660

#### Special notes for your reviewer:

This is a follow-up PR for #118665.
#118665 partly fixed `kubelet-gce-e2e-arm64-ubuntu-serial` job

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
