### PR TITLE
Automated cherry pick of #119229: Fix the converts an empty string to nil.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -231,7 +231,7 @@ func (c *fromUnstructuredContext) pushKey(key string) {
 
 }
 
-// FromUnstructuredWIthValidation converts an object from map[string]interface{} representation into a concrete type.
+// FromUnstructuredWithValidation converts an object from map[string]interface{} representation into a concrete type.
 // It uses encoding/json/Unmarshaler if object implements it or reflection if not.
 // It takes a validationDirective that indicates how to behave when it encounters unknown fields.
 func (c *unstructuredConverter) FromUnstructuredWithValidation(u map[string]interface{}, obj interface{}, returnUnknownFields bool) error {
@@ -465,7 +465,7 @@ func sliceFromUnstructured(sv, dv reflect.Value, ctx *fromUnstructuredContext) e
 			}
 			dv.SetBytes(data)
 		} else {
-			dv.Set(reflect.Zero(dt))
+			dv.Set(reflect.MakeSlice(dt, 0, 0))
 		}
 		return nil
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
@@ -91,6 +91,7 @@ type F struct {
 	G []int             `json:"fg"`
 	H []bool            `json:"fh"`
 	I []float32         `json:"fi"`
+	J []byte            `json:"fj"`
 }
 
 type G struct {
@@ -749,6 +750,10 @@ func TestUnrecognized(t *testing.T) {
 		},
 		{
 			data: "{\"ff\":[\"abc\"],\"fg\":[123],\"fh\":[true,false]}",
+			obj:  &F{},
+		},
+		{
+			data: "{\"fj\":\"\"}",
 			obj:  &F{},
 		},
 		{


### PR DESCRIPTION
Cherry pick of #119229 on release-1.24.

#119229: Fix the converts an empty string to nil.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```