### PR TITLE
Stream Translator Proxy and FallbackExecutor for WebSockets

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -179,6 +179,14 @@ const (
 	// Enables kubelet to detect CSI volume condition and send the event of the abnormal volume to the corresponding pod that is using it.
 	CSIVolumeHealth featuregate.Feature = "CSIVolumeHealth"
 
+	// owner: @seans3
+	// kep: http://kep.k8s.io/4006
+	// alpha: v1.29
+	//
+	// Enables StreamTranslator proxy to handle WebSockets upgrade requests for the
+	// version of the RemoteCommand subprotocol that supports the "close" signal.
+	TranslateStreamCloseWebsocketRequests featuregate.Feature = "TranslateStreamCloseWebsocketRequests"
+
 	// owner: @nckturner
 	// kep:  http://kep.k8s.io/2699
 	// alpha: v1.27
@@ -924,6 +932,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	CSIVolumeHealth: {Default: false, PreRelease: featuregate.Alpha},
 
 	SkipReadOnlyValidationGCE: {Default: true, PreRelease: featuregate.Deprecated}, // remove in 1.31
+
+	TranslateStreamCloseWebsocketRequests: {Default: false, PreRelease: featuregate.Alpha},
 
 	CloudControllerManagerWebhook: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -959,7 +960,10 @@ func TestServeExecInContainerIdleTimeout(t *testing.T) {
 
 	url := fw.testHTTPServer.URL + "/exec/" + podNamespace + "/" + podName + "/" + expectedContainerName + "?c=ls&c=-a&" + api.ExecStdinParam + "=1"
 
-	upgradeRoundTripper := spdy.NewRoundTripper(nil)
+	upgradeRoundTripper, err := spdy.NewRoundTripper(&tls.Config{})
+	if err != nil {
+		t.Fatalf("Error creating SpdyRoundTripper: %v", err)
+	}
 	c := &http.Client{Transport: upgradeRoundTripper}
 
 	resp, err := c.Do(makeReq(t, "POST", url, "v4.channel.k8s.io"))
@@ -1115,7 +1119,10 @@ func testExecAttach(t *testing.T, verb string) {
 				upgradeRoundTripper httpstream.UpgradeRoundTripper
 				c                   *http.Client
 			)
-			upgradeRoundTripper = spdy.NewRoundTripper(nil)
+			upgradeRoundTripper, err = spdy.NewRoundTripper(&tls.Config{})
+			if err != nil {
+				t.Fatalf("Error creating SpdyRoundTripper: %v", err)
+			}
 			c = &http.Client{Transport: upgradeRoundTripper}
 
 			resp, err = c.Do(makeReq(t, "POST", url, "v4.channel.k8s.io"))
@@ -1211,7 +1218,10 @@ func TestServePortForwardIdleTimeout(t *testing.T) {
 
 	url := fw.testHTTPServer.URL + "/portForward/" + podNamespace + "/" + podName
 
-	upgradeRoundTripper := spdy.NewRoundTripper(nil)
+	upgradeRoundTripper, err := spdy.NewRoundTripper(&tls.Config{})
+	if err != nil {
+		t.Fatalf("Error creating SpdyRoundTripper: %v", err)
+	}
 	c := &http.Client{Transport: upgradeRoundTripper}
 
 	req := makeReq(t, "POST", url, "portforward.k8s.io")
@@ -1310,7 +1320,10 @@ func TestServePortForward(t *testing.T) {
 				c                   *http.Client
 			)
 
-			upgradeRoundTripper = spdy.NewRoundTripper(nil)
+			upgradeRoundTripper, err = spdy.NewRoundTripper(&tls.Config{})
+			if err != nil {
+				t.Fatalf("Error creating SpdyRoundTripper: %v", err)
+			}
 			c = &http.Client{Transport: upgradeRoundTripper}
 
 			req := makeReq(t, "POST", url, "portforward.k8s.io")

--- a/pkg/registry/core/pod/rest/subresources.go
+++ b/pkg/registry/core/pod/rest/subresources.go
@@ -23,12 +23,16 @@ import (
 	"net/url"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/httpstream/wsstream"
 	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/proxy"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	translator "k8s.io/apiserver/pkg/util/proxy"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/capabilities"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/client"
 	"k8s.io/kubernetes/pkg/registry/core/pod"
 )
@@ -113,7 +117,21 @@ func (r *AttachREST) Connect(ctx context.Context, name string, opts runtime.Obje
 	if err != nil {
 		return nil, err
 	}
-	return newThrottledUpgradeAwareProxyHandler(location, transport, false, true, responder), nil
+	handler := newThrottledUpgradeAwareProxyHandler(location, transport, false, true, responder)
+	if utilfeature.DefaultFeatureGate.Enabled(features.TranslateStreamCloseWebsocketRequests) {
+		// Wrap the upgrade aware handler to implement stream translation
+		// for WebSocket/V5 upgrade requests.
+		streamOptions := translator.Options{
+			Stdin:  attachOpts.Stdin,
+			Stdout: attachOpts.Stdout,
+			Stderr: attachOpts.Stderr,
+			Tty:    attachOpts.TTY,
+		}
+		maxBytesPerSec := capabilities.Get().PerConnectionBandwidthLimitBytesPerSec
+		streamtranslator := translator.NewStreamTranslatorHandler(location, transport, maxBytesPerSec, streamOptions)
+		handler = translator.NewTranslatingHandler(handler, streamtranslator, wsstream.IsWebSocketRequestWithStreamCloseProtocol)
+	}
+	return handler, nil
 }
 
 // NewConnectOptions returns the versioned object that represents exec parameters
@@ -156,7 +174,21 @@ func (r *ExecREST) Connect(ctx context.Context, name string, opts runtime.Object
 	if err != nil {
 		return nil, err
 	}
-	return newThrottledUpgradeAwareProxyHandler(location, transport, false, true, responder), nil
+	handler := newThrottledUpgradeAwareProxyHandler(location, transport, false, true, responder)
+	if utilfeature.DefaultFeatureGate.Enabled(features.TranslateStreamCloseWebsocketRequests) {
+		// Wrap the upgrade aware handler to implement stream translation
+		// for WebSocket/V5 upgrade requests.
+		streamOptions := translator.Options{
+			Stdin:  execOpts.Stdin,
+			Stdout: execOpts.Stdout,
+			Stderr: execOpts.Stderr,
+			Tty:    execOpts.TTY,
+		}
+		maxBytesPerSec := capabilities.Get().PerConnectionBandwidthLimitBytesPerSec
+		streamtranslator := translator.NewStreamTranslatorHandler(location, transport, maxBytesPerSec, streamOptions)
+		handler = translator.NewTranslatingHandler(handler, streamtranslator, wsstream.IsWebSocketRequestWithStreamCloseProtocol)
+	}
+	return handler, nil
 }
 
 // NewConnectOptions returns the versioned object that represents exec parameters
@@ -213,7 +245,7 @@ func (r *PortForwardREST) Connect(ctx context.Context, name string, opts runtime
 	return newThrottledUpgradeAwareProxyHandler(location, transport, false, true, responder), nil
 }
 
-func newThrottledUpgradeAwareProxyHandler(location *url.URL, transport http.RoundTripper, wrapTransport, upgradeRequired bool, responder rest.Responder) *proxy.UpgradeAwareHandler {
+func newThrottledUpgradeAwareProxyHandler(location *url.URL, transport http.RoundTripper, wrapTransport, upgradeRequired bool, responder rest.Responder) http.Handler {
 	handler := proxy.NewUpgradeAwareHandler(location, transport, wrapTransport, upgradeRequired, proxy.NewErrorResponder(responder))
 	handler.MaxBytesPerSec = capabilities.Get().PerConnectionBandwidthLimitBytesPerSec
 	return handler

--- a/staging/src/k8s.io/apiextensions-apiserver/go.mod
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.mod
@@ -73,9 +73,11 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect

--- a/staging/src/k8s.io/apiextensions-apiserver/go.sum
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.sum
@@ -163,6 +163,7 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8V
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -378,6 +379,7 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -388,6 +390,7 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
 github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream.go
@@ -17,6 +17,7 @@ limitations under the License.
 package httpstream
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -93,6 +94,26 @@ type Stream interface {
 	Headers() http.Header
 	// Identifier returns the stream's ID.
 	Identifier() uint32
+}
+
+// UpgradeFailureError encapsulates the cause for why the streaming
+// upgrade request failed. Implements error interface.
+type UpgradeFailureError struct {
+	Cause error
+}
+
+func (u *UpgradeFailureError) Error() string {
+	return fmt.Sprintf("unable to upgrade streaming request: %s", u.Cause)
+}
+
+// IsUpgradeFailure returns true if the passed error is (or wrapped error contains)
+// the UpgradeFailureError.
+func IsUpgradeFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	var upgradeErr *UpgradeFailureError
+	return errors.As(err, &upgradeErr)
 }
 
 // IsUpgradeRequest returns true if the given request is a connection upgrade request

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/dial.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/dial.go
@@ -29,12 +29,12 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// dialURL will dial the specified URL using the underlying dialer held by the passed
+// DialURL will dial the specified URL using the underlying dialer held by the passed
 // RoundTripper. The primary use of this method is to support proxying upgradable connections.
 // For this reason this method will prefer to negotiate http/1.1 if the URL scheme is https.
 // If you wish to ensure ALPN negotiates http2 then set NextProto=[]string{"http2"} in the
 // TLSConfig of the http.Transport
-func dialURL(ctx context.Context, url *url.URL, transport http.RoundTripper) (net.Conn, error) {
+func DialURL(ctx context.Context, url *url.URL, transport http.RoundTripper) (net.Conn, error) {
 	dialAddr := netutil.CanonicalAddr(url)
 
 	dialer, err := utilnet.DialerFor(transport)

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/dial_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/dial_test.go
@@ -143,7 +143,7 @@ func TestDialURL(t *testing.T) {
 			u, _ := url.Parse(ts.URL)
 			_, p, _ := net.SplitHostPort(u.Host)
 			u.Host = net.JoinHostPort("127.0.0.1", p)
-			conn, err := dialURL(context.Background(), u, transport)
+			conn, err := DialURL(context.Background(), u, transport)
 
 			// Make sure dialing doesn't mutate the transport's TLSConfig
 			if !reflect.DeepEqual(tc.TLSConfig, tlsConfigCopy) {

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -492,7 +492,7 @@ func getResponse(r io.Reader) (*http.Response, []byte, error) {
 
 // dial dials the backend at req.URL and writes req to it.
 func dial(req *http.Request, transport http.RoundTripper) (net.Conn, error) {
-	conn, err := dialURL(req.Context(), req.URL, transport)
+	conn, err := DialURL(req.Context(), req.URL, transport)
 	if err != nil {
 		return nil, fmt.Errorf("error dialing backend: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.3
 	go.etcd.io/etcd/api/v3 v3.5.9
@@ -87,9 +88,9 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect

--- a/staging/src/k8s.io/apiserver/go.sum
+++ b/staging/src/k8s.io/apiserver/go.sum
@@ -163,6 +163,7 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8V
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -376,6 +377,7 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtranslator.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtranslator.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/mxk/go-flowrate/flowrate"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream/spdy"
+	constants "k8s.io/apimachinery/pkg/util/remotecommand"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/util/exec"
+)
+
+// StreamTranslatorHandler is a handler which translates WebSocket stream data
+// to SPDY to proxy to kubelet (and ContainerRuntime).
+type StreamTranslatorHandler struct {
+	// Location is the location of the upstream proxy. It is used as the location to Dial on the upstream server
+	// for upgrade requests.
+	Location *url.URL
+	// Transport provides an optional round tripper to use to proxy. If nil, the default proxy transport is used
+	Transport http.RoundTripper
+	// MaxBytesPerSec throttles stream Reader/Writer if necessary
+	MaxBytesPerSec int64
+	// Options define the requested streams (e.g. stdin, stdout).
+	Options Options
+}
+
+// NewStreamTranslatorHandler creates a new proxy handler. Responder is required for returning
+// errors to the caller.
+func NewStreamTranslatorHandler(location *url.URL, transport http.RoundTripper, maxBytesPerSec int64, opts Options) *StreamTranslatorHandler {
+	return &StreamTranslatorHandler{
+		Location:       location,
+		Transport:      transport,
+		MaxBytesPerSec: maxBytesPerSec,
+		Options:        opts,
+	}
+}
+
+func (h *StreamTranslatorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// Create WebSocket server, including particular streams requested. If this websocket
+	// endpoint is not able to be upgraded, the websocket library will return errors
+	// to the client.
+	websocketStreams, err := webSocketServerStreams(req, w, h.Options)
+	if err != nil {
+		return
+	}
+	defer websocketStreams.conn.Close()
+
+	// Creating SPDY executor, ensuring redirects are not followed.
+	spdyRoundTripper, err := spdy.NewRoundTripperWithConfig(spdy.RoundTripperConfig{UpgradeTransport: h.Transport})
+	if err != nil {
+		websocketStreams.writeStatus(apierrors.NewInternalError(err)) //nolint:errcheck
+		return
+	}
+	spdyExecutor, err := remotecommand.NewSPDYExecutorRejectRedirects(spdyRoundTripper, spdyRoundTripper, "POST", h.Location)
+	if err != nil {
+		websocketStreams.writeStatus(apierrors.NewInternalError(err)) //nolint:errcheck
+		return
+	}
+
+	// Wire the WebSocket server streams output to the SPDY client input. The stdin/stdout/stderr streams
+	// can be throttled if the transfer rate exceeds the "MaxBytesPerSec" (zero means unset). Throttling
+	// the streams instead of the underlying connection *may* not perform the same if two streams
+	// traveling the same direction (e.g. stdout, stderr) are being maxed out.
+	opts := remotecommand.StreamOptions{}
+	if h.Options.Stdin {
+		stdin := websocketStreams.stdinStream
+		if h.MaxBytesPerSec > 0 {
+			stdin = flowrate.NewReader(stdin, h.MaxBytesPerSec)
+		}
+		opts.Stdin = stdin
+	}
+	if h.Options.Stdout {
+		stdout := websocketStreams.stdoutStream
+		if h.MaxBytesPerSec > 0 {
+			stdout = flowrate.NewWriter(stdout, h.MaxBytesPerSec)
+		}
+		opts.Stdout = stdout
+	}
+	if h.Options.Stderr {
+		stderr := websocketStreams.stderrStream
+		if h.MaxBytesPerSec > 0 {
+			stderr = flowrate.NewWriter(stderr, h.MaxBytesPerSec)
+		}
+		opts.Stderr = stderr
+	}
+	if h.Options.Tty {
+		opts.Tty = true
+		opts.TerminalSizeQueue = &translatorSizeQueue{resizeChan: websocketStreams.resizeChan}
+	}
+	// Start the SPDY client with connected streams. Output from the WebSocket server
+	// streams will be forwarded into the SPDY client. Report SPDY execution errors
+	// through the websocket error stream.
+	err = spdyExecutor.StreamWithContext(req.Context(), opts)
+	if err != nil {
+		//nolint:errcheck   // Ignore writeStatus returned error
+		if statusErr, ok := err.(*apierrors.StatusError); ok {
+			websocketStreams.writeStatus(statusErr)
+		} else if exitErr, ok := err.(exec.CodeExitError); ok && exitErr.Exited() {
+			websocketStreams.writeStatus(codeExitToStatusError(exitErr))
+		} else {
+			websocketStreams.writeStatus(apierrors.NewInternalError(err))
+		}
+		return
+	}
+
+	// Write the success status back to the WebSocket client.
+	//nolint:errcheck
+	websocketStreams.writeStatus(&apierrors.StatusError{ErrStatus: metav1.Status{
+		Status: metav1.StatusSuccess,
+	}})
+}
+
+// translatorSizeQueue feeds the size events from the WebSocket
+// resizeChan into the SPDY client input. Implements TerminalSizeQueue
+// interface.
+type translatorSizeQueue struct {
+	resizeChan chan remotecommand.TerminalSize
+}
+
+func (t *translatorSizeQueue) Next() *remotecommand.TerminalSize {
+	size, ok := <-t.resizeChan
+	if !ok {
+		return nil
+	}
+	return &size
+}
+
+// codeExitToStatusError converts a passed CodeExitError to the type necessary
+// to send through an error stream using "writeStatus".
+func codeExitToStatusError(exitErr exec.CodeExitError) *apierrors.StatusError {
+	rc := exitErr.ExitStatus()
+	return &apierrors.StatusError{
+		ErrStatus: metav1.Status{
+			Status: metav1.StatusFailure,
+			Reason: constants.NonZeroExitCodeReason,
+			Details: &metav1.StatusDetails{
+				Causes: []metav1.StatusCause{
+					{
+						Type:    constants.ExitCodeCauseType,
+						Message: fmt.Sprintf("%d", rc),
+					},
+				},
+			},
+			Message: fmt.Sprintf("command terminated with non-zero exit code: %v", exitErr),
+		},
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtranslator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtranslator_test.go
@@ -1,0 +1,872 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	mrand "math/rand"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/httpstream/spdy"
+	rcconstants "k8s.io/apimachinery/pkg/util/remotecommand"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/transport"
+)
+
+// TestStreamTranslator_LoopbackStdinToStdout returns random data sent on the client's
+// STDIN channel back onto the client's STDOUT channel. There are two servers in this test: the
+// upstream fake SPDY server, and the StreamTranslator server. The StreamTranslator proxys the
+// data received from the websocket client upstream to the SPDY server (by translating the
+// websocket data into spdy). The returned data read on the websocket client STDOUT is then
+// compared the random data sent on STDIN to ensure they are the same.
+func TestStreamTranslator_LoopbackStdinToStdout(t *testing.T) {
+	// Create upstream fake SPDY server which copies STDIN back onto STDOUT stream.
+	spdyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx, err := createSPDYServerStreams(w, req, Options{
+			Stdin:  true,
+			Stdout: true,
+		})
+		if err != nil {
+			t.Errorf("error on createHTTPStreams: %v", err)
+			return
+		}
+		defer ctx.conn.Close()
+		// Loopback STDIN data onto STDOUT stream.
+		_, err = io.Copy(ctx.stdoutStream, ctx.stdinStream)
+		if err != nil {
+			t.Fatalf("error copying STDIN to STDOUT: %v", err)
+		}
+
+	}))
+	defer spdyServer.Close()
+	// Create StreamTranslatorHandler, which points upstream to fake SPDY server with
+	// streams STDIN and STDOUT. Create test server from StreamTranslatorHandler.
+	spdyLocation, err := url.Parse(spdyServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse spdy server URL: %s", spdyServer.URL)
+	}
+	spdyTransport, err := fakeTransport()
+	if err != nil {
+		t.Fatalf("Unexpected error creating transport: %v", err)
+	}
+	streams := Options{Stdin: true, Stdout: true}
+	streamTranslator := NewStreamTranslatorHandler(spdyLocation, spdyTransport, 0, streams)
+	streamTranslatorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		streamTranslator.ServeHTTP(w, req)
+	}))
+	defer streamTranslatorServer.Close()
+	// Now create the websocket client (executor), and point it to the "streamTranslatorServer".
+	streamTranslatorLocation, err := url.Parse(streamTranslatorServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse StreamTranslator server URL: %s", streamTranslatorServer.URL)
+	}
+	exec, err := remotecommand.NewWebSocketExecutor(&rest.Config{Host: streamTranslatorLocation.Host}, "GET", streamTranslatorServer.URL)
+	if err != nil {
+		t.Errorf("unexpected error creating websocket executor: %v", err)
+	}
+	// Generate random data, and set it up to stream on STDIN. The data will be
+	// returned on the STDOUT buffer.
+	randomSize := 1024 * 1024
+	randomData := make([]byte, randomSize)
+	if _, err := rand.Read(randomData); err != nil {
+		t.Errorf("unexpected error reading random data: %v", err)
+	}
+	var stdout bytes.Buffer
+	options := &remotecommand.StreamOptions{
+		Stdin:  bytes.NewReader(randomData),
+		Stdout: &stdout,
+	}
+	errorChan := make(chan error)
+	go func() {
+		// Start the streaming on the WebSocket "exec" client.
+		errorChan <- exec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+	data, err := io.ReadAll(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		t.Errorf("error reading the stream: %v", err)
+		return
+	}
+	// Check the random data sent on STDIN was the same returned on STDOUT.
+	if !bytes.Equal(randomData, data) {
+		t.Errorf("unexpected data received: %d sent: %d", len(data), len(randomData))
+	}
+}
+
+// TestStreamTranslator_LoopbackStdinToStderr returns random data sent on the client's
+// STDIN channel back onto the client's STDERR channel. There are two servers in this test: the
+// upstream fake SPDY server, and the StreamTranslator server. The StreamTranslator proxys the
+// data received from the websocket client upstream to the SPDY server (by translating the
+// websocket data into spdy). The returned data read on the websocket client STDERR is then
+// compared the random data sent on STDIN to ensure they are the same.
+func TestStreamTranslator_LoopbackStdinToStderr(t *testing.T) {
+	// Create upstream fake SPDY server which copies STDIN back onto STDERR stream.
+	spdyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx, err := createSPDYServerStreams(w, req, Options{
+			Stdin:  true,
+			Stderr: true,
+		})
+		if err != nil {
+			t.Errorf("error on createHTTPStreams: %v", err)
+			return
+		}
+		defer ctx.conn.Close()
+		// Loopback STDIN data onto STDERR stream.
+		_, err = io.Copy(ctx.stderrStream, ctx.stdinStream)
+		if err != nil {
+			t.Fatalf("error copying STDIN to STDERR: %v", err)
+		}
+	}))
+	defer spdyServer.Close()
+	// Create StreamTranslatorHandler, which points upstream to fake SPDY server with
+	// streams STDIN and STDERR. Create test server from StreamTranslatorHandler.
+	spdyLocation, err := url.Parse(spdyServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse spdy server URL: %s", spdyServer.URL)
+	}
+	spdyTransport, err := fakeTransport()
+	if err != nil {
+		t.Fatalf("Unexpected error creating transport: %v", err)
+	}
+	streams := Options{Stdin: true, Stderr: true}
+	streamTranslator := NewStreamTranslatorHandler(spdyLocation, spdyTransport, 0, streams)
+	streamTranslatorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		streamTranslator.ServeHTTP(w, req)
+	}))
+	defer streamTranslatorServer.Close()
+	// Now create the websocket client (executor), and point it to the "streamTranslatorServer".
+	streamTranslatorLocation, err := url.Parse(streamTranslatorServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse StreamTranslator server URL: %s", streamTranslatorServer.URL)
+	}
+	exec, err := remotecommand.NewWebSocketExecutor(&rest.Config{Host: streamTranslatorLocation.Host}, "GET", streamTranslatorServer.URL)
+	if err != nil {
+		t.Errorf("unexpected error creating websocket executor: %v", err)
+	}
+	// Generate random data, and set it up to stream on STDIN. The data will be
+	// returned on the STDERR buffer.
+	randomSize := 1024 * 1024
+	randomData := make([]byte, randomSize)
+	if _, err := rand.Read(randomData); err != nil {
+		t.Errorf("unexpected error reading random data: %v", err)
+	}
+	var stderr bytes.Buffer
+	options := &remotecommand.StreamOptions{
+		Stdin:  bytes.NewReader(randomData),
+		Stderr: &stderr,
+	}
+	errorChan := make(chan error)
+	go func() {
+		// Start the streaming on the WebSocket "exec" client.
+		errorChan <- exec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+	data, err := io.ReadAll(bytes.NewReader(stderr.Bytes()))
+	if err != nil {
+		t.Errorf("error reading the stream: %v", err)
+		return
+	}
+	// Check the random data sent on STDIN was the same returned on STDERR.
+	if !bytes.Equal(randomData, data) {
+		t.Errorf("unexpected data received: %d sent: %d", len(data), len(randomData))
+	}
+}
+
+// Returns a random exit code in the range(1-127).
+func randomExitCode() int {
+	errorCode := mrand.Intn(127) // Range: (0 - 126)
+	errorCode += 1               // Range: (1 - 127)
+	return errorCode
+}
+
+// TestStreamTranslator_ErrorStream tests the error stream by sending an error with a random
+// exit code, then validating the error arrives on the error stream.
+func TestStreamTranslator_ErrorStream(t *testing.T) {
+	expectedExitCode := randomExitCode()
+	// Create upstream fake SPDY server, returning a non-zero exit code
+	// on error stream within the structured error.
+	spdyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx, err := createSPDYServerStreams(w, req, Options{
+			Stdout: true,
+		})
+		if err != nil {
+			t.Errorf("error on createHTTPStreams: %v", err)
+			return
+		}
+		defer ctx.conn.Close()
+		// Read/discard STDIN data before returning error on error stream.
+		_, err = io.Copy(io.Discard, ctx.stdinStream)
+		if err != nil {
+			t.Fatalf("error copying STDIN to DISCARD: %v", err)
+		}
+		// Force an non-zero exit code error returned on the error stream.
+		err = ctx.writeStatus(&apierrors.StatusError{ErrStatus: metav1.Status{
+			Status: metav1.StatusFailure,
+			Reason: rcconstants.NonZeroExitCodeReason,
+			Details: &metav1.StatusDetails{
+				Causes: []metav1.StatusCause{
+					{
+						Type:    rcconstants.ExitCodeCauseType,
+						Message: fmt.Sprintf("%d", expectedExitCode),
+					},
+				},
+			},
+		}})
+		if err != nil {
+			t.Fatalf("error writing status: %v", err)
+		}
+	}))
+	defer spdyServer.Close()
+	// Create StreamTranslatorHandler, which points upstream to fake SPDY server, and
+	// create a test server using the  StreamTranslatorHandler.
+	spdyLocation, err := url.Parse(spdyServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse spdy server URL: %s", spdyServer.URL)
+	}
+	spdyTransport, err := fakeTransport()
+	if err != nil {
+		t.Fatalf("Unexpected error creating transport: %v", err)
+	}
+	streams := Options{Stdin: true}
+	streamTranslator := NewStreamTranslatorHandler(spdyLocation, spdyTransport, 0, streams)
+	streamTranslatorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		streamTranslator.ServeHTTP(w, req)
+	}))
+	defer streamTranslatorServer.Close()
+	// Now create the websocket client (executor), and point it to the "streamTranslatorServer".
+	streamTranslatorLocation, err := url.Parse(streamTranslatorServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse StreamTranslator server URL: %s", streamTranslatorServer.URL)
+	}
+	exec, err := remotecommand.NewWebSocketExecutor(&rest.Config{Host: streamTranslatorLocation.Host}, "GET", streamTranslatorServer.URL)
+	if err != nil {
+		t.Errorf("unexpected error creating websocket executor: %v", err)
+	}
+	// Generate random data, and set it up to stream on STDIN. The data will be discarded at
+	// upstream SDPY server.
+	randomSize := 1024 * 1024
+	randomData := make([]byte, randomSize)
+	if _, err := rand.Read(randomData); err != nil {
+		t.Errorf("unexpected error reading random data: %v", err)
+	}
+	options := &remotecommand.StreamOptions{
+		Stdin: bytes.NewReader(randomData),
+	}
+	errorChan := make(chan error)
+	go func() {
+		// Start the streaming on the WebSocket "exec" client.
+		errorChan <- exec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		// Expect exit code error on error stream.
+		if err == nil {
+			t.Errorf("expected error, but received none")
+		}
+		expectedError := fmt.Sprintf("command terminated with exit code %d", expectedExitCode)
+		// Compare expected error with exit code to actual error.
+		if expectedError != err.Error() {
+			t.Errorf("expected error (%s), got (%s)", expectedError, err)
+		}
+	}
+}
+
+// TestStreamTranslator_MultipleReadChannels tests two streams (STDOUT, STDERR) reading from
+// the connections at the same time.
+func TestStreamTranslator_MultipleReadChannels(t *testing.T) {
+	// Create upstream fake SPDY server which copies STDIN back onto STDOUT and STDERR stream.
+	spdyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx, err := createSPDYServerStreams(w, req, Options{
+			Stdin:  true,
+			Stdout: true,
+			Stderr: true,
+		})
+		if err != nil {
+			t.Errorf("error on createHTTPStreams: %v", err)
+			return
+		}
+		defer ctx.conn.Close()
+		// TeeReader copies data read on STDIN onto STDERR.
+		stdinReader := io.TeeReader(ctx.stdinStream, ctx.stderrStream)
+		// Also copy STDIN to STDOUT.
+		_, err = io.Copy(ctx.stdoutStream, stdinReader)
+		if err != nil {
+			t.Errorf("error copying STDIN to STDOUT: %v", err)
+		}
+	}))
+	defer spdyServer.Close()
+	// Create StreamTranslatorHandler, which points upstream to fake SPDY server with
+	// streams STDIN, STDOUT, and STDERR. Create test server from StreamTranslatorHandler.
+	spdyLocation, err := url.Parse(spdyServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse spdy server URL: %s", spdyServer.URL)
+	}
+	spdyTransport, err := fakeTransport()
+	if err != nil {
+		t.Fatalf("Unexpected error creating transport: %v", err)
+	}
+	streams := Options{Stdin: true, Stdout: true, Stderr: true}
+	streamTranslator := NewStreamTranslatorHandler(spdyLocation, spdyTransport, 0, streams)
+	streamTranslatorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		streamTranslator.ServeHTTP(w, req)
+	}))
+	defer streamTranslatorServer.Close()
+	// Now create the websocket client (executor), and point it to the "streamTranslatorServer".
+	streamTranslatorLocation, err := url.Parse(streamTranslatorServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse StreamTranslator server URL: %s", streamTranslatorServer.URL)
+	}
+	exec, err := remotecommand.NewWebSocketExecutor(&rest.Config{Host: streamTranslatorLocation.Host}, "GET", streamTranslatorServer.URL)
+	if err != nil {
+		t.Errorf("unexpected error creating websocket executor: %v", err)
+	}
+	// Generate random data, and set it up to stream on STDIN. The data will be
+	// returned on the STDOUT and STDERR buffer.
+	randomSize := 1024 * 1024
+	randomData := make([]byte, randomSize)
+	if _, err := rand.Read(randomData); err != nil {
+		t.Errorf("unexpected error reading random data: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	options := &remotecommand.StreamOptions{
+		Stdin:  bytes.NewReader(randomData),
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	errorChan := make(chan error)
+	go func() {
+		// Start the streaming on the WebSocket "exec" client.
+		errorChan <- exec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+	stdoutBytes, err := io.ReadAll(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		t.Errorf("error reading the stream: %v", err)
+		return
+	}
+	// Check the random data sent on STDIN was the same returned on STDOUT.
+	if !bytes.Equal(stdoutBytes, randomData) {
+		t.Errorf("unexpected data received: %d sent: %d", len(stdoutBytes), len(randomData))
+	}
+	stderrBytes, err := io.ReadAll(bytes.NewReader(stderr.Bytes()))
+	if err != nil {
+		t.Errorf("error reading the stream: %v", err)
+		return
+	}
+	// Check the random data sent on STDIN was the same returned on STDERR.
+	if !bytes.Equal(stderrBytes, randomData) {
+		t.Errorf("unexpected data received: %d sent: %d", len(stderrBytes), len(randomData))
+	}
+}
+
+// TestStreamTranslator_ThrottleReadChannels tests two streams (STDOUT, STDERR) using rate limited streams.
+func TestStreamTranslator_ThrottleReadChannels(t *testing.T) {
+	// Create upstream fake SPDY server which copies STDIN back onto STDOUT and STDERR stream.
+	spdyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx, err := createSPDYServerStreams(w, req, Options{
+			Stdin:  true,
+			Stdout: true,
+			Stderr: true,
+		})
+		if err != nil {
+			t.Errorf("error on createHTTPStreams: %v", err)
+			return
+		}
+		defer ctx.conn.Close()
+		// TeeReader copies data read on STDIN onto STDERR.
+		stdinReader := io.TeeReader(ctx.stdinStream, ctx.stderrStream)
+		// Also copy STDIN to STDOUT.
+		_, err = io.Copy(ctx.stdoutStream, stdinReader)
+		if err != nil {
+			t.Errorf("error copying STDIN to STDOUT: %v", err)
+		}
+	}))
+	defer spdyServer.Close()
+	// Create StreamTranslatorHandler, which points upstream to fake SPDY server with
+	// streams STDIN, STDOUT, and STDERR. Create test server from StreamTranslatorHandler.
+	spdyLocation, err := url.Parse(spdyServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse spdy server URL: %s", spdyServer.URL)
+	}
+	spdyTransport, err := fakeTransport()
+	if err != nil {
+		t.Fatalf("Unexpected error creating transport: %v", err)
+	}
+	streams := Options{Stdin: true, Stdout: true, Stderr: true}
+	maxBytesPerSec := 900 * 1024 // slightly less than the 1MB that is being transferred to exercise throttling.
+	streamTranslator := NewStreamTranslatorHandler(spdyLocation, spdyTransport, int64(maxBytesPerSec), streams)
+	streamTranslatorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		streamTranslator.ServeHTTP(w, req)
+	}))
+	defer streamTranslatorServer.Close()
+	// Now create the websocket client (executor), and point it to the "streamTranslatorServer".
+	streamTranslatorLocation, err := url.Parse(streamTranslatorServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse StreamTranslator server URL: %s", streamTranslatorServer.URL)
+	}
+	exec, err := remotecommand.NewWebSocketExecutor(&rest.Config{Host: streamTranslatorLocation.Host}, "GET", streamTranslatorServer.URL)
+	if err != nil {
+		t.Errorf("unexpected error creating websocket executor: %v", err)
+	}
+	// Generate random data, and set it up to stream on STDIN. The data will be
+	// returned on the STDOUT and STDERR buffer.
+	randomSize := 1024 * 1024
+	randomData := make([]byte, randomSize)
+	if _, err := rand.Read(randomData); err != nil {
+		t.Errorf("unexpected error reading random data: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	options := &remotecommand.StreamOptions{
+		Stdin:  bytes.NewReader(randomData),
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	errorChan := make(chan error)
+	go func() {
+		// Start the streaming on the WebSocket "exec" client.
+		errorChan <- exec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+	stdoutBytes, err := io.ReadAll(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		t.Errorf("error reading the stream: %v", err)
+		return
+	}
+	// Check the random data sent on STDIN was the same returned on STDOUT.
+	if !bytes.Equal(stdoutBytes, randomData) {
+		t.Errorf("unexpected data received: %d sent: %d", len(stdoutBytes), len(randomData))
+	}
+	stderrBytes, err := io.ReadAll(bytes.NewReader(stderr.Bytes()))
+	if err != nil {
+		t.Errorf("error reading the stream: %v", err)
+		return
+	}
+	// Check the random data sent on STDIN was the same returned on STDERR.
+	if !bytes.Equal(stderrBytes, randomData) {
+		t.Errorf("unexpected data received: %d sent: %d", len(stderrBytes), len(randomData))
+	}
+}
+
+// fakeTerminalSizeQueue implements TerminalSizeQueue, returning a random set of
+// "maxSizes" number of TerminalSizes, storing the TerminalSizes in "sizes" slice.
+type fakeTerminalSizeQueue struct {
+	maxSizes      int
+	terminalSizes []remotecommand.TerminalSize
+}
+
+// newTerminalSizeQueue returns a pointer to a fakeTerminalSizeQueue passing
+// "max" number of random TerminalSizes created.
+func newTerminalSizeQueue(max int) *fakeTerminalSizeQueue {
+	return &fakeTerminalSizeQueue{
+		maxSizes:      max,
+		terminalSizes: make([]remotecommand.TerminalSize, 0, max),
+	}
+}
+
+// Next returns a pointer to the next random TerminalSize, or nil if we have
+// already returned "maxSizes" TerminalSizes already. Stores the randomly
+// created TerminalSize in "terminalSizes" field for later validation.
+func (f *fakeTerminalSizeQueue) Next() *remotecommand.TerminalSize {
+	if len(f.terminalSizes) >= f.maxSizes {
+		return nil
+	}
+	size := randomTerminalSize()
+	f.terminalSizes = append(f.terminalSizes, size)
+	return &size
+}
+
+// randomTerminalSize returns a TerminalSize with random values in the
+// range (0-65535) for the fields Width and Height.
+func randomTerminalSize() remotecommand.TerminalSize {
+	randWidth := uint16(mrand.Intn(int(math.Pow(2, 16))))
+	randHeight := uint16(mrand.Intn(int(math.Pow(2, 16))))
+	return remotecommand.TerminalSize{
+		Width:  randWidth,
+		Height: randHeight,
+	}
+}
+
+// TestStreamTranslator_MultipleWriteChannels
+func TestStreamTranslator_TTYResizeChannel(t *testing.T) {
+	// Create the fake terminal size queue and the actualTerminalSizes which
+	// will be received at the opposite websocket endpoint.
+	numSizeQueue := 10000
+	sizeQueue := newTerminalSizeQueue(numSizeQueue)
+	actualTerminalSizes := make([]remotecommand.TerminalSize, 0, numSizeQueue)
+	// Create upstream fake SPDY server which copies STDIN back onto STDERR stream.
+	spdyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx, err := createSPDYServerStreams(w, req, Options{
+			Tty: true,
+		})
+		if err != nil {
+			t.Errorf("error on createHTTPStreams: %v", err)
+			return
+		}
+		defer ctx.conn.Close()
+		// Read the terminal resize requests, storing them in actualTerminalSizes
+		for i := 0; i < numSizeQueue; i++ {
+			actualTerminalSize := <-ctx.resizeChan
+			actualTerminalSizes = append(actualTerminalSizes, actualTerminalSize)
+		}
+	}))
+	defer spdyServer.Close()
+	// Create StreamTranslatorHandler, which points upstream to fake SPDY server with
+	// resize (TTY resize) stream. Create test server from StreamTranslatorHandler.
+	spdyLocation, err := url.Parse(spdyServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse spdy server URL: %s", spdyServer.URL)
+	}
+	spdyTransport, err := fakeTransport()
+	if err != nil {
+		t.Fatalf("Unexpected error creating transport: %v", err)
+	}
+	streams := Options{Tty: true}
+	streamTranslator := NewStreamTranslatorHandler(spdyLocation, spdyTransport, 0, streams)
+	streamTranslatorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		streamTranslator.ServeHTTP(w, req)
+	}))
+	defer streamTranslatorServer.Close()
+	// Now create the websocket client (executor), and point it to the "streamTranslatorServer".
+	streamTranslatorLocation, err := url.Parse(streamTranslatorServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse StreamTranslator server URL: %s", streamTranslatorServer.URL)
+	}
+	exec, err := remotecommand.NewWebSocketExecutor(&rest.Config{Host: streamTranslatorLocation.Host}, "GET", streamTranslatorServer.URL)
+	if err != nil {
+		t.Errorf("unexpected error creating websocket executor: %v", err)
+	}
+	options := &remotecommand.StreamOptions{
+		Tty:               true,
+		TerminalSizeQueue: sizeQueue,
+	}
+	errorChan := make(chan error)
+	go func() {
+		// Start the streaming on the WebSocket "exec" client.
+		errorChan <- exec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+	// Validate the random TerminalSizes sent on the resize stream are the same
+	// as the actual TerminalSizes received at the websocket server.
+	if len(actualTerminalSizes) != numSizeQueue {
+		t.Fatalf("expected to receive num terminal resizes (%d), got (%d)",
+			numSizeQueue, len(actualTerminalSizes))
+	}
+	for i, actual := range actualTerminalSizes {
+		expected := sizeQueue.terminalSizes[i]
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("expected terminal resize window %v, got %v", expected, actual)
+		}
+	}
+}
+
+// TestStreamTranslator_WebSocketServerErrors validates that when there is a problem creating
+// the websocket server as the first step of the StreamTranslator an error is properly returned.
+func TestStreamTranslator_WebSocketServerErrors(t *testing.T) {
+	spdyLocation, err := url.Parse("http://127.0.0.1")
+	if err != nil {
+		t.Fatalf("Unable to parse spdy server URL")
+	}
+	spdyTransport, err := fakeTransport()
+	if err != nil {
+		t.Fatalf("Unexpected error creating transport: %v", err)
+	}
+	streamTranslator := NewStreamTranslatorHandler(spdyLocation, spdyTransport, 0, Options{})
+	streamTranslatorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		streamTranslator.ServeHTTP(w, req)
+	}))
+	defer streamTranslatorServer.Close()
+	// Now create the websocket client (executor), and point it to the "streamTranslatorServer".
+	streamTranslatorLocation, err := url.Parse(streamTranslatorServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse StreamTranslator server URL: %s", streamTranslatorServer.URL)
+	}
+	exec, err := remotecommand.NewWebSocketExecutorForProtocols(
+		&rest.Config{Host: streamTranslatorLocation.Host},
+		"GET",
+		streamTranslatorServer.URL,
+		rcconstants.StreamProtocolV4Name, // RemoteCommand V4 protocol is unsupported
+	)
+	if err != nil {
+		t.Errorf("unexpected error creating websocket executor: %v", err)
+	}
+	errorChan := make(chan error)
+	go func() {
+		// Start the streaming on the WebSocket "exec" client. The WebSocket server within the
+		// StreamTranslator propagates an error here because the V4 protocol is not supported.
+		errorChan <- exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{})
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		// Must return "websocket unable to upgrade" (bad handshake) error.
+		if err == nil {
+			t.Fatalf("expected error, but received none")
+		}
+		if !strings.Contains(err.Error(), "unable to upgrade streaming request") {
+			t.Errorf("expected websocket bad handshake error, got (%s)", err)
+		}
+	}
+}
+
+// TestStreamTranslator_BlockRedirects verifies that the StreamTranslator will *not* follow
+// redirects; it will thrown an error instead.
+func TestStreamTranslator_BlockRedirects(t *testing.T) {
+	for _, statusCode := range []int{
+		http.StatusMovedPermanently,  // 301
+		http.StatusFound,             // 302
+		http.StatusSeeOther,          // 303
+		http.StatusTemporaryRedirect, // 307
+		http.StatusPermanentRedirect, // 308
+	} {
+		// Create upstream fake SPDY server which returns a redirect.
+		spdyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Location", "/")
+			w.WriteHeader(statusCode)
+		}))
+		defer spdyServer.Close()
+		spdyLocation, err := url.Parse(spdyServer.URL)
+		if err != nil {
+			t.Fatalf("Unable to parse spdy server URL: %s", spdyServer.URL)
+		}
+		spdyTransport, err := fakeTransport()
+		if err != nil {
+			t.Fatalf("Unexpected error creating transport: %v", err)
+		}
+		streams := Options{Stdout: true}
+		streamTranslator := NewStreamTranslatorHandler(spdyLocation, spdyTransport, 0, streams)
+		streamTranslatorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			streamTranslator.ServeHTTP(w, req)
+		}))
+		defer streamTranslatorServer.Close()
+		// Now create the websocket client (executor), and point it to the "streamTranslatorServer".
+		streamTranslatorLocation, err := url.Parse(streamTranslatorServer.URL)
+		if err != nil {
+			t.Fatalf("Unable to parse StreamTranslator server URL: %s", streamTranslatorServer.URL)
+		}
+		exec, err := remotecommand.NewWebSocketExecutor(&rest.Config{Host: streamTranslatorLocation.Host}, "GET", streamTranslatorServer.URL)
+		if err != nil {
+			t.Errorf("unexpected error creating websocket executor: %v", err)
+		}
+		errorChan := make(chan error)
+		go func() {
+			// Start the streaming on the WebSocket "exec" client.
+			// Should return "redirect not allowed" error.
+			errorChan <- exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{})
+		}()
+
+		select {
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Fatalf("expect stream to be closed after connection is closed.")
+		case err := <-errorChan:
+			// Must return "redirect now allowed" error.
+			if err == nil {
+				t.Fatalf("expected error, but received none")
+			}
+			if !strings.Contains(err.Error(), "redirect not allowed") {
+				t.Errorf("expected redirect not allowed error, got (%s)", err)
+			}
+		}
+	}
+}
+
+// streamContext encapsulates the structures necessary to communicate through
+// a SPDY connection, including the Reader/Writer streams.
+type streamContext struct {
+	conn         io.Closer
+	stdinStream  io.ReadCloser
+	stdoutStream io.WriteCloser
+	stderrStream io.WriteCloser
+	resizeStream io.ReadCloser
+	resizeChan   chan remotecommand.TerminalSize
+	writeStatus  func(status *apierrors.StatusError) error
+}
+
+type streamAndReply struct {
+	httpstream.Stream
+	replySent <-chan struct{}
+}
+
+// CreateSPDYServerStreams upgrades the passed HTTP request to a SPDY bi-directional streaming
+// connection with remote command streams defined in passed options. Returns a streamContext
+// structure containing the Reader/Writer streams to communicate through the SDPY connection.
+// Returns an error if unable to upgrade the HTTP connection to a SPDY connection.
+func createSPDYServerStreams(w http.ResponseWriter, req *http.Request, opts Options) (*streamContext, error) {
+	_, err := httpstream.Handshake(req, w, []string{rcconstants.StreamProtocolV4Name})
+	if err != nil {
+		return nil, err
+	}
+
+	upgrader := spdy.NewResponseUpgrader()
+	streamCh := make(chan streamAndReply)
+	conn := upgrader.UpgradeResponse(w, req, func(stream httpstream.Stream, replySent <-chan struct{}) error {
+		streamCh <- streamAndReply{Stream: stream, replySent: replySent}
+		return nil
+	})
+	ctx := &streamContext{
+		conn: conn,
+	}
+
+	// wait for stream
+	replyChan := make(chan struct{}, 5)
+	defer close(replyChan)
+	receivedStreams := 0
+	expectedStreams := 1 // expect at least the error stream
+	if opts.Stdout {
+		expectedStreams++
+	}
+	if opts.Stdin {
+		expectedStreams++
+	}
+	if opts.Stderr {
+		expectedStreams++
+	}
+	if opts.Tty {
+		expectedStreams++
+	}
+WaitForStreams:
+	for {
+		select {
+		case stream := <-streamCh:
+			streamType := stream.Headers().Get(v1.StreamType)
+			switch streamType {
+			case v1.StreamTypeError:
+				replyChan <- struct{}{}
+				ctx.writeStatus = v4WriteStatusFunc(stream)
+			case v1.StreamTypeStdout:
+				replyChan <- struct{}{}
+				ctx.stdoutStream = stream
+			case v1.StreamTypeStdin:
+				replyChan <- struct{}{}
+				ctx.stdinStream = stream
+			case v1.StreamTypeStderr:
+				replyChan <- struct{}{}
+				ctx.stderrStream = stream
+			case v1.StreamTypeResize:
+				replyChan <- struct{}{}
+				ctx.resizeStream = stream
+			default:
+				// add other stream ...
+				return nil, errors.New("unimplemented stream type")
+			}
+		case <-replyChan:
+			receivedStreams++
+			if receivedStreams == expectedStreams {
+				break WaitForStreams
+			}
+		}
+	}
+
+	if ctx.resizeStream != nil {
+		ctx.resizeChan = make(chan remotecommand.TerminalSize)
+		go handleResizeEvents(req.Context(), ctx.resizeStream, ctx.resizeChan)
+	}
+
+	return ctx, nil
+}
+
+func v4WriteStatusFunc(stream io.Writer) func(status *apierrors.StatusError) error {
+	return func(status *apierrors.StatusError) error {
+		bs, err := json.Marshal(status.Status())
+		if err != nil {
+			return err
+		}
+		_, err = stream.Write(bs)
+		return err
+	}
+}
+
+func fakeTransport() (*http.Transport, error) {
+	cfg := &transport.Config{
+		TLS: transport.TLSConfig{
+			Insecure: true,
+			CAFile:   "",
+		},
+	}
+	rt, err := transport.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	t, ok := rt.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("unknown transport type: %T", rt)
+	}
+	return t, nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/translatinghandler.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/translatinghandler.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"net/http"
+
+	"k8s.io/klog/v2"
+)
+
+// translatingHandler wraps the delegate handler, implementing the
+// http.Handler interface. The delegate handles all requests unless
+// the request satisfies the passed "shouldTranslate" function
+// (currently only for WebSocket/V5 request), in which case the translator
+// handles the request.
+type translatingHandler struct {
+	delegate        http.Handler
+	translator      http.Handler
+	shouldTranslate func(*http.Request) bool
+}
+
+func NewTranslatingHandler(delegate http.Handler, translator http.Handler, shouldTranslate func(*http.Request) bool) http.Handler {
+	return &translatingHandler{
+		delegate:        delegate,
+		translator:      translator,
+		shouldTranslate: shouldTranslate,
+	}
+}
+
+func (t *translatingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if t.shouldTranslate(req) {
+		klog.V(4).Infof("request handled by translator proxy")
+		t.translator.ServeHTTP(w, req)
+		return
+	}
+	t.delegate.ServeHTTP(w, req)
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/translatinghandler_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/translatinghandler_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/httpstream/wsstream"
+)
+
+// fakeHandler implements http.Handler interface
+type fakeHandler struct {
+	served bool
+}
+
+// ServeHTTP stores the fact that this fake handler was called.
+func (fh *fakeHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	fh.served = true
+}
+
+func TestTranslatingHandler(t *testing.T) {
+	tests := map[string]struct {
+		upgrade          string
+		version          string
+		expectTranslator bool
+	}{
+		"websocket/v5 upgrade, serves translator": {
+			upgrade:          "websocket",
+			version:          "v5.channel.k8s.io",
+			expectTranslator: true,
+		},
+		"websocket/v5 upgrade with multiple other versions, serves translator": {
+			upgrade:          "websocket",
+			version:          "v5.channel.k8s.io, v4.channel.k8s.io, v3.channel.k8s.io",
+			expectTranslator: true,
+		},
+		"websocket/v5 upgrade with multiple other versions out of order, serves translator": {
+			upgrade:          "websocket",
+			version:          "v4.channel.k8s.io, v3.channel.k8s.io, v5.channel.k8s.io",
+			expectTranslator: true,
+		},
+		"no upgrade, serves delegate": {
+			upgrade:          "",
+			version:          "",
+			expectTranslator: false,
+		},
+		"no upgrade with v5, serves delegate": {
+			upgrade:          "",
+			version:          "v5.channel.k8s.io",
+			expectTranslator: false,
+		},
+		"websocket/v5 wrong case upgrade, serves delegage": {
+			upgrade:          "websocket",
+			version:          "v5.CHANNEL.k8s.io",
+			expectTranslator: false,
+		},
+		"spdy/v5 upgrade, serves delegate": {
+			upgrade:          "spdy",
+			version:          "v5.channel.k8s.io",
+			expectTranslator: false,
+		},
+		"spdy/v4 upgrade, serves delegate": {
+			upgrade:          "spdy",
+			version:          "v4.channel.k8s.io",
+			expectTranslator: false,
+		},
+		"websocket/v4 upgrade, serves delegate": {
+			upgrade:          "websocket",
+			version:          "v4.channel.k8s.io",
+			expectTranslator: false,
+		},
+		"websocket without version upgrade, serves delegate": {
+			upgrade:          "websocket",
+			version:          "",
+			expectTranslator: false,
+		},
+	}
+	for name, test := range tests {
+		req, err := http.NewRequest("GET", "http://www.example.com/", nil)
+		require.NoError(t, err)
+		if test.upgrade != "" {
+			req.Header.Add("Connection", "Upgrade")
+			req.Header.Add("Upgrade", test.upgrade)
+		}
+		if len(test.version) > 0 {
+			req.Header.Add(wsstream.WebSocketProtocolHeader, test.version)
+		}
+		delegate := fakeHandler{}
+		translator := fakeHandler{}
+		translatingHandler := NewTranslatingHandler(&delegate, &translator,
+			wsstream.IsWebSocketRequestWithStreamCloseProtocol)
+		translatingHandler.ServeHTTP(nil, req)
+		if !delegate.served && !translator.served {
+			t.Errorf("unexpected neither translator nor delegate served")
+			continue
+		}
+		if test.expectTranslator {
+			if !translator.served {
+				t.Errorf("%s: expected translator served, got delegate served", name)
+			}
+		} else if !delegate.served {
+			t.Errorf("%s: expected delegate served, got translator served", name)
+		}
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/websocket.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/websocket.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/httpstream/wsstream"
+	constants "k8s.io/apimachinery/pkg/util/remotecommand"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+const (
+	// idleTimeout is the read/write deadline set for websocket server connection. Reading
+	// or writing the connection will return an i/o timeout if this deadline is exceeded.
+	// Currently, we use the same value as the kubelet websocket server.
+	defaultIdleConnectionTimeout = 4 * time.Hour
+
+	// Deadline for writing errors to the websocket connection before io/timeout.
+	writeErrorDeadline = 10 * time.Second
+)
+
+// Options contains details about which streams are required for
+// remote command execution.
+type Options struct {
+	Stdin  bool
+	Stdout bool
+	Stderr bool
+	Tty    bool
+}
+
+// conns contains the connection and streams used when
+// forwarding an attach or execute session into a container.
+type conns struct {
+	conn         io.Closer
+	stdinStream  io.ReadCloser
+	stdoutStream io.WriteCloser
+	stderrStream io.WriteCloser
+	writeStatus  func(status *apierrors.StatusError) error
+	resizeStream io.ReadCloser
+	resizeChan   chan remotecommand.TerminalSize
+	tty          bool
+}
+
+// Create WebSocket server streams to respond to a WebSocket client. Creates the streams passed
+// in the stream options.
+func webSocketServerStreams(req *http.Request, w http.ResponseWriter, opts Options) (*conns, error) {
+	ctx, err := createWebSocketStreams(req, w, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if ctx.resizeStream != nil {
+		ctx.resizeChan = make(chan remotecommand.TerminalSize)
+		go func() {
+			// Resize channel closes in panic case, and panic does not take down caller.
+			defer func() {
+				if p := recover(); p != nil {
+					// Standard panic logging.
+					for _, fn := range runtime.PanicHandlers {
+						fn(p)
+					}
+				}
+			}()
+			handleResizeEvents(req.Context(), ctx.resizeStream, ctx.resizeChan)
+		}()
+	}
+
+	return ctx, nil
+}
+
+// Read terminal resize events off of passed stream and queue into passed channel.
+func handleResizeEvents(ctx context.Context, stream io.Reader, channel chan<- remotecommand.TerminalSize) {
+	defer close(channel)
+
+	decoder := json.NewDecoder(stream)
+	for {
+		size := remotecommand.TerminalSize{}
+		if err := decoder.Decode(&size); err != nil {
+			break
+		}
+
+		select {
+		case channel <- size:
+		case <-ctx.Done():
+			// To avoid leaking this routine, exit if the http request finishes. This path
+			// would generally be hit if starting the process fails and nothing is started to
+			// ingest these resize events.
+			return
+		}
+	}
+}
+
+// createChannels returns the standard channel types for a shell connection (STDIN 0, STDOUT 1, STDERR 2)
+// along with the approximate duplex value. It also creates the error (3) and resize (4) channels.
+func createChannels(opts Options) []wsstream.ChannelType {
+	// open the requested channels, and always open the error channel
+	channels := make([]wsstream.ChannelType, 5)
+	channels[constants.StreamStdIn] = readChannel(opts.Stdin)
+	channels[constants.StreamStdOut] = writeChannel(opts.Stdout)
+	channels[constants.StreamStdErr] = writeChannel(opts.Stderr)
+	channels[constants.StreamErr] = wsstream.WriteChannel
+	channels[constants.StreamResize] = wsstream.ReadChannel
+	return channels
+}
+
+// readChannel returns wsstream.ReadChannel if real is true, or wsstream.IgnoreChannel.
+func readChannel(real bool) wsstream.ChannelType {
+	if real {
+		return wsstream.ReadChannel
+	}
+	return wsstream.IgnoreChannel
+}
+
+// writeChannel returns wsstream.WriteChannel if real is true, or wsstream.IgnoreChannel.
+func writeChannel(real bool) wsstream.ChannelType {
+	if real {
+		return wsstream.WriteChannel
+	}
+	return wsstream.IgnoreChannel
+}
+
+// createWebSocketStreams returns a "conns" struct containing the websocket connection and
+// streams needed to perform an exec or an attach.
+func createWebSocketStreams(req *http.Request, w http.ResponseWriter, opts Options) (*conns, error) {
+	channels := createChannels(opts)
+	conn := wsstream.NewConn(map[string]wsstream.ChannelProtocolConfig{
+		// WebSocket server only supports remote command version 5.
+		constants.StreamProtocolV5Name: {
+			Binary:   true,
+			Channels: channels,
+		},
+	})
+	conn.SetIdleTimeout(defaultIdleConnectionTimeout)
+	// Opening the connection responds to WebSocket client, negotiating
+	// the WebSocket upgrade connection and the subprotocol.
+	_, streams, err := conn.Open(w, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Send an empty message to the lowest writable channel to notify the client the connection is established
+	switch {
+	case opts.Stdout:
+		_, err = streams[constants.StreamStdOut].Write([]byte{})
+	case opts.Stderr:
+		_, err = streams[constants.StreamStdErr].Write([]byte{})
+	default:
+		_, err = streams[constants.StreamErr].Write([]byte{})
+	}
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("write error during websocket server creation: %v", err)
+	}
+
+	ctx := &conns{
+		conn:         conn,
+		stdinStream:  streams[constants.StreamStdIn],
+		stdoutStream: streams[constants.StreamStdOut],
+		stderrStream: streams[constants.StreamStdErr],
+		tty:          opts.Tty,
+		resizeStream: streams[constants.StreamResize],
+	}
+
+	// writeStatus returns a WriteStatusFunc that marshals a given api Status
+	// as json in the error channel.
+	ctx.writeStatus = func(status *apierrors.StatusError) error {
+		bs, err := json.Marshal(status.Status())
+		if err != nil {
+			return err
+		}
+		// Write status error to error stream with deadline.
+		conn.SetWriteDeadline(writeErrorDeadline)
+		_, err = streams[constants.StreamErr].Write(bs)
+		return err
+	}
+
+	return ctx, nil
+}

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect

--- a/staging/src/k8s.io/client-go/go.sum
+++ b/staging/src/k8s.io/client-go/go.sum
@@ -75,6 +75,7 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
 github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=

--- a/staging/src/k8s.io/client-go/tools/remotecommand/fallback.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/fallback.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"context"
+)
+
+var _ Executor = &fallbackExecutor{}
+
+type fallbackExecutor struct {
+	primary        Executor
+	secondary      Executor
+	shouldFallback func(error) bool
+}
+
+// NewFallbackExecutor creates an Executor that first attempts to use the
+// WebSocketExecutor, falling back to the legacy SPDYExecutor if the initial
+// websocket "StreamWithContext" call fails.
+// func NewFallbackExecutor(config *restclient.Config, method string, url *url.URL) (Executor, error) {
+func NewFallbackExecutor(primary, secondary Executor, shouldFallback func(error) bool) (Executor, error) {
+	return &fallbackExecutor{
+		primary:        primary,
+		secondary:      secondary,
+		shouldFallback: shouldFallback,
+	}, nil
+}
+
+// Stream is deprecated. Please use "StreamWithContext".
+func (f *fallbackExecutor) Stream(options StreamOptions) error {
+	return f.StreamWithContext(context.Background(), options)
+}
+
+// StreamWithContext initially attempts to call "StreamWithContext" using the
+// primary executor, falling back to calling the secondary executor if the
+// initial primary call to upgrade to a websocket connection fails.
+func (f *fallbackExecutor) StreamWithContext(ctx context.Context, options StreamOptions) error {
+	err := f.primary.StreamWithContext(ctx, options)
+	if f.shouldFallback(err) {
+		return f.secondary.StreamWithContext(ctx, options)
+	}
+	return err
+}

--- a/staging/src/k8s.io/client-go/tools/remotecommand/fallback_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/fallback_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/remotecommand"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+)
+
+func TestFallbackClient_WebSocketPrimarySucceeds(t *testing.T) {
+	// Create fake WebSocket server. Copy received STDIN data back onto STDOUT stream.
+	websocketServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conns, err := webSocketServerStreams(req, w, streamOptionsFromRequest(req))
+		if err != nil {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		defer conns.conn.Close()
+		// Loopback the STDIN stream onto the STDOUT stream.
+		_, err = io.Copy(conns.stdoutStream, conns.stdinStream)
+		require.NoError(t, err)
+	}))
+	defer websocketServer.Close()
+
+	// Now create the fallback client (executor), and point it to the "websocketServer".
+	// Must add STDIN and STDOUT query params for the client request.
+	websocketServer.URL = websocketServer.URL + "?" + "stdin=true" + "&" + "stdout=true"
+	websocketLocation, err := url.Parse(websocketServer.URL)
+	require.NoError(t, err)
+	websocketExecutor, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "GET", websocketServer.URL)
+	require.NoError(t, err)
+	spdyExecutor, err := NewSPDYExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketLocation)
+	require.NoError(t, err)
+	// Never fallback, so always use the websocketExecutor, which succeeds against websocket server.
+	exec, err := NewFallbackExecutor(websocketExecutor, spdyExecutor, func(error) bool { return false })
+	require.NoError(t, err)
+	// Generate random data, and set it up to stream on STDIN. The data will be
+	// returned on the STDOUT buffer.
+	randomSize := 1024 * 1024
+	randomData := make([]byte, randomSize)
+	if _, err := rand.Read(randomData); err != nil {
+		t.Errorf("unexpected error reading random data: %v", err)
+	}
+	var stdout bytes.Buffer
+	options := &StreamOptions{
+		Stdin:  bytes.NewReader(randomData),
+		Stdout: &stdout,
+	}
+	errorChan := make(chan error)
+	go func() {
+		// Start the streaming on the WebSocket "exec" client.
+		errorChan <- exec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		if err != nil {
+			t.Errorf("unexpected error")
+		}
+	}
+
+	data, err := io.ReadAll(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		t.Errorf("error reading the stream: %v", err)
+		return
+	}
+	// Check the random data sent on STDIN was the same returned on STDOUT.
+	if !bytes.Equal(randomData, data) {
+		t.Errorf("unexpected data received: %d sent: %d", len(data), len(randomData))
+	}
+}
+
+func TestFallbackClient_SPDYSecondarySucceeds(t *testing.T) {
+	// Create fake SPDY server. Copy received STDIN data back onto STDOUT stream.
+	spdyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var stdin, stdout bytes.Buffer
+		ctx, err := createHTTPStreams(w, req, &StreamOptions{
+			Stdin:  &stdin,
+			Stdout: &stdout,
+		})
+		if err != nil {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		defer ctx.conn.Close()
+		_, err = io.Copy(ctx.stdoutStream, ctx.stdinStream)
+		if err != nil {
+			t.Fatalf("error copying STDIN to STDOUT: %v", err)
+		}
+	}))
+	defer spdyServer.Close()
+
+	spdyLocation, err := url.Parse(spdyServer.URL)
+	require.NoError(t, err)
+	websocketExecutor, err := NewWebSocketExecutor(&rest.Config{Host: spdyLocation.Host}, "GET", spdyServer.URL)
+	require.NoError(t, err)
+	spdyExecutor, err := NewSPDYExecutor(&rest.Config{Host: spdyLocation.Host}, "POST", spdyLocation)
+	require.NoError(t, err)
+	// Always fallback to spdyExecutor, and spdyExecutor succeeds against fake spdy server.
+	exec, err := NewFallbackExecutor(websocketExecutor, spdyExecutor, func(error) bool { return true })
+	require.NoError(t, err)
+	// Generate random data, and set it up to stream on STDIN. The data will be
+	// returned on the STDOUT buffer.
+	randomSize := 1024 * 1024
+	randomData := make([]byte, randomSize)
+	if _, err := rand.Read(randomData); err != nil {
+		t.Errorf("unexpected error reading random data: %v", err)
+	}
+	var stdout bytes.Buffer
+	options := &StreamOptions{
+		Stdin:  bytes.NewReader(randomData),
+		Stdout: &stdout,
+	}
+	errorChan := make(chan error)
+	go func() {
+		errorChan <- exec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		if err != nil {
+			t.Errorf("unexpected error")
+		}
+	}
+
+	data, err := io.ReadAll(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		t.Errorf("error reading the stream: %v", err)
+		return
+	}
+	// Check the random data sent on STDIN was the same returned on STDOUT.
+	if !bytes.Equal(randomData, data) {
+		t.Errorf("unexpected data received: %d sent: %d", len(data), len(randomData))
+	}
+}
+
+func TestFallbackClient_PrimaryAndSecondaryFail(t *testing.T) {
+	// Create fake WebSocket server. Copy received STDIN data back onto STDOUT stream.
+	websocketServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conns, err := webSocketServerStreams(req, w, streamOptionsFromRequest(req))
+		if err != nil {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		defer conns.conn.Close()
+		// Loopback the STDIN stream onto the STDOUT stream.
+		_, err = io.Copy(conns.stdoutStream, conns.stdinStream)
+		require.NoError(t, err)
+	}))
+	defer websocketServer.Close()
+
+	// Now create the fallback client (executor), and point it to the "websocketServer".
+	// Must add STDIN and STDOUT query params for the client request.
+	websocketServer.URL = websocketServer.URL + "?" + "stdin=true" + "&" + "stdout=true"
+	websocketLocation, err := url.Parse(websocketServer.URL)
+	require.NoError(t, err)
+	websocketExecutor, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "GET", websocketServer.URL)
+	require.NoError(t, err)
+	spdyExecutor, err := NewSPDYExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketLocation)
+	require.NoError(t, err)
+	// Always fallback to spdyExecutor, but spdyExecutor fails against websocket server.
+	exec, err := NewFallbackExecutor(websocketExecutor, spdyExecutor, func(error) bool { return true })
+	require.NoError(t, err)
+	// Update the websocket executor to request remote command v4, which is unsupported.
+	fallbackExec, ok := exec.(*fallbackExecutor)
+	assert.True(t, ok, "error casting executor as fallbackExecutor")
+	websocketExec, ok := fallbackExec.primary.(*wsStreamExecutor)
+	assert.True(t, ok, "error casting executor as websocket executor")
+	// Set the attempted subprotocol version to V4; websocket server only accepts V5.
+	websocketExec.protocols = []string{remotecommand.StreamProtocolV4Name}
+
+	// Generate random data, and set it up to stream on STDIN. The data will be
+	// returned on the STDOUT buffer.
+	randomSize := 1024 * 1024
+	randomData := make([]byte, randomSize)
+	if _, err := rand.Read(randomData); err != nil {
+		t.Errorf("unexpected error reading random data: %v", err)
+	}
+	var stdout bytes.Buffer
+	options := &StreamOptions{
+		Stdin:  bytes.NewReader(randomData),
+		Stdout: &stdout,
+	}
+	errorChan := make(chan error)
+	go func() {
+		errorChan <- exec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		// Ensure secondary executor returned an error.
+		require.Error(t, err)
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/remotecommand/spdy_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/spdy_test.go
@@ -183,6 +183,7 @@ func TestSPDYExecutorStream(t *testing.T) {
 }
 
 func newTestHTTPServer(f AttachFunc, options *StreamOptions) *httptest.Server {
+	//nolint:errcheck
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		ctx, err := createHTTPStreams(writer, request, options)
 		if err != nil {
@@ -381,7 +382,7 @@ func TestStreamRandomData(t *testing.T) {
 		}
 		defer ctx.conn.Close()
 
-		io.Copy(ctx.stdoutStream, ctx.stdinStream)
+		io.Copy(ctx.stdoutStream, ctx.stdinStream) //nolint:errcheck
 	}))
 
 	defer server.Close()

