### PR TITLE
kubeadm: fix "migrate config --allow-experimental-api" to print v1beta4 kubeadm configurations instead of v1beta3

### DIFF
--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -199,7 +199,7 @@ func getDefaultInitConfigBytes() ([]byte, error) {
 		return []byte{}, err
 	}
 
-	return configutil.MarshalKubeadmConfigObject(internalcfg)
+	return configutil.MarshalKubeadmConfigObject(internalcfg, kubeadmapiv1.SchemeGroupVersion)
 }
 
 func getDefaultNodeConfigBytes() ([]byte, error) {
@@ -219,7 +219,7 @@ func getDefaultNodeConfigBytes() ([]byte, error) {
 		return []byte{}, err
 	}
 
-	return configutil.MarshalKubeadmConfigObject(internalcfg)
+	return configutil.MarshalKubeadmConfigObject(internalcfg, kubeadmapiv1.SchemeGroupVersion)
 }
 
 // newCmdConfigMigrate returns cobra.Command for "kubeadm config migrate" command

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/klog/v2"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
@@ -223,7 +224,7 @@ func printConfiguration(clustercfg *kubeadmapi.ClusterConfiguration, w io.Writer
 		return
 	}
 
-	cfgYaml, err := configutil.MarshalKubeadmConfigObject(clustercfg)
+	cfgYaml, err := configutil.MarshalKubeadmConfigObject(clustercfg, kubeadmapiv1.SchemeGroupVersion)
 	if err == nil {
 		printer.Fprintln(w, "[upgrade/config] Configuration used:")
 

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
@@ -25,6 +25,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
@@ -53,7 +54,7 @@ func UploadConfiguration(cfg *kubeadmapi.InitConfiguration, client clientset.Int
 	}
 
 	// Marshal the ClusterConfiguration into YAML
-	clusterConfigurationYaml, err := configutil.MarshalKubeadmConfigObject(clusterConfigurationToUpload)
+	clusterConfigurationYaml, err := configutil.MarshalKubeadmConfigObject(clusterConfigurationToUpload, kubeadmapiv1.SchemeGroupVersion)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
xref #118866

#### Special notes for your reviewer:
With  #118866, the migrate print old kubeadm version. With `--allow-experimental-api`, I think we should print v1beta4 instead.
```
[root@daocloud ~]# ./kubeadm config   migrate --allow-experimental-api --old-config v1beta3.yaml
apiVersion: kubeadm.k8s.io/v1beta3
bootstrapTokens:
- groups:
  - system:bootstrappers:kubeadm:default-node-token
  token: heb765.i3xq246pv7fwvhc0
  ttl: 24h0m0s
  usages:
  - signing
  - authentication
kind: InitConfiguration
localAPIEndpoint:
  advertiseAddress: 10.6.177.40
  bindPort: 6443
nodeRegistration:
  criSocket: unix:///var/run/containerd/containerd.sock
  imagePullPolicy: IfNotPresent
  name: daocloud
  taints:
  - effect: NoSchedule
    key: node-role.kubernetes.io/control-plane
...
```

#### Does this PR introduce a user-facing change?
```release-note
None
```
