### PR TITLE
fix(script): handle wait_for_success failed condition

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -685,6 +685,10 @@ function wait_node_ready(){
   local system_node_wait_time=60
   local interval_time=2
   kube::util::wait_for_success "$system_node_wait_time" "$interval_time" "$nodes_stats | grep $node_name"
+  if [ $? == "1" ]; then
+    echo "time out on waiting $node_name exist"
+    exit 1
+  fi
 
   local system_node_ready_time=300
   local node_ready="${KUBECTL} --kubeconfig '${CERT_DIR}/admin.kubeconfig' wait --for=condition=Ready --timeout=60s nodes $node_name"


### PR DESCRIPTION
#### What type of PR is this?
/kind script

#### What this PR does / why we need it:
fix hack/local-up-cluster.sh script:
In the wait_node_ready function, two steps are performed:
  1.Check if the node exists
  2.Wait for the node to enter the ready state
If one step fails, the second step should not continue, wasting 300 seconds.
