### PR TITLE
setcap: update to debian bookworm v1.0.0

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -98,7 +98,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 # These are the default versions (image tags) for their respective base images.
 readonly __default_distroless_iptables_version=v0.2.5
 readonly __default_go_runner_version=v2.3.1-go1.20.5-bullseye.0
-readonly __default_setcap_version=bullseye-v1.4.2
+readonly __default_setcap_version=bookworm-v1.0.0
 
 # These are the base images for the Docker-wrapped binaries.
 readonly KUBE_GORUNNER_IMAGE="${KUBE_GORUNNER_IMAGE:-$KUBE_BASE_IMAGE_REGISTRY/go-runner:$__default_go_runner_version}"

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -233,8 +233,8 @@ dependencies:
     - path: test/utils/image/manifest.go
       match: configs\[Pause\] = Config{list\.GcRegistry, "pause", "\d+\.\d+(.\d+)?"}
 
-  - name: "registry.k8s.io/setcap: dependents"
-    version: bullseye-v1.4.2
+  - name: "registry.k8s.io/build-image/setcap: dependents"
+    version: bookworm-v1.0.0
     refPaths:
     - path: build/common.sh
       match: __default_setcap_version=


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Update setcap image to the latest bookworm release.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refers to https://github.com/kubernetes/release/issues/3128

#### Special notes for your reviewer:
cc @kubernetes/release-engineering 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Updated setcap image to debian bookworm v1.0.0.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
