### PR TITLE
Remove deprecated scheduler CLI flags

### DIFF
--- a/cmd/kube-scheduler/app/options/deprecated.go
+++ b/cmd/kube-scheduler/app/options/deprecated.go
@@ -28,8 +28,6 @@ import (
 type DeprecatedOptions struct {
 	componentbaseconfig.DebuggingConfiguration
 	componentbaseconfig.ClientConnectionConfiguration
-	// Note that only the deprecated options (lock-object-name and lock-object-namespace) are populated here.
-	componentbaseconfig.LeaderElectionConfiguration
 	// PodMaxInUnschedulablePodsDuration is the maximum time a pod can stay in
 	// unschedulablePods. If a pod stays in unschedulablePods for longer than this
 	// value, the pod will be moved from unschedulablePods to backoffQ or activeQ.
@@ -49,7 +47,5 @@ func (o *DeprecatedOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ContentType, "kube-api-content-type", "application/vnd.kubernetes.protobuf", "DEPRECATED: content type of requests sent to apiserver. This parameter is ignored if a config file is specified in --config.")
 	fs.Float32Var(&o.QPS, "kube-api-qps", 50.0, "DEPRECATED: QPS to use while talking with kubernetes apiserver. This parameter is ignored if a config file is specified in --config.")
 	fs.Int32Var(&o.Burst, "kube-api-burst", 100, "DEPRECATED: burst to use while talking with kubernetes apiserver. This parameter is ignored if a config file is specified in --config.")
-	fs.StringVar(&o.ResourceNamespace, "lock-object-namespace", "kube-system", "DEPRECATED: define the namespace of the lock object. Will be removed in favor of leader-elect-resource-namespace. This parameter is ignored if a config file is specified in --config.")
-	fs.StringVar(&o.ResourceName, "lock-object-name", "kube-scheduler", "DEPRECATED: define the name of the lock object. Will be removed in favor of leader-elect-resource-name. This parameter is ignored if a config file is specified in --config.")
 	fs.DurationVar(&o.PodMaxInUnschedulablePodsDuration, "pod-max-in-unschedulable-pods-duration", 5*time.Minute, "DEPRECATED: the maximum time a pod can stay in unschedulablePods. If a pod stays in unschedulablePods for longer than this value, the pod will be moved from unschedulablePods to backoffQ or activeQ. This flag is deprecated and will be removed in 1.26")
 }

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -137,12 +137,6 @@ func (o *Options) ApplyDeprecated() {
 	if deprecated.Changed("kube-api-burst") {
 		o.ComponentConfig.ClientConnection.Burst = o.Deprecated.Burst
 	}
-	if deprecated.Changed("lock-object-namespace") {
-		o.ComponentConfig.LeaderElection.ResourceNamespace = o.Deprecated.ResourceNamespace
-	}
-	if deprecated.Changed("lock-object-name") {
-		o.ComponentConfig.LeaderElection.ResourceName = o.Deprecated.ResourceName
-	}
 }
 
 // ApplyLeaderElectionTo obtains the CLI args related with leaderelection, and override the values in `cfg`.

--- a/cmd/kube-scheduler/app/server_test.go
+++ b/cmd/kube-scheduler/app/server_test.go
@@ -253,12 +253,13 @@ leaderElection:
 	}
 
 	testcases := []struct {
-		name               string
-		flags              []string
-		registryOptions    []Option
-		restoreFeatures    map[featuregate.Feature]bool
-		wantPlugins        map[string]*config.Plugins
-		wantLeaderElection *componentbaseconfig.LeaderElectionConfiguration
+		name                 string
+		flags                []string
+		registryOptions      []Option
+		restoreFeatures      map[featuregate.Feature]bool
+		wantPlugins          map[string]*config.Plugins
+		wantLeaderElection   *componentbaseconfig.LeaderElectionConfiguration
+		wantClientConnection *componentbaseconfig.ClientConnectionConfiguration
 	}{
 		{
 			name: "default config with an alpha feature enabled",
@@ -396,7 +397,7 @@ leaderElection:
 			flags: []string{
 				"--leader-elect=false",
 				"--leader-elect-lease-duration=2h", // CLI args are favored over the fields in ComponentConfig
-				"--lock-object-namespace=default",  // deprecated CLI arg will be ignored if --config is specified
+				"--kubeconfig=foo",                 // deprecated CLI arg will be ignored if --config is specified
 				"--config", emptyLeaderElectionConfig,
 			},
 			wantLeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
@@ -408,14 +409,20 @@ leaderElection:
 				ResourceName:      v1beta3.SchedulerDefaultLockObjectName,
 				ResourceNamespace: v1beta3.SchedulerDefaultLockObjectNamespace,
 			},
+			wantClientConnection: &componentbaseconfig.ClientConnectionConfiguration{
+				Kubeconfig:  configKubeconfig,
+				ContentType: "application/vnd.kubernetes.protobuf",
+				QPS:         50,
+				Burst:       100,
+			},
 		},
 		{
 			name: "leader election CLI args, without --config arg",
 			flags: []string{
 				"--leader-elect=false",
 				"--leader-elect-lease-duration=2h",
-				"--lock-object-namespace=default", // deprecated CLI arg is honored if --config is not specified
-				"--kubeconfig", configKubeconfig,
+				"--leader-elect-resource-namespace=default",
+				"--kubeconfig", configKubeconfig, // deprecated CLI arg is honored if --config is not specified
 			},
 			wantLeaderElection: &componentbaseconfig.LeaderElectionConfiguration{
 				LeaderElect:       false,                                    // from CLI args
@@ -424,7 +431,13 @@ leaderElection:
 				RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
 				ResourceLock:      "leases",
 				ResourceName:      v1beta3.SchedulerDefaultLockObjectName,
-				ResourceNamespace: "default", // from deprecated CLI args
+				ResourceNamespace: "default", // from CLI args
+			},
+			wantClientConnection: &componentbaseconfig.ClientConnectionConfiguration{
+				Kubeconfig:  configKubeconfig, // from deprecated CLI args
+				ContentType: "application/vnd.kubernetes.protobuf",
+				QPS:         50,
+				Burst:       100,
 			},
 		},
 		{
@@ -518,6 +531,13 @@ leaderElection:
 				gotLeaderElection := opts.ComponentConfig.LeaderElection
 				if diff := cmp.Diff(*tc.wantLeaderElection, gotLeaderElection); diff != "" {
 					t.Errorf("Unexpected leaderElection diff (-want, +got): %s", diff)
+				}
+			}
+
+			if tc.wantClientConnection != nil {
+				gotClientConnection := opts.ComponentConfig.ClientConnection
+				if diff := cmp.Diff(*tc.wantClientConnection, gotClientConnection); diff != "" {
+					t.Errorf("Unexpected clientConnection diff (-want, +got): %s", diff)
 				}
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind deprecation


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Remove deprecated scheduler CLI flags  `--lock-object-namespace` and `--lock-object-name`.
CLI migration:
- `--lock-object-namespace` -> `--leader-elect-resource-namespace` or ComponentConfig
- `--lock-object-name` -> `--leader-elect-resource-name` or ComponentConfig


Deprecation policy for admin-facing CLI flags is "GA, admin-facing flag, longer of 6 months or 1 release". 
Verify deprecated since 1.18: https://github.com/kubernetes/kubernetes/blob/release-1.18/cmd/kube-scheduler/app/options/deprecated.go



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The deprecated flag `--lock-object-namespace` and `--lock-object-name` have been removed from kube-scheduler. Please use `--leader-elect-resource-namespace` and `--leader-elect-resource-name` or ComponentConfig instead to configure those parameters.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
