### PR TITLE
e2e: detect unexpected command line arguments

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -92,6 +92,11 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	}
 
+	if flag.CommandLine.NArg() > 0 {
+		fmt.Fprintf(os.Stderr, "unknown additional command line arguments: %s", flag.CommandLine.Args())
+		os.Exit(1)
+	}
+
 	// Enable embedded FS file lookup as fallback
 	testfiles.AddFileSource(e2etestingmanifests.GetE2ETestingManifestsFS())
 	testfiles.AddFileSource(testfixtures.GetTestFixturesFS())

--- a/test/e2e_kubeadm/e2e_kubeadm_suite_test.go
+++ b/test/e2e_kubeadm/e2e_kubeadm_suite_test.go
@@ -18,6 +18,7 @@ package kubeadm
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"testing"
 
@@ -42,6 +43,10 @@ func TestMain(m *testing.M) {
 	framework.RegisterClusterFlags(flag.CommandLine)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
+	if pflag.CommandLine.NArg() > 0 {
+		fmt.Fprintf(os.Stderr, "unknown additional command line arguments: %s", pflag.CommandLine.Args())
+		os.Exit(1)
+	}
 	framework.AfterReadingAllFlags(&framework.TestContext)
 	os.Exit(m.Run())
 }

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -130,6 +130,10 @@ func TestMain(m *testing.M) {
 
 	rand.Seed(time.Now().UnixNano())
 	pflag.Parse()
+	if pflag.CommandLine.NArg() > 0 {
+		fmt.Fprintf(os.Stderr, "unknown additional command line arguments: %s", pflag.CommandLine.Args())
+		os.Exit(1)
+	}
 	framework.AfterReadingAllFlags(&framework.TestContext)
 	if err := e2eskipper.InitFeatureGates(utilfeature.DefaultFeatureGate, featureGates); err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: initialize feature gates: %v", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Invalid flags are detected by flag parsing, but optional arguments are just passed through to the E2E suites. None of them support any, so rejecting them with an error message is useful because it helps catch typos (like a missing hyphen before a flag).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @aojea 