### PR TITLE
Replace lavalamp with jpbetz as feature-approver for api-machinery

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -506,11 +506,11 @@ aliases:
     - ehashman # Instrumentation
     - janetkuo # Apps
     - jayunit100 # Windows
+    - jpbetz # API Machinery
     - jsafrane # Storage
     - jsturtevant # Windows
     - justinsb # Cluster Lifecycle
     - kow3ns # Apps
-    - lavalamp # API Machinery
     - liggitt # Auth
     - logicalhan # Instrumentation
     - luxas # Cluster Lifecycle


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I've replaced @lavalamp as TL for sig-apimachinery and need to be able to approve features.

-->
```release-note
NONE
```

/sig api-machinery