### PR TITLE
docs: add periods to documentation of ResourceAttributes "namespace"

### DIFF
--- a/staging/src/k8s.io/api/authorization/v1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1/types.go
@@ -91,10 +91,10 @@ type LocalSubjectAccessReview struct {
 
 // ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface
 type ResourceAttributes struct {
-	// Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces
-	// "" (empty) is defaulted for LocalSubjectAccessReviews
-	// "" (empty) is empty for cluster-scoped resources
-	// "" (empty) means "all" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview
+	// Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces. 
+	// "" (empty) is defaulted for LocalSubjectAccessReviews. 
+	// "" (empty) is empty for cluster-scoped resources. 
+	// "" (empty) means "all" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview. 
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,1,opt,name=namespace"`
 	// Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  "*" means all.


### PR DESCRIPTION
The reference documentation for the ResourceAttributes "namespace" in the authorization API was very confusing.
With periods it should be more understandable.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Improve documentation.

#### Which issue(s) this PR fixes:

None, there is no issue ticket.

#### Special notes for your reviewer:

See current documentation here: 

* https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/subject-access-review-v1/#SubjectAccessReviewSpec
* Previous state: https://github.com/kubernetes/kubernetes/blob/bbc7ca94a429c600716b98add53a64f21c29cd61/api/openapi-spec/v3/apis__authorization.k8s.io__v1_openapi.json#L106

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
