### PR TITLE
[KMSv2] feat: implements metrics for encryption config hot reload

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/metrics/metrics.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	namespace = "apiserver"
+	subsystem = "encryption_config_controller"
+)
+
+var (
+	encryptionConfigAutomaticReloadFailureTotal = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "automatic_reload_failures_total",
+			Help:           "Total number of failed automatic reloads of encryption configuration.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	encryptionConfigAutomaticReloadSuccessTotal = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "automatic_reload_success_total",
+			Help:           "Total number of successful automatic reloads of encryption configuration.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	encryptionConfigAutomaticReloadLastTimestampSeconds = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "automatic_reload_last_timestamp_seconds",
+			Help:           "Timestamp of the last successful or failed automatic reload of encryption configuration.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"status"},
+	)
+)
+
+var registerMetrics sync.Once
+
+func RegisterMetrics() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(encryptionConfigAutomaticReloadFailureTotal)
+		legacyregistry.MustRegister(encryptionConfigAutomaticReloadSuccessTotal)
+		legacyregistry.MustRegister(encryptionConfigAutomaticReloadLastTimestampSeconds)
+	})
+}
+
+func RecordEncryptionConfigAutomaticReloadFailure() {
+	encryptionConfigAutomaticReloadFailureTotal.Inc()
+	recordEncryptionConfigAutomaticReloadTimestamp("failure")
+}
+
+func RecordEncryptionConfigAutomaticReloadSuccess() {
+	encryptionConfigAutomaticReloadSuccessTotal.Inc()
+	recordEncryptionConfigAutomaticReloadTimestamp("success")
+}
+
+func recordEncryptionConfigAutomaticReloadTimestamp(result string) {
+	encryptionConfigAutomaticReloadLastTimestampSeconds.WithLabelValues(result).SetToCurrentTime()
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/metrics/metrics_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestRecordEncryptionConfigAutomaticReloadFailure(t *testing.T) {
+	expectedValue := `
+	# HELP apiserver_encryption_config_controller_automatic_reload_failures_total [ALPHA] Total number of failed automatic reloads of encryption configuration.
+    # TYPE apiserver_encryption_config_controller_automatic_reload_failures_total counter
+    apiserver_encryption_config_controller_automatic_reload_failures_total 1
+	`
+	metrics := []string{
+		namespace + "_" + subsystem + "_automatic_reload_failures_total",
+	}
+
+	encryptionConfigAutomaticReloadFailureTotal.Reset()
+	RegisterMetrics()
+
+	RecordEncryptionConfigAutomaticReloadFailure()
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRecordEncryptionConfigAutomaticReloadSuccess(t *testing.T) {
+	expectedValue := `
+	# HELP apiserver_encryption_config_controller_automatic_reload_success_total [ALPHA] Total number of successful automatic reloads of encryption configuration.
+    # TYPE apiserver_encryption_config_controller_automatic_reload_success_total counter
+    apiserver_encryption_config_controller_automatic_reload_success_total 1
+	`
+	metrics := []string{
+		namespace + "_" + subsystem + "_automatic_reload_success_total",
+	}
+
+	encryptionConfigAutomaticReloadSuccessTotal.Reset()
+	RegisterMetrics()
+
+	RecordEncryptionConfigAutomaticReloadSuccess()
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEncryptionConfigAutomaticReloadLastTimestampSeconds(t *testing.T) {
+	testCases := []struct {
+		expectedValue string
+		resultLabel   string
+		timestamp     int64
+	}{
+		{
+			expectedValue: `
+                # HELP apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds [ALPHA] Timestamp of the last successful or failed automatic reload of encryption configuration.
+                # TYPE apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds gauge
+                apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds{status="failure"} 1.689101941e+09
+            `,
+			resultLabel: "failure",
+			timestamp:   1689101941,
+		},
+		{
+			expectedValue: `
+                # HELP apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds [ALPHA] Timestamp of the last successful or failed automatic reload of encryption configuration.
+                # TYPE apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds gauge
+                apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds{status="success"} 1.689101941e+09
+            `,
+			resultLabel: "success",
+			timestamp:   1689101941,
+		},
+	}
+
+	metrics := []string{
+		namespace + "_" + subsystem + "_automatic_reload_last_timestamp_seconds",
+	}
+	RegisterMetrics()
+
+	for _, tc := range testCases {
+		encryptionConfigAutomaticReloadLastTimestampSeconds.Reset()
+		encryptionConfigAutomaticReloadLastTimestampSeconds.WithLabelValues(tc.resultLabel).Set(float64(tc.timestamp))
+
+		if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tc.expectedValue), metrics...); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1528,6 +1528,7 @@ k8s.io/apiserver/pkg/server/mux
 k8s.io/apiserver/pkg/server/options
 k8s.io/apiserver/pkg/server/options/encryptionconfig
 k8s.io/apiserver/pkg/server/options/encryptionconfig/controller
+k8s.io/apiserver/pkg/server/options/encryptionconfig/metrics
 k8s.io/apiserver/pkg/server/resourceconfig
 k8s.io/apiserver/pkg/server/routes
 k8s.io/apiserver/pkg/server/storage


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

This PR implements metrics that record the total number of successful and failed encryption config hot reloads, along with the timestamp of the most recent successful hot reload.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #113704

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
New Metrics Added for Encryption Configuration Controller

This release adds new metrics to the Encryption Configuration Controller to help monitor the automatic reloading of encryption configuration. The new metrics include:

- `apiserver_encryption_config_controller_automatic_reload_failures_total`: Total number of failed automatic reloads of encryption configuration.
- `apiserver_encryption_config_controller_automatic_reload_success_total`: Total number of successful automatic reloads of encryption configuration.
- `apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds`: Timestamp of the last successful or failed automatic reload of encryption configuration.

These metrics can be used to monitor the health of the Encryption Configuration Controller and to troubleshoot any issues that may arise during automatic reloading of encryption configuration.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig auth
/triage accepted
/cc @ritazh @enj @aramase 
