### PR TITLE
Match both old and new kubectl version for a while in e2e

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1676,7 +1676,12 @@ metadata:
 			// we expect following values for: Major -> digit, Minor -> numeric followed by an optional '+',  GitCommit -> alphanumeric
 			requiredItems := []string{"Client Version: ", "Server Version: "}
 			for _, item := range requiredItems {
-				if matched, _ := regexp.MatchString(item+`v\d\.\d+\.[\d\w\-\.\+]+`, versionString); !matched {
+				// prior to 1.28 we printed long version information
+				oldMatched, _ := regexp.MatchString(item+`version.Info\{Major:"\d", Minor:"\d+\+?", GitVersion:"v\d\.\d+\.[\d\w\-\.\+]+", GitCommit:"[0-9a-f]+"`, versionString)
+				// 1.28+ prints short information
+				newMatched, _ := regexp.MatchString(item+`v\d\.\d+\.[\d\w\-\.\+]+`, versionString)
+				// due to backwards compatibility we need to match both until 1.30 most likely
+				if !oldMatched && !newMatched {
 					framework.Failf("Item %s value is not valid in %s\n", item, versionString)
 				}
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
/kind flake

/sig cli
/sig testing

#### What this PR does / why we need it:
In https://github.com/kubernetes/kubernetes/pull/116720 I dropped the deprecated long version, but our [release informing](https://testgrid.k8s.io/sig-release-master-informing#capz-windows-master) jobs are using an older version of kubectl which still prints the long version. 

Based on that, given our compatibility guarantees I'll match either the new or the old version until 1.30. 

#### Which issue(s) this PR fixes:
Fixes #119230

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
