### PR TITLE
Fix failing unit tests on systems with cgroup v2 unified mode.

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -41,6 +41,8 @@ import (
 
 var defaultPageSize = int64(os.Getpagesize())
 
+var isCgroup2UnifiedMode = libcontainercgroups.IsCgroup2UnifiedMode
+
 // applyPlatformSpecificContainerConfig applies platform specific configurations to runtimeapi.ContainerConfig.
 func (m *kubeGenericRuntimeManager) applyPlatformSpecificContainerConfig(config *runtimeapi.ContainerConfig, container *v1.Container, pod *v1.Pod, uid *int64, username string, nsTarget *kubecontainer.ContainerID) error {
 	enforceMemoryQoS := false
@@ -171,7 +173,7 @@ func (m *kubeGenericRuntimeManager) generateContainerResources(pod *v1.Pod, cont
 	enforceMemoryQoS := false
 	// Set memory.min and memory.high if MemoryQoS enabled with cgroups v2
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) &&
-		libcontainercgroups.IsCgroup2UnifiedMode() {
+		isCgroup2UnifiedMode() {
 		enforceMemoryQoS = true
 	}
 	return &runtimeapi.ContainerResources{
@@ -216,7 +218,7 @@ func (m *kubeGenericRuntimeManager) calculateLinuxResources(cpuRequest, cpuLimit
 	}
 
 	// runc requires cgroupv2 for unified mode
-	if libcontainercgroups.IsCgroup2UnifiedMode() {
+	if isCgroup2UnifiedMode() {
 		resources.Unified = map[string]string{
 			// Ask the kernel to kill all processes in the container cgroup in case of OOM.
 			// See memory.oom.group in https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html for


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
Since https://github.com/kubernetes/kubernetes/commit/4e20a8f52bcce054459f4df537c12e889a02b86c, some of the kuberuntime unit tests fail when run on systems that have cgroup v2 unified mode (Ubuntu 22.04 in my case).

The test failures are not happening in the build pipeline, only when you are running them locally on a system with cgroup v2 unified mode (`stat -fc %T /sys/fs/cgroup` returns `cgroup2fs` )

This PR updates the failing unit tests to mock `libcontainercgroups.IsCgroup2UnifiedMode` so they can pass regardless of whether cgroup v2 unified mode is actually enabled on the system where the unit tests are running.  It also enables the ability to write unit test cases which check the output in both scenarios (v1 and v2) of which I added a couple of new test cases.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

While I did add a couple of new unit test cases for cgroup v2, this PR is not intended to be comprehensive testing for cgroup v2 functionality.  My goal is to enable the existing unit tests to pass.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
