### PR TITLE
Automated cherry pick of #118631: Make CA valid 1 hour in the past

### DIFF
--- a/staging/src/k8s.io/client-go/util/cert/cert.go
+++ b/staging/src/k8s.io/client-go/util/cert/cert.go
@@ -64,7 +64,7 @@ func NewSelfSignedCACert(cfg Config, key crypto.Signer) (*x509.Certificate, erro
 			Organization: cfg.Organization,
 		},
 		DNSNames:              []string{cfg.CommonName},
-		NotBefore:             now.UTC(),
+		NotBefore:             now.Add(-time.Hour).UTC(), // valid an hour earlier to avoid flakes
 		NotAfter:              now.Add(duration365d * 10).UTC(),
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,


### PR DESCRIPTION
Cherry pick of #118631 on release-1.25.

#118631: Make CA valid 1 hour in the past

```release-note
client-go: make generated CA certificates valid 1 hour in the past (NewSelfSignedCACert). Applies to CA certificates and other certificates generated by kubeadm.
```