### PR TITLE
e2e_node: add container metrics from cadvisor test

### DIFF
--- a/test/e2e_node/container_metrics_test.go
+++ b/test/e2e_node/container_metrics_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
+	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = SIGDescribe("[NodeConformance] [LinuxOnly] ContainerMetrics", func() {
+	f := framework.NewDefaultFramework("container-metrics")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+	ginkgo.Context("when querying /metrics/cadvisor", func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			createMetricsPods(ctx, f)
+		})
+		ginkgo.It("should report container metrics", func(ctx context.Context) {
+			keys := gstruct.Keys{}
+			ctrMatches := map[string]types.GomegaMatcher{
+				// memory metrics
+				"container_blkio_device_usage_total":            preciseSample(0),
+				"container_cpu_load_average_10s":                boundedSample(0, 100),
+				"container_cpu_system_seconds_total":            boundedSample(0, 100),
+				"container_cpu_usage_seconds_total":             boundedSample(0, 100),
+				"container_cpu_user_seconds_total":              boundedSample(0, 100),
+				"container_file_descriptors":                    boundedSample(0, 100),
+				"container_fs_inodes_free":                      preciseSample(0),
+				"container_fs_inodes_total":                     boundedSample(0, 100),
+				"container_fs_io_current":                       preciseSample(0),
+				"container_fs_io_time_seconds_total":            preciseSample(0),
+				"container_fs_limit_bytes":                      boundedSample(100*e2evolume.Mb, 10*e2evolume.Tb),
+				"container_fs_reads_bytes_total":                preciseSample(0),
+				"container_fs_read_seconds_total":               preciseSample(0),
+				"container_fs_reads_merged_total":               preciseSample(0),
+				"container_fs_reads_total":                      preciseSample(0),
+				"container_fs_sector_reads_total":               preciseSample(0),
+				"container_fs_sector_writes_total":              preciseSample(0),
+				"container_fs_usage_bytes":                      boundedSample(0, 1000000),
+				"container_fs_writes_bytes_total":               preciseSample(0),
+				"container_fs_write_seconds_total":              preciseSample(0),
+				"container_fs_writes_merged_total":              preciseSample(0),
+				"container_fs_writes_total":                     preciseSample(0),
+				"container_memory_cache":                        boundedSample(1*e2evolume.Kb, 10*e2evolume.Mb),
+				"container_memory_failcnt":                      boundedSample(0, 1000000),
+				"container_memory_failures_total":               boundedSample(0, 1000000),
+				"container_memory_mapped_file":                  boundedSample(0, 1000000),
+				"container_memory_max_usage_bytes":              boundedSample(10*e2evolume.Kb, 80*e2evolume.Mb),
+				"container_memory_rss":                          boundedSample(10*e2evolume.Kb, 80*e2evolume.Mb),
+				"container_memory_swap":                         boundedSample(0, 1000000),
+				"container_memory_usage_bytes":                  boundedSample(10*e2evolume.Kb, 80*e2evolume.Mb),
+				"container_memory_working_set_bytes":            boundedSample(10*e2evolume.Kb, 80*e2evolume.Mb),
+				"container_oom_events_total":                    preciseSample(0),
+				"container_processes":                           boundedSample(0, 100),
+				"container_sockets":                             preciseSample(0),
+				"container_spec_cpu_period":                     preciseSample(100000),
+				"container_spec_cpu_shares":                     preciseSample(2),
+				"container_spec_memory_limit_bytes":             preciseSample(79998976),
+				"container_spec_memory_reservation_limit_bytes": preciseSample(0),
+				"container_spec_memory_swap_limit_bytes":        preciseSample(79998976),
+				"container_start_time_seconds":                  boundedSampleIgnoreTimestamp(time.Now().Add(-maxStatsAge).Unix(), time.Now().Add(2*time.Minute).Unix()),
+				"container_tasks_state":                         preciseSample(0),
+				"container_threads":                             preciseSample(2),
+				"container_threads_max":                         boundedSample(0, 100000),
+				"container_ulimits_soft":                        boundedSample(10*e2evolume.Kb, 80*e2evolume.Mb),
+			}
+			appendMatchesForContainer(f.Namespace.Name, pod0, pod1, "busybox-container", ctrMatches, keys)
+
+			podMatches := map[string]types.GomegaMatcher{
+				"container_network_receive_bytes_total":            boundedSample(10, 10*e2evolume.Mb),
+				"container_network_receive_errors_total":           boundedSample(0, 1000),
+				"container_network_receive_packets_dropped_total":  boundedSample(0, 1000),
+				"container_network_receive_packets_total":          boundedSample(0, 1000),
+				"container_network_transmit_bytes_total":           boundedSample(10, 10*e2evolume.Mb),
+				"container_network_transmit_errors_total":          boundedSample(0, 1000),
+				"container_network_transmit_packets_dropped_total": boundedSample(0, 1000),
+				"container_network_transmit_packets_total":         boundedSample(0, 1000),
+			}
+			appendMatchesForContainer(f.Namespace.Name, pod0, pod1, "POD", podMatches, keys)
+
+			matchResourceMetrics := gstruct.MatchKeys(gstruct.IgnoreExtras, keys)
+			ginkgo.By("Giving pods a minute to start up and produce metrics")
+			gomega.Eventually(ctx, getContainerMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
+			ginkgo.By("Ensuring the metrics match the expectations a few more times")
+			gomega.Consistently(ctx, getContainerMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
+		})
+		ginkgo.AfterEach(func(ctx context.Context) {
+			removeMetricsPods(ctx, f)
+		})
+	})
+})
+
+func getContainerMetrics(ctx context.Context) (e2emetrics.KubeletMetrics, error) {
+	ginkgo.By("getting container metrics from cadvisor")
+	return e2emetrics.GrabKubeletMetricsWithoutProxy(ctx, framework.TestContext.NodeName+":10255", "/metrics/cadvisor")
+}
+
+func preciseSample(value interface{}) types.GomegaMatcher {
+	return gstruct.PointTo(gstruct.MatchAllFields(gstruct.Fields{
+		"Metric":    gstruct.Ignore(),
+		"Value":     gomega.BeEquivalentTo(value),
+		"Timestamp": gstruct.Ignore(),
+		"Histogram": gstruct.Ignore(),
+	}))
+}
+
+func boundedSampleIgnoreTimestamp(lower, upper interface{}) types.GomegaMatcher {
+	return gstruct.PointTo(gstruct.MatchAllFields(gstruct.Fields{
+		// We already check Metric when matching the Id
+		"Metric":    gstruct.Ignore(),
+		"Value":     gomega.And(gomega.BeNumerically(">=", lower), gomega.BeNumerically("<=", upper)),
+		"Timestamp": gstruct.Ignore(),
+		"Histogram": gstruct.Ignore(),
+	}))
+}
+
+func appendMatchesForContainer(ns, pod1, pod2, ctr string, matches map[string]types.GomegaMatcher, keys gstruct.Keys) {
+	for k, v := range matches {
+		keys[k] = gstruct.MatchElements(containerID, gstruct.AllowDuplicates|gstruct.IgnoreExtras, gstruct.Elements{
+			fmt.Sprintf("%s::%s::%s", ns, pod1, ctr): v,
+			fmt.Sprintf("%s::%s::%s", ns, pod2, ctr): v,
+		})
+	}
+}

