### PR TITLE
Fix race in logging expectations

### DIFF
--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -466,8 +466,9 @@ func updateDS(t *testing.T, dsClient appstyped.DaemonSetInterface, dsName string
 
 func forEachStrategy(t *testing.T, tf func(t *testing.T, strategy *apps.DaemonSetUpdateStrategy)) {
 	for _, strategy := range updateStrategies() {
-		t.Run(fmt.Sprintf("%s_%s", t.Name(), strategy.Type),
-			func(tt *testing.T) { tf(tt, strategy) })
+		t.Run(string(strategy.Type), func(t *testing.T) {
+			tf(t, strategy)
+		})
 	}
 }
 
@@ -536,8 +537,8 @@ func TestSimpleDaemonSetLaunchesPods(t *testing.T) {
 
 func TestSimpleDaemonSetRestartsPodsOnTerminalPhase(t *testing.T) {
 	for _, podPhase := range []v1.PodPhase{v1.PodSucceeded, v1.PodFailed} {
-		t.Run(string(podPhase), func(tt *testing.T) {
-			forEachStrategy(tt, func(t *testing.T, strategy *apps.DaemonSetUpdateStrategy) {
+		t.Run(string(podPhase), func(t *testing.T) {
+			forEachStrategy(t, func(t *testing.T, strategy *apps.DaemonSetUpdateStrategy) {
 				ctx, closeFn, dc, informers, clientset := setup(t)
 				defer closeFn()
 				ns := framework.CreateNamespaceOrDie(clientset, "daemonset-restart-terminal-pod-test", t)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Introduce a thread-safe way of logging expectations. This solves data races that make integration tests fail when running with `-race`.

Side fixes:
- clean up unnecessary renames of variable `t`.
- Unnecessary prefix in subtest name.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Note that the logged information might be out-of-date since the last time it changed, but this was always the case.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
