### PR TITLE
Kubectl wait for multiple

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -380,10 +380,10 @@ func (o *DeleteOptions) DeleteResult(r *resource.Result) error {
 		UIDMap:         uidMap,
 		DynamicClient:  o.DynamicClient,
 		Timeout:        effectiveTimeout,
+		ForConditions:  map[string]cmdwait.ConditionFunc{"delete": cmdwait.IsDeleted},
 
-		Printer:     printers.NewDiscardingPrinter(),
-		ConditionFn: cmdwait.IsDeleted,
-		IOStreams:   o.IOStreams,
+		Printer:   printers.NewDiscardingPrinter(),
+		IOStreams: o.IOStreams,
 	}
 	err = waitOptions.RunWait()
 	if errors.IsForbidden(err) || errors.IsMethodNotSupported(err) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -1534,39 +1534,97 @@ func TestWaitForJSONPathCondition(t *testing.T) {
 	}
 }
 
-// TestWaitForJSONPathBadConditionParsing will test errors in parsing JSONPath bad condition expressions
-// except for parsing JSONPath expression itself (i.e. call to cmdget.RelaxedJSONPathExpression())
-func TestWaitForJSONPathBadConditionParsing(t *testing.T) {
+// TestConditionFuncFor tests that the condition string can be properly parsed into a ConditionFunc.
+func TestConditionFuncFor(t *testing.T) {
 	tests := []struct {
-		name           string
-		condition      string
-		expectedResult JSONPathWait
-		expectedErr    string
+		name        string
+		condition   string
+		expectedErr string
 	}{
 		{
-			name:        "missing JSONPath expression",
+			name:        "jsonpath missing JSONPath expression",
 			condition:   "jsonpath=",
 			expectedErr: "jsonpath expression cannot be empty",
 		},
 		{
-			name:        "value in JSONPath expression has equal sign",
+			name:        "jsonpath check for condition without value",
+			condition:   "jsonpath={.metadata.name}",
+			expectedErr: None,
+		},
+		{
+			name:        "jsonpath check for condition without value relaxed parsing",
+			condition:   "jsonpath=abc",
+			expectedErr: None,
+		},
+		{
+			name:        "jsonpath check for expression and value",
+			condition:   "jsonpath={.metadata.name}=foo-b6699dcfb-rnv7t",
+			expectedErr: None,
+		},
+		{
+			name:        "jsonpath check for expression and value relaxed parsing",
+			condition:   "jsonpath=.metadata.name=foo-b6699dcfb-rnv7t",
+			expectedErr: None,
+		},
+		{
+			name:        "jsonpath selecting based on condition",
+			condition:   "jsonpath=status.conditions[?(@.type==\"Available\")].status=True",
+			expectedErr: None,
+		},
+		{
+			name:        "jsonpath invalid expression with repeated '='",
 			condition:   "jsonpath={.metadata.name}='test=wrong'",
 			expectedErr: "jsonpath wait format must be --for=jsonpath='{.status.readyReplicas}'=3 or --for=jsonpath='{.status.readyReplicas}'",
 		},
 		{
-			name:        "undefined value",
+			name:        "jsonpath undefined value after '='",
 			condition:   "jsonpath={.metadata.name}=",
-			expectedErr: "jsonpath wait has to have a value after equal sign, like --for=jsonpath='{.status.readyReplicas}'=3",
+			expectedErr: "jsonpath wait has to have a value after equal sign",
+		},
+		{
+			name:        "jsonpath complex expressions not supported",
+			condition:   "jsonpath={.status.conditions[?(@.type==\"Failed\"||@.type==\"Complete\")].status}=True",
+			expectedErr: "unrecognized character in action: U+007C '|'",
+		},
+		{
+			name:      "jsonpath invalid expression",
+			condition: "jsonpath={=True",
+			expectedErr: "unexpected path string, expected a 'name1.name2' or '.name1.name2' or '{name1.name2}' or " +
+				"'{.name1.name2}'",
+		},
+		{
+			name:        "condition delete",
+			condition:   "delete",
+			expectedErr: None,
+		},
+		{
+			name:        "condition true",
+			condition:   "condition=hello",
+			expectedErr: None,
+		},
+		{
+			name:        "condition with value",
+			condition:   "condition=hello=world",
+			expectedErr: None,
+		},
+		{
+			name:        "unrecognized condition",
+			condition:   "cond=invalid",
+			expectedErr: "unrecognized condition: \"cond=invalid\"",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := conditionFuncFor(test.condition, io.Discard)
-			if err == nil && test.expectedErr != "" {
-				t.Fatalf("expected %q, got empty", test.expectedErr)
-			}
-			if !strings.Contains(err.Error(), test.expectedErr) {
-				t.Fatalf("expected %q, got %q", test.expectedErr, err.Error())
+			switch {
+			case err == nil && test.expectedErr != None:
+				t.Fatalf("expected error %q, got nil", test.expectedErr)
+			case err != nil && test.expectedErr == None:
+				t.Fatalf("expected no error, got %q", err)
+			case err != nil && test.expectedErr != None:
+				if !strings.Contains(err.Error(), test.expectedErr) {
+					t.Fatalf("expected error %q, got %q", test.expectedErr, err.Error())
+				}
 			}
 		})
 	}

--- a/test/cmd/wait.sh
+++ b/test/cmd/wait.sh
@@ -100,11 +100,16 @@ EOF
     # wait with jsonpath without value to succeed
     set +o errexit
     # Command: Wait with jsonpath without value
-    output_message=$(kubectl wait --for=jsonpath='{.status.replicas}' deploy/test-3 2>&1)
+    output_message_0=$(kubectl wait --for=jsonpath='{.status.replicas}' deploy/test-3 2>&1)
+    # Command: Wait with relaxed jsonpath and filter expression
+    output_message_1=$(kubectl wait \
+        --for='jsonpath=spec.template.spec.containers[?(@.name=="busybox")].image=busybox' \
+        deploy/test-3)
     set -o errexit
 
     # Post-Condition: Wait succeed
-    kube::test::if_has_string "${output_message}" 'deployment.apps/test-3 condition met'
+    kube::test::if_has_string "${output_message_0}" 'deployment.apps/test-3 condition met'
+    kube::test::if_has_string "${output_message_1}" 'deployment.apps/test-3 condition met'
 
     # Clean deployment
     kubectl delete deployment test-3

--- a/test/cmd/wait.sh
+++ b/test/cmd/wait.sh
@@ -105,11 +105,18 @@ EOF
     output_message_1=$(kubectl wait \
         --for='jsonpath=spec.template.spec.containers[?(@.name=="busybox")].image=busybox' \
         deploy/test-3)
+    # Command: Wait for all --for conditions
+    output_message_2=$(kubectl wait \
+        --for='jsonpath={.spec.template.spec.containers[?(@.name=="busybox")].image}=busybox' \
+        --for=jsonpath='{.status.replicas}' \
+        --for-all \
+        deploy/test-3)
     set -o errexit
 
     # Post-Condition: Wait succeed
     kube::test::if_has_string "${output_message_0}" 'deployment.apps/test-3 condition met'
     kube::test::if_has_string "${output_message_1}" 'deployment.apps/test-3 condition met'
+    kube::test::if_has_string "${output_message_2//$'\n'/ }" "deployment.apps/test-3 condition met deployment.apps/test-3 condition met"
 
     # Clean deployment
     kubectl delete deployment test-3


### PR DESCRIPTION
**Requires https://github.com/kubernetes/kubernetes/pull/118748 to merge first** - at that time, I'll rebase and remove the first commit in the series here, leaving only the second one.
**NOTE:** As discussed with Arda Guclu, I will bring this up at the next sig-cli meeting 2 weeks from now. Meanwhile, I drafted a preliminary KEP (only in my local repository) here https://github.com/andreaskaris/enhancements/tree/multiple-wait-for-conditions/keps/sig-cli/1224-multiple-wait-for-conditions

Implement support for multiple --for statements in wait. By default, multiple --for conditions are OR'ed. With the ptional --for-all flag, they can be AND'ed.

Reported-at: https://github.com/kubernetes/kubectl/issues/1224

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR adds support for multiple --for parameters and it adds a --for-all parameter to kubectl wait.
It also improves unit test coverage.

#### Which issue(s) this PR fixes:

Fixes: https://github.com/kubernetes/kubectl/issues/1224
And:   https://github.com/kubernetes/kubernetes/issues/95759

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Add support for multiple --for and add --for-all parameter.

```release-note
Improved handling of JSONPath expressions for `kubectl wait --for`.
Added a `--for-all` parameter to `kubectl wait`, that uses a logical AND (rather than OR) operation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
