### PR TITLE
ValidatingAdmissionPolicy - Type Checking for API Expensions types

### DIFF
--- a/pkg/controller/validatingadmissionpolicystatus/controller_test.go
+++ b/pkg/controller/validatingadmissionpolicystatus/controller_test.go
@@ -103,7 +103,7 @@ func TestTypeChecking(t *testing.T) {
 			client := fake.NewSimpleClientset(policy)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			typeChecker := &validatingadmissionpolicy.TypeChecker{
-				SchemaResolver: resolver.NewDefinitionsSchemaResolver(scheme.Scheme, openapi.GetOpenAPIDefinitions),
+				SchemaResolver: resolver.NewDefinitionsSchemaResolver(openapi.GetOpenAPIDefinitions, scheme.Scheme),
 				RestMapper:     testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme),
 			}
 			controller, err := NewController(

--- a/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/combined.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/combined.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// Combine combines the DefinitionsSchemaResolver with a secondary schema resolver.
+// The resulting schema resolver uses the DefinitionsSchemaResolver for a GVK that DefinitionsSchemaResolver knows,
+// and the secondary otherwise.
+func (d *DefinitionsSchemaResolver) Combine(secondary SchemaResolver) SchemaResolver {
+	return &combinedSchemaResolver{definitions: d, secondary: secondary}
+}
+
+type combinedSchemaResolver struct {
+	definitions *DefinitionsSchemaResolver
+	secondary   SchemaResolver
+}
+
+// ResolveSchema takes a GroupVersionKind (GVK) and returns the OpenAPI schema
+// identified by the GVK.
+// If the DefinitionsSchemaResolver knows the gvk, the DefinitionsSchemaResolver handles the resolution,
+// otherwise, the secondary does.
+func (r *combinedSchemaResolver) ResolveSchema(gvk schema.GroupVersionKind) (*spec.Schema, error) {
+	if _, ok := r.definitions.gvkToSchema[gvk]; ok {
+		return r.definitions.ResolveSchema(gvk)
+	}
+	return r.secondary.ResolveSchema(gvk)
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/definitions.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/definitions.go
@@ -35,11 +35,11 @@ type DefinitionsSchemaResolver struct {
 
 // NewDefinitionsSchemaResolver creates a new DefinitionsSchemaResolver.
 // An example working setup:
-// scheme         = "k8s.io/client-go/kubernetes/scheme".Scheme
 // getDefinitions = "k8s.io/kubernetes/pkg/generated/openapi".GetOpenAPIDefinitions
-func NewDefinitionsSchemaResolver(scheme *runtime.Scheme, getDefinitions common.GetOpenAPIDefinitions) *DefinitionsSchemaResolver {
+// scheme         = "k8s.io/client-go/kubernetes/scheme".Scheme
+func NewDefinitionsSchemaResolver(getDefinitions common.GetOpenAPIDefinitions, schemes ...*runtime.Scheme) *DefinitionsSchemaResolver {
 	gvkToSchema := make(map[schema.GroupVersionKind]*spec.Schema)
-	namer := openapi.NewDefinitionNamer(scheme)
+	namer := openapi.NewDefinitionNamer(schemes...)
 	defs := getDefinitions(func(path string) spec.Ref {
 		return spec.MustCreateRef(path)
 	})

--- a/test/e2e/apimachinery/validatingadmissionpolicy.go
+++ b/test/e2e/apimachinery/validatingadmissionpolicy.go
@@ -28,11 +28,15 @@ import (
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/features"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/openapi3"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 )
@@ -42,6 +46,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", frame
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 
 	var client clientset.Interface
+	var extensionsClient apiextensionsclientset.Interface
 
 	ginkgo.BeforeEach(func() {
 		var err error
@@ -52,6 +57,8 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", frame
 			// TODO: feature check should fail after GA graduation
 			ginkgo.Skip(fmt.Sprintf("server does not support ValidatingAdmissionPolicy v1beta1: %v, feature gate not enabled?", err))
 		}
+		extensionsClient, err = apiextensionsclientset.NewForConfig(f.ClientConfig())
+		framework.ExpectNoError(err, "initializing api-extensions client")
 	})
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
@@ -256,6 +263,98 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", frame
 			framework.ExpectNoError(err, "create non-replicated ReplicaSet")
 		})
 	})
