### PR TITLE
do a better job of validating IP family of kube-proxy config

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -567,6 +567,11 @@ func newProxyServer(config *kubeproxyconfig.KubeProxyConfiguration, master strin
 		s.HealthzServer = healthcheck.NewProxierHealthServer(config.HealthzBindAddress, 2*config.IPTables.SyncPeriod.Duration, s.Recorder, s.NodeRef)
 	}
 
+	err = s.platformSetup()
+	if err != nil {
+		return nil, err
+	}
+
 	s.Proxier, err = s.createProxier(config)
 	if err != nil {
 		return nil, err
@@ -705,12 +710,6 @@ func (s *ProxyServer) Run() error {
 
 	// Start up a metrics server if requested
 	serveMetrics(s.Config.MetricsBindAddress, s.Config.Mode, s.Config.EnableProfiling, errCh)
-
-	// Do platform-specific setup
-	err := s.platformSetup()
-	if err != nil {
-		return err
-	}
 
 	noProxyName, err := labels.NewRequirement(apis.LabelServiceProxyName, selection.DoesNotExist, nil)
 	if err != nil {

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -111,8 +111,6 @@ func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguratio
 		ipt[1] = iptInterface
 	}
 
-	nodePortAddresses := config.NodePortAddresses
-
 	if !ipt[0].Present() {
 		return nil, fmt.Errorf("iptables is not supported for primary IP family %q", primaryProtocol)
 	} else if !ipt[1].Present() {
@@ -125,7 +123,6 @@ func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguratio
 		badAddrs := npaByFamily[secondaryFamily]
 		if len(badAddrs) > 0 {
 			klog.InfoS("Ignoring --nodeport-addresses of the wrong family", "ipFamily", secondaryFamily, "addresses", badAddrs)
-			nodePortAddresses = npaByFamily[s.PrimaryIPFamily]
 		}
 	}
 
@@ -157,7 +154,7 @@ func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguratio
 				s.NodeIPs,
 				s.Recorder,
 				s.HealthzServer,
-				nodePortAddresses,
+				config.NodePortAddresses,
 			)
 		} else {
 			// Create a single-stack proxier if and only if the node does not support dual-stack (i.e, no iptables support).
@@ -183,7 +180,7 @@ func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguratio
 				s.NodeIPs[s.PrimaryIPFamily],
 				s.Recorder,
 				s.HealthzServer,
-				nodePortAddresses,
+				config.NodePortAddresses,
 			)
 		}
 
@@ -230,7 +227,7 @@ func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguratio
 				s.Recorder,
 				s.HealthzServer,
 				config.IPVS.Scheduler,
-				nodePortAddresses,
+				config.NodePortAddresses,
 				kernelHandler,
 			)
 		} else {
@@ -262,7 +259,7 @@ func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguratio
 				s.Recorder,
 				s.HealthzServer,
 				config.IPVS.Scheduler,
-				nodePortAddresses,
+				config.NodePortAddresses,
 				kernelHandler,
 			)
 		}

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -50,7 +50,6 @@ import (
 	utilipset "k8s.io/kubernetes/pkg/proxy/ipvs/ipset"
 	utilipvs "k8s.io/kubernetes/pkg/proxy/ipvs/util"
 	proxymetrics "k8s.io/kubernetes/pkg/proxy/metrics"
-	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	proxyutiliptables "k8s.io/kubernetes/pkg/proxy/util/iptables"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 	"k8s.io/utils/exec"
@@ -147,16 +146,6 @@ func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguratio
 	} else {
 		ipt[0] = utiliptables.New(execer, utiliptables.ProtocolIPv4)
 		ipt[1] = iptInterface
-	}
-
-	if !dualStack {
-		// Validate NodePortAddresses is single-stack
-		npaByFamily := proxyutil.MapCIDRsByIPFamily(config.NodePortAddresses)
-		secondaryFamily := proxyutil.OtherIPFamily(s.PrimaryIPFamily)
-		badAddrs := npaByFamily[secondaryFamily]
-		if len(badAddrs) > 0 {
-			klog.InfoS("Ignoring --nodeport-addresses of the wrong family", "ipFamily", secondaryFamily, "addresses", badAddrs)
-		}
 	}
 
 	if config.Mode == proxyconfigapi.ProxyModeIPTables {

--- a/cmd/kube-proxy/app/server_others_test.go
+++ b/cmd/kube-proxy/app/server_others_test.go
@@ -646,7 +646,7 @@ func TestGetConntrackMax(t *testing.T) {
 	}
 }
 
-func TestProxyServer_createProxier(t *testing.T) {
+func TestProxyServer_platformSetup(t *testing.T) {
 	tests := []struct {
 		name         string
 		node         *v1.Node
@@ -683,9 +683,8 @@ func TestProxyServer_createProxier(t *testing.T) {
 					v1.IPv6Protocol: net.IPv6zero,
 				},
 			}
-			_, err := s.createProxier(tt.config)
-			// TODO: mock the exec.Interface to not fail probing iptables
-			if (err != nil) && !strings.Contains(err.Error(), "iptables is not supported for primary IP family") {
+			err := s.platformSetup()
+			if err != nil {
 				t.Errorf("ProxyServer.createProxier() error = %v", err)
 				return
 			}

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -36,10 +36,20 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/winkernel"
 )
 
+// platformApplyDefaults is called after parsing command-line flags and/or reading the
+// config file, to apply platform-specific default values to config.
 func (o *Options) platformApplyDefaults(config *proxyconfigapi.KubeProxyConfiguration) {
 	if config.Mode == "" {
 		config.Mode = proxyconfigapi.ProxyModeKernelspace
 	}
+}
+
+// platformSetup is called after setting up the ProxyServer, but before creating the
+// Proxier. It should fill in any platform-specific fields and perform other
+// platform-specific setup.
+func (s *ProxyServer) platformSetup() error {
+	winkernel.RegisterMetrics()
+	return nil
 }
 
 // createProxier creates the proxy.Provider
@@ -91,11 +101,6 @@ func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguratio
 	}
 
 	return proxier, nil
-}
-
-func (s *ProxyServer) platformSetup() error {
-	winkernel.RegisterMetrics()
-	return nil
 }
 
 func getDualStackMode(networkname string, compatTester winkernel.StackCompatTester) bool {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:
spun out of #118408; this centralizes figuring out what mode kube-proxy is running in (single-stack IPv4, single-stack IPv6, dual-stack IPv4-primary or dual-stack IPv6-primary), and then checks that the configuration actually makes sense for that mode.

Alas, we don't want to retroactively make previously-working configurations be broken, so we merely warn rather than erroring out on most errors.

#### Does this PR introduce a user-facing change?
```release-note
Kube-proxy will now warn at startup if the configuration seems inconsistent
with respect to IP families. (For example, if you have an IPv4 node IP, but
`--cluster-cidr` is IPv6.)
```

/sig network
/assign @aojea