### PR TITLE
Convert intstr.FromInt() to take an int32 instead of an int

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -273,7 +273,7 @@ func createHTTPProbe(host, path string, port int, scheme v1.URIScheme, initialDe
 			HTTPGet: &v1.HTTPGetAction{
 				Host:   host,
 				Path:   path,
-				Port:   intstr.FromInt(port),
+				Port:   intstr.FromInt(int32(port)),
 				Scheme: scheme,
 			},
 		},

--- a/pkg/apis/apps/v1/defaults_test.go
+++ b/pkg/apis/apps/v1/defaults_test.go
@@ -175,7 +175,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 	}
 }
 
-func getMaxUnavailable(maxUnavailable int) *intstr.IntOrString {
+func getMaxUnavailable(maxUnavailable int32) *intstr.IntOrString {
 	maxUnavailableIntOrStr := intstr.FromInt(maxUnavailable)
 	return &maxUnavailableIntOrStr
 }

--- a/pkg/apis/apps/v1beta1/defaults_test.go
+++ b/pkg/apis/apps/v1beta1/defaults_test.go
@@ -531,7 +531,7 @@ func getPartition(partition int32) *int32 {
 	return &partition
 }
 
-func getMaxUnavailable(maxUnavailable int) *intstr.IntOrString {
+func getMaxUnavailable(maxUnavailable int32) *intstr.IntOrString {
 	maxUnavailableIntOrStr := intstr.FromInt(maxUnavailable)
 	return &maxUnavailableIntOrStr
 }

--- a/pkg/apis/apps/v1beta2/defaults_test.go
+++ b/pkg/apis/apps/v1beta2/defaults_test.go
@@ -175,7 +175,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 	}
 }
 
