### PR TITLE
Add optional labels to ExecConfig fields

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/types.go
@@ -221,6 +221,7 @@ type ExecConfig struct {
 	// This text is shown to the user when the executable doesn't seem to be
 	// present. For example, `brew install foo-cli` might be a good InstallHint for
 	// foo-cli on Mac OS systems.
+	// +optional
 	InstallHint string `json:"installHint,omitempty"`
 
 	// ProvideClusterInfo determines whether or not to provide cluster information,
@@ -228,6 +229,7 @@ type ExecConfig struct {
 	// part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
 	// to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
 	// reading this environment variable.
+	// +optional
 	ProvideClusterInfo bool `json:"provideClusterInfo"`
 
 	// InteractiveMode determines this plugin's relationship with standard input. Valid


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Fix autogenerated docs: https://kubernetes.io/docs/reference/config-api/kubeconfig.v1/#ExecConfig

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation
#### What this PR does / why we need it:

`InstallHint` and `ProvideClusterInfo` fields are incorrectly marked as required.