### PR TITLE
[KEP-2400] Add full cgroup v2 swap support with automatically calculated swap limit for LimitedSwap and Burstable QoS Pods

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -47,6 +47,8 @@ CGROUP_DRIVER=${CGROUP_DRIVER:-""}
 CGROUP_ROOT=${CGROUP_ROOT:-""}
 # owner of client certs, default to current user if not specified
 USER=${USER:-$(whoami)}
+# if true, limited swap is being used instead of unlimited swap (default)
+LIMITED_SWAP=${LIMITED_SWAP:-""}
 
 # required for cni installation
 CNI_CONFIG_DIR=${CNI_CONFIG_DIR:-/etc/cni/net.d}
@@ -829,6 +831,13 @@ EOF
 tracing:
   endpoint: localhost:4317 # the default value
   samplingRatePerMillion: 1000000 # sample always
+EOF
+    fi
+
+    if [[ "$LIMITED_SWAP" == "true" ]]; then
+        cat <<EOF >> "${TMP_DIR}"/kubelet.yaml
+memorySwap:
+  swapBehavior: LimitedSwap
 EOF
     fi
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -566,8 +566,9 @@ const (
 	// Allow pods to failover to a different node in case of non graceful node shutdown
 	NodeOutOfServiceVolumeDetach featuregate.Feature = "NodeOutOfServiceVolumeDetach"
 
-	// owner: @ehashman
+	// owner: @iholder101
 	// alpha: v1.22
+	// beta1: v1.28. For more info, please look at the KEP: https://kep.k8s.io/2400.
 	//
 	// Permits kubelet to run with swap enabled
 	NodeSwap featuregate.Feature = "NodeSwap"
@@ -1010,7 +1011,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	NodeOutOfServiceVolumeDetach: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
 
-	NodeSwap: {Default: false, PreRelease: featuregate.Alpha},
+	NodeSwap: {Default: false, PreRelease: featuregate.Beta},
 
 	PDBUnhealthyPodEvictionPolicy: {Default: true, PreRelease: featuregate.Beta},
 

--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -45,11 +45,12 @@ import (
 const (
 	// systemdSuffix is the cgroup name suffix for systemd
 	systemdSuffix string = ".slice"
-	// MemoryMin is memory.min for cgroup v2
-	MemoryMin string = "memory.min"
-	// MemoryHigh is memory.high for cgroup v2
-	MemoryHigh         string = "memory.high"
-	Cgroup2MaxCpuLimit string = "max"
+	// Cgroup2MemoryMin is memory.min for cgroup v2
+	Cgroup2MemoryMin string = "memory.min"
+	// Cgroup2MemoryHigh is memory.high for cgroup v2
+	Cgroup2MemoryHigh      string = "memory.high"
+	Cgroup2MaxCpuLimit     string = "max"
+	Cgroup2MaxSwapFilename string = "memory.swap.max"
 )
 
 var RootCgroupName = CgroupName([]string{})

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -196,7 +196,7 @@ func ResourceConfigForPod(pod *v1.Pod, enforceCPULimits bool, cpuPeriod uint64, 
 		}
 		if memoryMin > 0 {
 			result.Unified = map[string]string{
-				MemoryMin: strconv.FormatInt(memoryMin, 10),
+				Cgroup2MemoryMin: strconv.FormatInt(memoryMin, 10),
 			}
 		}
 	}

--- a/pkg/kubelet/cm/node_container_manager_linux.go
+++ b/pkg/kubelet/cm/node_container_manager_linux.go
@@ -147,7 +147,7 @@ func enforceExistingCgroup(cgroupManager CgroupManager, cName CgroupName, rl v1.
 			if rp.Unified == nil {
 				rp.Unified = make(map[string]string)
 			}
-			rp.Unified[MemoryMin] = strconv.FormatInt(*rp.Memory, 10)
+			rp.Unified[Cgroup2MemoryMin] = strconv.FormatInt(*rp.Memory, 10)
 		}
 	}
 

--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -292,7 +292,7 @@ func (m *qosContainerManagerImpl) setMemoryQoS(configs map[v1.PodQOSClass]*Cgrou
 		if configs[v1.PodQOSBurstable].ResourceParameters.Unified == nil {
 			configs[v1.PodQOSBurstable].ResourceParameters.Unified = make(map[string]string)
 		}
-		configs[v1.PodQOSBurstable].ResourceParameters.Unified[MemoryMin] = strconv.FormatInt(burstableMin, 10)
+		configs[v1.PodQOSBurstable].ResourceParameters.Unified[Cgroup2MemoryMin] = strconv.FormatInt(burstableMin, 10)
 		klog.V(4).InfoS("MemoryQoS config for qos", "qos", v1.PodQOSBurstable, "memoryMin", burstableMin)
 	}
 
