### PR TITLE
All sig node approvers should be able to merge changes to CRI API

### DIFF
--- a/staging/src/k8s.io/cri-api/OWNERS
+++ b/staging/src/k8s.io/cri-api/OWNERS
@@ -3,10 +3,7 @@
 approvers:
   - dims
   - feiskyer
-  - Random-Liu
-  - derekwaynecarr
-  - dchen1107
-  - yujuhong
+  - sig-node-approvers
   - sig-node-api-approvers
   - api-approvers
 reviewers:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node
/priority important-soon
/assign @dchen1107 

#### What this PR does / why we need it:

Fixes approvers for CRI API

#### Special notes for your reviewer:

I am not sure what is the history of this. I think the most logical change is to grant SIG Node approvers permissions to this folder.

Effective changes:

New people has approvership for the folder `staging/src/k8s.io/cri-api/OWNERS`
    - sjenning
    - mrunalp
    - klueska

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

