### PR TITLE
Decouple TaintManager from NodeLifeCycleController (KEP-3902)

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -57,7 +57,7 @@ import (
 	"k8s.io/component-base/featuregate"
 	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
-	"k8s.io/component-base/metrics/features"
+	metricsfeatures "k8s.io/component-base/metrics/features"
 	controllersmetrics "k8s.io/component-base/metrics/prometheus/controllers"
 	"k8s.io/component-base/metrics/prometheus/slis"
 	"k8s.io/component-base/term"
@@ -75,12 +75,13 @@ import (
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 	serviceaccountcontroller "k8s.io/kubernetes/pkg/controller/serviceaccount"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 )
 
 func init() {
 	utilruntime.Must(logsapi.AddFeatureGates(utilfeature.DefaultMutableFeatureGate))
-	utilruntime.Must(features.AddFeatureGates(utilfeature.DefaultMutableFeatureGate))
+	utilruntime.Must(metricsfeatures.AddFeatureGates(utilfeature.DefaultMutableFeatureGate))
 }
 
 const (
@@ -556,6 +557,10 @@ func NewControllerDescriptors() map[string]*ControllerDescriptor {
 	register(newResourceClaimControllerDescriptor())
 	register(newLegacyServiceAccountTokenCleanerControllerDescriptor())
 	register(newValidatingAdmissionPolicyStatusControllerDescriptor())
+	if utilfeature.DefaultFeatureGate.Enabled(features.SeparateTaintEvictionController) {
+		// register the flag only if the SeparateTaintEvictionController flag is enabled
+		register(newTaintEvictionControllerDescriptor())
+	}
 
 	for _, alias := range aliases.UnsortedList() {
 		if _, ok := controllers[alias]; ok {

--- a/cmd/kube-controller-manager/names/controller_names.go
+++ b/cmd/kube-controller-manager/names/controller_names.go
@@ -68,6 +68,7 @@ const (
 	TokenCleanerController                       = "token-cleaner-controller"
 	NodeIpamController                           = "node-ipam-controller"
 	NodeLifecycleController                      = "node-lifecycle-controller"
+	TaintEvictionController                      = "taint-eviction-controller"
 	PersistentVolumeBinderController             = "persistentvolume-binder-controller"
 	PersistentVolumeAttachDetachController       = "persistentvolume-attach-detach-controller"
 	PersistentVolumeExpanderController           = "persistentvolume-expander-controller"

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	appsv1informers "k8s.io/client-go/informers/apps/v1"
 	coordinformers "k8s.io/client-go/informers/coordination/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
@@ -54,7 +55,9 @@ import (
 	kubeletapis "k8s.io/kubelet/pkg/apis"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/nodelifecycle/scheduler"
+	"k8s.io/kubernetes/pkg/controller/tainteviction"
 	controllerutil "k8s.io/kubernetes/pkg/controller/util/node"
+	"k8s.io/kubernetes/pkg/features"
 	taintutils "k8s.io/kubernetes/pkg/util/taints"
 )
 
@@ -127,6 +130,13 @@ const (
 	// podUpdateWorkerSizes assumes that in most cases pod will be handled by monitorNodeHealth pass.
 	// Pod update workers will only handle lagging cache pods. 4 workers should be enough.
 	podUpdateWorkerSize = 4
+	// nodeUpdateWorkerSize defines the size of workers for node update or/and pod update.
+	nodeUpdateWorkerSize = 8
+
+	// taintEvictionController is defined here in order to prevent imports of
+	// k8s.io/kubernetes/cmd/kube-controller-manager/names which would result in validation errors.
+	// This constant will be removed upon graduation of the SeparateTaintEvictionController feature.
+	taintEvictionController = "taint-eviction-controller"
 )
 
 // labelReconcileInfo lists Node labels to reconcile, and how to reconcile them.
@@ -207,7 +217,7 @@ type podUpdateItem struct {
 
 // Controller is the controller that manages node's life cycle.
 type Controller struct {
-	taintManager *scheduler.NoExecuteTaintManager
+	taintManager *tainteviction.Controller
 
 	podLister         corelisters.PodLister
 	podInformerSynced cache.InformerSynced
@@ -326,7 +336,7 @@ func NewNodeLifecycleController(
 		nodeMonitorPeriod:           nodeMonitorPeriod,
 		nodeStartupGracePeriod:      nodeStartupGracePeriod,
 		nodeMonitorGracePeriod:      nodeMonitorGracePeriod,
-		nodeUpdateWorkerSize:        scheduler.UpdateWorkerSize,
+		nodeUpdateWorkerSize:        nodeUpdateWorkerSize,
 		zoneNoExecuteTainter:        make(map[string]*scheduler.RateLimitedTimedQueue),
 		nodesToRetry:                sync.Map{},
 		zoneStates:                  make(map[string]ZoneState),
@@ -346,17 +356,11 @@ func NewNodeLifecycleController(
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*v1.Pod)
 			nc.podUpdated(nil, pod)
-			if nc.taintManager != nil {
-				nc.taintManager.PodUpdated(nil, pod)
-			}
 		},
 		UpdateFunc: func(prev, obj interface{}) {
 			prevPod := prev.(*v1.Pod)
 			newPod := obj.(*v1.Pod)
 			nc.podUpdated(prevPod, newPod)
-			if nc.taintManager != nil {
-				nc.taintManager.PodUpdated(prevPod, newPod)
-			}
 		},
 		DeleteFunc: func(obj interface{}) {
 			pod, isPod := obj.(*v1.Pod)
@@ -374,9 +378,6 @@ func NewNodeLifecycleController(
 				}
 			}
 			nc.podUpdated(pod, nil)
-			if nc.taintManager != nil {
-				nc.taintManager.PodUpdated(pod, nil)
-			}
 		},
 	})
 	nc.podInformerSynced = podInformer.Informer().HasSynced
@@ -412,21 +413,14 @@ func NewNodeLifecycleController(
 	nc.podLister = podInformer.Lister()
 	nc.nodeLister = nodeInformer.Lister()
 
-	nc.taintManager = scheduler.NewNoExecuteTaintManager(ctx, kubeClient, nc.podLister, nc.nodeLister, nc.getPodsAssignedToNode)
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: controllerutil.CreateAddNodeHandler(func(node *v1.Node) error {
-			nc.taintManager.NodeUpdated(nil, node)
-			return nil
-		}),
-		UpdateFunc: controllerutil.CreateUpdateNodeHandler(func(oldNode, newNode *v1.Node) error {
-			nc.taintManager.NodeUpdated(oldNode, newNode)
-			return nil
-		}),
-		DeleteFunc: controllerutil.CreateDeleteNodeHandler(logger, func(node *v1.Node) error {
-			nc.taintManager.NodeUpdated(node, nil)
-			return nil
-		}),
-	})
+	if !utilfeature.DefaultFeatureGate.Enabled(features.SeparateTaintEvictionController) {
+		logger.Info("Running TaintEvictionController as part of NodeLifecyleController")
+		tm, err := tainteviction.New(ctx, kubeClient, podInformer, nodeInformer, taintEvictionController)
+		if err != nil {
+			return nil, err
+		}
+		nc.taintManager = tm
+	}
 
 	logger.Info("Controller will reconcile labels")
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -480,10 +474,13 @@ func (nc *Controller) Run(ctx context.Context) {
 		return
 	}
 
-	go nc.taintManager.Run(ctx)
+	if !utilfeature.DefaultFeatureGate.Enabled(features.SeparateTaintEvictionController) {
+		logger.Info("Starting", "controller", taintEvictionController)
+		go nc.taintManager.Run(ctx)
+	}
 
 	// Start workers to reconcile labels and/or update NoSchedule taint for nodes.
-	for i := 0; i < scheduler.UpdateWorkerSize; i++ {
+	for i := 0; i < nodeUpdateWorkerSize; i++ {
 		// Thanks to "workqueue", each worker just need to get item from queue, because
 		// the item is flagged when got from queue: if new event come, the new item will
 		// be re-queued until "Done", so no more than one worker handle the same item and

--- a/pkg/controller/tainteviction/OWNERS
+++ b/pkg/controller/tainteviction/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-scheduling-maintainers
+reviewers:
+  - sig-scheduling
+labels:
+  - sig/scheduling

--- a/pkg/controller/tainteviction/doc.go
+++ b/pkg/controller/tainteviction/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package tainteviction contains the logic implementing taint-based eviction
+// for Pods running on Nodes with NoExecute taints.
+package tainteviction

--- a/pkg/controller/tainteviction/metrics/metrics.go
+++ b/pkg/controller/tainteviction/metrics/metrics.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const taintEvictionControllerSubsystem = "taint_eviction_controller"
+
+var (
+	// PodDeletionsTotal counts the number of Pods deleted by TaintEvictionController since its start.
+	PodDeletionsTotal = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Subsystem:      taintEvictionControllerSubsystem,
+			Name:           "pod_deletions_total",
+			Help:           "Total number of Pods deleted by TaintEvictionController since its start.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	// PodDeletionsLatency tracks the latency, in seconds, between the time when a taint effect has been activated
+	// for the Pod and its deletion.
+	PodDeletionsLatency = metrics.NewHistogram(
+		&metrics.HistogramOpts{
+			Subsystem:      taintEvictionControllerSubsystem,
+			Name:           "pod_deletion_duration_seconds",
+			Help:           "Latency, in seconds, between the time when a taint effect has been activated for the Pod and its deletion via TaintEvictionController.",
+			Buckets:        []float64{0.005, 0.025, 0.1, 0.5, 1, 2.5, 10, 30, 60, 120, 180, 240}, // 5ms to 4m
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+)
+
+var registerMetrics sync.Once
+
+// Register registers TaintEvictionController metrics.
+func Register() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(PodDeletionsTotal)
+		legacyregistry.MustRegister(PodDeletionsLatency)
+	})
+}

--- a/pkg/controller/tainteviction/timed_workers_test.go
+++ b/pkg/controller/tainteviction/timed_workers_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scheduler
+package tainteviction
 
 import (
 	"context"
@@ -31,7 +31,7 @@ func TestExecute(t *testing.T) {
 	testVal := int32(0)
 	wg := sync.WaitGroup{}
 	wg.Add(5)
-	queue := CreateWorkerQueue(func(ctx context.Context, args *WorkArgs) error {
+	queue := CreateWorkerQueue(func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
 		atomic.AddInt32(&testVal, 1)
 		wg.Done()
 		return nil
@@ -59,7 +59,7 @@ func TestExecuteDelayed(t *testing.T) {
 	testVal := int32(0)
 	wg := sync.WaitGroup{}
 	wg.Add(5)
-	queue := CreateWorkerQueue(func(ctx context.Context, args *WorkArgs) error {
+	queue := CreateWorkerQueue(func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
 		atomic.AddInt32(&testVal, 1)
 		wg.Done()
 		return nil
@@ -90,7 +90,7 @@ func TestCancel(t *testing.T) {
 	testVal := int32(0)
 	wg := sync.WaitGroup{}
 	wg.Add(3)
-	queue := CreateWorkerQueue(func(ctx context.Context, args *WorkArgs) error {
+	queue := CreateWorkerQueue(func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
 		atomic.AddInt32(&testVal, 1)
 		wg.Done()
 		return nil
@@ -124,7 +124,7 @@ func TestCancelAndReadd(t *testing.T) {
 	testVal := int32(0)
 	wg := sync.WaitGroup{}
 	wg.Add(4)
-	queue := CreateWorkerQueue(func(ctx context.Context, args *WorkArgs) error {
+	queue := CreateWorkerQueue(func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
 		atomic.AddInt32(&testVal, 1)
 		wg.Done()
 		return nil

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -729,6 +729,13 @@ const (
 	// https://github.com/kubernetes/kubernetes/issues/111516
 	SecurityContextDeny featuregate.Feature = "SecurityContextDeny"
 
+	// owner: @atosatto @yuanchen8911
+	// kep: http://kep.k8s.io/3902
+	// beta: v1.29
+	//
+	// Decouples Taint Eviction Controller, performing taint-based Pod eviction, from Node Lifecycle Controller.
+	SeparateTaintEvictionController featuregate.Feature = "SeparateTaintEvictionController"
+
 	// owner: @xuzhenglun
 	// kep: http://kep.k8s.io/3682
 	// alpha: v1.27
@@ -1092,6 +1099,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	SchedulerQueueingHints: {Default: true, PreRelease: featuregate.Beta},
 
 	SecurityContextDeny: {Default: false, PreRelease: featuregate.Alpha},
+
+	SeparateTaintEvictionController: {Default: true, PreRelease: featuregate.Beta},
 
 	ServiceNodePortStaticSubrange: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.29; remove in 1.31
 

--- a/test/integration/node/lifecycle_test.go
+++ b/test/integration/node/lifecycle_test.go
@@ -32,8 +32,10 @@ import (
 	restclient "k8s.io/client-go/rest"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller/nodelifecycle"
+	"k8s.io/kubernetes/pkg/controller/tainteviction"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/plugin/pkg/admission/defaulttolerationseconds"
 	"k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction"
@@ -49,13 +51,34 @@ func TestEvictionForNoExecuteTaintAddedByUser(t *testing.T) {
 	nodeIndex := 1 // the exact node doesn't matter, pick one
 
 	tests := map[string]struct {
-		enablePodDisruptionConditions bool
+		enablePodDisruptionConditions          bool
+		enableSeparateTaintEvictionController  bool
+		startStandaloneTaintEvictionController bool
+		wantPodEvicted                         bool
 	}{
-		"Test eviciton for NoExecute taint added by user; pod condition added when PodDisruptionConditions enabled": {
-			enablePodDisruptionConditions: true,
+		"Test eviction for NoExecute taint added by user; pod condition added when PodDisruptionConditions enabled; separate taint eviction controller disabled": {
+			enablePodDisruptionConditions:          true,
+			enableSeparateTaintEvictionController:  false,
+			startStandaloneTaintEvictionController: false,
+			wantPodEvicted:                         true,
 		},
-		"Test eviciton for NoExecute taint added by user; no pod condition added when PodDisruptionConditions disabled": {
-			enablePodDisruptionConditions: false,
+		"Test eviction for NoExecute taint added by user; no pod condition added when PodDisruptionConditions disabled; separate taint eviction controller disabled": {
+			enablePodDisruptionConditions:          false,
+			enableSeparateTaintEvictionController:  false,
+			startStandaloneTaintEvictionController: false,
+			wantPodEvicted:                         true,
+		},
+		"Test eviction for NoExecute taint added by user; separate taint eviction controller enabled but not started": {
+			enablePodDisruptionConditions:          false,
+			enableSeparateTaintEvictionController:  true,
+			startStandaloneTaintEvictionController: false,
+			wantPodEvicted:                         false,
+		},
+		"Test eviction for NoExecute taint added by user; separate taint eviction controller enabled and started": {
+			enablePodDisruptionConditions:          false,
+			enableSeparateTaintEvictionController:  true,
+			startStandaloneTaintEvictionController: true,
+			wantPodEvicted:                         true,
 		},
 	}
 
@@ -102,6 +125,7 @@ func TestEvictionForNoExecuteTaintAddedByUser(t *testing.T) {
 			}
 
 			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodDisruptionConditions, test.enablePodDisruptionConditions)()
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.SeparateTaintEvictionController, test.enableSeparateTaintEvictionController)()
 			testCtx := testutils.InitTestAPIServer(t, "taint-no-execute", nil)
 			cs := testCtx.ClientSet
 
@@ -138,6 +162,18 @@ func TestEvictionForNoExecuteTaintAddedByUser(t *testing.T) {
 			// Run all controllers
 			go nc.Run(testCtx.Ctx)
 
+			// Start TaintManager
+			if test.startStandaloneTaintEvictionController {
+				tm, _ := tainteviction.New(
+					testCtx.Ctx,
+					testCtx.ClientSet,
+					externalInformers.Core().V1().Pods(),
+					externalInformers.Core().V1().Nodes(),
+					names.TaintEvictionController,
+				)
+				go tm.Run(testCtx.Ctx)
+			}
+
 			for index := range nodes {
 				nodes[index], err = cs.CoreV1().Nodes().Create(testCtx.Ctx, nodes[index], metav1.CreateOptions{})
 				if err != nil {
@@ -155,9 +191,12 @@ func TestEvictionForNoExecuteTaintAddedByUser(t *testing.T) {
 			}
 
 			err = wait.PollUntilContextTimeout(testCtx.Ctx, time.Second, time.Second*20, true, testutils.PodIsGettingEvicted(cs, testPod.Namespace, testPod.Name))
-			if err != nil {
-				t.Fatalf("Error %q in test %q when waiting for terminating pod: %q", err, name, klog.KObj(testPod))
+			if err != nil && test.wantPodEvicted {
+				t.Fatalf("Test Failed: error %v while waiting for pod %q to be evicted", err, klog.KObj(testPod))
+			} else if !wait.Interrupted(err) && !test.wantPodEvicted {
+				t.Fatalf("Test Failed: unexpected eviction of pod %q", klog.KObj(testPod))
 			}
+
 			testPod, err = cs.CoreV1().Pods(testCtx.NS.Name).Get(testCtx.Ctx, testPod.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Test Failed: error: %q, while getting updated pod", err)
@@ -196,23 +235,34 @@ func TestTaintBasedEvictions(t *testing.T) {
 		},
 	}
 	tests := []struct {
-		name                        string
-		nodeTaints                  []v1.Taint
-		nodeConditions              []v1.NodeCondition
-		pod                         *v1.Pod
-		tolerationSeconds           int64
-		expectedWaitForPodCondition string
+		name                                  string
+		nodeTaints                            []v1.Taint
+		nodeConditions                        []v1.NodeCondition
+		pod                                   *v1.Pod
+		tolerationSeconds                     int64
+		expectedWaitForPodCondition           string
+		enableSeparateTaintEvictionController bool
 	}{
 		{
-			name:                        "Taint based evictions for NodeNotReady and 200 tolerationseconds",
-			nodeTaints:                  []v1.Taint{{Key: v1.TaintNodeNotReady, Effect: v1.TaintEffectNoExecute}},
-			nodeConditions:              []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionFalse}},
-			pod:                         testPod.DeepCopy(),
-			tolerationSeconds:           200,
-			expectedWaitForPodCondition: "updated with tolerationSeconds of 200",
+			name:                                  "Taint based evictions for NodeNotReady and 200 tolerationseconds; separate taint eviction controller disabled",
+			nodeTaints:                            []v1.Taint{{Key: v1.TaintNodeNotReady, Effect: v1.TaintEffectNoExecute}},
+			nodeConditions:                        []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionFalse}},
+			pod:                                   testPod.DeepCopy(),
+			tolerationSeconds:                     200,
+			expectedWaitForPodCondition:           "updated with tolerationSeconds of 200",
+			enableSeparateTaintEvictionController: false,
 		},
 		{
-			name:           "Taint based evictions for NodeNotReady with no pod tolerations",
+			name:                                  "Taint based evictions for NodeNotReady and 200 tolerationseconds; separate taint eviction controller enabled",
+			nodeTaints:                            []v1.Taint{{Key: v1.TaintNodeNotReady, Effect: v1.TaintEffectNoExecute}},
+			nodeConditions:                        []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionFalse}},
+			pod:                                   testPod.DeepCopy(),
+			tolerationSeconds:                     200,
+			expectedWaitForPodCondition:           "updated with tolerationSeconds of 200",
+			enableSeparateTaintEvictionController: true,
+		},
+		{
+			name:           "Taint based evictions for NodeNotReady with no pod tolerations; separate taint eviction controller disabled",
 			nodeTaints:     []v1.Taint{{Key: v1.TaintNodeNotReady, Effect: v1.TaintEffectNoExecute}},
 			nodeConditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionFalse}},
 			pod: &v1.Pod{
@@ -223,21 +273,55 @@ func TestTaintBasedEvictions(t *testing.T) {
 					},
 				},
 			},
-			tolerationSeconds:           300,
-			expectedWaitForPodCondition: "updated with tolerationSeconds=300",
+			tolerationSeconds:                     300,
+			expectedWaitForPodCondition:           "updated with tolerationSeconds=300",
+			enableSeparateTaintEvictionController: false,
 		},
 		{
-			name:                        "Taint based evictions for NodeNotReady and 0 tolerationseconds",
-			nodeTaints:                  []v1.Taint{{Key: v1.TaintNodeNotReady, Effect: v1.TaintEffectNoExecute}},
-			nodeConditions:              []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionFalse}},
-			pod:                         testPod.DeepCopy(),
-			tolerationSeconds:           0,
-			expectedWaitForPodCondition: "terminating",
+			name:           "Taint based evictions for NodeNotReady with no pod tolerations; separate taint eviction controller enabled",
+			nodeTaints:     []v1.Taint{{Key: v1.TaintNodeNotReady, Effect: v1.TaintEffectNoExecute}},
+			nodeConditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionFalse}},
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "testpod1"},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "container", Image: imageutils.GetPauseImageName()},
+					},
+				},
+			},
+			tolerationSeconds:                     300,
+			expectedWaitForPodCondition:           "updated with tolerationSeconds=300",
+			enableSeparateTaintEvictionController: true,
 		},
 		{
-			name:           "Taint based evictions for NodeUnreachable",
-			nodeTaints:     []v1.Taint{{Key: v1.TaintNodeUnreachable, Effect: v1.TaintEffectNoExecute}},
-			nodeConditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionUnknown}},
+			name:                                  "Taint based evictions for NodeNotReady and 0 tolerationseconds; separate taint eviction controller disabled",
+			nodeTaints:                            []v1.Taint{{Key: v1.TaintNodeNotReady, Effect: v1.TaintEffectNoExecute}},
+			nodeConditions:                        []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionFalse}},
+			pod:                                   testPod.DeepCopy(),
+			tolerationSeconds:                     0,
+			expectedWaitForPodCondition:           "terminating",
+			enableSeparateTaintEvictionController: false,
+		},
+		{
+			name:                                  "Taint based evictions for NodeNotReady and 0 tolerationseconds; separate taint eviction controller enabled",
+			nodeTaints:                            []v1.Taint{{Key: v1.TaintNodeNotReady, Effect: v1.TaintEffectNoExecute}},
+			nodeConditions:                        []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionFalse}},
+			pod:                                   testPod.DeepCopy(),
+			tolerationSeconds:                     0,
+			expectedWaitForPodCondition:           "terminating",
+			enableSeparateTaintEvictionController: true,
+		},
+		{
+			name:                                  "Taint based evictions for NodeUnreachable; separate taint eviction controller disabled",
+			nodeTaints:                            []v1.Taint{{Key: v1.TaintNodeUnreachable, Effect: v1.TaintEffectNoExecute}},
+			nodeConditions:                        []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionUnknown}},
+			enableSeparateTaintEvictionController: false,
+		},
+		{
+			name:                                  "Taint based evictions for NodeUnreachable; separate taint eviction controller enabled",
+			nodeTaints:                            []v1.Taint{{Key: v1.TaintNodeUnreachable, Effect: v1.TaintEffectNoExecute}},
+			nodeConditions:                        []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionUnknown}},
+			enableSeparateTaintEvictionController: true,
 		},
 	}
 
@@ -249,6 +333,8 @@ func TestTaintBasedEvictions(t *testing.T) {
 	)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.SeparateTaintEvictionController, test.enableSeparateTaintEvictionController)()
