### PR TITLE
matchCondition metrics for beta graduation

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -54,6 +54,8 @@ var (
 type ObserverFunc func(ctx context.Context, elapsed time.Duration, rejected bool, attr admission.Attributes, stepType string, extraLabels ...string)
 
 const (
+	kindWebhook  = "webhook"
+	kindPolicy   = "policy"
 	stepValidate = "validate"
 	stepAdmit    = "admit"
 )
@@ -112,13 +114,15 @@ func (p pluginHandlerWithMetrics) Validate(ctx context.Context, a admission.Attr
 
 // AdmissionMetrics instruments admission with prometheus metrics.
 type AdmissionMetrics struct {
-	step                     *metricSet
-	controller               *metricSet
-	webhook                  *metricSet
-	webhookRejection         *metrics.CounterVec
-	webhookFailOpen          *metrics.CounterVec
-	webhookRequest           *metrics.CounterVec
-	matchConditionEvalErrors *metrics.CounterVec
+	step                            *metricSet
+	controller                      *metricSet
+	webhook                         *metricSet
+	webhookRejection                *metrics.CounterVec
+	webhookFailOpen                 *metrics.CounterVec
+	webhookRequest                  *metrics.CounterVec
+	matchConditionEvalErrors        *metrics.CounterVec
+	matchConditionExclusions        *metrics.CounterVec
+	matchConditionEvaluationSeconds *metricSet
 }
 
 // newAdmissionMetrics create a new AdmissionMetrics, configured with default metric names.
@@ -222,20 +226,47 @@ func newAdmissionMetrics() *AdmissionMetrics {
 		&metrics.CounterOpts{
 			Namespace:      namespace,
 			Subsystem:      subsystem,
-			Name:           "admission_match_condition_evaluation_errors_total",
-			Help:           "Admission match condition evaluation errors count, identified by name of resource containing the match condition and broken out for each admission type (validating or mutating).",
+			Name:           "match_condition_evaluation_errors_total",
+			Help:           "Admission match condition evaluation errors count, identified by name of resource containing the match condition and broken out for each kind containing matchConditions (webhook or policy), operation and admission type (validate or admit).",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{"name", "type"})
+		[]string{"name", "kind", "type", "operation"})
+
+	matchConditionExclusions := metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "match_condition_exclusions_total",
+			Help:           "Admission match condition evaluation exclusions count, identified by name of resource containing the match condition and broken out for each kind containing matchConditions (webhook or policy), operation and admission type (validate or admit).",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"name", "kind", "type", "operation"})
+
+	matchConditionEvaluationSeconds := &metricSet{
+		latencies: metrics.NewHistogramVec(
+			&metrics.HistogramOpts{
+				Namespace:      namespace,
+				Subsystem:      subsystem,
+				Name:           "match_condition_evaluation_seconds",
+				Help:           "Admission match condition evaluation time in seconds, identified by name and broken out for each kind containing matchConditions (webhook or policy), operation and type (validate or admit).",
+				Buckets:        []float64{0.005, 0.025, 0.1, 0.5, 1.0, 2.5},
+				StabilityLevel: metrics.ALPHA,
+			},
+			[]string{"name", "kind", "type", "operation"},
+		),
+		latenciesSummary: nil,
+	}
 
 	step.mustRegister()
 	controller.mustRegister()
 	webhook.mustRegister()
+	matchConditionEvaluationSeconds.mustRegister()
 	legacyregistry.MustRegister(webhookRejection)
 	legacyregistry.MustRegister(webhookFailOpen)
 	legacyregistry.MustRegister(webhookRequest)
 	legacyregistry.MustRegister(matchConditionEvalError)
