### PR TITLE
Document PVLabeler as deprecated

### DIFF
--- a/staging/src/k8s.io/cloud-provider/cloud.go
+++ b/staging/src/k8s.io/cloud-provider/cloud.go
@@ -285,6 +285,7 @@ type Zones interface {
 }
 
 // PVLabeler is an abstract, pluggable interface for fetching labels for volumes
+// DEPRECATED: PVLabeler is deprecated in favor of CSI topology feature.
 type PVLabeler interface {
 	GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVolume) (map[string]string, error)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/sig cloud-provider

#### What this PR does / why we need it:

This has no callers outside of the deprecated `PersistentVolumeLabel` admission controller, and it does not appear to be intended for implementation by external cloud provider implementations. The CSI topology feature, while not an exact equivalent, fulfils a very similar role. Indicate this.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

I'm unsure if this is correct approach. An alternative approach would be to start supporting this again in external cloud provider. While the CSI topology feature does allow us to restrict PVs to one or more "zones", there's no way to identify the exact zone that it ended up in. For example, the using cloud-provider-openstack with the Cinder CSI driver, we can define `allowedTopologies` on our `StorageClass`(es):

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: topology-aware-standard
provisioner: cinder.csi.openstack.org
reclaimPolicy: Delete
allowVolumeExpansion: true
volumeBindingMode: WaitForFirstConsumer
allowedTopologies:
- matchLabelExpressions:
  - key: topology.cinder.csi.openstack.org/zone
    values:
    - abc
    - xyz
    - mno
```

This results in `nodeAffinity` in our `PersistentVolume.spec`:

```yaml
kind: PersistentVolume
# ...
spec:
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: topology.cinder.csi.openstack.org/zone
          operator: In
          values:
          - abc
      - matchExpressions:
        - key: topology.cinder.csi.openstack.org/zone
          operator: In
          values:
          - xyz
      - matchExpressions:
        - key: topology.cinder.csi.openstack.org/zone
          operator: In
          values:
          - mno
  persistentVolumeReclaimPolicy: Delete
  storageClassName: topology-aware-standard
```

With this we can know it landed in one of three zones but we don't know which one. Previously, we've had seen the exact zone it ended up in. We can fetch this information directly from the cloud in question but I wonder if there's value in still having `topology.kubernetes.io/zone` and `topology.kubernetes.io/region` labels on PVs?

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
