### PR TITLE
fix the problem of multiplying two values of type time.Duration

### DIFF
--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -3958,12 +3958,12 @@ func generateScalingRules(pods, podsPeriod, percent, percentPeriod, stabilizatio
 //   - 120s (guaranteed to have all events)
 func generateEventsUniformDistribution(rawEvents []int, periodSeconds int) []timestampedScaleEvent {
 	events := make([]timestampedScaleEvent, len(rawEvents))
-	segmentDuration := float64(periodSeconds) / float64(len(rawEvents))
+	segmentDuration := time.Duration(float64(periodSeconds) / float64(len(rawEvents)))
 	for idx, event := range rawEvents {
-		segmentBoundary := time.Duration(float64(periodSeconds) - segmentDuration*float64(idx+1) + segmentDuration/float64(2))
+		segmentBoundary := time.Duration(float64(periodSeconds) - float64(idx+1)*float64(segmentDuration) + float64(segmentDuration)/2)
 		events[idx] = timestampedScaleEvent{
 			replicaChange: int32(event),
-			timestamp:     time.Now().Add(-time.Second * segmentBoundary),
+			timestamp:     time.Now().Add(-segmentBoundary),
 		}
 	}
 	return events

--- a/plugin/pkg/admission/imagepolicy/config_test.go
+++ b/plugin/pkg/admission/imagepolicy/config_test.go
@@ -37,8 +37,8 @@ func TestConfigNormalization(t *testing.T) {
 				RetryBackoff: ((minRetryBackoff + maxRetryBackoff) / 2) / time.Millisecond,
 			},
 			normalizedConfig: imagePolicyWebhookConfig{
-				AllowTTL:     ((minAllowTTL + maxAllowTTL) / 2) / time.Second * time.Second,
-				DenyTTL:      ((minDenyTTL + maxDenyTTL) / 2) / time.Second * time.Second,
+				AllowTTL:     ((minAllowTTL + maxAllowTTL) / 2) / time.Second,
+				DenyTTL:      ((minDenyTTL + maxDenyTTL) / 2) / time.Second,
 				RetryBackoff: (minRetryBackoff + maxRetryBackoff) / 2,
 			},
 			wantErr: false,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug


#### What this PR does / why we need it:

The time.Duration type represents the duration of time, which uses nanoseconds as the unit. Therefore, multiplying two time.Duration values will result in an increase in the duration of time, which may not have been intended by the code author

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
