### PR TITLE
Match on cri-o socket suffix only

### DIFF
--- a/pkg/kubelet/cadvisor/cadvisor_linux_test.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/google/cadvisor/container/crio"
 	cadvisorfs "github.com/google/cadvisor/fs"
 )
 
@@ -37,7 +38,7 @@ func TestImageFsInfoLabel(t *testing.T) {
 		expectedError   error
 	}{{
 		description:     "LabelCrioImages should be returned",
-		runtimeEndpoint: CrioSocket,
+		runtimeEndpoint: crio.CrioSocket,
 		expectedLabel:   cadvisorfs.LabelCrioImages,
 		expectedError:   nil,
 	}, {

--- a/pkg/kubelet/cadvisor/helpers_linux.go
+++ b/pkg/kubelet/cadvisor/helpers_linux.go
@@ -21,6 +21,7 @@ package cadvisor
 
 import (
 	"fmt"
+	"strings"
 
 	cadvisorfs "github.com/google/cadvisor/fs"
 )
@@ -37,7 +38,7 @@ func (i *imageFsInfoProvider) ImageFsInfoLabel() (string, error) {
 	// This is a temporary workaround to get stats for cri-o from cadvisor
 	// and should be removed.
 	// Related to https://github.com/kubernetes/kubernetes/issues/51798
-	if i.runtimeEndpoint == CrioSocket || i.runtimeEndpoint == "unix://"+CrioSocket {
+	if strings.HasSuffix(i.runtimeEndpoint, CrioSocketSuffix) {
 		return cadvisorfs.LabelCrioImages, nil
 	}
 	return "", fmt.Errorf("no imagefs label for configured runtime")

--- a/pkg/kubelet/cadvisor/util.go
+++ b/pkg/kubelet/cadvisor/util.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cadvisor
 
 import (
+	"strings"
+
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapi2 "github.com/google/cadvisor/info/v2"
 	"k8s.io/api/core/v1"
@@ -25,10 +27,12 @@ import (
 )
 
 const (
-	// CrioSocket is the path to the CRI-O socket.
+	// CrioSocketSuffix is the path to the CRI-O socket.
 	// Please keep this in sync with the one in:
 	// github.com/google/cadvisor/tree/master/container/crio/client.go
-	CrioSocket = "/var/run/crio/crio.sock"
+	// Note that however we only match on the suffix, as /var/run is often a
+	// symlink to /run, so the user can specify either path.
+	CrioSocketSuffix = "run/crio/crio.sock"
 )
 
 // CapacityFromMachineInfo returns the capacity of the resources from the machine info.
@@ -69,5 +73,5 @@ func EphemeralStorageCapacityFromFsInfo(info cadvisorapi2.FsInfo) v1.ResourceLis
 // be removed. Related issue:
 // https://github.com/kubernetes/kubernetes/issues/51798
 func UsingLegacyCadvisorStats(runtimeEndpoint string) bool {
-	return runtimeEndpoint == CrioSocket || runtimeEndpoint == "unix://"+CrioSocket
+	return strings.HasSuffix(runtimeEndpoint, CrioSocketSuffix)
 }

--- a/pkg/kubelet/cadvisor/util_test.go
+++ b/pkg/kubelet/cadvisor/util_test.go
@@ -21,6 +21,7 @@ package cadvisor
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/cadvisor/container/crio"
@@ -54,5 +55,5 @@ func TestCapacityFromMachineInfoWithHugePagesEnable(t *testing.T) {
 }
 
 func TestCrioSocket(t *testing.T) {
-	assert.EqualValues(t, CrioSocket, crio.CrioSocket, "CrioSocket in this package must equal the one in github.com/google/cadvisor/container/crio/client.go")
+	assert.True(t, strings.HasSuffix(crio.CrioSocket, CrioSocketSuffix), "CrioSocketSuffix in this package must be a suffix of the one in github.com/google/cadvisor/container/crio/client.go")
 }


### PR DESCRIPTION
This deals with the case that a user can configure cri-o to use /run/crio/crio.sock and get very confusing behavior.

See https://github.com/cri-o/cri-o/issues/7010#issuecomment-1594149469

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Updates the path used by the kubelet to decide whether the runtime is CRI-O to also match on `/run/crio/crio.sock`. This fixes a strange, non-obvious behaviour users may see if they configure a different (but valid) path to CRI-O. See https://github.com/cri-o/cri-o/issues/7010#issuecomment-1594149469

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Update the CRI-O socket path, so users who configure kubelet to use a location like `/run/crio/crio.sock` don't see strange behaviour from CRI stats provider.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
