### PR TITLE
Fix stable metric finder for NewDesc with custom import name

### DIFF
--- a/test/instrumentation/decode_metric.go
+++ b/test/instrumentation/decode_metric.go
@@ -144,7 +144,7 @@ func (c *metricDecoder) decodeDesc(ce *ast.CallExpr) (metric, error) {
 		return *m, newDecodeErrorf(ce, "can't decode const labels")
 	}
 	m.ConstLabels = cLabels
-	sl, err := decodeStabilityLevel(ce.Args[4], "metrics")
+	sl, err := decodeStabilityLevel(ce.Args[4], c.kubeMetricsImportName)
 	if err != nil {
 		return *m, newDecodeErrorf(ce, "can't decode stability level")
 	}

--- a/test/instrumentation/find_stable_metric.go
+++ b/test/instrumentation/find_stable_metric.go
@@ -66,7 +66,7 @@ func (f *stableMetricFinder) Visit(node ast.Node) (w ast.Visitor) {
 	case *ast.CallExpr:
 		if se, ok := opts.Fun.(*ast.SelectorExpr); ok {
 			if se.Sel.Name == "NewDesc" {
-				sl, _ := decodeStabilityLevel(opts.Args[4], "metrics")
+				sl, _ := decodeStabilityLevel(opts.Args[4], f.metricsImportName)
 				if sl != nil {
 					classes := []metrics.StabilityLevel{metrics.STABLE, metrics.BETA}
 					if ALL_STABILITY_CLASSES {

--- a/test/instrumentation/main_test.go
+++ b/test/instrumentation/main_test.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"k8s.io/component-base/metrics"
 )
 
@@ -308,6 +310,21 @@ var _ = custom.NewCounter(
 	)
 `},
 		{
+			testName: "Custom import NewDesc",
+			metric: metric{
+				Name:           "apiserver_storage_size_bytes",
+				Help:           "Size of the storage database file physically allocated in bytes.",
+				Labels:         []string{"server"},
+				StabilityLevel: "STABLE",
+				Type:           customType,
+				ConstLabels:    map[string]string{},
+			},
+			src: `
+package test
+import custom "k8s.io/component-base/metrics"
+var _ = custom.NewDesc("apiserver_storage_size_bytes", "Size of the storage database file physically allocated in bytes.", []string{"server"}, nil, custom.STABLE, "")
+`},
+		{
 			testName: "Const",
 			metric: metric{
 				Name:           "metric",
@@ -526,8 +543,8 @@ var _ = compbasemetrics.NewCounter(
 			if test.metric.Labels == nil {
 				test.metric.Labels = []string{}
 			}
-			if !reflect.DeepEqual(metrics[0], test.metric) {
-				t.Errorf("metric:\ngot  %v\nwant %v", metrics[0], test.metric)
+			if diff := cmp.Diff(metrics[0], test.metric); diff != "" {
+				t.Errorf("metric diff: %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
/kind bug

```release-note
NONE
```

Spin-off from https://github.com/kubernetes/kubernetes/pull/118812
/assign @logicalhan @dgrisonnet 
