### PR TITLE
DRA: for delayed allocation, deallocate when no longer used

### DIFF
--- a/test/e2e/dra/deploy.go
+++ b/test/e2e/dra/deploy.go
@@ -214,11 +214,11 @@ func (d *Driver) SetUp(nodes *Nodes, resources app.Resources) {
 		plugin, err := app.StartPlugin(logger, "/cdi", d.Name, nodename,
 			app.FileOperations{
 				Create: func(name string, content []byte) error {
-					ginkgo.By(fmt.Sprintf("creating CDI file %s on node %s:\n%s", name, nodename, string(content)))
+					klog.Background().Info("creating CDI file", "node", nodename, "filename", name, "content", string(content))
 					return d.createFile(&pod, name, content)
 				},
 				Remove: func(name string) error {
-					ginkgo.By(fmt.Sprintf("deleting CDI file %s on node %s", name, nodename))
+					klog.Background().Info("deleting CDI file", "node", nodename, "filename", name)
 					return d.removeFile(&pod, name)
 				},
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When a ResourceClaim:

- uses delayed allocation
- does not get created for a specific pod (i.e. not from a template)

then it currently gets allocated and remains allocated until:

- scheduling of a pod fails because the node originally chosen for the allocation isn't suitable, in which case the scheduler triggers deallocation via claim.status.deallocationRequested
- the user deletes the claim

What we want instead is that deallocation gets triggered when the last user of such an allocated claim gets removed from `claim.status.reservedFor`.

#### Which issue(s) this PR fixes:
Fixes #118613

#### Special notes for your reviewer:

A prior revision did this in the apiserver:
```patch
diff --git a/pkg/registry/resource/resourceclaim/strategy.go b/pkg/registry/resource/resourceclaim/strategy.go
index 1b65e87ade6..f82ac0253d4 100644
--- a/pkg/registry/resource/resourceclaim/strategy.go
+++ b/pkg/registry/resource/resourceclaim/strategy.go
@@ -124,6 +124,29 @@ func (resourceclaimStatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fi
 func (resourceclaimStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
        newClaim := obj.(*resource.ResourceClaim)
        oldClaim := old.(*resource.ResourceClaim)
+
+       // When a ResourceClaim uses delayed allocation, then it makes sense to
+       // deallocate the claim as soon as the last consumer stops using
+       // it. This ensures that the claim can be allocated again as needed by
+       // some future consumer instead of trying to schedule that consumer
+       // onto the node that was chosen for the previous consumer. It also
+       // releases the underlying resources for use by other claims.
+       //
+       // This has to be triggered by the transition from "was being used" to
+       // "is not used anymore" because a DRA driver is not required to set
+       // `status.reservedFor` together with `status.allocation`, i.e. a claim
+       // that is "currently unused" should not get deallocated.
+       //
+       // This does not matter for claims that were created for a pod. For
+       // those, the resource claim controller will trigger deletion when the
+       // pod is done. However, it doesn't hurt to also trigger deallocation
+       // for such claims and not checking for them keeps this code simpler.
+       if len(oldClaim.Status.ReservedFor) > 0 &&
+               len(newClaim.Status.ReservedFor) == 0 &&
+               newClaim.Spec.AllocationMode == resource.AllocationModeWaitForFirstConsumer {
+               newClaim.Status.DeallocationRequested = true
+       }
+
        newClaim.Spec = oldClaim.Spec
 }
```

But that interfered with handling of a failed allocation attempts when a pod uses multiple claims because in contrast to what we do now (= let the kube-scheduler decide what to deallocate), the apiserver deallocated all claims when the kube-scheduler released the reservation for the in-flight pod.

#### Does this PR introduce a user-facing change?
```release-note
Dynamic resource allocation: when a claim uses "wait for first consumer" allocation (the default), then it will now get deallocated after it was used by a pod. That ensures that the next pod isn't affected by previous scheduling decision and that resources are not kept allocated unless really needed. If keeping a claim allocated is desired, use "immediate allocation".
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3063
```
