### PR TITLE
Fail Kubelet at startup if swap is configured with cgroup v1

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -224,6 +224,8 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 				return nil, fmt.Errorf("running with swap on is not supported, please disable swap! or set --fail-swap-on flag to false. /proc/swaps contained: %v", swapLines)
 			}
 		}
+	} else if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.NodeSwap) && !cgroups.IsCgroup2UnifiedMode() {
+		return nil, fmt.Errorf("running swap with cgroups v1 is not supported. please either disable %s feature gate", kubefeatures.NodeSwap)
 	}
 
 	var internalCapacity = v1.ResourceList{}

--- a/test/e2e_node/swap_test.go
+++ b/test/e2e_node/swap_test.go
@@ -53,15 +53,14 @@ var _ = SIGDescribe("Swap [NodeConformance][LinuxOnly]", func() {
 		pod = runPodAndWaitUntilScheduled(f, pod)
 
 		isCgroupV2 := isPodCgroupV2(f, pod)
-		isLimitedSwap := isLimitedSwap(f, pod)
 
-		if !isSwapFeatureGateEnabled() || !isCgroupV2 || (isLimitedSwap && (qosClass != v1.PodQOSBurstable || memoryRequestEqualLimit)) {
-			ginkgo.By(fmt.Sprintf("Expecting no swap. feature gate on? %t isCgroupV2? %t is QoS burstable? %t", isSwapFeatureGateEnabled(), isCgroupV2, qosClass == v1.PodQOSBurstable))
+		if !isSwapFeatureGateEnabled() || !isCgroupV2 || (isLimitedSwap() && (qosClass != v1.PodQOSBurstable || memoryRequestEqualLimit)) {
+			ginkgo.By(fmt.Sprintf("Expecting no swap. feature gate on? %t isCgroupV2? %t is QoS burstable? %t is limited swap? %t", isSwapFeatureGateEnabled(), isCgroupV2, qosClass == v1.PodQOSBurstable, isLimitedSwap()))
 			expectNoSwap(f, pod, isCgroupV2)
 			return
 		}
 
-		if !isLimitedSwap {
+		if !isLimitedSwap() {
 			ginkgo.By("expecting unlimited swap")
 			expectUnlimitedSwap(f, pod, isCgroupV2)
 			return
@@ -246,7 +245,7 @@ func calcSwapForBurstablePod(f *framework.Framework, pod *v1.Pod) int64 {
 	return int64(swapAllocation)
 }
 
-func isLimitedSwap(f *framework.Framework, pod *v1.Pod) bool {
+func isLimitedSwap() bool {
 	kubeletCfg, err := getCurrentKubeletConfig(context.Background())
 	framework.ExpectNoError(err, "cannot get kubelet config")
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:
Follow-up to https://github.com/kubernetes/kubernetes/pull/118764 and https://github.com/kubernetes/kubernetes/issues/119726.

Since swap is no longer supported for cgroup v1, fail kubelet if it starts with swap and cgroup v1. This way, in future versions of k8s, we could turn NodeSwap on by default.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fail Kubelet at startup if swap is configured with cgroup v1
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md
```
