### PR TITLE
promote beta metrics

### DIFF
--- a/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
@@ -433,7 +433,7 @@ func TestFeatureGateMetrics(t *testing.T) {
 	const testBetaDisabled Feature = "TestBetaDisabled"
 	testedMetrics := []string{"kubernetes_feature_enabled"}
 	expectedOutput := `
-		# HELP kubernetes_feature_enabled [ALPHA] This metric records the data about the stage and enablement of a k8s feature.
+		# HELP kubernetes_feature_enabled [BETA] This metric records the data about the stage and enablement of a k8s feature.
         # TYPE kubernetes_feature_enabled gauge
         kubernetes_feature_enabled{name="TestAlpha",stage="ALPHA"} 0
         kubernetes_feature_enabled{name="TestBeta",stage="BETA"} 1

--- a/staging/src/k8s.io/component-base/metrics/prometheus/feature/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/feature/metrics.go
@@ -30,7 +30,7 @@ var (
 			Namespace:      "kubernetes",
 			Name:           "feature_enabled",
 			Help:           "This metric records the data about the stage and enablement of a k8s feature.",
-			StabilityLevel: k8smetrics.ALPHA,
+			StabilityLevel: k8smetrics.BETA,
 		},
 		[]string{"name", "stage"},
 	)

--- a/staging/src/k8s.io/component-base/metrics/prometheus/feature/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/feature/metrics_test.go
@@ -46,7 +46,7 @@ func TestObserveHealthcheck(t *testing.T) {
 			stage:   "ALPHA",
 			enabled: true,
 			want: `
-       	# HELP kubernetes_feature_enabled [ALPHA] This metric records the data about the stage and enablement of a k8s feature.
+       	# HELP kubernetes_feature_enabled [BETA] This metric records the data about the stage and enablement of a k8s feature.
         # TYPE kubernetes_feature_enabled gauge
         kubernetes_feature_enabled{name="feature-a",stage="ALPHA"} 1
 `,
@@ -57,7 +57,7 @@ func TestObserveHealthcheck(t *testing.T) {
 			stage:   "BETA",
 			enabled: false,
 			want: `
-       	# HELP kubernetes_feature_enabled [ALPHA] This metric records the data about the stage and enablement of a k8s feature.
+       	# HELP kubernetes_feature_enabled [BETA] This metric records the data about the stage and enablement of a k8s feature.
         # TYPE kubernetes_feature_enabled gauge
         kubernetes_feature_enabled{name="feature-b",stage="BETA"} 0
 `,

--- a/staging/src/k8s.io/component-base/metrics/prometheus/meta/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/meta/metrics.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meta
+
+import (
+	k8smetrics "k8s.io/component-base/metrics"
+)
+
+var (
+	RegisteredMetrics = k8smetrics.NewCounterVec(
+		&k8smetrics.CounterOpts{
+			Name:           "registered_metric_total",
+			Help:           "The count of registered metrics broken by stability level and deprecation version.",
+			StabilityLevel: k8smetrics.BETA,
+		},
+		[]string{"stability_level", "deprecated_version"},
+	)
+
+	DisabledMetricsTotal = k8smetrics.NewCounter(
+		&k8smetrics.CounterOpts{
+			Name:           "disabled_metric_total",
+			Help:           "The count of disabled metrics.",
+			StabilityLevel: k8smetrics.BETA,
+		},
+	)
+
+	HiddenMetricsTotal = k8smetrics.NewCounter(
+		&k8smetrics.CounterOpts{
+			Name:           "hidden_metric_total",
+			Help:           "The count of hidden metrics.",
+			StabilityLevel: k8smetrics.BETA,
+		},
+	)
+)

--- a/staging/src/k8s.io/component-base/metrics/prometheus/meta/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/meta/metrics.go
@@ -23,7 +23,7 @@ import (
 var (
 	RegisteredMetrics = k8smetrics.NewCounterVec(
 		&k8smetrics.CounterOpts{
-			Name:           "registered_metric_total",
+			Name:           "registered_metrics_total",
 			Help:           "The count of registered metrics broken by stability level and deprecation version.",
 			StabilityLevel: k8smetrics.BETA,
 		},
@@ -32,7 +32,7 @@ var (
 
 	DisabledMetricsTotal = k8smetrics.NewCounter(
 		&k8smetrics.CounterOpts{
-			Name:           "disabled_metric_total",
+			Name:           "disabled_metrics_total",
 			Help:           "The count of disabled metrics.",
 			StabilityLevel: k8smetrics.BETA,
 		},
@@ -40,7 +40,7 @@ var (
 
 	HiddenMetricsTotal = k8smetrics.NewCounter(
 		&k8smetrics.CounterOpts{
-			Name:           "hidden_metric_total",
+			Name:           "hidden_metrics_total",
 			Help:           "The count of hidden metrics.",
 			StabilityLevel: k8smetrics.BETA,
 		},

--- a/staging/src/k8s.io/component-base/metrics/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/registry.go
@@ -39,7 +39,7 @@ var (
 
 	registeredMetrics = NewCounterVec(
 		&CounterOpts{
-			Name:           "registered_metric_total",
+			Name:           "registered_metrics_total",
 			Help:           "The count of registered metrics broken by stability level and deprecation version.",
 			StabilityLevel: BETA,
 		},
@@ -48,7 +48,7 @@ var (
 
 	disabledMetricsTotal = NewCounter(
 		&CounterOpts{
-			Name:           "disabled_metric_total",
+			Name:           "disabled_metrics_total",
 			Help:           "The count of disabled metrics.",
 			StabilityLevel: BETA,
 		},
@@ -56,7 +56,7 @@ var (
 
 	hiddenMetricsTotal = NewCounter(
 		&CounterOpts{
-			Name:           "hidden_metric_total",
+			Name:           "hidden_metrics_total",
 			Help:           "The count of hidden metrics.",
 			StabilityLevel: BETA,
 		},

--- a/staging/src/k8s.io/component-base/metrics/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/registry.go
@@ -41,7 +41,7 @@ var (
 		&CounterOpts{
 			Name:           "registered_metric_total",
 			Help:           "The count of registered metrics broken by stability level and deprecation version.",
-			StabilityLevel: ALPHA,
+			StabilityLevel: BETA,
 		},
 		[]string{"stability_level", "deprecated_version"},
 	)
@@ -50,7 +50,7 @@ var (
 		&CounterOpts{
 			Name:           "disabled_metric_total",
 			Help:           "The count of disabled metrics.",
-			StabilityLevel: ALPHA,
+			StabilityLevel: BETA,
 		},
 	)
 
@@ -58,7 +58,7 @@ var (
 		&CounterOpts{
 			Name:           "hidden_metric_total",
 			Help:           "The count of hidden metrics.",
-			StabilityLevel: ALPHA,
+			StabilityLevel: BETA,
 		},
 	)
 )

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -491,6 +491,22 @@
   - 10
   - 15
   - 30
+- name: disabled_metrics_total
+  help: The count of disabled metrics.
+  type: Counter
+  stabilityLevel: BETA
+- name: hidden_metrics_total
+  help: The count of hidden metrics.
+  type: Counter
+  stabilityLevel: BETA
+- name: feature_enabled
+  namespace: kubernetes
+  help: This metric records the data about the stage and enablement of a k8s feature.
+  type: Gauge
+  stabilityLevel: BETA
+  labels:
+  - name
+  - stage
 - name: healthcheck
   namespace: kubernetes
   help: This metric records the result of a single healthcheck.
@@ -508,3 +524,11 @@
   - name
   - status
   - type
+- name: registered_metrics_total
+  help: The count of registered metrics broken by stability level and deprecation
+    version.
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - deprecated_version
+  - stability_level


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Promote registered_metric_total, disabled_metric_total, hidden_metric_total & kubernetes_feature_enabled to `BETA` stability.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
registered_metric_total, disabled_metric_total, hidden_metric_total & kubernetes_feature_enabled are promoted to `BETA` stability.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:

- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3498
```
