### PR TITLE
Update debian-base to bookworm

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -142,7 +142,7 @@ dependencies:
 
   # Base images
   - name: "registry.k8s.io/debian-base: dependents"
-    version: bullseye-v1.4.2
+    version: bookworm-v1.0.0
     refPaths:
     - path: cluster/images/etcd/Makefile
       match: BASEIMAGE\?\=registry\.k8s\.io\/build-image\/debian-base:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -92,19 +92,19 @@ DOCKERFILE.windows = Dockerfile.windows
 DOCKERFILE := ${DOCKERFILE.${OS}}
 
 ifeq ($(ARCH),amd64)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base:bullseye-v1.4.2
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base:bookworm-v1.0.0
 endif
 ifeq ($(ARCH),arm)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm:bullseye-v1.4.2
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.0
 endif
 ifeq ($(ARCH),arm64)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm64:bullseye-v1.4.2
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.0
 endif
 ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-ppc64le:bullseye-v1.4.2
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.0
 endif
 ifeq ($(ARCH),s390x)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-s390x:bullseye-v1.4.2
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.0
 endif
 
 BASE.windows = mcr.microsoft.com/windows/nanoserver

--- a/test/conformance/image/Dockerfile
+++ b/test/conformance/image/Dockerfile
@@ -21,6 +21,9 @@ FROM ${RUNNERIMAGE}
 
 # This is a dependency for `kubectl diff` tests
 COPY --from=debbase /usr/bin/diff /usr/local/bin/
+COPY --from=debbase /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu
+COPY --from=debbase /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu
+COPY --from=debbase /lib64/ld-linux-x86-64.so.2 /lib64
 
 COPY cluster /kubernetes/cluster
 COPY ginkgo /usr/local/bin/

--- a/test/conformance/image/Makefile
+++ b/test/conformance/image/Makefile
@@ -33,7 +33,7 @@ CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
 # This is defined in root Makefile, but some build contexts do not refer to them
 KUBE_BASE_IMAGE_REGISTRY?=registry.k8s.io
-BASE_IMAGE_VERSION?=bullseye-v1.4.2
+BASE_IMAGE_VERSION?=bookworm-v1.0.0
 BASEIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base-${ARCH}:${BASE_IMAGE_VERSION}
 
 # Keep debian releases (e.g. debian 11 == bullseye) consistent 


### PR DESCRIPTION



#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Rolling out the latest bookworm base image.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Refers to https://github.com/kubernetes/release/issues/3128
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Updated debian-base image to bookworm-v1.0.0.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
