### PR TITLE
Introduce larger buckets for request_filter_duration_seconds and request_wait_duration_seconds

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -229,7 +229,7 @@ var (
 			Subsystem:      APIServerComponent,
 			Name:           "request_filter_duration_seconds",
 			Help:           "Request filter latency distribution in seconds, for each filter type",
-			Buckets:        []float64{0.0001, 0.0003, 0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1.0, 5.0},
+			Buckets:        []float64{0.0001, 0.0003, 0.001, 0.003, 0.01, 0.03, 0.1, 0.3, 1.0, 5.0, 10.0, 15.0, 30.0},
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
 		[]string{"filter"},

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/metrics.go
@@ -47,7 +47,7 @@ const (
 
 var (
 	queueLengthBuckets            = []float64{0, 10, 25, 50, 100, 250, 500, 1000}
-	requestDurationSecondsBuckets = []float64{0, 0.005, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30}
+	requestDurationSecondsBuckets = []float64{0, 0.005, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 15, 30}
 )
 
 var registerMetrics sync.Once

--- a/test/instrumentation/documentation/documentation-list.yaml
+++ b/test/instrumentation/documentation/documentation-list.yaml
@@ -3612,6 +3612,7 @@
   - 2
   - 5
   - 10
+  - 15
   - 30
 - name: seat_fair_frac
   subsystem: flowcontrol

--- a/test/instrumentation/documentation/documentation-list.yaml
+++ b/test/instrumentation/documentation/documentation-list.yaml
@@ -2727,6 +2727,9 @@
   - 0.3
   - 1
   - 5
+  - 10
+  - 15
+  - 30
 - name: request_post_timeout_total
   subsystem: apiserver
   help: Tracks the activity of the request handlers after the associated requests


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

kube-apiserver currently uses max bucket of 5s for request_filter_duration_seconds and 30s for request_wait_duration_seconds. Comparing filter latency for type `priorityandfairness` with `request_wait_duration_seconds` can be misleading because queue wait times are configured to exceed 5s by default. In addition, the default request wait limit is 15s (default request timeout of 60 / 4), but since there is only a 10s and 30s bucket, requests reaching the default wait limit of 15s are being reported as waiting 30s.

This PR improves usability of these metrics by:
* adding a 10s, 15s and 30s bucket to request_filter_duration_seconds
* adding a 15s bucket to request_wait_duration_seconds

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Update apiserver metric request_filter_duration_seconds to include a 10s, 15s and 30s bucket.
- Update apiserver metric request_wait_duration_seconds to include a 15s bucket.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
