### PR TITLE
Pass runtime handler to image puller

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -66,6 +66,12 @@ func (m *kubeGenericRuntimeManager) createPodSandbox(ctx context.Context, pod *v
 		}
 	}
 
+	// Set runtime handler annotation.
+	if podSandboxConfig.Annotations == nil {
+		podSandboxConfig.Annotations = make(map[string]string)
+	}
+	podSandboxConfig.Annotations["kubernetes.io/runtimehandler"] = runtimeHandler
+
 	podSandBoxID, err := m.runtimeService.RunPodSandbox(ctx, podSandboxConfig, runtimeHandler)
 	if err != nil {
 		message := fmt.Sprintf("Failed to create sandbox for pod %q: %v", format.Pod(pod), err)

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
@@ -167,6 +167,7 @@ func TestCreatePodSandbox_RuntimeClass(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Contains(t, fakeRuntime.Called, "RunPodSandbox")
 				assert.Equal(t, test.expectedHandler, fakeRuntime.Sandboxes[id].RuntimeHandler)
+				assert.Equal(t, test.expectedHandler, fakeRuntime.Sandboxes[id].Annotations["kubernetes.io/runtimehandler"])
 			}
 		})
 	}


### PR DESCRIPTION
This allows CRI servers to adjust their behaviour based on properties of the runtime class. For example, now that containerd allows each runtime to have its own snapshotter, it needs to know which runtime handler the kubelet intends to use before it can pull an image or check if it exists.

Background: we'd like to be able to run different runtime handlers (runc, kata, kata CC) with different snapshotters. Containerd added support for this via an annotation in the pod yaml to indicate the runtime handler.
Since different snapshotters may have different stores, this also affects image pulling.
If the pod pull policy is “IfNotPresent”, then the kubelet calls containerd’s image service to determine if an image is present or not (by calling the ImageStatus function) to decide whether to pull.
 
The issue:
Containerd doesn’t check the runtime handler annotation to determine if an image is present. When we fix this, then everything works well for annotated pods yamls.
But pod yamls that aren’t annotated break as follows: if we run an annotated pod first (which pulls the image using its snapshotter), then when we run a pod without annotations, the kubelet will think that the image is already present because it was fetched by another snapshotter, and kata fails to start.
If we fix this by changing containerd to consider that the runtime handler for a pod without annotations is the default handler, then we break tools like crictl. For example, when we run `crictl rmi -a` to remove all images, it fails on images that aren’t on the snapshotter for the default handler.
 
The solution:
Annotate all pods.
 
We have two issues with that:
1.	We’d like to able to continue to run runc and kata handler unchanged. This isn’t possible if we require users to annotate their pod yamls.
2.	Even for kata cc pod yamls, the annotations lack usability because they require the runtime handler (not the runtime class). By changing containerd alone we can’t fix this because runtime classes are a Kubernetes concept.
 
Proposal: have the kubelet translate the a pod’s runtime class to runtime handler and add the annotation to ImageSpec.
 
This has been discussed in containerd upstream, for example, https://github.com/containerd/containerd/issues/6657#issuecomment-1066478023 suggests adding this annotation to ImageSpec. There’s also a KEP (https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/1301-windows-runtime-class) that talks about doing the same.