### PR TITLE
DRA Node E2E: add NodeAlphaFeature to fix CI

### DIFF
--- a/test/e2e_node/dra_test.go
+++ b/test/e2e_node/dra_test.go
@@ -59,7 +59,7 @@ const (
 	podInPendingStateTimeout  = time.Second * 60 // how long to wait for a pod to stay in pending state
 )
 
-var _ = ginkgo.Describe("[sig-node] DRA [Feature:DynamicResourceAllocation]", func() {
+var _ = ginkgo.Describe("[sig-node] DRA [Feature:DynamicResourceAllocation][NodeAlphaFeature:DynamicResourceAllocation]", func() {
 	f := framework.NewDefaultFramework("dra-node")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
 


### PR DESCRIPTION

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Added NodeAlphaFeature:DynamicResourceAllocation to the Node DRA test to fix failing cos-cgroupv1/v*-containerd-node-e2e-serial serial jobs. Those jobs skip tests labeled with NodeAlphaFeature.

NOTE: this is a follow-up for https://github.com/kubernetes/kubernetes/pull/118685, see https://github.com/kubernetes/kubernetes/pull/118685#pullrequestreview-1481260968 for further details

#### Which issue(s) this PR fixes:

Fixes #118660

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

