### PR TITLE
Update publishing-bot rules for release branches to Go 1.20.6

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -6,22 +6,22 @@ rules:
       branch: master
       dir: staging/src/k8s.io/code-generator
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/code-generator
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/code-generator
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/code-generator
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.27
       dir: staging/src/k8s.io/code-generator
@@ -32,22 +32,22 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.27
       dir: staging/src/k8s.io/apimachinery
@@ -62,7 +62,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/api
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -70,7 +70,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/api
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -78,7 +78,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/api
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -86,7 +86,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/api
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -110,7 +110,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -124,7 +124,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -138,7 +138,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -152,7 +152,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -180,7 +180,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/component-base
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -192,7 +192,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-base
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -204,7 +204,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-base
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -216,7 +216,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/component-base
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -242,7 +242,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -254,7 +254,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -266,7 +266,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -278,7 +278,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -304,12 +304,12 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kms
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/kms
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -339,7 +339,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apiserver
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -353,7 +353,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/apiserver
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -367,7 +367,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/apiserver
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -383,7 +383,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/apiserver
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -421,7 +421,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -439,7 +439,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -457,7 +457,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -477,7 +477,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -523,7 +523,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -546,7 +546,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -569,7 +569,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -594,7 +594,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -639,7 +639,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -658,7 +658,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -677,7 +677,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -696,7 +696,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -738,7 +738,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -758,7 +758,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -778,7 +778,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -800,7 +800,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -837,7 +837,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/metrics
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -851,7 +851,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/metrics
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -865,7 +865,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/metrics
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -879,7 +879,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/metrics
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -907,7 +907,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.24
@@ -919,7 +919,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.25
@@ -931,7 +931,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.26
@@ -943,7 +943,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -971,7 +971,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.24
@@ -985,7 +985,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.25
@@ -999,7 +999,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1013,7 +1013,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1042,7 +1042,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1056,7 +1056,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1070,7 +1070,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1084,7 +1084,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1105,22 +1105,22 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cri-api
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/cri-api
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/cri-api
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/cri-api
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.27
       dir: staging/src/k8s.io/cri-api
@@ -1147,7 +1147,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kubelet
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1161,7 +1161,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubelet
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1175,7 +1175,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubelet
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1189,7 +1189,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kubelet
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1219,7 +1219,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1233,7 +1233,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1247,7 +1247,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1261,7 +1261,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1295,7 +1295,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1311,7 +1311,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1327,7 +1327,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1345,7 +1345,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1387,7 +1387,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1407,7 +1407,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1427,7 +1427,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1449,7 +1449,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1497,7 +1497,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1519,7 +1519,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1541,7 +1541,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1565,7 +1565,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1601,7 +1601,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1611,7 +1611,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1621,7 +1621,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1631,7 +1631,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1653,7 +1653,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1663,7 +1663,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1673,7 +1673,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1683,7 +1683,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1700,22 +1700,22 @@ rules:
       branch: master
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     source:
       branch: release-1.27
       dir: staging/src/k8s.io/mount-utils
@@ -1746,7 +1746,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1772,7 +1772,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1798,7 +1798,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1826,7 +1826,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1874,7 +1874,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kubectl
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1896,7 +1896,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubectl
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1918,7 +1918,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubectl
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1940,7 +1940,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kubectl
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1982,7 +1982,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.24
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1998,7 +1998,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.25
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.25
@@ -2014,7 +2014,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2032,7 +2032,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2072,7 +2072,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2088,7 +2088,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.27
-    go: 1.20.5
+    go: 1.20.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Update publishing-bot rules for release branches to Go 1.20.6

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3148

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

/assign @saschagrunert @cpanato @liggitt @nikhita 
cc @kubernetes/release-engineering 