### PR TITLE
node: podresources: getallocatable: move to GA

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -435,9 +435,10 @@ const (
 	// Enable POD resources API with Get method
 	KubeletPodResourcesGet featuregate.Feature = "KubeletPodResourcesGet"
 
-	// owner: @fromanirh
+	// owner: @ffromani
 	// alpha: v1.21
 	// beta: v1.23
+	// GA: v1.28
 	// Enable POD resources API to return allocatable resources
 	KubeletPodResourcesGetAllocatable featuregate.Feature = "KubeletPodResourcesGetAllocatable"
 
@@ -972,7 +973,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	KubeletPodResourcesGet: {Default: false, PreRelease: featuregate.Alpha},
 
-	KubeletPodResourcesGetAllocatable: {Default: true, PreRelease: featuregate.Beta},
+	KubeletPodResourcesGetAllocatable: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.28, remove in 1.30
 
 	KubeletTracing: {Default: true, PreRelease: featuregate.Beta},
 

--- a/pkg/kubelet/apis/podresources/server_v1.go
+++ b/pkg/kubelet/apis/podresources/server_v1.go
@@ -90,11 +90,6 @@ func (p *v1PodResourcesServer) GetAllocatableResources(ctx context.Context, req 
 	metrics.PodResourcesEndpointRequestsTotalCount.WithLabelValues("v1").Inc()
 	metrics.PodResourcesEndpointRequestsGetAllocatableCount.WithLabelValues("v1").Inc()
 
-	if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.KubeletPodResourcesGetAllocatable) {
-		metrics.PodResourcesEndpointErrorsGetAllocatableCount.WithLabelValues("v1").Inc()
-		return nil, fmt.Errorf("PodResources API GetAllocatableResources disabled")
-	}
-
 	response := &v1.AllocatableResourcesResponse{
 		Devices: p.devicesProvider.GetAllocatableDevices(),
 		CpuIds:  p.cpusProvider.GetAllocatableCPUs(),

--- a/pkg/kubelet/apis/podresources/server_v1_test.go
+++ b/pkg/kubelet/apis/podresources/server_v1_test.go
@@ -251,8 +251,6 @@ func TestListPodResourcesV1(t *testing.T) {
 }
 
 func TestAllocatableResources(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.KubeletPodResourcesGetAllocatable, true)()
-
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -777,12 +777,10 @@ func Register(collectors ...metrics.StableCollector) {
 		legacyregistry.MustRegister(RestartedPodTotal)
 		legacyregistry.MustRegister(ManagedEphemeralContainers)
 		legacyregistry.MustRegister(PodResourcesEndpointRequestsTotalCount)
-		if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPodResourcesGetAllocatable) {
-			legacyregistry.MustRegister(PodResourcesEndpointRequestsListCount)
-			legacyregistry.MustRegister(PodResourcesEndpointRequestsGetAllocatableCount)
-			legacyregistry.MustRegister(PodResourcesEndpointErrorsListCount)
-			legacyregistry.MustRegister(PodResourcesEndpointErrorsGetAllocatableCount)
-		}
+		legacyregistry.MustRegister(PodResourcesEndpointRequestsListCount)
+		legacyregistry.MustRegister(PodResourcesEndpointRequestsGetAllocatableCount)
+		legacyregistry.MustRegister(PodResourcesEndpointErrorsListCount)
+		legacyregistry.MustRegister(PodResourcesEndpointErrorsGetAllocatableCount)
 		if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPodResourcesGet) {
 			legacyregistry.MustRegister(PodResourcesEndpointRequestsGetCount)
 			legacyregistry.MustRegister(PodResourcesEndpointErrorsGetCount)

--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -775,29 +775,6 @@ var _ = SIGDescribe("POD Resources [Serial] [Feature:PodResources][NodeFeature:P
 			})
 		})
 
-		ginkgo.Context("with disabled KubeletPodResourcesGetAllocatable feature gate", func() {
-			tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
-				if initialConfig.FeatureGates == nil {
-					initialConfig.FeatureGates = make(map[string]bool)
-				}
-				initialConfig.FeatureGates[string(kubefeatures.KubeletPodResourcesGetAllocatable)] = false
-			})
-
-			ginkgo.It("should return the expected error with the feature gate disabled", func(ctx context.Context) {
-				endpoint, err := util.LocalEndpoint(defaultPodResourcesPath, podresources.Socket)
-				framework.ExpectNoError(err, "LocalEndpoint() failed err: %v", err)
-
-				cli, conn, err := podresources.GetV1Client(endpoint, defaultPodResourcesTimeout, defaultPodResourcesMaxSize)
-				framework.ExpectNoError(err, "GetV1Client() failed err: %v", err)
-				defer conn.Close()
-
-				ginkgo.By("checking GetAllocatableResources fail if the feature gate is not enabled")
-				allocatableRes, err := cli.GetAllocatableResources(ctx, &kubeletpodresourcesv1.AllocatableResourcesRequest{})
-				framework.Logf("GetAllocatableResources result: %v, err: %v", allocatableRes, err)
-				framework.ExpectError(err, "With feature gate disabled, the call must fail")
-			})
-		})
-
 		ginkgo.Context("with disabled KubeletPodResourcesGet feature gate", func() {
 
 			ginkgo.It("should return the expected error with the feature gate disabled", func(ctx context.Context) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
graduate the `GetAllocatable` podresources endpoint to GA

#### Which issue(s) this PR fixes:
enhancement: https://github.com/kubernetes/enhancements/issues/2403

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
```release-note
The GetAllocatableResources podresources API endpoint is now GA
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/4045
```
