### PR TITLE
Better regexp in cpu manager node e2e test

### DIFF
--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -266,7 +266,7 @@ func runNonGuPodTest(ctx context.Context, f *framework.Framework, cpuCap int64) 
 	pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 	ginkgo.By("checking if the expected cpuset was assigned")
-	expAllowedCPUsListRegex = fmt.Sprintf("^0-%d\n$", cpuCap-1)
+	expAllowedCPUsListRegex = fmt.Sprintf("^0[-,]%d\n$", cpuCap-1)
 	// on the single CPU node the only possible value is 0
 	if cpuCap == 1 {
 		expAllowedCPUsListRegex = "^0\n$"


### PR DESCRIPTION
Looks like we may find comma(s) as well! 

Snippet from build log [here](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-cgroupv2-containerd-node-arm64-e2e-serial-ec2/1673830473123500032/build-log.txt). This is on an `ubuntu-2204` EC2 node:
```
  Jun 28 00:10:51.660: INFO: Unexpected error: expected log not found in container [non-gu-container] of pod [non-gu-pod]: 
      <*errors.errorString | 0x40014038d0>: 
      failed to match regexp "^0-3\n$" in output "0,3\n"
      {
          s: "failed to match regexp \"^0-3\\n$\" in output \"0,3\\n\"",
      }
  [FAILED] in [It] - test/e2e_node/cpu_manager_test.go:275 @ 06/28/23 00:10:51.661
```

A couple of our markdown files also show comma(s) in `Cpus_allowed_list`
https://cs.k8s.io/?q=Cpus_allowed_list.*%5C%2C&i=nope&files=&excludeFiles=&repos=

[cpuset man pages](https://man7.org/linux/man-pages/man7/cpuset.7.html#:~:text=1%2C%20and%200.-,List%20format,-The%20List%20Format) shows examples with comma(s)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
