### PR TITLE
kubeadm: Remove the usage to print the default component configs for `reset` and `join`

### DIFF
--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -133,8 +133,10 @@ func newCmdConfigPrintActionDefaults(out io.Writer, action string, configBytesPr
 		},
 		Args: cobra.NoArgs,
 	}
-	cmd.Flags().StringSliceVar(&kinds, "component-configs", kinds,
-		fmt.Sprintf("A comma-separated list for component config API objects to print the default values for. Available values: %v. If this flag is not set, no component configs will be printed.", getSupportedComponentConfigKinds()))
+	if action == "init" {
+		cmd.Flags().StringSliceVar(&kinds, "component-configs", kinds,
+			fmt.Sprintf("A comma-separated list for component config API objects to print the default values for. Available values: %v. If this flag is not set, no component configs will be printed.", getSupportedComponentConfigKinds()))
+	}
 	return cmd
 }
 

--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -426,56 +426,16 @@ func TestNewCmdConfigPrintActionDefaults(t *testing.T) {
 			cmdProc:          newCmdConfigPrintInitDefaults,
 		},
 		{
-			name: "JoinConfiguration: No component configs",
+			name: "JoinConfiguration",
 			expectedKinds: []string{
 				constants.JoinConfigurationKind,
 			},
 			cmdProc: newCmdConfigPrintJoinDefaults,
 		},
 		{
-			name: "JoinConfiguration: KubeProxyConfiguration",
-			expectedKinds: []string{
-				constants.JoinConfigurationKind,
-				"KubeProxyConfiguration",
-			},
-			componentConfigs: "KubeProxyConfiguration",
-			cmdProc:          newCmdConfigPrintJoinDefaults,
-		},
-		{
-			name: "JoinConfiguration: KubeProxyConfiguration and KubeletConfiguration",
-			expectedKinds: []string{
-				constants.JoinConfigurationKind,
-				"KubeProxyConfiguration",
-				"KubeletConfiguration",
-			},
-			componentConfigs: "KubeProxyConfiguration,KubeletConfiguration",
-			cmdProc:          newCmdConfigPrintJoinDefaults,
-		},
-		{
-			name: "ResetConfiguration: No component configs",
-			expectedKinds: []string{
-				constants.ResetConfigurationKind,
-			},
-			cmdProc: newCmdConfigPrintResetDefaults,
-		},
-		{
-			name: "JoinConfiguration: KubeProxyConfiguration",
-			expectedKinds: []string{
-				"KubeProxyConfiguration",
-				constants.ResetConfigurationKind,
-			},
-			componentConfigs: "KubeProxyConfiguration",
-			cmdProc:          newCmdConfigPrintResetDefaults,
-		},
-		{
-			name: "JoinConfiguration: KubeProxyConfiguration and KubeletConfiguration",
-			expectedKinds: []string{
-				"KubeProxyConfiguration",
-				"KubeletConfiguration",
-				constants.ResetConfigurationKind,
-			},
-			componentConfigs: "KubeProxyConfiguration,KubeletConfiguration",
-			cmdProc:          newCmdConfigPrintResetDefaults,
+			name:          "ResetConfiguration",
+			expectedKinds: []string{constants.ResetConfigurationKind},
+			cmdProc:       newCmdConfigPrintResetDefaults,
 		},
 	}
 
@@ -484,8 +444,10 @@ func TestNewCmdConfigPrintActionDefaults(t *testing.T) {
 			var output bytes.Buffer
 
 			command := test.cmdProc(&output)
-			if err := command.Flags().Set("component-configs", test.componentConfigs); err != nil {
-				t.Fatalf("failed to set component-configs flag")
+			if test.componentConfigs != "" {
+				if err := command.Flags().Set("component-configs", test.componentConfigs); err != nil {
+					t.Fatalf("failed to set component-configs flag")
+				}
 			}
 			if err := command.RunE(nil, nil); err != nil {
 				t.Fatalf("Error from running the print command: %v", err)


### PR DESCRIPTION
component configs is only needed for `kubeadm init`, the `join` and `reset` doesn't need to provid the config with component configs.



/kind bug

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: print the default component configs for `reset` and `join` is now not supported
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
