### PR TITLE
Extend Large Create Timeout to 60 min

### DIFF
--- a/test/e2e/framework/service/const.go
+++ b/test/e2e/framework/service/const.go
@@ -54,7 +54,7 @@ const (
 	loadBalancerCreateTimeoutDefault = 15 * time.Minute
 	// LoadBalancerCreateTimeoutLarge is the maximum time to wait for a load balancer to be created/modified.
 	// Hideen - use GetServiceLoadBalancerCreateTimeout function instead.
-	loadBalancerCreateTimeoutLarge = 45 * time.Minute
+	loadBalancerCreateTimeoutLarge = 60 * time.Minute
 
 	// LoadBalancerPropagationTimeoutDefault is the default time to wait for pods to
 	// be targeted by load balancers.


### PR DESCRIPTION
 * Load balancers are taking greater than 45 to provision
 * https://github.com/kubernetes/kubernetes/issues/118295

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind flake
-->

#### What this PR does / why we need it:

As discussed in https://github.com/kubernetes/kubernetes/issues/118295, the current timeout is not sufficient for the observed LB provisioning times. We need to extend the timeout to 60 minutes to reduce the flakes. 

We did investigate to ensure that there is no bugs and that the latency is in the underlay infra.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

https://github.com/kubernetes/kubernetes/issues/118295

/assign @aojea 
/sig network
/sig scalability
