### PR TITLE
Automated cherry pick of #114237: tools/events: retry on AlreadyExist for Series
#114236: tools/events: fix data race when emitting series
#112334: events: fix EventSeries starting count discrepancy

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -181,7 +181,7 @@ func (e *eventBroadcasterImpl) recordToSink(event *eventsv1.Event, clock clock.C
 					return nil
 				}
 				isomorphicEvent.Series = &eventsv1.EventSeries{
-					Count:            1,
+					Count:            2,
 					LastObservedTime: metav1.MicroTime{Time: clock.Now()},
 				}
 				// Make a copy of the Event to make sure that recording it

--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster_test.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	eventsv1 "k8s.io/api/events/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRecordEventToSink(t *testing.T) {
+	nonIsomorphicEvent := eventsv1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Series: nil,
+	}
+
+	isomorphicEvent := *nonIsomorphicEvent.DeepCopy()
+	isomorphicEvent.Series = &eventsv1.EventSeries{Count: 2}
+
+	testCases := []struct {
+		name                  string
+		eventsToRecord        []eventsv1.Event
+		expectedRecordedEvent eventsv1.Event
+	}{
+		{
+			name: "record one Event",
+			eventsToRecord: []eventsv1.Event{
+				nonIsomorphicEvent,
+			},
+			expectedRecordedEvent: nonIsomorphicEvent,
+		},
+		{
+			name: "record one Event followed by an isomorphic one",
+			eventsToRecord: []eventsv1.Event{
+				nonIsomorphicEvent,
+				isomorphicEvent,
+			},
+			expectedRecordedEvent: isomorphicEvent,
+		},
+		{
+			name: "record one isomorphic Event before the original",
+			eventsToRecord: []eventsv1.Event{
+				isomorphicEvent,
+				nonIsomorphicEvent,
+			},
+			expectedRecordedEvent: isomorphicEvent,
+		},
+		{
+			name: "record one isomorphic Event without one already existing",
+			eventsToRecord: []eventsv1.Event{
+				isomorphicEvent,
+			},
+			expectedRecordedEvent: isomorphicEvent,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset()
+			eventSink := &EventSinkImpl{Interface: kubeClient.EventsV1()}
+
+			for _, ev := range tc.eventsToRecord {
+				recordEvent(eventSink, &ev)
+			}
+
+			recordedEvents, err := kubeClient.EventsV1().Events(metav1.NamespaceDefault).List(context.TODO(), metav1.ListOptions{})
+			if err != nil {
+				t.Errorf("expected to be able to list Events from fake client")
+			}
+
+			if len(recordedEvents.Items) != 1 {
+				t.Errorf("expected one Event to be recorded, found: %d", len(recordedEvents.Items))
+			}
+
+			recordedEvent := recordedEvents.Items[0]
+			if !reflect.DeepEqual(recordedEvent, tc.expectedRecordedEvent) {
+				t.Errorf("expected to have recorded Event: %#+v, got: %#+v\n diff: %s", tc.expectedRecordedEvent, recordedEvent, diff.ObjectReflectDiff(tc.expectedRecordedEvent, recordedEvent))
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
+++ b/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
@@ -108,7 +108,7 @@ func TestEventSeriesf(t *testing.T) {
 	nonIsomorphicEvent := expectedEvent.DeepCopy()
 	nonIsomorphicEvent.Action = "stopped"
 
-	expectedEvent.Series = &eventsv1.EventSeries{Count: 1}
+	expectedEvent.Series = &eventsv1.EventSeries{Count: 2}
 	table := []struct {
 		regarding    k8sruntime.Object
 		related      k8sruntime.Object


### PR DESCRIPTION
Cherry pick of #114237 #114236 #112334 on release-1.26.

#114237: tools/events: retry on AlreadyExist for Series
#114236: tools/events: fix data race when emitting series
#112334: events: fix EventSeries starting count discrepancy

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### Special notes for your reviewer:

#112334 is the real user-facing bug fix that I am trying to backport here. All Kubernetes users are affected by this bug and could be seeing the following error in their kube-scheduler logs:
```
'Event "apiserver-7bc6866f9c-2vk6r.17123d9ef072db8c" is invalid: [series.count: Invalid value: "": should be at least 2]' (will not retry!)
```
In practice this error will cause the first repetition of an Event to be skipped which means that users will be aware that an Event occured but they will only know that it kept repeating itself after 30 minutes which in the case of the kube-scheduler might cause the users to be unaware of scheduling failures for quite a long time.

#114236 #114237 are side fixes that are required by #112334 integration test. They fix two different bugs that allow sending the same event consecutively without discarding any of them. e.g:
https://github.com/kubernetes/kubernetes/pull/112334/files#diff-4e1bcdea5320a17d795eb29ce0a180740058e0d09f27d4a21613c9e59b75a93fR132-R133

```release-note
Update the Event series starting count when emitting isomorphic events from 1 to 2.
```