### PR TITLE
Use cmp diff in controller_util_test.go

### DIFF
--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -54,6 +54,7 @@ import (
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/pointer"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -397,10 +398,9 @@ func TestActivePodFiltering(t *testing.T) {
 		gotNames.Insert(pod.Name)
 	}
 
-	assert.Equal(t, 0, expectedNames.Difference(gotNames).Len(),
-		"expected %v, got %v", expectedNames.List(), gotNames.List())
-	assert.Equal(t, 0, gotNames.Difference(expectedNames).Len(),
-		"expected %v, got %v", expectedNames.List(), gotNames.List())
+	if diff := cmp.Diff(expectedNames.List(), gotNames.List()); diff != "" {
+		t.Errorf("Active pod names (-want,+got):\n%s", diff)
+	}
 }
 
 func TestSortingActivePods(t *testing.T) {
@@ -618,10 +618,9 @@ func TestActiveReplicaSetsFiltering(t *testing.T) {
 		gotNames.Insert(rs.Name)
 	}
 
-	assert.Equal(t, 0, expectedNames.Difference(gotNames).Len(),
-		"expected %v, got %v", expectedNames.List(), gotNames.List())
-	assert.Equal(t, 0, gotNames.Difference(expectedNames).Len(),
-		"expected %v, got %v", expectedNames.List(), gotNames.List())
+	if diff := cmp.Diff(expectedNames.List(), gotNames.List()); diff != "" {
+		t.Errorf("Active replica set names (-want,+got):\n%s", diff)
+	}
 }
 
 func TestComputeHash(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
[controller_util_test.go](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/controller_utils_test.go) Not using Cmp.Diff means that we don't see diffs in the unit tests which makes the debug and testing difficult.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119133

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