--- a/staging/src/k8s.io/client-go/tools/remotecommand/websocket_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/websocket_test.go
@@ -74,7 +74,7 @@ func TestWebSocketClient_LoopbackStdinToStdout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
 	}
-	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "GET", websocketServer.URL)
 	if err != nil {
 		t.Errorf("unexpected error creating websocket executor: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestWebSocketClient_DifferentBufferSizes(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
 		}
-		exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+		exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "GET", websocketServer.URL)
 		if err != nil {
 			t.Errorf("unexpected error creating websocket executor: %v", err)
 		}
@@ -223,7 +223,7 @@ func TestWebSocketClient_LoopbackStdinAsPipe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
 	}
-	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "GET", websocketServer.URL)
 	if err != nil {
 		t.Errorf("unexpected error creating websocket executor: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestWebSocketClient_LoopbackStdinToStderr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
 	}
-	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "GET", websocketServer.URL)
 	if err != nil {
 		t.Errorf("unexpected error creating websocket executor: %v", err)
 	}
@@ -377,7 +377,7 @@ func TestWebSocketClient_MultipleReadChannels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
 	}
-	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "GET", websocketServer.URL)
 	if err != nil {
 		t.Errorf("unexpected error creating websocket executor: %v", err)
 	}
@@ -479,7 +479,7 @@ func TestWebSocketClient_ErrorStream(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
 	}