+
 			testCtx := testutils.InitTestAPIServer(t, "taint-based-evictions", admission)
 
 			// Build clientset and informers for controllers.
@@ -287,6 +373,18 @@ func TestTaintBasedEvictions(t *testing.T) {
 
 			// Run the controller
 			go nc.Run(testCtx.Ctx)
+
+			// Start TaintEvictionController
+			if test.enableSeparateTaintEvictionController {
+				tm, _ := tainteviction.New(
+					testCtx.Ctx,
+					testCtx.ClientSet,
+					externalInformers.Core().V1().Pods(),
+					externalInformers.Core().V1().Nodes(),
+					names.TaintEvictionController,
+				)
+				go tm.Run(testCtx.Ctx)
+			}
 
 			nodeRes := v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("4000m"),


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is implementing [KEP-3902](https://github.com/kubernetes/enhancements/pull/3901) by introducing a feature-flag, `SeparateTaintManager`, allowing to de-couple `taint-manager` from `node-lifecycle-controller`.

#### Which issue(s) this PR fixes:

https://github.com/kubernetes/enhancements/issues/3902

#### Special notes for your reviewer:

Unlike the KEP proposal, the flag used to disable/enable the controller in KCM has been named `taint-eviction-controller` in order to preserve the existing convention of having all of the controllers names ending with `-controller`. This has been preferred to the `taint-manager-controller` and/or `taint-manager` alternatives. For compatibility with the KEP a `taint-manager` legacy flag has been provided in the implementation.

#### Does this PR introduce a user-facing change?

```release-note
Decouple TaintManager from NodeLifeCycleController (KEP-3902)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP - https://github.com/kubernetes/enhancements/pull/3901
- Docs - https://github.com/kubernetes/website/pull/41970
