### PR TITLE
[StructuredAuthenticationConfig] Add feature flag and wire up `--authentication-config` flag

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -257,11 +257,8 @@ func TestAddFlags(t *testing.T) {
 					RetryBackoff: apiserveroptions.DefaultAuthWebhookRetryBackoff(),
 				},
 				BootstrapToken: &kubeoptions.BootstrapTokenAuthenticationOptions{},
-				OIDC: &kubeoptions.OIDCAuthenticationOptions{
-					UsernameClaim: "sub",
-					SigningAlgs:   []string{"RS256"},
-				},
-				RequestHeader: &apiserveroptions.RequestHeaderAuthenticationOptions{},
+				OIDC:           s.Authentication.OIDC,
+				RequestHeader:  &apiserveroptions.RequestHeaderAuthenticationOptions{},
 				ServiceAccounts: &kubeoptions.ServiceAccountAuthenticationOptions{
 					Lookup:           true,
 					ExtendExpiration: true,
@@ -327,7 +324,10 @@ func TestAddFlags(t *testing.T) {
 		},
 	}
 
+	expected.Authentication.OIDC.UsernameClaim = "sub"
+	expected.Authentication.OIDC.SigningAlgs = []string{"RS256"}
+
 	if !reflect.DeepEqual(expected, s) {
-		t.Errorf("Got different run options than expected.\nDifference detected on:\n%s", cmp.Diff(expected, s, cmpopts.IgnoreUnexported(admission.Plugins{})))
+		t.Errorf("Got different run options than expected.\nDifference detected on:\n%s", cmp.Diff(expected, s, cmpopts.IgnoreUnexported(admission.Plugins{}, kubeoptions.OIDCAuthenticationOptions{})))
 	}
 }

--- a/pkg/controlplane/apiserver/options/options_test.go
+++ b/pkg/controlplane/apiserver/options/options_test.go
@@ -243,11 +243,8 @@ func TestAddFlags(t *testing.T) {
 				RetryBackoff: apiserveroptions.DefaultAuthWebhookRetryBackoff(),
 			},
 			BootstrapToken: &kubeoptions.BootstrapTokenAuthenticationOptions{},
-			OIDC: &kubeoptions.OIDCAuthenticationOptions{
-				UsernameClaim: "sub",
-				SigningAlgs:   []string{"RS256"},
-			},
-			RequestHeader: &apiserveroptions.RequestHeaderAuthenticationOptions{},
+			OIDC:           s.Authentication.OIDC,
+			RequestHeader:  &apiserveroptions.RequestHeaderAuthenticationOptions{},
 			ServiceAccounts: &kubeoptions.ServiceAccountAuthenticationOptions{
 				Lookup:           true,
 				ExtendExpiration: true,
@@ -283,7 +280,10 @@ func TestAddFlags(t *testing.T) {
 		AggregatorRejectForwardingRedirects: true,
 	}
 
+	expected.Authentication.OIDC.UsernameClaim = "sub"
+	expected.Authentication.OIDC.SigningAlgs = []string{"RS256"}
+
 	if !reflect.DeepEqual(expected, s) {
-		t.Errorf("Got different run options than expected.\nDifference detected on:\n%s", cmp.Diff(expected, s, cmpopts.IgnoreUnexported(admission.Plugins{})))
+		t.Errorf("Got different run options than expected.\nDifference detected on:\n%s", cmp.Diff(expected, s, cmpopts.IgnoreUnexported(admission.Plugins{}, kubeoptions.OIDCAuthenticationOptions{})))
 	}
 }