-	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "GET", websocketServer.URL)
 	if err != nil {
 		t.Errorf("unexpected error creating websocket executor: %v", err)
 	}
@@ -637,7 +637,7 @@ func TestWebSocketClient_MultipleWriteChannels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
 	}
-	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "GET", websocketServer.URL)
 	if err != nil {
 		t.Errorf("unexpected error creating websocket executor: %v", err)
 	}
@@ -723,7 +723,7 @@ func TestWebSocketClient_ProtocolVersions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
 	}
-	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "GET", websocketServer.URL)
 	if err != nil {
 		t.Errorf("unexpected error creating websocket executor: %v", err)
 	}
@@ -766,11 +766,14 @@ func TestWebSocketClient_ProtocolVersions(t *testing.T) {
 func TestWebSocketClient_BadHandshake(t *testing.T) {
 	// Create fake WebSocket server (supports V5 subprotocol).
 	websocketServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		conns, err := webSocketServerStreams(req, w, streamOptionsFromRequest(req))
-		if err != nil {
-			t.Fatalf("error on webSocketServerStreams: %v", err)
+		// Bad handshake means websocket server will not completely initialize.
+		_, err := webSocketServerStreams(req, w, streamOptionsFromRequest(req))
+		if err == nil {
+			t.Fatalf("expected error, but received none.")
 		}
-		defer conns.conn.Close()
+		if !strings.Contains(err.Error(), "websocket server finished before becoming ready") {
+			t.Errorf("expected websocket server error, but got: %v", err)
+		}
 	}))
 	defer websocketServer.Close()
 
