### PR TITLE
Update godoc for Authorizer interface to reflect current signature.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/interfaces.go
@@ -64,10 +64,12 @@ type Attributes interface {
 	GetPath() string
 }
 
-// Authorizer makes an authorization decision based on information gained by making
-// zero or more calls to methods of the Attributes interface.  It returns nil when an action is
-// authorized, otherwise it returns an error.
+// Authorizer makes authorization decisions based on request attributes.
 type Authorizer interface {
+	// Authorize makes an authorization decision based on the provided Attributes. The returned
+	// reason may be empty. If nonempty, it is a human-readable explanation for the
+	// decision. The returned decision and reason are always valid, even if a non-nil error is
+	// also returned.
 	Authorize(ctx context.Context, a Attributes) (authorized Decision, reason string, err error)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The current godoc has remained unchanged since the introduction of the interface in 2014, when Authorize had a single error-typed return value. It has become stale as the signature of Authorize evolved over time.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
