### PR TITLE
Skip unit tests that assume the system does not use cgroup v2.

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux_test.go
@@ -233,6 +233,10 @@ func TestGenerateLinuxContainerConfigResources(t *testing.T) {
 }
 
 func TestCalculateLinuxResources(t *testing.T) {
+	if libcontainercgroups.IsCgroup2UnifiedMode() {
+		t.Skip("This test is skipped when running on systems using cgroup v2 unified mode")
+	}
+
 	_, _, m, err := createTestRuntimeManager()
 	m.cpuCFSQuota = true
 
@@ -725,6 +729,10 @@ func TestGenerateLinuxContainerConfigSwap(t *testing.T) {
 }
 
 func TestGenerateLinuxContainerResources(t *testing.T) {
+	if libcontainercgroups.IsCgroup2UnifiedMode() {
+		t.Skip("This test is skipped when running on systems using cgroup v2 unified mode")
+	}
+
 	_, _, m, err := createTestRuntimeManager()
 	assert.NoError(t, err)
 	m.machineInfo.MemoryCapacity = 17179860387 // 16GB

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux_test.go
@@ -22,6 +22,7 @@ package kuberuntime
 import (
 	"testing"
 
+	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -31,6 +32,10 @@ import (
 )
 
 func TestApplySandboxResources(t *testing.T) {
+	if libcontainercgroups.IsCgroup2UnifiedMode() {
+		t.Skip("This test is skipped when running on systems using cgroup v2 unified mode")
+	}
+
 	_, _, m, err := createTestRuntimeManager()
 	m.cpuCFSQuota = true
 


### PR DESCRIPTION

#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
Since https://github.com/kubernetes/kubernetes/commit/4e20a8f52bcce054459f4df537c12e889a02b86c, some of the kuberuntime unit tests fail when run on systems that have cgroup v2 unified mode (Ubuntu 22.04 in my case).

The test failures are not happening in the build pipeline, only when you are running them locally on a system with cgroup v2 unified mode (`stat -fc %T /sys/fs/cgroup` returns `cgroup2fs` )

This PR checks for cgroup v2 unified mode, and if detected, skips the tests that fail when running on a system using cgroup v2 unidified mode.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
This is an alternate solution to the problem proposed by https://github.com/kubernetes/kubernetes/pull/119292#issuecomment-1634578474

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