@@ -300,7 +300,7 @@ func (m *qosContainerManagerImpl) setMemoryQoS(configs map[v1.PodQOSClass]*Cgrou
 		if configs[v1.PodQOSGuaranteed].ResourceParameters.Unified == nil {
 			configs[v1.PodQOSGuaranteed].ResourceParameters.Unified = make(map[string]string)
 		}
-		configs[v1.PodQOSGuaranteed].ResourceParameters.Unified[MemoryMin] = strconv.FormatInt(guaranteedMin, 10)
+		configs[v1.PodQOSGuaranteed].ResourceParameters.Unified[Cgroup2MemoryMin] = strconv.FormatInt(guaranteedMin, 10)
 		klog.V(4).InfoS("MemoryQoS config for qos", "qos", v1.PodQOSGuaranteed, "memoryMin", guaranteedMin)
 	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -46,7 +46,7 @@ func (m *kubeGenericRuntimeManager) applyPlatformSpecificContainerConfig(config 
 	enforceMemoryQoS := false
 	// Set memory.min and memory.high if MemoryQoS enabled with cgroups v2
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) &&
-		libcontainercgroups.IsCgroup2UnifiedMode() {
+		isCgroup2UnifiedMode() {
 		enforceMemoryQoS = true
 	}
 	cl, err := m.generateLinuxContainerConfig(container, pod, uid, username, nsTarget, enforceMemoryQoS)
@@ -171,7 +171,7 @@ func (m *kubeGenericRuntimeManager) generateContainerResources(pod *v1.Pod, cont
 	enforceMemoryQoS := false
 	// Set memory.min and memory.high if MemoryQoS enabled with cgroups v2
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) &&
-		libcontainercgroups.IsCgroup2UnifiedMode() {
+		isCgroup2UnifiedMode() {
 		enforceMemoryQoS = true
 	}
 	return &runtimeapi.ContainerResources{
@@ -216,7 +216,7 @@ func (m *kubeGenericRuntimeManager) calculateLinuxResources(cpuRequest, cpuLimit
 	}
 
 	// runc requires cgroupv2 for unified mode
-	if libcontainercgroups.IsCgroup2UnifiedMode() {
+	if isCgroup2UnifiedMode() {
 		resources.Unified = map[string]string{
 			// Ask the kernel to kill all processes in the container cgroup in case of OOM.
 			// See memory.oom.group in https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html for
@@ -297,4 +297,8 @@ func toKubeContainerResources(statusResources *runtimeapi.ContainerResources) *k
 		}
 	}
 	return cStatusResources
+}
+
+var isCgroup2UnifiedMode = func() bool {
+	return libcontainercgroups.IsCgroup2UnifiedMode()
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -21,6 +21,9 @@ package kuberuntime
 
 import (
 	"context"
+	"fmt"
+	"k8s.io/kubernetes/pkg/kubelet/cm"
+	"k8s.io/kubernetes/pkg/kubelet/types"
 	"math"
 	"os"
 	"reflect"
@@ -38,7 +41,6 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 func makeExpectedConfig(m *kubeGenericRuntimeManager, pod *v1.Pod, containerIndex int, enforceMemoryQoS bool) *runtimeapi.ContainerConfig {
@@ -695,96 +697,6 @@ func TestGenerateLinuxContainerConfigNamespaces(t *testing.T) {
 	}
 }
 
-func TestGenerateLinuxContainerConfigSwap(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeSwap, true)()
-	_, _, m, err := createTestRuntimeManager()
-	if err != nil {
-		t.Fatalf("error creating test RuntimeManager: %v", err)
-	}
-	m.machineInfo.MemoryCapacity = 1000000
-	containerName := "test"
-
-	for _, tc := range []struct {
-		name        string
-		swapSetting string
-		pod         *v1.Pod
-		expected    int64
-	}{
-		{
-			name: "config unset, memory limit set",
-			// no swap setting
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{{
-						Name: containerName,
-						Resources: v1.ResourceRequirements{
-							Limits: v1.ResourceList{
-								"memory": resource.MustParse("1000"),
-							},
-							Requests: v1.ResourceList{
-								"memory": resource.MustParse("1000"),
-							},
-						},
-					}},
-				},
-			},
-			expected: 1000,
-		},
-		{
-			name: "config unset, no memory limit",
-			// no swap setting
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{Name: containerName},
-					},
-				},
-			},
-			expected: 0,
-		},
-		{
-			// Note: behaviour will be the same as previous two cases
-			name:        "config set to LimitedSwap, memory limit set",
-			swapSetting: kubelettypes.LimitedSwap,
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{{
-						Name: containerName,
-						Resources: v1.ResourceRequirements{
-							Limits: v1.ResourceList{
-								"memory": resource.MustParse("1000"),
-							},
-							Requests: v1.ResourceList{
-								"memory": resource.MustParse("1000"),
-							},
-						},
-					}},
-				},
-			},
-			expected: 1000,
-		},
-		{
-			name:        "UnlimitedSwap enabled",
-			swapSetting: kubelettypes.UnlimitedSwap,
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{Name: containerName},
-					},
-				},
-			},
-			expected: -1,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			m.memorySwapBehavior = tc.swapSetting
-			actual, err := m.generateLinuxContainerConfig(&tc.pod.Spec.Containers[0], tc.pod, nil, "", nil, false)
-			assert.NoError(t, err)
-			assert.Equal(t, tc.expected, actual.Resources.MemorySwapLimitInBytes, "memory swap config for %s", tc.name)
-		})
-	}
-}
-
 func TestGenerateLinuxContainerResources(t *testing.T) {
 	_, _, m, err := createTestRuntimeManager()
 	assert.NoError(t, err)
@@ -936,6 +848,10 @@ func TestGenerateLinuxContainerResources(t *testing.T) {
 			if tc.scalingFg {
 				defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)()
 			}
+
+			setCgroupVersionDuringTest(cgroupV1)
+			tc.expected.MemorySwapLimitInBytes = tc.expected.MemoryLimitInBytes
+
 			pod.Spec.Containers[0].Resources = v1.ResourceRequirements{Limits: tc.limits, Requests: tc.requests}
 			if len(tc.cStatus) > 0 {
 				pod.Status.ContainerStatuses = tc.cStatus
@@ -948,6 +864,279 @@ func TestGenerateLinuxContainerResources(t *testing.T) {
 		})
 	}
 	//TODO(vinaykul,InPlacePodVerticalScaling): Add unit tests for cgroup v1 & v2
