### PR TITLE
Fix a resourcequota naming issue in kubectl

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -140,7 +140,7 @@ func NewCmdCreate(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobr
 
 	// create subcommands
 	cmd.AddCommand(NewCmdCreateNamespace(f, ioStreams))
-	cmd.AddCommand(NewCmdCreateQuota(f, ioStreams))
+	cmd.AddCommand(NewCmdCreateResourceQuota(f, ioStreams))
 	cmd.AddCommand(NewCmdCreateSecret(f, ioStreams))
 	cmd.AddCommand(NewCmdCreateConfigMap(f, ioStreams))
 	cmd.AddCommand(NewCmdCreateServiceAccount(f, ioStreams))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
@@ -43,14 +43,14 @@ var (
 
 	quotaExample = templates.Examples(i18n.T(`
 		# Create a new resource quota named my-quota
-		kubectl create quota my-quota --hard=cpu=1,memory=1G,pods=2,services=3,replicationcontrollers=2,resourcequotas=1,secrets=5,persistentvolumeclaims=10
+		kubectl create resourcequota my-quota --hard=cpu=1,memory=1G,pods=2,services=3,replicationcontrollers=2,resourcequotas=1,secrets=5,persistentvolumeclaims=10
 
 		# Create a new resource quota named best-effort
-		kubectl create quota best-effort --hard=pods=100 --scopes=BestEffort`))
+		kubectl create resourcequota best-effort --hard=pods=100 --scopes=BestEffort`))
 )
 
-// QuotaOpts holds the command-line options for 'create quota' sub command
-type QuotaOpts struct {
+// QuotaOpts holds the command-line options for 'create resourcequota' sub command
+type ResourceQuotaOpts struct {
 	// PrintFlags holds options necessary for obtaining a printer
 	PrintFlags *genericclioptions.PrintFlags
 	PrintObj   func(obj runtime.Object) error
@@ -73,22 +73,22 @@ type QuotaOpts struct {
 }
 
 // NewQuotaOpts creates a new *QuotaOpts with sane defaults
-func NewQuotaOpts(ioStreams genericiooptions.IOStreams) *QuotaOpts {
-	return &QuotaOpts{
+func NewResourceQuotaOpts(ioStreams genericiooptions.IOStreams) *ResourceQuotaOpts {
+	return &ResourceQuotaOpts{
 		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:  ioStreams,
 	}
 }
 
-// NewCmdCreateQuota is a macro command to create a new quota
-func NewCmdCreateQuota(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
-	o := NewQuotaOpts(ioStreams)
+// NewCmdCreateQuota is a macro command to create a new resourcequota
+func NewCmdCreateResourceQuota(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Command {
+	o := NewResourceQuotaOpts(ioStreams)
 
 	cmd := &cobra.Command{
-		Use:                   "quota NAME [--hard=key1=value1,key2=value2] [--scopes=Scope1,Scope2] [--dry-run=server|client|none]",
+		Use:                   "resourcequota NAME [--hard=key1=value1,key2=value2] [--scopes=Scope1,Scope2] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
-		Aliases:               []string{"resourcequota"},
-		Short:                 i18n.T("Create a quota with the specified name"),
+		Aliases:               []string{"quota"},
+		Short:                 i18n.T("Create a resource quota with the specified name"),
 		Long:                  quotaLong,
 		Example:               quotaExample,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -104,13 +104,13 @@ func NewCmdCreateQuota(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) 
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddDryRunFlag(cmd)
 	cmd.Flags().StringVar(&o.Hard, "hard", o.Hard, i18n.T("A comma-delimited set of resource=quantity pairs that define a hard limit."))
-	cmd.Flags().StringVar(&o.Scopes, "scopes", o.Scopes, i18n.T("A comma-delimited set of quota scopes that must all match each object tracked by the quota."))
+	cmd.Flags().StringVar(&o.Scopes, "scopes", o.Scopes, i18n.T("A comma-delimited set of resourcequota scopes that must all match each object tracked by the resourcequota."))
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 	return cmd
 }
 
 // Complete completes all the required options
-func (o *QuotaOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+func (o *ResourceQuotaOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	var err error
 	o.Name, err = NameFromCommandArgs(cmd, args)
 	if err != nil {
@@ -158,7 +158,7 @@ func (o *QuotaOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []strin
 }
 
 // Validate checks to the QuotaOpts to see if there is sufficient information run the command.
-func (o *QuotaOpts) Validate() error {
+func (o *ResourceQuotaOpts) Validate() error {
 	if len(o.Name) == 0 {
 		return fmt.Errorf("name must be specified")
 	}
@@ -166,8 +166,8 @@ func (o *QuotaOpts) Validate() error {
 }
 
 // Run does the work
-func (o *QuotaOpts) Run() error {
-	resourceQuota, err := o.createQuota()
+func (o *ResourceQuotaOpts) Run() error {
+	resourceQuota, err := o.createResourceQuota()
 	if err != nil {
 		return err
 	}
@@ -187,13 +187,13 @@ func (o *QuotaOpts) Run() error {
 		}
 		resourceQuota, err = o.Client.ResourceQuotas(o.Namespace).Create(context.TODO(), resourceQuota, createOptions)
 		if err != nil {
-			return fmt.Errorf("failed to create quota: %v", err)
+			return fmt.Errorf("failed to create resourcequota: %v", err)
 		}
 	}
 	return o.PrintObj(resourceQuota)
 }
 
-func (o *QuotaOpts) createQuota() (*corev1.ResourceQuota, error) {
+func (o *ResourceQuotaOpts) createResourceQuota() (*corev1.ResourceQuota, error) {
 	namespace := ""
 	if o.EnforceNamespace {
 		namespace = o.Namespace
@@ -259,7 +259,7 @@ func parseScopes(spec string) ([]corev1.ResourceQuotaScope, error) {
 		// intentionally do not verify the scope against the valid scope list. This is done by the apiserver anyway.
 
 		if scope == "" {
-			return nil, fmt.Errorf("invalid resource quota scope \"\"")
+			return nil, fmt.Errorf("invalid resource resoucequota scope \"\"")
 		}
 
 		result = append(result, corev1.ResourceQuotaScope(scope))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota_test.go
@@ -36,11 +36,11 @@ func TestCreateQuota(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		options  *QuotaOpts
+		options  *ResourceQuotaOpts
 		expected *corev1.ResourceQuota
 	}{
 		"single resource": {
-			options: &QuotaOpts{
+			options: &ResourceQuotaOpts{
 				Name:   "my-quota",
 				Hard:   hards[0],
 				Scopes: "",
@@ -59,7 +59,7 @@ func TestCreateQuota(t *testing.T) {
 			},
 		},
 		"single resource with a scope": {
-			options: &QuotaOpts{
+			options: &ResourceQuotaOpts{
 				Name:   "my-quota",
 				Hard:   hards[0],
 				Scopes: "BestEffort",
@@ -79,7 +79,7 @@ func TestCreateQuota(t *testing.T) {
 			},
 		},
 		"multiple resources": {
-			options: &QuotaOpts{
+			options: &ResourceQuotaOpts{
 				Name:   "my-quota",
 				Hard:   hards[1],
 				Scopes: "BestEffort",
@@ -99,7 +99,7 @@ func TestCreateQuota(t *testing.T) {
 			},
 		},
 		"single resource with multiple scopes": {
-			options: &QuotaOpts{
+			options: &ResourceQuotaOpts{
 				Name:   "my-quota",
 				Hard:   hards[0],
 				Scopes: "BestEffort,NotTerminating",
@@ -122,7 +122,7 @@ func TestCreateQuota(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			resourceQuota, err := tc.options.createQuota()
+			resourceQuota, err := tc.options.createResourceQuota()
 			if err != nil {
 				t.Errorf("unexpected error:\n%#v\n", err)
 				return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

The established convention and common practice for `kubectl` is using the full name of a Kubernetes resource object as the formal name for CRUD operations with a shorter alias. A full name can also be pluralized. An  example is `namespace` with `ns` as an alias, and `namespaces` is a valid alternative. 

In the current kubectl codebase, the formal name of `resourcequota` is set as `quota`, while `resourcequota` is designated as the alias.  It's a divergence from this convention and introduce inconsistency. Actually, the command `kubectl get resourcequotas` functions correctly, whereas `kube get quotas` does not.  

This PR fixes the issue by using `resourcequota` as the formal name and `quota` as the alias. 

Hope this small change can enhance the codebase's consistency, readability, and maintainability. By adjusting the naming to align with the established `kubectl` convention, we can alleviate any possible confusion and streamline development efforts.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

A follow-up PR will rename the files for consistency: rename `create_quota.go` and `create_quota_test.go` to `create_resourcequota.go` and `create_resourcequota_test.go` respectively. Similarly,  change `create_pdb.go` and `create_pdb_test.go` to `create_poddisruptionbudge.go` and `create_pxoryloadbalancer_test.go`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
