### PR TITLE
kubeadm: add v1beta4 to scheme; add --allow-experimental-api flag

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/scheme/scheme.go
+++ b/cmd/kubeadm/app/apis/kubeadm/scheme/scheme.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta4"
 )
 
 // Scheme is the runtime.Scheme to which all kubeadm api types are registered.
@@ -42,5 +43,8 @@ func init() {
 func AddToScheme(scheme *runtime.Scheme) {
 	utilruntime.Must(kubeadm.AddToScheme(scheme))
 	utilruntime.Must(v1beta3.AddToScheme(scheme))
-	utilruntime.Must(scheme.SetVersionPriority(v1beta3.SchemeGroupVersion))
+	utilruntime.Must(v1beta4.AddToScheme(scheme))
+	// TODO: https://github.com/kubernetes/kubeadm/issues/2890
+	// make v1beta4 highest priority
+	utilruntime.Must(scheme.SetVersionPriority(v1beta3.SchemeGroupVersion, v1beta4.SchemeGroupVersion))
 }

--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -225,6 +225,8 @@ func getDefaultNodeConfigBytes() ([]byte, error) {
 // newCmdConfigMigrate returns cobra.Command for "kubeadm config migrate" command
 func newCmdConfigMigrate(out io.Writer) *cobra.Command {
 	var oldCfgPath, newCfgPath string
+	var allowExperimental bool
+
 	cmd := &cobra.Command{
 		Use:   "migrate",
 		Short: "Read an older version of the kubeadm configuration API types from a file, and output the similar config object for the newer version",
@@ -252,7 +254,7 @@ func newCmdConfigMigrate(out io.Writer) *cobra.Command {
 				return err
 			}
 
-			outputBytes, err := configutil.MigrateOldConfig(oldCfgBytes)
+			outputBytes, err := configutil.MigrateOldConfig(oldCfgBytes, allowExperimental)
 			if err != nil {
 				return err
 			}
@@ -270,12 +272,14 @@ func newCmdConfigMigrate(out io.Writer) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&oldCfgPath, "old-config", "", "Path to the kubeadm config file that is using an old API version and should be converted. This flag is mandatory.")
 	cmd.Flags().StringVar(&newCfgPath, "new-config", "", "Path to the resulting equivalent kubeadm config file using the new API version. Optional, if not specified output will be sent to STDOUT.")
+	cmd.Flags().BoolVar(&allowExperimental, options.AllowExperimentalAPI, false, "Allow migration to experimental, unreleased APIs.")
 	return cmd
 }
 
 // newCmdConfigValidate returns cobra.Command for the "kubeadm config validate" command
 func newCmdConfigValidate(out io.Writer) *cobra.Command {
 	var cfgPath string
+	var allowExperimental bool
 
 	cmd := &cobra.Command{
 		Use:   "validate",
@@ -300,7 +304,7 @@ func newCmdConfigValidate(out io.Writer) *cobra.Command {
 				return err
 			}
 
-			if err := configutil.ValidateConfig(cfgBytes); err != nil {
+			if err := configutil.ValidateConfig(cfgBytes, allowExperimental); err != nil {
 				return err
 			}
 			fmt.Fprintln(out, "ok")
@@ -310,6 +314,7 @@ func newCmdConfigValidate(out io.Writer) *cobra.Command {
 		Args: cobra.NoArgs,
 	}
 	options.AddConfigFlag(cmd.Flags(), &cfgPath)
+	cmd.Flags().BoolVar(&allowExperimental, options.AllowExperimentalAPI, false, "Allow validation of experimental, unreleased APIs.")
 	return cmd
 }
 

--- a/cmd/kubeadm/app/cmd/options/constant.go
+++ b/cmd/kubeadm/app/cmd/options/constant.go
@@ -142,4 +142,7 @@ const (
 
 	// CleanupTmpDir flag indicates whether reset will cleanup the tmp dir
 	CleanupTmpDir = "cleanup-tmp-dir"
+
+	// AllowExperimentalAPI flag can be used to allow experimental / work in progress APIs
+	AllowExperimentalAPI = "allow-experimental-api"
 )

--- a/cmd/kubeadm/app/util/config/common_test.go
+++ b/cmd/kubeadm/app/util/config/common_test.go
@@ -34,9 +34,10 @@ const KubeadmGroupName = "kubeadm.k8s.io"
 
 func TestValidateSupportedVersion(t *testing.T) {
 	tests := []struct {
-		gv              schema.GroupVersion
-		allowDeprecated bool
-		expectedErr     bool
+		gv                schema.GroupVersion
+		allowDeprecated   bool
+		allowExperimental bool
+		expectedErr       bool
 	}{
 		{
 			gv: schema.GroupVersion{
@@ -85,11 +86,25 @@ func TestValidateSupportedVersion(t *testing.T) {
 				Version: "v1",
 			},
 		},
+		{
+			gv: schema.GroupVersion{
+				Group:   KubeadmGroupName,
+				Version: "v1beta4",
+			},
+			allowExperimental: true,
+		},
+		{
+			gv: schema.GroupVersion{
+				Group:   KubeadmGroupName,
+				Version: "v1beta4",
+			},
+			expectedErr: true,
+		},
 	}
 
 	for _, rt := range tests {
 		t.Run(fmt.Sprintf("%s/allowDeprecated:%t", rt.gv, rt.allowDeprecated), func(t *testing.T) {
-			err := validateSupportedVersion(rt.gv, rt.allowDeprecated)
+			err := validateSupportedVersion(rt.gv, rt.allowDeprecated, rt.allowExperimental)
 			if rt.expectedErr && err == nil {
 				t.Error("unexpected success")
 			} else if !rt.expectedErr && err != nil {

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -287,17 +287,17 @@ func BytesToInitConfiguration(b []byte) (*kubeadmapi.InitConfiguration, error) {
 		return nil, err
 	}
 
-	return documentMapToInitConfiguration(gvkmap, false, false)
+	return documentMapToInitConfiguration(gvkmap, false, false, false)
 }
 
 // documentMapToInitConfiguration converts a map of GVKs and YAML documents to defaulted and validated configuration object.
-func documentMapToInitConfiguration(gvkmap kubeadmapi.DocumentMap, allowDeprecated, strictErrors bool) (*kubeadmapi.InitConfiguration, error) {
+func documentMapToInitConfiguration(gvkmap kubeadmapi.DocumentMap, allowDeprecated, allowExperimental, strictErrors bool) (*kubeadmapi.InitConfiguration, error) {
 	var initcfg *kubeadmapi.InitConfiguration
 	var clustercfg *kubeadmapi.ClusterConfiguration
 
 	for gvk, fileContent := range gvkmap {
 		// first, check if this GVK is supported and possibly not deprecated
-		if err := validateSupportedVersion(gvk.GroupVersion(), allowDeprecated); err != nil {
+		if err := validateSupportedVersion(gvk.GroupVersion(), allowDeprecated, allowExperimental); err != nil {
 			return nil, err
 		}
 

--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -85,12 +85,12 @@ func LoadJoinConfigurationFromFile(cfgPath string) (*kubeadmapi.JoinConfiguratio
 		return nil, err
 	}
 
-	return documentMapToJoinConfiguration(gvkmap, false, false)
+	return documentMapToJoinConfiguration(gvkmap, false, false, false)
 }
 
 // documentMapToJoinConfiguration takes a map between GVKs and YAML documents (as returned by SplitYAMLDocuments),
 // finds a JoinConfiguration, decodes it, dynamically defaults it and then validates it prior to return.
-func documentMapToJoinConfiguration(gvkmap kubeadmapi.DocumentMap, allowDeprecated, strictErrors bool) (*kubeadmapi.JoinConfiguration, error) {
+func documentMapToJoinConfiguration(gvkmap kubeadmapi.DocumentMap, allowDeprecated, allowExperimental, strictErrors bool) (*kubeadmapi.JoinConfiguration, error) {
 	joinBytes := []byte{}
 	for gvk, bytes := range gvkmap {
 		// not interested in anything other than JoinConfiguration
@@ -99,7 +99,7 @@ func documentMapToJoinConfiguration(gvkmap kubeadmapi.DocumentMap, allowDeprecat
 		}
 
 		// check if this version is supported and possibly not deprecated
-		if err := validateSupportedVersion(gvk.GroupVersion(), allowDeprecated); err != nil {
+		if err := validateSupportedVersion(gvk.GroupVersion(), allowDeprecated, allowExperimental); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
```
kubeadm: add v1beta4 to the kubeadm API scheme

The highest priority is still v1beta3.
```

```
kubeadm: add the --allow-experimental-api flag to "config" commands

Add the flag --allow-experimental-api to the "config migrate" and
"config validate" commands. The flag allows validating / migrating-to
a unreleased / experimental API version.

Add a new experimentalAPIVersions map in validateSupportedVersion()
that contains v1beta4.
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xrefs https://github.com/kubernetes/kubeadm/issues/2890

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: add the --allow-experimental-api flag to "kubeadm config migrate/validate" commands. It can be used to migrate or validate WIP / experimental APIs in the future.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
