### PR TITLE
Automated cherry pick of #114605: check umount result

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -331,19 +331,7 @@ func (mounter *Mounter) Unmount(target string) error {
 	command := exec.Command("umount", target)
 	output, err := command.CombinedOutput()
 	if err != nil {
-		if err.Error() == errNoChildProcesses {
-			if command.ProcessState.Success() {
-				// We don't consider errNoChildProcesses an error if the process itself succeeded (see - k/k issue #103753).
-				return nil
-			}
-			// Rewrite err with the actual exit error of the process.
-			err = &exec.ExitError{ProcessState: command.ProcessState}
-		}
-		if mounter.withSafeNotMountedBehavior && strings.Contains(string(output), errNotMounted) {
-			klog.V(4).Infof("ignoring 'not mounted' error for %s", target)
-			return nil
-		}
-		return fmt.Errorf("unmount failed: %v\nUnmounting arguments: %s\nOutput: %s", err, target, string(output))
+		return checkUmountError(target, command, output, err, mounter.withSafeNotMountedBehavior)
 	}
 	return nil
 }
@@ -351,11 +339,15 @@ func (mounter *Mounter) Unmount(target string) error {
 // UnmountWithForce unmounts given target but will retry unmounting with force option
 // after given timeout.
 func (mounter *Mounter) UnmountWithForce(target string, umountTimeout time.Duration) error {
+<<<<<<< HEAD
 	err := tryUnmount(target, umountTimeout)
+=======
+	err := tryUnmount(target, mounter.withSafeNotMountedBehavior, umountTimeout)
+>>>>>>> check umount result
 	if err != nil {
 		if err == context.DeadlineExceeded {
 			klog.V(2).Infof("Timed out waiting for unmount of %s, trying with -f", target)
-			err = forceUmount(target)
+			err = forceUmount(target, mounter.withSafeNotMountedBehavior)
 		}
 		return err
 	}
@@ -683,13 +675,18 @@ func SearchMountPoints(hostSource, mountInfoPath string) ([]string, error) {
 }
 
 // tryUnmount calls plain "umount" and waits for unmountTimeout for it to finish.
+<<<<<<< HEAD
 func tryUnmount(path string, unmountTimeout time.Duration) error {
 	klog.V(4).Infof("Unmounting %s", path)
+=======
+func tryUnmount(target string, withSafeNotMountedBehavior bool, unmountTimeout time.Duration) error {
+	klog.V(4).Infof("Unmounting %s", target)
+>>>>>>> check umount result
 	ctx, cancel := context.WithTimeout(context.Background(), unmountTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "umount", path)
-	out, cmderr := cmd.CombinedOutput()
+	command := exec.CommandContext(ctx, "umount", target)
+	output, err := command.CombinedOutput()
 
 	// CombinedOutput() does not return DeadlineExceeded, make sure it's
 	// propagated on timeout.
@@ -697,18 +694,40 @@ func tryUnmount(path string, unmountTimeout time.Duration) error {
 		return ctx.Err()
 	}
 
+<<<<<<< HEAD
 	if cmderr != nil {
 		return fmt.Errorf("unmount failed: %v\nUnmounting arguments: %s\nOutput: %s", cmderr, path, string(out))
+=======
+	if err != nil {
+		return checkUmountError(target, command, output, err, withSafeNotMountedBehavior)
+>>>>>>> check umount result
 	}
 	return nil
 }
 
-func forceUmount(path string) error {
-	cmd := exec.Command("umount", "-f", path)
-	out, cmderr := cmd.CombinedOutput()
+func forceUmount(target string, withSafeNotMountedBehavior bool) error {
+	command := exec.Command("umount", "-f", target)
+	output, err := command.CombinedOutput()
 
-	if cmderr != nil {
-		return fmt.Errorf("unmount failed: %v\nUnmounting arguments: %s\nOutput: %s", cmderr, path, string(out))
+	if err != nil {
+		return checkUmountError(target, command, output, err, withSafeNotMountedBehavior)
 	}
 	return nil
+}
+
+// checkUmountError checks a result of umount command and determine a return value.
+func checkUmountError(target string, command *exec.Cmd, output []byte, err error, withSafeNotMountedBehavior bool) error {
+	if err.Error() == errNoChildProcesses {
+		if command.ProcessState.Success() {
+			// We don't consider errNoChildProcesses an error if the process itself succeeded (see - k/k issue #103753).
+			return nil
+		}
+		// Rewrite err with the actual exit error of the process.
+		err = &exec.ExitError{ProcessState: command.ProcessState}
+	}
+	if withSafeNotMountedBehavior && strings.Contains(string(output), errNotMounted) {
+		klog.V(4).Infof("ignoring 'not mounted' error for %s", target)
+		return nil
+	}
+	return fmt.Errorf("unmount failed: %v\nUnmounting arguments: %s\nOutput: %s", err, target, string(output))
 }

--- a/staging/src/k8s.io/mount-utils/mount_linux_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux_test.go
@@ -26,6 +26,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	utilexec "k8s.io/utils/exec"
 	testexec "k8s.io/utils/exec/testing"
@@ -610,5 +611,30 @@ func makeFakeCommandAction(stdout string, err error) testexec.FakeCommandAction 
 	}
 	return func(cmd string, args ...string) utilexec.Cmd {
 		return testexec.InitFakeCmd(&c, cmd, args...)
+	}
+}
+
+func TestNotMountedBehaviorOfUnmount(t *testing.T) {
+	target, err := ioutil.TempDir("", "kubelet-umount")
+	if err != nil {
+		t.Errorf("Cannot create temp dir: %v", err)
+	}
+
+	defer os.RemoveAll(target)
+
+	m := Mounter{withSafeNotMountedBehavior: true}
+	if err = m.Unmount(target); err != nil {
+		t.Errorf(`Expect complete Unmount(), but it dose not: %v`, err)
+	}
+
+	if err = tryUnmount(target, m.withSafeNotMountedBehavior, time.Minute); err != nil {
+		t.Errorf(`Expect complete tryUnmount(), but it does not: %v`, err)
+	}
+
+	// forceUmount exec "umount -f", so skip this case if user is not root.
+	if os.Getuid() == 0 {
+		if err = forceUmount(target, m.withSafeNotMountedBehavior); err != nil {
+			t.Errorf(`Expect complete forceUnmount(), but it does not: %v`, err)
+		}
 	}
 }


### PR DESCRIPTION
Cherry pick of #114605 on release-1.24.

#114605: check umount result

This is required to Fix the problem Pod terminating stuck because of trying to umount not actual mounted dir.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```
release-note :

Cherry pick of #114605 - Fix: Pod terminating stuck because of trying to umount not actual mounted dir 

```