### PR TITLE
fix: align node memory usage for cgroup v1 and v2

### DIFF
--- a/pkg/kubelet/stats/helper_linux.go
+++ b/pkg/kubelet/stats/helper_linux.go
@@ -1,0 +1,30 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+import "github.com/opencontainers/runc/libcontainer/cgroups"
+
+func shouldAdjustCgroupv2NodeMemoryUsage(containerName string) bool {
+	return isCgroup2UnifiedMode() && containerName == "/"
+}
+
+var isCgroup2UnifiedMode = func() bool {
+	return cgroups.IsCgroup2UnifiedMode()
+}

--- a/pkg/kubelet/stats/helper_linux_test.go
+++ b/pkg/kubelet/stats/helper_linux_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	cadvisorapiv1 "github.com/google/cadvisor/info/v1"
+	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	cadvisortest "k8s.io/kubernetes/pkg/kubelet/cadvisor/testing"
+	"k8s.io/kubernetes/pkg/kubelet/cm"
+)
+
+/* using sample metrics from a v2 node:
+ *
+ * /# cat /sys/fs/cgroup/memory.stat
+ * anon 696201216
+ * file 6395928576
+ * /# cat /proc/meminfo
+ * MemTotal:       16374584 kB
+ * MemFree:         8745124 kB
+ *
+ * (16374584 - 8745124) * 1024 = 7812567040 bytes
+ */
+
+func TestAdjustCgroupv2NodeMemoryUsage(t *testing.T) {
+	metrics := &cadvisorapiv1.MemoryStats{
+		Usage: 7812567040,
+		Cache: 6395928576,
+		RSS:   696201216,
+		Swap:  0,
+	}
+	cInfo := cadvisorapiv2.ContainerInfo{
+		Stats: []*cadvisorapiv2.ContainerStats{
+			{
+				Memory: metrics,
+			},
+			{
+				Memory: metrics,
+			},
+		},
+	}
+
+	expectedUsage := metrics.Cache + metrics.RSS
+
+	adjustCgroupv2NodeMemoryUsage(&cInfo)
+
+	assert.Equal(t, cInfo.Stats[0].Memory.Usage, expectedUsage)
+	assert.Equal(t, cInfo.Stats[0].Memory.Swap, metrics.Swap)
+	assert.Equal(t, cInfo.Stats[1].Memory.Usage, expectedUsage)
+	assert.Equal(t, cInfo.Stats[1].Memory.Swap, metrics.Swap)
+}
+
+func TestGetCgroupInfoUsage(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	var (
+		mockCadvisor = cadvisortest.NewMockInterface(mockCtrl)
+
+		sandbox0       = makeFakePodSandbox("sandbox0-name", "sandbox0-uid", "sandbox0-ns", false)
+		sandbox0Cgroup = "/" + cm.GetPodCgroupNameSuffix(types.UID(sandbox0.PodSandboxStatus.Metadata.Uid))
+	)
+
+	cases := map[string]struct {
+		containerName          string
+		expectedUsage          uint64
+		infos                  map[string]cadvisorapiv2.ContainerInfo
+		isCgroup2UnifiedModeFn func() bool
+	}{
+		"root-v1": {
+			containerName: "/",
+			expectedUsage: uint64(seedRoot + offsetMemUsageBytes),
+			infos: map[string]cadvisorapiv2.ContainerInfo{
+				"/": getTestContainerInfo(seedRoot, "", "", ""),
+			},
+			isCgroup2UnifiedModeFn: isCgroupv1ForTest,
+		},
+		"kubelet-v1": {
+			containerName: "/kubelet",
+			expectedUsage: uint64(seedKubelet + offsetMemUsageBytes),
+			infos: map[string]cadvisorapiv2.ContainerInfo{
+				"/kubelet": getTestContainerInfo(seedKubelet, "", "", ""),
+			},
+			isCgroup2UnifiedModeFn: isCgroupv1ForTest,
+		},
+		"system-v1": {
+			containerName: "/system",
+			expectedUsage: uint64(seedMisc + offsetMemUsageBytes),
+			infos: map[string]cadvisorapiv2.ContainerInfo{
+				"/system": getTestContainerInfo(seedMisc, "", "", ""),
+			},
+			isCgroup2UnifiedModeFn: isCgroupv1ForTest,
+		},
+		"pod-v1": {
+			containerName: sandbox0Cgroup,
+			expectedUsage: uint64(seedSandbox0 + offsetMemUsageBytes),
+			infos: map[string]cadvisorapiv2.ContainerInfo{
+				sandbox0Cgroup: getTestContainerInfo(seedSandbox0, "", "", ""),
+			},
+			isCgroup2UnifiedModeFn: isCgroupv1ForTest,
+		},
+		"root-v2": {
+			containerName: "/",
+			expectedUsage: uint64(seedRoot + offsetMemRSSBytes + seedRoot + offsetMemCacheBytes),
+			infos: map[string]cadvisorapiv2.ContainerInfo{
+				"/": getTestContainerInfo(seedRoot, "", "", ""),
+			},
+			isCgroup2UnifiedModeFn: isCgroupv2ForTest,
+		},
+		"kubelet-v2": {
+			containerName: "/kubelet",
+			expectedUsage: uint64(seedKubelet + offsetMemUsageBytes),
+			infos: map[string]cadvisorapiv2.ContainerInfo{
+				"/kubelet": getTestContainerInfo(seedKubelet, "", "", ""),
+			},
+			isCgroup2UnifiedModeFn: isCgroupv2ForTest,
+		},
+		"system-v2": {
+			containerName: "/system",
+			expectedUsage: uint64(seedMisc + offsetMemUsageBytes),
+			infos: map[string]cadvisorapiv2.ContainerInfo{
+				"/system": getTestContainerInfo(seedMisc, "", "", ""),
+			},
+			isCgroup2UnifiedModeFn: isCgroupv2ForTest,
+		},
+		"pod-v2": {
+			containerName: sandbox0Cgroup,
+			expectedUsage: uint64(seedSandbox0 + offsetMemUsageBytes),
+			infos: map[string]cadvisorapiv2.ContainerInfo{
+				sandbox0Cgroup: getTestContainerInfo(seedSandbox0, "", "", ""),
+			},
+			isCgroup2UnifiedModeFn: isCgroupv2ForTest,
+		},
+	}
+
+	for name := range cases {
+		name := name
+		tc := cases[name]
+		t.Run(name, func(t *testing.T) {
+			var maxAge *time.Duration
+			age := 0 * time.Second
+			maxAge = &age
+
+			options := cadvisorapiv2.RequestOptions{
+				IdType:    cadvisorapiv2.TypeName,
+				Count:     2,
+				Recursive: false,
+				MaxAge:    maxAge,
+			}
+
+			mockCadvisor.EXPECT().ContainerInfoV2(tc.containerName, options).Return(tc.infos, nil)
+
+			isCgroup2UnifiedMode = tc.isCgroup2UnifiedModeFn
+
+			cInfo, err := getCgroupInfo(mockCadvisor, tc.containerName, true)
+			assert.NoError(t, err)
+			assert.NotNil(t, cInfo)
+
+			assert.Equal(t, cInfo.Stats[0].Memory.Usage, tc.expectedUsage)
+		})
+	}
+}
+
+func isCgroupv1ForTest() bool {
+	return false
+}
+
+func isCgroupv2ForTest() bool {
+	return true
+}

