### PR TITLE
kube-apiserver/corerest: normalize service IP range plumbing

### DIFF
--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -575,19 +575,21 @@ func labelAPIServerHeartbeatFunc(identity string) lease.ProcessLeaseFunc {
 // InstallLegacyAPI will install the legacy APIs for the restStorageProviders if they are enabled.
 func (m *Instance) InstallLegacyAPI(c *completedConfig, restOptionsGetter generic.RESTOptionsGetter) error {
 	legacyRESTStorageProvider := corerest.LegacyRESTStorageProvider{
-		StorageFactory:              c.ExtraConfig.StorageFactory,
-		ProxyTransport:              c.ExtraConfig.ProxyTransport,
-		KubeletClientConfig:         c.ExtraConfig.KubeletClientConfig,
-		EventTTL:                    c.ExtraConfig.EventTTL,
-		ServiceIPRange:              c.ExtraConfig.ServiceIPRange,
-		SecondaryServiceIPRange:     c.ExtraConfig.SecondaryServiceIPRange,
-		ServiceNodePortRange:        c.ExtraConfig.ServiceNodePortRange,
-		LoopbackClientConfig:        c.GenericConfig.LoopbackClientConfig,
-		ServiceAccountIssuer:        c.ExtraConfig.ServiceAccountIssuer,
-		ExtendExpiration:            c.ExtraConfig.ExtendExpiration,
-		ServiceAccountMaxExpiration: c.ExtraConfig.ServiceAccountMaxExpiration,
-		APIAudiences:                c.GenericConfig.Authentication.APIAudiences,
-		Informers:                   c.ExtraConfig.VersionedInformers,
+		GenericLegacyRESTStorageProvider: corerest.GenericLegacyRESTStorageProvider{
+			StorageFactory:              c.ExtraConfig.StorageFactory,
+			EventTTL:                    c.ExtraConfig.EventTTL,
+			LoopbackClientConfig:        c.GenericConfig.LoopbackClientConfig,
+			ServiceAccountIssuer:        c.ExtraConfig.ServiceAccountIssuer,
+			ExtendExpiration:            c.ExtraConfig.ExtendExpiration,
+			ServiceAccountMaxExpiration: c.ExtraConfig.ServiceAccountMaxExpiration,
+			APIAudiences:                c.GenericConfig.Authentication.APIAudiences,
+			Informers:                   c.ExtraConfig.VersionedInformers,
+		},
+		ProxyTransport:          c.ExtraConfig.ProxyTransport,
+		KubeletClientConfig:     c.ExtraConfig.KubeletClientConfig,
+		ServiceIPRange:          c.ExtraConfig.ServiceIPRange,
+		SecondaryServiceIPRange: c.ExtraConfig.SecondaryServiceIPRange,
+		ServiceNodePortRange:    c.ExtraConfig.ServiceNodePortRange,
 	}
 	legacyRESTStorage, apiGroupInfo, err := legacyRESTStorageProvider.NewLegacyRESTStorage(c.ExtraConfig.APIResourceConfigSource, restOptionsGetter)
 	if err != nil {

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -591,7 +591,7 @@ func (m *Instance) InstallLegacyAPI(c *completedConfig, restOptionsGetter generi
 		SecondaryServiceIPRange: c.ExtraConfig.SecondaryServiceIPRange,
 		ServiceNodePortRange:    c.ExtraConfig.ServiceNodePortRange,
 	}
-	legacyRESTStorage, apiGroupInfo, err := legacyRESTStorageProvider.NewLegacyRESTStorage(c.ExtraConfig.APIResourceConfigSource, restOptionsGetter)
+	rangeRegistries, apiGroupInfo, err := legacyRESTStorageProvider.NewLegacyRESTStorage(c.ExtraConfig.APIResourceConfigSource, restOptionsGetter)
 	if err != nil {
 		return fmt.Errorf("error building core storage: %v", err)
 	}
@@ -612,7 +612,7 @@ func (m *Instance) InstallLegacyAPI(c *completedConfig, restOptionsGetter generi
 	if err != nil {
 		return err
 	}
-	bootstrapController, err := kubernetesservice.New(*kubenetesserviceConfig, legacyRESTStorage)
+	bootstrapController, err := kubernetesservice.New(*kubenetesserviceConfig, rangeRegistries)
 	if err != nil {
 		return fmt.Errorf("error creating bootstrap controller: %v", err)
 	}

--- a/pkg/controlplane/instance_test.go
+++ b/pkg/controlplane/instance_test.go
@@ -153,14 +153,16 @@ func TestLegacyRestStorageStrategies(t *testing.T) {
 	defer etcdserver.Terminate(t)
 
 	storageProvider := corerest.LegacyRESTStorageProvider{
-		StorageFactory:       apiserverCfg.ExtraConfig.StorageFactory,
+		GenericLegacyRESTStorageProvider: corerest.GenericLegacyRESTStorageProvider{
+			StorageFactory:       apiserverCfg.ExtraConfig.StorageFactory,
+			EventTTL:             apiserverCfg.ExtraConfig.EventTTL,
+			LoopbackClientConfig: apiserverCfg.GenericConfig.LoopbackClientConfig,
+			Informers:            apiserverCfg.ExtraConfig.VersionedInformers,
+		},
 		ProxyTransport:       apiserverCfg.ExtraConfig.ProxyTransport,
 		KubeletClientConfig:  apiserverCfg.ExtraConfig.KubeletClientConfig,
-		EventTTL:             apiserverCfg.ExtraConfig.EventTTL,
 		ServiceIPRange:       apiserverCfg.ExtraConfig.ServiceIPRange,
 		ServiceNodePortRange: apiserverCfg.ExtraConfig.ServiceNodePortRange,
-		LoopbackClientConfig: apiserverCfg.GenericConfig.LoopbackClientConfig,
-		Informers:            apiserverCfg.ExtraConfig.VersionedInformers,
 	}
 
 	_, apiGroupInfo, err := storageProvider.NewLegacyRESTStorage(serverstorage.NewResourceConfig(), apiserverCfg.GenericConfig.RESTOptionsGetter)


### PR DESCRIPTION
The service IP range logic in the core REST storage provider is pretty complicated. This PR cleans up that code area by trying to move that complexity into a central function, not leaking into the main storage setup code.

This is pretty much just a code move.

Extracted from https://github.com/kubernetes/kubernetes/pull/119042. The split into generic-vs-non-generic is towards https://github.com/kubernetes/enhancements/pull/4052.

/kind cleanup

```release-note
NONE
```