### PR TITLE
Kubectl: Improve conditionFuncFor expression parsing for wait --for jsonpath

### DIFF
--- a/test/cmd/wait.sh
+++ b/test/cmd/wait.sh
@@ -100,11 +100,16 @@ EOF
     # wait with jsonpath without value to succeed
     set +o errexit
     # Command: Wait with jsonpath without value
-    output_message=$(kubectl wait --for=jsonpath='{.status.replicas}' deploy/test-3 2>&1)
+    output_message_0=$(kubectl wait --for=jsonpath='{.status.replicas}' deploy/test-3 2>&1)
+    # Command: Wait with relaxed jsonpath and filter expression
+    output_message_1=$(kubectl wait \
+        --for='jsonpath=spec.template.spec.containers[?(@.name=="busybox")].image=busybox' \
+        deploy/test-3)
     set -o errexit
 
     # Post-Condition: Wait succeed
-    kube::test::if_has_string "${output_message}" 'deployment.apps/test-3 condition met'
+    kube::test::if_has_string "${output_message_0}" 'deployment.apps/test-3 condition met'
+    kube::test::if_has_string "${output_message_1}" 'deployment.apps/test-3 condition met'
 
     # Clean deployment
     kubectl delete deployment test-3


### PR DESCRIPTION
Make it possible to parse jsonpath filter expressions: Split jsonpath expressions on single '=' only and leave '==' as part of the string.

Reported-at: https://github.com/kubernetes/kubectl/issues/1224

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR improves handling of the jsonpath expression in wait --for. 

#### Which issue(s) this PR fixes:

Fixes: https://github.com/kubernetes/kubectl/issues/1448

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Allow parsing a wider range of jsonpath expressions in `kubectl wait --for`.

```release-note
Improved handling of jsonpath expressions for kubectl wait --for. It is now possible to use simple filter expressions which match on a field's content.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
