### PR TITLE
Fix kubelet version skew handling for in-place pod resize feature.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1944,8 +1944,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 		if kl.podWorkers.CouldHaveRunningContainers(pod.UID) && !kubetypes.IsStaticPod(pod) {
 			pod = kl.handlePodResourcesResize(pod)
 		}
-	} else {
-		//todo(pbialon, InPlacePodVerticalScaling): check if we have any pending resize requests for this pod
+	} else if pod.Status.Phase != v1.PodRunning && kl.isPodResized(pod) {
 		pod = kl.podResizeInfeasible(pod)
 	}
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1695,6 +1695,7 @@ func (kl *Kubelet) Run(updates <-chan kubetypes.PodUpdate) {
 //   - Create the data directories for the pod if they do not exist
 //   - Wait for volumes to attach/mount
 //   - Fetch the pull secrets for the pod
+//   - If the FG InPlacePodVerticalScaling is enabled do the scaling
 //   - Call the container runtime's SyncPod callback
 //   - Update the traffic shaping for the pod's ingress and egress limits
 //

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1517,26 +1517,18 @@ func (kl *Kubelet) specStatusDiffers(pod *v1.Pod, podStatus *v1.PodStatus) bool 
 }
 
 func (kl *Kubelet) determinePodResizeStatus(pod *v1.Pod, podStatus *v1.PodStatus) v1.PodResizeStatus {
-	var podResizeStatus v1.PodResizeStatus
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
-		if !kl.specStatusDiffers(pod, podStatus) {
-			// Clear last resize state from checkpoint
-			if err := kl.statusManager.SetPodResizeStatus(pod.UID, ""); err != nil {
-				klog.ErrorS(err, "SetPodResizeStatus failed", "pod", pod.Name)
-			}
-		} else {
-			if resizeStatus, found := kl.statusManager.GetPodResizeStatus(string(pod.UID)); found {
-				podResizeStatus = resizeStatus
-			}
+	if !kl.specStatusDiffers(pod, podStatus) {
+		// Clear last resize state from checkpoint
+		if err := kl.statusManager.SetPodResizeStatus(pod.UID, ""); err != nil {
+			klog.ErrorS(err, "SetPodResizeStatus failed", "pod", pod.Name)
 		}
 	} else {
-		if kl.specStatusDiffers(pod, podStatus) {
-			podResizeStatus = v1.PodResizeStatusInfeasible
+		if resizeStatus, found := kl.statusManager.GetPodResizeStatus(string(pod.UID)); found {
+			return resizeStatus
 		}
 	}
 
-	return podResizeStatus
+	return ""
 }
 
 // generateAPIPodStatus creates the final API pod status for a pod, given the
@@ -1549,7 +1541,13 @@ func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.Po
 		oldPodStatus = pod.Status
 	}
 	s := kl.convertStatusToAPIStatus(pod, podStatus, oldPodStatus)
-	s.Resize = kl.determinePodResizeStatus(pod, s)
+	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
+		s.Resize = kl.determinePodResizeStatus(pod, s)
+	} else {
+		if !kl.specStatusDiffers(pod, s) {
+			s.Resize = v1.PodResizeStatusInfeasible
+		}
+	}
 
 	// calculate the next phase and preserve reason
 	allStatus := append(append([]v1.ContainerStatus{}, s.ContainerStatuses...), s.InitContainerStatuses...)

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1541,10 +1541,8 @@ func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.Po
 	s := kl.convertStatusToAPIStatus(pod, podStatus, oldPodStatus)
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		s.Resize = kl.determinePodResizeStatus(pod, s)
-	} else {
-		if !kl.specStatusDiffers(pod, s) {
-			s.Resize = v1.PodResizeStatusInfeasible
-		}
+	} else if kl.specStatusDiffers(pod, s) {
+		s.Resize = v1.PodResizeStatusInfeasible
 	}
 
 	// calculate the next phase and preserve reason

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1522,10 +1522,8 @@ func (kl *Kubelet) determinePodResizeStatus(pod *v1.Pod, podStatus *v1.PodStatus
 		if err := kl.statusManager.SetPodResizeStatus(pod.UID, ""); err != nil {
 			klog.ErrorS(err, "SetPodResizeStatus failed", "pod", pod.Name)
 		}
-	} else {
-		if resizeStatus, found := kl.statusManager.GetPodResizeStatus(string(pod.UID)); found {
-			return resizeStatus
-		}
+	} else if resizeStatus, found := kl.statusManager.GetPodResizeStatus(string(pod.UID)); found {
+		return resizeStatus
 	}
 
 	return ""

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -449,6 +449,7 @@ func TestSyncPodsStartPod(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
+	kubelet.statusManager = status.NewFakeManager()
 	fakeRuntime := testKubelet.fakeRuntime
 	pods := []*v1.Pod{
 		podWithUIDNameNsSpec("12345678", "foo", "new", v1.PodSpec{

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -449,7 +449,6 @@ func TestSyncPodsStartPod(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
-	kubelet.statusManager = status.NewFakeManager()
 	fakeRuntime := testKubelet.fakeRuntime
 	pods := []*v1.Pod{
 		podWithUIDNameNsSpec("12345678", "foo", "new", v1.PodSpec{

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -168,6 +168,7 @@ func NewManager(kubeClient clientset.Interface, podManager PodManager, podDeleti
 		podDeletionSafety:       podDeletionSafety,
 		podStartupLatencyHelper: podStartupLatencyHelper,
 		stateFileDirectory:      stateFileDirectory,
+		state:                   state.NewNoopStateCheckpoint(),
 	}
 }
 
@@ -191,9 +192,6 @@ func isPodStatusByKubeletEqual(oldStatus, status *v1.PodStatus) bool {
 }
 
 func (m *manager) Start() {
-	// Initialize m.state to no-op state checkpoint manager
-	m.state = state.NewNoopStateCheckpoint()
-
 	// Create pod allocation checkpoint manager even if client is nil so as to allow local get/set of AllocatedResources & Resize
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		stateImpl, err := state.NewStateCheckpoint(m.stateFileDirectory, podStatusManagerStateFile)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add a handling for in-place pod vertical scaling requests which are infeasible when the FG InPlacePodVerticalScaling is disabled. In this case we set `infeasible` `PodResizeStatus`. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref #117767

#### Special notes for your reviewer:

It's my first PR in kubernetes. I wasn't 100% sure if it is what we wanted here, so I haven't prepared any further tests or sth. Also the second part of the issue - `scheduler` is not covered here.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
