### PR TITLE
[UT] increase coverage ut for kubeadm/app/features

### DIFF
--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -102,15 +102,6 @@ func Supports(featureList FeatureList, featureName string) bool {
 	return false
 }
 
-// Keys returns a slice of feature names for a given feature set
-func Keys(featureList FeatureList) []string {
-	var list []string
-	for k := range featureList {
-		list = append(list, k)
-	}
-	return list
-}
-
 // KnownFeatures returns a slice of strings describing the FeatureList features.
 func KnownFeatures(f *FeatureList) []string {
 	var known []string

--- a/cmd/kubeadm/app/features/features_test.go
+++ b/cmd/kubeadm/app/features/features_test.go
@@ -207,13 +207,44 @@ func TestCheckDeprecatedFlags(t *testing.T) {
 			features:    map[string]bool{"feature1": true},
 			expectedMsg: map[string]string{},
 		},
+		{
+			name:        "invalid feature",
+			features:    map[string]bool{"feature2": true},
+			expectedMsg: map[string]string{"feature2": "Unknown feature gate flag: feature2"},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			msg := CheckDeprecatedFlags(&someFeatures, test.features)
 			if !reflect.DeepEqual(test.expectedMsg, msg) {
-				t.Error("CheckDeprecatedFlags didn't returned expected message")
+				t.Errorf("CheckDeprecatedFlags() = %v, want %v", msg, test.expectedMsg)
+			}
+		})
+	}
+}
+
+func TestSupports(t *testing.T) {
+	tests := []struct {
+		name        string
+		featureName string
+		want        bool
+	}{
+		{
+			name:        "the feature is not supported",
+			featureName: "foo",
+			want:        false,
+		},
+		{
+			name:        "the feature is supported",
+			featureName: PublicKeysECDSA,
+			want:        true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := Supports(InitFeatureGates, test.featureName); got != test.want {
+				t.Errorf("Supports() = %v, want %v", got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[UT] increase coverage ut for kubeadm/app/features

before:

```
        k8s.io/kubernetes/cmd/kubeadm/app/features      coverage: 79.7% of statements
```

after this change:

```
        k8s.io/kubernetes/cmd/kubeadm/app/features      coverage: 94.9% of statements
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
