### PR TITLE
Make intstr.FromInt() accept any signed integer

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
@@ -21,11 +21,10 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"runtime/debug"
 	"strconv"
 	"strings"
 
-	"k8s.io/klog/v2"
+	"golang.org/x/exp/constraints"
 )
 
 // IntOrString is a type that can hold an int32 or a string.  When used in
@@ -54,18 +53,13 @@ const (
 // FromInt creates an IntOrString object with an int32 value. It is
 // your responsibility not to call this method with a value greater
 // than int32.
-// Deprecated: use FromInt32 instead.
-func FromInt(val int) IntOrString {
-	if val > math.MaxInt32 || val < math.MinInt32 {
-		klog.Errorf("value: %d overflows int32\n%s\n", val, debug.Stack())
-	}
+func FromInt[T constraints.Signed](val T) IntOrString {
 	return IntOrString{Type: Int, IntVal: int32(val)}
 }
 
 // FromInt32 creates an IntOrString object with an int32 value.
-func FromInt32(val int32) IntOrString {
-	return IntOrString{Type: Int, IntVal: val}
-}
+// Deprecated: use FromInt instead.
+var FromInt32 = FromInt[int32]
 
 // FromString creates an IntOrString object with a string value.
 func FromString(val string) IntOrString {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
@@ -532,12 +532,7 @@ func (o *ExposeServiceOptions) createService() (*corev1.Service, error) {
 	}
 	targetPortString := o.TargetPort
 	if len(targetPortString) > 0 {
-		var targetPort intstr.IntOrString
-		if portNum, err := strconv.Atoi(targetPortString); err != nil {
-			targetPort = intstr.FromString(targetPortString)
-		} else {
-			targetPort = intstr.FromInt(portNum)
-		}
+		targetPort := intstr.Parse(targetPortString)
 		// Use the same target-port for every port
 		for i := range service.Spec.Ports {
 			service.Spec.Ports[i].TargetPort = targetPort

--- a/test/e2e/apimachinery/crd_conversion_webhook.go
+++ b/test/e2e/apimachinery/crd_conversion_webhook.go
@@ -291,7 +291,7 @@ func deployCustomResourceWebhookAndService(ctx context.Context, f *framework.Fra
 				ProbeHandler: v1.ProbeHandler{
 					HTTPGet: &v1.HTTPGetAction{
 						Scheme: v1.URISchemeHTTPS,
-						Port:   intstr.FromInt(int(containerPort)),
+						Port:   intstr.FromInt(containerPort),
 						Path:   "/readyz",
 					},
 				},
@@ -333,7 +333,7 @@ func deployCustomResourceWebhookAndService(ctx context.Context, f *framework.Fra
 				{
 					Protocol:   v1.ProtocolTCP,
 					Port:       servicePort,
-					TargetPort: intstr.FromInt(int(containerPort)),
+					TargetPort: intstr.FromInt(containerPort),
 				},
 			},
 		},

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -790,7 +790,7 @@ func deployWebhookAndService(ctx context.Context, f *framework.Framework, image 
 				ProbeHandler: v1.ProbeHandler{
 					HTTPGet: &v1.HTTPGetAction{
 						Scheme: v1.URISchemeHTTPS,
-						Port:   intstr.FromInt(int(containerPort)),
+						Port:   intstr.FromInt(containerPort),
 						Path:   "/readyz",
 					},
 				},
@@ -829,7 +829,7 @@ func deployWebhookAndService(ctx context.Context, f *framework.Framework, image 
 				{
 					Protocol:   v1.ProtocolTCP,
 					Port:       servicePort,
-					TargetPort: intstr.FromInt(int(containerPort)),
+					TargetPort: intstr.FromInt(containerPort),
 				},
 			},
 		},

--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -716,7 +716,7 @@ func (j *TestJig) CreatePDB(ctx context.Context, rc *v1.ReplicationController) (
 // this j, but does not actually create the PDB.  The default PDB specifies a
 // MinAvailable of N-1 and matches the pods created by the RC.
 func (j *TestJig) newPDBTemplate(rc *v1.ReplicationController) *policyv1.PodDisruptionBudget {
-	minAvailable := intstr.FromInt(int(*rc.Spec.Replicas) - 1)
+	minAvailable := intstr.FromInt(*rc.Spec.Replicas - 1)
 
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -1425,7 +1425,7 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 				// Change service port to avoid collision with opened hostPorts
 				// in other tests that run in parallel.
 				if len(svc.Spec.Ports) != 0 {
-					svc.Spec.Ports[0].TargetPort = intstr.FromInt(int(svc.Spec.Ports[0].Port))
+					svc.Spec.Ports[0].TargetPort = intstr.FromInt(svc.Spec.Ports[0].Port)
 					svc.Spec.Ports[0].Port = 8081
 				}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is based on comments on #117631 and #119285.

This changes `intstr.FromInt()` so that it can accept any signed integer, not just `int` (or `int32`). `FromInt32()` is deprecated in favour of `FromInt()`, but existing uses aren’t touched. Redundant casts are removed but no change is made to types used for input values.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