+}
+
+func TestGenerateLinuxContainerResourcesWithSwap(t *testing.T) {
+	_, _, m, err := createTestRuntimeManager()
+	assert.NoError(t, err)
+	m.machineInfo.MemoryCapacity = 42949672960 // 40Gb == 40 * 1024^3
+	m.machineInfo.SwapCapacity = 5368709120    // 5Gb == 5 * 1024^3
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "12345678",
+			Name:      "foo",
+			Namespace: "bar",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "c1",
+				},
+				{
+					Name: "c2",
+				},
+			},
+		},
+		Status: v1.PodStatus{},
+	}
+
+	expectNoSwap := func(cgroupVersion CgroupVersion, resources ...*runtimeapi.LinuxContainerResources) {
+		const msg = "container is expected to not have swap access"
+
+		for _, r := range resources {
+			switch cgroupVersion {
+			case cgroupV1:
+				assert.Equal(t, r.MemoryLimitInBytes, r.MemorySwapLimitInBytes, msg)
+			case cgroupV2:
+				assert.Equal(t, "0", r.Unified[cm.Cgroup2MaxSwapFilename], msg)
+			}
+		}
+	}
+
+	expectUnlimitedSwap := func(cgroupVersion CgroupVersion, resources ...*runtimeapi.LinuxContainerResources) {
+		const msg = "container is expected to have unlimited swap access"
+
+		for _, r := range resources {
+			switch cgroupVersion {
+			case cgroupV1:
+				assert.Equal(t, int64(-1), r.MemorySwapLimitInBytes, msg)
+			case cgroupV2:
+				assert.Equal(t, "max", r.Unified[cm.Cgroup2MaxSwapFilename], msg)
+			}
+		}
+	}
+
+	expectSwap := func(cgroupVersion CgroupVersion, swapBytesExpected int64, resources *runtimeapi.LinuxContainerResources) {
+		msg := fmt.Sprintf("container swap is expected to be limited by %d bytes", swapBytesExpected)
+
+		switch cgroupVersion {
+		case cgroupV1:
+			assert.Equal(t, resources.MemoryLimitInBytes+swapBytesExpected, resources.MemorySwapLimitInBytes, msg)
+		case cgroupV2:
+			assert.Equal(t, fmt.Sprintf("%d", swapBytesExpected), resources.Unified[cm.Cgroup2MaxSwapFilename], msg)
+		}
+	}
+
+	calcSwapForBurstablePods := func(containerMemoryRequest int64) int64 {
+		swapSize, err := calcSwapForBurstablePods(containerMemoryRequest, int64(m.machineInfo.MemoryCapacity), int64(m.machineInfo.SwapCapacity))
+		assert.NoError(t, err)
+
+		return swapSize
+	}
+
+	for _, tc := range []struct {
+		name                        string
+		cgroupVersion               CgroupVersion
+		qosClass                    v1.PodQOSClass
+		nodeSwapFeatureGateEnabled  bool
+		swapBehavior                string
+		addContainerWithoutRequests bool
+		addGuaranteedContainer      bool
+	}{
+		// With cgroup v1
+		{
+			name:                       "cgroups v1, LimitedSwap, Burstable QoS",
+			cgroupVersion:              cgroupV1,
+			qosClass:                   v1.PodQOSBurstable,
+			nodeSwapFeatureGateEnabled: true,
+			swapBehavior:               types.LimitedSwap,
+		},
+		{
+			name:                       "cgroups v1, UnlimitedSwap, Burstable QoS",
+			cgroupVersion:              cgroupV1,
+			qosClass:                   v1.PodQOSBurstable,
+			nodeSwapFeatureGateEnabled: true,
+			swapBehavior:               types.UnlimitedSwap,
+		},
+		{
+			name:                       "cgroups v1, LimitedSwap, Best-effort QoS",
+			cgroupVersion:              cgroupV1,
+			qosClass:                   v1.PodQOSBestEffort,
+			nodeSwapFeatureGateEnabled: true,
+			swapBehavior:               types.LimitedSwap,
+		},
+
+		// With feature gate turned off
+		{
+			name:                       "NodeSwap feature gate turned off, cgroups v2, LimitedSwap",
+			cgroupVersion:              cgroupV2,
+			qosClass:                   v1.PodQOSBurstable,
+			nodeSwapFeatureGateEnabled: false,
+			swapBehavior:               types.LimitedSwap,
+		},
+		{
+			name:                       "NodeSwap feature gate turned off, cgroups v2, UnlimitedSwap",
+			cgroupVersion:              cgroupV2,
+			qosClass:                   v1.PodQOSBurstable,
+			nodeSwapFeatureGateEnabled: false,
+			swapBehavior:               types.UnlimitedSwap,
+		},
+
+		// With no swapBehavior, UnlimitedSwap should be the default
+		{
+			name:                       "With no swapBehavior - UnlimitedSwap should be the default",
+			cgroupVersion:              cgroupV2,
+			qosClass:                   v1.PodQOSBestEffort,
+			nodeSwapFeatureGateEnabled: true,
+			swapBehavior:               "",
+		},
+
+		// With Guaranteed and Best-effort QoS
+		{
+			name:                       "Best-effort Qos, cgroups v2, LimitedSwap",
+			cgroupVersion:              cgroupV2,
+			qosClass:                   v1.PodQOSBurstable,
+			nodeSwapFeatureGateEnabled: true,
+			swapBehavior:               types.LimitedSwap,
+		},
+		{
+			name:                       "Best-effort Qos, cgroups v2, UnlimitedSwap",
+			cgroupVersion:              cgroupV2,
+			qosClass:                   v1.PodQOSBurstable,
+			nodeSwapFeatureGateEnabled: true,
+			swapBehavior:               types.UnlimitedSwap,
+		},
+		{
+			name:                       "Guaranteed Qos, cgroups v2, LimitedSwap",
+			cgroupVersion:              cgroupV2,
+			qosClass:                   v1.PodQOSGuaranteed,
+			nodeSwapFeatureGateEnabled: true,
+			swapBehavior:               types.LimitedSwap,
+		},
+		{
+			name:                       "Guaranteed Qos, cgroups v2, UnlimitedSwap",
+			cgroupVersion:              cgroupV2,
+			qosClass:                   v1.PodQOSGuaranteed,
+			nodeSwapFeatureGateEnabled: true,
+			swapBehavior:               types.UnlimitedSwap,
+		},
+
+		// With a "guaranteed" container (when memory requests equal to limits)
+		{
+			name:                        "Burstable Qos, cgroups v2, LimitedSwap, with a guaranteed container",
+			cgroupVersion:               cgroupV2,
+			qosClass:                    v1.PodQOSBurstable,
+			nodeSwapFeatureGateEnabled:  true,
+			swapBehavior:                types.LimitedSwap,
+			addContainerWithoutRequests: false,
+			addGuaranteedContainer:      true,
+		},
+		{
+			name:                        "Burstable Qos, cgroups v2, UnlimitedSwap, with a guaranteed container",
+			cgroupVersion:               cgroupV2,
+			qosClass:                    v1.PodQOSBurstable,
+			nodeSwapFeatureGateEnabled:  true,
+			swapBehavior:                types.UnlimitedSwap,
+			addContainerWithoutRequests: false,
+			addGuaranteedContainer:      true,
+		},
+
+		// Swap is expected to be allocated
+		{
+			name:                        "Burstable Qos, cgroups v2, LimitedSwap",
+			cgroupVersion:               cgroupV2,
+			qosClass:                    v1.PodQOSBurstable,
+			nodeSwapFeatureGateEnabled:  true,
+			swapBehavior:                types.LimitedSwap,
+			addContainerWithoutRequests: false,
+			addGuaranteedContainer:      false,
+		},
+		{
+			name:                        "Burstable Qos, cgroups v2, UnlimitedSwap",
+			cgroupVersion:               cgroupV2,
+			qosClass:                    v1.PodQOSBurstable,
+			nodeSwapFeatureGateEnabled:  true,
+			swapBehavior:                types.UnlimitedSwap,
+			addContainerWithoutRequests: false,
+			addGuaranteedContainer:      false,
+		},
+		{
+			name:                        "Burstable Qos, cgroups v2, LimitedSwap, with a container with no requests",
+			cgroupVersion:               cgroupV2,
+			qosClass:                    v1.PodQOSBurstable,
+			nodeSwapFeatureGateEnabled:  true,
+			swapBehavior:                types.LimitedSwap,
+			addContainerWithoutRequests: true,
+			addGuaranteedContainer:      false,
+		},
+		{
+			name:                        "Burstable Qos, cgroups v2, UnlimitedSwap, with a container with no requests",
+			cgroupVersion:               cgroupV2,
+			qosClass:                    v1.PodQOSBurstable,
+			nodeSwapFeatureGateEnabled:  true,
+			swapBehavior:                types.UnlimitedSwap,
+			addContainerWithoutRequests: true,
+			addGuaranteedContainer:      false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setCgroupVersionDuringTest(tc.cgroupVersion)
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeSwap, tc.nodeSwapFeatureGateEnabled)()
+			m.memorySwapBehavior = tc.swapBehavior
+
+			var resourceReqsC1, resourceReqsC2 v1.ResourceRequirements
+			switch tc.qosClass {
+			case v1.PodQOSBurstable:
+				resourceReqsC1 = v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceMemory: resource.MustParse("1Gi")},
+				}
+
+				if !tc.addContainerWithoutRequests {
+					resourceReqsC2 = v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceMemory: resource.MustParse("2Gi")},
+					}
+
+					if tc.addGuaranteedContainer {
+						resourceReqsC2.Limits = v1.ResourceList{v1.ResourceMemory: resource.MustParse("2Gi")}
+					}
+				}
+			case v1.PodQOSGuaranteed:
+				resourceReqsC1 = v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceMemory: resource.MustParse("1Gi"), v1.ResourceCPU: resource.MustParse("1")},
+					Limits:   v1.ResourceList{v1.ResourceMemory: resource.MustParse("1Gi"), v1.ResourceCPU: resource.MustParse("1")},
+				}
+				resourceReqsC2 = v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceMemory: resource.MustParse("2Gi"), v1.ResourceCPU: resource.MustParse("1")},
+					Limits:   v1.ResourceList{v1.ResourceMemory: resource.MustParse("2Gi"), v1.ResourceCPU: resource.MustParse("1")},
+				}
+			}
+			pod.Spec.Containers[0].Resources = resourceReqsC1
+			pod.Spec.Containers[1].Resources = resourceReqsC2
+
+			resourcesC1 := m.generateLinuxContainerResources(pod, &pod.Spec.Containers[0], false)
+			resourcesC2 := m.generateLinuxContainerResources(pod, &pod.Spec.Containers[1], false)
+
+			if !tc.nodeSwapFeatureGateEnabled || tc.cgroupVersion == cgroupV1 || (tc.swapBehavior == types.LimitedSwap && tc.qosClass != v1.PodQOSBurstable) {
+				expectNoSwap(tc.cgroupVersion, resourcesC1, resourcesC2)
+				return
+			}
+
+			if tc.swapBehavior == types.UnlimitedSwap || tc.swapBehavior == "" {
+				expectUnlimitedSwap(tc.cgroupVersion, resourcesC1, resourcesC2)
+				return
+			}
+
+			c1ExpectedSwap := calcSwapForBurstablePods(resourceReqsC1.Requests.Memory().Value())
+			c2ExpectedSwap := int64(0)
+			if !tc.addContainerWithoutRequests && !tc.addGuaranteedContainer {
+				c2ExpectedSwap = calcSwapForBurstablePods(resourceReqsC2.Requests.Memory().Value())
+			}
+
+			expectSwap(tc.cgroupVersion, c1ExpectedSwap, resourcesC1)
+			expectSwap(tc.cgroupVersion, c2ExpectedSwap, resourcesC2)
+		})
+	}
 }
 
 type CgroupVersion string

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux_test.go
@@ -38,6 +38,59 @@ func TestApplySandboxResources(t *testing.T) {
 		Linux: &runtimeapi.LinuxPodSandboxConfig{},
 	}
 