--- a/test/e2e_node/resource_metrics_test.go
+++ b/test/e2e_node/resource_metrics_test.go
@@ -48,24 +48,7 @@ var _ = SIGDescribe("ResourceMetricsAPI [NodeFeature:ResourceMetrics]", func() {
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	ginkgo.Context("when querying /resource/metrics", func() {
 		ginkgo.BeforeEach(func(ctx context.Context) {
-			ginkgo.By("Creating test pods to measure their resource usage")
-			numRestarts := int32(1)
-			pods := getSummaryTestPods(f, numRestarts, pod0, pod1)
-			e2epod.NewPodClient(f).CreateBatch(ctx, pods)
-
-			ginkgo.By("restarting the containers to ensure container metrics are still being gathered after a container is restarted")
-			gomega.Eventually(ctx, func(ctx context.Context) error {
-				for _, pod := range pods {
-					err := verifyPodRestartCount(ctx, f, pod.Name, len(pod.Spec.Containers), numRestarts)
-					if err != nil {
-						return err
-					}
-				}
-				return nil
-			}, time.Minute, 5*time.Second).Should(gomega.Succeed())
-
-			ginkgo.By("Waiting 15 seconds for cAdvisor to collect 2 stats points")
-			time.Sleep(15 * time.Second)
+			createMetricsPods(ctx, f)
 		})
 		ginkgo.It("should report resource usage through the resource metrics api", func(ctx context.Context) {
 			ginkgo.By("Fetching node so we can match against an appropriate memory limit")
@@ -113,21 +96,31 @@ var _ = SIGDescribe("ResourceMetricsAPI [NodeFeature:ResourceMetrics]", func() {
 			gomega.Consistently(ctx, getResourceMetrics, 1*time.Minute, 15*time.Second).Should(matchResourceMetrics)
 		})
 		ginkgo.AfterEach(func(ctx context.Context) {
-			ginkgo.By("Deleting test pods")
-			var zero int64 = 0
-			e2epod.NewPodClient(f).DeleteSync(ctx, pod0, metav1.DeleteOptions{GracePeriodSeconds: &zero}, 10*time.Minute)
-			e2epod.NewPodClient(f).DeleteSync(ctx, pod1, metav1.DeleteOptions{GracePeriodSeconds: &zero}, 10*time.Minute)
-			if !ginkgo.CurrentSpecReport().Failed() {
-				return
-			}
-			if framework.TestContext.DumpLogsOnFailure {
-				e2ekubectl.LogFailedContainers(ctx, f.ClientSet, f.Namespace.Name, framework.Logf)
-			}
-			ginkgo.By("Recording processes in system cgroups")
-			recordSystemCgroupProcesses(ctx)
+			removeMetricsPods(ctx, f)
 		})
 	})
 })
+
+func createMetricsPods(ctx context.Context, f *framework.Framework) {
+	ginkgo.By("Creating test pods to measure their resource usage")
+	numRestarts := int32(1)
+	pods := getSummaryTestPods(f, numRestarts, pod0, pod1)
+	e2epod.NewPodClient(f).CreateBatch(ctx, pods)
+
+	ginkgo.By("restarting the containers to ensure container metrics are still being gathered after a container is restarted")
+	gomega.Eventually(ctx, func(ctx context.Context) error {
+		for _, pod := range pods {
+			err := verifyPodRestartCount(ctx, f, pod.Name, len(pod.Spec.Containers), numRestarts)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}, time.Minute, 5*time.Second).Should(gomega.Succeed())
+
+	ginkgo.By("Waiting 15 seconds for cAdvisor to collect 2 stats points")
+	time.Sleep(15 * time.Second)
+}
 
 func getResourceMetrics(ctx context.Context) (e2emetrics.KubeletMetrics, error) {
 	ginkgo.By("getting stable resource metrics API")
@@ -164,4 +157,19 @@ func boundedSample(lower, upper interface{}) types.GomegaMatcher {
 		),
 		"Histogram": gstruct.Ignore(),
 	}))
+}
+
+func removeMetricsPods(ctx context.Context, f *framework.Framework) {
+	ginkgo.By("Deleting test pods")
+	var zero int64 = 0
+	e2epod.NewPodClient(f).DeleteSync(ctx, pod0, metav1.DeleteOptions{GracePeriodSeconds: &zero}, 10*time.Minute)
+	e2epod.NewPodClient(f).DeleteSync(ctx, pod1, metav1.DeleteOptions{GracePeriodSeconds: &zero}, 10*time.Minute)
+	if !ginkgo.CurrentSpecReport().Failed() {
+		return
+	}
+	if framework.TestContext.DumpLogsOnFailure {
+		e2ekubectl.LogFailedContainers(ctx, f.ClientSet, f.Namespace.Name, framework.Logf)
+	}
+	ginkgo.By("Recording processes in system cgroups")
+	recordSystemCgroupProcesses(ctx)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:
add tests that verify the contents of the `/metrics/cadvisor` endpoint. This is in part defining a formal relationship the kubelet has with these metrics, and preparing to take them away from cadvisor as part of KEP-2371

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:

- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2371
```