+
+	ginkgo.It("should type check a CRD", func(ctx context.Context) {
+		crd := crontabExampleCRD()
+		crd.Spec.Group = "stable." + f.UniqueName
+		crd.Name = crd.Spec.Names.Plural + "." + crd.Spec.Group
+		var policy *admissionregistrationv1beta1.ValidatingAdmissionPolicy
+		ginkgo.By("creating the CRD", func() {
+			var err error
+			crd, err = extensionsClient.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, crd, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "create CRD")
+			err = wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (done bool, err error) {
+				// wait for the CRD to be published.
+				root := openapi3.NewRoot(client.Discovery().OpenAPIV3())
+				_, err = root.GVSpec(schema.GroupVersion{Group: crd.Spec.Group, Version: "v1"})
+				return err == nil, nil
+			})
+			framework.ExpectNoError(err, "wait for CRD.")
+			ginkgo.DeferCleanup(func(ctx context.Context, name string) error {
+				return extensionsClient.ApiextensionsV1().CustomResourceDefinitions().Delete(ctx, name, metav1.DeleteOptions{})
+			}, crd.Name)
+		})
+		ginkgo.By("creating a vaild policy for crontabs", func() {
+			policy = newValidatingAdmissionPolicyBuilder(f.UniqueName+".correct-crd-policy.example.com").
+				MatchUniqueNamespace(f.UniqueName).
+				StartResourceRule().
+				MatchResource([]string{crd.Spec.Group}, []string{"v1"}, []string{"crontabs"}).
+				EndResourceRule().
+				WithValidation(admissionregistrationv1beta1.Validation{
+					Expression: "object.spec.replicas > 1",
+				}).
+				Build()
+			policy, err := client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().Create(ctx, policy, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "create policy")
+			ginkgo.DeferCleanup(func(ctx context.Context, name string) error {
+				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicies().Delete(ctx, name, metav1.DeleteOptions{})
+			}, policy.Name)
+		})
+		ginkgo.By("waiting for the type check to finish without warnings", func() {
+			err := wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (done bool, err error) {
+				policy, err = client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().Get(ctx, policy.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				if policy.Status.TypeChecking != nil {
+					return true, nil
+				}
+				return false, nil
+			})
+			framework.ExpectNoError(err, "wait for type checking")
+			gomega.Expect(policy.Status.TypeChecking.ExpressionWarnings).To(gomega.BeEmpty(), "expect no warnings")
+		})
+		ginkgo.By("creating a policy with type-confused expressions for crontabs", func() {
+			policy = newValidatingAdmissionPolicyBuilder(f.UniqueName+".confused-crd-policy.example.com").
+				MatchUniqueNamespace(f.UniqueName).
+				StartResourceRule().
+				MatchResource([]string{crd.Spec.Group}, []string{"v1"}, []string{"crontabs"}).
+				EndResourceRule().
+				WithValidation(admissionregistrationv1beta1.Validation{
+					Expression: "object.spec.replicas > '1'", // type confusion
+				}).
+				WithValidation(admissionregistrationv1beta1.Validation{
+					Expression: "object.spec.maxRetries < 10", // not yet existing field
+				}).
+				Build()
+			policy, err := client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().Create(ctx, policy, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "create policy")
+			ginkgo.DeferCleanup(func(ctx context.Context, name string) error {
+				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicies().Delete(ctx, name, metav1.DeleteOptions{})
+			}, policy.Name)
+		})
+		ginkgo.By("waiting for the type check to finish with warnings", func() {
+			err := wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (done bool, err error) {
+				policy, err = client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().Get(ctx, policy.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				if policy.Status.TypeChecking != nil {
+					return true, nil
+				}
+				return false, nil
+			})
+			framework.ExpectNoError(err, "wait for type checking")
+
+			gomega.Expect(policy.Status.TypeChecking.ExpressionWarnings).To(gomega.HaveLen(2))
+			warning := policy.Status.TypeChecking.ExpressionWarnings[0]
+			gomega.Expect(warning.FieldRef).To(gomega.Equal("spec.validations[0].expression"))
+			gomega.Expect(warning.Warning).To(gomega.ContainSubstring("found no matching overload for '_>_' applied to '(int, string)'"))
+			warning = policy.Status.TypeChecking.ExpressionWarnings[1]
+			gomega.Expect(warning.FieldRef).To(gomega.Equal("spec.validations[1].expression"))
+			gomega.Expect(warning.Warning).To(gomega.ContainSubstring("undefined field 'maxRetries'"))
+		})
+	})
 })
 
 func createBinding(bindingName string, uniqueLabel string, policyName string) *admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding {
@@ -407,4 +506,49 @@ func (b *validatingAdmissionPolicyBuilder) WithVariable(variable admissionregist
 
 func (b *validatingAdmissionPolicyBuilder) Build() *admissionregistrationv1beta1.ValidatingAdmissionPolicy {
 	return b.policy
+}
+
+func crontabExampleCRD() *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "crontabs.stable.example.com",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "stable.example.com",
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"spec": {
+									Type: "object",
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"cronSpec": {
+											Type: "string",
+										},
+										"image": {
+											Type: "string",
+										},
+										"replicas": {
+											Type: "integer",
+										},
+									},
+								},
+							},
+						}},
+				},
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:     "crontabs",
+				Singular:   "crontab",
+				Kind:       "CronTab",
+				ShortNames: []string{"ct"},
+			},
+		},
+	}
 }

--- a/test/integration/apiserver/cel/typeresolution_test.go
+++ b/test/integration/apiserver/cel/typeresolution_test.go
@@ -79,7 +79,7 @@ func TestTypeResolver(t *testing.T) {
 		}
 	}(crd)
 	discoveryResolver := &resolver.ClientDiscoveryResolver{Discovery: client.Discovery()}
-	definitionsResolver := resolver.NewDefinitionsSchemaResolver(k8sscheme.Scheme, openapi.GetOpenAPIDefinitions)
+	definitionsResolver := resolver.NewDefinitionsSchemaResolver(openapi.GetOpenAPIDefinitions, k8sscheme.Scheme)
 	// wait until the CRD schema is published at the OpenAPI v3 endpoint
 	err = wait.PollImmediate(time.Second, time.Minute, func() (done bool, err error) {
 		p, err := client.OpenAPIV3().Paths()
@@ -330,7 +330,7 @@ func TestBuiltinResolution(t *testing.T) {
 	}{
 		{
 			name:     "definitions",
-			resolver: resolver.NewDefinitionsSchemaResolver(k8sscheme.Scheme, openapi.GetOpenAPIDefinitions),
+			resolver: resolver.NewDefinitionsSchemaResolver(openapi.GetOpenAPIDefinitions, k8sscheme.Scheme),
 			scheme:   buildTestScheme(),
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds ValidatingAdmissionPolicy type checking support for CRDs and other API extensions APIS
#### Special notes for your reviewer:
There is no API changes.

Performance impact:
The RESTMapper is refreshed more often. To limit the impact, the RESTMapper can only be refreshed at most once per policy.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ValidatingAdmissionPolicy Type Checking now supports CRDs and API extensions types.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
