### PR TITLE
Replace deprecated sets.Int with sets.Set[int] in Job integration tests

### DIFF
--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -998,7 +998,7 @@ func TestIndexedJob(t *testing.T) {
 		Active: 3,
 		Ready:  pointer.Int32(0),
 	})
-	validateIndexedJobPods(ctx, t, clientSet, jobObj, sets.NewInt(0, 1, 2), "")
+	validateIndexedJobPods(ctx, t, clientSet, jobObj, sets.New(0, 1, 2), "")
 
 	// One Pod succeeds.
 	if err := setJobPhaseForIndex(ctx, clientSet, jobObj, v1.PodSucceeded, 1); err != nil {
@@ -1009,7 +1009,7 @@ func TestIndexedJob(t *testing.T) {
 		Succeeded: 1,
 		Ready:     pointer.Int32(0),
 	})
-	validateIndexedJobPods(ctx, t, clientSet, jobObj, sets.NewInt(0, 2, 3), "1")
+	validateIndexedJobPods(ctx, t, clientSet, jobObj, sets.New(0, 2, 3), "1")
 
 	// One Pod fails, which should be recreated.
 	if err := setJobPhaseForIndex(ctx, clientSet, jobObj, v1.PodFailed, 2); err != nil {
@@ -1021,7 +1021,7 @@ func TestIndexedJob(t *testing.T) {
 		Succeeded: 1,
 		Ready:     pointer.Int32(0),
 	})
-	validateIndexedJobPods(ctx, t, clientSet, jobObj, sets.NewInt(0, 2, 3), "1")
+	validateIndexedJobPods(ctx, t, clientSet, jobObj, sets.New(0, 2, 3), "1")
 
 	// Remaining Pods succeed.
 	if err, _ := setJobPodsPhase(ctx, clientSet, jobObj, v1.PodSucceeded, 3); err != nil {
@@ -1047,7 +1047,7 @@ func TestElasticIndexedJob(t *testing.T) {
 		failIndexes          []int
 		wantSucceededIndexes string
 		wantFailed           int
-		wantRemainingIndexes sets.Int
+		wantRemainingIndexes sets.Set[int]
 		wantActivePods       int
 	}
 	cases := map[string]struct {
@@ -1087,7 +1087,7 @@ func TestElasticIndexedJob(t *testing.T) {
 					failIndexes:          []int{2},
 					wantSucceededIndexes: "1",
 					wantFailed:           1,
-					wantRemainingIndexes: sets.NewInt(0, 2),
+					wantRemainingIndexes: sets.New(0, 2),
 					wantActivePods:       2,
 				},
 				// Scale down completions 3->1, verify prev failure out of range still counts
@@ -1107,13 +1107,13 @@ func TestElasticIndexedJob(t *testing.T) {
 				{
 					succeedIndexes:       []int{2},
 					wantSucceededIndexes: "2",
-					wantRemainingIndexes: sets.NewInt(0, 1),
+					wantRemainingIndexes: sets.New(0, 1),
 					wantActivePods:       2,
 				},
 				// Scale completions down 3->2 to exclude previously succeeded index.
 				{
 					completions:          pointer.Int32Ptr(2),
-					wantRemainingIndexes: sets.NewInt(0, 1),
+					wantRemainingIndexes: sets.New(0, 1),
 					wantActivePods:       2,
 				},
 				// Scale completions back up to include previously succeeded index that was temporarily out of range.
@@ -1815,7 +1815,7 @@ func validateFinishedPodsNoFinalizer(ctx context.Context, t *testing.T, clientSe
 // validateIndexedJobPods validates indexes and hostname of
 // active and completed Pods of an Indexed Job.
 // Call after validateJobPodsStatus
-func validateIndexedJobPods(ctx context.Context, t *testing.T, clientSet clientset.Interface, jobObj *batchv1.Job, wantActive sets.Int, gotCompleted string) {
+func validateIndexedJobPods(ctx context.Context, t *testing.T, clientSet clientset.Interface, jobObj *batchv1.Job, wantActive sets.Set[int], gotCompleted string) {
 	t.Helper()
 	updatedJob, err := clientSet.BatchV1().Jobs(jobObj.Namespace).Get(ctx, jobObj.Name, metav1.GetOptions{})
 	if err != nil {
@@ -1828,7 +1828,7 @@ func validateIndexedJobPods(ctx context.Context, t *testing.T, clientSet clients
 	if err != nil {
 		t.Fatalf("Failed to list Job Pods: %v", err)
 	}
-	gotActive := sets.NewInt()
+	gotActive := sets.New[int]()
 	for _, pod := range pods.Items {
 		if metav1.IsControlledBy(&pod, jobObj) {
 			if pod.Status.Phase == v1.PodPending || pod.Status.Phase == v1.PodRunning {
@@ -1846,9 +1846,9 @@ func validateIndexedJobPods(ctx context.Context, t *testing.T, clientSet clients
 		}
 	}
 	if wantActive == nil {
-		wantActive = sets.NewInt()
+		wantActive = sets.New[int]()
 	}
-	if diff := cmp.Diff(wantActive.List(), gotActive.List()); diff != "" {
+	if diff := cmp.Diff(sets.List(wantActive), sets.List(gotActive)); diff != "" {
 		t.Errorf("Unexpected active indexes (-want,+got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

sets.Int is now deprecated: https://pkg.go.dev/k8s.io/apimachinery/pkg/util/sets#NewInt.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

The code of Job controller itself is already adjusted in: https://github.com/kubernetes/kubernetes/pull/117855

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
