### PR TITLE
kubectl debug: add sysadmin profile

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -192,7 +192,7 @@ func (o *DebugOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.ShareProcesses, "share-processes", o.ShareProcesses, i18n.T("When used with '--copy-to', enable process namespace sharing in the copy."))
 	cmd.Flags().StringVar(&o.TargetContainer, "target", "", i18n.T("When using an ephemeral container, target processes in this container name."))
 	cmd.Flags().BoolVarP(&o.TTY, "tty", "t", o.TTY, i18n.T("Allocate a TTY for the debugging container."))
-	cmd.Flags().StringVar(&o.Profile, "profile", ProfileLegacy, i18n.T(`Debugging profile. Options are "legacy", "general", "baseline", "netadmin", or "restricted".`))
+	cmd.Flags().StringVar(&o.Profile, "profile", ProfileLegacy, i18n.T(`Options are "legacy", "general", "baseline", "netadmin", "restricted" or "sysadmin".`))
 }
 
 // Complete finishes run-time initialization of debug.DebugOptions.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -316,6 +316,25 @@ func TestGenerateDebugContainer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "sysadmin profile",
+			opts: &DebugOptions{
+				Image:      "busybox",
+				PullPolicy: corev1.PullIfNotPresent,
+				Profile:    ProfileSysadmin,
+			},
+			expected: &corev1.EphemeralContainer{
+				EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+					Name:                     "debugger-1",
+					Image:                    "busybox",
+					ImagePullPolicy:          corev1.PullIfNotPresent,
+					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: pointer.Bool(true),
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.opts.IOStreams = genericiooptions.NewTestIOStreamsDiscard()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles.go
@@ -54,6 +54,8 @@ const (
 	ProfileRestricted = "restricted"
 	// ProfileNetadmin offers elevated privileges for network debugging.
 	ProfileNetadmin = "netadmin"
+	// ProfileSysadmin offers elevated privileges for debugging.
+	ProfileSysadmin = "sysadmin"
 )
 
 type ProfileApplier interface {
@@ -74,6 +76,8 @@ func NewProfileApplier(profile string) (ProfileApplier, error) {
 		return &restrictedProfile{}, nil
 	case ProfileNetadmin:
 		return &netadminProfile{}, nil
+	case ProfileSysadmin:
+		return &sysadminProfile{}, nil
 	}
 
 	return nil, fmt.Errorf("unknown profile: %s", profile)
@@ -92,6 +96,9 @@ type restrictedProfile struct {
 }
 
 type netadminProfile struct {
+}
+
+type sysadminProfile struct {
 }
 
 func (p *legacyProfile) Apply(pod *corev1.Pod, containerName string, target runtime.Object) error {
@@ -212,6 +219,29 @@ func (p *netadminProfile) Apply(pod *corev1.Pod, containerName string, target ru
 	return nil
 }
 
+func (p *sysadminProfile) Apply(pod *corev1.Pod, containerName string, target runtime.Object) error {
+	style, err := getDebugStyle(pod, target)
+	if err != nil {
+		return fmt.Errorf("sysadmin profile: %s", err)
+	}
+
+	setPrivileged(pod, containerName)
+
+	switch style {
+	case node:
+		useHostNamespaces(pod)
+		mountRootPartition(pod, containerName)
+
+	case podCopy:
+		// to mimic general, default and baseline
+		shareProcessNamespace(pod)
+	case ephemeral:
+		// no additional modifications needed
+	}
+
+	return nil
+}
+
 // removeLabelsAndProbes removes labels from the pod and remove probes
 // from all containers of the pod.
 func removeLabelsAndProbes(p *corev1.Pod) {
@@ -267,6 +297,20 @@ func clearSecurityContext(p *corev1.Pod, containerName string) {
 			return true
 		}
 		c.SecurityContext = nil
+		return false
+	})
+}
+
+// setPrivileged configures the containers as privileged.
+func setPrivileged(p *corev1.Pod, containerName string) {
+	podutils.VisitContainers(&p.Spec, podutils.AllContainers, func(c *corev1.Container, _ podutils.ContainerType) bool {
+		if c.Name != containerName {
+			return true
+		}
+		if c.SecurityContext == nil {
+			c.SecurityContext = &corev1.SecurityContext{}
+		}
+		c.SecurityContext.Privileged = pointer.Bool(true)
 		return false
 	})
 }


### PR DESCRIPTION
Add the sysadmin profile from KEP 1441
https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug#debugging-profiles

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds the `sysadmin` profile as designed in [KEP 1441](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug#debugging-profiles).

#### Which issue(s) this PR fixes:

https://github.com/kubernetes/kubectl/issues/1108

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kubectl debug: add sysadmin profile
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug#debugging-profiles
```