-	return &AdmissionMetrics{step: step, controller: controller, webhook: webhook, webhookRejection: webhookRejection, webhookFailOpen: webhookFailOpen, webhookRequest: webhookRequest, matchConditionEvalErrors: matchConditionEvalError}
+	legacyregistry.MustRegister(matchConditionExclusions)
+	return &AdmissionMetrics{step: step, controller: controller, webhook: webhook, webhookRejection: webhookRejection, webhookFailOpen: webhookFailOpen, webhookRequest: webhookRequest, matchConditionEvalErrors: matchConditionEvalError, matchConditionExclusions: matchConditionExclusions, matchConditionEvaluationSeconds: matchConditionEvaluationSeconds}
 }
 
 func (m *AdmissionMetrics) reset() {
@@ -280,8 +311,18 @@ func (m *AdmissionMetrics) ObserveWebhookFailOpen(ctx context.Context, name, ste
 }
 
 // ObserveMatchConditionEvalError records validating or mutating webhook that are not called due to match conditions
-func (m *AdmissionMetrics) ObserveMatchConditionEvalError(ctx context.Context, name, stepType string) {
-	m.matchConditionEvalErrors.WithContext(ctx).WithLabelValues(name, stepType).Inc()
+func (m *AdmissionMetrics) ObserveMatchConditionEvalError(ctx context.Context, name, kind, stepType, operation string) {
+	m.matchConditionEvalErrors.WithContext(ctx).WithLabelValues(name, kind, stepType, operation).Inc()
+}
+
+// ObserveMatchConditionExclusion records validating or mutating webhook that are not called due to match conditions
+func (m *AdmissionMetrics) ObserveMatchConditionExclusion(ctx context.Context, name, kind, stepType, operation string) {
+	m.matchConditionExclusions.WithContext(ctx).WithLabelValues(name, kind, stepType, operation).Inc()
+}
+
+// ObserveMatchConditionEvaluationTime records duration of match condition evaluation process.
+func (m *AdmissionMetrics) ObserveMatchConditionEvaluationTime(ctx context.Context, elapsed time.Duration, name, kind, stepType, operation string) {
+	m.matchConditionEvaluationSeconds.observe(ctx, elapsed, name, kind, stepType, operation)
 }
 
 type metricSet struct {

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -249,7 +249,7 @@ func newAdmissionMetrics() *AdmissionMetrics {
 				Subsystem:      subsystem,
 				Name:           "match_condition_evaluation_seconds",
 				Help:           "Admission match condition evaluation time in seconds, identified by name and broken out for each kind containing matchConditions (webhook or policy), operation and type (validate or admit).",
-				Buckets:        []float64{0.005, 0.025, 0.1, 0.5, 1.0, 2.5},
+				Buckets:        []float64{0.001, 0.005, 0.01, 0.025, 0.1, 0.2, 0.25},
 				StabilityLevel: metrics.ALPHA,
 			},
 			[]string{"name", "kind", "type", "operation"},

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
@@ -176,6 +176,121 @@ func TestObserveWebhookFailOpen(t *testing.T) {
 	expectCounterValue(t, "apiserver_admission_webhook_fail_open_count", wantLabelsCounterValidate, 1)
 }
 
+func TestObserveMatchConditionEvalError(t *testing.T) {
+	defer Metrics.reset()
+	defer legacyregistry.Reset()
+	Metrics.ObserveMatchConditionEvalError(context.TODO(), "x", kindWebhook, stepAdmit, string(admission.Create))
+	Metrics.ObserveMatchConditionEvalError(context.TODO(), "x", kindWebhook, stepValidate, string(admission.Create))
+	Metrics.ObserveMatchConditionEvalError(context.TODO(), "x", kindPolicy, stepAdmit, string(admission.Create))
+	Metrics.ObserveMatchConditionEvalError(context.TODO(), "x", kindPolicy, stepValidate, string(admission.Create))
+	wantLabelsCounterPolicyAdmit := map[string]string{
+		"name":      "x",
+		"type":      "admit",
+		"kind":      "policy",
+		"operation": string(admission.Create),
+	}
+	wantLabelsCounterPolicyValidate := map[string]string{
+		"name":      "x",
+		"type":      "validate",
+		"kind":      "policy",
+		"operation": string(admission.Create),
+	}
+	wantLabelsCounterWebhookAdmit := map[string]string{
+		"name":      "x",
+		"type":      "admit",
+		"kind":      "webhook",
+		"operation": string(admission.Create),
+	}
+	wantLabelsCounterWebhookValidate := map[string]string{
+		"name":      "x",
+		"type":      "validate",
+		"kind":      "webhook",
+		"operation": string(admission.Create),
+	}
+	expectCounterValue(t, "apiserver_admission_match_condition_evaluation_errors_total", wantLabelsCounterPolicyAdmit, 1)
+	expectCounterValue(t, "apiserver_admission_match_condition_evaluation_errors_total", wantLabelsCounterPolicyValidate, 1)
+	expectCounterValue(t, "apiserver_admission_match_condition_evaluation_errors_total", wantLabelsCounterWebhookAdmit, 1)
+	expectCounterValue(t, "apiserver_admission_match_condition_evaluation_errors_total", wantLabelsCounterWebhookValidate, 1)
+}
+
+func TestObserveMatchConditionExclusion(t *testing.T) {
+	defer Metrics.reset()
+	defer legacyregistry.Reset()
+	Metrics.ObserveMatchConditionExclusion(context.TODO(), "x", kindWebhook, stepAdmit, string(admission.Create))
+	Metrics.ObserveMatchConditionExclusion(context.TODO(), "x", kindWebhook, stepValidate, string(admission.Create))
+	Metrics.ObserveMatchConditionExclusion(context.TODO(), "x", kindPolicy, stepAdmit, string(admission.Create))
+	Metrics.ObserveMatchConditionExclusion(context.TODO(), "x", kindPolicy, stepValidate, string(admission.Create))
+	wantLabelsCounterPolicyAdmit := map[string]string{
+		"name":      "x",
+		"type":      "admit",
+		"kind":      "policy",
+		"operation": string(admission.Create),
+	}
+	wantLabelsCounterPolicyValidate := map[string]string{
+		"name":      "x",
+		"type":      "validate",
+		"kind":      "policy",
+		"operation": string(admission.Create),
+	}
+	wantLabelsCounterWebhookAdmit := map[string]string{
+		"name":      "x",
+		"type":      "admit",
+		"kind":      "webhook",
+		"operation": string(admission.Create),
+	}
+	wantLabelsCounterWebhookValidate := map[string]string{
+		"name":      "x",
+		"type":      "validate",
+		"kind":      "webhook",
+		"operation": string(admission.Create),
+	}
+	metrics, _ := legacyregistry.DefaultGatherer.Gather()
+	for _, mf := range metrics {
+		t.Logf("%v", *mf.Name)
+	}
+	expectCounterValue(t, "apiserver_admission_match_condition_exclusions_total", wantLabelsCounterPolicyAdmit, 1)
+	expectCounterValue(t, "apiserver_admission_match_condition_exclusions_total", wantLabelsCounterPolicyValidate, 1)
+	expectCounterValue(t, "apiserver_admission_match_condition_exclusions_total", wantLabelsCounterWebhookAdmit, 1)
+	expectCounterValue(t, "apiserver_admission_match_condition_exclusions_total", wantLabelsCounterWebhookValidate, 1)
+}
+
+func TestObserveMatchConditionEvaluationTime(t *testing.T) {
+	defer Metrics.reset()
+	defer legacyregistry.Reset()
+	Metrics.ObserveMatchConditionEvaluationTime(context.TODO(), 2*time.Second, "x", kindPolicy, stepAdmit, string(admission.Create))
+	Metrics.ObserveMatchConditionEvaluationTime(context.TODO(), 2*time.Second, "x", kindPolicy, stepValidate, string(admission.Create))
+	Metrics.ObserveMatchConditionEvaluationTime(context.TODO(), 2*time.Second, "x", kindWebhook, stepAdmit, string(admission.Create))
+	Metrics.ObserveMatchConditionEvaluationTime(context.TODO(), 2*time.Second, "x", kindWebhook, stepValidate, string(admission.Create))
+	wantLabelsCounterPolicyAdmit := map[string]string{
+		"name":      "x",
+		"type":      "admit",
+		"kind":      "policy",
+		"operation": string(admission.Create),
+	}
+	wantLabelsCounterPolicyValidate := map[string]string{
+		"name":      "x",
+		"type":      "validate",
+		"kind":      "policy",
+		"operation": string(admission.Create),
+	}
+	wantLabelsCounterWebhookAdmit := map[string]string{
+		"name":      "x",
+		"type":      "admit",
+		"kind":      "webhook",
+		"operation": string(admission.Create),
+	}
+	wantLabelsCounterWebhookValidate := map[string]string{
+		"name":      "x",
+		"type":      "validate",
+		"kind":      "webhook",
+		"operation": string(admission.Create),
+	}
+	expectHistogramCountTotal(t, "apiserver_admission_match_condition_evaluation_seconds", wantLabelsCounterPolicyAdmit, 1)
+	expectHistogramCountTotal(t, "apiserver_admission_match_condition_evaluation_seconds", wantLabelsCounterPolicyValidate, 1)
+	expectHistogramCountTotal(t, "apiserver_admission_match_condition_evaluation_seconds", wantLabelsCounterWebhookAdmit, 1)
+	expectHistogramCountTotal(t, "apiserver_admission_match_condition_evaluation_seconds", wantLabelsCounterWebhookValidate, 1)
+}
+
 func TestWithMetrics(t *testing.T) {
 	defer Metrics.reset()
 	defer legacyregistry.Reset()

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/controller_reconcile.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/controller_reconcile.go
@@ -481,7 +481,7 @@ func (c *policyController) latestPolicyData() []policyData {
 					for i := range matchConditions {
 						matchExpressionAccessors[i] = (*matchconditions.MatchCondition)(&matchConditions[i])
 					}
-					matcher = matchconditions.NewMatcher(filterCompiler.Compile(matchExpressionAccessors, optionalVars, environment.StoredExpressions), failurePolicy, "validatingadmissionpolicy", definitionInfo.lastReconciledValue.Name)
+					matcher = matchconditions.NewMatcher(filterCompiler.Compile(matchExpressionAccessors, optionalVars, environment.StoredExpressions), failurePolicy, "policy", "validate", definitionInfo.lastReconciledValue.Name)
 				}
 				bindingInfo.validator = c.newValidator(
 					filterCompiler.Compile(convertv1alpha1Validations(definitionInfo.lastReconciledValue.Spec.Validations), optionalVars, environment.StoredExpressions),

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook.go
@@ -22,6 +22,7 @@ import (
 	"io"
 
 	admissionmetrics "k8s.io/apiserver/pkg/admission/metrics"
+	"k8s.io/klog/v2"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
@@ -41,7 +42,6 @@ import (
 	webhookutil "k8s.io/apiserver/pkg/util/webhook"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 )
 
 // Webhook is an abstract admission plugin with all the infrastructure to define Admit or Validate on-top.
@@ -219,7 +219,6 @@ func (a *Webhook) ShouldCallHook(ctx context.Context, h webhook.WebhookAccessor,
 	if matchObjErr != nil {
 		return nil, matchObjErr
 	}
-	//TODO: maybe this sould be before the invocations are created
 	matchConditions := h.GetMatchConditions()
 	if len(matchConditions) > 0 {
 		versionedAttr, err := v.VersionedAttribute(invocation.Kind)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions/matcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions/matcher.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/cel-go/cel"
 	celtypes "github.com/google/cel-go/common/types"
@@ -55,10 +56,11 @@ type matcher struct {
 	filter      celplugin.Filter
 	failPolicy  v1.FailurePolicyType
 	matcherType string
+	matcherKind string
 	objectName  string
 }
 
-func NewMatcher(filter celplugin.Filter, failPolicy *v1.FailurePolicyType, matcherType, objectName string) Matcher {
+func NewMatcher(filter celplugin.Filter, failPolicy *v1.FailurePolicyType, matcherKind, matcherType, objectName string) Matcher {
 	var f v1.FailurePolicyType
 	if failPolicy == nil {
 		f = v1.Fail
@@ -68,18 +70,21 @@ func NewMatcher(filter celplugin.Filter, failPolicy *v1.FailurePolicyType, match
 	return &matcher{
 		filter:      filter,
 		failPolicy:  f,
+		matcherKind: matcherKind,
 		matcherType: matcherType,
 		objectName:  objectName,
 	}
 }
 
 func (m *matcher) Match(ctx context.Context, versionedAttr *admission.VersionedAttributes, versionedParams runtime.Object, authz authorizer.Authorizer) MatchResult {
+	t := time.Now()
 	evalResults, _, err := m.filter.ForInput(ctx, versionedAttr, celplugin.CreateAdmissionRequest(versionedAttr.Attributes), celplugin.OptionalVariableBindings{
 		VersionedParams: versionedParams,
 		Authorizer:      authz,
 	}, celconfig.RuntimeCELCostBudgetMatchConditions)
 
 	if err != nil {
+		admissionmetrics.Metrics.ObserveMatchConditionEvaluationTime(ctx, time.Since(t), m.objectName, m.matcherKind, m.matcherType, string(versionedAttr.GetOperation()))
 		// filter returning error is unexpected and not an evaluation error so not incrementing metric here
 		if m.failPolicy == v1.Fail {
 			return MatchResult{
@@ -104,10 +109,10 @@ func (m *matcher) Match(ctx context.Context, versionedAttr *admission.VersionedA
 		}
 		if evalResult.Error != nil {
 			errorList = append(errorList, evalResult.Error)
-			//TODO: what's the best way to handle this metric since its reused by VAP for match conditions
-			admissionmetrics.Metrics.ObserveMatchConditionEvalError(ctx, m.objectName, m.matcherType)
+			admissionmetrics.Metrics.ObserveMatchConditionEvalError(ctx, m.objectName, m.matcherKind, m.matcherType, string(versionedAttr.GetOperation()))
 		}
 		if evalResult.EvalResult == celtypes.False {
+			admissionmetrics.Metrics.ObserveMatchConditionEvaluationTime(ctx, time.Since(t), m.objectName, m.matcherKind, m.matcherType, string(versionedAttr.GetOperation()))
 			// If any condition false, skip calling webhook always
 			return MatchResult{
 				Matches:             false,
@@ -116,6 +121,7 @@ func (m *matcher) Match(ctx context.Context, versionedAttr *admission.VersionedA
 		}
 	}
 	if len(errorList) > 0 {
+		admissionmetrics.Metrics.ObserveMatchConditionEvaluationTime(ctx, time.Since(t), m.objectName, m.matcherKind, m.matcherType, string(versionedAttr.GetOperation()))
 		// If mix of true and eval errors then resort to fail policy
 		if m.failPolicy == v1.Fail {
 			// mix of true and errors with fail policy fail should fail request without calling webhook

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions/matcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/matchconditions/matcher_test.go
@@ -334,7 +334,7 @@ func TestMatch(t *testing.T) {
 			m := NewMatcher(&fakeCelFilter{
 				evaluations: tc.evaluations,
 				throwError:  tc.throwError,
-			}, tc.failPolicy, "test", "testhook")
+			}, tc.failPolicy, "webhook", "test", "testhook")
 			ctx := context.TODO()
 			matchResult := m.Match(ctx, fakeVersionedAttr, nil, nil)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Adds metrics for beta graduation of https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3716-admission-webhook-match-conditions 

#### Special notes for your reviewer:

matcher is shared by validatingadmissionpolicies and webhooks so it has to handle emitting both metrics, chose to use label to determine if it's policy or webhook.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds apiserver_admission_match_condition_evaluation_seconds and apiserver_admission_match_condition_exclusions_total metrics
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: [kep-3716](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3716-admission-webhook-match-conditions
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP-3716]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3716-admission-webhook-match-conditions
```
