### PR TITLE
refactor: export `loadConfigFile` as a public function `LoadConfigFile`

### DIFF
--- a/cmd/kube-scheduler/app/options/configfile.go
+++ b/cmd/kube-scheduler/app/options/configfile.go
@@ -30,6 +30,7 @@ import (
 	configv1beta3 "k8s.io/kubernetes/pkg/scheduler/apis/config/v1beta3"
 )
 
+// LoadConfigFromFile loads scheduler config from the specified file path
 func LoadConfigFromFile(logger klog.Logger, file string) (*config.KubeSchedulerConfiguration, error) {
 	data, err := os.ReadFile(file)
 	if err != nil {

--- a/cmd/kube-scheduler/app/options/configfile.go
+++ b/cmd/kube-scheduler/app/options/configfile.go
@@ -30,16 +30,16 @@ import (
 	configv1beta3 "k8s.io/kubernetes/pkg/scheduler/apis/config/v1beta3"
 )
 
-func loadConfigFromFile(logger klog.Logger, file string) (*config.KubeSchedulerConfiguration, error) {
+func LoadConfigFromFile(logger klog.Logger, file string) (*config.KubeSchedulerConfiguration, error) {
 	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
 
-	return loadConfig(logger, data)
+	return LoadConfig(logger, data)
 }
 
-func loadConfig(logger klog.Logger, data []byte) (*config.KubeSchedulerConfiguration, error) {
+func LoadConfig(logger klog.Logger, data []byte) (*config.KubeSchedulerConfiguration, error) {
 	// The UniversalDecoder runs defaulting and returns the internal type by default.
 	obj, gvk, err := scheme.Codecs.UniversalDecoder().Decode(data, nil, nil)
 	if err != nil {

--- a/cmd/kube-scheduler/app/options/configfile.go
+++ b/cmd/kube-scheduler/app/options/configfile.go
@@ -36,10 +36,10 @@ func LoadConfigFromFile(logger klog.Logger, file string) (*config.KubeSchedulerC
 		return nil, err
 	}
 
-	return LoadConfig(logger, data)
+	return loadConfig(logger, data)
 }
 
-func LoadConfig(logger klog.Logger, data []byte) (*config.KubeSchedulerConfiguration, error) {
+func loadConfig(logger klog.Logger, data []byte) (*config.KubeSchedulerConfiguration, error) {
 	// The UniversalDecoder runs defaulting and returns the internal type by default.
 	obj, gvk, err := scheme.Codecs.UniversalDecoder().Decode(data, nil, nil)
 	if err != nil {

--- a/cmd/kube-scheduler/app/options/configfile_test.go
+++ b/cmd/kube-scheduler/app/options/configfile_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+)
+
+const (
+	apiVersionMissing = "'apiVersion' is missing"
+	apiVersionTooOld  = "no kind \"KubeSchedulerConfiguration\" is registered for" +
+		" version \"kubescheduler.config.k8s.io/v1alpha1\""
+	fileNotFound = "no such file or directory"
+
+	// schedulerConfigMinimalCorrect is the minimal
+	// correct scheduler config
+	schedulerConfigMinimalCorrect = `
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration`
+
+	// schedulerConfigDecodeErr is the scheduler config
+	// which throws decoding error when we try to load it
+	schedulerConfigDecodeErr = `
+kind: KubeSchedulerConfiguration`
+
+	// schedulerConfigVersionTooOld is the scheduler config
+	// which throws error because the config version 'v1alpha1'
+	// is too old
+	schedulerConfigVersionTooOld = `
+apiVersion: kubescheduler.config.k8s.io/v1alpha1
+kind: KubeSchedulerConfiguration
+`
+)
+
+func TestLoadConfigFromFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "scheduler-configs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	correctConfigFile := filepath.Join(tmpDir, "correct_config.yaml")
+	if err := os.WriteFile(correctConfigFile,
+		[]byte(schedulerConfigMinimalCorrect),
+		os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
+	decodeErrConfigFile := filepath.Join(tmpDir, "decode_err_no_version_config.yaml")
+	if err := os.WriteFile(decodeErrConfigFile,
+		[]byte(schedulerConfigDecodeErr),
+		os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
+	versionTooOldConfigFile := filepath.Join(tmpDir, "version_too_old_config.yaml")
+	if err := os.WriteFile(versionTooOldConfigFile,
+		[]byte(schedulerConfigVersionTooOld),
+		os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name           string
+		path           string
+		expectedErr    error
+		expectedConfig *config.KubeSchedulerConfiguration
+	}{
+		{
+			name:           "Empty scheduler config file path",
+			path:           "",
+			expectedErr:    fmt.Errorf(fileNotFound),
+			expectedConfig: nil,
+		},
+		{
+			name:           "Correct scheduler config",
+			path:           correctConfigFile,
+			expectedErr:    nil,
+			expectedConfig: &config.KubeSchedulerConfiguration{},
+		},
+		{
+			name:           "Scheduler config with decode error",
+			path:           decodeErrConfigFile,
+			expectedErr:    fmt.Errorf(apiVersionMissing),
+			expectedConfig: nil,
+		},
+		{
+			name:           "Scheduler config version too old",
+			path:           versionTooOldConfigFile,
+			expectedErr:    fmt.Errorf(apiVersionTooOld),
+			expectedConfig: nil,
+		},
+	}
+
+	logger := klog.FromContext(context.Background())
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("case_%d: %s", i, test.name), func(t *testing.T) {
+			cfg, err := LoadConfigFromFile(logger, test.path)
+			if test.expectedConfig == nil {
+				assert.Nil(t, cfg)
+			} else {
+				assert.NotNil(t, cfg)
+			}
+
+			if test.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, test.expectedErr.Error())
+			}
+		})
+
+	}
+}

--- a/cmd/kube-scheduler/app/options/configfile_test.go
+++ b/cmd/kube-scheduler/app/options/configfile_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -204,7 +204,7 @@ func (o *Options) ApplyTo(logger klog.Logger, c *schedulerappconfig.Config) erro
 		o.ApplyLeaderElectionTo(o.ComponentConfig)
 		c.ComponentConfig = *o.ComponentConfig
 	} else {
-		cfg, err := loadConfigFromFile(logger, o.ConfigFile)
+		cfg, err := LoadConfigFromFile(logger, o.ConfigFile)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- so that users who import kube-scheduler libraries can use these functions to read kube scheduler config

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature (marked it as a feature but I think this is more of a `refactor`)


#### What this PR does / why we need it:
Check the issue: #119056
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119056

#### Special notes for your reviewer:
NA
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
