### PR TITLE
KEP-127: Update PSS based on feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -884,6 +884,18 @@ const (
 	// ImageMaximumGCAge enables the Kubelet configuration field of the same name, allowing an admin
 	// to specify the age after which an image will be garbage collected.
 	ImageMaximumGCAge featuregate.Feature = "ImageMaximumGCAge"
+
+	// owner: @saschagrunert
+	// alpha: v1.28
+	//
+	// Enables user namespace support for Pod Security Standards. Enabling this
+	// feature will modify all Pod Security Standard rules to allow setting:
+	// spec[.*].securityContext.[runAsNonRoot,runAsUser]
+	// This feature gate should only be enabled if all nodes in the cluster
+	// support the user namespace feature and have it enabled. The feature gate
+	// will not graduate or be enabled by default in future Kubernetes
+	// releases.
+	UserNamespacesPodSecurityStandards featuregate.Feature = "UserNamespacesPodSecurityStandards"
 )
 
 func init() {
@@ -1122,6 +1134,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	LoadBalancerIPMode: {Default: false, PreRelease: featuregate.Alpha},
 
 	ImageMaximumGCAge: {Default: false, PreRelease: featuregate.Alpha},
+
+	UserNamespacesPodSecurityStandards: {Default: false, PreRelease: featuregate.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/plugin/pkg/admission/security/podsecurity/admission.go
+++ b/plugin/pkg/admission/security/podsecurity/admission.go
@@ -27,6 +27,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/apps/install"
 	_ "k8s.io/kubernetes/pkg/apis/batch/install"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
+	"k8s.io/kubernetes/pkg/features"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -151,6 +152,7 @@ func (p *Plugin) updateDelegate() {
 
 func (c *Plugin) InspectFeatureGates(featureGates featuregate.FeatureGate) {
 	c.inspectedFeatureGates = true
+	policy.RelaxPolicyForUserNamespacePods(featureGates.Enabled(features.UserNamespacesPodSecurityStandards))
 }
 
 // ValidateInitialization ensures all required options are set

--- a/staging/src/k8s.io/pod-security-admission/policy/check_runAsNonRoot.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_runAsNonRoot.go
@@ -59,6 +59,11 @@ func CheckRunAsNonRoot() Check {
 }
 
 func runAsNonRoot_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
+	// See KEP-127: https://github.com/kubernetes/enhancements/blob/308ba8d/keps/sig-node/127-user-namespaces/README.md?plain=1#L411-L447
+	if relaxPolicyForUserNamespacePod(podSpec) {
+		return CheckResult{Allowed: true}
+	}
+
 	// things that explicitly set runAsNonRoot=false
 	var badSetters []string
 

--- a/staging/src/k8s.io/pod-security-admission/policy/check_runAsUser.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_runAsUser.go
@@ -60,6 +60,11 @@ func CheckRunAsUser() Check {
 }
 
 func runAsUser_1_23(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
+	// See KEP-127: https://github.com/kubernetes/enhancements/blob/308ba8d/keps/sig-node/127-user-namespaces/README.md?plain=1#L411-L447
+	if relaxPolicyForUserNamespacePod(podSpec) {
+		return CheckResult{Allowed: true}
+	}
+
 	// things that explicitly set runAsUser=0
 	var badSetters []string
 

--- a/staging/src/k8s.io/pod-security-admission/policy/check_runAsUser_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_runAsUser_test.go
@@ -25,11 +25,12 @@ import (
 
 func TestRunAsUser(t *testing.T) {
 	tests := []struct {
-		name         string
-		pod          *corev1.Pod
-		expectAllow  bool
-		expectReason string
-		expectDetail string
+		name                                     string
+		pod                                      *corev1.Pod
+		expectAllow                              bool
+		expectReason                             string
+		expectDetail                             string
+		enableUserNamespacesPodSecurityStandards bool
 	}{
 		{
 			name: "pod runAsUser=0",
@@ -90,10 +91,35 @@ func TestRunAsUser(t *testing.T) {
 			}},
 			expectAllow: true,
 		},
+		{
+			name: "UserNamespacesPodSecurityStandards enabled without HostUsers",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				HostUsers: utilpointer.Bool(false),
+			}},
+			expectAllow:                              true,
+			enableUserNamespacesPodSecurityStandards: true,
+		},
+		{
+			name: "UserNamespacesPodSecurityStandards enabled with HostUsers",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{RunAsUser: utilpointer.Int64(0)},
+				Containers: []corev1.Container{
+					{Name: "a", SecurityContext: nil},
+				},
+				HostUsers: utilpointer.Bool(true),
+			}},
+			expectAllow:                              false,
+			expectReason:                             `runAsUser=0`,
+			expectDetail:                             `pod must not set runAsUser=0`,
+			enableUserNamespacesPodSecurityStandards: true,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.enableUserNamespacesPodSecurityStandards {
+				RelaxPolicyForUserNamespacePods(true)
+			}
 			result := runAsUser_1_23(&tc.pod.ObjectMeta, &tc.pod.Spec)
 			if tc.expectAllow {
 				if !result.Allowed {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

- Introducing a `UserNamespacesPosSecurityStandards` feature gate in the API server
- Updating the PSS to be less restriced as described in https://github.com/kubernetes/enhancements/blob/308ba8d/keps/sig-node/127-user-namespaces/README.md?plain=1#L411-L447

#### Which issue(s) this PR fixes:

Refers to https://github.com/kubernetes/enhancements/issues/127

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

```release-note
Added `UserNamespacesPodSecurityStandards` feature gate to enable user namespace support for Pod Security Standards.
Enabling this feature will modify all Pod Security Standard rules to allow setting: `spec[.*].securityContext.[runAsNonRoot,runAsUser]`.
This feature gate should only be enabled if all nodes in the cluster support the user namespace feature and have it enabled.
The feature gate will not graduate or be enabled by default in future Kubernetes releases.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
KEP: https://github.com/kubernetes/enhancements/issues/127
```
