### PR TITLE
scheduler test: Use cmp.Diff instead of reflect.DeepEqual for pkg/scheduler/framework/

### DIFF
--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring_test.go
@@ -18,7 +18,6 @@ package interpodaffinity
 
 import (
 	"context"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -974,8 +973,8 @@ func TestPreferredAffinityWithHardPodAffinitySymmetricWeight(t *testing.T) {
 				t.Errorf("unexpected error: %v", status)
 			}
 
-			if !reflect.DeepEqual(test.expectedList, gotList) {
-				t.Errorf("expected:\n\t%+v,\ngot:\n\t%+v", test.expectedList, gotList)
+			if diff := cmp.Diff(test.expectedList, gotList); diff != "" {
+				t.Errorf("Unexpected NodeScoreList (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/nodename/node_name_test.go
+++ b/pkg/scheduler/framework/plugins/nodename/node_name_test.go
@@ -18,9 +18,9 @@ package nodename
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
@@ -58,8 +58,8 @@ func TestNodeName(t *testing.T) {
 
 			p, _ := New(nil, nil)
 			gotStatus := p.(framework.FilterPlugin).Filter(context.Background(), nil, test.pod, nodeInfo)
-			if !reflect.DeepEqual(gotStatus, test.wantStatus) {
-				t.Errorf("status does not match: %v, want: %v", gotStatus, test.wantStatus)
+			if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
+				t.Errorf("Unexpected status (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
@@ -18,9 +18,9 @@ package noderesources
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -402,8 +402,8 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 				if !status.IsSuccess() {
 					t.Errorf("Score is expected to return success, but didn't. Got status: %v", status)
 				}
-				if !reflect.DeepEqual(test.expectedList[i].Score, hostResult) {
-					t.Errorf("got score %v for host %v, expected %v", hostResult, test.nodes[i].Name, test.expectedList[i].Score)
+				if diff := cmp.Diff(test.expectedList[i].Score, hostResult); diff != "" {
+					t.Errorf("Unexpected node %v score (-want, +got):\n%s", test.nodes[i].Name, diff)
 				}
 			}
 		})

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
@@ -18,9 +18,9 @@ package nodeunschedulable
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -77,8 +77,8 @@ func TestNodeUnschedulable(t *testing.T) {
 
 		p, _ := New(nil, nil)
 		gotStatus := p.(framework.FilterPlugin).Filter(context.Background(), nil, test.pod, nodeInfo)
-		if !reflect.DeepEqual(gotStatus, test.wantStatus) {
-			t.Errorf("status does not match: %v, want: %v", gotStatus, test.wantStatus)
+		if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
+			t.Errorf("Unexpected status (-want, +got):\n%s", diff)
 		}
 	}
 }

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -191,8 +190,8 @@ func TestEphemeralLimits(t *testing.T) {
 
 			if gotPreFilterStatus.Code() != framework.Skip {
 				gotStatus := p.Filter(context.Background(), nil, test.newPod, node)
-				if !reflect.DeepEqual(gotStatus, test.wantStatus) {
-					t.Errorf("Filter status does not match: %v, want: %v", gotStatus, test.wantStatus)
+				if diff := cmp.Diff(test.wantStatus, gotStatus, cmpOpts...); diff != "" {
+					t.Errorf("Unexpected Filter status (-want, +got):\n%s", diff)
 				}
 			}
 		})
@@ -421,8 +420,8 @@ func TestAzureDiskLimits(t *testing.T) {
 
 			if gotPreFilterStatus.Code() != framework.Skip {
 				gotStatus := p.Filter(context.Background(), nil, test.newPod, node)
-				if !reflect.DeepEqual(gotStatus, test.wantStatus) {
-					t.Errorf("Filter status does not match: %v, want: %v", gotStatus, test.wantStatus)
+				if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
+					t.Errorf("Unexpected Filter status (-want, +got):\n%s", diff)
 				}
 			}
 		})
@@ -702,8 +701,8 @@ func TestEBSLimits(t *testing.T) {
 
 			if gotPreFilterStatus.Code() != framework.Skip {
 				gotStatus := p.Filter(context.Background(), nil, test.newPod, node)
-				if !reflect.DeepEqual(gotStatus, test.wantStatus) {
-					t.Errorf("Filter status does not match: %v, want: %v", gotStatus, test.wantStatus)
+				if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
+					t.Errorf("Unexpected Filter status (-want, +got):\n%s", diff)
 				}
 			}
 		})
@@ -932,8 +931,8 @@ func TestGCEPDLimits(t *testing.T) {
 
 			if gotPreFilterStatus.Code() != framework.Skip {
 				gotStatus := p.Filter(context.Background(), nil, test.newPod, node)
-				if !reflect.DeepEqual(gotStatus, test.wantStatus) {
-					t.Errorf("Filter status does not match: %v, want: %v", gotStatus, test.wantStatus)
+				if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
+					t.Errorf("Unexpected Filter status (-want, +got):\n%s", diff)
 				}
 			}
 		})

--- a/pkg/scheduler/framework/plugins/selectorspread/selector_spread_test.go
+++ b/pkg/scheduler/framework/plugins/selectorspread/selector_spread_test.go
@@ -19,10 +19,10 @@ package selectorspread
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"sort"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -435,9 +435,8 @@ func TestSelectorSpreadScore(t *testing.T) {
 			if !status.IsSuccess() {
 				t.Errorf("unexpected error: %v", status)
 			}
-
-			if !reflect.DeepEqual(test.expectedList, gotList) {
-				t.Errorf("expected:\n\t%+v,\ngot:\n\t%+v", test.expectedList, gotList)
+			if diff := cmp.Diff(test.expectedList, gotList); diff != "" {
+				t.Errorf("Unexpected NodeScoreList (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -697,8 +696,8 @@ func TestZoneSelectorSpreadPriority(t *testing.T) {
 
 			sortNodeScoreList(test.expectedList)
 			sortNodeScoreList(gotList)
-			if !reflect.DeepEqual(test.expectedList, gotList) {
-				t.Errorf("expected:\n\t%+v,\ngot:\n\t%+v", test.expectedList, gotList)
+			if diff := cmp.Diff(test.expectedList, gotList); diff != "" {
+				t.Errorf("Unexpected NodeScoreList (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
@@ -18,9 +18,9 @@ package tainttoleration
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2/ktesting"
@@ -257,8 +257,8 @@ func TestTaintTolerationScore(t *testing.T) {
 				t.Errorf("unexpected error: %v", status)
 			}
 
-			if !reflect.DeepEqual(test.expectedList, gotList) {
-				t.Errorf("expected:\n\t%+v,\ngot:\n\t%+v", test.expectedList, gotList)
+			if diff := cmp.Diff(test.expectedList, gotList); diff != "" {
+				t.Errorf("Unexpected NodeScoreList (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -339,8 +339,8 @@ func TestTaintTolerationFilter(t *testing.T) {
 			nodeInfo.SetNode(test.node)
 			p, _ := New(nil, nil)
 			gotStatus := p.(framework.FilterPlugin).Filter(context.Background(), nil, test.pod, nodeInfo)
-			if !reflect.DeepEqual(gotStatus, test.wantStatus) {
-				t.Errorf("status does not match: %v, want: %v", gotStatus, test.wantStatus)
+			if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
+				t.Errorf("Unexpected status (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -901,8 +900,8 @@ func TestPreEnqueuePlugins(t *testing.T) {
 			}
 
 			got := f.PreEnqueuePlugins()
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("PreEnqueuePlugins(): want %v, but got %v", tt.want, got)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Unexpected PreEnqueuePlugins() (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -1412,8 +1411,8 @@ func TestRunScorePlugins(t *testing.T) {
 			if !status.IsSuccess() {
 				t.Errorf("Expected status to be success.")
 			}
-			if !reflect.DeepEqual(res, tt.want) {
-				t.Errorf("Score map after RunScorePlugin. got: %+v, want: %+v.", res, tt.want)
+			if diff := cmp.Diff(tt.want, res); diff != "" {
+				t.Errorf("Unexpected score map after RunScorePlugin (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -2076,8 +2075,8 @@ func TestPostFilterPlugins(t *testing.T) {
 				t.Fatalf("fail to create framework: %s", err)
 			}
 			_, gotStatus := f.RunPostFilterPlugins(ctx, nil, pod, nil)
-			if !reflect.DeepEqual(gotStatus, tt.wantStatus) {
-				t.Errorf("Unexpected status. got: %v, want: %v", gotStatus, tt.wantStatus)
+			if diff := cmp.Diff(tt.wantStatus, gotStatus, cmpOpts...); diff != "" {
+				t.Errorf("Unexpected status (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -2386,8 +2385,8 @@ func TestPreBindPlugins(t *testing.T) {
 
 			status := f.RunPreBindPlugins(ctx, nil, pod, "")
 
-			if !reflect.DeepEqual(status, tt.wantStatus) {
-				t.Errorf("wrong status code. got %v, want %v", status, tt.wantStatus)
+			if diff := cmp.Diff(tt.wantStatus, status, cmpOpts...); diff != "" {
+				t.Errorf("Unexpected status code (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -2544,8 +2543,8 @@ func TestReservePlugins(t *testing.T) {
 
 			status := f.RunReservePluginsReserve(ctx, nil, pod, "")
 
-			if !reflect.DeepEqual(status, tt.wantStatus) {
-				t.Errorf("wrong status code. got %v, want %v", status, tt.wantStatus)
+			if diff := cmp.Diff(tt.wantStatus, status, cmpOpts...); diff != "" {
+				t.Errorf("Unexpected status code (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -2669,8 +2668,8 @@ func TestPermitPlugins(t *testing.T) {
 			}
 
 			status := f.RunPermitPlugins(ctx, nil, pod, "")
-			if !reflect.DeepEqual(status, tt.want) {
-				t.Errorf("wrong status code. got %v, want %v", status, tt.want)
+			if diff := cmp.Diff(tt.want, status, cmpOpts...); diff != "" {
+				t.Errorf("Unexpected status code (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -3081,8 +3080,8 @@ func TestWaitOnPermit(t *testing.T) {
 			go tt.action(f)
 
 			got := f.WaitOnPermit(ctx, pod)
-			if !reflect.DeepEqual(tt.want, got) {
-				t.Errorf("Unexpected status: want %v, but got %v", tt.want, got)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Unexpected status (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/runtime/registry_test.go
+++ b/pkg/scheduler/framework/runtime/registry_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package runtime
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -65,9 +65,8 @@ func TestDecodeInto(t *testing.T) {
 			if err := DecodeInto(test.args, &pluginFooConf); err != nil {
 				t.Errorf("DecodeInto(): failed to decode args %+v: %v", test.args, err)
 			}
-			if !reflect.DeepEqual(test.expected, pluginFooConf) {
-				t.Errorf("DecodeInto(): failed to decode plugin config, expected: %+v, got: %+v",
-					test.expected, pluginFooConf)
+			if diff := cmp.Diff(test.expected, pluginFooConf); diff != "" {
+				t.Errorf("Unexpected decode plugin config (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -18,7 +18,6 @@ package framework
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -67,8 +66,8 @@ func TestNewResource(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r := NewResource(test.resourceList)
-			if !reflect.DeepEqual(test.expected, r) {
-				t.Errorf("expected: %#v, got: %#v", test.expected, r)
+			if diff := cmp.Diff(test.expected, r); diff != "" {
+				t.Errorf("Unexpected resource (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -106,8 +105,8 @@ func TestResourceClone(t *testing.T) {
 			r := test.resource.Clone()
 			// Modify the field to check if the result is a clone of the origin one.
 			test.resource.MilliCPU += 1000
-			if !reflect.DeepEqual(test.expected, r) {
-				t.Errorf("expected: %#v, got: %#v", test.expected, r)
+			if diff := cmp.Diff(test.expected, r); diff != "" {
+				t.Errorf("Unexpected resource (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -151,8 +150,8 @@ func TestResourceAddScalar(t *testing.T) {
 	for _, test := range tests {
 		t.Run(string(test.scalarName), func(t *testing.T) {
 			test.resource.AddScalar(test.scalarName, test.scalarQuantity)
-			if !reflect.DeepEqual(test.expected, test.resource) {
-				t.Errorf("expected: %#v, got: %#v", test.expected, test.resource)
+			if diff := cmp.Diff(test.expected, test.resource); diff != "" {
+				t.Errorf("Unexpected resource (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -203,8 +202,8 @@ func TestSetMaxResource(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
 			test.resource.SetMaxResource(test.resourceList)
-			if !reflect.DeepEqual(test.expected, test.resource) {
-				t.Errorf("expected: %#v, got: %#v", test.expected, test.resource)
+			if diff := cmp.Diff(test.expected, test.resource); diff != "" {
+				t.Errorf("Unexpected resource (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -348,8 +347,8 @@ func TestNewNodeInfo(t *testing.T) {
 		t.Errorf("Generation is not incremented. previous: %v, current: %v", gen, ni.Generation)
 	}
 	expected.Generation = ni.Generation
-	if !reflect.DeepEqual(expected, ni) {
-		t.Errorf("expected: %#v, got: %#v", expected, ni)
+	if diff := cmp.Diff(expected, ni, cmp.AllowUnexported(NodeInfo{})); diff != "" {
+		t.Errorf("Unexpected node info (-want, +got):\n%s", diff)
 	}
 }
 
@@ -517,8 +516,8 @@ func TestNodeInfoClone(t *testing.T) {
 			// Modify the field to check if the result is a clone of the origin one.
 			test.nodeInfo.Generation += 10
 			test.nodeInfo.UsedPorts.Remove("127.0.0.1", "TCP", 80)
-			if !reflect.DeepEqual(test.expected, ni) {
-				t.Errorf("expected: %#v, got: %#v", test.expected, ni)
+			if diff := cmp.Diff(test.expected, ni, cmp.AllowUnexported(NodeInfo{})); diff != "" {
+				t.Errorf("Unexpected node info (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -833,8 +832,8 @@ func TestNodeInfoAddPod(t *testing.T) {
 	}
 
 	expected.Generation = ni.Generation
-	if !reflect.DeepEqual(expected, ni) {
-		t.Errorf("expected: %#v, got: %#v", expected, ni)
+	if diff := cmp.Diff(expected, ni, cmp.AllowUnexported(NodeInfo{})); diff != "" {
+		t.Errorf("Unexpected node info (-want, +got):\n%s", diff)
 	}
 }
 
@@ -1104,8 +1103,8 @@ func TestNodeInfoRemovePod(t *testing.T) {
 			}
 
 			test.expectedNodeInfo.Generation = ni.Generation
-			if !reflect.DeepEqual(test.expectedNodeInfo, ni) {
-				t.Errorf("expected: %#v, got: %#v", test.expectedNodeInfo, ni)
+			if diff := cmp.Diff(test.expectedNodeInfo, ni, cmp.AllowUnexported(NodeInfo{})); diff != "" {
+				t.Errorf("Unexpected node info (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -1571,8 +1570,8 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 			pod.Status.Resize = tt.resizeStatus
 
 			res, non0CPU, non0Mem := calculateResource(pod)
-			if !reflect.DeepEqual(tt.expectedResource, res) {
-				t.Errorf("Test: %s expected resource: %+v, got: %+v", tt.name, tt.expectedResource, res)
+			if diff := cmp.Diff(tt.expectedResource, res); diff != "" {
+				t.Errorf("Unexpected resource (-want, +got):\n%s", diff)
 			}
 			if non0CPU != tt.expectedNon0CPU {
 				t.Errorf("Test: %s expected non0CPU: %d, got: %d", tt.name, tt.expectedNon0CPU, non0CPU)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
follow up https://github.com/kubernetes/kubernetes/pull/118312#discussion_r1243327155

https://github.com/kubernetes/kubernetes/pull/118926#issuecomment-1611057582
> Basically, our recommendation (at least in our scheduler area) is to use cmp.Diff for a better visibility of comparison results. reflect.DeepEqual also works, but reducing it in the existing tests contributes to unifying how we compare things

Use `cmp.Diff` instead of `reflect.DeepEqual` for `pkg/scheduler/framework/`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
related issue: https://github.com/kubernetes/kubernetes/issues/55722
xref #118926

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

