### PR TITLE
scheduler: migrate --pod-max-in-unschedulable-pods-duration flag into KubeSchedulerConfiguration

### DIFF
--- a/cmd/kube-scheduler/app/config/config.go
+++ b/cmd/kube-scheduler/app/config/config.go
@@ -17,8 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"time"
-
 	apiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
@@ -51,12 +49,6 @@ type Config struct {
 
 	// LeaderElection is optional.
 	LeaderElection *leaderelection.LeaderElectionConfig
-
-	// PodMaxInUnschedulablePodsDuration is the maximum time a pod can stay in
-	// unschedulablePods. If a pod stays in unschedulablePods for longer than this
-	// value, the pod will be moved from unschedulablePods to backoffQ or activeQ.
-	// If this value is empty, the default value (5min) will be used.
-	PodMaxInUnschedulablePodsDuration time.Duration
 }
 
 type completedConfig struct {

--- a/cmd/kube-scheduler/app/options/deprecated.go
+++ b/cmd/kube-scheduler/app/options/deprecated.go
@@ -31,7 +31,7 @@ type DeprecatedOptions struct {
 	// PodMaxInUnschedulablePodsDuration is the maximum time a pod can stay in
 	// unschedulablePods. If a pod stays in unschedulablePods for longer than this
 	// value, the pod will be moved from unschedulablePods to backoffQ or activeQ.
-	// If this value is empty, the default value (5min) will be used.
+	// If this value is empty, the default value (24h) will be used.
 	PodMaxInUnschedulablePodsDuration time.Duration
 }
 
@@ -47,5 +47,5 @@ func (o *DeprecatedOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ContentType, "kube-api-content-type", "application/vnd.kubernetes.protobuf", "DEPRECATED: content type of requests sent to apiserver. This parameter is ignored if a config file is specified in --config.")
 	fs.Float32Var(&o.QPS, "kube-api-qps", 50.0, "DEPRECATED: QPS to use while talking with kubernetes apiserver. This parameter is ignored if a config file is specified in --config.")
 	fs.Int32Var(&o.Burst, "kube-api-burst", 100, "DEPRECATED: burst to use while talking with kubernetes apiserver. This parameter is ignored if a config file is specified in --config.")
-	fs.DurationVar(&o.PodMaxInUnschedulablePodsDuration, "pod-max-in-unschedulable-pods-duration", 5*time.Minute, "DEPRECATED: the maximum time a pod can stay in unschedulablePods. If a pod stays in unschedulablePods for longer than this value, the pod will be moved from unschedulablePods to backoffQ or activeQ. This flag is deprecated and will be removed in 1.26")
+	fs.DurationVar(&o.PodMaxInUnschedulablePodsDuration, "pod-max-in-unschedulable-pods-duration", 24*time.Hour, "DEPRECATED: the maximum time a pod can stay in unschedulablePods. If a pod stays in unschedulablePods for longer than this value, the pod will be moved from unschedulablePods to backoffQ or activeQ. This parameter is ignored if a config file is specified in --config. This flag is deprecated and will be removed in 1.29")
 }

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -137,6 +137,11 @@ func (o *Options) ApplyDeprecated() {
 	if deprecated.Changed("kube-api-burst") {
 		o.ComponentConfig.ClientConnection.Burst = o.Deprecated.Burst
 	}
+	if deprecated.Changed("pod-max-in-unschedulable-pods-duration") {
+		o.ComponentConfig.PodMaxInUnschedulablePodsDuration = metav1.Duration{
+			Duration: o.Deprecated.PodMaxInUnschedulablePodsDuration,
+		}
+	}
 }
 
 // ApplyLeaderElectionTo obtains the CLI args related with leaderelection, and override the values in `cfg`.
@@ -239,11 +244,6 @@ func (o *Options) ApplyTo(logger klog.Logger, c *schedulerappconfig.Config) erro
 		}
 	}
 	o.Metrics.Apply()
