### PR TITLE
kubeadm: Support user-specified kubelet run directory

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/init/preflight.go
@@ -65,6 +65,14 @@ func runPreflight(c workflow.RunData) error {
 		return err
 	}
 
+	val, ok := data.Cfg().NodeRegistration.KubeletExtraArgs["root-dir"]
+	if ok && val != data.KubeletDir() {
+		fmt.Println("[preflight] KubeletRunDirectory is user-specified, checking files info")
+		if err := preflight.RunKubeletDirCheck(utilsexec.New(), data.KubeletDir(), val, data.IgnorePreflightErrors()); err != nil {
+			return err
+		}
+	}
+
 	if data.DryRun() {
 		fmt.Println("[preflight] Would pull the required images (like 'kubeadm config images pull')")
 		return nil

--- a/cmd/kubeadm/app/cmd/phases/join/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/join/preflight.go
@@ -95,6 +95,14 @@ func runPreflight(c workflow.RunData) error {
 		return err
 	}
 
+	val, ok := j.Cfg().NodeRegistration.KubeletExtraArgs["root-dir"]
+	if ok && val != j.KubeletDir() {
+		fmt.Println("[preflight] KubeletRunDirectory is user-specified, checking files info")
+		if err := preflight.RunKubeletDirCheck(utilsexec.New(), j.KubeletDir(), val, j.IgnorePreflightErrors()); err != nil {
+			return err
+		}
+	}
+
 	initCfg, err := j.InitCfg()
 	if err != nil {
 		return err

--- a/cmd/kubeadm/app/cmd/util/cmdutil.go
+++ b/cmd/kubeadm/app/cmd/util/cmdutil.go
@@ -141,3 +141,18 @@ func GetClientSet(file string, dryRun bool) (clientset.Interface, error) {
 	}
 	return kubeconfigutil.ClientSetFromFile(file)
 }
+
+// IsPathASymlinkPointingToDir returns true if path is a symlink and it's pointing to dir, false otherwise
+func IsPathASymlinkPointingToDir(path string, targetDir string) bool {
+	fileInfo, err := os.Lstat(path)
+	// return false if path isn't a symlink
+	if err != nil || fileInfo.Mode()&os.ModeSymlink == 0 {
+		return false
+	}
+
+	linkTarget, err := os.Readlink(path)
+	if err != nil {
+		return false
+	}
+	return linkTarget == targetDir
+}


### PR DESCRIPTION
Signed-off-by: Ruquan Zhao ruquan.zhao@arm.com

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add support for user-specified kubelet run directory.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubeadm/issues/2104

#### Special notes for your reviewer:
If user configured `--root-dir` in `nodeRegistration/kubeletExtraArgs`, kubeadm will:

1.  In preflight phases: check if `root-dir` and default-kubelet-run-directory(now it's `/var/lib/kubelet`) is usable.
2. In kubelet-start phases: create a symlink from default-kubelet-run-directory(now it's `/var/lib/kubelet`) to `root-dir`.

Support both init and join
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE( I am not sure)
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
