### PR TITLE
use stopCh to avoid goroutine leak in tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
@@ -107,7 +107,11 @@ func TestAccessReviewCheckOnMissingNamespace(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error initializing handler: %v", err)
 	}
-	informerFactory.Start(wait.NeverStop)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	informerFactory.Start(stopCh)
 
 	err = handler.Admit(context.TODO(), admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{Group: "authorization.k8s.io", Version: "v1", Kind: "LocalSubjectAccesReview"}, namespace, "", schema.GroupVersionResource{Group: "authorization.k8s.io", Version: "v1", Resource: "localsubjectaccessreviews"}, "", admission.Create, &metav1.CreateOptions{}, false, nil), nil)
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter_test.go
@@ -115,15 +115,17 @@ func TestQueueWaitTimeLatencyTracker(t *testing.T) {
 		QueueSetFactory:        fqs.NewQueueSetFactory(clk),
 	})
 
-	informerFactory.Start(nil)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
 
-	status := informerFactory.WaitForCacheSync(nil)
+	informerFactory.Start(stopCh)
+	status := informerFactory.WaitForCacheSync(stopCh)
 	if names := unsynced(status); len(names) > 0 {
 		t.Fatalf("WaitForCacheSync did not successfully complete, resources=%#v", names)
 	}
 
 	go func() {
-		controller.Run(nil)
+		controller.Run(stopCh)
 	}()
 
 	// ensure that the controller has run its first loop.

--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
@@ -1656,8 +1656,11 @@ func Test_syncNode(t *testing.T) {
 				nodeStatusUpdateFrequency: 1 * time.Second,
 			}
 
-			factory.Start(nil)
-			factory.WaitForCacheSync(nil)
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			factory.Start(stopCh)
+			factory.WaitForCacheSync(stopCh)
 
 			w := eventBroadcaster.StartLogging(klog.Infof)
 			defer w.Stop()
@@ -1740,8 +1743,11 @@ func TestGCEConditionV2(t *testing.T) {
 		nodeStatusUpdateFrequency: 1 * time.Second,
 	}
 
-	factory.Start(nil)
-	factory.WaitForCacheSync(nil)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
 
 	w := eventBroadcaster.StartLogging(klog.Infof)
 	defer w.Stop()
@@ -1828,8 +1834,11 @@ func TestGCECondition(t *testing.T) {
 		nodeStatusUpdateFrequency: 1 * time.Second,
 	}
 
-	factory.Start(nil)
-	factory.WaitForCacheSync(nil)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	factory.Start(stopCh)
+	factory.WaitForCacheSync(stopCh)
 
 	w := eventBroadcaster.StartLogging(klog.Infof)
 	defer w.Stop()
@@ -1934,10 +1943,13 @@ func Test_reconcileNodeLabels(t *testing.T) {
 				nodeInformer: factory.Core().V1().Nodes(),
 			}
 
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
 			// activate node informer
 			factory.Core().V1().Nodes().Informer()
-			factory.Start(nil)
-			factory.WaitForCacheSync(nil)
+			factory.Start(stopCh)
+			factory.WaitForCacheSync(stopCh)
 
 			err := cnc.reconcileNodeLabels("node01")
 			if err != test.expectedErr {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
These tests has goroutine leaks as they use `nil` instead of  a `stopCh`, thus the goroutine controlled by the stopCh cannot be handled as expect. 

For instance, as the stopCh is nil, this routine will panic at `<-stopCh` and  the method `c.config.Queue.Close()` not execute, i think that may causes leaks.

https://github.com/kubernetes/kubernetes/blob/d48fc2ad2d1b4b5000c8794d457a52e3a944fd10/staging/src/k8s.io/client-go/tools/cache/controller.go#L129-L134

The leak report:
```
=== RUN   TestAccessReviewCheckOnMissingNamespace
E0706 17:59:41.445674   84091 reflector.go:147] k8s.io/client-go/informers/factory.go:150: Failed to watch *v1.Namespace: unhandled watch: testing.WatchActionImpl{ActionImpl:testing.ActionImpl{Namespace:"", Verb:"watch", Resource:schema.GroupVersionResource{Group:"", Version:"v1", Resource:"namespaces"}, Subresource:""}, WatchRestrictions:testing.WatchRestrictions{Labels:labels.internalSelector(nil), Fields:fields.andTerm{}, ResourceVersion:"0"}}
    admission_test.go:121: found unexpected goroutines:
        [Goroutine 44 in state sync.Cond.Wait, with sync.runtime_notifyListWait on top of the stack:
        goroutine 44 [sync.Cond.Wait]:
        sync.runtime_notifyListWait(0xc0001b0238, 0x0)
        	/Users/b/go/go1.20.4/src/runtime/sema.go:527 +0x14c
        sync.(*Cond).Wait(0x10f9907?)
        	/Users/b/go/go1.20.4/src/sync/cond.go:70 +0x8c
        k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc0001b0210, 0xc000180240)
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go:575 +0x256
        k8s.io/client-go/tools/cache.(*controller).processLoop(0xc000432000)
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/client-go/tools/cache/controller.go:188 +0x36
        k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x3e
        k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x187c7c5?, {0x288d2e0, 0xc000168030}, 0x1, 0x0)
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xb6
        k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000432078?, 0x3b9aca00, 0x0, 0x0?, 0x45d964b800?)
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x89
        k8s.io/apimachinery/pkg/util/wait.Until(...)
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:161
        k8s.io/client-go/tools/cache.(*controller).Run(0xc000432000, 0x0)
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/client-go/tools/cache/controller.go:159 +0x34f
        k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run(0xc0001382c0, 0xc000486790?)
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/client-go/tools/cache/shared_informer.go:504 +0x224
        k8s.io/client-go/informers.(*sharedInformerFactory).Start.func1()
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/client-go/informers/factory.go:150 +0x6b
        created by k8s.io/client-go/informers.(*sharedInformerFactory).Start
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/client-go/informers/factory.go:148 +0x21b
        
         Goroutine 14 in state chan receive, with k8s.io/client-go/tools/cache.(*sharedProcessor).run on top of the stack:
        goroutine 14 [chan receive]:
        k8s.io/client-go/tools/cache.(*sharedProcessor).run(0xc000257d60, 0x0?)
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/client-go/tools/cache/shared_informer.go:803 +0x58
        k8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel.func1()
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:55 +0x22
        k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x5a
        created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x85
        
         Goroutine 15 in state chan receive (nil chan), with k8s.io/client-go/tools/cache.(*controller).Run.func1 on top of the stack:
        goroutine 15 [chan receive (nil chan)]:
        k8s.io/client-go/tools/cache.(*controller).Run.func1()
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/client-go/tools/cache/controller.go:132 +0x28
        created by k8s.io/client-go/tools/cache.(*controller).Run
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/client-go/tools/cache/controller.go:131 +0xc5
        
         Goroutine 16 in state select, with k8s.io/apimachinery/pkg/util/wait.BackoffUntil on top of the stack:
        goroutine 16 [select]:
        k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0001a6060?, {0x288d2c0, 0xc00016a000}, 0x1, 0x0)
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/backoff.go:238 +0x135
        k8s.io/client-go/tools/cache.(*Reflector).Run(0xc0001ee0e0, 0x0)
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/client-go/tools/cache/reflector.go:290 +0x17d
        k8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel.func1()
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:55 +0x22
        k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x5a
        created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
        	/Users/b/GolandProjects/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x85
        ]
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
