### PR TITLE
bump npd to v0.8.13

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -93,6 +93,8 @@ dependencies:
       match: const defaultImage
     - path: test/kubemark/resources/hollow-node_template.yaml
       match: registry.k8s.io/node-problem-detector/node-problem-detector
+    - path: cluster/addons/node-problem-detector/npd.yaml
+      match: registry.k8s.io/node-problem-detector/node-problem-detector
     # TODO(dims): Ensure newer versions get uploaded to
     # - https://console.cloud.google.com/storage/browser/gke-release/winnode/node-problem-detector
     # - https://gcsweb.k8s.io/gcs/kubernetes-release/node-problem-detector/

--- a/cluster/addons/node-problem-detector/npd.yaml
+++ b/cluster/addons/node-problem-detector/npd.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
       - name: node-problem-detector
-        image: registry.k8s.io/node-problem-detector/node-problem-detector:v0.8.9
+        image: registry.k8s.io/node-problem-detector/node-problem-detector:v0.8.13
         command:
         - "/bin/sh"
         - "-c"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
bump npd to v0.8.13:
https://github.com/kubernetes/node-problem-detector/releases/tag/v0.8.13