### PR TITLE
Change the log level from info to error if volume usage metrics calculation fail

### DIFF
--- a/pkg/kubelet/server/stats/volume_stat_calculator.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator.go
@@ -149,6 +149,8 @@ func (s *volumeStatCalculator) calcAndStoreStats(errors map[string]error) {
 				}
 			}
 			continue
+		} else {
+			delete(errors, name)
 		}
 		// Lookup the volume spec and add a 'PVCReference' for volumes that reference a PVC
 		volSpec := volumesSpec[name]

--- a/pkg/kubelet/server/stats/volume_stat_calculator.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator.go
@@ -142,7 +142,7 @@ func (s *volumeStatCalculator) calcAndStoreStats() {
 		if err != nil {
 			// Expected for Volumes that don't support Metrics
 			if !volume.IsNotSupported(err) {
-				klog.V(4).InfoS("Failed to calculate volume metrics", "pod", klog.KObj(s.pod), "podUID", s.pod.UID, "volumeName", name, "err", err)
+				klog.ErrorS(err, "Failed to calculate volume metrics", "pod", klog.KObj(s.pod), "podUID", s.pod.UID, "volumeName", name)
 			}
 			continue
 		}

--- a/pkg/kubelet/server/stats/volume_stat_calculator.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator.go
@@ -144,7 +144,7 @@ func (s *volumeStatCalculator) calcAndStoreStats(errors map[string]error) {
 			// Expected for Volumes that don't support Metrics
 			if !volume.IsNotSupported(err) {
 				if oldErr, found := errors[name]; !found || oldErr.Error() != err.Error() {
-					klog.InfoS("Failed to calculate volume metrics", "pod", klog.KObj(s.pod), "podUID", s.pod.UID, "volumeName", name, "err", err)
+					klog.ErrorS(err, "Failed to calculate volume metrics", "pod", klog.KObj(s.pod), "podUID", s.pod.UID, "volumeName", name)
 					errors[name] = err
 				}
 			}

--- a/pkg/kubelet/server/stats/volume_stat_calculator_test.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator_test.go
@@ -122,8 +122,7 @@ func TestPVCRef(t *testing.T) {
 
 	// Calculate stats for pod
 	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
-	errors := make(map[string]error)
-	statsCalculator.calcAndStoreStats(errors)
+	statsCalculator.calcAndStoreStats(make(map[string]error))
 	vs, _ := statsCalculator.GetLatest()
 
 	assert.Len(t, append(vs.EphemeralVolumes, vs.PersistentVolumes...), 4)
@@ -182,8 +181,7 @@ func TestNormalVolumeEvent(t *testing.T) {
 
 	// Calculate stats for pod
 	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
-	errors := make(map[string]error)
-	statsCalculator.calcAndStoreStats(errors)
+	statsCalculator.calcAndStoreStats(make(map[string]error))
 
 	event, err := WatchEvent(eventStore)
 	assert.NotNil(t, err)
@@ -213,8 +211,7 @@ func TestAbnormalVolumeEvent(t *testing.T) {
 		volumeCondition.Abnormal = true
 	}
 	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
-	errors := make(map[string]error)
-	statsCalculator.calcAndStoreStats(errors)
+	statsCalculator.calcAndStoreStats(make(map[string]error))
 
 	event, err := WatchEvent(eventStore)
 	assert.Nil(t, err)

--- a/pkg/kubelet/server/stats/volume_stat_calculator_test.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator_test.go
@@ -122,7 +122,8 @@ func TestPVCRef(t *testing.T) {
 
 	// Calculate stats for pod
 	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
-	statsCalculator.calcAndStoreStats()
+	errors := make(map[string]error)
+	statsCalculator.calcAndStoreStats(errors)
 	vs, _ := statsCalculator.GetLatest()
 
 	assert.Len(t, append(vs.EphemeralVolumes, vs.PersistentVolumes...), 4)
@@ -181,7 +182,8 @@ func TestNormalVolumeEvent(t *testing.T) {
 
 	// Calculate stats for pod
 	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
-	statsCalculator.calcAndStoreStats()
+	errors := make(map[string]error)
+	statsCalculator.calcAndStoreStats(errors)
 
 	event, err := WatchEvent(eventStore)
 	assert.NotNil(t, err)
@@ -211,7 +213,8 @@ func TestAbnormalVolumeEvent(t *testing.T) {
 		volumeCondition.Abnormal = true
 	}
 	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod, &fakeEventRecorder)
-	statsCalculator.calcAndStoreStats()
+	errors := make(map[string]error)
+	statsCalculator.calcAndStoreStats(errors)
 
 	event, err := WatchEvent(eventStore)
 	assert.Nil(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The current logging level is too low to investigate why we get error during volume usage metrics calculation. Since we have error during the volume stat calculation, change the logging level from Info to Error.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #118062

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
