### PR TITLE
allow api-approvers to approve directories touched by generation

### DIFF
--- a/pkg/generated/openapi/OWNERS
+++ b/pkg/generated/openapi/OWNERS
@@ -2,6 +2,8 @@ approvers:
   - sttts
   - roycaihw
   - liggitt
+  # APIs frequently hit this directory for zz_generate.openapi.go
+  - api-approvers
 reviewers:
   - sttts
   - roycaihw


### PR DESCRIPTION
zz_generated.openapi.go is in this directory.

/assign @liggitt

```release-note
NONE
```