### PR TITLE
test: Use table-driven test for TestPerPodSchedulingMetrics

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -418,7 +418,7 @@ func (p *PriorityQueue) runPreEnqueuePlugins(ctx context.Context, pInfo *framewo
 	logger := klog.FromContext(ctx)
 	var s *framework.Status
 	pod := pInfo.Pod
-	startTime := time.Now()
+	startTime := p.clock.Now()
 	defer func() {
 		metrics.FrameworkExtensionPointDuration.WithLabelValues(preEnqueue, s.Code().String(), pod.Spec.SchedulerName).Observe(metrics.SinceInSeconds(startTime))
 	}()


### PR DESCRIPTION
#### What type of PR is this?
Following up on the PR https://github.com/kubernetes/kubernetes/pull/118049#discussion_r1237386109 discussion to use table-driven test to make tests easier to debug in the future.

/kind cleanup
/sig scheduling

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes # 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No.
```release-note
Use table-driven test for TestPerPodSchedulingMetrics
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A

```docs

```
