### PR TITLE
use loopback client to find enabled resources to store as servedversions in StorageVersion API

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
@@ -105,7 +105,11 @@ func (o *ResourceConfig) EnableVersions(versions ...schema.GroupVersion) {
 
 // TODO this must be removed and we enable/disable individual resources.
 func (o *ResourceConfig) versionEnabled(version schema.GroupVersion) bool {
-	enabled, _ := o.GroupVersionConfigs[version]
+	enabled, ok := o.GroupVersionConfigs[version]
+	if !ok {
+		// enabled by default
+		return true
+	}
 	return enabled
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storageversion/updater_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storageversion/updater_test.go
@@ -26,8 +26,8 @@ import (
 )
 
 var (
-	v1   = "v1"
-	v2   = "v2"
+	v_1  = "v1"
+	v_2  = "v2"
 	ssv1 = v1alpha1.ServerStorageVersion{
 		APIServerID:       "1",
 		EncodingVersion:   "v1",
@@ -73,7 +73,7 @@ func TestLocalUpdateStorageVersion(t *testing.T) {
 			newSSV: ssv1,
 			expected: v1alpha1.StorageVersionStatus{
 				StorageVersions:       []v1alpha1.ServerStorageVersion{ssv1},
-				CommonEncodingVersion: &v1,
+				CommonEncodingVersion: &v_1,
 				Conditions:            commonVersionTrueCondition(),
 			},
 			expectLastTransitionTimeUpdate: true,
@@ -81,7 +81,7 @@ func TestLocalUpdateStorageVersion(t *testing.T) {
 		{
 			old: v1alpha1.StorageVersionStatus{
 				StorageVersions:       []v1alpha1.ServerStorageVersion{ssv1, ssv2},
-				CommonEncodingVersion: &v1,
+				CommonEncodingVersion: &v_1,
 				Conditions:            commonVersionTrueCondition(),
 			},
 			newSSV: ssv3,
@@ -94,13 +94,13 @@ func TestLocalUpdateStorageVersion(t *testing.T) {
 		{
 			old: v1alpha1.StorageVersionStatus{
 				StorageVersions:       []v1alpha1.ServerStorageVersion{ssv1, ssv2},
-				CommonEncodingVersion: &v1,
+				CommonEncodingVersion: &v_1,
 				Conditions:            commonVersionTrueCondition(),
 			},
 			newSSV: ssv4,
 			expected: v1alpha1.StorageVersionStatus{
 				StorageVersions:       []v1alpha1.ServerStorageVersion{ssv1, ssv2, ssv4},
-				CommonEncodingVersion: &v1,
+				CommonEncodingVersion: &v_1,
 				Conditions:            commonVersionTrueCondition(),
 			},
 		},
@@ -170,7 +170,7 @@ func TestSetCommonEncodingVersion(t *testing.T) {
 			name: "no-common_transition",
 			old: v1alpha1.StorageVersionStatus{
 				StorageVersions:       []v1alpha1.ServerStorageVersion{ssv1, ssv2, ssv3},
-				CommonEncodingVersion: &v1,
+				CommonEncodingVersion: &v_1,
 				Conditions:            commonVersionTrueCondition(),
 			},
 			expected: v1alpha1.StorageVersionStatus{
@@ -197,7 +197,7 @@ func TestSetCommonEncodingVersion(t *testing.T) {
 			},
 			expected: v1alpha1.StorageVersionStatus{
 				StorageVersions:       []v1alpha1.ServerStorageVersion{ssv1, ssv2},
-				CommonEncodingVersion: &v1,
+				CommonEncodingVersion: &v_1,
 				Conditions:            commonVersionTrueCondition(),
 			},
 			expectLastTransitionTimeUpdate: true,
@@ -206,12 +206,12 @@ func TestSetCommonEncodingVersion(t *testing.T) {
 			name: "common_no-transition",
 			old: v1alpha1.StorageVersionStatus{
 				StorageVersions:       []v1alpha1.ServerStorageVersion{ssv1, ssv2},
-				CommonEncodingVersion: &v1,
+				CommonEncodingVersion: &v_1,
 				Conditions:            commonVersionTrueCondition(),
 			},
 			expected: v1alpha1.StorageVersionStatus{
 				StorageVersions:       []v1alpha1.ServerStorageVersion{ssv1, ssv2},
-				CommonEncodingVersion: &v1,
+				CommonEncodingVersion: &v_1,
 				Conditions:            commonVersionTrueCondition(),
 			},
 		},
@@ -223,7 +223,7 @@ func TestSetCommonEncodingVersion(t *testing.T) {
 			},
 			expected: v1alpha1.StorageVersionStatus{
 				StorageVersions:       []v1alpha1.ServerStorageVersion{ssv1, ssv2},
-				CommonEncodingVersion: &v1,
+				CommonEncodingVersion: &v_1,
 				Conditions:            commonVersionTrueCondition(),
 			},
 			expectLastTransitionTimeUpdate: true,
@@ -232,12 +232,12 @@ func TestSetCommonEncodingVersion(t *testing.T) {
 			name: "common_version-changed",
 			old: v1alpha1.StorageVersionStatus{
 				StorageVersions:       []v1alpha1.ServerStorageVersion{ssv3, ssv5},
-				CommonEncodingVersion: &v1,
+				CommonEncodingVersion: &v_1,
 				Conditions:            commonVersionTrueCondition(),
 			},
 			expected: v1alpha1.StorageVersionStatus{
 				StorageVersions:       []v1alpha1.ServerStorageVersion{ssv3, ssv5},
-				CommonEncodingVersion: &v2,
+				CommonEncodingVersion: &v_2,
 				Conditions:            commonVersionTrueCondition(),
 			},
 			expectLastTransitionTimeUpdate: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:
Uses a loopback client to find enabled resources for an apiserver that are then stored as servedVersion in StorageVersion API

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```