### PR TITLE
kuberuntime: Fix tests on machines with IsCgroup2UnifiedMode true

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux_test.go
@@ -123,8 +123,23 @@ func TestApplySandboxResources(t *testing.T) {
 
 	for i, test := range tests {
 		m.applySandboxResources(test.pod, config)
-		assert.Equal(t, test.expectedResource, config.Linux.Resources, "TestCase[%d]: %s", i, test.description)
-		assert.Equal(t, test.expectedOverhead, config.Linux.Overhead, "TestCase[%d]: %s", i, test.description)
+
+		if config.Linux.Resources.Unified["memory.oom.group"] != "" {
+			if test.expectedResource.Unified == nil {
+				test.expectedResource.Unified = map[string]string{}
+			}
+			test.expectedResource.Unified["memory.oom.group"] = "1"
+		}
+
+		if config.Linux.Overhead.Unified["memory.oom.group"] != "" {
+			if test.expectedOverhead.Unified == nil {
+				test.expectedOverhead.Unified = map[string]string{}
+			}
+			test.expectedOverhead.Unified["memory.oom.group"] = "1"
+		}
+
+		assert.Equal(t, test.expectedResource, config.Linux.Resources, "TestCase[%d]: %s: expected resources", i, test.description)
+		assert.Equal(t, test.expectedOverhead, config.Linux.Overhead, "TestCase[%d]: %s: expected overhead", i, test.description)
 	}
 }
 


### PR DESCRIPTION
On a machine where libcontainercgroups.IsCgroup2UnifiedMode() returns true (whatever that means), several tests in kuberuntime will consistently fail because they don't account for the hardcoded "memory.oom.group": "1" entry we add to the unified resource map.

This commit fixes these tests by checking for this entry in the output. If it exists, it is added to the expected output before diffing.

/kind bug
/kind failing-test

```release-note
NONE
```