### PR TITLE
dynamic resource allocation: Improve code coverage of state checkpoint

### DIFF
--- a/pkg/kubelet/cm/dra/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/dra/state/state_checkpoint.go
@@ -67,6 +67,10 @@ type stateCheckpoint struct {
 
 // NewCheckpointState creates new State for keeping track of claim info  with checkpoint backend
 func NewCheckpointState(stateDir, checkpointName string) (*stateCheckpoint, error) {
+	if len(checkpointName) == 0 {
+		return nil, fmt.Errorf("received empty string instead of checkpointName")
+	}
+
 	checkpointManager, err := checkpointmanager.NewCheckpointManager(stateDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize checkpoint manager: %v", err)

--- a/pkg/kubelet/cm/dra/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/dra/state/state_checkpoint_test.go
@@ -183,6 +183,11 @@ func TestCheckpointStateStore(t *testing.T) {
 
 	expectedCheckpoint := `{"version":"v1","entries":[{"DriverName":"test-driver.cdi.k8s.io","ClassName":"class-name","ClaimUID":"067798be-454e-4be4-9047-1aa06aea63f7","ClaimName":"example","Namespace":"default","PodUIDs":{"139cdb46-f989-4f17-9561-ca10cfb509a6":{}},"CDIDevices":{"test-driver.cdi.k8s.io":["example.com/example=cdi-example"]}}],"checksum":153446146}`
 
+	// Should return an error, stateDir cannot be an empty string
+	if _, err := NewCheckpointState("", testingCheckpoint); err == nil {
+		t.Fatal("expected error but got nil")
+	}
+
 	// create temp dir
 	testingDir, err := os.MkdirTemp("", "dramanager_state_test")
 	if err != nil {
@@ -203,4 +208,9 @@ func TestCheckpointStateStore(t *testing.T) {
 	checkpointData, err := checkpoint.MarshalCheckpoint()
 	assert.NoError(t, err, "could not Marshal Checkpoint")
 	assert.Equal(t, expectedCheckpoint, string(checkpointData), "expected ClaimInfoState does not equal to restored one")
+
+	// NewCheckpointState with an empty checkpointName should return an error
+	if _, err = NewCheckpointState(testingDir, ""); err == nil {
+		t.Fatal("expected error but got nil")
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If applied this commit will increase the code coverage of `pkg/kubelet/cm/dra/state/state_checkpoint.go`

- before changes

<img width="730" alt="Screenshot 2023-07-04 at 08 25 16" src="https://github.com/kubernetes/kubernetes/assets/9576370/504215e0-70ec-4d17-90c5-9ee8f5168dcb">

- after changes

<img width="726" alt="Screenshot 2023-07-04 at 08 24 51" src="https://github.com/kubernetes/kubernetes/assets/9576370/dd2632ef-11ac-44af-8d69-cd12111675d4">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
