### PR TITLE
Automated cherry pick of #119160: Only declare job as finished after removing all finalizers

### DIFF
--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -882,7 +882,9 @@ func TestOrphanPodsFinalizersClearedWithGC(t *testing.T) {
 
 func TestFinalizersClearedWhenBackoffLimitExceeded(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobTrackingWithFinalizers, true)()
-
+	// Set a maximum number of uncounted pods below parallelism, to ensure it
+	// doesn't affect the termination of pods.
+	t.Cleanup(setDuringTest(&jobcontroller.MaxUncountedPods, 50))
 	closeFn, restConfig, clientSet, ns := setup(t, "simple")
 	defer closeFn()
 	ctx, cancel := startJobControllerAndWaitForCaches(restConfig)


### PR DESCRIPTION
Cherry pick of #119160 on release-1.25, in turn, cherry pick of #119159

#119160: Only declare job as finished after removing all finalizers

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Only declare Job as finished after removing all Pod finalizers to avoid orphan Pods
```