### PR TITLE
Fix configuration getting overridden for concurrent actions

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/client.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/client.go
@@ -28,6 +28,7 @@ func (clientConfigFn ClientConfigFunc) clientForGroupVersion(gv schema.GroupVers
 	if err != nil {
 		return nil, err
 	}
+	cfg = rest.CopyConfig(cfg)
 	if negotiatedSerializer != nil {
 		cfg.ContentConfig.NegotiatedSerializer = negotiatedSerializer
 	}
@@ -46,6 +47,7 @@ func (clientConfigFn ClientConfigFunc) unstructuredClientForGroupVersion(gv sche
 	if err != nil {
 		return nil, err
 	}
+	cfg = rest.CopyConfig(cfg)
 	cfg.ContentConfig = UnstructuredPlusDefaultContentConfig()
 	cfg.GroupVersion = &gv
 	if len(gv.Group) == 0 {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

This fixes a problem when running multiple actions concurrently, where retrieving a client for a configuration overwrites the GroupVersion information for another (probably only if `usePersistentConfig` is enabled).

#### Which issue(s) this PR fixes:

Fixes an issue we have noticed when using pulumi-kubernetes, see [here](https://github.com/pulumi/pulumi-kubernetes/issues/2481)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
