### PR TITLE
Revert "Make CA valid 1 hour in the past"

### DIFF
--- a/staging/src/k8s.io/client-go/util/cert/cert.go
+++ b/staging/src/k8s.io/client-go/util/cert/cert.go
@@ -71,7 +71,7 @@ func NewSelfSignedCACert(cfg Config, key crypto.Signer) (*x509.Certificate, erro
 			Organization: cfg.Organization,
 		},
 		DNSNames:              []string{cfg.CommonName},
-		NotBefore:             now.Add(-time.Hour).UTC(), // valid an hour earlier to avoid flakes
+		NotBefore:             now.UTC(),
 		NotAfter:              now.Add(duration365d * 10).UTC(),
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,


### PR DESCRIPTION
Reverts kubernetes/kubernetes#118631

As discussed on slack (https://kubernetes.slack.com/archives/C0EG7JC6T/p1687815949656259), we will make a new version that doesn't change the default behavior