### PR TITLE
add UT for cluster/images/etcd/migrate/copy_file.go

### DIFF
--- a/cluster/images/etcd/migrate/copy_file_test.go
+++ b/cluster/images/etcd/migrate/copy_file_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+
+	"testing"
+)
+
+func TestCopyFile(t *testing.T) {
+
+	// create testing file
+
+	_, err := os.Create("test1.txt")
+	if err != nil {
+		t.Errorf("got error: %v", err)
+	}
+	defer os.Remove("test1.txt")
+
+	// call copyFile function
+	err = copyFile("test1.txt", "test2.txt")
+	if err != nil {
+		t.Errorf("got error: %v", err)
+	}
+
+	// verify copy file completed
+	if _, err := os.Stat("test2.txt"); os.IsNotExist(err) {
+		t.Errorf("file test2.txt does not exist")
+	}
+
+	// verify copy file content is same
+	content1, _ := ioutil.ReadFile("test1.txt")
+	content2, _ := ioutil.ReadFile("test2.txt")
+	if !bytes.Equal(content1, content2) {
+		t.Errorf("file content is not the same")
+	}
+
+	// clean up testing file
+	os.Remove("test2.txt")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

add UT for cluster/images/etcd/migrate/copy_file.go

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
None
