### PR TITLE
cmd/kubelet: implement drop-in configuration directory for kubelet

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -86,6 +86,10 @@ type KubeletFlags struct {
 	// Omit this flag to use the combination of built-in default configuration values and flags.
 	KubeletConfigFile string
 
+	// kubeletDropinConfigDirectory is a path to a directory to specify dropins allows the user to optionally specify
+	// additional configs to overwrite what is provided by default and in the KubeletConfigFile flag
+	KubeletDropinConfigDirectory string
+
 	// WindowsService should be set to true if kubelet is running as a service on Windows.
 	// Its corresponding flag only gets registered in Windows builds.
 	WindowsService bool
@@ -281,6 +285,7 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 	f.addOSFlags(fs)
 
 	fs.StringVar(&f.KubeletConfigFile, "config", f.KubeletConfigFile, "The Kubelet will load its initial configuration from this file. The path may be absolute or relative; relative paths start at the Kubelet's current working directory. Omit this flag to use the built-in default configuration values. Command-line flags override configuration from this file.")
+	fs.StringVar(&f.KubeletDropinConfigDirectory, "config-dir", "", "Path to a directory to specify drop-ins, allows the user to optionally specify additional configs to overwrite what is provided by default and in the KubeletConfigFile flag. Note: Set the 'KUBELET_CONFIG_DROPIN_DIR_ALPHA' environment variable to specify the directory. [default='']")
 	fs.StringVar(&f.KubeConfig, "kubeconfig", f.KubeConfig, "Path to a kubeconfig file, specifying how to connect to the API server. Providing --kubeconfig enables API server mode, omitting --kubeconfig enables standalone mode.")
 
 	fs.StringVar(&f.BootstrapKubeconfig, "bootstrap-kubeconfig", f.BootstrapKubeconfig, "Path to a kubeconfig file that will be used to get client certificate for kubelet. "+

--- a/cmd/kubelet/app/server_test.go
+++ b/cmd/kubelet/app/server_test.go
@@ -17,7 +17,14 @@ limitations under the License.
 package app
 
 import (
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/kubernetes/cmd/kubelet/app/options"
+	kubeletconfiginternal "k8s.io/kubernetes/pkg/kubelet/apis/config"
 )
 
 func TestValueOfAllocatableResources(t *testing.T) {
@@ -59,5 +66,196 @@ func TestValueOfAllocatableResources(t *testing.T) {
 				t.Errorf("%s: unexpected error: %v, %v", test.name, err1, err2)
 			}
 		}
+	}
+}
+
+func TestMergeKubeletConfigurations(t *testing.T) {
+	testCases := []struct {
+		kubeletConfig           string
+		dropin1                 string
+		dropin2                 string
+		overwrittenConfigFields map[string]interface{}
+		cliArgs                 []string
+		name                    string
+	}{
+		{
+			kubeletConfig: `
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+port: 9080
+readOnlyPort: 10257
+`,
+			dropin1: `
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+port: 9090
+`,
+			dropin2: `
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+port: 8080
+readOnlyPort: 10255
+`,
+			overwrittenConfigFields: map[string]interface{}{
+				"Port":         int32(8080),
+				"ReadOnlyPort": int32(10255),
+			},
+			name: "kubelet.conf.d overrides kubelet.conf",
+		},
+		{
+			kubeletConfig: `
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+readOnlyPort: 10256
+kubeReserved:
+	memory: 70Mi
+`,
+			dropin1: `
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+readOnlyPort: 10255
+kubeReserved:
+  memory: 150Mi
+  cpu: 200m
+`,
+			dropin2: `
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+readOnlyPort: 10257
+kubeReserved:
+  memory: 100Mi
+`,
+			overwrittenConfigFields: map[string]interface{}{
+				"ReadOnlyPort": int32(10257),
+				"KubeReserved": map[string]string{
+					"cpu":    "200m",
+					"memory": "100Mi",
+				},
+			},
+			name: "kubelet.conf.d overrides kubelet.conf with subfield override",
+		},
+		{
+			kubeletConfig: `
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+port: 9090
+clusterDNS:
+	- 192.168.1.3
+	- 192.168.1.4
+`,
+			dropin1: `
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+port: 9090
+systemReserved:
+  memory: 1Gi
+`,
+			dropin2: `
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+port: 8080
+readOnlyPort: 10255
+systemReserved:
+  memory: 2Gi
+clusterDNS:
+  - 192.168.1.1
+  - 192.168.1.5
+  - 192.168.1.8
+`,
+			overwrittenConfigFields: map[string]interface{}{
+				"Port":         int32(8080),
+				"ReadOnlyPort": int32(10255),
+				"SystemReserved": map[string]string{
+					"memory": "2Gi",
+				},
+				"ClusterDNS": []string{"192.168.1.1", "192.168.1.5", "192.168.1.8"},
+			},
+			name: "kubelet.conf.d overrides kubelet.conf with slices/lists",
+		},
+		{
+			dropin1: `
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+port: 9090
+`,
+			dropin2: `
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+port: 8080
+readOnlyPort: 10255
+`,
+			overwrittenConfigFields: map[string]interface{}{
+				"Port":         int32(8081),
+				"ReadOnlyPort": int32(10256),
+			},
+			cliArgs: []string{
+				"--port=8081",
+				"--read-only-port=10256",
+			},
+			name: "cli args override kubelet.conf.d",
+		},
+		{
+			kubeletConfig: `
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+port: 9090
+clusterDNS:
+	- 192.168.1.3
+`,
+			overwrittenConfigFields: map[string]interface{}{
+				"Port":       int32(9090),
+				"ClusterDNS": []string{"192.168.1.2"},
+			},
+			cliArgs: []string{
+				"--port=9090",
+				"--cluster-dns=192.168.1.2",
+			},
+			name: "cli args override kubelet.conf",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			// Prepare a temporary directory for testing
+			tempDir := t.TempDir()
+
+			kubeletConfig := &kubeletconfiginternal.KubeletConfiguration{}
+			kubeletFlags := &options.KubeletFlags{}
+
+			if len(test.kubeletConfig) > 0 {
+				// Create the Kubeletconfig
+				kubeletConfFile := filepath.Join(tempDir, "kubelet.conf")
+				err := os.WriteFile(kubeletConfFile, []byte(test.kubeletConfig), 0644)
+				require.NoError(t, err, "failed to create config from a yaml file")
+				kubeletFlags.KubeletConfigFile = kubeletConfFile
+			}
+			if len(test.dropin1) > 0 || len(test.dropin2) > 0 {
+				// Create kubelet.conf.d directory and drop-in configuration files
+				kubeletConfDir := filepath.Join(tempDir, "kubelet.conf.d")
+				err := os.Mkdir(kubeletConfDir, 0755)
+				require.NoError(t, err, "Failed to create kubelet.conf.d directory")
+
+				err = os.WriteFile(filepath.Join(kubeletConfDir, "10-kubelet.conf"), []byte(test.dropin1), 0644)
+				require.NoError(t, err, "failed to create config from a yaml file")
+
+				err = os.WriteFile(filepath.Join(kubeletConfDir, "20-kubelet.conf"), []byte(test.dropin2), 0644)
+				require.NoError(t, err, "failed to create config from a yaml file")
+
+				// Merge the kubelet configurations
+				err = mergeKubeletConfigurations(kubeletConfig, kubeletConfDir)
+				require.NoError(t, err, "failed to merge kubelet drop-in configs")
+			}
+
+			// Use kubelet config flag precedence
+			err := kubeletConfigFlagPrecedence(kubeletConfig, test.cliArgs)
+			require.NoError(t, err, "failed to set the kubelet config flag precedence")
+
+			// Verify the merged configuration fields
+			for fieldName, expectedValue := range test.overwrittenConfigFields {
+				value := reflect.ValueOf(kubeletConfig).Elem()
+				field := value.FieldByName(fieldName)
+				require.Equal(t, expectedValue, field.Interface(), "Field mismatch: "+fieldName)
+			}
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.3.0
+	github.com/imdario/mergo v0.3.6
 	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
 	github.com/libopenstorage/openstorage v1.0.0
 	github.com/lithammer/dedent v1.1.0
@@ -183,7 +184,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
-	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect


### PR DESCRIPTION
This implements a drop-in configuration directory for the kubelet by introducing a `--config-dir` flag. Users can provide individual kubelet config snippets in separate files, formatted similarly to `kubelet.conf`. The kubelet will process the files in alphanumeric order, appending configurations if subfield(s) doesn't exist, overwriting them if they do, and handling lists by overwriting instead of merging.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Implement alpha support for a drop-in kubelet configuration directory
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP-3983](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3983-drop-in-configuration/README.md)
```
