### PR TITLE
[postponed]promote MemoryQoS to Beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -512,6 +512,7 @@ const (
 	// owner: @xiaoxubeii
 	// kep: https://kep.k8s.io/2570
 	// alpha: v1.22
+	// beta: v1.28
 	//
 	// Enables kubelet to support memory QoS with cgroups v2.
 	MemoryQoS featuregate.Feature = "MemoryQoS"
@@ -984,7 +985,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	MemoryManager: {Default: true, PreRelease: featuregate.Beta},
 
-	MemoryQoS: {Default: false, PreRelease: featuregate.Alpha},
+	MemoryQoS: {Default: true, PreRelease: featuregate.Beta},
 
 	MinDomainsInPodTopologySpread: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

sync with https://github.com/kubernetes/enhancements/pull/4093
- https://github.com/kubernetes/enhancements/issues/2570
- https://github.com/kubernetes/website/pull/41655 sync the website
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Promote MemoryQos to beta
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2570-memory-qos
```