+	getPodWithOverhead := func() *v1.Pod {
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:       "12345678",
+				Name:      "bar",
+				Namespace: "new",
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceMemory: resource.MustParse("128Mi"),
+								v1.ResourceCPU:    resource.MustParse("2"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceMemory: resource.MustParse("256Mi"),
+								v1.ResourceCPU:    resource.MustParse("4"),
+							},
+						},
+					},
+				},
+				Overhead: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("128Mi"),
+					v1.ResourceCPU:    resource.MustParse("1"),
+				},
+			},
+		}
+	}
+	getPodWithoutOverhead := func() *v1.Pod {
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:       "12345678",
+				Name:      "bar",
+				Namespace: "new",
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceMemory: resource.MustParse("128Mi"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceMemory: resource.MustParse("256Mi"),
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -45,36 +98,11 @@ func TestApplySandboxResources(t *testing.T) {
 		pod              *v1.Pod
 		expectedResource *runtimeapi.LinuxContainerResources
 		expectedOverhead *runtimeapi.LinuxContainerResources
+		cgroupVersion    CgroupVersion
 	}{
 		{
 			description: "pod with overhead defined",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					UID:       "12345678",
-					Name:      "bar",
-					Namespace: "new",
-				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceMemory: resource.MustParse("128Mi"),
-									v1.ResourceCPU:    resource.MustParse("2"),
-								},
-								Limits: v1.ResourceList{
-									v1.ResourceMemory: resource.MustParse("256Mi"),
-									v1.ResourceCPU:    resource.MustParse("4"),
-								},
-							},
-						},
-					},
-					Overhead: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("128Mi"),
-						v1.ResourceCPU:    resource.MustParse("1"),
-					},
-				},
-			},
+			pod:         getPodWithOverhead(),
 			expectedResource: &runtimeapi.LinuxContainerResources{
 				MemoryLimitInBytes: 268435456,
 				CpuPeriod:          100000,
@@ -87,30 +115,11 @@ func TestApplySandboxResources(t *testing.T) {
 				CpuQuota:           100000,
 				CpuShares:          1024,
 			},
+			cgroupVersion: cgroupV1,
 		},
 		{
 			description: "pod without overhead defined",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					UID:       "12345678",
-					Name:      "bar",
-					Namespace: "new",
-				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceMemory: resource.MustParse("128Mi"),
-								},
-								Limits: v1.ResourceList{
-									v1.ResourceMemory: resource.MustParse("256Mi"),
-								},
-							},
-						},
-					},
-				},
-			},
+			pod:         getPodWithoutOverhead(),
 			expectedResource: &runtimeapi.LinuxContainerResources{
 				MemoryLimitInBytes: 268435456,
 				CpuPeriod:          100000,
@@ -118,10 +127,45 @@ func TestApplySandboxResources(t *testing.T) {
 				CpuShares:          2,
 			},
 			expectedOverhead: &runtimeapi.LinuxContainerResources{},
+			cgroupVersion:    cgroupV1,
+		},
+		{
+			description: "pod with overhead defined",
+			pod:         getPodWithOverhead(),
+			expectedResource: &runtimeapi.LinuxContainerResources{
+				MemoryLimitInBytes: 268435456,
+				CpuPeriod:          100000,
+				CpuQuota:           400000,
+				CpuShares:          2048,
+				Unified:            map[string]string{"memory.oom.group": "1"},
+			},
+			expectedOverhead: &runtimeapi.LinuxContainerResources{
+				MemoryLimitInBytes: 134217728,
+				CpuPeriod:          100000,
+				CpuQuota:           100000,
+				CpuShares:          1024,
+				Unified:            map[string]string{"memory.oom.group": "1"},
+			},
+			cgroupVersion: cgroupV2,
+		},
+		{
+			description: "pod without overhead defined",
+			pod:         getPodWithoutOverhead(),
+			expectedResource: &runtimeapi.LinuxContainerResources{
+				MemoryLimitInBytes: 268435456,
+				CpuPeriod:          100000,
+				CpuQuota:           0,
+				CpuShares:          2,
+				Unified:            map[string]string{"memory.oom.group": "1"},
+			},
+			expectedOverhead: &runtimeapi.LinuxContainerResources{},
+			cgroupVersion:    cgroupV2,
 		},
 	}
 
 	for i, test := range tests {
+		setCgroupVersionDuringTest(test.cgroupVersion)
+
 		m.applySandboxResources(test.pod, config)
 		assert.Equal(t, test.expectedResource, config.Linux.Resources, "TestCase[%d]: %s", i, test.description)
 		assert.Equal(t, test.expectedOverhead, config.Linux.Overhead, "TestCase[%d]: %s", i, test.description)

--- a/test/e2e_node/swap_test.go
+++ b/test/e2e_node/swap_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"fmt"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	testutils "k8s.io/kubernetes/test/utils"
+	admissionapi "k8s.io/pod-security-admission/api"
+	"path/filepath"
+	"strconv"
+)
+
+const (
+	cgroupBasePath        = "/sys/fs/cgroup/"
+	cgroupV1SwapLimitFile = "/memory/memory.memsw.limit_in_bytes"
+	cgroupV2SwapLimitFile = "memory.swap.max"
+	cgroupV1MemLimitFile  = "/memory/memory.limit_in_bytes"
+)
+
+var _ = SIGDescribe("Swap [NodeConformance][LinuxOnly]", func() {
+	f := framework.NewDefaultFramework("swap-test")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
+
+	ginkgo.DescribeTable("with configuration", func(qosClass v1.PodQOSClass, memoryRequestEqualLimit bool) {
+		ginkgo.By(fmt.Sprintf("Creating a pod of QOS class %s. memoryRequestEqualLimit: %t", qosClass, memoryRequestEqualLimit))
+		pod := getSwapTestPod(f, qosClass, memoryRequestEqualLimit)
+		pod = runPodAndWaitUntilScheduled(f, pod)
+
+		isCgroupV2 := isPodCgroupV2(f, pod)
+		isLimitedSwap := isLimitedSwap(f, pod)
+
+		if !isSwapFeatureGateEnabled() || !isCgroupV2 || (isLimitedSwap && (qosClass != v1.PodQOSBurstable || memoryRequestEqualLimit)) {
+			ginkgo.By(fmt.Sprintf("Expecting no swap. feature gate on? %t isCgroupV2? %t is QoS burstable? %t", isSwapFeatureGateEnabled(), isCgroupV2, qosClass == v1.PodQOSBurstable))
+			expectNoSwap(f, pod, isCgroupV2)
+			return
+		}
+
+		if !isLimitedSwap {
+			ginkgo.By("expecting unlimited swap")
+			expectUnlimitedSwap(f, pod, isCgroupV2)
+			return
+		}
+
+		ginkgo.By("expecting limited swap")
+		expectedSwapLimit := calcSwapForBurstablePod(f, pod)
+		expectLimitedSwap(f, pod, expectedSwapLimit)
+	},
+		ginkgo.Entry("QOS Best-effort", v1.PodQOSBestEffort, false),
+		ginkgo.Entry("QOS Burstable", v1.PodQOSBurstable, false),
+		ginkgo.Entry("QOS Burstable with memory request equals to limit", v1.PodQOSBurstable, true),
+		ginkgo.Entry("QOS Guaranteed", v1.PodQOSGuaranteed, false),
+	)
+})
+
+// Note that memoryRequestEqualLimit is effective only when qosClass is PodQOSBestEffort.
+func getSwapTestPod(f *framework.Framework, qosClass v1.PodQOSClass, memoryRequestEqualLimit bool) *v1.Pod {
+	podMemoryAmount := resource.MustParse("128Mi")
+
+	var resources v1.ResourceRequirements
+	switch qosClass {
+	case v1.PodQOSBestEffort:
+		// nothing to do in this case
+	case v1.PodQOSBurstable:
+		resources = v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceMemory: podMemoryAmount,
+			},
+		}
+
+		if memoryRequestEqualLimit {
+			resources.Limits = resources.Requests
+		}
+	case v1.PodQOSGuaranteed:
+		resources = v1.ResourceRequirements{
+			Limits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("200m"),
+				v1.ResourceMemory: podMemoryAmount,
+			},
+		}
+		resources.Requests = resources.Limits
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-swap-" + rand.String(5),
+			Namespace: f.Namespace.Name,
+		},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyAlways,
+			Containers: []v1.Container{
+				{
+					Name:      "busybox-container",
+					Image:     busyboxImage,
+					Command:   []string{"sleep", "600"},
+					Resources: resources,
+				},
+			},
+		},
+	}
+
+	return pod
+}
+
+func runPodAndWaitUntilScheduled(f *framework.Framework, pod *v1.Pod) *v1.Pod {
+	ginkgo.By("running swap test pod")
+	podClient := e2epod.NewPodClient(f)
+
+	pod = podClient.CreateSync(context.Background(), pod)
+	pod, err := podClient.Get(context.Background(), pod.Name, metav1.GetOptions{})
+
+	framework.ExpectNoError(err)
+	isReady, err := testutils.PodRunningReady(pod)
+	framework.ExpectNoError(err)
+	gomega.ExpectWithOffset(1, isReady).To(gomega.BeTrue(), "pod should be ready")
+
+	return pod
+}
+
+func isSwapFeatureGateEnabled() bool {
+	ginkgo.By("figuring if NodeSwap feature gate is turned on")
+	return utilfeature.DefaultFeatureGate.Enabled(features.NodeSwap)
+}
+
+func readCgroupFile(f *framework.Framework, pod *v1.Pod, filename string) string {
+	filePath := filepath.Join(cgroupBasePath, filename)
+
+	ginkgo.By("reading cgroup file " + filePath)
+	output := e2epod.ExecCommandInContainer(f, pod.Name, pod.Spec.Containers[0].Name, "/bin/sh", "-ec", "cat "+filePath)
+
+	return output
+}
+
+func isPodCgroupV2(f *framework.Framework, pod *v1.Pod) bool {
+	ginkgo.By("figuring is test pod runs cgroup v2")
+	output := e2epod.ExecCommandInContainer(f, pod.Name, pod.Spec.Containers[0].Name, "/bin/sh", "-ec", `if test -f "/sys/fs/cgroup/cgroup.controllers"; then echo "true"; else echo "false"; fi`)
+
+	return output == "true"
+}
+
+func expectNoSwap(f *framework.Framework, pod *v1.Pod, isCgroupV2 bool) {
+	if isCgroupV2 {
+		swapLimit := readCgroupFile(f, pod, cgroupV2SwapLimitFile)
+		gomega.ExpectWithOffset(1, swapLimit).To(gomega.Equal("0"), "max swap allowed should be zero")
+	} else {
+		swapPlusMemLimit := readCgroupFile(f, pod, cgroupV1SwapLimitFile)
+		memLimit := readCgroupFile(f, pod, cgroupV1MemLimitFile)
+		gomega.ExpectWithOffset(1, swapPlusMemLimit).ToNot(gomega.BeEmpty())
+		gomega.ExpectWithOffset(1, swapPlusMemLimit).To(gomega.Equal(memLimit))
+	}
+}
+
+func expectUnlimitedSwap(f *framework.Framework, pod *v1.Pod, isCgroupV2 bool) {
+	if isCgroupV2 {
+		swapLimit := readCgroupFile(f, pod, cgroupV2SwapLimitFile)
+		gomega.ExpectWithOffset(1, swapLimit).To(gomega.Equal("max"), "max swap allowed should be \"max\"")
+	} else {
+		swapPlusMemLimit := readCgroupFile(f, pod, cgroupV1SwapLimitFile)
+		gomega.ExpectWithOffset(1, swapPlusMemLimit).To(gomega.Equal("-1"))
+	}
+}
+
+// supports v2 only as v1 shouldn't support LimitedSwap
+func expectLimitedSwap(f *framework.Framework, pod *v1.Pod, expectedSwapLimit int64) {
+	swapLimitStr := readCgroupFile(f, pod, cgroupV2SwapLimitFile)
+
+	swapLimit, err := strconv.Atoi(swapLimitStr)
+	framework.ExpectNoError(err, "cannot convert swap limit to int")
+
+	// cgroup values are always aligned w.r.t. the page size, which is usually 4Ki
+	const cgroupAlignment int64 = 4 * 1024 // 4Ki
+	const errMsg = "swap limitation is not as expected"
+
+	gomega.ExpectWithOffset(1, int64(swapLimit)).To(
+		gomega.Or(
+			gomega.BeNumerically(">=", expectedSwapLimit-cgroupAlignment),
+			gomega.BeNumerically("<=", expectedSwapLimit+cgroupAlignment),
+		),
+		errMsg,
+	)
+}
+
+func getSwapCapacity(f *framework.Framework, pod *v1.Pod) int64 {
+	output := e2epod.ExecCommandInContainer(f, pod.Name, pod.Spec.Containers[0].Name, "/bin/sh", "-ec", "free -b | grep Swap | xargs | cut -d\" \" -f2")
+
+	swapCapacity, err := strconv.Atoi(output)
+	framework.ExpectNoError(err, "cannot convert swap size to int")
+
+	ginkgo.By(fmt.Sprintf("providing swap capacity: %d", swapCapacity))
+
+	return int64(swapCapacity)
+}
+
+func getMemoryCapacity(f *framework.Framework, pod *v1.Pod) int64 {
+	nodes, err := f.ClientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	framework.ExpectNoError(err, "failed listing nodes")
+
+	for _, node := range nodes.Items {
+		if node.Name != pod.Spec.NodeName {
+			continue
+		}
+
+		memCapacity := node.Status.Capacity[v1.ResourceMemory]
+		return memCapacity.Value()
+	}
+
+	framework.ExpectNoError(fmt.Errorf("node %s wasn't found", pod.Spec.NodeName))
+	return 0
+}
+
+func calcSwapForBurstablePod(f *framework.Framework, pod *v1.Pod) int64 {
+	nodeMemoryCapacity := getMemoryCapacity(f, pod)
+	nodeSwapCapacity := getSwapCapacity(f, pod)
+	containerMemoryRequest := pod.Spec.Containers[0].Resources.Requests.Memory().Value()
+
+	containerMemoryProportion := float64(containerMemoryRequest) / float64(nodeMemoryCapacity)
+	swapAllocation := containerMemoryProportion * float64(nodeSwapCapacity)
+	ginkgo.By(fmt.Sprintf("Calculating swap for burstable pods: nodeMemoryCapacity: %d, nodeSwapCapacity: %d, containerMemoryRequest: %d, swapAllocation: %d",
+		nodeMemoryCapacity, nodeSwapCapacity, containerMemoryRequest, int64(swapAllocation)))
+
+	return int64(swapAllocation)
+}
+
+func isLimitedSwap(f *framework.Framework, pod *v1.Pod) bool {
+	kubeletCfg, err := getCurrentKubeletConfig(context.Background())
+	framework.ExpectNoError(err, "cannot get kubelet config")
+
+	return kubeletCfg.MemorySwap.SwapBehavior == types.LimitedSwap
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature
/sig node

#### What this PR does / why we need it:
Adds full support for node swap running on cgroup v2, for both Limited and Unlimited swap behaviors as per KEP 2400 [1].

In addition, as the KEP dictates, support for cgroup v1 is being removed.

In addition, as per the KEP, when LimitedSwap is enabled the swap limit would be automatically calculated for
Burstable QoS pods. For Best-Effort / Guaranteed QoS pods, swap would be disabled.

The formula for the swap limit for Burstable QoS pods is:
`(<memory-request>/<node-memory-capacity>)*<node-swap-capacity>`.

In addition, containers with memory limits that are equal memory requests would not be able to access swap as well.
This is a nice way to opt-out of swap usage when LimitedSwap is enabled.

[1] https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119427
Fixes #119428
Fixes #119430

#### Special notes for your reviewer:
~~This PR introduces a commit to fix a cadvisor bug. This bug was [fixed upstream](https://github.com/google/cadvisor/pull/3293), although cadvisor did not seem to have a new release since then. For testing purposes I keep the commit as being part of the PR, but it should eventually be removed in favor of bumping cadvisor's version.~~

UPDATE: new cadvisor version with the fix is now consumed with this PR: https://github.com/kubernetes/kubernetes/pull/119225.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add full cgroup v2 swap support for both Limited and Unlimited swap.

When LimitedSwap is enabled the swap limit would be automatically calculated for
Burstable QoS pods. For Best-Effort / Guaranteed QoS pods, swap would be disabled.

Containers with memory requests equal to their memory limits also won't have
swap access, and it is a way to opt-out of swap for a single container.

The formula for the swap limit for Burstable QoS pods is:
`(<memory-request>/<node-memory-capacity>)*<node-swap-capacity>`.

Support for cgroup v1 is removed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/
```

### Manual testing and sample output
In order to ease the review process and give an clearer idea about how this feature functions,
I'll present some sample outputs and show swap usage in action.

In the following test cases, I'll be using the following test pod:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
spec:
  containers:
  - name: c1
    resources:
      requests:
        memory: "512M"
    image: quay.io/mabekitzur/fedora-with-stress-ng:12-3-2022
    command: ["/bin/bash"]
    args: ["-c", "sleep 9999"]
```

The container image is based on the latest fedora, but also installs stress-ng. This would be useful to test swap behavior.
In addition, I'm using `k` instead of `./cluster/kubectl.sh` for simplicity.

#### Test case #1 - sanity check: without swap enabled
Create the pod:
```bash
> k create -f pod.yaml
pod/test-pod created
```

Check the swap memory limit:
```bash
> k exec -it test-pod -- "cat" "/sys/fs/cgroup/memory.swap.max"
0
```

See that swap is disabled (equals to 0).
Before this PR, it used to be `max`, which means there is no limitation for swap usage. This is fixed in this PR.

Now, let's try to stress the pod in order to show swap is being used. In order to achieve that, we can run the following two in parallel.
First, continuously print the swap usage on that Pod:
```bash
> k exec -it test-pod -- bash
[root@test-pod /]> while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 7; done
```

Meanwhile, let's stress the pod to force swapping out pages:
```bash
> k exec -it test-pod -- bash
[root@test-pod /]> stress-ng --vm-bytes 525158751436b --vm-keep -m 1
```

The current swap usage is as follows:
```bash
> k exec -it test-pod -c c1 -- bash
[root@test-pod /]# while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 2; done
0
0
...
```

As can be seen, swap is not being used as expected.

#### Case #2 - With unlimited swap
First, before deploying the cluster, the following environment variable has to be defined:
```bash
> export FEATURE_GATES="NodeSwap=true"
```

Create the pod:
```bash
> k create -f pod.yaml
pod/test-pod created
```

Check the swap memory limit:
```bash
> k exec -it test-pod -- "cat" "/sys/fs/cgroup/memory.swap.max"
max
```

This is now set to `max` as expected.

Now, let's try to stress the pod in order to show swap is being used. In order to achieve that, we can run the following two in parallel.
First, continuously print the swap usage on that Pod:
```bash
> k exec -it test-pod -- bash
[root@test-pod /]> while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 7; done
```

Meanwhile, let's stress the pod to force swapping out pages:
```bash
> k exec -it test-pod -- bash
[root@test-pod /]> stress-ng --vm-bytes 525158751436b --vm-keep -m 1
```

When we look back at the previous command continuously printing the swap usage we see:
```bash
> k exec -it test-pod -- bash
[root@test-pod /]> while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 7; done
0
# ... many zeros
0
...
2653233152
6713556992
9481170944
12596342784
16045711360
19471413248
22949982208
26457309184
30129651712
33872568320
37397729280
41005793280
```

As can be seen, the swap usage is getting larger and larger as time goes by.

#### Case #3 - With limited swap and a Burstable QoS Pod
First, before deploying the cluster, the following environment variable has to be defined:
```bash
> export FEATURE_GATES="NodeSwap=true"
> export LIMITED_SWAP=true
```

_Note that `LIMITED_SWAP` is a new environment variable introduced in this PR._

Create the pod:
```bash
> k create -f pod.yaml
pod/test-pod created
```

As per [KEP2400](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md#steps-to-calculate-swap-limit), the swap limit is being automatically calculated for Burstable QoS pods. As written in the KEP, the fomula is: `(<container-request>/<node-memory-capacity>)*<swap-size>)`. On my system, I have approximately 400Gi of total memory and a swap size of approximately 40Gi. Therefore, the swap limit needs to be approximately `(0.5Gi/400Gi)*40Gi == 0.5Gi`.

Let's check the memory limit that was set automatically:
Check the swap memory limit:
```bash
> k exec -it test-pod -- "cat" "/sys/fs/cgroup/memory.swap.max"
54435840
```

Since `54,435,840 bytes == (54,435,840/1024^3)Gi ~= 0.5Gi`, we can tell that the limit was set as expected.

Now, as before, let's stress the pod and see the actual swap usage:
```bash
> k exec -it test-pod -- bash
[root@test-pod /]> while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 7; done
0
# ... many zeros
0
...
54435840
54435840
54435840
54435840
...
```

As we can see, the pod cannot exceed its swap limit, as expected.

#### Case #4 - With limited swap and a Burstable QoS Pod with memory limits==requests
In this case the KEP dictates that no swap memory should be allocated to the container.
This way it's easy to opt-out of swap.

_Note: the same behavior would apply to Best-Effort / Guaranteed QoS Pods._
_Note: for this example I've changed the pod example above so that memory limits are equal to requests_

As before, we'll depoloy the cluster with NodeSwap feature gate and LimitedSwap and create the pod:
```bash
> export FEATURE_GATES="NodeSwap=true"
> export LIMITED_SWAP=true
```

```bash
> k create -f pod.yaml
pod/test-pod created
```

Check the swap memory limit:
```bash
> k exec -it test-pod -- "cat" "/sys/fs/cgroup/memory.swap.max"
0
```

See that swap is disabled (equals to 0).

If we would repeat the same steps as before, meaning stressing the container:
```bash
> k exec -it test-pod -c c1 -- bash
[root@test-pod /]# while true; do cat /sys/fs/cgroup/memory.swap.current; sleep 2; done
0
0
...
```

As can be seen, swap is not being used as expected.
