### PR TITLE
cmd/kube-apiserver: move back master count variable from generic controlplane

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -58,6 +58,8 @@ type Extra struct {
 	ServiceNodePortRange utilnet.PortRange
 
 	EndpointReconcilerType string
+
+	MasterCount int
 }
 
 // NewServerRunOptions creates a new ServerRunOptions object with default parameters
@@ -86,6 +88,7 @@ func NewServerRunOptions() *ServerRunOptions {
 				HTTPTimeout: time.Duration(5) * time.Second,
 			},
 			ServiceNodePortRange: kubeoptions.DefaultServiceNodePortRange,
+			MasterCount:          1,
 		},
 	}
 
@@ -145,6 +148,10 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 
 	fs.StringVar(&s.KubeletConfig.TLSClientConfig.CAFile, "kubelet-certificate-authority", s.KubeletConfig.TLSClientConfig.CAFile,
 		"Path to a cert file for the certificate authority.")
+
+	fs.IntVar(&s.MasterCount, "apiserver-count", s.MasterCount,
+		"The number of apiservers running in the cluster, must be a positive number. (In use when --endpoint-reconciler-type=master-count is enabled.)")
+	fs.MarkDeprecated("apiserver-count", "apiserver-count is deprecated and will be removed in a future version.")
 
 	return fss
 }

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -127,7 +127,6 @@ func TestAddFlags(t *testing.T) {
 	// This is a snapshot of expected options parsed by args.
 	expected := &ServerRunOptions{
 		Options: &controlplaneapiserver.Options{
-			MasterCount: 5,
 			GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
 				AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
@@ -320,6 +319,7 @@ func TestAddFlags(t *testing.T) {
 					CAFile:   "/var/run/kubernetes/caserver.crt",
 				},
 			},
+			MasterCount: 5,
 		},
 		CloudProvider: &kubeoptions.CloudProviderOptions{
 			CloudConfigFile: "/cloud-config",

--- a/cmd/kube-apiserver/app/options/validation.go
+++ b/cmd/kube-apiserver/app/options/validation.go
@@ -110,5 +110,9 @@ func (s CompletedOptions) Validate() []error {
 	errs = append(errs, validateClusterIPFlags(s.Extra)...)
 	errs = append(errs, validateServiceNodePort(s.Extra)...)
 
+	if s.MasterCount <= 0 {
+		errs = append(errs, fmt.Errorf("--apiserver-count should be a positive number, but value '%d' provided", s.MasterCount))
+	}
+
 	return errs
 }

--- a/pkg/controlplane/apiserver/options/options.go
+++ b/pkg/controlplane/apiserver/options/options.go
@@ -66,8 +66,6 @@ type Options struct {
 	EnableAggregatorRouting             bool
 	AggregatorRejectForwardingRedirects bool
 
-	MasterCount int
-
 	ServiceAccountSigningKeyFile     string
 	ServiceAccountIssuer             serviceaccount.TokenGenerator
 	ServiceAccountTokenMaxExpiration time.Duration
@@ -104,7 +102,6 @@ func NewOptions() *Options {
 
 		EnableLogsHandler:                   true,
 		EventTTL:                            1 * time.Hour,
-		MasterCount:                         1,
 		AggregatorRejectForwardingRedirects: true,
 	}
 
@@ -143,10 +140,6 @@ func (s *Options) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.Int64Var(&s.MaxConnectionBytesPerSec, "max-connection-bytes-per-sec", s.MaxConnectionBytesPerSec, ""+
 		"If non-zero, throttle each user connection to this number of bytes/sec. "+
 		"Currently only applies to long-running requests.")
-
-	fs.IntVar(&s.MasterCount, "apiserver-count", s.MasterCount,
-		"The number of apiservers running in the cluster, must be a positive number. (In use when --endpoint-reconciler-type=master-count is enabled.)")
-	fs.MarkDeprecated("apiserver-count", "apiserver-count is deprecated and will be removed in a future version.")
 
 	fs.StringVar(&s.ProxyClientCertFile, "proxy-client-cert-file", s.ProxyClientCertFile, ""+
 		"Client certificate used to prove the identity of the aggregator or kube-apiserver "+

--- a/pkg/controlplane/apiserver/options/options_test.go
+++ b/pkg/controlplane/apiserver/options/options_test.go
@@ -54,7 +54,6 @@ func TestAddFlags(t *testing.T) {
 		"--admission-control-config-file=/admission-control-config",
 		"--advertise-address=192.168.10.10",
 		"--anonymous-auth=false",
-		"--apiserver-count=5",
 		"--audit-log-maxage=11",
 		"--audit-log-maxbackup=12",
 		"--audit-log-maxsize=13",
@@ -114,7 +113,6 @@ func TestAddFlags(t *testing.T) {
 
 	// This is a snapshot of expected options parsed by args.
 	expected := &Options{
-		MasterCount: 5,
 		GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
 			AdvertiseAddress:            netutils.ParseIPSloppy("192.168.10.10"),
 			CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},

--- a/pkg/controlplane/apiserver/options/validation.go
+++ b/pkg/controlplane/apiserver/options/validation.go
@@ -72,9 +72,7 @@ func validateAPIPriorityAndFairness(options *Options) []error {
 // Validate checks Options and return a slice of found errs.
 func (s *Options) Validate() []error {
 	var errs []error
-	if s.MasterCount <= 0 {
-		errs = append(errs, fmt.Errorf("--apiserver-count should be a positive number, but value '%d' provided", s.MasterCount))
-	}
+
 	errs = append(errs, s.Etcd.Validate()...)
 	errs = append(errs, validateAPIPriorityAndFairness(s)...)
 	errs = append(errs, s.SecureServing.Validate()...)

--- a/pkg/controlplane/apiserver/options/validation_test.go
+++ b/pkg/controlplane/apiserver/options/validation_test.go
@@ -90,7 +90,6 @@ func TestValidateOptions(t *testing.T) {
 			name:         "validate master count equal 0",
 			expectErrors: true,
 			options: &Options{
-				MasterCount:             0,
 				GenericServerRunOptions: &genericoptions.ServerRunOptions{},
 				Etcd:                    &genericoptions.EtcdOptions{},
 				SecureServing:           &genericoptions.SecureServingOptionsWithLoopback{},
@@ -117,7 +116,6 @@ func TestValidateOptions(t *testing.T) {
 			name:         "validate token request enable not attempted",
 			expectErrors: true,
 			options: &Options{
-				MasterCount:             1,
 				GenericServerRunOptions: &genericoptions.ServerRunOptions{},
 				Etcd:                    &genericoptions.EtcdOptions{},
 				SecureServing:           &genericoptions.SecureServingOptionsWithLoopback{},


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/118633 went too far for the master count. The master count is only used by kube-apiserver with serices and endpoints.

/kind cleanup

```release-note
NONE
```