@@ -779,7 +782,7 @@ func TestWebSocketClient_BadHandshake(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
 	}
-	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "GET", websocketServer.URL)
 	if err != nil {
 		t.Errorf("unexpected error creating websocket executor: %v", err)
 	}
@@ -831,7 +834,7 @@ func TestWebSocketClient_HeartbeatTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
 	}
-	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "GET", websocketServer.URL)
 	if err != nil {
 		t.Errorf("unexpected error creating websocket executor: %v", err)
 	}
@@ -909,7 +912,7 @@ func TestWebSocketClient_TextMessageTypeError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
 	}
-	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "GET", websocketServer.URL)
 	if err != nil {
 		t.Errorf("unexpected error creating websocket executor: %v", err)
 	}
@@ -970,7 +973,7 @@ func TestWebSocketClient_EmptyMessageHandled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
 	}
-	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "GET", websocketServer.URL)
 	if err != nil {
 		t.Errorf("unexpected error creating websocket executor: %v", err)
 	}
@@ -1009,14 +1012,14 @@ func TestWebSocketClient_ExecutorErrors(t *testing.T) {
 		ExecProvider: &clientcmdapi.ExecConfig{},
 		AuthProvider: &clientcmdapi.AuthProviderConfig{},
 	}
-	_, err := NewWebSocketExecutor(&config, "POST", "http://localhost")
+	_, err := NewWebSocketExecutor(&config, "GET", "http://localhost")
 	if err == nil {
 		t.Errorf("expecting executor constructor error, but received none.")
 	} else if !strings.Contains(err.Error(), "error creating websocket transports") {
 		t.Errorf("expecting error creating transports, got (%s)", err.Error())
 	}
 	// Verify that a nil context will cause an error in StreamWithContext
