### PR TITLE
test-e2e: Retrigger the RBD image post merge job

### DIFF
--- a/test/images/volume/rbd/README.md
+++ b/test/images/volume/rbd/README.md
@@ -1,6 +1,6 @@
 # rbd and ceph target container for testing.
 
-* The container needs to run with docker --privileged
+* The container needs to run with `docker --privileged` mode
 
 block.tar.gz is a small ext2 filesystem created by `create_block.sh` (run as root!)
 


### PR DESCRIPTION
The post merge job was failed @ https://github.com/kubernetes/kubernetes/pull/117103 and this causes the e2e tests to fail. This PR retrigger the same.


/kind bug

```release-note
NONE
```

