### PR TITLE
--resource-version flag for kubectl GETs and LISTs

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -85,9 +85,10 @@ type Builder struct {
 	limitChunks       int64
 	requestTransforms []RequestTransform
 
-	resources       []string
-	subresource     string
-	resourceVersion string
+	resources            []string
+	subresource          string
+	resourceVersion      string
+	resourceVersionMatch metav1.ResourceVersionMatch
 
 	namespace    string
 	allNamespace bool
@@ -579,6 +580,13 @@ func (b *Builder) ResourceVersion(resourceVersion string) *Builder {
 	return b
 }
 
+// ResourceVersionMatch adds to the builder the resourceVersionMatch parameter to be used as a request parameter
+// validation of the ResourceVersionMatch value is done on the server side
+func (b *Builder) ResourceVersionMatch(resourceVersionMatch string) *Builder {
+	b.resourceVersionMatch = metav1.ResourceVersionMatch(resourceVersionMatch)
+	return b
+}
+
 // SelectEverythingParam
 func (b *Builder) SelectAllParam(selectAll bool) *Builder {
 	if selectAll && (b.labelSelector != nil || b.fieldSelector != nil) {
@@ -939,7 +947,7 @@ func (b *Builder) visitBySelector() *Result {
 		if mapping.Scope.Name() != meta.RESTScopeNameNamespace {
 			selectorNamespace = ""
 		}
-		visitors = append(visitors, NewSelector(client, mapping, selectorNamespace, labelSelector, fieldSelector, b.limitChunks, b.resourceVersion))
+		visitors = append(visitors, NewSelector(client, mapping, selectorNamespace, labelSelector, fieldSelector, b.limitChunks, b.resourceVersion, b.resourceVersionMatch))
 	}
 	if b.continueOnError {
 		result.visitor = EagerVisitorList(visitors)

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -1043,12 +1043,13 @@ func (b *Builder) visitByResource() *Result {
 		}
 
 		info := &Info{
-			Client:          client,
-			Mapping:         mapping,
-			Namespace:       selectorNamespace,
-			Name:            tuple.Name,
-			Subresource:     b.subresource,
-			ResourceVersion: b.resourceVersion,
+			Client:               client,
+			Mapping:              mapping,
+			Namespace:            selectorNamespace,
+			Name:                 tuple.Name,
+			Subresource:          b.subresource,
+			ResourceVersion:      b.resourceVersion,
+			ResourceVersionMatch: b.resourceVersionMatch,
 		}
 		items = append(items, info)
 	}
@@ -1109,12 +1110,13 @@ func (b *Builder) visitByName() *Result {
 	visitors := []Visitor{}
 	for _, name := range b.names {
 		info := &Info{
-			Client:          client,
-			Mapping:         mapping,
-			Namespace:       selectorNamespace,
-			Name:            name,
-			Subresource:     b.subresource,
-			ResourceVersion: b.resourceVersion,
+			Client:               client,
+			Mapping:              mapping,
+			Namespace:            selectorNamespace,
+			Name:                 name,
+			Subresource:          b.subresource,
+			ResourceVersion:      b.resourceVersion,
+			ResourceVersionMatch: b.resourceVersionMatch,
 		}
 		visitors = append(visitors, info)
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -572,7 +572,8 @@ func (b *Builder) Subresource(subresource string) *Builder {
 }
 
 // ResourceVersion instructs the builder to retrieve the object at a
-// specific version instead of the latest version.
+// specific version instead of the latest version by adding the ResourceVersion parameter
+// to the request.
 func (b *Builder) ResourceVersion(resourceVersion string) *Builder {
 	b.resourceVersion = resourceVersion
 	return b
@@ -1039,6 +1040,7 @@ func (b *Builder) visitByResource() *Result {
 			Namespace:   selectorNamespace,
 			Name:        tuple.Name,
 			Subresource: b.subresource,
+			ResourceVersion: b.resourceVersion,
 		}
 		items = append(items, info)
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -1035,11 +1035,11 @@ func (b *Builder) visitByResource() *Result {
 		}
 
 		info := &Info{
-			Client:      client,
-			Mapping:     mapping,
-			Namespace:   selectorNamespace,
-			Name:        tuple.Name,
-			Subresource: b.subresource,
+			Client:          client,
+			Mapping:         mapping,
+			Namespace:       selectorNamespace,
+			Name:            tuple.Name,
+			Subresource:     b.subresource,
 			ResourceVersion: b.resourceVersion,
 		}
 		items = append(items, info)

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -85,8 +85,9 @@ type Builder struct {
 	limitChunks       int64
 	requestTransforms []RequestTransform
 
-	resources   []string
-	subresource string
+	resources       []string
+	subresource     string
+	resourceVersion string
 
 	namespace    string
 	allNamespace bool
@@ -570,6 +571,13 @@ func (b *Builder) Subresource(subresource string) *Builder {
 	return b
 }
 
+// ResourceVersion instructs the builder to retrieve the object at a
+// specific version instead of the latest version.
+func (b *Builder) ResourceVersion(resourceVersion string) *Builder {
+	b.resourceVersion = resourceVersion
+	return b
+}
+
 // SelectEverythingParam
 func (b *Builder) SelectAllParam(selectAll bool) *Builder {
 	if selectAll && (b.labelSelector != nil || b.fieldSelector != nil) {
@@ -930,7 +938,7 @@ func (b *Builder) visitBySelector() *Result {
 		if mapping.Scope.Name() != meta.RESTScopeNameNamespace {
 			selectorNamespace = ""
 		}
-		visitors = append(visitors, NewSelector(client, mapping, selectorNamespace, labelSelector, fieldSelector, b.limitChunks))
+		visitors = append(visitors, NewSelector(client, mapping, selectorNamespace, labelSelector, fieldSelector, b.limitChunks, b.resourceVersion))
 	}
 	if b.continueOnError {
 		result.visitor = EagerVisitorList(visitors)
@@ -1091,11 +1099,12 @@ func (b *Builder) visitByName() *Result {
 	visitors := []Visitor{}
 	for _, name := range b.names {
 		info := &Info{
-			Client:      client,
-			Mapping:     mapping,
-			Namespace:   selectorNamespace,
-			Name:        name,
-			Subresource: b.subresource,
+			Client:          client,
+			Mapping:         mapping,
+			Namespace:       selectorNamespace,
+			Name:            name,
+			Subresource:     b.subresource,
+			ResourceVersion: b.resourceVersion,
 		}
 		visitors = append(visitors, info)
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/client-go/rest/fake"
 	restclientwatch "k8s.io/client-go/rest/watch"
 	"k8s.io/client-go/restmapper"
+
 	// TODO we need to remove this linkage and create our own scheme
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -1732,16 +1733,18 @@ func TestGetObjectResourceVersion(t *testing.T) {
 }
 
 func TestListObjectResourceVersion(t *testing.T) {
+	resourceVersionMatch := metav1.ResourceVersionMatchExact
 	targetRV := "13"
 	newPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "test", ResourceVersion: "13"},
 	}
 	obj, err := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
-		"/namespaces/test/pods?resourceVersion=" + targetRV: runtime.EncodeOrDie(corev1Codec, newPod),
+		"/namespaces/test/pods?resourceVersion=" + targetRV + "&resourceVersionMatch=" + string(resourceVersionMatch): runtime.EncodeOrDie(corev1Codec, newPod),
 	})).
 		NamespaceParam("test").
 		ResourceTypeOrNameArgs(true, "pods").
 		ResourceVersion(targetRV).
+		ResourceVersionMatch(string(resourceVersionMatch)).
 		Flatten().
 		Do().Object()
 

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -46,7 +46,6 @@ import (
 	"k8s.io/client-go/rest/fake"
 	restclientwatch "k8s.io/client-go/rest/watch"
 	"k8s.io/client-go/restmapper"
-
 	// TODO we need to remove this linkage and create our own scheme
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
@@ -41,6 +41,8 @@ type Helper struct {
 	Subresource string
 	// The resource version to look for
 	ResourceVersion string
+	// The match method for the resource version
+	ResourceVersionMatch metav1.ResourceVersionMatch
 	// A RESTClient capable of mutating this resource.
 	RESTClient RESTClient
 	// True if the resource type is scoped to namespaces
@@ -105,11 +107,19 @@ func (m *Helper) WithResourceVersion(resourceVersion string) *Helper {
 	return m
 }
 
+// WithResourceVersionMatch sets the helper to request a resource version with a specific method
+// (<resource>/[ns/<namespace>/]<name>?ResourceVersionMatch=<resourceVersionMatch>)
+func (m *Helper) WithResourceVersionMatch(resourceVersionMatch metav1.ResourceVersionMatch) *Helper {
+	m.ResourceVersionMatch = resourceVersionMatch
+	return m
+}
+
 func (m *Helper) Get(namespace, name string) (runtime.Object, error) {
 	req := m.RESTClient.Get().
 		NamespaceIfScoped(namespace, m.NamespaceScoped).
 		Resource(m.Resource).
 		ResourceVersion(m.ResourceVersion).
+		ResourceVersionMatch(m.ResourceVersionMatch).
 		Name(name).
 		SubResource(m.Subresource)
 	return req.Do(context.TODO()).Get()

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
@@ -39,6 +39,8 @@ type Helper struct {
 	Resource string
 	// The name of the subresource as the server would recognize it
 	Subresource string
+	// The resource version to look for
+	ResourceVersion string
 	// A RESTClient capable of mutating this resource.
 	RESTClient RESTClient
 	// True if the resource type is scoped to namespaces
@@ -96,10 +98,17 @@ func (m *Helper) WithSubresource(subresource string) *Helper {
 	return m
 }
 
+// WithResourceVersion sets the helper to request a resource with a specific version
+func (m *Helper) WithResourceVersion(resourceVersion string) *Helper {
+	m.ResourceVersion = resourceVersion
+	return m
+}
+
 func (m *Helper) Get(namespace, name string) (runtime.Object, error) {
 	req := m.RESTClient.Get().
 		NamespaceIfScoped(namespace, m.NamespaceScoped).
 		Resource(m.Resource).
+		ResourceVersion(m.ResourceVersion).
 		Name(name).
 		SubResource(m.Subresource)
 	return req.Do(context.TODO()).Get()

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
@@ -99,6 +99,7 @@ func (m *Helper) WithSubresource(subresource string) *Helper {
 }
 
 // WithResourceVersion sets the helper to request a resource with a specific version
+// (<resource>/[ns/<namespace>/]<name>?ResourceVersion=<resourceVersion>)
 func (m *Helper) WithResourceVersion(resourceVersion string) *Helper {
 	m.ResourceVersion = resourceVersion
 	return m

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/selector.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/selector.go
@@ -25,25 +25,27 @@ import (
 
 // Selector is a Visitor for resources that match a label selector.
 type Selector struct {
-	Client          RESTClient
-	Mapping         *meta.RESTMapping
-	Namespace       string
-	LabelSelector   string
-	FieldSelector   string
-	LimitChunks     int64
-	ResourceVersion string
+	Client               RESTClient
+	Mapping              *meta.RESTMapping
+	Namespace            string
+	LabelSelector        string
+	FieldSelector        string
+	LimitChunks          int64
+	ResourceVersion      string
+	ResourceVersionMatch metav1.ResourceVersionMatch
 }
 
 // NewSelector creates a resource selector which hides details of getting items by their label selector.
-func NewSelector(client RESTClient, mapping *meta.RESTMapping, namespace, labelSelector, fieldSelector string, limitChunks int64, resourceVersion string) *Selector {
+func NewSelector(client RESTClient, mapping *meta.RESTMapping, namespace, labelSelector, fieldSelector string, limitChunks int64, resourceVersion string, resourceVersionMatch metav1.ResourceVersionMatch) *Selector {
 	return &Selector{
-		Client:          client,
-		Mapping:         mapping,
-		Namespace:       namespace,
-		LabelSelector:   labelSelector,
-		FieldSelector:   fieldSelector,
-		LimitChunks:     limitChunks,
-		ResourceVersion: resourceVersion,
+		Client:               client,
+		Mapping:              mapping,
+		Namespace:            namespace,
+		LabelSelector:        labelSelector,
+		FieldSelector:        fieldSelector,
+		LimitChunks:          limitChunks,
+		ResourceVersion:      resourceVersion,
+		ResourceVersionMatch: resourceVersionMatch,
 	}
 }
 
@@ -51,10 +53,11 @@ func NewSelector(client RESTClient, mapping *meta.RESTMapping, namespace, labelS
 func (r *Selector) Visit(fn VisitorFunc) error {
 	helper := NewHelper(r.Client, r.Mapping)
 	initialOpts := metav1.ListOptions{
-		LabelSelector:   r.LabelSelector,
-		FieldSelector:   r.FieldSelector,
-		Limit:           r.LimitChunks,
-		ResourceVersion: r.ResourceVersion,
+		LabelSelector:        r.LabelSelector,
+		FieldSelector:        r.FieldSelector,
+		Limit:                r.LimitChunks,
+		ResourceVersion:      r.ResourceVersion,
+		ResourceVersionMatch: r.ResourceVersionMatch,
 	}
 	return FollowContinue(&initialOpts, func(options metav1.ListOptions) (runtime.Object, error) {
 		list, err := helper.List(

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/selector.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/selector.go
@@ -25,23 +25,25 @@ import (
 
 // Selector is a Visitor for resources that match a label selector.
 type Selector struct {
-	Client        RESTClient
-	Mapping       *meta.RESTMapping
-	Namespace     string
-	LabelSelector string
-	FieldSelector string
-	LimitChunks   int64
+	Client          RESTClient
+	Mapping         *meta.RESTMapping
+	Namespace       string
+	LabelSelector   string
+	FieldSelector   string
+	LimitChunks     int64
+	ResourceVersion string
 }
 
 // NewSelector creates a resource selector which hides details of getting items by their label selector.
-func NewSelector(client RESTClient, mapping *meta.RESTMapping, namespace, labelSelector, fieldSelector string, limitChunks int64) *Selector {
+func NewSelector(client RESTClient, mapping *meta.RESTMapping, namespace, labelSelector, fieldSelector string, limitChunks int64, resourceVersion string) *Selector {
 	return &Selector{
-		Client:        client,
-		Mapping:       mapping,
-		Namespace:     namespace,
-		LabelSelector: labelSelector,
-		FieldSelector: fieldSelector,
-		LimitChunks:   limitChunks,
+		Client:          client,
+		Mapping:         mapping,
+		Namespace:       namespace,
+		LabelSelector:   labelSelector,
+		FieldSelector:   fieldSelector,
+		LimitChunks:     limitChunks,
+		ResourceVersion: resourceVersion,
 	}
 }
 
@@ -49,9 +51,10 @@ func NewSelector(client RESTClient, mapping *meta.RESTMapping, namespace, labelS
 func (r *Selector) Visit(fn VisitorFunc) error {
 	helper := NewHelper(r.Client, r.Mapping)
 	initialOpts := metav1.ListOptions{
-		LabelSelector: r.LabelSelector,
-		FieldSelector: r.FieldSelector,
-		Limit:         r.LimitChunks,
+		LabelSelector:   r.LabelSelector,
+		FieldSelector:   r.FieldSelector,
+		Limit:           r.LimitChunks,
+		ResourceVersion: r.ResourceVersion,
 	}
 	return FollowContinue(&initialOpts, func(options metav1.ListOptions) (runtime.Object, error) {
 		list, err := helper.List(

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
@@ -85,6 +85,9 @@ type Info struct {
 	// but if set it should be equal to or newer than the resource version of the
 	// object (however the server defines resource version).
 	ResourceVersion string
+	// Optional, should only be set when ResourceVersion is set.
+	// Specifies how the resourceVersion parameter is applied.
+	ResourceVersionMatch metav1.ResourceVersionMatch
 	// Optional, if specified, the object is the most recent value of the subresource
 	// returned by the server if available.
 	Subresource string
@@ -97,7 +100,7 @@ func (i *Info) Visit(fn VisitorFunc) error {
 
 // Get retrieves the object from the Namespace and Name fields
 func (i *Info) Get() (err error) {
-	obj, err := NewHelper(i.Client, i.Mapping).WithSubresource(i.Subresource).WithResourceVersion(i.ResourceVersion).Get(i.Namespace, i.Name)
+	obj, err := NewHelper(i.Client, i.Mapping).WithSubresource(i.Subresource).WithResourceVersion(i.ResourceVersion).WithResourceVersionMatch(i.ResourceVersionMatch).Get(i.Namespace, i.Name)
 	if err != nil {
 		if errors.IsNotFound(err) && len(i.Namespace) > 0 && i.Namespace != metav1.NamespaceDefault && i.Namespace != metav1.NamespaceAll {
 			err2 := i.Client.Get().AbsPath("api", "v1", "namespaces", i.Namespace).Do(context.TODO()).Error()

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
@@ -97,7 +97,7 @@ func (i *Info) Visit(fn VisitorFunc) error {
 
 // Get retrieves the object from the Namespace and Name fields
 func (i *Info) Get() (err error) {
-	obj, err := NewHelper(i.Client, i.Mapping).WithSubresource(i.Subresource).Get(i.Namespace, i.Name)
+	obj, err := NewHelper(i.Client, i.Mapping).WithSubresource(i.Subresource).WithResourceVersion(i.ResourceVersion).Get(i.Namespace, i.Name)
 	if err != nil {
 		if errors.IsNotFound(err) && len(i.Namespace) > 0 && i.Namespace != metav1.NamespaceDefault && i.Namespace != metav1.NamespaceAll {
 			err2 := i.Client.Get().AbsPath("api", "v1", "namespaces", i.Namespace).Do(context.TODO()).Error()

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -323,6 +323,13 @@ func (r *Request) ResourceVersion(resourceVersion string) *Request {
 	return r.setParam("resourceVersion", resourceVersion)
 }
 
+func (r *Request) ResourceVersionMatch(resourceVersionMatch metav1.ResourceVersionMatch) *Request {
+	if r.err != nil {
+		return r
+	}
+	return r.setParam("resourceVersion", string(resourceVersionMatch))
+}
+
 // AbsPath overwrites an existing path with the segments provided. Trailing slashes are preserved
 // when a single segment is passed.
 func (r *Request) AbsPath(segments ...string) *Request {

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -320,11 +320,7 @@ func (r *Request) ResourceVersion(resourceVersion string) *Request {
 	if r.err != nil {
 		return r
 	}
-	if r.params == nil {
-		r.params = make(url.Values)
-	}
-	r.params.Set("resourceVersion", resourceVersion)
-	return r
+	return r.setParam("resourceVersion", resourceVersion)
 }
 
 // AbsPath overwrites an existing path with the segments provided. Trailing slashes are preserved

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -315,6 +315,18 @@ func (r *Request) NamespaceIfScoped(namespace string, scoped bool) *Request {
 	return r
 }
 
+// ResourceVersion sets the requested version of the resource
+func (r *Request) ResourceVersion(resourceVersion string) *Request {
+	if r.err != nil {
+		return r
+	}
+	if r.params == nil {
+		r.params = make(url.Values)
+	}
+	r.params.Set("resourceVersion", resourceVersion)
+	return r
+}
+
 // AbsPath overwrites an existing path with the segments provided. Trailing slashes are preserved
 // when a single segment is passed.
 func (r *Request) AbsPath(segments ...string) *Request {

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -315,7 +315,7 @@ func (r *Request) NamespaceIfScoped(namespace string, scoped bool) *Request {
 	return r
 }
 
-// ResourceVersion sets the requested version of the resource
+// ResourceVersion sets the requested version of the resource as a request parameter
 func (r *Request) ResourceVersion(resourceVersion string) *Request {
 	if r.err != nil {
 		return r

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -62,10 +62,11 @@ type GetOptions struct {
 
 	resource.FilenameOptions
 
-	Raw       string
-	Watch     bool
-	WatchOnly bool
-	ChunkSize int64
+	Raw             string
+	Watch           bool
+	WatchOnly       bool
+	ChunkSize       int64
+	ResourceVersion string
 
 	OutputWatchEvents bool
 
@@ -182,6 +183,7 @@ func NewCmdGet(parent string, f cmdutil.Factory, streams genericiooptions.IOStre
 	cmd.Flags().BoolVar(&o.IgnoreNotFound, "ignore-not-found", o.IgnoreNotFound, "If the requested object does not exist the command will return exit code 0.")
 	cmd.Flags().StringVar(&o.FieldSelector, "field-selector", o.FieldSelector, "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
 	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", o.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+	cmd.Flags().StringVar(&o.ResourceVersion, "resource-version", o.ResourceVersion, "If present, get the exact resourceVersion of the specified resource")
 	addServerPrintColumnFlags(cmd, o)
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to get from a server.")
 	cmdutil.AddChunkSizeFlag(cmd, &o.ChunkSize)
@@ -462,6 +464,7 @@ func (o *GetOptions) Run(f cmdutil.Factory, args []string) error {
 		LabelSelectorParam(o.LabelSelector).
 		FieldSelectorParam(o.FieldSelector).
 		Subresource(o.Subresource).
+		ResourceVersion(o.ResourceVersion).
 		RequestChunksOf(chunkSize).
 		ResourceTypeOrNameArgs(true, args...).
 		ContinueOnError().

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -50,10 +50,9 @@ import (
 )
 
 const (
-	ApplyAnnotationsFlag        = "save-config"
-	DefaultErrorExitCode        = 1
-	DefaultChunkSize            = 500
-	DefaultResourceVersionMatch = metav1.ResourceVersionMatchNotOlderThan
+	ApplyAnnotationsFlag = "save-config"
+	DefaultErrorExitCode = 1
+	DefaultChunkSize     = 500
 )
 
 type debugError interface {
@@ -534,10 +533,6 @@ func AddSubresourceFlags(cmd *cobra.Command, subresource *string, usage string, 
 	CheckErr(cmd.RegisterFlagCompletionFunc("subresource", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return allowedSubresources, cobra.ShellCompDirectiveNoFileComp
 	}))
-}
-
-func AddResourceVersionMatchFlags(cmd *cobra.Command, resourceVersionMatch *string, usage string, allowedResourceVersionMatch ...string) {
-	cmd.Flags().StringVar(resourceVersionMatch, "resource-version-match", "", fmt.Sprintf("%s Must be one of %v. Defaults to %s.\nSee [https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list]", usage, allowedResourceVersionMatch, DefaultResourceVersionMatch))
 }
 
 type ValidateOptions struct {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -50,9 +50,10 @@ import (
 )
 
 const (
-	ApplyAnnotationsFlag = "save-config"
-	DefaultErrorExitCode = 1
-	DefaultChunkSize     = 500
+	ApplyAnnotationsFlag        = "save-config"
+	DefaultErrorExitCode        = 1
+	DefaultChunkSize            = 500
+	DefaultResourceVersionMatch = metav1.ResourceVersionMatchNotOlderThan
 )
 
 type debugError interface {
@@ -533,6 +534,10 @@ func AddSubresourceFlags(cmd *cobra.Command, subresource *string, usage string, 
 	CheckErr(cmd.RegisterFlagCompletionFunc("subresource", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return allowedSubresources, cobra.ShellCompDirectiveNoFileComp
 	}))
+}
+
+func AddResourceVersionMatchFlags(cmd *cobra.Command, resourceVersionMatch *string, usage string, allowedResourceVersionMatch ...string) {
+	cmd.Flags().StringVar(resourceVersionMatch, "resource-version-match", "", fmt.Sprintf("%s Must be one of %v. Defaults to %s.\nSee [https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list]", usage, allowedResourceVersionMatch, DefaultResourceVersionMatch))
 }
 
 type ValidateOptions struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Implements the `--resource-version` flag which allows setting the ResourceVersion parameter on GET and LIST requests with kubectl which will allow users to use the different [semantics for get and list](https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list) that rely on ResourceVersion.

As stated in the related issue:
> "Today, kubectl get only supports LISTing with ResourceVersion="" which on large clusters can be slow for users and impact the control plane and etcd in particular."

The ability to retrieve stale lists of objects allows kubectl users to see the state of past objects (as long as they haven't been compacted by etcd) which opens the possibility for reverting accidental patches or deletions.

The ability to get stale reads from the API is only available for LIST operations but would ideally also be implemented for GET operations in a following PR.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/965

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds the --resource-version flag:
If present, sets the ResourceVersion parameter in the request
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
kubectl get configmaps --resource-version=500 
kubectl get secrets mysecret --resource-version=60
```
