### PR TITLE
fix PodTopologySpread plugin conflict the volume node affinity

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -342,16 +342,6 @@ func getPersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) map[string]v1
 		claim := templates[i]
 		claim.Name = getPersistentVolumeClaimName(set, &claim, ordinal)
 		claim.Namespace = set.Namespace
-		var ownReferences []metav1.OwnerReference
-		for _, reference := range pod.OwnerReferences {
-			ownReferences = append(ownReferences, *reference.DeepCopy())
-		}
-		ownReferences = append(ownReferences, metav1.OwnerReference{
-			APIVersion: "v1",
-			Kind:       "Pod",
-			Name:       pod.Name,
-		})
-		claim.OwnerReferences = ownReferences
 		if claim.Labels != nil {
 			for key, value := range set.Spec.Selector.MatchLabels {
 				claim.Labels[key] = value

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -342,6 +342,16 @@ func getPersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) map[string]v1
 		claim := templates[i]
 		claim.Name = getPersistentVolumeClaimName(set, &claim, ordinal)
 		claim.Namespace = set.Namespace
+		var ownReferences []metav1.OwnerReference
+		for _, reference := range pod.OwnerReferences {
+			ownReferences = append(ownReferences, *reference.DeepCopy())
+		}
+		ownReferences = append(ownReferences, metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "Pod",
+			Name:       pod.Name,
+		})
+		claim.OwnerReferences = ownReferences
 		if claim.Labels != nil {
 			for key, value := range set.Spec.Selector.MatchLabels {
 				claim.Labels[key] = value

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -549,6 +549,8 @@ const (
 	// Enable MatchLabelKeys in PodTopologySpread.
 	MatchLabelKeysInPodTopologySpread featuregate.Feature = "MatchLabelKeysInPodTopologySpread"
 
+	PodNotExistInclusionPolicyInPodTopologySpread featuregate.Feature = "PodNotExistInclusionPolicyInPodTopologySpread"
+
 	// owner: @krmayankk
 	// alpha: v1.24
 	//
@@ -1099,6 +1101,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	LogarithmicScaleDown: {Default: true, PreRelease: featuregate.Beta},
 
 	MatchLabelKeysInPodTopologySpread: {Default: true, PreRelease: featuregate.Beta},
+
+	PodNotExistInclusionPolicyInPodTopologySpread: {Default: false, PreRelease: featuregate.Alpha},
 
 	MaxUnavailableStatefulSet: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/scheduler/framework/plugins/feature/feature.go
+++ b/pkg/scheduler/framework/plugins/feature/feature.go
@@ -20,14 +20,15 @@ package feature
 // This struct allows us to break the dependency of the plugins on
 // the internal k8s features pkg.
 type Features struct {
-	EnableDynamicResourceAllocation              bool
-	EnableReadWriteOncePod                       bool
-	EnableVolumeCapacityPriority                 bool
-	EnableMinDomainsInPodTopologySpread          bool
-	EnableNodeInclusionPolicyInPodTopologySpread bool
-	EnableMatchLabelKeysInPodTopologySpread      bool
-	EnablePodSchedulingReadiness                 bool
-	EnablePodDisruptionConditions                bool
-	EnableInPlacePodVerticalScaling              bool
-	EnableSidecarContainers                      bool
+	EnableDynamicResourceAllocation                     bool
+	EnableReadWriteOncePod                              bool
+	EnableVolumeCapacityPriority                        bool
+	EnableMinDomainsInPodTopologySpread                 bool
+	EnableNodeInclusionPolicyInPodTopologySpread        bool
+	EnableMatchLabelKeysInPodTopologySpread             bool
+	EnablePodSchedulingReadiness                        bool
+	EnablePodDisruptionConditions                       bool
+	EnableInPlacePodVerticalScaling                     bool
+	EnableSidecarContainers                             bool
+	EnablePodNotExistInclusionPolicyInPodTopologySpread bool
 }

--- a/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
@@ -114,10 +114,6 @@ func New(plArgs runtime.Object, h framework.Handle, fts feature.Features) (frame
 		}
 		pl.setListers(h.SharedInformerFactory())
 	}
-	if pl.enablePodNotExistInclusionPolicyInPodTopologySpread {
-		pl.statefulSets = h.SharedInformerFactory().Apps().V1().StatefulSets().Lister()
-		pl.pvcs = h.SharedInformerFactory().Core().V1().PersistentVolumeClaims().Lister()
-	}
 	return pl, nil
 }
 
@@ -133,6 +129,8 @@ func (pl *PodTopologySpread) setListers(factory informers.SharedInformerFactory)
 	pl.services = factory.Core().V1().Services().Lister()
 	pl.replicationCtrls = factory.Core().V1().ReplicationControllers().Lister()
 	pl.replicaSets = factory.Apps().V1().ReplicaSets().Lister()
+	pl.statefulSets = factory.Apps().V1().StatefulSets().Lister()
+	pl.pvcs = factory.Core().V1().PersistentVolumeClaims().Lister()
 }
 
 // EventsToRegister returns the possible events that may make a Pod

