### PR TITLE
Correct flaky test in pull-kubernetes-e2e-gci-gce-ipvs

### DIFF
--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -1148,7 +1148,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 		}
 	})
 
-	ginkgo.It("should be able to preserve UDP traffic when server pod cycles for a LoadBalancer service on the same nodes", func(ctx context.Context) {
+	ginkgo.It("should be able to preserve UDP traffic when server pod cycles for a LoadBalancer service on the same node (1)", func(ctx context.Context) {
 		// requires cloud load-balancer support
 		e2eskipper.SkipUnlessProviderIs("gce", "gke", "azure")
 		ns := f.Namespace.Name


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

Aims to fix the flaky test:
`[It] [sig-network] LoadBalancers should be able to preserve UDP traffic when server pod cycles for a LoadBalancer service on the same nodes`

#### Which issue(s) this PR fixes:

Fixes #118233

#### Special notes for your reviewer:

From start this PR is only updated to run the flaky test. Never mind until the `draft` label is removed.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A