### PR TITLE
kube-proxy service health: add new  header with number of local endpoints

### DIFF
--- a/pkg/proxy/healthcheck/service_health.go
+++ b/pkg/proxy/healthcheck/service_health.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -233,6 +234,8 @@ func (h hcHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 
 	resp.Header().Set("Content-Type", "application/json")
 	resp.Header().Set("X-Content-Type-Options", "nosniff")
+	resp.Header().Set("X-Load-Balancing-Endpoint-Weight", strconv.Itoa(count))
+
 	if count != 0 && kubeProxyHealthy {
 		resp.WriteHeader(http.StatusOK)
 	} else {


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:

- add new header "X-Load-Balancing-Endpoint-Weight" returned from service health. Value of the header is number of local endpoints. Header can be used in weighted load balancing. Parsing header for number of endpoints is faster than unmarshalling json from the content body.

- add missing unit test for new and old headers returned from service health


#### Special notes for your reviewer:

I am happy to discuss this on SIG Network meeting

#### Does this PR introduce a user-facing change?

yes, to some extend
kube-proxy service health will return additional http header "X-Load-Balancing-Endpoint-Weight" with number of local endpoints.
no action is required from users 



```release-note
kube-proxy service health returns http header "X-Load-Balancing-Endpoint-Weight" with number of local endpoints. The same information is still available in response body JSON payload.LocalEndpoints.
```


