### PR TITLE
Alternative kep-4017 statefulset implementation

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -390,12 +390,17 @@ func initIdentity(set *apps.StatefulSet, pod *v1.Pod) {
 // updateIdentity updates pod's name, hostname, and subdomain, and StatefulSetPodNameLabel to conform to set's name
 // and headless service.
 func updateIdentity(set *apps.StatefulSet, pod *v1.Pod) {
-	pod.Name = getPodName(set, getOrdinal(pod))
+	ordinal := getOrdinal(pod)
+	pod.Name = getPodName(set, ordinal)
+	pod.Name = getPodName(set, ordinal)
 	pod.Namespace = set.Namespace
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)
 	}
 	pod.Labels[apps.StatefulSetPodNameLabel] = pod.Name
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodIndexLabel) {
+		pod.Labels[apps.StatefulSetPodIndexLabel] = strconv.Itoa(ordinal)
+	}
 }
 
 // isRunningAndReady returns true if pod is in the PodRunning Phase, if it has a condition of PodReady.

--- a/staging/src/k8s.io/api/apps/v1/types.go
+++ b/staging/src/k8s.io/api/apps/v1/types.go
@@ -29,6 +29,7 @@ const (
 	DeprecatedRollbackTo           = "deprecated.deployment.rollback.to"
 	DeprecatedTemplateGeneration   = "deprecated.daemonset.template.generation"
 	StatefulSetPodNameLabel        = "statefulset.kubernetes.io/pod-name"
+	StatefulSetPodIndexLabel       = "apps.kubernetes.io/pod-index"
 )
 
 // +genclient


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig apps

#### What this PR does / why we need it:
Alternative testing implementation of StatefulSet changes for [KEP-4017](https://github.com/kubernetes/enhancements/pull/4019) that includes test cases for toggling the feature gate both on and off, but requires an undesirable refactor of the unit test code.  Original implementation in https://github.com/kubernetes/kubernetes/pull/119232 for comparison.

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/enhancements/issues/4017

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes, the pod index of a StatefulSet pod will now be added as a pod a label, `statefulset.kubernetes.io/pod-index`.

```release-note
StatefulSet pods now have the pod index set as a pod label `statefulset.kubernetes.io/pod-index`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
[KEP](https://github.com/kubernetes/enhancements/pull/4019)
```
