### PR TITLE
Fix lifecycle generator to check the version correctly

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/prerelease-lifecycle-gen/prerelease-lifecycle-generators/status.go
+++ b/staging/src/k8s.io/code-generator/cmd/prerelease-lifecycle-gen/prerelease-lifecycle-generators/status.go
@@ -71,7 +71,7 @@ func extractKubeVersionTag(tagName string, t *types.Type) (*tagValue, int, int, 
 	}
 
 	splitValue := strings.Split(rawTag.value, ".")
-	if len(splitValue) != 2 || len(splitValue[0]) == 0 || len(splitValue[0]) == 0 {
+	if len(splitValue) != 2 || len(splitValue[0]) == 0 || len(splitValue[1]) == 0 {
 		return nil, -1, -1, fmt.Errorf("%v format must match %v=xx.yy tag", t, tagName)
 	}
 	major, err := strconv.ParseInt(splitValue[0], 10, 32)
@@ -159,16 +159,7 @@ func extractTag(tagName string, comments []string) *tagValue {
 	for i := range parts {
 		kv := strings.SplitN(parts[i], "=", 2)
 		k := kv[0]
-		//v := ""
-		//if len(kv) == 2 {
-		//	v = kv[1]
-		//}
-		switch k {
-		//case "register":
-		//	if v != "false" {
-		//		tag.register = true
-		//	}
-		default:
+		if k != "" {
 			klog.Fatalf("Unsupported %s param: %q", tagName, parts[i])
 		}
 	}

--- a/staging/src/k8s.io/code-generator/cmd/prerelease-lifecycle-gen/prerelease-lifecycle-generators/status_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/prerelease-lifecycle-gen/prerelease-lifecycle-generators/status_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/code-generator/cmd/prerelease-lifecycle-gen/prerelease-lifecycle-generators/status_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/prerelease-lifecycle-gen/prerelease-lifecycle-generators/status_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prereleaselifecyclegenerators
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/gengo/types"
+)
+
+var mockType = &types.Type{
+	CommentLines: []string{
+		"RandomType defines a random structure in Kubernetes",
+		"It should be used just when you need something different than 42",
+	},
+	SecondClosestCommentLines: []string{},
+}
+
+func Test_extractKubeVersionTag(t *testing.T) {
+	tests := []struct {
+		name        string
+		tagName     string
+		tagComments []string
+		wantValue   *tagValue
+		wantMajor   int
+		wantMinor   int
+		wantErr     bool
+	}{
+		{
+			name:    "not found tag should generate an error",
+			tagName: "someVersionTag:version",
+			tagComments: []string{
+				"+someOtherTag:version=1.5",
+			},
+			wantValue: nil,
+			wantErr:   true,
+		},
+		{
+			name:    "found tag should return correctly",
+			tagName: "someVersionTag:version",
+			tagComments: []string{
+				"+someVersionTag:version=1.5",
+			},
+			wantValue: &tagValue{
+				value: "1.5",
+			},
+			wantMajor: 1,
+			wantMinor: 5,
+			wantErr:   false,
+		},
+		/*{
+			name:    "multiple declarations of same tag should return an error",
+			tagName: "someVersionTag:version",
+			tagComments: []string{
+				"+someVersionTag:version=1.5",
+				"+someVersionTag:version=v1.7",
+			},
+			wantValue: nil,
+			wantErr:   true, // TODO: Today it is klog.Fatal, check how to capture it
+		},
+		{
+			name:    "multiple values on same tag should return an error",
+			tagName: "someVersionTag:version",
+			tagComments: []string{
+				"+someVersionTag:version=1.5,something",
+			},
+			wantValue: nil,
+			wantErr:   true, // TODO: Today it is klog.Fatal, check how to capture it
+		},*/
+		{
+			name:    "wrong tag major value should return an error",
+			tagName: "someVersionTag:version",
+			tagComments: []string{
+				"+someVersionTag:version=.5",
+			},
+			wantErr: true,
+		},
+		{
+			name:    "wrong tag minor value should return an error",
+			tagName: "someVersionTag:version",
+			tagComments: []string{
+				"+someVersionTag:version=1.",
+			},
+			wantErr: true,
+		},
+		{
+			name:    "wrong tag format should return an error",
+			tagName: "someVersionTag:version",
+			tagComments: []string{
+				"+someVersionTag:version=1.5.7",
+			},
+			wantErr: true,
+		},
+		{
+			name:    "wrong tag major int value should return an error",
+			tagName: "someVersionTag:version",
+			tagComments: []string{
+				"+someVersionTag:version=blah.5",
+			},
+			wantErr: true,
+		},
+		{
+			name:    "wrong tag minor int value should return an error",
+			tagName: "someVersionTag:version",
+			tagComments: []string{
+				"+someVersionTag:version=1.blah",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockType.SecondClosestCommentLines = tt.tagComments
+			gotTag, gotMajor, gotMinor, err := extractKubeVersionTag(tt.tagName, mockType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractKubeVersionTag() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(gotTag, tt.wantValue) {
+				t.Errorf("extractKubeVersionTag() got = %v, want %v", gotTag, tt.wantValue)
+			}
+			if gotMajor != tt.wantMajor {
+				t.Errorf("extractKubeVersionTag() got1 = %v, want %v", gotMajor, tt.wantMajor)
+			}
+			if gotMinor != tt.wantMinor {
+				t.Errorf("extractKubeVersionTag() got2 = %v, want %v", gotMinor, tt.wantMinor)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
While testing the lifecycle generator, I figured out that it wasn't properly checking if the minor version was set correctly. It is always checking the first item of the array (major) but never minor.

Also there is some dead code on switch/case so I have just simplified to check if the string is not null


#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
