### PR TITLE
Check dbus error on container runtime start/stop

### DIFF
--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -393,7 +393,7 @@ const (
 )
 
 func performContainerRuntimeUnitOp(op containerRuntimeUnitOp) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	conn, err := dbus.NewWithContext(ctx)
@@ -409,12 +409,13 @@ func performContainerRuntimeUnitOp(op containerRuntimeUnitOp) error {
 
 	switch op {
 	case startContainerRuntimeUnitOp:
-		conn.StartUnitContext(ctx, containerRuntimeUnitName, "replace", reschan)
+		_, err = conn.StartUnitContext(ctx, containerRuntimeUnitName, "replace", reschan)
 	case stopContainerRuntimeUnitOp:
-		conn.StopUnitContext(ctx, containerRuntimeUnitName, "replace", reschan)
+		_, err = conn.StopUnitContext(ctx, containerRuntimeUnitName, "replace", reschan)
 	default:
 		framework.Failf("Unexpected container runtime op: %v", op)
 	}
+	framework.ExpectNoError(err, "dbus connection error")
 
 	job := <-reschan
 	framework.ExpectEqual(job, "done", "Expected job to complete with done")


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
We should evaluate the error, otherwise we risk to hang indefinately on waiting for the `reschan` in:

https://github.com/kubernetes/kubernetes/blob/64939b66c65b7c3daac41ece56776582532bf94b/test/e2e_node/util.go#L419

We also increase the timeout, because it can take a bit longer for runtimes to determinate depending on the work they have to be done on running containers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/116872

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
