### PR TITLE
Fix endpoint-related names to use consistent singular/plural

### DIFF
--- a/pkg/proxy/conntrack/cleanup.go
+++ b/pkg/proxy/conntrack/cleanup.go
@@ -27,23 +27,23 @@ import (
 
 // CleanStaleEntries takes care of flushing stale conntrack entries for services and endpoints.
 func CleanStaleEntries(isIPv6 bool, exec utilexec.Interface, svcPortMap proxy.ServicePortMap,
-	serviceUpdateResult proxy.UpdateServiceMapResult, endpointUpdateResult proxy.UpdateEndpointMapResult) {
+	serviceUpdateResult proxy.UpdateServiceMapResult, endpointsUpdateResult proxy.UpdateEndpointsMapResult) {
 
-	deleteStaleServiceConntrackEntries(isIPv6, exec, svcPortMap, serviceUpdateResult, endpointUpdateResult)
-	deleteStaleEndpointConntrackEntries(exec, svcPortMap, endpointUpdateResult)
+	deleteStaleServiceConntrackEntries(isIPv6, exec, svcPortMap, serviceUpdateResult, endpointsUpdateResult)
+	deleteStaleEndpointConntrackEntries(exec, svcPortMap, endpointsUpdateResult)
 }
 
 // deleteStaleServiceConntrackEntries takes care of flushing stale conntrack entries related
 // to UDP Service IPs. When a service has no endpoints and we drop traffic to it, conntrack
 // may create "black hole" entries for that IP+port. When the service gets endpoints we
 // need to delete those entries so further traffic doesn't get dropped.
-func deleteStaleServiceConntrackEntries(isIPv6 bool, exec utilexec.Interface, svcPortMap proxy.ServicePortMap, serviceUpdateResult proxy.UpdateServiceMapResult, endpointUpdateResult proxy.UpdateEndpointMapResult) {
+func deleteStaleServiceConntrackEntries(isIPv6 bool, exec utilexec.Interface, svcPortMap proxy.ServicePortMap, serviceUpdateResult proxy.UpdateServiceMapResult, endpointsUpdateResult proxy.UpdateEndpointsMapResult) {
 	conntrackCleanupServiceIPs := serviceUpdateResult.DeletedUDPClusterIPs
 	conntrackCleanupServiceNodePorts := sets.New[int]()
 
-	// merge newly active services gathered from updateEndpointsMap
+	// merge newly active services gathered from endpointsUpdateResult
 	// a UDP service that changes from 0 to non-0 endpoints is newly active.
-	for _, svcPortName := range endpointUpdateResult.NewlyActiveUDPServices {
+	for _, svcPortName := range endpointsUpdateResult.NewlyActiveUDPServices {
 		if svcInfo, ok := svcPortMap[svcPortName]; ok {
 			klog.V(4).InfoS("Newly-active UDP service may have stale conntrack entries", "servicePortName", svcPortName)
 			conntrackCleanupServiceIPs.Insert(svcInfo.ClusterIP().String())
@@ -78,8 +78,8 @@ func deleteStaleServiceConntrackEntries(isIPv6 bool, exec utilexec.Interface, sv
 // deleteStaleEndpointConntrackEntries takes care of flushing stale conntrack entries related
 // to UDP endpoints. After a UDP endpoint is removed we must flush any conntrack entries
 // for it so that if the same client keeps sending, the packets will get routed to a new endpoint.
-func deleteStaleEndpointConntrackEntries(exec utilexec.Interface, svcPortMap proxy.ServicePortMap, endpointUpdateResult proxy.UpdateEndpointMapResult) {
-	for _, epSvcPair := range endpointUpdateResult.DeletedUDPEndpoints {
+func deleteStaleEndpointConntrackEntries(exec utilexec.Interface, svcPortMap proxy.ServicePortMap, endpointsUpdateResult proxy.UpdateEndpointsMapResult) {
+	for _, epSvcPair := range endpointsUpdateResult.DeletedUDPEndpoints {
 		if svcInfo, ok := svcPortMap[epSvcPair.ServicePortName]; ok {
 			endpointIP := proxyutil.IPPart(epSvcPair.Endpoint)
 			nodePort := svcInfo.NodePort()

--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -1340,7 +1340,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 
 	testCases := map[string]struct {
 		startingSlices           []*discovery.EndpointSlice
-		endpointChangeTracker    *EndpointChangeTracker
+		endpointsChangeTracker   *EndpointsChangeTracker
 		namespacedName           types.NamespacedName
 		paramEndpointSlice       *discovery.EndpointSlice
 		paramRemoveSlice         bool
@@ -1350,12 +1350,12 @@ func TestEndpointSliceUpdate(t *testing.T) {
 	}{
 		// test starting from an empty state
 		"add a simple slice that doesn't already exist": {
-			startingSlices:        []*discovery.EndpointSlice{},
-			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
-			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:    generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-			paramRemoveSlice:      false,
-			expectedReturnVal:     true,
+			startingSlices:         []*discovery.EndpointSlice{},
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramRemoveSlice:       false,
+			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80", IsLocal: false, Ready: true, Serving: true, Terminating: false},
@@ -1375,7 +1375,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			startingSlices: []*discovery.EndpointSlice{
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker:    NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker:   NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
 			namespacedName:           types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			paramEndpointSlice:       generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			paramRemoveSlice:         false,
@@ -1388,7 +1388,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			startingSlices: []*discovery.EndpointSlice{
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker:    NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker:   NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
 			namespacedName:           types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			paramEndpointSlice:       fqdnSlice,
 			paramRemoveSlice:         false,
@@ -1402,11 +1402,11 @@ func TestEndpointSliceUpdate(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
-			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:    generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-			paramRemoveSlice:      false,
-			expectedReturnVal:     true,
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramRemoveSlice:       false,
+			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80", IsLocal: true, Ready: true, Serving: true, Terminating: false},
@@ -1435,11 +1435,11 @@ func TestEndpointSliceUpdate(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
-			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:    generateEndpointSliceWithOffset("svc1", "ns1", 3, 1, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80)}),
-			paramRemoveSlice:      false,
-			expectedReturnVal:     true,
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			paramEndpointSlice:     generateEndpointSliceWithOffset("svc1", "ns1", 3, 1, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80)}),
+			paramRemoveSlice:       false,
+			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80", IsLocal: true, Ready: true, Serving: true, Terminating: false},
@@ -1466,11 +1466,11 @@ func TestEndpointSliceUpdate(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
-			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:    generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-			paramRemoveSlice:      true,
-			expectedReturnVal:     true,
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramRemoveSlice:       true,
+			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.2.1:80", IsLocal: false, Ready: true, Serving: true, Terminating: false},
@@ -1489,7 +1489,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker:    NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker:   NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
 			namespacedName:           types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			paramEndpointSlice:       generateEndpointSlice("svc1", "ns1", 3, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			paramRemoveSlice:         true,
@@ -1502,11 +1502,11 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			startingSlices: []*discovery.EndpointSlice{
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
-			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:    generateEndpointSlice("svc1", "ns1", 1, 3, 1, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-			paramRemoveSlice:      false,
-			expectedReturnVal:     true,
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 1, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramRemoveSlice:       false,
+			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80", IsLocal: true, Ready: false, Serving: false, Terminating: false},
@@ -1526,11 +1526,11 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			startingSlices: []*discovery.EndpointSlice{
 				generateEndpointSlice("svc1", "ns1", 1, 2, 1, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
-			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:    generateEndpointSlice("svc1", "ns1", 1, 2, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-			paramRemoveSlice:      false,
-			expectedReturnVal:     true,
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 2, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramRemoveSlice:       false,
+			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80", IsLocal: true, Ready: true, Serving: true, Terminating: false},
@@ -1549,11 +1549,11 @@ func TestEndpointSliceUpdate(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 3, 2, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 				generateEndpointSlice("svc1", "ns1", 2, 2, 2, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
-			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:    generateEndpointSlice("svc1", "ns1", 1, 3, 3, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-			paramRemoveSlice:      false,
-			expectedReturnVal:     true,
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 3, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramRemoveSlice:       false,
+			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80", IsLocal: true, Ready: true, Serving: true, Terminating: false},
@@ -1578,11 +1578,11 @@ func TestEndpointSliceUpdate(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 3, 2, 2, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 				generateEndpointSlice("svc1", "ns1", 2, 2, 2, 2, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
-			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:    generateEndpointSlice("svc1", "ns1", 1, 3, 3, 2, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-			paramRemoveSlice:      false,
-			expectedReturnVal:     true,
+			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 3, 2, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramRemoveSlice:       false,
+			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80", IsLocal: true, Ready: true, Serving: true, Terminating: false},
@@ -1605,19 +1605,19 @@ func TestEndpointSliceUpdate(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			initializeCache(tc.endpointChangeTracker.endpointSliceCache, tc.startingSlices)
+			initializeCache(tc.endpointsChangeTracker.endpointSliceCache, tc.startingSlices)
 
-			got := tc.endpointChangeTracker.EndpointSliceUpdate(tc.paramEndpointSlice, tc.paramRemoveSlice)
+			got := tc.endpointsChangeTracker.EndpointSliceUpdate(tc.paramEndpointSlice, tc.paramRemoveSlice)
 			if !reflect.DeepEqual(got, tc.expectedReturnVal) {
 				t.Errorf("EndpointSliceUpdate return value got: %v, want %v", got, tc.expectedReturnVal)
 			}
 
-			pendingChanges := tc.endpointChangeTracker.PendingChanges()
+			pendingChanges := tc.endpointsChangeTracker.PendingChanges()
 			if !pendingChanges.Equal(tc.expectedChangedEndpoints) {
 				t.Errorf("expected changed endpoints %q, got %q", tc.expectedChangedEndpoints.UnsortedList(), pendingChanges.UnsortedList())
 			}
 
-			changes := tc.endpointChangeTracker.checkoutChanges()
+			changes := tc.endpointsChangeTracker.checkoutChanges()
 			if tc.expectedCurrentChange == nil {
 				if len(changes) != 0 {
 					t.Errorf("Expected %s to have no changes", tc.namespacedName)
@@ -1637,20 +1637,20 @@ func TestCheckoutChanges(t *testing.T) {
 	svcPortName1 := ServicePortName{types.NamespacedName{Namespace: "ns1", Name: "svc1"}, "port-1", v1.ProtocolTCP}
 
 	testCases := map[string]struct {
-		endpointChangeTracker *EndpointChangeTracker
-		expectedChanges       []*endpointsChange
-		items                 map[types.NamespacedName]*endpointsChange
-		appliedSlices         []*discovery.EndpointSlice
-		pendingSlices         []*discovery.EndpointSlice
+		endpointsChangeTracker *EndpointsChangeTracker
+		expectedChanges        []*endpointsChange
+		items                  map[types.NamespacedName]*endpointsChange
+		appliedSlices          []*discovery.EndpointSlice
+		pendingSlices          []*discovery.EndpointSlice
 	}{
 		"empty slices": {
-			endpointChangeTracker: NewEndpointChangeTracker("", nil, v1.IPv4Protocol, nil, nil),
-			expectedChanges:       []*endpointsChange{},
-			appliedSlices:         []*discovery.EndpointSlice{},
-			pendingSlices:         []*discovery.EndpointSlice{},
+			endpointsChangeTracker: NewEndpointsChangeTracker("", nil, v1.IPv4Protocol, nil, nil),
+			expectedChanges:        []*endpointsChange{},
+			appliedSlices:          []*discovery.EndpointSlice{},
+			pendingSlices:          []*discovery.EndpointSlice{},
 		},
 		"adding initial slice": {
-			endpointChangeTracker: NewEndpointChangeTracker("", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker: NewEndpointsChangeTracker("", nil, v1.IPv4Protocol, nil, nil),
 			expectedChanges: []*endpointsChange{{
 				previous: EndpointsMap{},
 				current: EndpointsMap{
@@ -1663,7 +1663,7 @@ func TestCheckoutChanges(t *testing.T) {
 			},
 		},
 		"removing port in update": {
-			endpointChangeTracker: NewEndpointChangeTracker("", nil, v1.IPv4Protocol, nil, nil),
+			endpointsChangeTracker: NewEndpointsChangeTracker("", nil, v1.IPv4Protocol, nil, nil),
 			expectedChanges: []*endpointsChange{{
 				previous: EndpointsMap{
 					svcPortName0: []Endpoint{newTestEp("10.0.1.1:80", "host1", true, true, false), newTestEp("10.0.1.2:80", "host1", true, true, false), newTestEp("10.0.1.3:80", "host1", false, false, false)},
@@ -1685,13 +1685,13 @@ func TestCheckoutChanges(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			for _, slice := range tc.appliedSlices {
-				tc.endpointChangeTracker.EndpointSliceUpdate(slice, false)
+				tc.endpointsChangeTracker.EndpointSliceUpdate(slice, false)
 			}
-			tc.endpointChangeTracker.checkoutChanges()
+			tc.endpointsChangeTracker.checkoutChanges()
 			for _, slice := range tc.pendingSlices {
-				tc.endpointChangeTracker.EndpointSliceUpdate(slice, false)
+				tc.endpointsChangeTracker.EndpointSliceUpdate(slice, false)
 			}
-			changes := tc.endpointChangeTracker.checkoutChanges()
+			changes := tc.endpointsChangeTracker.checkoutChanges()
 
 			if len(tc.expectedChanges) != len(changes) {
 				t.Fatalf("Expected %d changes, got %d", len(tc.expectedChanges), len(changes))
@@ -1730,7 +1730,7 @@ func compareEndpointsMapsStr(t *testing.T, newMap EndpointsMap, expected map[Ser
 			for i := range expected[x] {
 				newEp, ok := newMap[x][i].(*BaseEndpointInfo)
 				if !ok {
-					t.Fatalf("Failed to cast endpointsInfo")
+					t.Fatalf("Failed to cast endpointInfo")
 				}
 				if !endpointEqual(newEp, expected[x][i]) {
 					t.Fatalf("expected new[%v][%d] to be %v, got %v"+

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -219,7 +219,7 @@ type Proxier struct {
 	// services that happened since last syncProxyRules call. For a single object,
 	// changes are accumulated, i.e. previous is state from before all of them,
 	// current is state after applying all of those.
-	endpointsChanges *proxy.EndpointChangeTracker
+	endpointsChanges *proxy.EndpointsChangeTracker
 	serviceChanges   *proxy.ServiceChangeTracker
 
 	mu           sync.Mutex // protects the following fields
@@ -413,7 +413,7 @@ func NewProxier(ipFamily v1.IPFamily,
 		svcPortMap:            make(proxy.ServicePortMap),
 		serviceChanges:        proxy.NewServiceChangeTracker(newServiceInfo, ipFamily, recorder, nil),
 		endpointsMap:          make(proxy.EndpointsMap),
-		endpointsChanges:      proxy.NewEndpointChangeTracker(hostname, nil, ipFamily, recorder, nil),
+		endpointsChanges:      proxy.NewEndpointsChangeTracker(hostname, nil, ipFamily, recorder, nil),
 		initialSync:           true,
 		syncPeriod:            syncPeriod,
 		minSyncPeriod:         minSyncPeriod,

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -154,7 +154,7 @@ func NewFakeProxier(ipt utiliptables.Interface, ipvs utilipvs.Interface, ipset u
 		svcPortMap:            make(proxy.ServicePortMap),
 		serviceChanges:        proxy.NewServiceChangeTracker(newServiceInfo, ipFamily, nil, nil),
 		endpointsMap:          make(proxy.EndpointsMap),
-		endpointsChanges:      proxy.NewEndpointChangeTracker(testHostname, nil, ipFamily, nil, nil),
+		endpointsChanges:      proxy.NewEndpointsChangeTracker(testHostname, nil, ipFamily, nil, nil),
 		excludeCIDRs:          excludeCIDRs,
 		iptables:              ipt,
 		ipvs:                  ipvs,
@@ -4358,7 +4358,7 @@ raid10 57344 0 - Live 0xffffffffc0597000`,
 }
 
 // The majority of EndpointSlice specific tests are not ipvs specific and focus on
-// the shared EndpointChangeTracker and EndpointSliceCache. This test ensures that the
+// the shared EndpointsChangeTracker and EndpointSliceCache. This test ensures that the
 // ipvs proxier supports translating EndpointSlices to ipvs output.
 func TestEndpointSliceE2E(t *testing.T) {
 	ipt := iptablestest.NewFake()

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -595,7 +595,7 @@ func TestServiceToServiceMap(t *testing.T) {
 }
 
 type FakeProxier struct {
-	endpointsChanges *EndpointChangeTracker
+	endpointsChanges *EndpointsChangeTracker
 	serviceChanges   *ServiceChangeTracker
 	svcPortMap       ServicePortMap
 	endpointsMap     EndpointsMap
@@ -607,7 +607,7 @@ func newFakeProxier(ipFamily v1.IPFamily, t time.Time) *FakeProxier {
 		svcPortMap:     make(ServicePortMap),
 		serviceChanges: NewServiceChangeTracker(nil, ipFamily, nil, nil),
 		endpointsMap:   make(EndpointsMap),
-		endpointsChanges: &EndpointChangeTracker{
+		endpointsChanges: &EndpointsChangeTracker{
 			lastChangeTriggerTimes:    make(map[types.NamespacedName][]time.Time),
 			trackerStartTime:          t,
 			processEndpointsMapChange: nil,

--- a/pkg/proxy/winkernel/hns_test.go
+++ b/pkg/proxy/winkernel/hns_test.go
@@ -203,7 +203,7 @@ func TestCreateEndpointLocal(t *testing.T) {
 	hns := hns{hcn: newHcnImpl()}
 	Network := mustTestNetwork(t)
 
-	endpoint := &endpointsInfo{
+	endpoint := &endpointInfo{
 		ip:         epIpAddress,
 		macAddress: epMacAddress,
 		isLocal:    true,
@@ -242,7 +242,7 @@ func TestCreateEndpointRemote(t *testing.T) {
 	Network := mustTestNetwork(t)
 	providerAddress := epPaAddress
 
-	endpoint := &endpointsInfo{
+	endpoint := &endpointInfo{
 		ip:              epIpAddressRemote,
 		macAddress:      epMacAddress,
 		isLocal:         false,
@@ -350,11 +350,11 @@ func TestGetLoadBalancerExisting(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	endpoint := &endpointsInfo{
+	endpoint := &endpointInfo{
 		ip:    Endpoint.IpConfigurations[0].IpAddress,
 		hnsID: Endpoint.Id,
 	}
-	endpoints := []endpointsInfo{*endpoint}
+	endpoints := []endpointInfo{*endpoint}
 	hash, err := hashEndpoints(endpoints)
 	if err != nil {
 		t.Error(err)
@@ -409,11 +409,11 @@ func TestGetLoadBalancerNew(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	endpoint := &endpointsInfo{
+	endpoint := &endpointInfo{
 		ip:    Endpoint.IpConfigurations[0].IpAddress,
 		hnsID: Endpoint.Id,
 	}
-	endpoints := []endpointsInfo{*endpoint}
+	endpoints := []endpointInfo{*endpoint}
 	lb, err := hns.getLoadBalancer(endpoints, loadBalancerFlags{}, sourceVip, serviceVip, protocol, internalPort, externalPort, lbs)
 	if err != nil {
 		t.Error(err)
@@ -523,7 +523,7 @@ func TestHashEndpoints(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	endpointInfoA := &endpointsInfo{
+	endpointInfoA := &endpointInfo{
 		ip:    endpointA.IpConfigurations[0].IpAddress,
 		hnsID: endpointA.Id,
 	}
@@ -543,12 +543,12 @@ func TestHashEndpoints(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	endpointInfoB := &endpointsInfo{
+	endpointInfoB := &endpointInfo{
 		ip:    endpointB.IpConfigurations[0].IpAddress,
 		hnsID: endpointB.Id,
 	}
-	endpoints := []endpointsInfo{*endpointInfoA, *endpointInfoB}
-	endpointsReverse := []endpointsInfo{*endpointInfoB, *endpointInfoA}
+	endpoints := []endpointInfo{*endpointInfoA, *endpointInfoB}
+	endpointsReverse := []endpointInfo{*endpointInfoB, *endpointInfoA}
 	h1, err := hashEndpoints(endpoints)
 	if err != nil {
 		t.Error(err)

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -123,8 +123,8 @@ func NewFakeProxier(syncPeriod time.Duration, minSyncPeriod time.Duration, clust
 	}
 
 	serviceChanges := proxy.NewServiceChangeTracker(proxier.newServiceInfo, v1.IPv4Protocol, nil, proxier.serviceMapChange)
-	endpointChangeTracker := proxy.NewEndpointChangeTracker(hostname, proxier.newEndpointInfo, v1.IPv4Protocol, nil, proxier.endpointsMapChange)
-	proxier.endpointsChanges = endpointChangeTracker
+	endpointsChangeTracker := proxy.NewEndpointsChangeTracker(hostname, proxier.newEndpointInfo, v1.IPv4Protocol, nil, proxier.endpointsMapChange)
+	proxier.endpointsChanges = endpointsChangeTracker
 	proxier.serviceChanges = serviceChanges
 
 	return proxier
@@ -232,9 +232,9 @@ func TestCreateRemoteEndpointOverlay(t *testing.T) {
 	proxier.syncProxyRules()
 
 	ep := proxier.endpointsMap[svcPortName][0]
-	epInfo, ok := ep.(*endpointsInfo)
+	epInfo, ok := ep.(*endpointInfo)
 	if !ok {
-		t.Errorf("Failed to cast endpointsInfo %q", svcPortName.String())
+		t.Errorf("Failed to cast endpointInfo %q", svcPortName.String())
 
 	} else {
 		if epInfo.hnsID != "EPID-3" {
@@ -296,9 +296,9 @@ func TestCreateRemoteEndpointL2Bridge(t *testing.T) {
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 	ep := proxier.endpointsMap[svcPortName][0]
-	epInfo, ok := ep.(*endpointsInfo)
+	epInfo, ok := ep.(*endpointInfo)
 	if !ok {
-		t.Errorf("Failed to cast endpointsInfo %q", svcPortName.String())
+		t.Errorf("Failed to cast endpointInfo %q", svcPortName.String())
 
 	} else {
 		if epInfo.hnsID != endpointGuid1 {
@@ -389,9 +389,9 @@ func TestSharedRemoteEndpointDelete(t *testing.T) {
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 	ep := proxier.endpointsMap[svcPortName1][0]
-	epInfo, ok := ep.(*endpointsInfo)
+	epInfo, ok := ep.(*endpointInfo)
 	if !ok {
-		t.Errorf("Failed to cast endpointsInfo %q", svcPortName1.String())
+		t.Errorf("Failed to cast endpointInfo %q", svcPortName1.String())
 
 	} else {
 		if epInfo.hnsID != endpointGuid1 {
@@ -439,9 +439,9 @@ func TestSharedRemoteEndpointDelete(t *testing.T) {
 	proxier.syncProxyRules()
 
 	ep = proxier.endpointsMap[svcPortName1][0]
-	epInfo, ok = ep.(*endpointsInfo)
+	epInfo, ok = ep.(*endpointInfo)
 	if !ok {
-		t.Errorf("Failed to cast endpointsInfo %q", svcPortName1.String())
+		t.Errorf("Failed to cast endpointInfo %q", svcPortName1.String())
 
 	} else {
 		if epInfo.hnsID != endpointGuid1 {
@@ -534,9 +534,9 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 	ep := proxier.endpointsMap[svcPortName1][0]
-	epInfo, ok := ep.(*endpointsInfo)
+	epInfo, ok := ep.(*endpointInfo)
 	if !ok {
-		t.Errorf("Failed to cast endpointsInfo %q", svcPortName1.String())
+		t.Errorf("Failed to cast endpointInfo %q", svcPortName1.String())
 
 	} else {
 		if epInfo.hnsID != endpointGuid1 {
@@ -613,10 +613,10 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 	proxier.syncProxyRules()
 
 	ep = proxier.endpointsMap[svcPortName1][0]
-	epInfo, ok = ep.(*endpointsInfo)
+	epInfo, ok = ep.(*endpointInfo)
 
 	if !ok {
-		t.Errorf("Failed to cast endpointsInfo %q", svcPortName1.String())
+		t.Errorf("Failed to cast endpointInfo %q", svcPortName1.String())
 
 	} else {
 		if epInfo.hnsID != endpointGuid1 {
@@ -913,9 +913,9 @@ func TestEndpointSlice(t *testing.T) {
 	}
 
 	ep := proxier.endpointsMap[svcPortName][0]
-	epInfo, ok := ep.(*endpointsInfo)
+	epInfo, ok := ep.(*endpointInfo)
 	if !ok {
-		t.Errorf("Failed to cast endpointsInfo %q", svcPortName.String())
+		t.Errorf("Failed to cast endpointInfo %q", svcPortName.String())
 
 	} else {
 		if epInfo.hnsID != "EPID-3" {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig network

#### What this PR does / why we need it:
See below, https://github.com/kubernetes/kubernetes/pull/118729#issuecomment-1753915385

~Due to the fact that `v1.Endpoints` has a plural name, lots of endpoint-related things in kube-proxy used "`endpoints`" in their names even when they were referring to a single object, while others used just "`endpoint`", generally in reference to the more generic concept. This always made it hard to remember the names correctly, and that went from "understandably confusing" to "pointlessly confusing" when we replaced all usage of `v1.Endpoints` with `discoveryv1.EndpointSlice`.~

~Fix the names of endpoint-related types/functions/variables to use singular "`Endpoint`" in all cases where the corresponding service-related types/functions/variables use singular "`Service`"/"`ServicePort`".~

~(Also fix some comments that referred to other things by the wrong
names...)~

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