--- a/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
@@ -62,6 +62,7 @@ type PodTopologySpread struct {
 	replicationCtrls                             corelisters.ReplicationControllerLister
 	replicaSets                                  appslisters.ReplicaSetLister
 	statefulSets                                 appslisters.StatefulSetLister
+	pvcs                                         corelisters.PersistentVolumeClaimLister
 	enableMinDomainsInPodTopologySpread          bool
 	enableNodeInclusionPolicyInPodTopologySpread bool
 	enableMatchLabelKeysInPodTopologySpread      bool
@@ -127,6 +128,7 @@ func (pl *PodTopologySpread) setListers(factory informers.SharedInformerFactory)
 	pl.replicationCtrls = factory.Core().V1().ReplicationControllers().Lister()
 	pl.replicaSets = factory.Apps().V1().ReplicaSets().Lister()
 	pl.statefulSets = factory.Apps().V1().StatefulSets().Lister()
+	pl.pvcs = factory.Core().V1().PersistentVolumeClaims().Lister()
 }
 
 // EventsToRegister returns the possible events that may make a Pod

--- a/pkg/scheduler/framework/plugins/registry.go
+++ b/pkg/scheduler/framework/plugins/registry.go
@@ -46,16 +46,17 @@ import (
 // through the WithFrameworkOutOfTreeRegistry option.
 func NewInTreeRegistry() runtime.Registry {
 	fts := plfeature.Features{
-		EnableDynamicResourceAllocation:              feature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation),
-		EnableReadWriteOncePod:                       feature.DefaultFeatureGate.Enabled(features.ReadWriteOncePod),
-		EnableVolumeCapacityPriority:                 feature.DefaultFeatureGate.Enabled(features.VolumeCapacityPriority),
-		EnableMinDomainsInPodTopologySpread:          feature.DefaultFeatureGate.Enabled(features.MinDomainsInPodTopologySpread),
-		EnableNodeInclusionPolicyInPodTopologySpread: feature.DefaultFeatureGate.Enabled(features.NodeInclusionPolicyInPodTopologySpread),
-		EnableMatchLabelKeysInPodTopologySpread:      feature.DefaultFeatureGate.Enabled(features.MatchLabelKeysInPodTopologySpread),
-		EnablePodSchedulingReadiness:                 feature.DefaultFeatureGate.Enabled(features.PodSchedulingReadiness),
-		EnablePodDisruptionConditions:                feature.DefaultFeatureGate.Enabled(features.PodDisruptionConditions),
-		EnableInPlacePodVerticalScaling:              feature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling),
-		EnableSidecarContainers:                      feature.DefaultFeatureGate.Enabled(features.SidecarContainers),
+		EnableDynamicResourceAllocation:                     feature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation),
+		EnableReadWriteOncePod:                              feature.DefaultFeatureGate.Enabled(features.ReadWriteOncePod),
+		EnableVolumeCapacityPriority:                        feature.DefaultFeatureGate.Enabled(features.VolumeCapacityPriority),
+		EnableMinDomainsInPodTopologySpread:                 feature.DefaultFeatureGate.Enabled(features.MinDomainsInPodTopologySpread),
+		EnableNodeInclusionPolicyInPodTopologySpread:        feature.DefaultFeatureGate.Enabled(features.NodeInclusionPolicyInPodTopologySpread),
+		EnableMatchLabelKeysInPodTopologySpread:             feature.DefaultFeatureGate.Enabled(features.MatchLabelKeysInPodTopologySpread),
+		EnablePodSchedulingReadiness:                        feature.DefaultFeatureGate.Enabled(features.PodSchedulingReadiness),
+		EnablePodDisruptionConditions:                       feature.DefaultFeatureGate.Enabled(features.PodDisruptionConditions),
+		EnableInPlacePodVerticalScaling:                     feature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling),
+		EnableSidecarContainers:                             feature.DefaultFeatureGate.Enabled(features.SidecarContainers),
+		EnablePodNotExistInclusionPolicyInPodTopologySpread: feature.DefaultFeatureGate.Enabled(features.PodNotExistInclusionPolicyInPodTopologySpread),
 	}
 
 	registry := runtime.Registry{

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -19,6 +19,7 @@ package testing
 import (
 	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	resourcev1alpha2 "k8s.io/api/resource/v1alpha2"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -688,6 +689,53 @@ func (p *PodWrapper) Overhead(rl v1.ResourceList) *PodWrapper {
 	return p
 }
 
+// StatefulSetWrapper wraps a StatefulSet inside.
+type StatefulSetWrapper struct{ appsv1.StatefulSet }
+
+// MakeStatefulSet creates a StatefulSet wrapper.
+func MakeStatefulSet() *StatefulSetWrapper {
+	w := &StatefulSetWrapper{appsv1.StatefulSet{}}
+	return w
+}
+
+// Obj returns the inner Node.
+func (sts *StatefulSetWrapper) Obj() *appsv1.StatefulSet {
+	return &sts.StatefulSet
+}
+
+// Name sets `s` as the name of the inner pod.
+func (sts *StatefulSetWrapper) Name(s string) *StatefulSetWrapper {
+	sts.SetName(s)
+	return sts
+}
+
+// Namespace sets `s` as the namespace of the inner StatefulSet.
+func (sts *StatefulSetWrapper) Namespace(s string) *StatefulSetWrapper {
+	sts.SetNamespace(s)
+	return sts
+}
+
+// UID sets `s` as the UID of the inner StatefulSet.
+func (sts *StatefulSetWrapper) UID(s string) *StatefulSetWrapper {
+	sts.SetUID(types.UID(s))
+	return sts
+}
+
+// Label applies a {k,v} label pair to the inner StatefulSet.
+func (sts *StatefulSetWrapper) Label(k, v string) *StatefulSetWrapper {
+	if sts.Labels == nil {
+		sts.Labels = make(map[string]string)
+	}
+	sts.Labels[k] = v
+	return sts
+}
+
+// PodTemplate applies PodTemplateSpec to the inner StatefulSet.
+func (sts *StatefulSetWrapper) PodTemplate(spec v1.PodTemplateSpec) *StatefulSetWrapper {
+	sts.Spec.Template = spec
+	return sts
+}
+
 // NodeWrapper wraps a Node inside.
 type NodeWrapper struct{ v1.Node }
 
@@ -803,6 +851,13 @@ func (p *PersistentVolumeClaimWrapper) AccessModes(accessModes []v1.PersistentVo
 // PersistentVolumeClaim.
 func (p *PersistentVolumeClaimWrapper) Resources(resources v1.VolumeResourceRequirements) *PersistentVolumeClaimWrapper {
 	p.PersistentVolumeClaim.Spec.Resources = resources
+	return p
+}
+
+// OwnerReference sets `OwnerReferences` as of the inner
+// PersistentVolumeClaim.
+func (p *PersistentVolumeClaimWrapper) OwnerReference(reference metav1.OwnerReference) *PersistentVolumeClaimWrapper {
+	p.PersistentVolumeClaim.OwnerReferences = append(p.PersistentVolumeClaim.OwnerReferences, reference)
 	return p
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
PodTopologySpread plugin will schedule new pod to the same node, when pod of statefulset with local storage volume(node affinity) was not exist,  will due to the old pod created can't schedule

#### Which issue(s) this PR fixes:
Fixes #116629


#### Does this PR introduce a user-facing change?

```release-note
Fixed PodTopologySpread plugin conflict the volume node affinity, which affect old not exist pod schedule
```

- [KEP]: [PodTopologySpread include terminated pod](https://github.com/kubernetes/enhancements/issues/4120)