### PR TITLE
scheduler-perf: metrics for perfdash

### DIFF
--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -996,7 +996,10 @@ func runWorkload(ctx context.Context, tb testing.TB, tc *testCase, w *workload, 
 			if concreteOp.CollectMetrics {
 				collectorCtx, collectorCancel = context.WithCancel(ctx)
 				defer collectorCancel()
-				collectors = getTestDataCollectors(tb, podInformer, fmt.Sprintf("%s/%s", tb.Name(), namespace), namespace, tc.MetricsCollectorConfig, throughputErrorMargin)
+				name := tb.Name()
+				// The first part is the same for each work load, therefore we can strip it.
+				name = name[strings.Index(name, "/")+1:]
+				collectors = getTestDataCollectors(tb, podInformer, fmt.Sprintf("%s/%s", name, namespace), namespace, tc.MetricsCollectorConfig, throughputErrorMargin)
 				for _, collector := range collectors {
 					// Need loop-local variable for function below.
 					collector := collector


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

http://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfResults&Metric=scheduler_framework_extension_point_duration_seconds&Name=BenchmarkPerfScheduling%2FUnschedulable%2F5000Nodes%2F200InitPods%2Fnamespace-2&extension_point=Filter&result=unschedulable doesn't render the current JSON files because it cannot handle unset labels. Backfilling unset labels with "not applicable" should fix that.

While at it, the "Name" label values get shortened from "BenchmarkPerfScheduling/SchedulingBasic/5000Nodes/namespace-2" to "SchedulingBasic/5000Nodes/namespace-2".

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/issues/116204

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
