### PR TITLE
Add probe triggered log and shift the periodics timer after manual run

### DIFF
--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -178,7 +178,10 @@ probeLoop:
 		case <-w.stopCh:
 			break probeLoop
 		case <-probeTicker.C:
+			klog.V(3).InfoS("Triggerd Probe by periodSeconds", "probeType", w.probeType, "pod", klog.KObj(w.pod), "podUID", w.pod.UID, "containerName", w.container.Name)
+			// continue
 		case <-w.manualTriggerCh:
+			klog.V(3).InfoS("Triggerd Probe by manual run", "probeType", w.probeType, "pod", klog.KObj(w.pod), "podUID", w.pod.UID, "containerName", w.container.Name)
 			// continue
 		}
 	}

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -178,7 +178,6 @@ probeLoop:
 		case <-w.stopCh:
 			break probeLoop
 		case <-probeTicker.C:
-			klog.V(4).InfoS("Triggerd Probe by periodSeconds", "probeType", w.probeType, "pod", klog.KObj(w.pod), "podUID", w.pod.UID, "containerName", w.container.Name)
 			// continue
 		case <-w.manualTriggerCh:
 			// Updating the periodic timer to run the probe again at intervals of probeTickerPeriod

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -178,10 +178,13 @@ probeLoop:
 		case <-w.stopCh:
 			break probeLoop
 		case <-probeTicker.C:
-			klog.V(3).InfoS("Triggerd Probe by periodSeconds", "probeType", w.probeType, "pod", klog.KObj(w.pod), "podUID", w.pod.UID, "containerName", w.container.Name)
+			klog.V(4).InfoS("Triggerd Probe by periodSeconds", "probeType", w.probeType, "pod", klog.KObj(w.pod), "podUID", w.pod.UID, "containerName", w.container.Name)
 			// continue
 		case <-w.manualTriggerCh:
-			klog.V(3).InfoS("Triggerd Probe by manual run", "probeType", w.probeType, "pod", klog.KObj(w.pod), "podUID", w.pod.UID, "containerName", w.container.Name)
+			// Updating the periodic timer to run the probe again at intervals of probeTickerPeriod
+			// starting from the moment a manual run occurs.
+			probeTicker.Reset(probeTickerPeriod)
+			klog.V(4).InfoS("Triggerd Probe by manual run", "probeType", w.probeType, "pod", klog.KObj(w.pod), "podUID", w.pod.UID, "containerName", w.container.Name)
 			// continue
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Output a log when probe is triggered.
Especially `readinessProbe`, it will be executed by two triggers:

- Constant interval(depends on `periodSeconds` which is `readinessProbe`'s field)
- Manual run(it's implemented #98376)

However, there are no means to know which executed `readinessProbe`, and it may make confusion like #118815.
In addition, shift the periodic timer of `ReadinessProbe` after manual run.

#### Which issue(s) this PR fixes:

Fixes #118815

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Output a log as v4-level when probe is triggered and shift the periodic timer of ReadinessProbe after manual run.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
