### PR TITLE
Add StatefulSet pod index as pod label

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apiserver/pkg/util/feature"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	appsinformers "k8s.io/client-go/informers/apps/v1"
@@ -229,7 +228,7 @@ func CreatesPods(t *testing.T, set *apps.StatefulSet, invariants invariantFunc) 
 		t.Error("Failed to set UpdatedReplicas correctly")
 	}
 	// Check all pods have correct pod index label.
-	if feature.DefaultFeatureGate.Enabled(features.PodIndexLabel) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodIndexLabel) {
 		selector, err := metav1.LabelSelectorAsSelector(set.Spec.Selector)
 		if err != nil {
 			t.Error(err)

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -237,15 +237,18 @@ func CreatesPods(t *testing.T, set *apps.StatefulSet, invariants invariantFunc) 
 		if err != nil {
 			t.Error(err)
 		}
+		if len(pods) != 3 {
+			t.Errorf("Expected 3 pods, got %d", len(pods))
+		}
 		for _, pod := range pods {
 			podIndexFromLabel, exists := pod.Labels[apps.StatefulSetPodIndexLabel]
 			if !exists {
-				t.Errorf("missing pod index label: %s", apps.StatefulSetPodIndexLabel)
+				t.Errorf("Missing pod index label: %s", apps.StatefulSetPodIndexLabel)
 				continue
 			}
 			podIndexFromName := strconv.Itoa(getOrdinal(pod))
 			if podIndexFromLabel != podIndexFromName {
-				t.Errorf("pod index label value (%s) does not match pod index in pod name (%s)", podIndexFromLabel, podIndexFromName)
+				t.Errorf("Pod index label value (%s) does not match pod index in pod name (%s)", podIndexFromLabel, podIndexFromName)
 			}
 		}
 	}

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -241,9 +241,9 @@ func CreatesPods(t *testing.T, set *apps.StatefulSet, invariants invariantFunc) 
 			t.Errorf("Expected 3 pods, got %d", len(pods))
 		}
 		for _, pod := range pods {
-			podIndexFromLabel, exists := pod.Labels[apps.StatefulSetPodIndexLabel]
+			podIndexFromLabel, exists := pod.Labels[apps.PodIndexLabel]
 			if !exists {
-				t.Errorf("Missing pod index label: %s", apps.StatefulSetPodIndexLabel)
+				t.Errorf("Missing pod index label: %s", apps.PodIndexLabel)
 				continue
 			}
 			podIndexFromName := strconv.Itoa(getOrdinal(pod))

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -390,12 +390,16 @@ func initIdentity(set *apps.StatefulSet, pod *v1.Pod) {
 // updateIdentity updates pod's name, hostname, and subdomain, and StatefulSetPodNameLabel to conform to set's name
 // and headless service.
 func updateIdentity(set *apps.StatefulSet, pod *v1.Pod) {
-	pod.Name = getPodName(set, getOrdinal(pod))
+	ordinal := getOrdinal(pod)
+	pod.Name = getPodName(set, ordinal)
 	pod.Namespace = set.Namespace
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)
 	}
 	pod.Labels[apps.StatefulSetPodNameLabel] = pod.Name
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodIndexLabel) {
+		pod.Labels[apps.StatefulSetPodIndexLabel] = strconv.Itoa(ordinal)
+	}
 }
 
 // isRunningAndReady returns true if pod is in the PodRunning Phase, if it has a condition of PodReady.

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -398,7 +398,7 @@ func updateIdentity(set *apps.StatefulSet, pod *v1.Pod) {
 	}
 	pod.Labels[apps.StatefulSetPodNameLabel] = pod.Name
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodIndexLabel) {
-		pod.Labels[apps.StatefulSetPodIndexLabel] = strconv.Itoa(ordinal)
+		pod.Labels[apps.PodIndexLabel] = strconv.Itoa(ordinal)
 	}
 }
 

--- a/staging/src/k8s.io/api/apps/v1/types.go
+++ b/staging/src/k8s.io/api/apps/v1/types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -29,7 +29,7 @@ const (
 	DeprecatedRollbackTo           = "deprecated.deployment.rollback.to"
 	DeprecatedTemplateGeneration   = "deprecated.daemonset.template.generation"
 	StatefulSetPodNameLabel        = "statefulset.kubernetes.io/pod-name"
-	StatefulSetPodIndexLabel       = "statefulset.kubernetes.io/pod-index"
+	StatefulSetPodIndexLabel       = "apps.kubernetes.io/pod-index"
 )
 
 // +genclient

--- a/staging/src/k8s.io/api/apps/v1/types.go
+++ b/staging/src/k8s.io/api/apps/v1/types.go
@@ -29,6 +29,7 @@ const (
 	DeprecatedRollbackTo           = "deprecated.deployment.rollback.to"
 	DeprecatedTemplateGeneration   = "deprecated.daemonset.template.generation"
 	StatefulSetPodNameLabel        = "statefulset.kubernetes.io/pod-name"
+	StatefulSetPodIndexLabel       = "statefulset.kubernetes.io/pod-index"
 )
 
 // +genclient

--- a/staging/src/k8s.io/api/apps/v1/types.go
+++ b/staging/src/k8s.io/api/apps/v1/types.go
@@ -29,7 +29,7 @@ const (
 	DeprecatedRollbackTo           = "deprecated.deployment.rollback.to"
 	DeprecatedTemplateGeneration   = "deprecated.daemonset.template.generation"
 	StatefulSetPodNameLabel        = "statefulset.kubernetes.io/pod-name"
-	StatefulSetPodIndexLabel       = "apps.kubernetes.io/pod-index"
+	PodIndexLabel                  = "apps.kubernetes.io/pod-index"
 )
 
 // +genclient


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Implementing StatefulSet changes for [KEP-4017](https://github.com/kubernetes/enhancements/pull/4019).

Reviewer note: please only look at commit https://github.com/kubernetes/kubernetes/pull/119232/commits/42302f3e06b82520e1a5eb277d58291943f6bcaa and beyond, since this branch is based off the branch where I implemented the corresponding changes for indexed jobs.

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/enhancements/issues/4017

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes, the pod index of a StatefulSet pod will now be added as a pod a label, `statefulset.kubernetes.io/pod-index`.

```release-note
StatefulSet pods now have the pod index set as a pod label `statefulset.kubernetes.io/pod-index`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
[KEP](https://github.com/kubernetes/enhancements/pull/4019)
```
