### PR TITLE
bump kube-dns to v1.22.23

### DIFF
--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -114,7 +114,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: kubedns
-        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.20
+        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.23
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -170,7 +170,7 @@ spec:
           runAsUser: 1001
           runAsGroup: 1001
       - name: dnsmasq
-        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.20
+        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.23
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -217,7 +217,7 @@ spec:
               - NET_BIND_SERVICE
               - SETGID
       - name: sidecar
-        image: registry.k8s.io/dns/k8s-dns-sidecar:1.22.20
+        image: registry.k8s.io/dns/k8s-dns-sidecar:1.22.23
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -114,7 +114,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: kubedns
-        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.20
+        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.23
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -170,7 +170,7 @@ spec:
           runAsUser: 1001
           runAsGroup: 1001
       - name: dnsmasq
-        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.20
+        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.23
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -217,7 +217,7 @@ spec:
               - NET_BIND_SERVICE
               - SETGID
       - name: sidecar
-        image: registry.k8s.io/dns/k8s-dns-sidecar:1.22.20
+        image: registry.k8s.io/dns/k8s-dns-sidecar:1.22.23
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -114,7 +114,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: kubedns
-        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.20
+        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.23
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -170,7 +170,7 @@ spec:
           runAsUser: 1001
           runAsGroup: 1001
       - name: dnsmasq
-        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.20
+        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.23
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -217,7 +217,7 @@ spec:
               - NET_BIND_SERVICE
               - SETGID
       - name: sidecar
-        image: registry.k8s.io/dns/k8s-dns-sidecar:1.22.20
+        image: registry.k8s.io/dns/k8s-dns-sidecar:1.22.23
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+++ b/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
@@ -138,7 +138,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.20
+        image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.23
         resources:
           requests:
             cpu: 25m


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
bump kube-dns to v1.22.23:

- Update distroless-iptables image https://github.com/kubernetes/dns/issues/590
- Update base images https://github.com/kubernetes/dns/pull/588

**Which issue(s) this PR fixes:**
Fixes #

**Special notes for your reviewer:**
Does this PR introduce a user-facing change?
```
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
```