### PR TITLE
dra: kubelet must skip NodePrepareResource if not used by any container

### DIFF
--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -67,7 +67,8 @@ func NewManagerImpl(kubeClient clientset.Interface, stateFileDirectory string) (
 // containerResources on success.
 func (m *ManagerImpl) PrepareResources(pod *v1.Pod) error {
 	for i := range pod.Spec.ResourceClaims {
-		claimName := resourceclaim.Name(pod, &pod.Spec.ResourceClaims[i])
+		podClaim := &pod.Spec.ResourceClaims[i]
+		claimName := resourceclaim.Name(pod, podClaim)
 		klog.V(3).InfoS("Processing resource", "claim", claimName, "pod", pod.Name)
 
 		// Query claim object from the API server
@@ -83,6 +84,13 @@ func (m *ManagerImpl) PrepareResources(pod *v1.Pod) error {
 		if !resourceclaim.IsReservedForPod(pod, resourceClaim) {
 			return fmt.Errorf("pod %s(%s) is not allowed to use resource claim %s(%s)",
 				pod.Name, pod.UID, claimName, resourceClaim.UID)
+		}
+
+		// If no container actually uses the claim, then we don't need
+		// to prepare it.
+		if !claimIsUsedByPod(podClaim, pod) {
+			klog.V(5).InfoS("Skipping unused resource", "claim", claimName, "pod", pod.Name)
+			continue
 		}
 
 		// Is the resource already prepared? Then add the pod UID to it.
@@ -176,6 +184,34 @@ func (m *ManagerImpl) PrepareResources(pod *v1.Pod) error {
 		return fmt.Errorf("failed to checkpoint claimInfo state, err: %+v", err)
 	}
 	return nil
+}
+
+func claimIsUsedByPod(podClaim *v1.PodResourceClaim, pod *v1.Pod) bool {
+	if claimIsUsedByContainers(podClaim, pod.Spec.InitContainers) {
+		return true
+	}
+	if claimIsUsedByContainers(podClaim, pod.Spec.Containers) {
+		return true
+	}
+	return false
+}
+
+func claimIsUsedByContainers(podClaim *v1.PodResourceClaim, containers []v1.Container) bool {
+	for i := range containers {
+		if claimIsUsedByContainer(podClaim, &containers[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func claimIsUsedByContainer(podClaim *v1.PodResourceClaim, container *v1.Container) bool {
+	for _, c := range container.Resources.Claims {
+		if c.Name == podClaim.Name {
+			return true
+		}
+	}
+	return false
 }
 
 // GetResources gets a ContainerInfo object from the claimInfo cache.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If (for whatever reason) no container uses a claim, then there's no need to prepare it. We also need to test this.

#### Does this PR introduce a user-facing change?
```release-note
As in Kubernetes 1.26 and 1.27, resource claims do not get prepared by kubelet when no container uses them. This was changed accidentally in [v1.28.0-alpha.1](https://github.com/kubernetes/kubernetes/releases/tag/v1.28.0-alpha.1).
```
