### PR TITLE
Automated cherry pick of #118237: Delete CRDs created during field validation tests.

### DIFF
--- a/test/e2e/apimachinery/field_validation.go
+++ b/test/e2e/apimachinery/field_validation.go
@@ -247,6 +247,11 @@ var _ = SIGDescribe("FieldValidation", func() {
 			framework.Failf("cannot create crd %s", err)
 		}
 
+		defer func() {
+			err = fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
+			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
+		}()
+
 		kind := noxuDefinition.Spec.Names.Kind
 		apiVersion := noxuDefinition.Spec.Group + "/" + noxuDefinition.Spec.Versions[0].Name
 		name := "mytest"
@@ -257,8 +262,6 @@ apiVersion: %s
 kind: %s
 metadata:
   name: %s
-  finalizers:
-  - test-finalizer
 spec:
   foo: foo1
   cronSpec: "* * * * */5"
@@ -304,6 +307,11 @@ spec:
 			framework.Failf("cannot create crd %s", err)
 		}
 
+		defer func() {
+			err = fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
+			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
+		}()
+
 		kind := noxuDefinition.Spec.Names.Kind
 		apiVersion := noxuDefinition.Spec.Group + "/" + noxuDefinition.Spec.Versions[0].Name
 		name := "mytest"
@@ -314,8 +322,6 @@ apiVersion: %s
 kind: %s
 metadata:
   name: %s
-  finalizers:
-  - test-finalizer
 spec:
   unknown: uk1
   cronSpec: "* * * * */5"
@@ -424,6 +430,11 @@ spec:
 			framework.Failf("cannot create crd %s", err)
 		}
 
+		defer func() {
+			err = fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
+			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
+		}()
+
 		kind := noxuDefinition.Spec.Names.Kind
 		apiVersion := noxuDefinition.Spec.Group + "/" + noxuDefinition.Spec.Versions[0].Name
 		name := "mytest"
@@ -434,8 +445,6 @@ apiVersion: %s
 kind: %s
 metadata:
   name: %s
-  finalizers:
-  - test-finalizer
 unknownField: unknown
 spec:
   foo: foo1
@@ -563,6 +572,11 @@ spec:
 			framework.Failf("cannot create crd %s", err)
 		}
 
+		defer func() {
+			err = fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
+			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
+		}()
+
 		kind := noxuDefinition.Spec.Names.Kind
 		apiVersion := noxuDefinition.Spec.Group + "/" + noxuDefinition.Spec.Versions[0].Name
 		name := "mytest"
@@ -574,8 +588,6 @@ kind: %s
 metadata:
   name: %s
   unknownMeta: unknown
-  finalizers:
-  - test-finalizer
 spec:
   template:
     apiversion: foo/v1
@@ -690,6 +702,11 @@ spec:
 			framework.Failf("cannot create crd %s", err)
 		}
 
+		defer func() {
+			err = fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
+			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
+		}()
+
 		kind := noxuDefinition.Spec.Names.Kind
 		apiVersion := noxuDefinition.Spec.Group + "/" + noxuDefinition.Spec.Versions[0].Name
 		name := "mytest"
@@ -700,8 +717,6 @@ apiVersion: %s
 kind: %s
 metadata:
   name: %s
-  finalizers:
-  - test-finalizer
 spec:
   unknown: uk1
   foo: foo1
@@ -718,7 +733,7 @@ spec:
 			Param("fieldValidation", "Strict").
 			Body(yamlBody).
 			DoRaw(ctx)
-		if !(strings.Contains(string(result), `line 11: key \"foo\" already set in map`)) {
+		if !(strings.Contains(string(result), `line 9: key \"foo\" already set in map`)) {
 			framework.Failf("error missing duplicate field: %v:\n%v", err, string(result))
 		}
 	})


### PR DESCRIPTION
Cherry pick of #118237 on release-1.27.

#118237: Delete CRDs created during field validation tests.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```