--- a/pkg/kubelet/stats/helper_unsupported.go
+++ b/pkg/kubelet/stats/helper_unsupported.go
@@ -1,0 +1,24 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+func shouldAdjustCgroupv2NodeMemoryUsage(containerName string) bool {
+	return false
+}

--- a/pkg/kubelet/stats/provider_test.go
+++ b/pkg/kubelet/stats/provider_test.go
@@ -49,6 +49,7 @@ const (
 	offsetMemMajorPageFaults
 	offsetMemUsageBytes
 	offsetMemRSSBytes
+	offsetMemCacheBytes
 	offsetMemWorkingSetBytes
 	offsetNetRxBytes
 	offsetNetRxErrors
@@ -517,6 +518,7 @@ func getTestContainerInfo(seed int, podName string, podNamespace string, contain
 			Usage:      uint64(seed + offsetMemUsageBytes),
 			WorkingSet: uint64(seed + offsetMemWorkingSetBytes),
 			RSS:        uint64(seed + offsetMemRSSBytes),
+			Cache:      uint64(seed + offsetMemCacheBytes),
 			ContainerData: cadvisorapiv1.MemoryStatsMemoryData{
 				Pgfault:    uint64(seed + offsetMemPageFaults),
 				Pgmajfault: uint64(seed + offsetMemMajorPageFaults),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

aligns node memory usage for cgroup v1 and v2 by using `rss + cache` as whole node usage in both cases.

```bash
root@Ubuntu-2204-jammy-amd64-base ~/go/src/k8s.io/kubernetes # kubectl top node
NAME                                CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%
aks-nodepool1-11357399-vmss000000   113m         2%     744Mi           5%      <== v2, with fix
aks-nodepool1-11357399-vmss000001   139m         3%     1178Mi          9%     <== v2, no fix
aks-nodepool1-11357399-vmss000002   128m         3%     894Mi           7%      <== v1, no fix
```

roughly similar pod and node usage (no workloads, a few DS + 2x metric server pods + 2x coredns + 2x konnectivity, which is why the balance isn't exact.).

rebooting node 001 into cgroupv1 with no pod or system process changes highlights the diff from same node usage:
```bash
aks-nodepool1-11357399-vmss000000   120m         3%     832Mi           6%
aks-nodepool1-11357399-vmss000001   123m         3%     767Mi           6%
aks-nodepool1-11357399-vmss000002   124m         3%     732Mi           5%
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #118916

#### Special notes for your reviewer:

`TestGetCgroupInfoUsage` unfortunately has a real host dependency on v1/v2. I've tested it on a machine using both v1 and v2. The point is to demonstrate v2 adjusts while v1 does not. Although we could simply do the math for both, I'd rather leave v1 as is. Thoughts?

I feel it's more correct to fix this in runc or cadvisor, but there are some concerns in runc at least about changing behavior. For Kubernetes, this fix works even if runc or cadvisor changes under us. The diff would become zero or trivially close to it, and we could revert the adjustment.

https://github.com/opencontainers/runc/pull/3933

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adjust root cgroup memory usage reported by kubelet to align cgroup v2 calculation more closely with cgroup v1.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
