### PR TITLE
scheduler test: Use cmp.Diff instead of reflect.DeepEqual for pkg/scheduler/internal/cache

### DIFF
--- a/pkg/scheduler/internal/cache/debugger/comparer_test.go
+++ b/pkg/scheduler/internal/cache/debugger/comparer_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package debugger
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -79,12 +80,12 @@ func testCompareNodes(actual, cached, missing, redundant []string, t *testing.T)
 
 	m, r := compare.CompareNodes(nodes, nodeInfo)
 
-	if !reflect.DeepEqual(m, missing) {
-		t.Errorf("missing expected to be %s; got %s", missing, m)
+	if diff := cmp.Diff(missing, m); diff != "" {
+		t.Errorf("Unexpected missing (-want, +got):\n%s", diff)
 	}
 
-	if !reflect.DeepEqual(r, redundant) {
-		t.Errorf("redundant expected to be %s; got %s", redundant, r)
+	if diff := cmp.Diff(redundant, r); diff != "" {
+		t.Errorf("Unexpected redundant (-want, +got):\n%s", diff)
 	}
 }
 
@@ -182,11 +183,11 @@ func testComparePods(actual, cached, queued, missing, redundant []string, t *tes
 
 	m, r := compare.ComparePods(pods, queuedPods, nodeInfo)
 
-	if !reflect.DeepEqual(m, missing) {
-		t.Errorf("missing expected to be %s; got %s", missing, m)
+	if diff := cmp.Diff(missing, m); diff != "" {
+		t.Errorf("Unexpected missing (-want, +got):\n%s", diff)
 	}
 
-	if !reflect.DeepEqual(r, redundant) {
-		t.Errorf("redundant expected to be %s; got %s", redundant, r)
+	if diff := cmp.Diff(redundant, r); diff != "" {
+		t.Errorf("Unexpected redundant (-want, +got):\n%s", diff)
 	}
 }

--- a/pkg/scheduler/internal/cache/node_tree_test.go
+++ b/pkg/scheduler/internal/cache/node_tree_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package cache
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -142,8 +143,8 @@ func verifyNodeTree(t *testing.T, nt *nodeTree, expectedTree map[string][]string
 	if numNodes := nt.numNodes; numNodes != expectedNumNodes {
 		t.Errorf("unexpected nodeTree.numNodes. Expected: %v, Got: %v", expectedNumNodes, numNodes)
 	}
-	if !reflect.DeepEqual(nt.tree, expectedTree) {
-		t.Errorf("The node tree is not the same as expected. Expected: %v, Got: %v", expectedTree, nt.tree)
+	if diff := cmp.Diff(expectedTree, nt.tree); diff != "" {
+		t.Errorf("Unexpected node tree (-want, +got):\n%s", diff)
 	}
 	if len(nt.zones) != len(expectedTree) {
 		t.Errorf("Number of zones in nodeTree.zones is not expected. Expected: %v, Got: %v", len(expectedTree), len(nt.zones))
@@ -395,8 +396,8 @@ func TestNodeTree_List(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(output, test.expectedOutput) {
-				t.Errorf("unexpected output. Expected: %v, Got: %v", test.expectedOutput, output)
+			if diff := cmp.Diff(test.expectedOutput, output); diff != "" {
+				t.Errorf("Unexpected output (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -487,8 +488,8 @@ func TestNodeTreeMultiOperations(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(output, test.expectedOutput) {
-				t.Errorf("unexpected output. Expected: %v, Got: %v", test.expectedOutput, output)
+			if diff := cmp.Diff(test.expectedOutput, output); diff != "" {
+				t.Errorf("Unexpected output (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/internal/cache/snapshot_test.go
+++ b/pkg/scheduler/internal/cache/snapshot_test.go
@@ -18,7 +18,6 @@ package cache
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -89,8 +88,8 @@ func TestGetNodeImageStates(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
 			imageStates := getNodeImageStates(test.node, test.imageExistenceMap)
-			if !reflect.DeepEqual(test.expected, imageStates) {
-				t.Errorf("expected: %#v, got: %#v", test.expected, imageStates)
+			if diff := cmp.Diff(test.expected, imageStates); diff != "" {
+				t.Errorf("Unexpected imageStates (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -177,8 +176,8 @@ func TestCreateImageExistenceMap(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
 			imageMap := createImageExistenceMap(test.nodes)
-			if !reflect.DeepEqual(test.expected, imageMap) {
-				t.Errorf("expected: %#v, got: %#v", test.expected, imageMap)
+			if diff := cmp.Diff(test.expected, imageMap); diff != "" {
+				t.Errorf("Unexpected imageMap (-want, +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
follow up https://github.com/kubernetes/kubernetes/pull/118312#discussion_r1243327155

> Basically, our recommendation (at least in our scheduler area) is to use cmp.Diff for a better visibility of comparison results. reflect.DeepEqual also works, but reducing it in the existing tests contributes to unifying how we compare things

Use `cmp.Diff` instead of `reflect.DeepEqual` for pkg/scheduler/internal/cache


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
related issue: https://github.com/kubernetes/kubernetes/issues/55722

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/cc @sanposhiho 