-
-	// Apply value independently instead of using ApplyDeprecated() because it can't be configured via ComponentConfig.
-	if o.Deprecated != nil {
-		c.PodMaxInUnschedulablePodsDuration = o.Deprecated.PodMaxInUnschedulablePodsDuration
-	}
 
 	return nil
 }

--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -349,6 +349,7 @@ profiles:
 
 	defaultPodInitialBackoffSeconds := int64(1)
 	defaultPodMaxBackoffSeconds := int64(10)
+	defaultPodMaxInUnschedulablePodsDuration := metav1.Duration{Duration: 24 * time.Hour}
 	defaultPercentageOfNodesToScore := pointer.Int32(0)
 
 	testcases := []struct {
@@ -419,9 +420,10 @@ profiles:
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
-				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
+				PercentageOfNodesToScore:          defaultPercentageOfNodesToScore,
+				PodInitialBackoffSeconds:          defaultPodInitialBackoffSeconds,
+				PodMaxBackoffSeconds:              defaultPodMaxBackoffSeconds,
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
 					{
 						SchedulerName: "default-scheduler",
@@ -491,9 +493,10 @@ profiles:
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
-				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
+				PercentageOfNodesToScore:          defaultPercentageOfNodesToScore,
+				PodInitialBackoffSeconds:          defaultPodInitialBackoffSeconds,
+				PodMaxBackoffSeconds:              defaultPodMaxBackoffSeconds,
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
 					{
 						SchedulerName: "default-scheduler",
@@ -594,9 +597,10 @@ profiles:
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
-				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
+				PercentageOfNodesToScore:          defaultPercentageOfNodesToScore,
+				PodInitialBackoffSeconds:          defaultPodInitialBackoffSeconds,
+				PodMaxBackoffSeconds:              defaultPodMaxBackoffSeconds,
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
 					{
 						SchedulerName: "default-scheduler",
@@ -665,9 +669,10 @@ profiles:
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
-				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
+				PercentageOfNodesToScore:          defaultPercentageOfNodesToScore,
+				PodInitialBackoffSeconds:          defaultPodInitialBackoffSeconds,
+				PodMaxBackoffSeconds:              defaultPodMaxBackoffSeconds,
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
 					{
 						SchedulerName: "default-scheduler",
@@ -710,9 +715,10 @@ profiles:
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
-				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
+				PercentageOfNodesToScore:          defaultPercentageOfNodesToScore,
+				PodInitialBackoffSeconds:          defaultPodInitialBackoffSeconds,
+				PodMaxBackoffSeconds:              defaultPodMaxBackoffSeconds,
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
 					{
 						SchedulerName: "default-scheduler",
@@ -830,9 +836,10 @@ profiles:
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
-				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
+				PercentageOfNodesToScore:          defaultPercentageOfNodesToScore,
+				PodInitialBackoffSeconds:          defaultPodInitialBackoffSeconds,
+				PodMaxBackoffSeconds:              defaultPodMaxBackoffSeconds,
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
 					{
 						SchedulerName: "default-scheduler",
@@ -953,9 +960,10 @@ profiles:
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
-				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
+				PercentageOfNodesToScore:          defaultPercentageOfNodesToScore,
+				PodInitialBackoffSeconds:          defaultPodInitialBackoffSeconds,
+				PodMaxBackoffSeconds:              defaultPodMaxBackoffSeconds,
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
 					{
 						SchedulerName: "foo-profile",
@@ -1068,9 +1076,10 @@ profiles:
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
-				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
+				PercentageOfNodesToScore:          defaultPercentageOfNodesToScore,
+				PodInitialBackoffSeconds:          defaultPodInitialBackoffSeconds,
+				PodMaxBackoffSeconds:              defaultPodMaxBackoffSeconds,
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
 					{
 						SchedulerName: "foo-profile",
@@ -1208,9 +1217,10 @@ profiles:
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: defaultPercentageOfNodesToScore,
-				PodInitialBackoffSeconds: defaultPodInitialBackoffSeconds,
-				PodMaxBackoffSeconds:     defaultPodMaxBackoffSeconds,
+				PercentageOfNodesToScore:          defaultPercentageOfNodesToScore,
+				PodInitialBackoffSeconds:          defaultPodInitialBackoffSeconds,
+				PodMaxBackoffSeconds:              defaultPodMaxBackoffSeconds,
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []kubeschedulerconfig.KubeSchedulerProfile{
 					{
 						SchedulerName: "high-throughput-profile",

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -363,7 +363,7 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 		scheduler.WithFrameworkOutOfTreeRegistry(outOfTreeRegistry),
 		scheduler.WithPodMaxBackoffSeconds(cc.ComponentConfig.PodMaxBackoffSeconds),
 		scheduler.WithPodInitialBackoffSeconds(cc.ComponentConfig.PodInitialBackoffSeconds),
-		scheduler.WithPodMaxInUnschedulablePodsDuration(cc.PodMaxInUnschedulablePodsDuration),
+		scheduler.WithPodMaxInUnschedulablePodsDuration(cc.ComponentConfig.PodMaxInUnschedulablePodsDuration.Duration),
 		scheduler.WithExtenders(cc.ComponentConfig.Extenders...),
 		scheduler.WithParallelism(cc.ComponentConfig.Parallelism),
 		scheduler.WithBuildFrameworkCapturer(func(profile kubeschedulerconfig.KubeSchedulerProfile) {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -54600,6 +54600,12 @@ func schema_k8sio_kube_scheduler_config_v1_KubeSchedulerConfiguration(ref common
 							Format:      "int64",
 						},
 					},
+					"podMaxInUnschedulablePodsDuration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PodMaxInUnschedulablePodsDuration is the maximum time a pod can stay in unschedulablePods. If a pod stays in unschedulablePods for longer than this value, the pod will be moved from unschedulablePods to backoffQ or activeQ. If this value is empty, the default value (24h) will be used.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
 					"profiles": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -54653,7 +54659,7 @@ func schema_k8sio_kube_scheduler_config_v1_KubeSchedulerConfiguration(ref common
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/component-base/config/v1alpha1.ClientConnectionConfiguration", "k8s.io/component-base/config/v1alpha1.LeaderElectionConfiguration", "k8s.io/kube-scheduler/config/v1.Extender", "k8s.io/kube-scheduler/config/v1.KubeSchedulerProfile"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Duration", "k8s.io/component-base/config/v1alpha1.ClientConnectionConfiguration", "k8s.io/component-base/config/v1alpha1.LeaderElectionConfiguration", "k8s.io/kube-scheduler/config/v1.Extender", "k8s.io/kube-scheduler/config/v1.KubeSchedulerProfile"},
 	}
 }
 
@@ -55720,6 +55726,12 @@ func schema_k8sio_kube_scheduler_config_v1beta3_KubeSchedulerConfiguration(ref c
 							Format:      "int64",
 						},
 					},
+					"podMaxInUnschedulablePodsDuration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PodMaxInUnschedulablePodsDuration is the maximum time a pod can stay in unschedulablePods. If a pod stays in unschedulablePods for longer than this value, the pod will be moved from unschedulablePods to backoffQ or activeQ. If this value is empty, the default value (24h) will be used.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
 					"profiles": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -55766,7 +55778,7 @@ func schema_k8sio_kube_scheduler_config_v1beta3_KubeSchedulerConfiguration(ref c
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/component-base/config/v1alpha1.ClientConnectionConfiguration", "k8s.io/component-base/config/v1alpha1.LeaderElectionConfiguration", "k8s.io/kube-scheduler/config/v1beta3.Extender", "k8s.io/kube-scheduler/config/v1beta3.KubeSchedulerProfile"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Duration", "k8s.io/component-base/config/v1alpha1.ClientConnectionConfiguration", "k8s.io/component-base/config/v1alpha1.LeaderElectionConfiguration", "k8s.io/kube-scheduler/config/v1beta3.Extender", "k8s.io/kube-scheduler/config/v1beta3.KubeSchedulerProfile"},
 	}
 }
 

--- a/pkg/scheduler/apis/config/scheme/scheme_test.go
+++ b/pkg/scheduler/apis/config/scheme/scheme_test.go
@@ -1060,6 +1060,7 @@ leaderElection:
 parallelism: 8
 podInitialBackoffSeconds: 0
 podMaxBackoffSeconds: 0
+podMaxInUnschedulablePodsDuration: 0s
 profiles:
 - pluginConfig:
   - args:
@@ -1282,6 +1283,7 @@ leaderElection:
 parallelism: 8
 podInitialBackoffSeconds: 0
 podMaxBackoffSeconds: 0
+podMaxInUnschedulablePodsDuration: 0s
 profiles:
 - pluginConfig:
   - args:
@@ -1356,6 +1358,7 @@ leaderElection:
 parallelism: 8
 podInitialBackoffSeconds: 0
 podMaxBackoffSeconds: 0
+podMaxInUnschedulablePodsDuration: 0s
 profiles:
 - pluginConfig:
   - args:

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -87,6 +87,12 @@ type KubeSchedulerConfiguration struct {
 	// the default value (10s) will be used.
 	PodMaxBackoffSeconds int64
 
+	// PodMaxInUnschedulablePodsDuration is the maximum time a pod can stay in
+	// unschedulablePods. If a pod stays in unschedulablePods for longer than this
+	// value, the pod will be moved from unschedulablePods to backoffQ or activeQ.
+	// If this value is empty, the default value (24h) will be used.
+	PodMaxInUnschedulablePodsDuration metav1.Duration
+
 	// Profiles are scheduling profiles that kube-scheduler supports. Pods can
 	// choose to be scheduled under a particular profile by setting its associated
 	// scheduler name. Pods that don't specify any scheduler name are scheduled

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -17,7 +17,10 @@ limitations under the License.
 package v1
 
 import (
+	"time"
+
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/util/feature"
@@ -29,10 +32,15 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-var defaultResourceSpec = []configv1.ResourceSpec{
-	{Name: string(v1.ResourceCPU), Weight: 1},
-	{Name: string(v1.ResourceMemory), Weight: 1},
-}
+var (
+	defaultResourceSpec = []configv1.ResourceSpec{
+		{Name: string(v1.ResourceCPU), Weight: 1},
+		{Name: string(v1.ResourceMemory), Weight: 1},
+	}
+	defaultPodMaxInUnschedulablePodsDuration = &metav1.Duration{
+		Duration: 24 * time.Hour,
+	}
+)
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
@@ -160,6 +168,10 @@ func SetDefaults_KubeSchedulerConfiguration(obj *configv1.KubeSchedulerConfigura
 
 	if obj.PodMaxBackoffSeconds == nil {
 		obj.PodMaxBackoffSeconds = pointer.Int64(10)
+	}
+
+	if obj.PodMaxInUnschedulablePodsDuration == nil {
+		obj.PodMaxInUnschedulablePodsDuration = defaultPodMaxInUnschedulablePodsDuration
 	}
 
 	// Enable profiling by default in the scheduler

--- a/pkg/scheduler/apis/config/v1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1/defaults_test.go
@@ -145,9 +145,10 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64(1),
-				PodMaxBackoffSeconds:     pointer.Int64(10),
+				PercentageOfNodesToScore:          pointer.Int32(config.DefaultPercentageOfNodesToScore),
+				PodInitialBackoffSeconds:          pointer.Int64(1),
+				PodMaxBackoffSeconds:              pointer.Int64(10),
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						Plugins:       getDefaultPlugins(),
@@ -182,9 +183,10 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64(1),
-				PodMaxBackoffSeconds:     pointer.Int64(10),
+				PercentageOfNodesToScore:          pointer.Int32(config.DefaultPercentageOfNodesToScore),
+				PodInitialBackoffSeconds:          pointer.Int64(1),
+				PodMaxBackoffSeconds:              pointer.Int64(10),
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						SchedulerName: pointer.String("default-scheduler"),
@@ -238,9 +240,10 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64(1),
-				PodMaxBackoffSeconds:     pointer.Int64(10),
+				PercentageOfNodesToScore:          pointer.Int32(config.DefaultPercentageOfNodesToScore),
+				PodInitialBackoffSeconds:          pointer.Int64(1),
+				PodMaxBackoffSeconds:              pointer.Int64(10),
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						Plugins: getDefaultPlugins(),
@@ -390,9 +393,10 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64(1),
-				PodMaxBackoffSeconds:     pointer.Int64(10),
+				PercentageOfNodesToScore:          pointer.Int32(config.DefaultPercentageOfNodesToScore),
+				PodInitialBackoffSeconds:          pointer.Int64(1),
+				PodMaxBackoffSeconds:              pointer.Int64(10),
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						Plugins:       getDefaultPlugins(),
@@ -427,9 +431,10 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64(1),
-				PodMaxBackoffSeconds:     pointer.Int64(10),
+				PercentageOfNodesToScore:          pointer.Int32(config.DefaultPercentageOfNodesToScore),
+				PodInitialBackoffSeconds:          pointer.Int64(1),
+				PodMaxBackoffSeconds:              pointer.Int64(10),
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						Plugins:       getDefaultPlugins(),
@@ -465,9 +470,10 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64(1),
-				PodMaxBackoffSeconds:     pointer.Int64(10),
+				PercentageOfNodesToScore:          pointer.Int32(config.DefaultPercentageOfNodesToScore),
+				PodInitialBackoffSeconds:          pointer.Int64(1),
+				PodMaxBackoffSeconds:              pointer.Int64(10),
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						Plugins:       getDefaultPlugins(),
@@ -502,9 +508,10 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32(50),
-				PodInitialBackoffSeconds: pointer.Int64(1),
-				PodMaxBackoffSeconds:     pointer.Int64(10),
+				PercentageOfNodesToScore:          pointer.Int32(50),
+				PodInitialBackoffSeconds:          pointer.Int64(1),
+				PodMaxBackoffSeconds:              pointer.Int64(10),
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						Plugins:       getDefaultPlugins(),
@@ -543,9 +550,10 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64(1),
-				PodMaxBackoffSeconds:     pointer.Int64(10),
+				PercentageOfNodesToScore:          pointer.Int32(config.DefaultPercentageOfNodesToScore),
+				PodInitialBackoffSeconds:          pointer.Int64(1),
+				PodMaxBackoffSeconds:              pointer.Int64(10),
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						Plugins:                  getDefaultPlugins(),
@@ -586,9 +594,10 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32(10),
-				PodInitialBackoffSeconds: pointer.Int64(1),
-				PodMaxBackoffSeconds:     pointer.Int64(10),
+				PercentageOfNodesToScore:          pointer.Int32(10),
+				PodInitialBackoffSeconds:          pointer.Int64(1),
+				PodMaxBackoffSeconds:              pointer.Int64(10),
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []configv1.KubeSchedulerProfile{
 					{
 						Plugins:                  getDefaultPlugins(),

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -417,6 +417,9 @@ func autoConvert_v1_KubeSchedulerConfiguration_To_config_KubeSchedulerConfigurat
 	if err := metav1.Convert_Pointer_int64_To_int64(&in.PodMaxBackoffSeconds, &out.PodMaxBackoffSeconds, s); err != nil {
 		return err
 	}
+	if err := metav1.Convert_Pointer_v1_Duration_To_v1_Duration(&in.PodMaxInUnschedulablePodsDuration, &out.PodMaxInUnschedulablePodsDuration, s); err != nil {
+		return err
+	}
 	if in.Profiles != nil {
 		in, out := &in.Profiles, &out.Profiles
 		*out = make([]config.KubeSchedulerProfile, len(*in))
@@ -453,6 +456,9 @@ func autoConvert_config_KubeSchedulerConfiguration_To_v1_KubeSchedulerConfigurat
 		return err
 	}
 	if err := metav1.Convert_int64_To_Pointer_int64(&in.PodMaxBackoffSeconds, &out.PodMaxBackoffSeconds, s); err != nil {
+		return err
+	}
+	if err := metav1.Convert_v1_Duration_To_Pointer_v1_Duration(&in.PodMaxInUnschedulablePodsDuration, &out.PodMaxInUnschedulablePodsDuration, s); err != nil {
 		return err
 	}
 	if in.Profiles != nil {

--- a/pkg/scheduler/apis/config/v1beta3/defaults.go
+++ b/pkg/scheduler/apis/config/v1beta3/defaults.go
@@ -17,7 +17,10 @@ limitations under the License.
 package v1beta3
 
 import (
+	"time"
+
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/util/feature"
@@ -28,10 +31,15 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-var defaultResourceSpec = []v1beta3.ResourceSpec{
-	{Name: string(v1.ResourceCPU), Weight: 1},
-	{Name: string(v1.ResourceMemory), Weight: 1},
-}
+var (
+	defaultResourceSpec = []v1beta3.ResourceSpec{
+		{Name: string(v1.ResourceCPU), Weight: 1},
+		{Name: string(v1.ResourceMemory), Weight: 1},
+	}
+	defaultPodMaxInUnschedulablePodsDuration = &metav1.Duration{
+		Duration: 24 * time.Hour,
+	}
+)
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
@@ -158,6 +166,10 @@ func SetDefaults_KubeSchedulerConfiguration(obj *v1beta3.KubeSchedulerConfigurat
 
 	if obj.PodMaxBackoffSeconds == nil {
 		obj.PodMaxBackoffSeconds = pointer.Int64(10)
+	}
+
+	if obj.PodMaxInUnschedulablePodsDuration == nil {
+		obj.PodMaxInUnschedulablePodsDuration = defaultPodMaxInUnschedulablePodsDuration
 	}
 
 	// Enable profiling by default in the scheduler

--- a/pkg/scheduler/apis/config/v1beta3/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1beta3/defaults_test.go
@@ -145,9 +145,10 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64(1),
-				PodMaxBackoffSeconds:     pointer.Int64(10),
+				PercentageOfNodesToScore:          pointer.Int32(config.DefaultPercentageOfNodesToScore),
+				PodInitialBackoffSeconds:          pointer.Int64(1),
+				PodMaxBackoffSeconds:              pointer.Int64(10),
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []v1beta3.KubeSchedulerProfile{
 					{
 						Plugins:       getDefaultPlugins(),
@@ -182,9 +183,10 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64(1),
-				PodMaxBackoffSeconds:     pointer.Int64(10),
+				PercentageOfNodesToScore:          pointer.Int32(config.DefaultPercentageOfNodesToScore),
+				PodInitialBackoffSeconds:          pointer.Int64(1),
+				PodMaxBackoffSeconds:              pointer.Int64(10),
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []v1beta3.KubeSchedulerProfile{
 					{
 						SchedulerName: pointer.String("default-scheduler"),
@@ -238,9 +240,10 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64(1),
-				PodMaxBackoffSeconds:     pointer.Int64(10),
+				PercentageOfNodesToScore:          pointer.Int32(config.DefaultPercentageOfNodesToScore),
+				PodInitialBackoffSeconds:          pointer.Int64(1),
+				PodMaxBackoffSeconds:              pointer.Int64(10),
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []v1beta3.KubeSchedulerProfile{
 					{
 						Plugins: getDefaultPlugins(),
@@ -390,9 +393,10 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64(1),
-				PodMaxBackoffSeconds:     pointer.Int64(10),
+				PercentageOfNodesToScore:          pointer.Int32(config.DefaultPercentageOfNodesToScore),
+				PodInitialBackoffSeconds:          pointer.Int64(1),
+				PodMaxBackoffSeconds:              pointer.Int64(10),
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []v1beta3.KubeSchedulerProfile{
 					{
 						Plugins:       getDefaultPlugins(),
@@ -427,9 +431,10 @@ func TestSchedulerDefaults(t *testing.T) {
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				PercentageOfNodesToScore: pointer.Int32(config.DefaultPercentageOfNodesToScore),
-				PodInitialBackoffSeconds: pointer.Int64(1),
-				PodMaxBackoffSeconds:     pointer.Int64(10),
+				PercentageOfNodesToScore:          pointer.Int32(config.DefaultPercentageOfNodesToScore),
+				PodInitialBackoffSeconds:          pointer.Int64(1),
+				PodMaxBackoffSeconds:              pointer.Int64(10),
+				PodMaxInUnschedulablePodsDuration: defaultPodMaxInUnschedulablePodsDuration,
 				Profiles: []v1beta3.KubeSchedulerProfile{
 					{
 						Plugins:       getDefaultPlugins(),

--- a/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1beta3/zz_generated.conversion.go
@@ -417,6 +417,9 @@ func autoConvert_v1beta3_KubeSchedulerConfiguration_To_config_KubeSchedulerConfi
 	if err := v1.Convert_Pointer_int64_To_int64(&in.PodMaxBackoffSeconds, &out.PodMaxBackoffSeconds, s); err != nil {
 		return err
 	}
+	if err := v1.Convert_Pointer_v1_Duration_To_v1_Duration(&in.PodMaxInUnschedulablePodsDuration, &out.PodMaxInUnschedulablePodsDuration, s); err != nil {
+		return err
+	}
 	if in.Profiles != nil {
 		in, out := &in.Profiles, &out.Profiles
 		*out = make([]config.KubeSchedulerProfile, len(*in))
@@ -452,6 +455,9 @@ func autoConvert_config_KubeSchedulerConfiguration_To_v1beta3_KubeSchedulerConfi
 		return err
 	}
 	if err := v1.Convert_int64_To_Pointer_int64(&in.PodMaxBackoffSeconds, &out.PodMaxBackoffSeconds, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_v1_Duration_To_Pointer_v1_Duration(&in.PodMaxInUnschedulablePodsDuration, &out.PodMaxInUnschedulablePodsDuration, s); err != nil {
 		return err
 	}
 	if in.Profiles != nil {

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -162,6 +162,7 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 		*out = new(int32)
 		**out = **in
 	}
+	out.PodMaxInUnschedulablePodsDuration = in.PodMaxInUnschedulablePodsDuration
 	if in.Profiles != nil {
 		in, out := &in.Profiles, &out.Profiles
 		*out = make([]KubeSchedulerProfile, len(*in))

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -56,9 +56,9 @@ const (
 	// DefaultPodMaxInUnschedulablePodsDuration is the default value for the maximum
 	// time a pod can stay in unschedulablePods. If a pod stays in unschedulablePods
 	// for longer than this value, the pod will be moved from unschedulablePods to
-	// backoffQ or activeQ. If this value is empty, the default value (5min)
+	// backoffQ or activeQ. If this value is empty, the default value (24h)
 	// will be used.
-	DefaultPodMaxInUnschedulablePodsDuration time.Duration = 5 * time.Minute
+	DefaultPodMaxInUnschedulablePodsDuration time.Duration = 24 * time.Hour
 	// Scheduling queue names
 	activeQ           = "Active"
 	backoffQ          = "Backoff"

--- a/staging/src/k8s.io/kube-scheduler/config/v1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/types.go
@@ -77,6 +77,12 @@ type KubeSchedulerConfiguration struct {
 	// the default value (10s) will be used.
 	PodMaxBackoffSeconds *int64 `json:"podMaxBackoffSeconds,omitempty"`
 
+	// PodMaxInUnschedulablePodsDuration is the maximum time a pod can stay in
+	// unschedulablePods. If a pod stays in unschedulablePods for longer than this
+	// value, the pod will be moved from unschedulablePods to backoffQ or activeQ.
+	// If this value is empty, the default value (24h) will be used.
+	PodMaxInUnschedulablePodsDuration *metav1.Duration `json:"podMaxInUnschedulablePodsDuration,omitempty"`
+
 	// Profiles are scheduling profiles that kube-scheduler supports. Pods can
 	// choose to be scheduled under a particular profile by setting its associated
 	// scheduler name. Pods that don't specify any scheduler name are scheduled

--- a/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -190,6 +191,11 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 	if in.PodMaxBackoffSeconds != nil {
 		in, out := &in.PodMaxBackoffSeconds, &out.PodMaxBackoffSeconds
 		*out = new(int64)
+		**out = **in
+	}
+	if in.PodMaxInUnschedulablePodsDuration != nil {
+		in, out := &in.PodMaxInUnschedulablePodsDuration, &out.PodMaxInUnschedulablePodsDuration
+		*out = new(metav1.Duration)
 		**out = **in
 	}
 	if in.Profiles != nil {

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta3/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta3/types.go
@@ -77,6 +77,12 @@ type KubeSchedulerConfiguration struct {
 	// the default value (10s) will be used.
 	PodMaxBackoffSeconds *int64 `json:"podMaxBackoffSeconds,omitempty"`
 
+	// PodMaxInUnschedulablePodsDuration is the maximum time a pod can stay in
+	// unschedulablePods. If a pod stays in unschedulablePods for longer than this
+	// value, the pod will be moved from unschedulablePods to backoffQ or activeQ.
+	// If this value is empty, the default value (24h) will be used.
+	PodMaxInUnschedulablePodsDuration *metav1.Duration `json:"podMaxInUnschedulablePodsDuration,omitempty"`
+
 	// Profiles are scheduling profiles that kube-scheduler supports. Pods can
 	// choose to be scheduled under a particular profile by setting its associated
 	// scheduler name. Pods that don't specify any scheduler name are scheduled

--- a/staging/src/k8s.io/kube-scheduler/config/v1beta3/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1beta3/zz_generated.deepcopy.go
@@ -22,7 +22,8 @@ limitations under the License.
 package v1beta3
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -192,6 +193,11 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 		*out = new(int64)
 		**out = **in
 	}
+	if in.PodMaxInUnschedulablePodsDuration != nil {
+		in, out := &in.PodMaxInUnschedulablePodsDuration, &out.PodMaxInUnschedulablePodsDuration
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.Profiles != nil {
 		in, out := &in.Profiles, &out.Profiles
 		*out = make([]KubeSchedulerProfile, len(*in))
@@ -266,7 +272,7 @@ func (in *NodeAffinityArgs) DeepCopyInto(out *NodeAffinityArgs) {
 	out.TypeMeta = in.TypeMeta
 	if in.AddedAffinity != nil {
 		in, out := &in.AddedAffinity, &out.AddedAffinity
-		*out = new(v1.NodeAffinity)
+		*out = new(corev1.NodeAffinity)
 		(*in).DeepCopyInto(*out)
 	}
 	return
@@ -463,7 +469,7 @@ func (in *PodTopologySpreadArgs) DeepCopyInto(out *PodTopologySpreadArgs) {
 	out.TypeMeta = in.TypeMeta
 	if in.DefaultConstraints != nil {
 		in, out := &in.DefaultConstraints, &out.DefaultConstraints
-		*out = make([]v1.TopologySpreadConstraint, len(*in))
+		*out = make([]corev1.TopologySpreadConstraint, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
scheduler: migrate `--pod-max-in-unschedulable-pods-duration` flag into KubeSchedulerConfiguration

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #87850

From: https://github.com/kubernetes/kubernetes/issues/87850#issuecomment-1338277493 https://github.com/kubernetes/kubernetes/issues/87850#issuecomment-1338487037

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-scheduler: the `--pod-max-in-unschedulable-pods-duration` flag is already deprecated and will be removed in a future release, please use `--config` flag to setup it in KubeSchedulerConfiguration component config instead. Please note that the default maximum time a pod can stay in unschedulablePodshas has been extended from 5min to 24h.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
