### PR TITLE
Add metrics for cloud controller manager initial node sync

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/node/metrics.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/metrics.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	metricsSubsystem = "node_controller"
+)
+
+var (
+	removeCloudProviderTaintDelay = metrics.NewHistogram(
+		&metrics.HistogramOpts{
+			Subsystem:      metricsSubsystem,
+			Name:           "cloud_provider_taint_removal_delay_seconds",
+			Help:           "Number of seconds after node creation when NodeController removed the cloud-provider taint of a single node.",
+			Buckets:        metrics.ExponentialBuckets(1, 4, 6), // 1s -> ~17m
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+	initialNodeSyncDelay = metrics.NewHistogram(
+		&metrics.HistogramOpts{
+			Subsystem:      metricsSubsystem,
+			Name:           "initial_node_sync_delay_seconds",
+			Help:           "Number of seconds after node creation when NodeController finished the initial synchronization of a single node.",
+			Buckets:        metrics.ExponentialBuckets(1, 4, 6), // 1s -> ~17m
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+)
+
+var metricRegistration sync.Once
+
+// registerMetrics registers the metrics that are to be monitored.
+func registerMetrics() {
+	metricRegistration.Do(func() {
+		legacyregistry.MustRegister(removeCloudProviderTaintDelay)
+		legacyregistry.MustRegister(initialNodeSyncDelay)
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

In 1.27, cloud controller manager's node controller has a new flag, `--concurrent-node-syncs`, that controls the parallelism of node controller's actions; such as the handlers that remove  the node's initial cloud provider taint. This flag is useful for reducing the amount of time that a new node remains tainted before it can be scheduled work (for example).

- Flag added in https://github.com/kubernetes/kubernetes/pull/113104.
- Related work done in https://github.com/kubernetes/kubernetes/pull/115521.

The default value is `1` (serial). There is currently no guidance on tuning this value in different environments.

This PR adds metrics to better understand the performance of the node controller's, with a goal of tuning the value for `--concurrent-node-syncs` in a specific environment and potentially increasng the default value.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

I've mostly copied this from the node lifecycle controller's metric setup, let me know if there's a new pattern I should be following: https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/nodelifecycle/metrics.go

#### Does this PR introduce a user-facing change?
Yes.
```release-note
Cloud controller manager's node controller now emits timing metrics for initial `Node` synchronization. These metrics measure the delay between the creation of a new `Node` and the node controller's initial management actions, such as removing the cloud provider taint. These metrics should be consulted when setting cloud controller manager's `--concurrent-node-syncs` flag.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
