### PR TITLE
DRA controller: batch resource claims for Allocate

### DIFF
--- a/test/e2e/dra/README.md
+++ b/test/e2e/dra/README.md
@@ -41,10 +41,10 @@ $ kind create cluster --config test/e2e/dra/kind.yaml --image dra/node:latest
 
 - Build ginkgo
 
-> NB: If you are using go workspace you must disable it `GOWORK=off make gingko`
+> NB: If you are using go workspace you must disable it `GOWORK=off make ginkgo`
 
 ```bash
-$ make gingko
+$ make ginkgo
 ```
 
 - Run e2e tests for the `Dynamic Resource Allocation` feature:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is a first part of [#117104](https://github.com/kubernetes/kubernetes/issues/117104) - batching the Allocate calls for controller part of resource driver, to make it similar to UnsuitableNodes call, so all Pod claims of particular resource driver can be considered at once during allocation as well as they are considered in UnsuitableNodes.

#### Which issue(s) this PR fixes:

Fixes #117104

#### Special notes for your reviewer:

This is only first part. Updating kubelet plugin and documentation will follow.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```