### PR TITLE
kube-controller-manager: finish conversion to contextual logging

### DIFF
--- a/cmd/cloud-controller-manager/.import-restrictions
+++ b/cmd/cloud-controller-manager/.import-restrictions
@@ -42,3 +42,4 @@ rules:
       - k8s.io/kubernetes/pkg/proxy/util/testing
       - k8s.io/kubernetes/pkg/util/slice
       - k8s.io/kubernetes/pkg/util/sysctl
+      - k8s.io/kubernetes/test/utils/ktesting

--- a/cmd/kube-controller-manager/app/discovery.go
+++ b/cmd/kube-controller-manager/app/discovery.go
@@ -43,6 +43,7 @@ func startEndpointSliceController(ctx context.Context, controllerContext Control
 
 func startEndpointSliceMirroringController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
 	go endpointslicemirroringcontroller.NewController(
+		ctx,
 		controllerContext.InformerFactory.Core().V1().Endpoints(),
 		controllerContext.InformerFactory.Discovery().V1().EndpointSlices(),
 		controllerContext.InformerFactory.Core().V1().Services(),

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -34,19 +34,6 @@ contextual k8s.io/kubernetes/cmd/kube-scheduler/.*
 contextual k8s.io/kubernetes/pkg/controller/.*
 contextual k8s.io/kubernetes/test/e2e/dra/.*
 
-# Most of kube-controller-manager has been converted, but not everything.  At
-# this point it is easier to list the exceptions.
--contextual k8s.io/kubernetes/pkg/controller/controller_ref_manager.go
--contextual k8s.io/kubernetes/pkg/controller/controller_utils.go
--contextual k8s.io/kubernetes/pkg/controller/endpoint/.*
--contextual k8s.io/kubernetes/pkg/controller/endpointslicemirroring/.*
--contextual k8s.io/kubernetes/pkg/controller/garbagecollector/.*
--contextual k8s.io/kubernetes/pkg/controller/nodeipam/.*
--contextual k8s.io/kubernetes/pkg/controller/podgc/.*
--contextual k8s.io/kubernetes/pkg/controller/replicaset/.*
--contextual k8s.io/kubernetes/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
--contextual k8s.io/kubernetes/pkg/controller/volume/pvprotection/pv_protection_controller_test.go
-
 # As long as contextual logging is alpha or beta, all WithName, WithValues,
 # NewContext calls have to go through klog. Once it is GA, we can lift
 # this restriction. Whether we then do a global search/replace remains

--- a/pkg/controller/controller_ref_manager.go
+++ b/pkg/controller/controller_ref_manager.go
@@ -236,8 +236,8 @@ func (m *PodControllerRefManager) AdoptPod(ctx context.Context, pod *v1.Pod) err
 // ReleasePod sends a patch to free the pod from the control of the controller.
 // It returns the error if the patching fails. 404 and 422 errors are ignored.
 func (m *PodControllerRefManager) ReleasePod(ctx context.Context, pod *v1.Pod) error {
-	klog.V(2).Infof("patching pod %s_%s to remove its controllerRef to %s/%s:%s",
-		pod.Namespace, pod.Name, m.controllerKind.GroupVersion(), m.controllerKind.Kind, m.Controller.GetName())
+	logger := klog.FromContext(ctx)
+	logger.V(2).Info("Patching pod to remove its controllerRef", "pod", klog.KObj(pod), "gvk", m.controllerKind, "controller", m.Controller.GetName())
 	patchBytes, err := GenerateDeleteOwnerRefStrategicMergeBytes(pod.UID, []types.UID{m.Controller.GetUID()}, m.finalizers...)
 	if err != nil {
 		return err
@@ -361,8 +361,8 @@ func (m *ReplicaSetControllerRefManager) AdoptReplicaSet(ctx context.Context, rs
 // ReleaseReplicaSet sends a patch to free the ReplicaSet from the control of the Deployment controller.
 // It returns the error if the patching fails. 404 and 422 errors are ignored.
 func (m *ReplicaSetControllerRefManager) ReleaseReplicaSet(ctx context.Context, replicaSet *apps.ReplicaSet) error {
-	klog.V(2).Infof("patching ReplicaSet %s_%s to remove its controllerRef to %s/%s:%s",
-		replicaSet.Namespace, replicaSet.Name, m.controllerKind.GroupVersion(), m.controllerKind.Kind, m.Controller.GetName())
+	logger := klog.FromContext(ctx)
+	logger.V(2).Info("Patching ReplicaSet to remove its controllerRef", "replicaSet", klog.KObj(replicaSet), "gvk", m.controllerKind, "controller", m.Controller.GetName())
 	patchBytes, err := GenerateDeleteOwnerRefStrategicMergeBytes(replicaSet.UID, []types.UID{m.Controller.GetUID()})
 	if err != nil {
 		return err
@@ -499,8 +499,8 @@ func (m *ControllerRevisionControllerRefManager) AdoptControllerRevision(ctx con
 // ReleaseControllerRevision sends a patch to free the ControllerRevision from the control of its controller.
 // It returns the error if the patching fails. 404 and 422 errors are ignored.
 func (m *ControllerRevisionControllerRefManager) ReleaseControllerRevision(ctx context.Context, history *apps.ControllerRevision) error {
-	klog.V(2).Infof("patching ControllerRevision %s_%s to remove its controllerRef to %s/%s:%s",
-		history.Namespace, history.Name, m.controllerKind.GroupVersion(), m.controllerKind.Kind, m.Controller.GetName())
+	logger := klog.FromContext(ctx)
+	logger.V(2).Info("Patching ControllerRevision to remove its controllerRef", "controllerRevision", klog.KObj(history), "gvk", m.controllerKind, "controller", m.Controller.GetName())
 	patchBytes, err := GenerateDeleteOwnerRefStrategicMergeBytes(history.UID, []types.UID{m.Controller.GetUID()})
 	if err != nil {
 		return err

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -146,15 +146,15 @@ var ExpKeyFunc = func(obj interface{}) (string, error) {
 // types of controllers, because the keys might conflict across types.
 type ControllerExpectationsInterface interface {
 	GetExpectations(controllerKey string) (*ControlleeExpectations, bool, error)
-	SatisfiedExpectations(controllerKey string) bool
-	DeleteExpectations(controllerKey string)
-	SetExpectations(controllerKey string, add, del int) error
-	ExpectCreations(controllerKey string, adds int) error
-	ExpectDeletions(controllerKey string, dels int) error
-	CreationObserved(controllerKey string)
-	DeletionObserved(controllerKey string)
-	RaiseExpectations(controllerKey string, add, del int)
-	LowerExpectations(controllerKey string, add, del int)
+	SatisfiedExpectations(logger klog.Logger, controllerKey string) bool
+	DeleteExpectations(logger klog.Logger, controllerKey string)
+	SetExpectations(logger klog.Logger, controllerKey string, add, del int) error
+	ExpectCreations(logger klog.Logger, controllerKey string, adds int) error
+	ExpectDeletions(logger klog.Logger, controllerKey string, dels int) error
+	CreationObserved(logger klog.Logger, controllerKey string)
+	DeletionObserved(logger klog.Logger, controllerKey string)
+	RaiseExpectations(logger klog.Logger, controllerKey string, add, del int)
+	LowerExpectations(logger klog.Logger, controllerKey string, add, del int)
 }
 
 // ControllerExpectations is a cache mapping controllers to what they expect to see before being woken up for a sync.
@@ -172,10 +172,11 @@ func (r *ControllerExpectations) GetExpectations(controllerKey string) (*Control
 }
 
 // DeleteExpectations deletes the expectations of the given controller from the TTLStore.
-func (r *ControllerExpectations) DeleteExpectations(controllerKey string) {
+func (r *ControllerExpectations) DeleteExpectations(logger klog.Logger, controllerKey string) {
 	if exp, exists, err := r.GetByKey(controllerKey); err == nil && exists {
 		if err := r.Delete(exp); err != nil {
-			klog.V(2).Infof("Error deleting expectations for controller %v: %v", controllerKey, err)
+
+			logger.V(2).Info("Error deleting expectations", "controller", controllerKey, "err", err)
 		}
 	}
 }
@@ -183,27 +184,27 @@ func (r *ControllerExpectations) DeleteExpectations(controllerKey string) {
 // SatisfiedExpectations returns true if the required adds/dels for the given controller have been observed.
 // Add/del counts are established by the controller at sync time, and updated as controllees are observed by the controller
 // manager.
-func (r *ControllerExpectations) SatisfiedExpectations(controllerKey string) bool {
+func (r *ControllerExpectations) SatisfiedExpectations(logger klog.Logger, controllerKey string) bool {
 	if exp, exists, err := r.GetExpectations(controllerKey); exists {
 		if exp.Fulfilled() {
-			klog.V(4).InfoS("Controller expectations fulfilled", "expectations", exp)
+			logger.V(4).Info("Controller expectations fulfilled", "expectations", exp)
 			return true
 		} else if exp.isExpired() {
-			klog.V(4).InfoS("Controller expectations expired", "expectations", exp)
+			logger.V(4).Info("Controller expectations expired", "expectations", exp)
 			return true
 		} else {
-			klog.V(4).InfoS("Controller still waiting on expectations", "expectations", exp)
+			logger.V(4).Info("Controller still waiting on expectations", "expectations", exp)
 			return false
 		}
 	} else if err != nil {
-		klog.V(2).Infof("Error encountered while checking expectations %#v, forcing sync", err)
+		logger.V(2).Info("Error encountered while checking expectations, forcing sync", "err", err)
 	} else {
 		// When a new controller is created, it doesn't have expectations.
 		// When it doesn't see expected watch events for > TTL, the expectations expire.
 		//	- In this case it wakes up, creates/deletes controllees, and sets expectations again.
 		// When it has satisfied expectations and no controllees need to be created/destroyed > TTL, the expectations expire.
 		//	- In this case it continues without setting expectations till it needs to create/delete controllees.
-		klog.V(4).Infof("Controller %v either never recorded expectations, or the ttl expired.", controllerKey)
+		logger.V(4).Info("Controller either never recorded expectations, or the ttl expired", "controller", controllerKey)
 	}
 	// Trigger a sync if we either encountered and error (which shouldn't happen since we're
 	// getting from local store) or this controller hasn't established expectations.
@@ -218,46 +219,46 @@ func (exp *ControlleeExpectations) isExpired() bool {
 }
 
 // SetExpectations registers new expectations for the given controller. Forgets existing expectations.
-func (r *ControllerExpectations) SetExpectations(controllerKey string, add, del int) error {
+func (r *ControllerExpectations) SetExpectations(logger klog.Logger, controllerKey string, add, del int) error {
 	exp := &ControlleeExpectations{add: int64(add), del: int64(del), key: controllerKey, timestamp: clock.RealClock{}.Now()}
-	klog.V(4).InfoS("Setting expectations", "expectations", exp)
+	logger.V(4).Info("Setting expectations", "expectations", exp)
 	return r.Add(exp)
 }
 
-func (r *ControllerExpectations) ExpectCreations(controllerKey string, adds int) error {
-	return r.SetExpectations(controllerKey, adds, 0)
+func (r *ControllerExpectations) ExpectCreations(logger klog.Logger, controllerKey string, adds int) error {
+	return r.SetExpectations(logger, controllerKey, adds, 0)
 }
 
-func (r *ControllerExpectations) ExpectDeletions(controllerKey string, dels int) error {
-	return r.SetExpectations(controllerKey, 0, dels)
+func (r *ControllerExpectations) ExpectDeletions(logger klog.Logger, controllerKey string, dels int) error {
+	return r.SetExpectations(logger, controllerKey, 0, dels)
 }
 
 // Decrements the expectation counts of the given controller.
-func (r *ControllerExpectations) LowerExpectations(controllerKey string, add, del int) {
+func (r *ControllerExpectations) LowerExpectations(logger klog.Logger, controllerKey string, add, del int) {
 	if exp, exists, err := r.GetExpectations(controllerKey); err == nil && exists {
 		exp.Add(int64(-add), int64(-del))
 		// The expectations might've been modified since the update on the previous line.
-		klog.V(4).InfoS("Lowered expectations", "expectations", exp)
+		logger.V(4).Info("Lowered expectations", "expectations", exp)
 	}
 }
 
 // Increments the expectation counts of the given controller.
-func (r *ControllerExpectations) RaiseExpectations(controllerKey string, add, del int) {
+func (r *ControllerExpectations) RaiseExpectations(logger klog.Logger, controllerKey string, add, del int) {
 	if exp, exists, err := r.GetExpectations(controllerKey); err == nil && exists {
 		exp.Add(int64(add), int64(del))
 		// The expectations might've been modified since the update on the previous line.
-		klog.V(4).Infof("Raised expectations", "expectations", exp)
+		logger.V(4).Info("Raised expectations", "expectations", exp)
 	}
 }
 
 // CreationObserved atomically decrements the `add` expectation count of the given controller.
-func (r *ControllerExpectations) CreationObserved(controllerKey string) {
-	r.LowerExpectations(controllerKey, 1, 0)
+func (r *ControllerExpectations) CreationObserved(logger klog.Logger, controllerKey string) {
+	r.LowerExpectations(logger, controllerKey, 1, 0)
 }
 
 // DeletionObserved atomically decrements the `del` expectation count of the given controller.
-func (r *ControllerExpectations) DeletionObserved(controllerKey string) {
-	r.LowerExpectations(controllerKey, 0, 1)
+func (r *ControllerExpectations) DeletionObserved(logger klog.Logger, controllerKey string) {
+	r.LowerExpectations(logger, controllerKey, 0, 1)
 }
 
 // ControlleeExpectations track controllee creates/deletes.
@@ -349,47 +350,47 @@ func (u *UIDTrackingControllerExpectations) GetUIDs(controllerKey string) sets.S
 }
 
 // ExpectDeletions records expectations for the given deleteKeys, against the given controller.
-func (u *UIDTrackingControllerExpectations) ExpectDeletions(rcKey string, deletedKeys []string) error {
+func (u *UIDTrackingControllerExpectations) ExpectDeletions(logger klog.Logger, rcKey string, deletedKeys []string) error {
 	expectedUIDs := sets.NewString()
 	for _, k := range deletedKeys {
 		expectedUIDs.Insert(k)
 	}
-	klog.V(4).Infof("Controller %v waiting on deletions for: %+v", rcKey, deletedKeys)
+	logger.V(4).Info("Controller waiting on deletions", "controller", rcKey, "keys", deletedKeys)
 	u.uidStoreLock.Lock()
 	defer u.uidStoreLock.Unlock()
 
 	if existing := u.GetUIDs(rcKey); existing != nil && existing.Len() != 0 {
-		klog.Errorf("Clobbering existing delete keys: %+v", existing)
+		logger.Error(nil, "Clobbering existing delete keys", "keys", existing)
 	}
 	if err := u.uidStore.Add(&UIDSet{expectedUIDs, rcKey}); err != nil {
 		return err
 	}
-	return u.ControllerExpectationsInterface.ExpectDeletions(rcKey, expectedUIDs.Len())
+	return u.ControllerExpectationsInterface.ExpectDeletions(logger, rcKey, expectedUIDs.Len())
 }
 
 // DeletionObserved records the given deleteKey as a deletion, for the given rc.
-func (u *UIDTrackingControllerExpectations) DeletionObserved(rcKey, deleteKey string) {
+func (u *UIDTrackingControllerExpectations) DeletionObserved(logger klog.Logger, rcKey, deleteKey string) {
 	u.uidStoreLock.Lock()
 	defer u.uidStoreLock.Unlock()
 
 	uids := u.GetUIDs(rcKey)
 	if uids != nil && uids.Has(deleteKey) {
-		klog.V(4).Infof("Controller %v received delete for pod %v", rcKey, deleteKey)
-		u.ControllerExpectationsInterface.DeletionObserved(rcKey)
+		logger.V(4).Info("Controller received delete for pod", "controller", rcKey, "key", deleteKey)
+		u.ControllerExpectationsInterface.DeletionObserved(logger, rcKey)
 		uids.Delete(deleteKey)
 	}
 }
 
 // DeleteExpectations deletes the UID set and invokes DeleteExpectations on the
 // underlying ControllerExpectationsInterface.
-func (u *UIDTrackingControllerExpectations) DeleteExpectations(rcKey string) {
+func (u *UIDTrackingControllerExpectations) DeleteExpectations(logger klog.Logger, rcKey string) {
 	u.uidStoreLock.Lock()
 	defer u.uidStoreLock.Unlock()
 
-	u.ControllerExpectationsInterface.DeleteExpectations(rcKey)
+	u.ControllerExpectationsInterface.DeleteExpectations(logger, rcKey)
 	if uidExp, exists, err := u.uidStore.GetByKey(rcKey); err == nil && exists {
 		if err := u.uidStore.Delete(uidExp); err != nil {
-			klog.V(2).Infof("Error deleting uid expectations for controller %v: %v", rcKey, err)
+			logger.V(2).Info("Error deleting uid expectations", "controller", rcKey, "err", err)
 		}
 	}
 }
@@ -587,12 +588,13 @@ func (r RealPodControl) createPods(ctx context.Context, namespace string, pod *v
 		}
 		return err
 	}
+	logger := klog.FromContext(ctx)
 	accessor, err := meta.Accessor(object)
 	if err != nil {
-		klog.Errorf("parentObject does not have ObjectMeta, %v", err)
+		logger.Error(err, "parentObject does not have ObjectMeta")
 		return nil
 	}
-	klog.V(4).Infof("Controller %v created pod %v", accessor.GetName(), newPod.Name)
+	logger.V(4).Info("Controller created pod", "controller", accessor.GetName(), "pod", klog.KObj(newPod))
 	r.Recorder.Eventf(object, v1.EventTypeNormal, SuccessfulCreatePodReason, "Created pod: %v", newPod.Name)
 
 	return nil
@@ -603,10 +605,11 @@ func (r RealPodControl) DeletePod(ctx context.Context, namespace string, podID s
 	if err != nil {
 		return fmt.Errorf("object does not have ObjectMeta, %v", err)
 	}
-	klog.V(2).InfoS("Deleting pod", "controller", accessor.GetName(), "pod", klog.KRef(namespace, podID))
+	logger := klog.FromContext(ctx)
+	logger.V(2).Info("Deleting pod", "controller", accessor.GetName(), "pod", klog.KRef(namespace, podID))
 	if err := r.KubeClient.CoreV1().Pods(namespace).Delete(ctx, podID, metav1.DeleteOptions{}); err != nil {
 		if apierrors.IsNotFound(err) {
-			klog.V(4).Infof("pod %v/%v has already been deleted.", namespace, podID)
+			logger.V(4).Info("Pod has already been deleted.", "pod", klog.KRef(namespace, podID))
 			return err
 		}
 		r.Recorder.Eventf(object, v1.EventTypeWarning, FailedDeletePodReason, "Error deleting: %v", err)
@@ -943,14 +946,13 @@ func maxContainerRestarts(pod *v1.Pod) int {
 }
 
 // FilterActivePods returns pods that have not terminated.
-func FilterActivePods(pods []*v1.Pod) []*v1.Pod {
+func FilterActivePods(logger klog.Logger, pods []*v1.Pod) []*v1.Pod {
 	var result []*v1.Pod
 	for _, p := range pods {
 		if IsPodActive(p) {
 			result = append(result, p)
 		} else {
-			klog.V(4).Infof("Ignoring inactive pod %v/%v in state %v, deletion time %v",
-				p.Namespace, p.Name, p.Status.Phase, p.DeletionTimestamp)
+			logger.V(4).Info("Ignoring inactive pod", "pod", klog.KObj(p), "phase", p.Status.Phase, "deletionTime", p.DeletionTimestamp)
 		}
 	}
 	return result

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -272,7 +272,7 @@ func (dsc *DaemonSetsController) deleteDaemonset(logger klog.Logger, obj interfa
 	}
 
 	// Delete expectations for the DaemonSet so if we create a new one with the same name it starts clean
-	dsc.expectations.DeleteExpectations(key)
+	dsc.expectations.DeleteExpectations(logger, key)
 
 	dsc.queue.Add(key)
 }
@@ -518,7 +518,7 @@ func (dsc *DaemonSetsController) addPod(logger klog.Logger, obj interface{}) {
 			return
 		}
 		logger.V(4).Info("Pod added", "pod", klog.KObj(pod))
-		dsc.expectations.CreationObserved(dsKey)
+		dsc.expectations.CreationObserved(logger, dsKey)
 		dsc.enqueueDaemonSet(ds)
 		return
 	}
@@ -635,7 +635,7 @@ func (dsc *DaemonSetsController) deletePod(logger klog.Logger, obj interface{}) 
 		return
 	}
 	logger.V(4).Info("Pod deleted", "pod", klog.KObj(pod))
-	dsc.expectations.DeletionObserved(dsKey)
+	dsc.expectations.DeletionObserved(logger, dsKey)
 	dsc.enqueueDaemonSet(ds)
 }
 
@@ -934,7 +934,7 @@ func (dsc *DaemonSetsController) updateDaemonSet(ctx context.Context, ds *apps.D
 	}
 
 	// Process rolling updates if we're ready.
-	if dsc.expectations.SatisfiedExpectations(key) {
+	if dsc.expectations.SatisfiedExpectations(klog.FromContext(ctx), key) {
 		switch ds.Spec.UpdateStrategy.Type {
 		case apps.OnDeleteDaemonSetStrategyType:
 		case apps.RollingUpdateDaemonSetStrategyType:
@@ -1008,7 +1008,7 @@ func (dsc *DaemonSetsController) syncNodes(ctx context.Context, ds *apps.DaemonS
 		deleteDiff = dsc.burstReplicas
 	}
 
-	dsc.expectations.SetExpectations(dsKey, createDiff, deleteDiff)
+	dsc.expectations.SetExpectations(logger, dsKey, createDiff, deleteDiff)
 
 	// error channel to communicate back failures.  make the buffer big enough to avoid any blocking
 	errCh := make(chan error, createDiff+deleteDiff)
@@ -1057,7 +1057,7 @@ func (dsc *DaemonSetsController) syncNodes(ctx context.Context, ds *apps.DaemonS
 				}
 				if err != nil {
 					logger.V(2).Info("Failed creation, decrementing expectations for daemon set", "daemonset", klog.KObj(ds))
-					dsc.expectations.CreationObserved(dsKey)
+					dsc.expectations.CreationObserved(logger, dsKey)
 					errCh <- err
 					utilruntime.HandleError(err)
 				}
@@ -1068,7 +1068,7 @@ func (dsc *DaemonSetsController) syncNodes(ctx context.Context, ds *apps.DaemonS
 		skippedPods := createDiff - (batchSize + pos)
 		if errorCount < len(errCh) && skippedPods > 0 {
 			logger.V(2).Info("Slow-start failure. Skipping creation pods, decrementing expectations for daemon set", "skippedPods", skippedPods, "daemonset", klog.KObj(ds))
-			dsc.expectations.LowerExpectations(dsKey, skippedPods, 0)
+			dsc.expectations.LowerExpectations(logger, dsKey, skippedPods, 0)
 			// The skipped pods will be retried later. The next controller resync will
 			// retry the slow start process.
 			break
@@ -1082,7 +1082,7 @@ func (dsc *DaemonSetsController) syncNodes(ctx context.Context, ds *apps.DaemonS
 		go func(ix int) {
 			defer deleteWait.Done()
 			if err := dsc.podControl.DeletePod(ctx, ds.Namespace, podsToDelete[ix], ds); err != nil {
-				dsc.expectations.DeletionObserved(dsKey)
+				dsc.expectations.DeletionObserved(logger, dsKey)
 				if !apierrors.IsNotFound(err) {
 					logger.V(2).Info("Failed deletion, decremented expectations for daemon set", "daemonset", klog.KObj(ds))
 					errCh <- err
@@ -1232,7 +1232,7 @@ func (dsc *DaemonSetsController) syncDaemonSet(ctx context.Context, key string) 
 	ds, err := dsc.dsLister.DaemonSets(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
 		logger.V(3).Info("Daemon set has been deleted", "daemonset", key)
-		dsc.expectations.DeleteExpectations(key)
+		dsc.expectations.DeleteExpectations(logger, key)
 		return nil
 	}
 	if err != nil {
@@ -1277,7 +1277,7 @@ func (dsc *DaemonSetsController) syncDaemonSet(ctx context.Context, key string) 
 	}
 	hash := cur.Labels[apps.DefaultDaemonSetUniqueLabelKey]
 
-	if !dsc.expectations.SatisfiedExpectations(dsKey) {
+	if !dsc.expectations.SatisfiedExpectations(logger, dsKey) {
 		// Only update status. Don't raise observedGeneration since controller didn't process object of that generation.
 		return dsc.updateDaemonSetStatus(ctx, ds, nodeList, hash, false)
 	}

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
@@ -67,13 +67,14 @@ const (
 )
 
 // NewController creates and initializes a new Controller
-func NewController(endpointsInformer coreinformers.EndpointsInformer,
+func NewController(ctx context.Context, endpointsInformer coreinformers.EndpointsInformer,
 	endpointSliceInformer discoveryinformers.EndpointSliceInformer,
 	serviceInformer coreinformers.ServiceInformer,
 	maxEndpointsPerSubset int32,
 	client clientset.Interface,
 	endpointUpdatesBatchPeriod time.Duration,
 ) *Controller {
+	logger := klog.FromContext(ctx)
 	broadcaster := record.NewBroadcaster()
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "endpoint-slice-mirroring-controller"})
 
@@ -96,16 +97,24 @@ func NewController(endpointsInformer coreinformers.EndpointsInformer,
 	}
 
 	endpointsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.onEndpointsAdd,
-		UpdateFunc: c.onEndpointsUpdate,
-		DeleteFunc: c.onEndpointsDelete,
+		AddFunc: func(obj interface{}) {
+			c.onEndpointsAdd(logger, obj)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			c.onEndpointsUpdate(logger, oldObj, newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			c.onEndpointsDelete(logger, obj)
+		},
 	})
 	c.endpointsLister = endpointsInformer.Lister()
 	c.endpointsSynced = endpointsInformer.Informer().HasSynced
 
 	endpointSliceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.onEndpointSliceAdd,
-		UpdateFunc: c.onEndpointSliceUpdate,
+		AddFunc: c.onEndpointSliceAdd,
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			c.onEndpointSliceUpdate(logger, oldObj, newObj)
+		},
 		DeleteFunc: c.onEndpointSliceDelete,
 	})
 
@@ -393,21 +402,21 @@ func (c *Controller) onServiceDelete(obj interface{}) {
 }
 
 // onEndpointsAdd queues a sync for the relevant Endpoints resource.
-func (c *Controller) onEndpointsAdd(obj interface{}) {
+func (c *Controller) onEndpointsAdd(logger klog.Logger, obj interface{}) {
 	endpoints := obj.(*v1.Endpoints)
 	if endpoints == nil {
 		utilruntime.HandleError(fmt.Errorf("onEndpointsAdd() expected type v1.Endpoints, got %T", obj))
 		return
 	}
 	if !c.shouldMirror(endpoints) {
-		klog.V(5).Infof("Skipping mirroring for %s/%s", endpoints.Namespace, endpoints.Name)
+		logger.V(5).Info("Skipping mirroring", "endpoints", klog.KObj(endpoints))
 		return
 	}
 	c.queueEndpoints(obj)
 }
 
 // onEndpointsUpdate queues a sync for the relevant Endpoints resource.
-func (c *Controller) onEndpointsUpdate(prevObj, obj interface{}) {
+func (c *Controller) onEndpointsUpdate(logger klog.Logger, prevObj, obj interface{}) {
 	endpoints := obj.(*v1.Endpoints)
 	prevEndpoints := prevObj.(*v1.Endpoints)
 	if endpoints == nil || prevEndpoints == nil {
@@ -415,21 +424,21 @@ func (c *Controller) onEndpointsUpdate(prevObj, obj interface{}) {
 		return
 	}
 	if !c.shouldMirror(endpoints) && !c.shouldMirror(prevEndpoints) {
-		klog.V(5).Infof("Skipping mirroring for %s/%s", endpoints.Namespace, endpoints.Name)
+		logger.V(5).Info("Skipping mirroring", "endpoints", klog.KObj(endpoints))
 		return
 	}
 	c.queueEndpoints(obj)
 }
 
 // onEndpointsDelete queues a sync for the relevant Endpoints resource.
-func (c *Controller) onEndpointsDelete(obj interface{}) {
+func (c *Controller) onEndpointsDelete(logger klog.Logger, obj interface{}) {
 	endpoints := getEndpointsFromDeleteAction(obj)
 	if endpoints == nil {
 		utilruntime.HandleError(fmt.Errorf("onEndpointsDelete() expected type v1.Endpoints, got %T", obj))
 		return
 	}
 	if !c.shouldMirror(endpoints) {
-		klog.V(5).Infof("Skipping mirroring for %s/%s", endpoints.Namespace, endpoints.Name)
+		logger.V(5).Info("Skipping mirroring", "endpoints", klog.KObj(endpoints))
 		return
 	}
 	c.queueEndpoints(obj)
@@ -453,7 +462,7 @@ func (c *Controller) onEndpointSliceAdd(obj interface{}) {
 // sync if the EndpointSlice resource version does not match the expected
 // version in the endpointSliceTracker or the managed-by value of the
 // EndpointSlice has changed from or to this controller.
-func (c *Controller) onEndpointSliceUpdate(prevObj, obj interface{}) {
+func (c *Controller) onEndpointSliceUpdate(logger klog.Logger, prevObj, obj interface{}) {
 	prevEndpointSlice := obj.(*discovery.EndpointSlice)
 	endpointSlice := prevObj.(*discovery.EndpointSlice)
 	if endpointSlice == nil || prevEndpointSlice == nil {
@@ -466,7 +475,7 @@ func (c *Controller) onEndpointSliceUpdate(prevObj, obj interface{}) {
 	svcName := endpointSlice.Labels[discovery.LabelServiceName]
 	prevSvcName := prevEndpointSlice.Labels[discovery.LabelServiceName]
 	if svcName != prevSvcName {
-		klog.Warningf("%s label changed from %s  to %s for %s", discovery.LabelServiceName, prevSvcName, svcName, endpointSlice.Name)
+		logger.Info("LabelServiceName changed", "labelServiceName", discovery.LabelServiceName, "oldName", prevSvcName, "newName", svcName, "endpointSlice", klog.KObj(endpointSlice))
 		c.queueEndpointsForEndpointSlice(endpointSlice)
 		c.queueEndpointsForEndpointSlice(prevEndpointSlice)
 		return

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -785,6 +785,7 @@ func TestControllerSyncJob(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
 			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobReadyPods, tc.jobReadyPodsEnabled)()
 
 			// job manager setup
@@ -828,9 +829,9 @@ func TestControllerSyncJob(t *testing.T) {
 				manager.podBackoffStore.updateBackoffRecord(*tc.backoffRecord)
 			}
 			if tc.fakeExpectationAtCreation < 0 {
-				manager.expectations.ExpectDeletions(key, int(-tc.fakeExpectationAtCreation))
+				manager.expectations.ExpectDeletions(logger, key, int(-tc.fakeExpectationAtCreation))
 			} else if tc.fakeExpectationAtCreation > 0 {
-				manager.expectations.ExpectCreations(key, int(tc.fakeExpectationAtCreation))
+				manager.expectations.ExpectCreations(logger, key, int(tc.fakeExpectationAtCreation))
 			}
 			if tc.wasSuspended {
 				job.Status.Conditions = append(job.Status.Conditions, *newCondition(batch.JobSuspended, v1.ConditionTrue, "JobSuspended", "Job suspended", realClock.Now()))
@@ -3673,7 +3674,7 @@ type FakeJobExpectations struct {
 	expSatisfied func()
 }
 
-func (fe FakeJobExpectations) SatisfiedExpectations(controllerKey string) bool {
+func (fe FakeJobExpectations) SatisfiedExpectations(logger klog.Logger, controllerKey string) bool {
 	fe.expSatisfied()
 	return fe.satisfied
 }

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
-	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/controller"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
@@ -445,7 +444,7 @@ func TestPVCProtectionController(t *testing.T) {
 				break
 			}
 			if ctrl.queue.Len() > 0 {
-				klog.V(5).Infof("Test %q: %d events queue, processing one", test.name, ctrl.queue.Len())
+				logger.V(5).Info("Non-empty queue, processing one", "test", test.name, "queueLength", ctrl.queue.Len())
 				ctrl.processNextWorkItem(context.TODO())
 			}
 			if ctrl.queue.Len() > 0 {
@@ -456,7 +455,7 @@ func TestPVCProtectionController(t *testing.T) {
 			if currentActionCount < len(test.expectedActions) {
 				// Do not log every wait, only when the action count changes.
 				if lastReportedActionCount < currentActionCount {
-					klog.V(5).Infof("Test %q: got %d actions out of %d, waiting for the rest", test.name, currentActionCount, len(test.expectedActions))
+					logger.V(5).Info("Waiting for the remaining actions", "test", test.name, "currentActionCount", currentActionCount, "expectedActionCount", len(test.expectedActions))
 					lastReportedActionCount = currentActionCount
 				}
 				// The test expected more to happen, wait for the actions.

--- a/pkg/controller/volume/pvprotection/pv_protection_controller_test.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
-	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/controller"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
@@ -227,7 +226,7 @@ func TestPVProtectionController(t *testing.T) {
 				break
 			}
 			if ctrl.queue.Len() > 0 {
-				klog.V(5).Infof("Test %q: %d events queue, processing one", test.name, ctrl.queue.Len())
+				logger.V(5).Info("Non-empty events queue, processing one", "test", test.name, "queueLength", ctrl.queue.Len())
 				ctrl.processNextWorkItem(context.TODO())
 			}
 			if ctrl.queue.Len() > 0 {
@@ -238,7 +237,7 @@ func TestPVProtectionController(t *testing.T) {
 			if currentActionCount < len(test.expectedActions) {
 				// Do not log evey wait, only when the action count changes.
 				if lastReportedActionCount < currentActionCount {
-					klog.V(5).Infof("Test %q: got %d actions out of %d, waiting for the rest", test.name, currentActionCount, len(test.expectedActions))
+					logger.V(5).Info("Waiting for the remaining actions", "test", test.name, "currentActionCount", currentActionCount, "expectedActionCount", len(test.expectedActions))
 					lastReportedActionCount = currentActionCount
 				}
 				// The test expected more to happen, wait for the actions.

--- a/test/integration/endpointslice/endpointslicemirroring_test.go
+++ b/test/integration/endpointslice/endpointslicemirroring_test.go
@@ -70,6 +70,7 @@ func TestEndpointSliceMirroring(t *testing.T) {
 		1*time.Second)
 
 	epsmController := endpointslicemirroring.NewController(
+		ctx,
 		informers.Core().V1().Endpoints(),
 		informers.Discovery().V1().EndpointSlices(),
 		informers.Core().V1().Services(),
@@ -311,6 +312,7 @@ func TestEndpointSliceMirroring(t *testing.T) {
 }
 
 func TestEndpointSliceMirroringUpdates(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins=ServiceAccount"}, framework.SharedEtcd())
 	defer server.TearDownFn()
@@ -324,6 +326,7 @@ func TestEndpointSliceMirroringUpdates(t *testing.T) {
 	informers := informers.NewSharedInformerFactory(client, resyncPeriod)
 
 	epsmController := endpointslicemirroring.NewController(
+		ctx,
 		informers.Core().V1().Endpoints(),
 		informers.Discovery().V1().EndpointSlices(),
 		informers.Core().V1().Services(),
@@ -332,7 +335,6 @@ func TestEndpointSliceMirroringUpdates(t *testing.T) {
 		1*time.Second)
 
 	// Start informer and controllers
-	_, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	informers.Start(ctx.Done())
@@ -487,6 +489,7 @@ func TestEndpointSliceMirroringUpdates(t *testing.T) {
 }
 
 func TestEndpointSliceMirroringSelectorTransition(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins=ServiceAccount"}, framework.SharedEtcd())
 	defer server.TearDownFn()
@@ -500,6 +503,7 @@ func TestEndpointSliceMirroringSelectorTransition(t *testing.T) {
 	informers := informers.NewSharedInformerFactory(client, resyncPeriod)
 
 	epsmController := endpointslicemirroring.NewController(
+		ctx,
 		informers.Core().V1().Endpoints(),
 		informers.Discovery().V1().EndpointSlices(),
 		informers.Core().V1().Services(),
@@ -508,7 +512,6 @@ func TestEndpointSliceMirroringSelectorTransition(t *testing.T) {
 		1*time.Second)
 
 	// Start informer and controllers
-	_, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	informers.Start(ctx.Done())


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Migrate pkg/controller/podgc to structured and contextual logging and clean up some left-over log calls in other controllers.

#### Which issue(s) this PR fixes:

Related-to: https://github.com/kubernetes/enhancements/issues/3077

#### Does this PR introduce a user-facing change?
```release-note
Migrated the podgc controller and some other remaining log calls within `kube-controller-manager` to use [contextual logging](https://k8s.io/docs/concepts/cluster-administration/system-logs/#contextual-logging). `kube-controller-manager` is now converted completely.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
-[KEP]: https://github.com/kubernetes/enhancements/issues/3077
```
