### PR TITLE
Automated cherry pick of #114338: kubeadm: set priority for "system-node-critical" Pods

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -59,6 +59,8 @@ var (
 
 // ComponentPod returns a Pod object from the container, volume and annotations specifications
 func ComponentPod(container v1.Container, volumes map[string]v1.Volume, annotations map[string]string) v1.Pod {
+	// priority value for system-node-critical class
+	priority := int32(2000001000)
 	return v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -74,6 +76,7 @@ func ComponentPod(container v1.Container, volumes map[string]v1.Volume, annotati
 		},
 		Spec: v1.PodSpec{
 			Containers:        []v1.Container{container},
+			Priority:          &priority,
 			PriorityClassName: "system-node-critical",
 			HostNetwork:       true,
 			Volumes:           VolumeMapToSlice(volumes),

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -392,6 +392,8 @@ func TestGetEtcdProbeEndpoint(t *testing.T) {
 }
 
 func TestComponentPod(t *testing.T) {
+	// priority value for system-node-critical class
+	priority := int32(2000001000)
 	var tests = []struct {
 		name     string
 		expected v1.Pod
@@ -419,6 +421,7 @@ func TestComponentPod(t *testing.T) {
 							Name: "foo",
 						},
 					},
+					Priority:          &priority,
 					PriorityClassName: "system-node-critical",
 					HostNetwork:       true,
 					Volumes:           []v1.Volume{},


### PR DESCRIPTION
Cherry pick of #114338 on release-1.26.

#114338: kubeadm: set priority for "system-node-critical" Pods

```release-note
kubeadm: explicitly set `priority` for static pods with `priorityClassName: system-node-critical`
```