--- a/pkg/kubeapiserver/options/authentication_test.go
+++ b/pkg/kubeapiserver/options/authentication_test.go
@@ -32,18 +32,22 @@ import (
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/authenticatorfactory"
 	"k8s.io/apiserver/pkg/authentication/request/headerrequest"
+	"k8s.io/apiserver/pkg/features"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	kubeauthenticator "k8s.io/kubernetes/pkg/kubeapiserver/authenticator"
 	"k8s.io/utils/pointer"
 )
 
 func TestAuthenticationValidate(t *testing.T) {
 	testCases := []struct {
-		name        string
-		testOIDC    *OIDCAuthenticationOptions
-		testSA      *ServiceAccountAuthenticationOptions
-		testWebHook *WebHookAuthenticationOptions
-		expectErr   string
+		name                         string
+		testOIDC                     *OIDCAuthenticationOptions
+		testSA                       *ServiceAccountAuthenticationOptions
+		testWebHook                  *WebHookAuthenticationOptions
+		testAuthenticationConfigFile string
+		expectErr                    string
 	}{
 		{
 			name: "test when OIDC and ServiceAccounts are nil",
@@ -51,10 +55,11 @@ func TestAuthenticationValidate(t *testing.T) {
 		{
 			name: "test when OIDC and ServiceAccounts are valid",
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim: "sub",
-				SigningAlgs:   []string{"RS256"},
-				IssuerURL:     "https://testIssuerURL",
-				ClientID:      "testClientID",
+				UsernameClaim:      "sub",
+				SigningAlgs:        []string{"RS256"},
+				IssuerURL:          "https://testIssuerURL",
+				ClientID:           "testClientID",
+				areFlagsConfigured: func() bool { return true },
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers:  []string{"http://foo.bar.com"},
@@ -64,23 +69,25 @@ func TestAuthenticationValidate(t *testing.T) {
 		{
 			name: "test when OIDC is invalid",
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim: "sub",
-				SigningAlgs:   []string{"RS256"},
-				IssuerURL:     "https://testIssuerURL",
+				UsernameClaim:      "sub",
+				SigningAlgs:        []string{"RS256"},
+				IssuerURL:          "https://testIssuerURL",
+				areFlagsConfigured: func() bool { return true },
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers:  []string{"http://foo.bar.com"},
 				KeyFiles: []string{"testkeyfile1", "testkeyfile2"},
 			},
-			expectErr: "oidc-issuer-url and oidc-client-id should be specified together",
+			expectErr: "oidc-issuer-url and oidc-client-id must be specified together when any oidc-* flags are set",
 		},
 		{
 			name: "test when ServiceAccounts doesn't have key file",
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim: "sub",
-				SigningAlgs:   []string{"RS256"},
-				IssuerURL:     "https://testIssuerURL",
-				ClientID:      "testClientID",
+				UsernameClaim:      "sub",
+				SigningAlgs:        []string{"RS256"},
+				IssuerURL:          "https://testIssuerURL",
+				ClientID:           "testClientID",
+				areFlagsConfigured: func() bool { return true },
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers: []string{"http://foo.bar.com"},
@@ -90,10 +97,11 @@ func TestAuthenticationValidate(t *testing.T) {
 		{
 			name: "test when ServiceAccounts doesn't have issuer",
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim: "sub",
-				SigningAlgs:   []string{"RS256"},
-				IssuerURL:     "https://testIssuerURL",
-				ClientID:      "testClientID",
+				UsernameClaim:      "sub",
+				SigningAlgs:        []string{"RS256"},
+				IssuerURL:          "https://testIssuerURL",
+				ClientID:           "testClientID",
+				areFlagsConfigured: func() bool { return true },
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers: []string{},
@@ -103,10 +111,11 @@ func TestAuthenticationValidate(t *testing.T) {
 		{
 			name: "test when ServiceAccounts has empty string as issuer",
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim: "sub",
-				SigningAlgs:   []string{"RS256"},
-				IssuerURL:     "https://testIssuerURL",
-				ClientID:      "testClientID",
+				UsernameClaim:      "sub",
+				SigningAlgs:        []string{"RS256"},
+				IssuerURL:          "https://testIssuerURL",
+				ClientID:           "testClientID",
+				areFlagsConfigured: func() bool { return true },
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers: []string{""},
@@ -116,10 +125,11 @@ func TestAuthenticationValidate(t *testing.T) {
 		{
 			name: "test when ServiceAccounts has duplicate issuers",
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim: "sub",
-				SigningAlgs:   []string{"RS256"},
-				IssuerURL:     "https://testIssuerURL",
-				ClientID:      "testClientID",
+				UsernameClaim:      "sub",
+				SigningAlgs:        []string{"RS256"},
+				IssuerURL:          "https://testIssuerURL",
+				ClientID:           "testClientID",
+				areFlagsConfigured: func() bool { return true },
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers: []string{"http://foo.bar.com", "http://foo.bar.com"},
@@ -129,10 +139,11 @@ func TestAuthenticationValidate(t *testing.T) {
 		{
 			name: "test when ServiceAccount has bad issuer",
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim: "sub",
-				SigningAlgs:   []string{"RS256"},
-				IssuerURL:     "https://testIssuerURL",
-				ClientID:      "testClientID",
+				UsernameClaim:      "sub",
+				SigningAlgs:        []string{"RS256"},
+				IssuerURL:          "https://testIssuerURL",
+				ClientID:           "testClientID",
+				areFlagsConfigured: func() bool { return true },
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				Issuers: []string{"http://[::1]:namedport"},
@@ -142,10 +153,11 @@ func TestAuthenticationValidate(t *testing.T) {
 		{
 			name: "test when ServiceAccounts has invalid JWKSURI",
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim: "sub",
-				SigningAlgs:   []string{"RS256"},
-				IssuerURL:     "https://testIssuerURL",
-				ClientID:      "testClientID",
+				UsernameClaim:      "sub",
+				SigningAlgs:        []string{"RS256"},
+				IssuerURL:          "https://testIssuerURL",
+				ClientID:           "testClientID",
+				areFlagsConfigured: func() bool { return true },
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				KeyFiles: []string{"cert", "key"},
@@ -157,10 +169,11 @@ func TestAuthenticationValidate(t *testing.T) {
 		{
 			name: "test when ServiceAccounts has invalid JWKSURI (not https scheme)",
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim: "sub",
-				SigningAlgs:   []string{"RS256"},
-				IssuerURL:     "https://testIssuerURL",
-				ClientID:      "testClientID",
+				UsernameClaim:      "sub",
+				SigningAlgs:        []string{"RS256"},
+				IssuerURL:          "https://testIssuerURL",
+				ClientID:           "testClientID",
+				areFlagsConfigured: func() bool { return true },
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				KeyFiles: []string{"cert", "key"},
@@ -172,10 +185,11 @@ func TestAuthenticationValidate(t *testing.T) {
 		{
 			name: "test when WebHook has invalid retry attempts",
 			testOIDC: &OIDCAuthenticationOptions{
-				UsernameClaim: "sub",
-				SigningAlgs:   []string{"RS256"},
-				IssuerURL:     "https://testIssuerURL",
-				ClientID:      "testClientID",
+				UsernameClaim:      "sub",
+				SigningAlgs:        []string{"RS256"},
+				IssuerURL:          "https://testIssuerURL",
+				ClientID:           "testClientID",
+				areFlagsConfigured: func() bool { return true },
 			},
 			testSA: &ServiceAccountAuthenticationOptions{
 				KeyFiles: []string{"cert", "key"},
@@ -195,6 +209,23 @@ func TestAuthenticationValidate(t *testing.T) {
 			},
 			expectErr: "number of webhook retry attempts must be greater than 0, but is: 0",
 		},
+		{
+			name:                         "test when authentication config file is set without feature gate",
+			testAuthenticationConfigFile: "configfile",
+			expectErr:                    "set --feature-gates=StructuredAuthenticationConfiguration=true to use authentication-config file",
+		},
+		{
+			name:                         "test when authentication config file and oidc-* flags are set",
+			testAuthenticationConfigFile: "configfile",
+			testOIDC: &OIDCAuthenticationOptions{
+				UsernameClaim:      "sub",
+				SigningAlgs:        []string{"RS256"},
+				IssuerURL:          "https://testIssuerURL",
+				ClientID:           "testClientID",
+				areFlagsConfigured: func() bool { return true },
+			},
+			expectErr: "authentication-config file and oidc-* flags are mutually exclusive",
+		},
 	}
 
 	for _, testcase := range testCases {
@@ -203,6 +234,7 @@ func TestAuthenticationValidate(t *testing.T) {
 			options.OIDC = testcase.testOIDC
 			options.ServiceAccounts = testcase.testSA
 			options.WebHook = testcase.testWebHook
+			options.AuthenticationConfigFile = testcase.testAuthenticationConfigFile
 
 			errs := options.Validate()
 			if len(errs) > 0 && (!strings.Contains(utilerrors.NewAggregate(errs).Error(), testcase.expectErr) || testcase.expectErr == "") {
@@ -402,8 +434,14 @@ func TestBuiltInAuthenticationOptionsAddFlags(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if !opts.OIDC.areFlagsConfigured() {
+		t.Fatal("OIDC flags should be configured")
+	}
+	// nil these out because you cannot compare functions
+	opts.OIDC.areFlagsConfigured = nil
+
 	if !reflect.DeepEqual(opts, expected) {
-		t.Error(cmp.Diff(opts, expected))
+		t.Error(cmp.Diff(opts, expected, cmp.AllowUnexported(OIDCAuthenticationOptions{})))
 	}
 }
 
@@ -623,4 +661,356 @@ func TestToAuthenticationConfig_OIDC(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateOIDCOptions(t *testing.T) {
+	testCases := []struct {
+		name                                  string
+		args                                  []string
+		structuredAuthenticationConfigEnabled bool
+		expectErr                             string
+	}{
+		{
+			name: "issuer url and client id are not set",
+			args: []string{
+				"--oidc-username-claim=testClaim",
+			},
+			expectErr: "oidc-issuer-url and oidc-client-id must be specified together when any oidc-* flags are set",
+		},
+		{
+			name: "issuer url set, client id is not set",
+			args: []string{
+				"--oidc-issuer-url=https://testIssuerURL",
+				"--oidc-username-claim=testClaim",
+			},
+			expectErr: "oidc-issuer-url and oidc-client-id must be specified together when any oidc-* flags are set",
+		},
+		{
+			name: "issuer url is not set, client id is set",
+			args: []string{
+				"--oidc-client-id=testClientID",
+				"--oidc-username-claim=testClaim",
+			},
+			expectErr: "oidc-issuer-url and oidc-client-id must be specified together when any oidc-* flags are set",
+		},
+		{
+			name: "issuer url and client id are set",
+			args: []string{
+				"--oidc-client-id=testClientID",
+				"--oidc-issuer-url=https://testIssuerURL",
+			},
+			expectErr: "",
+		},
+		{
+			name: "authentication-config file, feature gate is not enabled",
+			args: []string{
+				"--authentication-config=configfile",
+			},
+			expectErr: "set --feature-gates=StructuredAuthenticationConfiguration=true to use authentication-config file",
+		},
+		{
+			name: "authentication-config file, --oidc-issuer-url is set",
+			args: []string{
+				"--authentication-config=configfile",
+				"--oidc-issuer-url=https://testIssuerURL",
+			},
+			expectErr: "authentication-config file and oidc-* flags are mutually exclusive",
+		},
+		{
+			name: "authentication-config file, --oidc-client-id is set",
+			args: []string{
+				"--authentication-config=configfile",
+				"--oidc-client-id=testClientID",
+			},
+			expectErr: "authentication-config file and oidc-* flags are mutually exclusive",
+		},
+		{
+			name: "authentication-config file, --oidc-username-claim is set",
+			args: []string{
+				"--authentication-config=configfile",
+				"--oidc-username-claim=testClaim",
+			},
+			expectErr: "authentication-config file and oidc-* flags are mutually exclusive",
+		},
+		{
+			name: "authentication-config file, --oidc-username-prefix is set",
+			args: []string{
+				"--authentication-config=configfile",
+				"--oidc-username-prefix=testPrefix",
+			},
+			expectErr: "authentication-config file and oidc-* flags are mutually exclusive",
+		},
+		{
+			name: "authentication-config file, --oidc-ca-file is set",
+			args: []string{
+				"--authentication-config=configfile",
+				"--oidc-ca-file=testCAFile",
+			},
+			expectErr: "authentication-config file and oidc-* flags are mutually exclusive",
+		},
+		{
+			name: "authentication-config file, --oidc-groups-claim is set",
+			args: []string{
+				"--authentication-config=configfile",
+				"--oidc-groups-claim=testClaim",
+			},
+			expectErr: "authentication-config file and oidc-* flags are mutually exclusive",
+		},
+		{
+			name: "authentication-config file, --oidc-groups-prefix is set",
+			args: []string{
+				"--authentication-config=configfile",
+				"--oidc-groups-prefix=testPrefix",
+			},
+			expectErr: "authentication-config file and oidc-* flags are mutually exclusive",
+		},
+		{
+			name: "authentication-config file, --oidc-required-claim is set",
+			args: []string{
+				"--authentication-config=configfile",
+				"--oidc-required-claim=foo=bar",
+			},
+			expectErr: "authentication-config file and oidc-* flags are mutually exclusive",
+		},
+		{
+			name: "authentication-config file, --oidc-signature-algs is set",
+			args: []string{
+				"--authentication-config=configfile",
+				"--oidc-signing-algs=RS512",
+			},
+			expectErr: "authentication-config file and oidc-* flags are mutually exclusive",
+		},
+		{
+			name: "authentication-config file, --oidc-username-claim flag not set, defaulting shouldn't error",
+			args: []string{
+				"--authentication-config=configfile",
+			},
+			expectErr:                             "",
+			structuredAuthenticationConfigEnabled: true,
+		},
+		{
+			name: "authentication-config file, --oidc-username-claim flag explicitly set with default value should error",
+			args: []string{
+				"--authentication-config=configfile",
+				"--oidc-username-claim=sub",
+			},
+			expectErr: "authentication-config file and oidc-* flags are mutually exclusive",
+		},
+		{
+			name: "valid authentication-config file",
+			args: []string{
+				"--authentication-config=configfile",
+			},
+			structuredAuthenticationConfigEnabled: true,
+			expectErr:                             "",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StructuredAuthenticationConfiguration, tt.structuredAuthenticationConfigEnabled)()
+
+			opts := NewBuiltInAuthenticationOptions().WithOIDC()
+			pf := pflag.NewFlagSet("test-builtin-authentication-opts", pflag.ContinueOnError)
+			opts.AddFlags(pf)
+
+			if err := pf.Parse(tt.args); err != nil {
+				t.Fatal(err)
+			}
+
+			errs := opts.Validate()
+			if len(errs) > 0 && (!strings.Contains(utilerrors.NewAggregate(errs).Error(), tt.expectErr) || tt.expectErr == "") {
+				t.Errorf("Got err: %v, Expected err: %s", errs, tt.expectErr)
+			}
+			if len(errs) == 0 && len(tt.expectErr) != 0 {
+				t.Errorf("Got err nil, Expected err: %s", tt.expectErr)
+			}
+			if len(errs) > 0 && len(tt.expectErr) == 0 {
+				t.Errorf("Got err: %v, Expected err nil", errs)
+			}
+		})
+	}
+}
+
+func TestLoadAuthenticationConfig(t *testing.T) {
+	testCases := []struct {
+		name           string
+		file           func() string
+		expectErr      string
+		expectedConfig *apiserver.AuthenticationConfiguration
+	}{
+		{
+			name:           "empty file",
+			file:           func() string { return writeTempFile(t, ``) },
+			expectErr:      "empty config file",
+			expectedConfig: nil,
+		},
+		{
+			name: "valid file",
+			file: func() string {
+				return writeTempFile(t,
+					`{
+						"apiVersion":"apiserver.config.k8s.io/v1alpha1",
+						"kind":"AuthenticationConfiguration",
+						"jwt":[{"issuer":{"url": "https://test-issuer"}}]}`)
+			},
+			expectErr: "",
+			expectedConfig: &apiserver.AuthenticationConfiguration{
+				JWT: []apiserver.JWTAuthenticator{
+					{
+						Issuer: apiserver.Issuer{URL: "https://test-issuer"},
+					},
+				},
+			},
+		},
+		{
+			name:           "missing file",
+			file:           func() string { return "bogus-missing-file" },
+			expectErr:      "no such file or directory",
+			expectedConfig: nil,
+		},
+		{
+			name: "invalid content file",
+			file: func() string {
+				return writeTempFile(t, `{"apiVersion":"apiserver.config.k8s.io/v99","kind":"AuthenticationConfiguration","authorizers":{"type":"Webhook"}}`)
+			},
+			expectErr:      `no kind "AuthenticationConfiguration" is registered for version "apiserver.config.k8s.io/v99"`,
+			expectedConfig: nil,
+		},
+		{
+			name:      "missing apiVersion",
+			file:      func() string { return writeTempFile(t, `{"kind":"AuthenticationConfiguration"}`) },
+			expectErr: `'apiVersion' is missing`,
+		},
+		{
+			name:      "missing kind",
+			file:      func() string { return writeTempFile(t, `{"apiVersion":"apiserver.config.k8s.io/v1alpha1"}`) },
+			expectErr: `'Kind' is missing`,
+		},
+		{
+			name: "unknown group",
+			file: func() string {
+				return writeTempFile(t, `{"apiVersion":"apps/v1alpha1","kind":"AuthenticationConfiguration"}`)
+			},
+			expectErr: `apps/v1alpha1`,
+		},
+		{
+			name: "unknown version",
+			file: func() string {
+				return writeTempFile(t, `{"apiVersion":"apiserver.config.k8s.io/v99","kind":"AuthenticationConfiguration"}`)
+			},
+			expectErr: `apiserver.config.k8s.io/v99`,
+		},
+		{
+			name: "unknown kind",
+			file: func() string {
+				return writeTempFile(t, `{"apiVersion":"apiserver.config.k8s.io/v1alpha1","kind":"SomeConfiguration"}`)
+			},
+			expectErr: `SomeConfiguration`,
+		},
+		{
+			name: "unknown field",
+			file: func() string {
+				return writeTempFile(t, `{
+							"apiVersion":"apiserver.config.k8s.io/v1alpha1",
+							"kind":"AuthenticationConfiguration",
+							"jwt1":[{"issuer":{"url": "https://test-issuer"}}]}`)
+			},
+			expectErr: `unknown field "jwt1"`,
+		},
+		{
+			name: "v1alpha1 - json",
+			file: func() string {
+				return writeTempFile(t, `{
+							"apiVersion":"apiserver.config.k8s.io/v1alpha1",
+							"kind":"AuthenticationConfiguration",
+							"jwt":[{"issuer":{"url": "https://test-issuer"}}]}`)
+			},
+			expectedConfig: &apiserver.AuthenticationConfiguration{
+				JWT: []apiserver.JWTAuthenticator{
+					{
+						Issuer: apiserver.Issuer{
+							URL: "https://test-issuer",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "v1alpha1 - yaml",
+			file: func() string {
+				return writeTempFile(t, `
+apiVersion: apiserver.config.k8s.io/v1alpha1
+kind: AuthenticationConfiguration
+jwt:
+- issuer:
+    url: https://test-issuer
+  claimMappings:
+    username:
+      claim: sub
+      prefix: ""
+`)
+			},
+			expectedConfig: &apiserver.AuthenticationConfiguration{
+				JWT: []apiserver.JWTAuthenticator{
+					{
+						Issuer: apiserver.Issuer{
+							URL: "https://test-issuer",
+						},
+						ClaimMappings: apiserver.ClaimMappings{
+							Username: apiserver.PrefixedClaimOrExpression{
+								Claim:  "sub",
+								Prefix: pointer.String(""),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "v1alpha1 - no jwt",
+			file: func() string {
+				return writeTempFile(t, `{
+							"apiVersion":"apiserver.config.k8s.io/v1alpha1",
+							"kind":"AuthenticationConfiguration"}`)
+			},
+			expectedConfig: &apiserver.AuthenticationConfiguration{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config, err := loadAuthenticationConfig(tc.file())
+			if !strings.Contains(errString(err), tc.expectErr) {
+				t.Fatalf("expected error %q, got %v", tc.expectErr, err)
+			}
+			if !reflect.DeepEqual(config, tc.expectedConfig) {
+				t.Fatalf("unexpected config:\n%s", cmp.Diff(tc.expectedConfig, config))
+			}
+		})
+	}
+}
+
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+	file, err := os.CreateTemp("", "config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Remove(file.Name()); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if err := os.WriteFile(file.Name(), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return file.Name()
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/register.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/register.go
@@ -43,6 +43,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	)
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&AdmissionConfiguration{},
+		&AuthenticationConfiguration{},
 		&EgressSelectorConfiguration{},
 		&TracingConfiguration{},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/register.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/register.go
@@ -53,6 +53,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&EgressSelectorConfiguration{},
 	)
 	scheme.AddKnownTypes(ConfigSchemeGroupVersion,
+		&AuthenticationConfiguration{},
 		&TracingConfiguration{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -198,6 +198,13 @@ const (
 	// document.
 	StorageVersionHash featuregate.Feature = "StorageVersionHash"
 
+	// owner: @aramase, @enj, @nabokihms
+	// kep: https://kep.k8s.io/3331
+	// alpha: v1.29
+	//
+	// Enables Structured Authentication Configuration
+	StructuredAuthenticationConfiguration featuregate.Feature = "StructuredAuthenticationConfiguration"
+
 	// owner: @wojtek-t
 	// alpha: v1.15
 	// beta: v1.16
@@ -277,6 +284,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	StorageVersionAPI: {Default: false, PreRelease: featuregate.Alpha},
 
 	StorageVersionHash: {Default: true, PreRelease: featuregate.Beta},
+
+	StructuredAuthenticationConfiguration: {Default: false, PreRelease: featuregate.Alpha},
 
 	WatchBookmark: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 


### PR DESCRIPTION
Implements the first phase of Structured Authentication Configuration
- Adds `StructuredAuthenticationConfiguration` feature gate
- kube-apiserver flag (`--authentication-config`) for authentication configuration file


fixes https://github.com/kubernetes/kubernetes/issues/118833

/kind feature
/sig auth
/triage accepted
/milestone v1.28
/priority important-soon

```release-note
kube-apiserver: adds --authentication-config flag for reading AuthenticationConfiguration files. --authentication-config flag is mutually exclusive with the existing --oidc-* flags.
```

```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3331-structured-authentication-configuration
```
