### PR TITLE
update the unwanted-dependencies order

### DIFF
--- a/cmd/dependencyverifier/dependencyverifier.go
+++ b/cmd/dependencyverifier/dependencyverifier.go
@@ -25,6 +25,8 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 type Unwanted struct {
@@ -269,6 +271,7 @@ func main() {
 	if !bytes.Equal(expected, actual) {
 		log.Printf("Expected status of\n%s", string(expected))
 		log.Printf("Got status of\n%s", string(actual))
+		log.Fatal("Status diff:\n", cmp.Diff(actual, expected))
 	}
 	for expectedRef, expectedFrom := range configFromFile.Status.UnwantedReferences {
 		actualFrom, ok := config.Status.UnwantedReferences[expectedRef]

--- a/hack/lint-dependencies.sh
+++ b/hack/lint-dependencies.sh
@@ -43,6 +43,7 @@ rc=0
 
 # List of dependencies we need to avoid dragging back into kubernetes/kubernetes
 # Check if unwanted dependencies are removed
+# The array and map in `unwanted-dependencies.json` are in alphabetical order.
 go run k8s.io/kubernetes/cmd/dependencyverifier "${KUBE_ROOT}/hack/unwanted-dependencies.json"
 
 outdated=$(go list -m -json all | jq -r "

--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -153,6 +153,10 @@
         "sigs.k8s.io/kustomize/api",
         "sigs.k8s.io/kustomize/kustomize/v5"
       ],
+      "golang.org/x/exp": [
+        "github.com/antlr/antlr4/runtime/Go/antlr/v4",
+        "github.com/google/cel-go"
+      ],
       "google.golang.org/api": [
         "cloud.google.com/go",
         "cloud.google.com/go/bigquery",
@@ -184,10 +188,6 @@
         "google.golang.org/genproto/googleapis/api",
         "google.golang.org/grpc",
         "sigs.k8s.io/apiserver-network-proxy/konnectivity-client"
-      ],
-      "golang.org/x/exp": [
-        "github.com/google/cel-go",
-        "github.com/antlr/antlr4/runtime/Go/antlr/v4"
       ]
     }
   }


### PR DESCRIPTION
Fix the current failure when running `hack/lint-dependencies.sh` on the master branch.

`golang.org/x/exp` should be before `google.golang.org/*`. Not sure why this is not failed during the merge of https://github.com/kubernetes/kubernetes/pull/118339

```release-note
None
```

https://github.com/kubernetes/kubernetes/blob/ec87834bae787ab6687921d65c3bcfde8a6e01b9/cmd/dependencyverifier/dependencyverifier.go#L269-L272

Here we don't fail the case when not equals. I fixed the code here and update the unwanted json then.

/cc @dims

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/118705/pull-kubernetes-dependencies/1669629300048924672
- a failed example without change  of dependencies.