### PR TITLE
CLEANUP: cmd/kube-apiserver: fully qualify option references for clarity

### DIFF
--- a/cmd/kube-apiserver/app/config.go
+++ b/cmd/kube-apiserver/app/config.go
@@ -77,14 +77,14 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 	}
 	c.ControlPlane = controlPlane
 
-	apiExtensions, err := apiserver.CreateAPIExtensionsConfig(*controlPlane.GenericConfig, controlPlane.ExtraConfig.VersionedInformers, pluginInitializer, opts.CompletedOptions, opts.MasterCount,
+	apiExtensions, err := apiserver.CreateAPIExtensionsConfig(*controlPlane.GenericConfig, controlPlane.ExtraConfig.VersionedInformers, pluginInitializer, opts.ControlPlane, opts.ControlPlane.MasterCount,
 		serviceResolver, webhook.NewDefaultAuthenticationInfoResolverWrapper(controlPlane.ExtraConfig.ProxyTransport, controlPlane.GenericConfig.EgressSelector, controlPlane.GenericConfig.LoopbackClientConfig, controlPlane.GenericConfig.TracerProvider))
 	if err != nil {
 		return nil, err
 	}
 	c.ApiExtensions = apiExtensions
 
-	aggregator, err := createAggregatorConfig(*controlPlane.GenericConfig, opts.CompletedOptions, controlPlane.ExtraConfig.VersionedInformers, serviceResolver, controlPlane.ExtraConfig.ProxyTransport, pluginInitializer)
+	aggregator, err := createAggregatorConfig(*controlPlane.GenericConfig, opts.ControlPlane, controlPlane.ExtraConfig.VersionedInformers, serviceResolver, controlPlane.ExtraConfig.ProxyTransport, pluginInitializer)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kube-apiserver/app/options/completion.go
+++ b/cmd/kube-apiserver/app/options/completion.go
@@ -32,7 +32,7 @@ import (
 
 // completedOptions is a private wrapper that enforces a call of Complete() before Run can be invoked.
 type completedOptions struct {
-	controlplane.CompletedOptions
+	ControlPlane  controlplane.CompletedOptions
 	CloudProvider *kubeoptions.CloudProviderOptions
 
 	Extra
@@ -56,14 +56,14 @@ func (opts *ServerRunOptions) Complete() (CompletedOptions, error) {
 	if err != nil {
 		return CompletedOptions{}, err
 	}
-	controlplane, err := opts.Options.Complete([]string{"kubernetes.default.svc", "kubernetes.default", "kubernetes"}, []net.IP{apiServerServiceIP})
+	controlplane, err := opts.GenericControlPlane.Complete([]string{"kubernetes.default.svc", "kubernetes.default", "kubernetes"}, []net.IP{apiServerServiceIP})
 	if err != nil {
 		return CompletedOptions{}, err
 	}
 
 	completed := completedOptions{
-		CompletedOptions: controlplane,
-		CloudProvider:    opts.CloudProvider,
+		ControlPlane:  controlplane,
+		CloudProvider: opts.CloudProvider,
 
 		Extra: opts.Extra,
 	}
@@ -72,17 +72,17 @@ func (opts *ServerRunOptions) Complete() (CompletedOptions, error) {
 	completed.SecondaryServiceClusterIPRange = secondaryServiceIPRange
 	completed.APIServerServiceIP = apiServerServiceIP
 
-	if completed.Etcd != nil && completed.Etcd.EnableWatchCache {
+	if completed.ControlPlane.Etcd != nil && completed.ControlPlane.Etcd.EnableWatchCache {
 		sizes := kubeapiserver.DefaultWatchCacheSizes()
 		// Ensure that overrides parse correctly.
-		userSpecified, err := apiserveroptions.ParseWatchCacheSizes(completed.Etcd.WatchCacheSizes)
+		userSpecified, err := apiserveroptions.ParseWatchCacheSizes(completed.ControlPlane.Etcd.WatchCacheSizes)
 		if err != nil {
 			return CompletedOptions{}, err
 		}
 		for resource, size := range userSpecified {
 			sizes[resource] = size
 		}
-		completed.Etcd.WatchCacheSizes, err = apiserveroptions.WriteWatchCacheSizes(sizes)
+		completed.ControlPlane.Etcd.WatchCacheSizes, err = apiserveroptions.WriteWatchCacheSizes(sizes)
 		if err != nil {
 			return CompletedOptions{}, err
 		}

--- a/cmd/kube-apiserver/app/options/completion.go
+++ b/cmd/kube-apiserver/app/options/completion.go
@@ -35,7 +35,7 @@ type completedOptions struct {
 	ControlPlane  controlplane.CompletedOptions
 	CloudProvider *kubeoptions.CloudProviderOptions
 
-	Extra
+	Values
 }
 
 type CompletedOptions struct {
@@ -65,7 +65,7 @@ func (opts *ServerRunOptions) Complete() (CompletedOptions, error) {
 		ControlPlane:  controlplane,
 		CloudProvider: opts.CloudProvider,
 
-		Extra: opts.Extra,
+		Values: opts.Values,
 	}
 
 	completed.PrimaryServiceClusterIPRange = primaryServiceIPRange

--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -39,10 +39,10 @@ type ServerRunOptions struct {
 	GenericControlPlane *controlplaneapiserver.Options // embedded to avoid noise in existing consumers
 	CloudProvider       *kubeoptions.CloudProviderOptions
 
-	Extra
+	Values
 }
 
-type Extra struct {
+type Values struct {
 	AllowPrivileged           bool
 	KubeletConfig             kubeletclient.KubeletClientConfig
 	KubernetesServiceNodePort int
@@ -66,7 +66,7 @@ func NewServerRunOptions() *ServerRunOptions {
 		GenericControlPlane: controlplaneapiserver.NewOptions(),
 		CloudProvider:       kubeoptions.NewCloudProviderOptions(),
 
-		Extra: Extra{
+		Values: Values{
 			EndpointReconcilerType: string(reconcilers.LeaseEndpointReconcilerType),
 			KubeletConfig: kubeletclient.KubeletClientConfig{
 				Port:         ports.KubeletPort,

--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -36,8 +36,8 @@ import (
 
 // ServerRunOptions runs a kubernetes api server.
 type ServerRunOptions struct {
-	*controlplaneapiserver.Options // embedded to avoid noise in existing consumers
-	CloudProvider                  *kubeoptions.CloudProviderOptions
+	GenericControlPlane *controlplaneapiserver.Options // embedded to avoid noise in existing consumers
+	CloudProvider       *kubeoptions.CloudProviderOptions
 
 	Extra
 }
@@ -63,8 +63,8 @@ type Extra struct {
 // NewServerRunOptions creates a new ServerRunOptions object with default parameters
 func NewServerRunOptions() *ServerRunOptions {
 	s := ServerRunOptions{
-		Options:       controlplaneapiserver.NewOptions(),
-		CloudProvider: kubeoptions.NewCloudProviderOptions(),
+		GenericControlPlane: controlplaneapiserver.NewOptions(),
+		CloudProvider:       kubeoptions.NewCloudProviderOptions(),
 
 		Extra: Extra{
 			EndpointReconcilerType: string(reconcilers.LeaseEndpointReconcilerType),
@@ -94,7 +94,7 @@ func NewServerRunOptions() *ServerRunOptions {
 
 // Flags returns flags for a specific APIServer by section name
 func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
-	s.Options.AddFlags(&fss)
+	s.GenericControlPlane.AddFlags(&fss)
 	s.CloudProvider.AddFlags(fss.FlagSet("cloud provider"))
 
 	// Note: the weird ""+ in below lines seems to be the only way to get gofmt to

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -126,9 +126,9 @@ func TestAddFlags(t *testing.T) {
 
 	// This is a snapshot of expected options parsed by args.
 	expected := &ServerRunOptions{
-		Options: &controlplaneapiserver.Options{
+		GenericControlPlane: &controlplaneapiserver.Options{
 			MasterCount: 5,
-			GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
+			GenericAPIServer: &apiserveroptions.ServerRunOptions{
 				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 				MaxRequestsInFlight:         400,
@@ -140,12 +140,12 @@ func TestAddFlags(t *testing.T) {
 			},
 			Admission: &kubeoptions.AdmissionOptions{
 				GenericAdmission: &apiserveroptions.AdmissionOptions{
-					RecommendedPluginOrder: s.Options.Admission.GenericAdmission.RecommendedPluginOrder,
-					DefaultOffPlugins:      s.Options.Admission.GenericAdmission.DefaultOffPlugins,
+					RecommendedPluginOrder: s.GenericControlPlane.Admission.GenericAdmission.RecommendedPluginOrder,
+					DefaultOffPlugins:      s.GenericControlPlane.Admission.GenericAdmission.DefaultOffPlugins,
 					EnablePlugins:          []string{"AlwaysDeny"},
 					ConfigFile:             "/admission-control-config",
-					Plugins:                s.Options.Admission.GenericAdmission.Plugins,
-					Decorators:             s.Options.Admission.GenericAdmission.Decorators,
+					Plugins:                s.GenericControlPlane.Admission.GenericAdmission.Plugins,
+					Decorators:             s.GenericControlPlane.Admission.GenericAdmission.Decorators,
 				},
 			},
 			Etcd: &apiserveroptions.EtcdOptions{

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -298,7 +298,7 @@ func TestAddFlags(t *testing.T) {
 			AggregatorRejectForwardingRedirects: true,
 		},
 
-		Extra: Extra{
+		Values: Values{
 			ServiceNodePortRange:   kubeoptions.DefaultServiceNodePortRange,
 			ServiceClusterIPRanges: (&net.IPNet{IP: netutils.ParseIPSloppy("192.168.128.0"), Mask: net.CIDRMask(17, 32)}).String(),
 			EndpointReconcilerType: string(reconcilers.LeaseEndpointReconcilerType),

--- a/cmd/kube-apiserver/app/options/validation.go
+++ b/cmd/kube-apiserver/app/options/validation.go
@@ -106,7 +106,7 @@ func validateServiceNodePort(options Extra) []error {
 func (s CompletedOptions) Validate() []error {
 	var errs []error
 
-	errs = append(errs, s.CompletedOptions.Validate()...)
+	errs = append(errs, s.ControlPlane.Validate()...)
 	errs = append(errs, validateClusterIPFlags(s.Extra)...)
 	errs = append(errs, validateServiceNodePort(s.Extra)...)
 

--- a/cmd/kube-apiserver/app/options/validation.go
+++ b/cmd/kube-apiserver/app/options/validation.go
@@ -29,7 +29,7 @@ import (
 
 // TODO: Longer term we should read this from some config store, rather than a flag.
 // validateClusterIPFlags is expected to be called after Complete()
-func validateClusterIPFlags(options Extra) []error {
+func validateClusterIPFlags(options Values) []error {
 	var errs []error
 	// maxCIDRBits is used to define the maximum CIDR size for the cluster ip(s)
 	maxCIDRBits := 20
@@ -89,7 +89,7 @@ func validateMaxCIDRRange(cidr net.IPNet, maxCIDRBits int, cidrFlag string) erro
 	return nil
 }
 
-func validateServiceNodePort(options Extra) []error {
+func validateServiceNodePort(options Values) []error {
 	var errs []error
 
 	if options.KubernetesServiceNodePort < 0 || options.KubernetesServiceNodePort > 65535 {
@@ -107,8 +107,8 @@ func (s CompletedOptions) Validate() []error {
 	var errs []error
 
 	errs = append(errs, s.ControlPlane.Validate()...)
-	errs = append(errs, validateClusterIPFlags(s.Extra)...)
-	errs = append(errs, validateServiceNodePort(s.Extra)...)
+	errs = append(errs, validateClusterIPFlags(s.Values)...)
+	errs = append(errs, validateServiceNodePort(s.Values)...)
 
 	return errs
 }

--- a/cmd/kube-apiserver/app/options/validation_test.go
+++ b/cmd/kube-apiserver/app/options/validation_test.go
@@ -48,7 +48,7 @@ func makeOptionsWithCIDRs(serviceCIDR string, secondaryServiceCIDR string) *Serv
 		}
 	}
 	return &ServerRunOptions{
-		Extra: Extra{
+		Values: Values{
 			ServiceClusterIPRanges:         value,
 			PrimaryServiceClusterIPRange:   primaryCIDR,
 			SecondaryServiceClusterIPRange: secondaryCIDR,
@@ -143,7 +143,7 @@ func TestClusterServiceIPRange(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.MultiCIDRServiceAllocator, tc.gate)()
 
-			errs := validateClusterIPFlags(tc.options.Extra)
+			errs := validateClusterIPFlags(tc.options.Values)
 			if len(errs) > 0 && !tc.expectErrors {
 				t.Errorf("expected no errors, errors found %+v", errs)
 			}
@@ -200,7 +200,7 @@ func TestValidateServiceNodePort(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validateServiceNodePort(tc.options.Extra)
+			errs := validateServiceNodePort(tc.options.Values)
 			if errs != nil && !tc.expectErrors {
 				t.Errorf("expected no errors, error found %+v", errs)
 			}
@@ -214,7 +214,7 @@ func makeOptionsWithPort(kubernetesServiceNodePort int, base int, size int) *Ser
 		Size: size,
 	}
 	return &ServerRunOptions{
-		Extra: Extra{
+		Values: Values{
 			ServiceNodePortRange:      portRange,
 			KubernetesServiceNodePort: kubernetesServiceNodePort,
 		},

--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -63,7 +63,7 @@ func BuildGenericConfig(
 	genericConfig = genericapiserver.NewConfig(legacyscheme.Codecs)
 	genericConfig.MergedResourceConfig = controlplane.DefaultAPIResourceConfigSource()
 
-	if lastErr = s.GenericServerRunOptions.ApplyTo(genericConfig); lastErr != nil {
+	if lastErr = s.GenericAPIServer.ApplyTo(genericConfig); lastErr != nil {
 		return
 	}
 
@@ -155,7 +155,7 @@ func BuildGenericConfig(
 		return
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIPriorityAndFairness) && s.GenericServerRunOptions.EnablePriorityAndFairness {
+	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIPriorityAndFairness) && s.GenericAPIServer.EnablePriorityAndFairness {
 		genericConfig.FlowControl, lastErr = BuildPriorityAndFairness(s, clientgoExternalClient, versionedInformers)
 	}
 
@@ -183,13 +183,13 @@ func BuildAuthorizer(s controlplaneapiserver.CompletedOptions, EgressSelector *e
 
 // BuildPriorityAndFairness constructs the guts of the API Priority and Fairness filter
 func BuildPriorityAndFairness(s controlplaneapiserver.CompletedOptions, extclient clientgoclientset.Interface, versionedInformer clientgoinformers.SharedInformerFactory) (utilflowcontrol.Interface, error) {
-	if s.GenericServerRunOptions.MaxRequestsInFlight+s.GenericServerRunOptions.MaxMutatingRequestsInFlight <= 0 {
-		return nil, fmt.Errorf("invalid configuration: MaxRequestsInFlight=%d and MaxMutatingRequestsInFlight=%d; they must add up to something positive", s.GenericServerRunOptions.MaxRequestsInFlight, s.GenericServerRunOptions.MaxMutatingRequestsInFlight)
+	if s.GenericAPIServer.MaxRequestsInFlight+s.GenericAPIServer.MaxMutatingRequestsInFlight <= 0 {
+		return nil, fmt.Errorf("invalid configuration: MaxRequestsInFlight=%d and MaxMutatingRequestsInFlight=%d; they must add up to something positive", s.GenericAPIServer.MaxRequestsInFlight, s.GenericAPIServer.MaxMutatingRequestsInFlight)
 	}
 	return utilflowcontrol.New(
 		versionedInformer,
 		extclient.FlowcontrolV1beta3(),
-		s.GenericServerRunOptions.MaxRequestsInFlight+s.GenericServerRunOptions.MaxMutatingRequestsInFlight,
-		s.GenericServerRunOptions.RequestTimeout/4,
+		s.GenericAPIServer.MaxRequestsInFlight+s.GenericAPIServer.MaxMutatingRequestsInFlight,
+		s.GenericAPIServer.RequestTimeout/4,
 	), nil
 }

--- a/pkg/controlplane/apiserver/options/options.go
+++ b/pkg/controlplane/apiserver/options/options.go
@@ -42,19 +42,19 @@ import (
 )
 
 type Options struct {
-	GenericServerRunOptions *genericoptions.ServerRunOptions
-	Etcd                    *genericoptions.EtcdOptions
-	SecureServing           *genericoptions.SecureServingOptionsWithLoopback
-	Audit                   *genericoptions.AuditOptions
-	Features                *genericoptions.FeatureOptions
-	Admission               *kubeoptions.AdmissionOptions
-	Authentication          *kubeoptions.BuiltInAuthenticationOptions
-	Authorization           *kubeoptions.BuiltInAuthorizationOptions
-	APIEnablement           *genericoptions.APIEnablementOptions
-	EgressSelector          *genericoptions.EgressSelectorOptions
-	Metrics                 *metrics.Options
-	Logs                    *logs.Options
-	Traces                  *genericoptions.TracingOptions
+	GenericAPIServer *genericoptions.ServerRunOptions
+	Etcd             *genericoptions.EtcdOptions
+	SecureServing    *genericoptions.SecureServingOptionsWithLoopback
+	Audit            *genericoptions.AuditOptions
+	Features         *genericoptions.FeatureOptions
+	Admission        *kubeoptions.AdmissionOptions
+	Authentication   *kubeoptions.BuiltInAuthenticationOptions
+	Authorization    *kubeoptions.BuiltInAuthorizationOptions
+	APIEnablement    *genericoptions.APIEnablementOptions
+	EgressSelector   *genericoptions.EgressSelectorOptions
+	Metrics          *metrics.Options
+	Logs             *logs.Options
+	Traces           *genericoptions.TracingOptions
 
 	EnableLogsHandler        bool
 	EventTTL                 time.Duration
@@ -88,19 +88,19 @@ type CompletedOptions struct {
 // NewOptions creates a new ServerRunOptions object with default parameters
 func NewOptions() *Options {
 	s := Options{
-		GenericServerRunOptions: genericoptions.NewServerRunOptions(),
-		Etcd:                    genericoptions.NewEtcdOptions(storagebackend.NewDefaultConfig(kubeoptions.DefaultEtcdPathPrefix, nil)),
-		SecureServing:           kubeoptions.NewSecureServingOptions(),
-		Audit:                   genericoptions.NewAuditOptions(),
-		Features:                genericoptions.NewFeatureOptions(),
-		Admission:               kubeoptions.NewAdmissionOptions(),
-		Authentication:          kubeoptions.NewBuiltInAuthenticationOptions().WithAll(),
-		Authorization:           kubeoptions.NewBuiltInAuthorizationOptions(),
-		APIEnablement:           genericoptions.NewAPIEnablementOptions(),
-		EgressSelector:          genericoptions.NewEgressSelectorOptions(),
-		Metrics:                 metrics.NewOptions(),
-		Logs:                    logs.NewOptions(),
-		Traces:                  genericoptions.NewTracingOptions(),
+		GenericAPIServer: genericoptions.NewServerRunOptions(),
+		Etcd:             genericoptions.NewEtcdOptions(storagebackend.NewDefaultConfig(kubeoptions.DefaultEtcdPathPrefix, nil)),
+		SecureServing:    kubeoptions.NewSecureServingOptions(),
+		Audit:            genericoptions.NewAuditOptions(),
+		Features:         genericoptions.NewFeatureOptions(),
+		Admission:        kubeoptions.NewAdmissionOptions(),
+		Authentication:   kubeoptions.NewBuiltInAuthenticationOptions().WithAll(),
+		Authorization:    kubeoptions.NewBuiltInAuthorizationOptions(),
+		APIEnablement:    genericoptions.NewAPIEnablementOptions(),
+		EgressSelector:   genericoptions.NewEgressSelectorOptions(),
+		Metrics:          metrics.NewOptions(),
+		Logs:             logs.NewOptions(),
+		Traces:           genericoptions.NewTracingOptions(),
 
 		EnableLogsHandler:                   true,
 		EventTTL:                            1 * time.Hour,
@@ -116,7 +116,7 @@ func NewOptions() *Options {
 
 func (s *Options) AddFlags(fss *cliflag.NamedFlagSets) {
 	// Add the generic flags.
-	s.GenericServerRunOptions.AddUniversalFlags(fss.FlagSet("generic"))
+	s.GenericAPIServer.AddUniversalFlags(fss.FlagSet("generic"))
 	s.Etcd.AddFlags(fss.FlagSet("etcd"))
 	s.SecureServing.AddFlags(fss.FlagSet("secure serving"))
 	s.Audit.AddFlags(fss.FlagSet("auditing"))
@@ -181,25 +181,25 @@ func (o *Options) Complete(alternateDNS []string, alternateIPs []net.IP) (Comple
 	}
 
 	// set defaults
-	if err := completed.GenericServerRunOptions.DefaultAdvertiseAddress(completed.SecureServing.SecureServingOptions); err != nil {
+	if err := completed.GenericAPIServer.DefaultAdvertiseAddress(completed.SecureServing.SecureServingOptions); err != nil {
 		return CompletedOptions{}, err
 	}
 
-	if err := completed.SecureServing.MaybeDefaultWithSelfSignedCerts(completed.GenericServerRunOptions.AdvertiseAddress.String(), alternateDNS, alternateIPs); err != nil {
+	if err := completed.SecureServing.MaybeDefaultWithSelfSignedCerts(completed.GenericAPIServer.AdvertiseAddress.String(), alternateDNS, alternateIPs); err != nil {
 		return CompletedOptions{}, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 
-	if len(completed.GenericServerRunOptions.ExternalHost) == 0 {
-		if len(completed.GenericServerRunOptions.AdvertiseAddress) > 0 {
-			completed.GenericServerRunOptions.ExternalHost = completed.GenericServerRunOptions.AdvertiseAddress.String()
+	if len(completed.GenericAPIServer.ExternalHost) == 0 {
+		if len(completed.GenericAPIServer.AdvertiseAddress) > 0 {
+			completed.GenericAPIServer.ExternalHost = completed.GenericAPIServer.AdvertiseAddress.String()
 		} else {
 			hostname, err := os.Hostname()
 			if err != nil {
 				return CompletedOptions{}, fmt.Errorf("error finding host name: %v", err)
 			}
-			completed.GenericServerRunOptions.ExternalHost = hostname
+			completed.GenericAPIServer.ExternalHost = hostname
 		}
-		klog.Infof("external host was not specified, using %v", completed.GenericServerRunOptions.ExternalHost)
+		klog.Infof("external host was not specified, using %v", completed.GenericAPIServer.ExternalHost)
 	}
 
 	completed.Authentication.ApplyAuthorization(completed.Authorization)

--- a/pkg/controlplane/apiserver/options/options_test.go
+++ b/pkg/controlplane/apiserver/options/options_test.go
@@ -115,7 +115,7 @@ func TestAddFlags(t *testing.T) {
 	// This is a snapshot of expected options parsed by args.
 	expected := &Options{
 		MasterCount: 5,
-		GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
+		GenericAPIServer: &apiserveroptions.ServerRunOptions{
 			AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 			CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
 			MaxRequestsInFlight:         400,

--- a/pkg/controlplane/apiserver/options/validation.go
+++ b/pkg/controlplane/apiserver/options/validation.go
@@ -50,7 +50,7 @@ func validateTokenRequest(options *Options) []error {
 }
 
 func validateAPIPriorityAndFairness(options *Options) []error {
-	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIPriorityAndFairness) && options.GenericServerRunOptions.EnablePriorityAndFairness {
+	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIPriorityAndFairness) && options.GenericAPIServer.EnablePriorityAndFairness {
 		// If none of the following runtime config options are specified,
 		// APF is assumed to be turned on. The internal APF controller uses
 		// v1beta3 so it should be enabled.

--- a/pkg/controlplane/apiserver/options/validation_test.go
+++ b/pkg/controlplane/apiserver/options/validation_test.go
@@ -62,7 +62,7 @@ func TestValidateAPIPriorityAndFairness(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.runtimeConfig, func(t *testing.T) {
 			options := &Options{
-				GenericServerRunOptions: &genericoptions.ServerRunOptions{
+				GenericAPIServer: &genericoptions.ServerRunOptions{
 					EnablePriorityAndFairness: true,
 				},
 				APIEnablement: genericoptions.NewAPIEnablementOptions(),
@@ -90,11 +90,11 @@ func TestValidateOptions(t *testing.T) {
 			name:         "validate master count equal 0",
 			expectErrors: true,
 			options: &Options{
-				MasterCount:             0,
-				GenericServerRunOptions: &genericoptions.ServerRunOptions{},
-				Etcd:                    &genericoptions.EtcdOptions{},
-				SecureServing:           &genericoptions.SecureServingOptionsWithLoopback{},
-				Audit:                   &genericoptions.AuditOptions{},
+				MasterCount:      0,
+				GenericAPIServer: &genericoptions.ServerRunOptions{},
+				Etcd:             &genericoptions.EtcdOptions{},
+				SecureServing:    &genericoptions.SecureServingOptionsWithLoopback{},
+				Audit:            &genericoptions.AuditOptions{},
 				Admission: &kubeoptions.AdmissionOptions{
 					GenericAdmission: &genericoptions.AdmissionOptions{
 						EnablePlugins: []string{"foo"},
@@ -117,11 +117,11 @@ func TestValidateOptions(t *testing.T) {
 			name:         "validate token request enable not attempted",
 			expectErrors: true,
 			options: &Options{
-				MasterCount:             1,
-				GenericServerRunOptions: &genericoptions.ServerRunOptions{},
-				Etcd:                    &genericoptions.EtcdOptions{},
-				SecureServing:           &genericoptions.SecureServingOptionsWithLoopback{},
-				Audit:                   &genericoptions.AuditOptions{},
+				MasterCount:      1,
+				GenericAPIServer: &genericoptions.ServerRunOptions{},
+				Etcd:             &genericoptions.EtcdOptions{},
+				SecureServing:    &genericoptions.SecureServingOptionsWithLoopback{},
+				Audit:            &genericoptions.AuditOptions{},
 				Admission: &kubeoptions.AdmissionOptions{
 					GenericAdmission: &genericoptions.AdmissionOptions{
 						EnablePlugins: []string{""},

--- a/test/e2e_node/services/apiserver.go
+++ b/test/e2e_node/services/apiserver.go
@@ -61,22 +61,22 @@ func (a *APIServer) Start() error {
 	const tokenFilePath = "known_tokens.csv"
 
 	o := options.NewServerRunOptions()
-	o.Etcd.StorageConfig = a.storageConfig
+	o.GenericControlPlane.Etcd.StorageConfig = a.storageConfig
 	_, ipnet, err := netutils.ParseCIDRSloppy(clusterIPRange)
 	if err != nil {
 		return err
 	}
 	if len(framework.TestContext.RuntimeConfig) > 0 {
-		o.APIEnablement.RuntimeConfig = framework.TestContext.RuntimeConfig
+		o.GenericControlPlane.APIEnablement.RuntimeConfig = framework.TestContext.RuntimeConfig
 	}
-	o.SecureServing.BindAddress = netutils.ParseIPSloppy("127.0.0.1")
+	o.GenericControlPlane.SecureServing.BindAddress = netutils.ParseIPSloppy("127.0.0.1")
 	o.ServiceClusterIPRanges = ipnet.String()
 	o.AllowPrivileged = true
 	if err := generateTokenFile(tokenFilePath); err != nil {
 		return fmt.Errorf("failed to generate token file %s: %w", tokenFilePath, err)
 	}
-	o.Authentication.TokenFile.TokenFile = tokenFilePath
-	o.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
+	o.GenericControlPlane.Authentication.TokenFile.TokenFile = tokenFilePath
+	o.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
 
 	saSigningKeyFile, err := os.CreateTemp("/tmp", "insecure_test_key")
 	if err != nil {
@@ -86,10 +86,10 @@ func (a *APIServer) Start() error {
 	if err = os.WriteFile(saSigningKeyFile.Name(), []byte(ecdsaPrivateKey), 0666); err != nil {
 		return fmt.Errorf("write file %s failed: %w", saSigningKeyFile.Name(), err)
 	}
-	o.ServiceAccountSigningKeyFile = saSigningKeyFile.Name()
-	o.Authentication.APIAudiences = []string{"https://foo.bar.example.com"}
-	o.Authentication.ServiceAccounts.Issuers = []string{"https://foo.bar.example.com"}
-	o.Authentication.ServiceAccounts.KeyFiles = []string{saSigningKeyFile.Name()}
+	o.GenericControlPlane.ServiceAccountSigningKeyFile = saSigningKeyFile.Name()
+	o.GenericControlPlane.Authentication.APIAudiences = []string{"https://foo.bar.example.com"}
+	o.GenericControlPlane.Authentication.ServiceAccounts.Issuers = []string{"https://foo.bar.example.com"}
+	o.GenericControlPlane.Authentication.ServiceAccounts.KeyFiles = []string{saSigningKeyFile.Name()}
 
 	o.KubeletConfig.PreferredAddressTypes = []string{"InternalIP"}
 

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -386,8 +386,8 @@ func TestListOptions(t *testing.T) {
 			var storageTransport *storagebackend.TransportConfig
 			clientSet, _, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 				ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-					opts.Etcd.EnableWatchCache = watchCacheEnabled
-					storageTransport = &opts.Etcd.StorageConfig.Transport
+					opts.GenericControlPlane.Etcd.EnableWatchCache = watchCacheEnabled
+					storageTransport = &opts.GenericControlPlane.Etcd.StorageConfig.Transport
 				},
 			})
 			defer tearDownFn()
@@ -631,7 +631,7 @@ func TestListResourceVersion0(t *testing.T) {
 
 			clientSet, _, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 				ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-					opts.Etcd.EnableWatchCache = tc.watchCacheEnabled
+					opts.GenericControlPlane.Etcd.EnableWatchCache = tc.watchCacheEnabled
 				},
 			})
 			defer tearDownFn()

--- a/test/integration/apiserver/certreload/certreload_test.go
+++ b/test/integration/apiserver/certreload/certreload_test.go
@@ -177,10 +177,10 @@ func testClientCA(t *testing.T, recreate bool) {
 
 	kubeClient, kubeconfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.GenericServerRunOptions.MaxRequestBodyBytes = 1024 * 1024
-			clientCAFilename = opts.Authentication.ClientCert.ClientCA
-			frontProxyCAFilename = opts.Authentication.RequestHeader.ClientCAFile
-			opts.Authentication.RequestHeader.AllowedNames = append(opts.Authentication.RequestHeader.AllowedNames, "test-aggregated-apiserver")
+			opts.GenericControlPlane.GenericAPIServer.MaxRequestBodyBytes = 1024 * 1024
+			clientCAFilename = opts.GenericControlPlane.Authentication.ClientCert.ClientCA
+			frontProxyCAFilename = opts.GenericControlPlane.Authentication.RequestHeader.ClientCAFile
+			opts.GenericControlPlane.Authentication.RequestHeader.AllowedNames = append(opts.GenericControlPlane.Authentication.RequestHeader.AllowedNames, "test-aggregated-apiserver")
 		},
 	})
 	defer tearDownFn()
@@ -481,8 +481,8 @@ func testServingCert(t *testing.T, recreate bool) {
 
 	_, kubeconfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.GenericServerRunOptions.MaxRequestBodyBytes = 1024 * 1024
-			servingCertPath = opts.SecureServing.ServerCert.CertDirectory
+			opts.GenericControlPlane.GenericAPIServer.MaxRequestBodyBytes = 1024 * 1024
+			servingCertPath = opts.GenericControlPlane.SecureServing.ServerCert.CertDirectory
 		},
 	})
 	defer tearDownFn()
@@ -524,8 +524,8 @@ func TestSNICert(t *testing.T) {
 
 	_, kubeconfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.GenericServerRunOptions.MaxRequestBodyBytes = 1024 * 1024
-			servingCertPath = opts.SecureServing.ServerCert.CertDirectory
+			opts.GenericControlPlane.GenericAPIServer.MaxRequestBodyBytes = 1024 * 1024
+			servingCertPath = opts.GenericControlPlane.SecureServing.ServerCert.CertDirectory
 
 			if err := os.WriteFile(path.Join(servingCertPath, "foo.key"), anotherServerKey, 0644); err != nil {
 				t.Fatal(err)
@@ -534,7 +534,7 @@ func TestSNICert(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			opts.SecureServing.SNICertKeys = []flag.NamedCertKey{{
+			opts.GenericControlPlane.SecureServing.SNICertKeys = []flag.NamedCertKey{{
 				Names:    []string{"foo"},
 				CertFile: path.Join(servingCertPath, "foo.crt"),
 				KeyFile:  path.Join(servingCertPath, "foo.key"),

--- a/test/integration/apiserver/flowcontrol/concurrency_test.go
+++ b/test/integration/apiserver/flowcontrol/concurrency_test.go
@@ -56,9 +56,9 @@ func setup(t testing.TB, maxReadonlyRequestsInFlight, maxMutatingRequestsInFligh
 	_, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Ensure all clients are allowed to send requests.
-			opts.Authorization.Modes = []string{"AlwaysAllow"}
-			opts.GenericServerRunOptions.MaxRequestsInFlight = maxReadonlyRequestsInFlight
-			opts.GenericServerRunOptions.MaxMutatingRequestsInFlight = maxMutatingRequestsInFlight
+			opts.GenericControlPlane.Authorization.Modes = []string{"AlwaysAllow"}
+			opts.GenericControlPlane.GenericAPIServer.MaxRequestsInFlight = maxReadonlyRequestsInFlight
+			opts.GenericControlPlane.GenericAPIServer.MaxMutatingRequestsInFlight = maxMutatingRequestsInFlight
 		},
 	})
 

--- a/test/integration/apiserver/flowcontrol/concurrency_util_test.go
+++ b/test/integration/apiserver/flowcontrol/concurrency_util_test.go
@@ -158,9 +158,9 @@ func TestConcurrencyIsolation(t *testing.T) {
 	_, kubeConfig, closeFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Ensure all clients are allowed to send requests.
-			opts.Authorization.Modes = []string{"AlwaysAllow"}
-			opts.GenericServerRunOptions.MaxRequestsInFlight = 10
-			opts.GenericServerRunOptions.MaxMutatingRequestsInFlight = 10
+			opts.GenericControlPlane.Authorization.Modes = []string{"AlwaysAllow"}
+			opts.GenericControlPlane.GenericAPIServer.MaxRequestsInFlight = 10
+			opts.GenericControlPlane.GenericAPIServer.MaxMutatingRequestsInFlight = 10
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Wrap default authorizer with one that delays requests from noxu clients

--- a/test/integration/apiserver/max_json_patch_operations_test.go
+++ b/test/integration/apiserver/max_json_patch_operations_test.go
@@ -39,7 +39,7 @@ func TestMaxJSONPatchOperations(t *testing.T) {
 
 	clientSet, _, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.GenericServerRunOptions.MaxRequestBodyBytes = 1024 * 1024
+			opts.GenericControlPlane.GenericAPIServer.MaxRequestBodyBytes = 1024 * 1024
 		},
 	})
 	defer tearDownFn()

--- a/test/integration/apiserver/podlogs/podlogs_test.go
+++ b/test/integration/apiserver/podlogs/podlogs_test.go
@@ -84,7 +84,7 @@ Bgqc+dJN9xS9Ah5gLiGQJ6C4niUA11piCpvMsy+j/LQ1Erx47KMar5fuMXYk7iPq
 
 	clientSet, _, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.GenericServerRunOptions.MaxRequestBodyBytes = 1024 * 1024
+			opts.GenericControlPlane.GenericAPIServer.MaxRequestBodyBytes = 1024 * 1024
 			// I have no idea what this cert is, but it doesn't matter, we just want something that always fails validation
 			opts.KubeletConfig.TLSClientConfig.CAFile = badCA
 		},
@@ -257,7 +257,7 @@ func TestPodLogsKubeletClientCertReload(t *testing.T) {
 
 	clientSet, _, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.GenericServerRunOptions.MaxRequestBodyBytes = 1024 * 1024
+			opts.GenericControlPlane.GenericAPIServer.MaxRequestBodyBytes = 1024 * 1024
 			opts.KubeletConfig.TLSClientConfig.CAFile = kubeletCA
 			opts.KubeletConfig.TLSClientConfig.CertFile = startingCerts.clientCertFile
 			opts.KubeletConfig.TLSClientConfig.KeyFile = startingCerts.clientCertKeyFile

--- a/test/integration/apiserver/watchcache_test.go
+++ b/test/integration/apiserver/watchcache_test.go
@@ -57,7 +57,7 @@ func multiEtcdSetup(ctx context.Context, t *testing.T) (clientset.Interface, fra
 	clientSet, _, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Ensure we're using the same etcd across apiserver restarts.
-			opts.Etcd = etcdOptions
+			opts.GenericControlPlane.Etcd = etcdOptions
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Switch off endpoints reconciler to avoid unnecessary operations.

--- a/test/integration/auth/auth_test.go
+++ b/test/integration/auth/auth_test.go
@@ -461,8 +461,8 @@ func TestAuthModeAlwaysAllow(t *testing.T) {
 	kubeClient, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-			opts.Authorization.Modes = []string{"AlwaysAllow"}
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Authorization.Modes = []string{"AlwaysAllow"}
 		},
 	})
 	defer tearDownFn()
@@ -569,9 +569,9 @@ func TestAuthModeAlwaysDeny(t *testing.T) {
 	kubeClient, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-			opts.Authorization.Modes = []string{"AlwaysDeny"}
-			opts.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Authorization.Modes = []string{"AlwaysDeny"}
+			opts.GenericControlPlane.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
 		},
 	})
 	defer tearDownFn()
@@ -617,10 +617,10 @@ func TestAliceNotForbiddenOrUnauthorized(t *testing.T) {
 	kubeClient, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-			opts.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
-			opts.Authorization.Modes = []string{"ABAC"}
-			opts.Authorization.PolicyFile = "testdata/allowalice.jsonl"
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
+			opts.GenericControlPlane.Authorization.Modes = []string{"ABAC"}
+			opts.GenericControlPlane.Authorization.PolicyFile = "testdata/allowalice.jsonl"
 		},
 	})
 	defer tearDownFn()
@@ -697,10 +697,10 @@ func TestBobIsForbidden(t *testing.T) {
 	kubeClient, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-			opts.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
-			opts.Authorization.Modes = []string{"ABAC"}
-			opts.Authorization.PolicyFile = "testdata/allowalice.jsonl"
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
+			opts.GenericControlPlane.Authorization.Modes = []string{"ABAC"}
+			opts.GenericControlPlane.Authorization.PolicyFile = "testdata/allowalice.jsonl"
 		},
 	})
 	defer tearDownFn()
@@ -750,10 +750,10 @@ func TestUnknownUserIsUnauthorized(t *testing.T) {
 	kubeClient, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-			opts.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
-			opts.Authorization.Modes = []string{"ABAC"}
-			opts.Authorization.PolicyFile = "testdata/allowalice.jsonl"
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
+			opts.GenericControlPlane.Authorization.Modes = []string{"ABAC"}
+			opts.GenericControlPlane.Authorization.PolicyFile = "testdata/allowalice.jsonl"
 		},
 	})
 	defer tearDownFn()
@@ -826,8 +826,8 @@ func TestImpersonateIsForbidden(t *testing.T) {
 	kubeClient, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-			opts.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Prepend an impersonation authorizer with specific opinions about alice and bob
@@ -1134,8 +1134,8 @@ func TestAuthorizationAttributeDetermination(t *testing.T) {
 	kubeClient, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-			opts.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			config.GenericConfig.Authorization.Authorizer = unionauthz.New(config.GenericConfig.Authorization.Authorizer, trackingAuthorizer)
@@ -1208,10 +1208,10 @@ func TestNamespaceAuthorization(t *testing.T) {
 	kubeClient, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-			opts.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
-			opts.Authorization.PolicyFile = newABACFileWithContents(t, `{"namespace": "auth-namespace"}`)
-			opts.Authorization.Modes = []string{"ABAC"}
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
+			opts.GenericControlPlane.Authorization.PolicyFile = newABACFileWithContents(t, `{"namespace": "auth-namespace"}`)
+			opts.GenericControlPlane.Authorization.Modes = []string{"ABAC"}
 		},
 	})
 	defer tearDownFn()
@@ -1313,10 +1313,10 @@ func TestKindAuthorization(t *testing.T) {
 	kubeClient, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-			opts.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
-			opts.Authorization.PolicyFile = newABACFileWithContents(t, `{"resource": "services"}`)
-			opts.Authorization.Modes = []string{"ABAC"}
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
+			opts.GenericControlPlane.Authorization.PolicyFile = newABACFileWithContents(t, `{"resource": "services"}`)
+			opts.GenericControlPlane.Authorization.Modes = []string{"ABAC"}
 		},
 	})
 	defer tearDownFn()
@@ -1400,10 +1400,10 @@ func TestReadOnlyAuthorization(t *testing.T) {
 	kubeClient, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-			opts.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
-			opts.Authorization.PolicyFile = newABACFileWithContents(t, `{"readonly": true}`)
-			opts.Authorization.Modes = []string{"ABAC"}
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
+			opts.GenericControlPlane.Authorization.PolicyFile = newABACFileWithContents(t, `{"readonly": true}`)
+			opts.GenericControlPlane.Authorization.Modes = []string{"ABAC"}
 		},
 	})
 	defer tearDownFn()
@@ -1483,9 +1483,9 @@ func testWebhookTokenAuthenticator(customDialer bool, t *testing.T) {
 	kubeClient, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-			opts.Authorization.Modes = []string{"ABAC"}
-			opts.Authorization.PolicyFile = "testdata/allowalice.jsonl"
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Authorization.Modes = []string{"ABAC"}
+			opts.GenericControlPlane.Authorization.PolicyFile = "testdata/allowalice.jsonl"
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			config.GenericConfig.Authentication.Authenticator = group.NewAuthenticatedGroupAdder(authenticator)

--- a/test/integration/auth/bootstraptoken_test.go
+++ b/test/integration/auth/bootstraptoken_test.go
@@ -129,7 +129,7 @@ func TestBootstrapTokenAuth(t *testing.T) {
 
 			kubeClient, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 				ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-					opts.Authorization.Modes = []string{"AlwaysAllow"}
+					opts.GenericControlPlane.Authorization.Modes = []string{"AlwaysAllow"}
 				},
 				ModifyServerConfig: func(config *controlplane.Config) {
 					config.GenericConfig.Authentication.Authenticator = authenticator

--- a/test/integration/auth/dynamic_client_test.go
+++ b/test/integration/auth/dynamic_client_test.go
@@ -60,19 +60,19 @@ func TestDynamicClientBuilder(t *testing.T) {
 
 	baseClient, baseConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.ServiceAccountSigningKeyFile = tmpfile.Name()
-			opts.ServiceAccountTokenMaxExpiration = maxExpirationDuration
-			if opts.Authentication == nil {
-				opts.Authentication = &kubeoptions.BuiltInAuthenticationOptions{}
+			opts.GenericControlPlane.ServiceAccountSigningKeyFile = tmpfile.Name()
+			opts.GenericControlPlane.ServiceAccountTokenMaxExpiration = maxExpirationDuration
+			if opts.GenericControlPlane.Authentication == nil {
+				opts.GenericControlPlane.Authentication = &kubeoptions.BuiltInAuthenticationOptions{}
 			}
 
-			opts.Authentication.APIAudiences = aud
-			if opts.Authentication.ServiceAccounts == nil {
-				opts.Authentication.ServiceAccounts = &kubeoptions.ServiceAccountAuthenticationOptions{}
+			opts.GenericControlPlane.Authentication.APIAudiences = aud
+			if opts.GenericControlPlane.Authentication.ServiceAccounts == nil {
+				opts.GenericControlPlane.Authentication.ServiceAccounts = &kubeoptions.ServiceAccountAuthenticationOptions{}
 			}
-			opts.Authentication.ServiceAccounts.Issuers = []string{iss}
-			opts.Authentication.ServiceAccounts.KeyFiles = []string{tmpfile.Name()}
-			opts.Authorization.Modes = []string{"AlwaysAllow"}
+			opts.GenericControlPlane.Authentication.ServiceAccounts.Issuers = []string{iss}
+			opts.GenericControlPlane.Authentication.ServiceAccounts.KeyFiles = []string{tmpfile.Name()}
+			opts.GenericControlPlane.Authorization.Modes = []string{"AlwaysAllow"}
 		},
 	})
 	defer tearDownFn()

--- a/test/integration/auth/rbac_test.go
+++ b/test/integration/auth/rbac_test.go
@@ -554,9 +554,9 @@ func TestRBAC(t *testing.T) {
 					// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
 					// Also disable namespace lifecycle to workaroung the test limitation that first creates
 					// roles/rolebindings and only then creates corresponding namespaces.
-					opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "NamespaceLifecycle"}
+					opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "NamespaceLifecycle"}
 					// Disable built-in authorizers
-					opts.Authorization.Modes = []string{"AlwaysDeny"}
+					opts.GenericControlPlane.Authorization.Modes = []string{"AlwaysDeny"}
 				},
 				ModifyServerConfig: func(config *controlplane.Config) {
 					// Append our custom test authenticator
@@ -681,7 +681,7 @@ func TestBootstrapping(t *testing.T) {
 
 	clientset, _, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.Authorization.Modes = []string{"RBAC"}
+			opts.GenericControlPlane.Authorization.Modes = []string{"RBAC"}
 		},
 	})
 	defer tearDownFn()
@@ -743,8 +743,8 @@ func TestDiscoveryUpgradeBootstrapping(t *testing.T) {
 	client, _, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Ensure we're using the same etcd across apiserver restarts.
-			opts.Etcd.StorageConfig = *etcdConfig
-			opts.Authorization.Modes = []string{"RBAC"}
+			opts.GenericControlPlane.Etcd.StorageConfig = *etcdConfig
+			opts.GenericControlPlane.Authorization.Modes = []string{"RBAC"}
 		},
 	})
 
@@ -791,8 +791,8 @@ func TestDiscoveryUpgradeBootstrapping(t *testing.T) {
 	client, _, tearDownFn = framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Ensure we're using the same etcd across apiserver restarts.
-			opts.Etcd.StorageConfig = *etcdConfig
-			opts.Authorization.Modes = []string{"RBAC"}
+			opts.GenericControlPlane.Etcd.StorageConfig = *etcdConfig
+			opts.GenericControlPlane.Authorization.Modes = []string{"RBAC"}
 		},
 	})
 

--- a/test/integration/auth/selfsubjectreview_test.go
+++ b/test/integration/auth/selfsubjectreview_test.go
@@ -102,10 +102,10 @@ func TestGetsSelfAttributes(t *testing.T) {
 
 	kubeClient, _, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1alpha1=true")
-			opts.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1beta1=true")
-			opts.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1=true")
-			opts.Authorization.Modes = []string{"AlwaysAllow"}
+			opts.GenericControlPlane.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1alpha1=true")
+			opts.GenericControlPlane.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1beta1=true")
+			opts.GenericControlPlane.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1=true")
+			opts.GenericControlPlane.Authorization.Modes = []string{"AlwaysAllow"}
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Unset BearerToken to disable BearerToken authenticator.
@@ -221,10 +221,10 @@ func TestGetsSelfAttributesError(t *testing.T) {
 
 	kubeClient, _, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1alpha1=true")
-			opts.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1beta1=true")
-			opts.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1=true")
-			opts.Authorization.Modes = []string{"AlwaysAllow"}
+			opts.GenericControlPlane.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1alpha1=true")
+			opts.GenericControlPlane.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1beta1=true")
+			opts.GenericControlPlane.APIEnablement.RuntimeConfig.Set("authentication.k8s.io/v1=true")
+			opts.GenericControlPlane.Authorization.Modes = []string{"AlwaysAllow"}
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Unset BearerToken to disable BearerToken authenticator.

--- a/test/integration/auth/svcaccttoken_test.go
+++ b/test/integration/auth/svcaccttoken_test.go
@@ -84,15 +84,15 @@ func TestServiceAccountTokenCreate(t *testing.T) {
 	kubeClient, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-			opts.Authorization.Modes = []string{"AlwaysAllow"}
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Authorization.Modes = []string{"AlwaysAllow"}
 			// Disable token cache so we can check reaction to service account deletion quickly
-			opts.Authentication.TokenSuccessCacheTTL = 0
-			opts.Authentication.TokenFailureCacheTTL = 0
+			opts.GenericControlPlane.Authentication.TokenSuccessCacheTTL = 0
+			opts.GenericControlPlane.Authentication.TokenFailureCacheTTL = 0
 			// Pin to fixed URLs for easier testing
-			opts.Authentication.ServiceAccounts.JWKSURI = "https:///openid/v1/jwks"
-			opts.Authentication.ServiceAccounts.Issuers = []string{iss}
-			opts.Authentication.APIAudiences = aud
+			opts.GenericControlPlane.Authentication.ServiceAccounts.JWKSURI = "https:///openid/v1/jwks"
+			opts.GenericControlPlane.Authentication.ServiceAccounts.Issuers = []string{iss}
+			opts.GenericControlPlane.Authentication.APIAudiences = aud
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// extract token generator

--- a/test/integration/clustercidr/ipam_test.go
+++ b/test/integration/clustercidr/ipam_test.go
@@ -53,8 +53,8 @@ func TestIPAMMultiCIDRRangeAllocatorCIDRAllocate(t *testing.T) {
 	_, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
-			opts.APIEnablement.RuntimeConfig.Set("networking.k8s.io/v1alpha1=true")
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
+			opts.GenericControlPlane.APIEnablement.RuntimeConfig.Set("networking.k8s.io/v1alpha1=true")
 		},
 	})
 	defer tearDownFn()
@@ -140,8 +140,8 @@ func TestIPAMMultiCIDRRangeAllocatorCIDRRelease(t *testing.T) {
 	_, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
-			opts.APIEnablement.RuntimeConfig.Set("networking.k8s.io/v1alpha1=true")
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
+			opts.GenericControlPlane.APIEnablement.RuntimeConfig.Set("networking.k8s.io/v1alpha1=true")
 		},
 	})
 	defer tearDownFn()
@@ -218,8 +218,8 @@ func TestIPAMMultiCIDRRangeAllocatorClusterCIDRDelete(t *testing.T) {
 	_, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
-			opts.APIEnablement.RuntimeConfig.Set("networking.k8s.io/v1alpha1=true")
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
+			opts.GenericControlPlane.APIEnablement.RuntimeConfig.Set("networking.k8s.io/v1alpha1=true")
 		},
 	})
 	defer tearDownFn()
@@ -315,8 +315,8 @@ func TestIPAMMultiCIDRRangeAllocatorClusterCIDRTerminate(t *testing.T) {
 	_, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
-			opts.APIEnablement.RuntimeConfig.Set("networking.k8s.io/v1alpha1=true")
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
+			opts.GenericControlPlane.APIEnablement.RuntimeConfig.Set("networking.k8s.io/v1alpha1=true")
 		},
 	})
 	defer tearDownFn()
@@ -401,8 +401,8 @@ func TestIPAMMultiCIDRRangeAllocatorClusterCIDRTieBreak(t *testing.T) {
 	_, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
-			opts.APIEnablement.RuntimeConfig.Set("networking.k8s.io/v1alpha1=true")
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
+			opts.GenericControlPlane.APIEnablement.RuntimeConfig.Set("networking.k8s.io/v1alpha1=true")
 		},
 	})
 	defer tearDownFn()

--- a/test/integration/controlplane/kube_apiserver_test.go
+++ b/test/integration/controlplane/kube_apiserver_test.go
@@ -428,7 +428,7 @@ func getEndpointIPs(endpoints *corev1.Endpoints) []string {
 func verifyEndpointsWithIPs(servers []*kubeapiservertesting.TestServer, ips []string) bool {
 	listenAddresses := make([]string, 0)
 	for _, server := range servers {
-		listenAddresses = append(listenAddresses, server.ServerOpts.GenericServerRunOptions.AdvertiseAddress.String())
+		listenAddresses = append(listenAddresses, server.ServerOpts.GenericControlPlane.GenericAPIServer.AdvertiseAddress.String())
 	}
 	return reflect.DeepEqual(listenAddresses, ips)
 }

--- a/test/integration/controlplane/synthetic_controlplane_test.go
+++ b/test/integration/controlplane/synthetic_controlplane_test.go
@@ -147,11 +147,11 @@ func TestEmptyList(t *testing.T) {
 }
 
 func initStatusForbiddenControlPlaneConfig(options *options.ServerRunOptions) {
-	options.Authorization.Modes = []string{"AlwaysDeny"}
+	options.GenericControlPlane.Authorization.Modes = []string{"AlwaysDeny"}
 }
 
 func initUnauthorizedControlPlaneConfig(options *options.ServerRunOptions) {
-	options.Authentication.Anonymous.Allow = false
+	options.GenericControlPlane.Authentication.Anonymous.Allow = false
 }
 
 func TestStatus(t *testing.T) {

--- a/test/integration/controlplane/transformation/kms_transformation_test.go
+++ b/test/integration/controlplane/transformation/kms_transformation_test.go
@@ -570,7 +570,7 @@ resources:
 			}
 		}
 
-		rawClient, etcdClient, err := integration.GetEtcdClients(test.kubeAPIServer.ServerOpts.Etcd.StorageConfig.Transport)
+		rawClient, etcdClient, err := integration.GetEtcdClients(test.kubeAPIServer.ServerOpts.GenericControlPlane.Etcd.StorageConfig.Transport)
 		if err != nil {
 			t.Fatalf("failed to create etcd client: %v", err)
 		}
@@ -578,7 +578,7 @@ resources:
 		// close the client (which we can do by closing rawClient).
 		defer rawClient.Close()
 
-		response, err := etcdClient.Get(context.TODO(), "/"+test.kubeAPIServer.ServerOpts.Etcd.StorageConfig.Prefix, clientv3.WithPrefix())
+		response, err := etcdClient.Get(context.TODO(), "/"+test.kubeAPIServer.ServerOpts.GenericControlPlane.Etcd.StorageConfig.Prefix, clientv3.WithPrefix())
 		if err != nil {
 			t.Fatalf("failed to retrieve secret from etcd %v", err)
 		}

--- a/test/integration/controlplane/transformation/kmsv2_transformation_test.go
+++ b/test/integration/controlplane/transformation/kmsv2_transformation_test.go
@@ -263,7 +263,7 @@ resources:
 	t.Cleanup(cancel)
 
 	var firstEncryptedDEK []byte
-	assertPodDEKs(ctx, t, test.kubeAPIServer.ServerOpts.Etcd.StorageConfig,
+	assertPodDEKs(ctx, t, test.kubeAPIServer.ServerOpts.GenericControlPlane.Etcd.StorageConfig,
 		1, 1,
 		"k8s:enc:kms:v2:kms-provider:",
 		func(_ int, counter uint64, etcdKey string, obj kmstypes.EncryptedObject) {
@@ -392,7 +392,7 @@ resources:
 		t.Fatalf("Resource version should not have changed again after the initial version updated as a result of the keyID update. old pod: %v, new pod: %v", newPod, updatedNewPod)
 	}
 
-	assertPodDEKs(ctx, t, test.kubeAPIServer.ServerOpts.Etcd.StorageConfig,
+	assertPodDEKs(ctx, t, test.kubeAPIServer.ServerOpts.GenericControlPlane.Etcd.StorageConfig,
 		1, 1, "k8s:enc:kms:v2:kms-provider:", checkDEK,
 	)
 }
@@ -445,7 +445,7 @@ resources:
 		}
 	}
 
-	assertPodDEKs(ctx, t, test.kubeAPIServer.ServerOpts.Etcd.StorageConfig,
+	assertPodDEKs(ctx, t, test.kubeAPIServer.ServerOpts.GenericControlPlane.Etcd.StorageConfig,
 		podCount, 1, // key ID does not change during the test so we should only have a single DEK
 		"k8s:enc:kms:v2:kms-provider:",
 		func(i int, counter uint64, etcdKey string, obj kmstypes.EncryptedObject) {

--- a/test/integration/controlplane/transformation/transformation_test.go
+++ b/test/integration/controlplane/transformation/transformation_test.go
@@ -473,7 +473,7 @@ func (e *transformTest) inplaceUpdatePod(namespace string, obj *unstructured.Uns
 }
 
 func (e *transformTest) readRawRecordFromETCD(path string) (*clientv3.GetResponse, error) {
-	rawClient, etcdClient, err := integration.GetEtcdClients(e.kubeAPIServer.ServerOpts.Etcd.StorageConfig.Transport)
+	rawClient, etcdClient, err := integration.GetEtcdClients(e.kubeAPIServer.ServerOpts.GenericControlPlane.Etcd.StorageConfig.Transport)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create etcd client: %v", err)
 	}
@@ -490,7 +490,7 @@ func (e *transformTest) readRawRecordFromETCD(path string) (*clientv3.GetRespons
 }
 
 func (e *transformTest) writeRawRecordToETCD(path string, data []byte) (*clientv3.PutResponse, error) {
-	rawClient, etcdClient, err := integration.GetEtcdClients(e.kubeAPIServer.ServerOpts.Etcd.StorageConfig.Transport)
+	rawClient, etcdClient, err := integration.GetEtcdClients(e.kubeAPIServer.ServerOpts.GenericControlPlane.Etcd.StorageConfig.Transport)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create etcd client: %v", err)
 	}

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -68,7 +68,7 @@ func setupWithServerSetup(t *testing.T, serverSetup framework.TestServerSetup) (
 			modifyServerRunOptions(opts)
 		}
 
-		opts.Admission.GenericAdmission.DisablePlugins = append(opts.Admission.GenericAdmission.DisablePlugins,
+		opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = append(opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins,
 			// Disable ServiceAccount admission plugin as we don't have
 			// serviceaccount controller running.
 			"ServiceAccount",

--- a/test/integration/dualstack/dualstack_endpoints_test.go
+++ b/test/integration/dualstack/dualstack_endpoints_test.go
@@ -52,7 +52,7 @@ func TestDualStackEndpoints(t *testing.T) {
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			opts.ServiceClusterIPRanges = fmt.Sprintf("%s,%s", serviceCIDR, secondaryServiceCIDR)
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
 		},
 	})
 	defer tearDownFn()

--- a/test/integration/dualstack/dualstack_test.go
+++ b/test/integration/dualstack/dualstack_test.go
@@ -284,7 +284,7 @@ func TestCreateServiceDualStackIPv6(t *testing.T) {
 	client, _, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			opts.ServiceClusterIPRanges = serviceCIDR
-			opts.GenericServerRunOptions.AdvertiseAddress = netutils.ParseIPSloppy("2001:db8::10")
+			opts.GenericControlPlane.GenericAPIServer.AdvertiseAddress = netutils.ParseIPSloppy("2001:db8::10")
 		},
 	})
 	defer tearDownFn()
@@ -771,7 +771,7 @@ func TestCreateServiceDualStackIPv6IPv4(t *testing.T) {
 	client, _, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			opts.ServiceClusterIPRanges = fmt.Sprintf("%s,%s", serviceCIDR, secondaryServiceCIDR)
-			opts.GenericServerRunOptions.AdvertiseAddress = netutils.ParseIPSloppy("2001:db8::10")
+			opts.GenericControlPlane.GenericAPIServer.AdvertiseAddress = netutils.ParseIPSloppy("2001:db8::10")
 		},
 	})
 	defer tearDownFn()
@@ -1427,7 +1427,7 @@ func TestUpgradeServicePreferToDualStack(t *testing.T) {
 
 	client, _, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.Etcd.StorageConfig = *sharedEtcd
+			opts.GenericControlPlane.Etcd.StorageConfig = *sharedEtcd
 			opts.ServiceClusterIPRanges = serviceCIDR
 		},
 	})
@@ -1485,7 +1485,7 @@ func TestUpgradeServicePreferToDualStack(t *testing.T) {
 
 	client, _, tearDownFn = framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.Etcd.StorageConfig = *sharedEtcd
+			opts.GenericControlPlane.Etcd.StorageConfig = *sharedEtcd
 			opts.ServiceClusterIPRanges = fmt.Sprintf("%s,%s", serviceCIDR, secondaryServiceCIDR)
 		},
 	})
@@ -1525,7 +1525,7 @@ func TestDowngradeServicePreferToDualStack(t *testing.T) {
 
 	client, _, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.Etcd.StorageConfig = *sharedEtcd
+			opts.GenericControlPlane.Etcd.StorageConfig = *sharedEtcd
 			opts.ServiceClusterIPRanges = fmt.Sprintf("%s,%s", serviceCIDR, secondaryServiceCIDR)
 		},
 	})
@@ -1579,7 +1579,7 @@ func TestDowngradeServicePreferToDualStack(t *testing.T) {
 	// reset secondary
 	client, _, tearDownFn = framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
-			opts.Etcd.StorageConfig = *sharedEtcd
+			opts.GenericControlPlane.Etcd.StorageConfig = *sharedEtcd
 			opts.ServiceClusterIPRanges = serviceCIDR
 		},
 	})

--- a/test/integration/etcd/server.go
+++ b/test/integration/etcd/server.go
@@ -89,18 +89,18 @@ func StartRealAPIServerOrDie(t *testing.T, configFuncs ...func(*options.ServerRu
 	}
 
 	opts := options.NewServerRunOptions()
-	opts.Options.SecureServing.Listener = listener
-	opts.Options.SecureServing.ServerCert.CertDirectory = certDir
-	opts.Options.ServiceAccountSigningKeyFile = saSigningKeyFile.Name()
-	opts.Options.Etcd.StorageConfig.Transport.ServerList = []string{framework.GetEtcdURL()}
-	opts.Options.Etcd.DefaultStorageMediaType = runtime.ContentTypeJSON // force json we can easily interpret the result in etcd
+	opts.GenericControlPlane.SecureServing.Listener = listener
+	opts.GenericControlPlane.SecureServing.ServerCert.CertDirectory = certDir
+	opts.GenericControlPlane.ServiceAccountSigningKeyFile = saSigningKeyFile.Name()
+	opts.GenericControlPlane.Etcd.StorageConfig.Transport.ServerList = []string{framework.GetEtcdURL()}
+	opts.GenericControlPlane.Etcd.DefaultStorageMediaType = runtime.ContentTypeJSON // force json we can easily interpret the result in etcd
 	opts.ServiceClusterIPRanges = defaultServiceClusterIPRange.String()
-	opts.Options.Authentication.APIAudiences = []string{"https://foo.bar.example.com"}
-	opts.Options.Authentication.ServiceAccounts.Issuers = []string{"https://foo.bar.example.com"}
-	opts.Options.Authentication.ServiceAccounts.KeyFiles = []string{saSigningKeyFile.Name()}
-	opts.Options.Authorization.Modes = []string{"RBAC"}
-	opts.Options.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-	opts.Options.APIEnablement.RuntimeConfig["api/all"] = "true"
+	opts.GenericControlPlane.Authentication.APIAudiences = []string{"https://foo.bar.example.com"}
+	opts.GenericControlPlane.Authentication.ServiceAccounts.Issuers = []string{"https://foo.bar.example.com"}
+	opts.GenericControlPlane.Authentication.ServiceAccounts.KeyFiles = []string{saSigningKeyFile.Name()}
+	opts.GenericControlPlane.Authorization.Modes = []string{"RBAC"}
+	opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+	opts.GenericControlPlane.APIEnablement.RuntimeConfig["api/all"] = "true"
 	for _, f := range configFuncs {
 		f(opts)
 	}
@@ -114,7 +114,7 @@ func StartRealAPIServerOrDie(t *testing.T, configFuncs ...func(*options.ServerRu
 	}
 
 	// get etcd client before starting API server
-	rawClient, kvClient, err := integration.GetEtcdClients(completedOptions.Etcd.StorageConfig.Transport)
+	rawClient, kvClient, err := integration.GetEtcdClients(completedOptions.ControlPlane.Etcd.StorageConfig.Transport)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -128,23 +128,23 @@ func StartTestServer(ctx context.Context, t testing.TB, setup TestServerSetup) (
 	}
 
 	opts := options.NewServerRunOptions()
-	opts.SecureServing.Listener = listener
-	opts.SecureServing.BindAddress = netutils.ParseIPSloppy("127.0.0.1")
-	opts.SecureServing.ServerCert.CertDirectory = certDir
-	opts.ServiceAccountSigningKeyFile = saSigningKeyFile.Name()
-	opts.Etcd.StorageConfig.Prefix = path.Join("/", uuid.New().String(), "registry")
-	opts.Etcd.StorageConfig.Transport.ServerList = []string{GetEtcdURL()}
+	opts.GenericControlPlane.SecureServing.Listener = listener
+	opts.GenericControlPlane.SecureServing.BindAddress = netutils.ParseIPSloppy("127.0.0.1")
+	opts.GenericControlPlane.SecureServing.ServerCert.CertDirectory = certDir
+	opts.GenericControlPlane.ServiceAccountSigningKeyFile = saSigningKeyFile.Name()
+	opts.GenericControlPlane.Etcd.StorageConfig.Prefix = path.Join("/", uuid.New().String(), "registry")
+	opts.GenericControlPlane.Etcd.StorageConfig.Transport.ServerList = []string{GetEtcdURL()}
 	opts.ServiceClusterIPRanges = defaultServiceClusterIPRange.String()
-	opts.Authentication.RequestHeader.UsernameHeaders = []string{"X-Remote-User"}
-	opts.Authentication.RequestHeader.GroupHeaders = []string{"X-Remote-Group"}
-	opts.Authentication.RequestHeader.ExtraHeaderPrefixes = []string{"X-Remote-Extra-"}
-	opts.Authentication.RequestHeader.AllowedNames = []string{"kube-aggregator"}
-	opts.Authentication.RequestHeader.ClientCAFile = proxyCACertFile.Name()
-	opts.Authentication.APIAudiences = []string{"https://foo.bar.example.com"}
-	opts.Authentication.ServiceAccounts.Issuers = []string{"https://foo.bar.example.com"}
-	opts.Authentication.ServiceAccounts.KeyFiles = []string{saSigningKeyFile.Name()}
-	opts.Authentication.ClientCert.ClientCA = clientCACertFile.Name()
-	opts.Authorization.Modes = []string{"Node", "RBAC"}
+	opts.GenericControlPlane.Authentication.RequestHeader.UsernameHeaders = []string{"X-Remote-User"}
+	opts.GenericControlPlane.Authentication.RequestHeader.GroupHeaders = []string{"X-Remote-Group"}
+	opts.GenericControlPlane.Authentication.RequestHeader.ExtraHeaderPrefixes = []string{"X-Remote-Extra-"}
+	opts.GenericControlPlane.Authentication.RequestHeader.AllowedNames = []string{"kube-aggregator"}
+	opts.GenericControlPlane.Authentication.RequestHeader.ClientCAFile = proxyCACertFile.Name()
+	opts.GenericControlPlane.Authentication.APIAudiences = []string{"https://foo.bar.example.com"}
+	opts.GenericControlPlane.Authentication.ServiceAccounts.Issuers = []string{"https://foo.bar.example.com"}
+	opts.GenericControlPlane.Authentication.ServiceAccounts.KeyFiles = []string{saSigningKeyFile.Name()}
+	opts.GenericControlPlane.Authentication.ClientCert.ClientCA = clientCACertFile.Name()
+	opts.GenericControlPlane.Authorization.Modes = []string{"Node", "RBAC"}
 
 	if setup.ModifyServerRunOptions != nil {
 		setup.ModifyServerRunOptions(opts)

--- a/test/integration/ipamperf/ipam_test.go
+++ b/test/integration/ipamperf/ipam_test.go
@@ -130,7 +130,7 @@ func TestPerformance(t *testing.T) {
 	_, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
 		},
 	})
 	defer tearDownFn()

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -68,7 +68,7 @@ func TestQuota(t *testing.T) {
 	_, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
 		},
 	})
 	defer tearDownFn()
@@ -298,8 +298,8 @@ plugins:
 	_, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-			opts.Admission.GenericAdmission.ConfigFile = admissionConfigFile.Name()
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Admission.GenericAdmission.ConfigFile = admissionConfigFile.Name()
 
 		},
 	})
@@ -425,8 +425,8 @@ plugins:
 	_, kubeConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-			opts.Admission.GenericAdmission.ConfigFile = admissionConfigFile.Name()
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+			opts.GenericControlPlane.Admission.GenericAdmission.ConfigFile = admissionConfigFile.Name()
 
 		},
 	})

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -87,11 +87,11 @@ func mustSetupScheduler(ctx context.Context, b *testing.B, config *config.KubeSc
 	_, kubeConfig, tearDownFn := framework.StartTestServer(ctx, b, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition", "Priority"}
+			opts.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition", "Priority"}
 
 			// Enable DRA API group.
 			if enabledFeatures[features.DynamicResourceAllocation] {
-				opts.APIEnablement.RuntimeConfig = cliflag.ConfigurationMap{
+				opts.GenericControlPlane.APIEnablement.RuntimeConfig = cliflag.ConfigurationMap{
 					resourcev1alpha2.SchemeGroupVersion.String(): "true",
 				}
 			}

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -354,7 +354,7 @@ func startServiceAccountTestServerAndWaitForCaches(ctx context.Context, t *testi
 	rootClientset, clientConfig, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			var err error
-			serviceAccountKey, err = keyutil.PrivateKeyFromFile(opts.ServiceAccountSigningKeyFile)
+			serviceAccountKey, err = keyutil.PrivateKeyFromFile(opts.GenericControlPlane.ServiceAccountSigningKeyFile)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/integration/servicecidr/allocator_test.go
+++ b/test/integration/servicecidr/allocator_test.go
@@ -127,8 +127,8 @@ func TestServiceAllocIPAddress(t *testing.T) {
 	client, _, tearDownFn := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
 			opts.ServiceClusterIPRanges = serviceCIDR
-			opts.GenericServerRunOptions.AdvertiseAddress = netutils.ParseIPSloppy("2001:db8::10")
-			opts.APIEnablement.RuntimeConfig.Set("networking.k8s.io/v1alpha1=true")
+			opts.GenericControlPlane.GenericAPIServer.AdvertiseAddress = netutils.ParseIPSloppy("2001:db8::10")
+			opts.GenericControlPlane.APIEnablement.RuntimeConfig.Set("networking.k8s.io/v1alpha1=true")
 		},
 	})
 	defer tearDownFn()

--- a/test/integration/serving/serving_test.go
+++ b/test/integration/serving/serving_test.go
@@ -128,7 +128,7 @@ users:
 - name: controller-manager
   user:
     token: %s
-`, server.ClientConfig.Host, server.ServerOpts.SecureServing.ServerCert.CertKey.CertFile, token))
+`, server.ClientConfig.Host, server.ServerOpts.GenericControlPlane.SecureServing.ServerCert.CertKey.CertFile, token))
 	apiserverConfig.Close()
 
 	// create BROKEN kubeconfig for the apiserver
@@ -154,7 +154,7 @@ users:
 - name: controller-manager
   user:
     token: WRONGTOKEN
-`, server.ClientConfig.Host, server.ServerOpts.SecureServing.ServerCert.CertKey.CertFile))
+`, server.ClientConfig.Host, server.ServerOpts.GenericControlPlane.SecureServing.ServerCert.CertKey.CertFile))
 	brokenApiserverConfig.Close()
 
 	tests := []struct {

--- a/test/integration/tls/ciphers_test.go
+++ b/test/integration/tls/ciphers_test.go
@@ -30,7 +30,7 @@ import (
 func runBasicSecureAPIServer(t *testing.T, ciphers []string) (kubeapiservertesting.TearDownFunc, int) {
 	flags := []string{"--tls-cipher-suites", strings.Join(ciphers, ",")}
 	testServer := kubeapiservertesting.StartTestServerOrDie(t, nil, flags, framework.SharedEtcd())
-	return testServer.TearDownFn, testServer.ServerOpts.SecureServing.BindPort
+	return testServer.TearDownFn, testServer.ServerOpts.GenericControlPlane.SecureServing.BindPort
 }
 
 func TestAPICiphers(t *testing.T) {

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -370,7 +370,7 @@ func InitTestAPIServer(t *testing.T, nsPrefix string, admission admission.Interf
 
 	testCtx.ClientSet, testCtx.KubeConfig, testCtx.CloseFn = framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(options *options.ServerRunOptions) {
-			options.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition", "Priority", "StorageObjectInUseProtection"}
+			options.GenericControlPlane.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition", "Priority", "StorageObjectInUseProtection"}
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			if admission != nil {


### PR DESCRIPTION
/kind cleanup

Cleanup the option field names and make structure explicit. Pure field renaming.

```release-note
NONE
```