### PR TITLE
Stop using deprecated API

### DIFF
--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -271,7 +271,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 			}
 
 			// remove RuntimeClass
-			_ = cs.NodeV1beta1().RuntimeClasses().Delete(ctx, e2eruntimeclass.PreconfiguredRuntimeClassHandler, metav1.DeleteOptions{})
+			_ = cs.NodeV1().RuntimeClasses().Delete(ctx, e2eruntimeclass.PreconfiguredRuntimeClassHandler, metav1.DeleteOptions{})
 		})
 
 		ginkgo.It("verify pod overhead is accounted for", func(ctx context.Context) {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig scheduling
/sig testing

#### What this PR does / why we need it:
v1beta1.RuntimeClass has been [deprecated in v1.22](https://github.com/kubernetes/kubernetes/blob/51429cb5afad998cae107e1917b88539fa95bdb8/staging/src/k8s.io/api/node/v1beta1/types.go#L28) so we should not be using that code anywhere. 

#### Which issue(s) this PR fixes:
None.

#### Special notes for your reviewer:
/assign @alculquicondor 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```