### PR TITLE
Automated cherry pick of #112334: events: fix EventSeries starting count discrepancy

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -181,7 +181,7 @@ func (e *eventBroadcasterImpl) recordToSink(event *eventsv1.Event, clock clock.C
 					return nil
 				}
 				isomorphicEvent.Series = &eventsv1.EventSeries{
-					Count:            1,
+					Count:            2,
 					LastObservedTime: metav1.MicroTime{Time: clock.Now()},
 				}
 				return isomorphicEvent

--- a/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
+++ b/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
@@ -106,7 +106,7 @@ func TestEventSeriesf(t *testing.T) {
 	nonIsomorphicEvent := expectedEvent.DeepCopy()
 	nonIsomorphicEvent.Action = "stopped"
 
-	expectedEvent.Series = &eventsv1.EventSeries{Count: 1}
+	expectedEvent.Series = &eventsv1.EventSeries{Count: 2}
 	table := []struct {
 		regarding    k8sruntime.Object
 		related      k8sruntime.Object

--- a/test/integration/events/events_test.go
+++ b/test/integration/events/events_test.go
@@ -18,6 +18,7 @@ package events
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -91,4 +92,63 @@ func TestEventCompatibility(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
+}
+
+func TestEventSeries(t *testing.T) {
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--disable-admission-plugins", "ServiceAccount"}, framework.SharedEtcd())
+	defer result.TearDownFn()
+
+	client := clientset.NewForConfigOrDie(result.ClientConfig)
+
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+			UID:       "bar",
+		},
+	}
+
+	regarding, err := ref.GetReference(scheme.Scheme, testPod)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	related, err := ref.GetPartialReference(scheme.Scheme, testPod, ".spec.containers[0]")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	broadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client.EventsV1()})
+	defer broadcaster.Shutdown()
+	recorder := broadcaster.NewRecorder(scheme.Scheme, "k8s.io/kube-scheduler")
+	broadcaster.StartRecordingToSink(stopCh)
+	recorder.Eventf(regarding, related, v1.EventTypeNormal, "memoryPressure", "killed", "memory pressure")
+	recorder.Eventf(regarding, related, v1.EventTypeNormal, "memoryPressure", "killed", "memory pressure")
+	err = wait.PollImmediate(100*time.Millisecond, 20*time.Second, func() (done bool, err error) {
+		events, err := client.EventsV1().Events("").List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if len(events.Items) != 1 {
+			return false, nil
+		}
+
+		if events.Items[0].Series == nil {
+			return false, nil
+		}
+
+		if events.Items[0].Series.Count != 2 {
+			return false, fmt.Errorf("expected EventSeries to have a starting count of 2, got: %d", events.Items[0].Series.Count)
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("error waiting for an Event with a non nil Series to be created: %v", err)
+	}
+
 }


### PR DESCRIPTION
Cherry pick of #112334 on release-1.24.

#112334: events: fix EventSeries starting count discrepancy

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Update the Event series starting count when emitting isomorphic events from 1 to 2.
```