-func getMaxUnavailable(maxUnavailable int) *intstr.IntOrString {
+func getMaxUnavailable(maxUnavailable int32) *intstr.IntOrString {
 	maxUnavailableIntOrStr := intstr.FromInt(maxUnavailable)
 	return &maxUnavailableIntOrStr
 }

--- a/pkg/controller/daemon/update_test.go
+++ b/pkg/controller/daemon/update_test.go
@@ -40,7 +40,7 @@ func TestDaemonSetUpdatesPods(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating DaemonSets controller: %v", err)
 	}
-	maxUnavailable := 2
+	maxUnavailable := int32(2)
 	addNodes(manager.nodeStore, 0, 5, nil)
 	manager.dsStore.Add(ds)
 	expectSyncDaemonSets(t, manager, ds, podControl, 5, 0, 0)
@@ -88,7 +88,7 @@ func TestDaemonSetUpdatesPodsWithMaxSurge(t *testing.T) {
 	markPodsReady(podControl.podStore)
 
 	// surge is thhe controlling amount
-	maxSurge := 2
+	maxSurge := int32(2)
 	ds.Spec.Template.Spec.Containers[0].Image = "foo2/bar2"
 	ds.Spec.UpdateStrategy = newUpdateSurge(intstr.FromInt(maxSurge))
 	manager.dsStore.Update(ds)
@@ -124,7 +124,7 @@ func TestDaemonSetUpdatesWhenNewPosIsNotReady(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating DaemonSets controller: %v", err)
 	}
-	maxUnavailable := 3
+	maxUnavailable := int32(3)
 	addNodes(manager.nodeStore, 0, 5, nil)
 	err = manager.dsStore.Add(ds)
 	if err != nil {
@@ -161,7 +161,7 @@ func TestDaemonSetUpdatesAllOldPodsNotReady(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating DaemonSets controller: %v", err)
 	}
-	maxUnavailable := 3
+	maxUnavailable := int32(3)
 	addNodes(manager.nodeStore, 0, 5, nil)
 	err = manager.dsStore.Add(ds)
 	if err != nil {
@@ -201,7 +201,7 @@ func TestDaemonSetUpdatesAllOldPodsNotReadyMaxSurge(t *testing.T) {
 	manager.dsStore.Add(ds)
 	expectSyncDaemonSets(t, manager, ds, podControl, 5, 0, 0)
 
-	maxSurge := 3
+	maxSurge := int32(3)
 	ds.Spec.Template.Spec.Containers[0].Image = "foo2/bar2"
 	ds.Spec.UpdateStrategy = newUpdateSurge(intstr.FromInt(maxSurge))
 	manager.dsStore.Update(ds)
@@ -341,7 +341,7 @@ func TestDaemonSetUpdatesNoTemplateChanged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating DaemonSets controller: %v", err)
 	}
-	maxUnavailable := 3
+	maxUnavailable := int32(3)
 	addNodes(manager.nodeStore, 0, 5, nil)
 	manager.dsStore.Add(ds)
 	expectSyncDaemonSets(t, manager, ds, podControl, 5, 0, 0)

--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -34,7 +34,7 @@ import (
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 )
 
-func intOrStrP(val int) *intstr.IntOrString {
+func intOrStrP(val int32) *intstr.IntOrString {
 	intOrStr := intstr.FromInt(val)
 	return &intOrStr
 }

--- a/pkg/controller/deployment/util/deployment_util_test.go
+++ b/pkg/controller/deployment/util/deployment_util_test.go
@@ -486,7 +486,7 @@ func TestNewRSNewReplicas(t *testing.T) {
 		strategyType  apps.DeploymentStrategyType
 		depReplicas   int32
 		newRSReplicas int32
-		maxSurge      int
+		maxSurge      int32
 		expected      int32
 	}{
 		{
@@ -515,11 +515,11 @@ func TestNewRSNewReplicas(t *testing.T) {
 			*(newDeployment.Spec.Replicas) = test.depReplicas
 			newDeployment.Spec.Strategy = apps.DeploymentStrategy{Type: test.strategyType}
 			newDeployment.Spec.Strategy.RollingUpdate = &apps.RollingUpdateDeployment{
-				MaxUnavailable: func(i int) *intstr.IntOrString {
+				MaxUnavailable: func(i int32) *intstr.IntOrString {
 					x := intstr.FromInt(i)
 					return &x
 				}(1),
-				MaxSurge: func(i int) *intstr.IntOrString {
+				MaxSurge: func(i int32) *intstr.IntOrString {
 					x := intstr.FromInt(i)
 					return &x
 				}(test.maxSurge),
@@ -705,8 +705,8 @@ func TestDeploymentComplete(t *testing.T) {
 				Replicas: &desired,
 				Strategy: apps.DeploymentStrategy{
 					RollingUpdate: &apps.RollingUpdateDeployment{
-						MaxUnavailable: func(i int) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(int(maxUnavailable)),
-						MaxSurge:       func(i int) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(int(maxSurge)),
+						MaxUnavailable: func(i int32) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(maxUnavailable),
+						MaxSurge:       func(i int32) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(maxSurge),
 					},
 					Type: apps.RollingUpdateDeploymentStrategyType,
 				},
@@ -960,7 +960,7 @@ func TestMaxUnavailable(t *testing.T) {
 				Replicas: func(i int32) *int32 { return &i }(replicas),
 				Strategy: apps.DeploymentStrategy{
 					RollingUpdate: &apps.RollingUpdateDeployment{
-						MaxSurge:       func(i int) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(int(1)),
+						MaxSurge:       func(i int32) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(1),
 						MaxUnavailable: &maxUnavailable,
 					},
 					Type: apps.RollingUpdateDeploymentStrategyType,
@@ -1255,7 +1255,7 @@ func TestGetDeploymentsForReplicaSet(t *testing.T) {
 }
 
 func TestMinAvailable(t *testing.T) {
-	maxSurge := func(i int) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(int(1))
+	maxSurge := func(i int32) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(1)
 	deployment := func(replicas int32, maxUnavailable intstr.IntOrString) *apps.Deployment {
 		return &apps.Deployment{
 			Spec: apps.DeploymentSpec{

--- a/pkg/controlplane/controller/kubernetesservice/controller.go
+++ b/pkg/controlplane/controller/kubernetesservice/controller.go
@@ -177,7 +177,7 @@ func (c *Controller) UpdateKubernetesService(reconcile bool) error {
 
 // createPortAndServiceSpec creates an array of service ports.
 // If the NodePort value is 0, just the servicePort is used, otherwise, a node port is exposed.
-func createPortAndServiceSpec(servicePort int, targetServicePort int, nodePort int, servicePortName string) ([]corev1.ServicePort, corev1.ServiceType) {
+func createPortAndServiceSpec(servicePort int, targetServicePort int32, nodePort int, servicePortName string) ([]corev1.ServicePort, corev1.ServiceType) {
 	// Use the Cluster IP type for the service port if NodePort isn't provided.
 	// Otherwise, we will be binding the master service to a NodePort.
 	servicePorts := []corev1.ServicePort{{

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -45,7 +45,7 @@ import (
 
 func TestResolvePortInt(t *testing.T) {
 	expected := 80
-	port, err := resolvePort(intstr.FromInt(expected), &v1.Container{})
+	port, err := resolvePort(intstr.FromInt(int32(expected)), &v1.Container{})
 	if port != expected {
 		t.Errorf("expected: %d, saw: %d", expected, port)
 	}

--- a/pkg/kubelet/prober/scale_test.go
+++ b/pkg/kubelet/prober/scale_test.go
@@ -251,7 +251,7 @@ type fakePod struct {
 }
 
 func (f *fakePod) probeHandler() v1.ProbeHandler {
-	port := f.ln.Addr().(*net.TCPAddr).Port
+	port := int32(f.ln.Addr().(*net.TCPAddr).Port)
 	var handler v1.ProbeHandler
 	if f.http {
 		handler = v1.ProbeHandler{

--- a/pkg/proxy/iptables/number_generated_rules_test.go
+++ b/pkg/proxy/iptables/number_generated_rules_test.go
@@ -359,7 +359,7 @@ func generateServiceEndpoints(nServices, nEndpoints int, epsFunc func(eps *disco
 
 	// generate a base endpoint slice object
 	baseEp := netutils.BigForIP(netutils.ParseIPSloppy("172.16.0.1"))
-	epPort := 8080
+	epPort := int32(8080)
 
 	tcpProtocol := v1.ProtocolTCP
 
@@ -372,7 +372,7 @@ func generateServiceEndpoints(nServices, nEndpoints int, epsFunc func(eps *disco
 		Endpoints:   []discovery.Endpoint{},
 		Ports: []discovery.EndpointPort{{
 			Name:     pointer.String(fmt.Sprintf("%d", epPort)),
-			Port:     pointer.Int32(int32(epPort)),
+			Port:     pointer.Int32(epPort),
 			Protocol: &tcpProtocol,
 		}},
 	}

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -1529,7 +1529,7 @@ type packetFlowTest struct {
 	name     string
 	sourceIP string
 	destIP   string
-	destPort int
+	destPort int32
 	output   string
 	masq     bool
 }
@@ -2152,8 +2152,8 @@ func TestLoadBalancer(t *testing.T) {
 	ipt := iptablestest.NewFake()
 	fp := NewFakeProxier(ipt)
 	svcIP := "172.30.0.41"
-	svcPort := 80
-	svcNodePort := 3001
+	svcPort := int32(80)
+	svcNodePort := int32(3001)
 	svcLBIP1 := "1.2.3.4"
 	svcLBIP2 := "5.6.7.8"
 	svcPortName := proxy.ServicePortName{
@@ -2364,8 +2364,8 @@ func TestNodePort(t *testing.T) {
 	ipt := iptablestest.NewFake()
 	fp := NewFakeProxier(ipt)
 	svcIP := "172.30.0.41"
-	svcPort := 80
-	svcNodePort := 3001
+	svcPort := int32(80)
+	svcNodePort := int32(3001)
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
 		Port:           "p80",
@@ -2482,9 +2482,9 @@ func TestHealthCheckNodePort(t *testing.T) {
 	fp.nodePortAddresses = proxyutil.NewNodePortAddresses(v1.IPv4Protocol, []string{"127.0.0.0/8"})
 
 	svcIP := "172.30.0.42"
-	svcPort := 80
-	svcNodePort := 3001
-	svcHealthCheckNodePort := 30000
+	svcPort := int32(80)
+	svcNodePort := int32(3001)
+	svcHealthCheckNodePort := int32(30000)
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
 		Port:           "p80",
@@ -2607,7 +2607,7 @@ func TestExternalIPsReject(t *testing.T) {
 	ipt := iptablestest.NewFake()
 	fp := NewFakeProxier(ipt)
 	svcIP := "172.30.0.41"
-	svcPort := 80
+	svcPort := int32(80)
 	svcExternalIPs := "192.168.99.11"
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
@@ -2621,7 +2621,7 @@ func TestExternalIPsReject(t *testing.T) {
 			svc.Spec.ExternalIPs = []string{svcExternalIPs}
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:       svcPortName.Port,
-				Port:       int32(svcPort),
+				Port:       svcPort,
 				Protocol:   v1.ProtocolTCP,
 				TargetPort: intstr.FromInt(svcPort),
 			}}
@@ -2681,7 +2681,7 @@ func TestOnlyLocalExternalIPs(t *testing.T) {
 	ipt := iptablestest.NewFake()
 	fp := NewFakeProxier(ipt)
 	svcIP := "172.30.0.41"
-	svcPort := 80
+	svcPort := int32(80)
 	svcExternalIPs := "192.168.99.11"
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
@@ -2795,7 +2795,7 @@ func TestNonLocalExternalIPs(t *testing.T) {
 	ipt := iptablestest.NewFake()
 	fp := NewFakeProxier(ipt)
 	svcIP := "172.30.0.41"
-	svcPort := 80
+	svcPort := int32(80)
 	svcExternalIPs := "192.168.99.11"
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
@@ -2902,8 +2902,8 @@ func TestNodePortReject(t *testing.T) {
 	ipt := iptablestest.NewFake()
 	fp := NewFakeProxier(ipt)
 	svcIP := "172.30.0.41"
-	svcPort := 80
-	svcNodePort := 3001
+	svcPort := int32(80)
+	svcNodePort := int32(3001)
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
 		Port:           "p80",
@@ -2982,9 +2982,9 @@ func TestLoadBalancerReject(t *testing.T) {
 	ipt := iptablestest.NewFake()
 	fp := NewFakeProxier(ipt)
 	svcIP := "172.30.0.41"
-	svcPort := 80
-	svcNodePort := 3001
-	svcHealthCheckNodePort := 30000
+	svcPort := int32(80)
+	svcNodePort := int32(3001)
+	svcHealthCheckNodePort := int32(30000)
 	svcLBIP := "1.2.3.4"
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
@@ -3076,9 +3076,9 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 	ipt := iptablestest.NewFake()
 	fp := NewFakeProxier(ipt)
 	svcIP := "172.30.0.41"
-	svcPort := 80
-	svcNodePort := 3001
-	svcHealthCheckNodePort := 30000
+	svcPort := int32(80)
+	svcNodePort := int32(3001)
+	svcHealthCheckNodePort := int32(30000)
 	svcLBIP := "1.2.3.4"
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
@@ -3780,8 +3780,8 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 
 func onlyLocalNodePorts(t *testing.T, fp *Proxier, ipt *iptablestest.FakeIPTables, expected string, line int) {
 	svcIP := "172.30.0.41"
-	svcPort := 80
-	svcNodePort := 3001
+	svcPort := int32(80)
+	svcNodePort := int32(3001)
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
 		Port:           "p80",
@@ -3926,7 +3926,7 @@ func makeTestService(namespace, name string, svcFunc func(*v1.Service)) *v1.Serv
 	return svc
 }
 
-func addTestPort(array []v1.ServicePort, name string, protocol v1.Protocol, port, nodeport int32, targetPort int) []v1.ServicePort {
+func addTestPort(array []v1.ServicePort, name string, protocol v1.Protocol, port, nodeport, targetPort int32) []v1.ServicePort {
 	svcPort := v1.ServicePort{
 		Name:       name,
 		Protocol:   protocol,

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -240,7 +240,7 @@ func TestCleanupLeftovers(t *testing.T) {
 	ipset := ipsettest.NewFake(testIPSetVersion)
 	fp := NewFakeProxier(ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	svcIP := "10.20.30.41"
-	svcPort := 80
+	svcPort := int32(80)
 	svcNodePort := 3001
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
@@ -253,7 +253,7 @@ func TestCleanupLeftovers(t *testing.T) {
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:     svcPortName.Port,
-				Port:     int32(svcPort),
+				Port:     svcPort,
 				Protocol: v1.ProtocolTCP,
 				NodePort: int32(svcNodePort),
 			}}
@@ -269,7 +269,7 @@ func TestCleanupLeftovers(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     pointer.String(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     pointer.Int32(svcPort),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -1727,7 +1727,7 @@ func TestExternalIPsNoEndpoint(t *testing.T) {
 	ipset := ipsettest.NewFake(testIPSetVersion)
 	fp := NewFakeProxier(ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	svcIP := "10.20.30.41"
-	svcPort := 80
+	svcPort := int32(80)
 	svcExternalIPs := "50.60.70.81"
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
@@ -1741,7 +1741,7 @@ func TestExternalIPsNoEndpoint(t *testing.T) {
 			svc.Spec.ExternalIPs = []string{svcExternalIPs}
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:       svcPortName.Port,
-				Port:       int32(svcPort),
+				Port:       svcPort,
 				Protocol:   v1.ProtocolTCP,
 				TargetPort: intstr.FromInt(svcPort),
 			}}
@@ -1779,7 +1779,7 @@ func TestExternalIPs(t *testing.T) {
 	ipset := ipsettest.NewFake(testIPSetVersion)
 	fp := NewFakeProxier(ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	svcIP := "10.20.30.41"
-	svcPort := 80
+	svcPort := int32(80)
 	svcExternalIPs := sets.New[string]("50.60.70.81", "2012::51", "127.0.0.1")
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
@@ -1793,7 +1793,7 @@ func TestExternalIPs(t *testing.T) {
 			svc.Spec.ExternalIPs = svcExternalIPs.UnsortedList()
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:       svcPortName.Port,
-				Port:       int32(svcPort),
+				Port:       svcPort,
 				Protocol:   v1.ProtocolTCP,
 				TargetPort: intstr.FromInt(svcPort),
 			}}
@@ -1810,7 +1810,7 @@ func TestExternalIPs(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     pointer.String(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     pointer.Int32(svcPort),
 				Protocol: &udpProtocol,
 			}}
 		}),
@@ -1850,7 +1850,7 @@ func TestOnlyLocalExternalIPs(t *testing.T) {
 	ipset := ipsettest.NewFake(testIPSetVersion)
 	fp := NewFakeProxier(ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
 	svcIP := "10.20.30.41"
-	svcPort := 80
+	svcPort := int32(80)
 	svcExternalIPs := sets.New[string]("50.60.70.81", "2012::51", "127.0.0.1")
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
@@ -1864,7 +1864,7 @@ func TestOnlyLocalExternalIPs(t *testing.T) {
 			svc.Spec.ExternalIPs = svcExternalIPs.UnsortedList()
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:       svcPortName.Port,
-				Port:       int32(svcPort),
+				Port:       svcPort,
 				Protocol:   v1.ProtocolTCP,
 				TargetPort: intstr.FromInt(svcPort),
 			}}
@@ -1889,7 +1889,7 @@ func TestOnlyLocalExternalIPs(t *testing.T) {
 				}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     pointer.String(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     pointer.Int32(svcPort),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -1929,7 +1929,7 @@ func TestOnlyLocalExternalIPs(t *testing.T) {
 func TestLoadBalancer(t *testing.T) {
 	ipt, fp := buildFakeProxier()
 	svcIP := "10.20.30.41"
-	svcPort := 80
+	svcPort := int32(80)
 	svcNodePort := 3001
 	svcLBIP := "1.2.3.4"
 	svcPortName := proxy.ServicePortName{
@@ -1943,7 +1943,7 @@ func TestLoadBalancer(t *testing.T) {
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:     svcPortName.Port,
-				Port:     int32(svcPort),
+				Port:     svcPort,
 				Protocol: v1.ProtocolTCP,
 				NodePort: int32(svcNodePort),
 			}}
@@ -1963,7 +1963,7 @@ func TestLoadBalancer(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     pointer.String(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     pointer.Int32(svcPort),
 				Protocol: &udpProtocol,
 			}}
 		}),
@@ -1983,7 +1983,7 @@ func TestLoadBalancer(t *testing.T) {
 	epIPSet := netlinktest.ExpectedIPSet{
 		kubeLoadBalancerSet: {{
 			IP:       svcLBIP,
-			Port:     svcPort,
+			Port:     int(svcPort),
 			Protocol: strings.ToLower(string(v1.ProtocolTCP)),
 			SetType:  utilipset.HashIPPort,
 		}},
@@ -2017,7 +2017,7 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 	ipt, fp := buildFakeProxier()
 
 	svcIP := "10.20.30.41"
-	svcPort := 80
+	svcPort := int32(80)
 	svcNodePort := 3001
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
@@ -2030,7 +2030,7 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:     svcPortName.Port,
-				Port:     int32(svcPort),
+				Port:     svcPort,
 				Protocol: v1.ProtocolTCP,
 				NodePort: int32(svcNodePort),
 			}}
@@ -2056,7 +2056,7 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     pointer.String(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     pointer.Int32(svcPort),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -2118,7 +2118,7 @@ func TestHealthCheckNodePort(t *testing.T) {
 	ipt, fp := buildFakeProxier()
 
 	svcIP := "10.20.30.41"
-	svcPort := 80
+	svcPort := int32(80)
 	svcNodePort := 3000
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
@@ -2130,7 +2130,7 @@ func TestHealthCheckNodePort(t *testing.T) {
 		svc.Spec.ClusterIP = svcIP
 		svc.Spec.Ports = []v1.ServicePort{{
 			Name:     svcPortName.Port,
-			Port:     int32(svcPort),
+			Port:     svcPort,
 			Protocol: v1.ProtocolTCP,
 			NodePort: int32(svcNodePort),
 		}}
@@ -2191,7 +2191,7 @@ func TestLoadBalancerSourceRanges(t *testing.T) {
 	ipt, fp := buildFakeProxier()
 
 	svcIP := "10.20.30.41"
-	svcPort := 80
+	svcPort := int32(80)
 	svcLBIP := "1.2.3.4"
 	svcLBSource := "10.0.0.0/8"
 	svcPortName := proxy.ServicePortName{
@@ -2207,7 +2207,7 @@ func TestLoadBalancerSourceRanges(t *testing.T) {
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:     svcPortName.Port,
-				Port:     int32(svcPort),
+				Port:     svcPort,
 				Protocol: v1.ProtocolTCP,
 			}}
 			svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{
@@ -2226,7 +2226,7 @@ func TestLoadBalancerSourceRanges(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     pointer.String(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     pointer.Int32(svcPort),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -2246,19 +2246,19 @@ func TestLoadBalancerSourceRanges(t *testing.T) {
 	epIPSet := netlinktest.ExpectedIPSet{
 		kubeLoadBalancerSet: {{
 			IP:       svcLBIP,
-			Port:     svcPort,
+			Port:     int(svcPort),
 			Protocol: strings.ToLower(string(v1.ProtocolTCP)),
 			SetType:  utilipset.HashIPPort,
 		}},
 		kubeLoadBalancerFWSet: {{
 			IP:       svcLBIP,
-			Port:     svcPort,
+			Port:     int(svcPort),
 			Protocol: strings.ToLower(string(v1.ProtocolTCP)),
 			SetType:  utilipset.HashIPPort,
 		}},
 		kubeLoadBalancerSourceCIDRSet: {{
 			IP:       svcLBIP,
-			Port:     svcPort,
+			Port:     int(svcPort),
 			Protocol: strings.ToLower(string(v1.ProtocolTCP)),
 			Net:      svcLBSource,
 			SetType:  utilipset.HashIPPortNet,
@@ -2368,7 +2368,7 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 	ipt, fp := buildFakeProxier()
 
 	svcIP := "10.20.30.41"
-	svcPort := 80
+	svcPort := int32(80)
 	svcNodePort := 3001
 	svcLBIP := "1.2.3.4"
 	svcPortName := proxy.ServicePortName{
@@ -2382,7 +2382,7 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:     svcPortName.Port,
-				Port:     int32(svcPort),
+				Port:     svcPort,
 				Protocol: v1.ProtocolTCP,
 				NodePort: int32(svcNodePort),
 			}}
@@ -2413,7 +2413,7 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 				}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     pointer.String(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     pointer.Int32(svcPort),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -2433,13 +2433,13 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 	epIPSet := netlinktest.ExpectedIPSet{
 		kubeLoadBalancerSet: {{
 			IP:       svcLBIP,
-			Port:     svcPort,
+			Port:     int(svcPort),
 			Protocol: strings.ToLower(string(v1.ProtocolTCP)),
 			SetType:  utilipset.HashIPPort,
 		}},
 		kubeLoadBalancerLocalSet: {{
 			IP:       svcLBIP,
-			Port:     svcPort,
+			Port:     int(svcPort),
 			Protocol: strings.ToLower(string(v1.ProtocolTCP)),
 			SetType:  utilipset.HashIPPort,
 		}},
@@ -2470,7 +2470,7 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 	checkIptables(t, ipt, epIpt)
 }
 
-func addTestPort(array []v1.ServicePort, name string, protocol v1.Protocol, port, nodeport int32, targetPort int) []v1.ServicePort {
+func addTestPort(array []v1.ServicePort, name string, protocol v1.Protocol, port, nodeport, targetPort int32) []v1.ServicePort {
 	svcPort := v1.ServicePort{
 		Name:       name,
 		Protocol:   protocol,
@@ -2761,7 +2761,7 @@ func TestSessionAffinity(t *testing.T) {
 	nodeIP := "100.101.102.103"
 	fp := NewFakeProxier(ipt, ipvs, ipset, []string{nodeIP}, nil, v1.IPv4Protocol)
 	svcIP := "10.20.30.41"
-	svcPort := 80
+	svcPort := int32(80)
 	svcNodePort := 3001
 	svcExternalIPs := "50.60.70.81"
 	svcPortName := proxy.ServicePortName{
@@ -2783,7 +2783,7 @@ func TestSessionAffinity(t *testing.T) {
 			}
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:     svcPortName.Port,
-				Port:     int32(svcPort),
+				Port:     svcPort,
 				Protocol: v1.ProtocolTCP,
 				NodePort: int32(svcNodePort),
 			}}

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -61,7 +61,7 @@ func makeTestService(namespace, name string, svcFunc func(*v1.Service)) *v1.Serv
 	return svc
 }
 
-func addTestPort(array []v1.ServicePort, name string, protocol v1.Protocol, port, nodeport int32, targetPort int) []v1.ServicePort {
+func addTestPort(array []v1.ServicePort, name string, protocol v1.Protocol, port, nodeport, targetPort int32) []v1.ServicePort {
 	svcPort := v1.ServicePort{
 		Name:       name,
 		Protocol:   protocol,

--- a/pkg/registry/apps/statefulset/strategy_test.go
+++ b/pkg/registry/apps/statefulset/strategy_test.go
@@ -305,7 +305,7 @@ func generateStatefulSetWithMinReadySeconds(minReadySeconds int32) *apps.Statefu
 	}
 }
 
-func makeStatefulSetWithMaxUnavailable(maxUnavailable *int) *apps.StatefulSet {
+func makeStatefulSetWithMaxUnavailable(maxUnavailable *int32) *apps.StatefulSet {
 	rollingUpdate := apps.RollingUpdateStatefulSetStrategy{}
 	if maxUnavailable != nil {
 		maxUnavailableIntStr := intstr.FromInt(*maxUnavailable)
@@ -324,7 +324,7 @@ func makeStatefulSetWithMaxUnavailable(maxUnavailable *int) *apps.StatefulSet {
 	}
 }
 
-func getMaxUnavailable(maxUnavailable int) *int {
+func getMaxUnavailable(maxUnavailable int32) *int32 {
 	return &maxUnavailable
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
@@ -21,11 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"runtime/debug"
 	"strconv"
 	"strings"
-
-	"k8s.io/klog/v2"
 )
 
 // IntOrString is a type that can hold an int32 or a string.  When used in
@@ -51,35 +48,28 @@ const (
 	String             // The IntOrString holds a string.
 )
 
-// FromInt creates an IntOrString object with an int32 value. It is
-// your responsibility not to call this method with a value greater
-// than int32.
-// Deprecated: use FromInt32 instead.
-func FromInt(val int) IntOrString {
-	if val > math.MaxInt32 || val < math.MinInt32 {
-		klog.Errorf("value: %d overflows int32\n%s\n", val, debug.Stack())
-	}
-	return IntOrString{Type: Int, IntVal: int32(val)}
+// FromInt creates an IntOrString object with an int32 value.
+func FromInt(val int32) IntOrString {
+	return IntOrString{Type: Int, IntVal: val}
 }
 
 // FromInt32 creates an IntOrString object with an int32 value.
-func FromInt32(val int32) IntOrString {
-	return IntOrString{Type: Int, IntVal: val}
-}
+// Deprecated: use FromInt instead.
+var FromInt32 = FromInt
 
 // FromString creates an IntOrString object with a string value.
 func FromString(val string) IntOrString {
 	return IntOrString{Type: String, StrVal: val}
 }
 
-// Parse the given string and try to convert it to an integer before
+// Parse the given string and try to convert it to an int32 before
 // setting it as a string value.
 func Parse(val string) IntOrString {
-	i, err := strconv.Atoi(val)
+	i, err := strconv.ParseInt(val, 10, 32)
 	if err != nil {
 		return FromString(val)
 	}
-	return FromInt(i)
+	return FromInt(int32(i))
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
@@ -97,7 +97,7 @@ func tweakAddLBIngress(ip string) serviceTweak {
 	}
 }
 
-func makeServicePort(protocol v1.Protocol, targetPort int) []v1.ServicePort {
+func makeServicePort(protocol v1.Protocol, targetPort int32) []v1.ServicePort {
 	sp := v1.ServicePort{Port: 80, Protocol: protocol}
 	if targetPort > 0 {
 		sp.TargetPort = intstr.FromInt(targetPort)
@@ -105,7 +105,7 @@ func makeServicePort(protocol v1.Protocol, targetPort int) []v1.ServicePort {
 	return []v1.ServicePort{sp}
 }
 
-func tweakAddPorts(protocol v1.Protocol, targetPort int) serviceTweak {
+func tweakAddPorts(protocol v1.Protocol, targetPort int32) serviceTweak {
 	return func(s *v1.Service) {
 		s.Spec.Ports = makeServicePort(protocol, targetPort)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
@@ -532,12 +532,7 @@ func (o *ExposeServiceOptions) createService() (*corev1.Service, error) {
 	}
 	targetPortString := o.TargetPort
 	if len(targetPortString) > 0 {
-		var targetPort intstr.IntOrString
-		if portNum, err := strconv.Atoi(targetPortString); err != nil {
-			targetPort = intstr.FromString(targetPortString)
-		} else {
-			targetPort = intstr.FromInt(portNum)
-		}
+		targetPort := intstr.Parse(targetPortString)
 		// Use the same target-port for every port
 		for i := range service.Spec.Ports {
 			service.Spec.Ports[i].TargetPort = targetPort

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/service.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/service.go
@@ -196,7 +196,7 @@ func generateService(genericParams map[string]interface{}) (runtime.Object, erro
 		if portNum, err := strconv.Atoi(targetPortString); err != nil {
 			targetPort = intstr.FromString(targetPortString)
 		} else {
-			targetPort = intstr.FromInt(portNum)
+			targetPort = intstr.FromInt(int32(portNum))
 		}
 		// Use the same target-port for every port
 		for i := range service.Spec.Ports {

--- a/test/e2e/apimachinery/crd_conversion_webhook.go
+++ b/test/e2e/apimachinery/crd_conversion_webhook.go
@@ -291,7 +291,7 @@ func deployCustomResourceWebhookAndService(ctx context.Context, f *framework.Fra
 				ProbeHandler: v1.ProbeHandler{
 					HTTPGet: &v1.HTTPGetAction{
 						Scheme: v1.URISchemeHTTPS,
-						Port:   intstr.FromInt(int(containerPort)),
+						Port:   intstr.FromInt(containerPort),
 						Path:   "/readyz",
 					},
 				},
@@ -333,7 +333,7 @@ func deployCustomResourceWebhookAndService(ctx context.Context, f *framework.Fra
 				{
 					Protocol:   v1.ProtocolTCP,
 					Port:       servicePort,
-					TargetPort: intstr.FromInt(int(containerPort)),
+					TargetPort: intstr.FromInt(containerPort),
 				},
 			},
 		},

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -790,7 +790,7 @@ func deployWebhookAndService(ctx context.Context, f *framework.Framework, image 
 				ProbeHandler: v1.ProbeHandler{
 					HTTPGet: &v1.HTTPGetAction{
 						Scheme: v1.URISchemeHTTPS,
-						Port:   intstr.FromInt(int(containerPort)),
+						Port:   intstr.FromInt(containerPort),
 						Path:   "/readyz",
 					},
 				},
@@ -829,7 +829,7 @@ func deployWebhookAndService(ctx context.Context, f *framework.Framework, image 
 				{
 					Protocol:   v1.ProtocolTCP,
 					Port:       servicePort,
-					TargetPort: intstr.FromInt(int(containerPort)),
+					TargetPort: intstr.FromInt(containerPort),
 				},
 			},
 		},

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -670,7 +670,7 @@ func failureTrap(ctx context.Context, c clientset.Interface, ns string) {
 	}
 }
 
-func intOrStrP(num int) *intstr.IntOrString {
+func intOrStrP(num int32) *intstr.IntOrString {
 	intstr := intstr.FromInt(num)
 	return &intstr
 }

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -1035,7 +1035,7 @@ func runDrainTest(ctx context.Context, f *framework.Framework, migSizes map[stri
 	ginkgo.DeferCleanup(e2erc.DeleteRCAndWaitForGC, f.ClientSet, namespace, "reschedulable-pods")
 
 	ginkgo.By("Create a PodDisruptionBudget")
-	minAvailable := intstr.FromInt(numPods - pdbSize)
+	minAvailable := intstr.FromInt(int32(numPods - pdbSize))
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test_pdb",
@@ -1902,7 +1902,7 @@ func addKubeSystemPdbs(ctx context.Context, f *framework.Framework) error {
 
 	type pdbInfo struct {
 		label        string
-		minAvailable int
+		minAvailable int32
 	}
 	pdbsToAdd := []pdbInfo{
 		{label: "kube-dns", minAvailable: 1},

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -898,7 +898,7 @@ func execHandler(cmd []string) v1.ProbeHandler {
 	}
 }
 
-func httpGetHandler(path string, port int) v1.ProbeHandler {
+func httpGetHandler(path string, port int32) v1.ProbeHandler {
 	return v1.ProbeHandler{
 		HTTPGet: &v1.HTTPGetAction{
 			Path: path,
@@ -907,7 +907,7 @@ func httpGetHandler(path string, port int) v1.ProbeHandler {
 	}
 }
 
-func tcpSocketHandler(port int) v1.ProbeHandler {
+func tcpSocketHandler(port int32) v1.ProbeHandler {
 	return v1.ProbeHandler{
 		TCPSocket: &v1.TCPSocketAction{
 			Port: intstr.FromInt(port),

--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -120,7 +120,7 @@ func SubstituteImageName(content string) string {
 	return contentWithImageName.String()
 }
 
-func svcByName(name string, port int) *v1.Service {
+func svcByName(name string, port int32) *v1.Service {
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -131,7 +131,7 @@ func svcByName(name string, port int) *v1.Service {
 				"name": name,
 			},
 			Ports: []v1.ServicePort{{
-				Port:       int32(port),
+				Port:       port,
 				TargetPort: intstr.FromInt(port),
 			}},
 		},

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -576,7 +576,7 @@ func (rc *ResourceConsumer) CleanUp(ctx context.Context) {
 	}
 }
 
-func createService(ctx context.Context, c clientset.Interface, name, ns string, annotations, selectors map[string]string, port int32, targetPort int) (*v1.Service, error) {
+func createService(ctx context.Context, c clientset.Interface, name, ns string, annotations, selectors map[string]string, port, targetPort int32) (*v1.Service, error) {
 	return c.CoreV1().Services(ns).Create(ctx, &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,

--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -688,8 +688,8 @@ func (config *NetworkingTestConfig) createNodePortServiceSpec(svcName string, se
 		Spec: v1.ServiceSpec{
 			Type: v1.ServiceTypeNodePort,
 			Ports: []v1.ServicePort{
-				{Port: ClusterHTTPPort, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(EndpointHTTPPort)},
-				{Port: ClusterUDPPort, Name: "udp", Protocol: v1.ProtocolUDP, TargetPort: intstr.FromInt(EndpointUDPPort)},
+				{Port: ClusterHTTPPort, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(int32(EndpointHTTPPort))},
+				{Port: ClusterUDPPort, Name: "udp", Protocol: v1.ProtocolUDP, TargetPort: intstr.FromInt(int32(EndpointUDPPort))},
 			},
 			Selector:        selector,
 			SessionAffinity: sessionAffinity,
@@ -697,7 +697,7 @@ func (config *NetworkingTestConfig) createNodePortServiceSpec(svcName string, se
 	}
 
 	if config.SCTPEnabled {
-		res.Spec.Ports = append(res.Spec.Ports, v1.ServicePort{Port: ClusterSCTPPort, Name: "sctp", Protocol: v1.ProtocolSCTP, TargetPort: intstr.FromInt(EndpointSCTPPort)})
+		res.Spec.Ports = append(res.Spec.Ports, v1.ServicePort{Port: ClusterSCTPPort, Name: "sctp", Protocol: v1.ProtocolSCTP, TargetPort: intstr.FromInt(int32(EndpointSCTPPort))})
 	}
 	if config.DualStackEnabled {
 		requireDual := v1.IPFamilyPolicyRequireDualStack

--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -716,7 +716,7 @@ func (j *TestJig) CreatePDB(ctx context.Context, rc *v1.ReplicationController) (
 // this j, but does not actually create the PDB.  The default PDB specifies a
 // MinAvailable of N-1 and matches the pods created by the RC.
 func (j *TestJig) newPDBTemplate(rc *v1.ReplicationController) *policyv1.PodDisruptionBudget {
-	minAvailable := intstr.FromInt(int(*rc.Spec.Replicas) - 1)
+	minAvailable := intstr.FromInt(*rc.Spec.Replicas - 1)
 
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/framework/service/resource.go
+++ b/test/e2e/framework/service/resource.go
@@ -120,7 +120,7 @@ func GetServiceLoadBalancerPropagationTimeout(ctx context.Context, cs clientset.
 }
 
 // CreateServiceForSimpleAppWithPods is a convenience wrapper to create a service and its matching pods all at once.
-func CreateServiceForSimpleAppWithPods(ctx context.Context, c clientset.Interface, contPort int, svcPort int, namespace, appName string, podSpec func(n v1.Node) v1.PodSpec, count int, block bool) (*v1.Service, error) {
+func CreateServiceForSimpleAppWithPods(ctx context.Context, c clientset.Interface, contPort, svcPort int32, namespace, appName string, podSpec func(n v1.Node) v1.PodSpec, count int, block bool) (*v1.Service, error) {
 	var err error
 	theService := CreateServiceForSimpleApp(ctx, c, contPort, svcPort, namespace, appName)
 	e2enode.CreatePodsPerNodeForSimpleApp(ctx, c, namespace, appName, podSpec, count)
@@ -131,7 +131,7 @@ func CreateServiceForSimpleAppWithPods(ctx context.Context, c clientset.Interfac
 }
 
 // CreateServiceForSimpleApp returns a service that selects/exposes pods (send -1 ports if no exposure needed) with an app label.
-func CreateServiceForSimpleApp(ctx context.Context, c clientset.Interface, contPort, svcPort int, namespace, appName string) *v1.Service {
+func CreateServiceForSimpleApp(ctx context.Context, c clientset.Interface, contPort, svcPort int32, namespace, appName string) *v1.Service {
 	if appName == "" {
 		panic(fmt.Sprintf("no app name provided"))
 	}
@@ -147,7 +147,7 @@ func CreateServiceForSimpleApp(ctx context.Context, c clientset.Interface, contP
 		}
 		return []v1.ServicePort{{
 			Protocol:   v1.ProtocolTCP,
-			Port:       int32(svcPort),
+			Port:       svcPort,
 			TargetPort: intstr.FromInt(contPort),
 		}}
 	}

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -196,7 +196,7 @@ func (t *dnsTestCommon) restoreDNSConfigMap(ctx context.Context, configMapData m
 
 func (t *dnsTestCommon) createUtilPodLabel(ctx context.Context, baseName string) {
 	// Actual port # doesn't matter, just needs to exist.
-	const servicePort = 10101
+	const servicePort = int32(10101)
 	podName := fmt.Sprintf("%s-%s", baseName, string(uuid.NewUUID()))
 	ports := []v1.ContainerPort{{ContainerPort: servicePort, Protocol: v1.ProtocolTCP}}
 	t.utilPod = e2epod.NewAgnhostPod(t.f.Namespace.Name, podName, nil, nil, ports)

--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -1425,7 +1425,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 				// Change service port to avoid collision with opened hostPorts
 				// in other tests that run in parallel.
 				if len(svc.Spec.Ports) != 0 {
-					svc.Spec.Ports[0].TargetPort = intstr.FromInt(int(svc.Spec.Ports[0].Port))
+					svc.Spec.Ports[0].TargetPort = intstr.FromInt(svc.Spec.Ports[0].Port)
 					svc.Spec.Ports[0].Port = 8081
 				}
 

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1764,7 +1764,7 @@ var _ = common.SIGDescribe("Services", func() {
 
 		t.Name = "slow-terminating-unready-pod"
 		t.Image = imageutils.GetE2EImage(imageutils.Agnhost)
-		port := 80
+		port := int32(80)
 		terminateSeconds := int64(100)
 
 		service := &v1.Service{
@@ -1776,7 +1776,7 @@ var _ = common.SIGDescribe("Services", func() {
 				Selector: t.Labels,
 				Ports: []v1.ServicePort{{
 					Name:       "http",
-					Port:       int32(port),
+					Port:       port,
 					TargetPort: intstr.FromInt(port),
 				}},
 				PublishNotReadyAddresses: true,
@@ -1786,7 +1786,7 @@ var _ = common.SIGDescribe("Services", func() {
 			Args:  []string{"netexec", fmt.Sprintf("--http-port=%d", port)},
 			Name:  t.Name,
 			Image: t.Image,
-			Ports: []v1.ContainerPort{{ContainerPort: int32(port), Protocol: v1.ProtocolTCP}},
+			Ports: []v1.ContainerPort{{ContainerPort: port, Protocol: v1.ProtocolTCP}},
 			ReadinessProbe: &v1.Probe{
 				ProbeHandler: v1.ProbeHandler{
 					Exec: &v1.ExecAction{
@@ -2629,7 +2629,7 @@ var _ = common.SIGDescribe("Services", func() {
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 		svc, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
 			svc.Spec.Ports = []v1.ServicePort{
-				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(endpointPort)},
+				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(int32(endpointPort))},
 			}
 			svc.Spec.InternalTrafficPolicy = &local
 		})
@@ -3354,7 +3354,7 @@ var _ = common.SIGDescribe("Services", func() {
 				Ports: []v1.ServicePort{{
 					Name:       "http",
 					Protocol:   v1.ProtocolTCP,
-					Port:       int32(80),
+					Port:       80,
 					TargetPort: intstr.FromInt(80),
 				}},
 			},
@@ -3564,7 +3564,7 @@ var _ = common.SIGDescribe("Services", func() {
 		testServices := []struct {
 			name  string
 			label map[string]string
-			port  int
+			port  int32
 		}{
 			{
 				name:  "e2e-svc-a-" + utilrand.String(5),
@@ -3627,7 +3627,7 @@ var _ = common.SIGDescribe("Services", func() {
 		serviceName := "multiprotocol-test"
 		testLabels := map[string]string{"app": "multiport"}
 		ns := f.Namespace.Name
-		containerPort := 80
+		containerPort := int32(80)
 
 		svcTCPport := v1.ServicePort{
 			Name:       "tcp-port",
@@ -3660,16 +3660,16 @@ var _ = common.SIGDescribe("Services", func() {
 
 		containerPorts := []v1.ContainerPort{{
 			Name:          svcTCPport.Name,
-			ContainerPort: int32(containerPort),
+			ContainerPort: containerPort,
 			Protocol:      v1.ProtocolTCP,
 		}, {
 			Name:          svcUDPport.Name,
-			ContainerPort: int32(containerPort),
+			ContainerPort: containerPort,
 			Protocol:      v1.ProtocolUDP,
 		}}
 		podname1 := "pod1"
 		ginkgo.By("creating pod " + podname1 + " in namespace " + ns)
-		createPodOrFail(ctx, f, ns, podname1, testLabels, containerPorts, "netexec", "--http-port", strconv.Itoa(containerPort), "--udp-port", strconv.Itoa(containerPort))
+		createPodOrFail(ctx, f, ns, podname1, testLabels, containerPorts, "netexec", "--http-port", strconv.Itoa(int(containerPort)), "--udp-port", strconv.Itoa(int(containerPort)))
 		validateEndpointsPortsWithProtocolsOrFail(cs, ns, serviceName, fullPortsByPodName{podname1: containerPorts})
 
 		ginkgo.By("Checking if the Service forwards traffic to the TCP and UDP port")

--- a/test/e2e/network/topology_hints.go
+++ b/test/e2e/network/topology_hints.go
@@ -53,7 +53,7 @@ var _ = common.SIGDescribe("[Feature:Topology Hints]", func() {
 	})
 
 	ginkgo.It("should distribute endpoints evenly", func(ctx context.Context) {
-		portNum := 9376
+		portNum := int32(9376)
 		thLabels := map[string]string{labelKey: clientLabelValue}
 		img := imageutils.GetE2EImage(imageutils.Agnhost)
 		ports := []v1.ContainerPort{{ContainerPort: int32(portNum)}}

--- a/test/e2e/network/util.go
+++ b/test/e2e/network/util.go
@@ -194,7 +194,7 @@ func createSecondNodePortService(ctx context.Context, f *framework.Framework, co
 					Port:       e2enetwork.ClusterHTTPPort,
 					Name:       "http",
 					Protocol:   v1.ProtocolTCP,
-					TargetPort: intstr.FromInt(e2enetwork.EndpointHTTPPort),
+					TargetPort: intstr.FromInt(int32(e2enetwork.EndpointHTTPPort)),
 				},
 			},
 			Selector: config.NodePortService.Spec.Selector,

--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -211,7 +211,7 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 func createGitServer(ctx context.Context, f *framework.Framework) (gitURL string, gitRepo string, cleanup func()) {
 	var err error
 	gitServerPodName := "git-server-" + string(uuid.NewUUID())
-	containerPort := 8000
+	containerPort := int32(8000)
 
 	labels := map[string]string{"name": gitServerPodName}
 

--- a/test/integration/deployment/util.go
+++ b/test/integration/deployment/util.go
@@ -186,7 +186,7 @@ func markPodReady(c clientset.Interface, ns string, pod *v1.Pod) error {
 	return err
 }
 
-func intOrStrP(num int) *intstr.IntOrString {
+func intOrStrP(num int32) *intstr.IntOrString {
 	intstr := intstr.FromInt(num)
 	return &intstr
 }

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -1188,7 +1188,7 @@ func TestNominatedNodeCleanUp(t *testing.T) {
 	}
 }
 
-func mkMinAvailablePDB(name, namespace string, uid types.UID, minAvailable int, matchLabels map[string]string) *policy.PodDisruptionBudget {
+func mkMinAvailablePDB(name, namespace string, uid types.UID, minAvailable int32, matchLabels map[string]string) *policy.PodDisruptionBudget {
 	intMinAvailable := intstr.FromInt(minAvailable)
 	return &policy.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This is based on comments on #117631.

Instead of moving the conversion to `FromInt32()`, this changes `FromInt()` itself to take an `int32` directly. `FromInt32()` is deprecated in favour of `FromInt()`, but existing uses aren't touched.

`Parse()` is modified to use `ParseInt()` instead of `Atoi()`, applying the 32-bit size limit directly. (Note however that `Atoi()` has a fast path, so this will be slower in many cases.)

`IntValue()` should arguably be changed to return an `int32`, so that the output matches the input. As it stands, `intstr.FromInt(foo).IntValue()` returns a value that can’t be assigned directly to `foo`...

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
