### PR TITLE
Add enj to apiserver options approver

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+  - enj
 reviewers:
   - smarterclayton
   - wojtek-t


### PR DESCRIPTION
Primarily related to the encryption at rest work such as KMS v2.

/kind cleanup
/sig auth
/assign @deads2k 
/triage accepted

```release-note
NONE
```