-	exec, err := NewWebSocketExecutor(&rest.Config{}, "POST", "http://localhost")
+	exec, err := NewWebSocketExecutor(&rest.Config{}, "GET", "http://localhost")
 	if err != nil {
 		t.Errorf("unexpected error creating websocket executor: %v", err)
 	}
@@ -1316,7 +1319,16 @@ func createWebSocketStreams(req *http.Request, w http.ResponseWriter, opts *opti
 		resizeStream: streams[remotecommand.StreamResize],
 	}
 
-	wsStreams.writeStatus = v4WriteStatusFunc(streams[remotecommand.StreamErr])
+	wsStreams.writeStatus = func(stream io.Writer) func(status *apierrors.StatusError) error {
+		return func(status *apierrors.StatusError) error {
+			bs, err := json.Marshal(status.Status())
+			if err != nil {
+				return err
+			}
+			_, err = stream.Write(bs)
+			return err
+		}
+	}(streams[remotecommand.StreamErr])
 
 	return wsStreams, nil
 }

--- a/staging/src/k8s.io/client-go/transport/spdy/spdy.go
+++ b/staging/src/k8s.io/client-go/transport/spdy/spdy.go
@@ -43,11 +43,15 @@ func RoundTripperFor(config *restclient.Config) (http.RoundTripper, Upgrader, er
 	if config.Proxy != nil {
 		proxy = config.Proxy
 	}
-	upgradeRoundTripper := spdy.NewRoundTripperWithConfig(spdy.RoundTripperConfig{
-		TLS:        tlsConfig,
-		Proxier:    proxy,
-		PingPeriod: time.Second * 5,
+	upgradeRoundTripper, err := spdy.NewRoundTripperWithConfig(spdy.RoundTripperConfig{
+		TLS:              tlsConfig,
+		Proxier:          proxy,
+		PingPeriod:       time.Second * 5,
+		UpgradeTransport: nil,
 	})
+	if err != nil {
+		return nil, nil, err
+	}
 	wrapper, err := restclient.HTTPWrappersForConfig(config, upgradeRoundTripper)
 	if err != nil {
 		return nil, nil, err

--- a/staging/src/k8s.io/client-go/transport/websocket/roundtripper.go
+++ b/staging/src/k8s.io/client-go/transport/websocket/roundtripper.go
@@ -108,10 +108,7 @@ func (rt *RoundTripper) RoundTrip(request *http.Request) (retResp *http.Response
 	}
 	wsConn, resp, err := dialer.DialContext(request.Context(), request.URL.String(), request.Header)
 	if err != nil {
-		if err != gwebsocket.ErrBadHandshake {
-			return nil, err
-		}
-		return nil, fmt.Errorf("unable to upgrade connection: %v", err)
+		return nil, &httpstream.UpgradeFailureError{Cause: err}
 	}
 
 	rt.Conn = wsConn
@@ -155,7 +152,7 @@ func Negotiate(rt http.RoundTripper, connectionInfo ConnectionHolder, req *http.
 	req.Header[httpstream.HeaderProtocolVersion] = protocols
 	resp, err := rt.RoundTrip(req)
 	if err != nil {
-		return nil, fmt.Errorf("error sending request: %v", err)
+		return nil, err
 	}
 	err = resp.Body.Close()
 	if err != nil {

--- a/staging/src/k8s.io/kube-aggregator/go.mod
+++ b/staging/src/k8s.io/kube-aggregator/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/google/cel-go v0.17.6 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
@@ -57,6 +58,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/staging/src/k8s.io/kube-aggregator/go.sum
+++ b/staging/src/k8s.io/kube-aggregator/go.sum
@@ -163,6 +163,7 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8V
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -326,6 +327,7 @@ github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -369,6 +371,7 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach_test.go
@@ -43,13 +43,11 @@ import (
 )
 
 type fakeRemoteAttach struct {
-	method string
-	url    *url.URL
-	err    error
+	url *url.URL
+	err error
 }
 
-func (f *fakeRemoteAttach) Attach(method string, url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool, terminalSizeQueue remotecommand.TerminalSizeQueue) error {
-	f.method = method
+func (f *fakeRemoteAttach) Attach(url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool, terminalSizeQueue remotecommand.TerminalSizeQueue) error {
 	f.url = url
 	return f.err
 }
@@ -327,7 +325,7 @@ func TestAttach(t *testing.T) {
 						return err
 					}
 
-					return options.Attach.Attach("POST", u, nil, nil, nil, nil, raw, sizeQueue)
+					return options.Attach.Attach(u, nil, nil, nil, nil, raw, sizeQueue)
 				}
 			}
 
@@ -346,9 +344,6 @@ func TestAttach(t *testing.T) {
 			if remoteAttach.url.Path != test.attachPath {
 				t.Errorf("%s: Did not get expected path for exec request: %q %q", test.name, test.attachPath, remoteAttach.url.Path)
 				return
-			}
-			if remoteAttach.method != "POST" {
-				t.Errorf("%s: Did not get method for attach request: %s", test.name, remoteAttach.method)
 			}
 			if remoteAttach.url.Query().Get("container") != "bar" {
 				t.Errorf("%s: Did not have query parameters: %s", test.name, remoteAttach.url.Query())
@@ -428,7 +423,7 @@ func TestAttachWarnings(t *testing.T) {
 						return err
 					}
 
-					return options.Attach.Attach("POST", u, nil, nil, nil, nil, raw, sizeQueue)
+					return options.Attach.Attach(u, nil, nil, nil, nil, raw, sizeQueue)
 				}
 			}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
@@ -40,13 +40,11 @@ import (
 )
 
 type fakeRemoteExecutor struct {
-	method  string
 	url     *url.URL
 	execErr error
 }
 
-func (f *fakeRemoteExecutor) Execute(method string, url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool, terminalSizeQueue remotecommand.TerminalSizeQueue) error {
-	f.method = method
+func (f *fakeRemoteExecutor) Execute(url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool, terminalSizeQueue remotecommand.TerminalSizeQueue) error {
 	f.url = url
 	return f.execErr
 }
@@ -263,9 +261,6 @@ func TestExec(t *testing.T) {
 			if strings.Count(ex.url.RawQuery, "container=bar") != 1 {
 				t.Errorf("%s: Did not get expected container query param for exec request", test.name)
 				return
-			}
-			if ex.method != "POST" {
-				t.Errorf("%s: Did not get method for exec request: %s", test.name, ex.method)
 			}
 		})
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -425,8 +425,10 @@ func GetPodRunningTimeoutFlag(cmd *cobra.Command) (time.Duration, error) {
 type FeatureGate string
 
 const (
-	ApplySet              FeatureGate = "KUBECTL_APPLYSET"
-	CmdPluginAsSubcommand FeatureGate = "KUBECTL_ENABLE_CMD_SHADOW"
+	ApplySet                FeatureGate = "KUBECTL_APPLYSET"
+	CmdPluginAsSubcommand   FeatureGate = "KUBECTL_ENABLE_CMD_SHADOW"
+	InteractiveDelete       FeatureGate = "KUBECTL_INTERACTIVE_DELETE"
+	RemoteCommandWebsockets FeatureGate = "KUBECTL_REMOTE_COMMAND_WEBSOCKETS"
 )
 
 // IsEnabled returns true iff environment variable is set to true.

--- a/staging/src/k8s.io/kubelet/go.mod
+++ b/staging/src/k8s.io/kubelet/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect

--- a/staging/src/k8s.io/kubelet/go.sum
+++ b/staging/src/k8s.io/kubelet/go.sum
@@ -111,6 +111,7 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
 github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=


### PR DESCRIPTION
* Implements `StreamTranslator` proxy, which forwards data from a websocket server into a SPDY client. This proxy allows incremental WebSocket communication legs. This proxy is wrapped by the `TranslatingHandler`, delegating to the `StreamTranslator` proxy if the upgrade request is `WebSockets/V5`.
* Implements `FallbackExecutor`, which first attempts a WebSocket upgrade, then fallsback to legacy SPDY.
* Adds `TranslateStreamCloseWebsocketRequests` feature gate, which is off by default (WebSockets is alpha). An enabled feature gate allows the `StreamTranslator` proxy to be delegated from the current `UpgradeAware` proxy for `WebSockets/V5` upgrade requests.
* Adds `KUBECTL_REMOTE_COMMAND_WEBSOCKETS` environment variable feature gate for `kubectl`, which is off by default. An enabled feature gate substitutes a `FallbackExecutor` for the legacy `SPDYExecutor`.
* Merging this PR will complete `alpha` functionality for transitioning from SPDY to WebSocket for bi-directional streaming. When both feature gates are turned on, the communication leg from `kubectl` to the API Server will use the WebSocket protocol for `RemoteCommand` (e.g. `kubectl exec, cp, and attach`) instead of SPDY.

* Manually tested successfully  with the following commands using the `nginx` pod:
  * `$ ./kubectl exec nginx -- date` (basic command with STDOUT)
  * `$ echo "this is a test" | ./kubectl exec -i nginx -- cat` (pipe STDIN to command running on container)
  * `$ ./kubectl cp ~/deploy-1.yaml nginx:/` (cp file from local to container)
  * `$ ./kubectl cp nginx:/product_name /tmp/product_name` (cp file from container to local)
  * `$ ./kubectl exec -it nginx -- bash` (interactive terminal)

#### Example stress test for WebSocket client running through the `StreamTranslator` proxy testing STDIN and STDOUT streams
```
$ stress ./remotecommand.test -test.run TestWebSocketStreamTranslator_LoopbackStdinToStdout
5s: 4005 runs so far, 0 failures
10s: 8037 runs so far, 0 failures
15s: 12031 runs so far, 0 failures
20s: 15969 runs so far, 0 failures
25s: 19898 runs so far, 0 failures
30s: 23731 runs so far, 0 failures
35s: 27561 runs so far, 0 failures
40s: 31360 runs so far, 0 failures
45s: 35082 runs so far, 0 failures
50s: 38797 runs so far, 0 failures
```


/kind feature

Fixes: https://github.com/kubernetes/kubernetes/issues/89163

```release-note
NONE
```

- [KEP Transition from SPDY to WebSockets - 4006](https://github.com/kubernetes/enhancements/issues/4006)
