### PR TITLE
Remove KUBECTL_EXPLAIN_OPENAPIV3 environment variable

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
@@ -76,8 +76,7 @@ type ExplainOptions struct {
 	Mapper meta.RESTMapper
 	Schema openapi.Resources
 
-	// Name of the template to use with the openapiv3 template renderer. If
-	// `EnableOpenAPIV3` is disabled, this does nothing
+	// Name of the template to use with the openapiv3 template renderer.
 	OutputFormat string
 
 	// Client capable of fetching openapi documents from the user's cluster

--- a/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain_test.go
@@ -185,9 +185,7 @@ func TestExplainOpenAPIV3(t *testing.T) {
 	}
 	cases = append(cases, explainV2Cases...)
 
-	cmdtesting.WithAlphaEnvs([]cmdutil.FeatureGate{cmdutil.ExplainOpenapiV3}, t, func(t *testing.T) {
-		runExplainTestCases(t, cases)
-	})
+	runExplainTestCases(t, cases)
 }
 
 func runExplainTestCases(t *testing.T, cases []explainTestCase) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -426,7 +426,6 @@ type FeatureGate string
 
 const (
 	ApplySet              FeatureGate = "KUBECTL_APPLYSET"
-	ExplainOpenapiV3      FeatureGate = "KUBECTL_EXPLAIN_OPENAPIV3"
 	CmdPluginAsSubcommand FeatureGate = "KUBECTL_ENABLE_CMD_SHADOW"
 	InteractiveDelete     FeatureGate = "KUBECTL_INTERACTIVE_DELETE"
 )


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Since explain openapiv3 has been moved to beta already with this https://github.com/kubernetes/kubernetes/pull/116390,  there is no point to having this environment variable.

This PR removes it.

#### Does this PR introduce a user-facing change?
```release-note
Remove KUBECTL_EXPLAIN_OPENAPIV3 which is already redundant
```
