### PR TITLE
Fix stale conntrack flow detection logic

### DIFF
--- a/pkg/proxy/endpoints.go
+++ b/pkg/proxy/endpoints.go
@@ -117,13 +117,6 @@ func (info *BaseEndpointInfo) Port() (int, error) {
 	return proxyutil.PortPart(info.Endpoint)
 }
 
-// Equal is part of proxy.Endpoint interface.
-func (info *BaseEndpointInfo) Equal(other Endpoint) bool {
-	return info.String() == other.String() &&
-		info.GetIsLocal() == other.GetIsLocal() &&
-		info.IsReady() == other.IsReady()
-}
-
 // GetNodeName returns the NodeName for this endpoint.
 func (info *BaseEndpointInfo) GetNodeName() string {
 	return info.NodeName
@@ -425,7 +418,9 @@ func detectStaleConntrackEntries(oldEndpointsMap, newEndpointsMap EndpointsMap, 
 			// ready to not ready. If it did change stale entries for the old
 			// endpoint have to be cleared.
 			for i := range newEndpointsMap[svcPortName] {
-				if newEndpointsMap[svcPortName][i].Equal(ep) {
+				if newEndpointsMap[svcPortName][i].String() == ep.String() &&
+					newEndpointsMap[svcPortName][i].IsReady() == ep.IsReady() &&
+					newEndpointsMap[svcPortName][i].GetIsLocal() == ep.GetIsLocal() {
 					deleted = false
 					break
 				}

--- a/pkg/proxy/endpoints.go
+++ b/pkg/proxy/endpoints.go
@@ -407,20 +407,18 @@ func detectStaleConntrackEntries(oldEndpointsMap, newEndpointsMap EndpointsMap, 
 		}
 
 		for _, ep := range epList {
-			// If the old endpoint wasn't Ready then there can't be stale
+			// If the old endpoint wasn't Serving then there can't be stale
 			// conntrack entries since there was no traffic sent to it.
-			if !ep.IsReady() {
+			if !ep.IsServing() {
 				continue
 			}
 
 			deleted := true
 			// Check if the endpoint has changed, including if it went from
-			// ready to not ready. If it did change stale entries for the old
+			// serving to not serving. If it did change stale entries for the old
 			// endpoint have to be cleared.
 			for i := range newEndpointsMap[svcPortName] {
-				if newEndpointsMap[svcPortName][i].String() == ep.String() &&
-					newEndpointsMap[svcPortName][i].IsReady() == ep.IsReady() &&
-					newEndpointsMap[svcPortName][i].GetIsLocal() == ep.GetIsLocal() {
+				if newEndpointsMap[svcPortName][i].String() == ep.String() {
 					deleted = false
 					break
 				}
@@ -441,21 +439,21 @@ func detectStaleConntrackEntries(oldEndpointsMap, newEndpointsMap EndpointsMap, 
 			continue
 		}
 
-		epReady := 0
+		epServing := 0
 		for _, ep := range epList {
-			if ep.IsReady() {
-				epReady++
+			if ep.IsServing() {
+				epServing++
 			}
 		}
 
-		oldEpReady := 0
+		oldEpServing := 0
 		for _, ep := range oldEndpointsMap[svcPortName] {
-			if ep.IsReady() {
-				oldEpReady++
+			if ep.IsServing() {
+				oldEpServing++
 			}
 		}
 
-		if epReady > 0 && oldEpReady == 0 {
+		if epServing > 0 && oldEpServing == 0 {
 			*newlyActiveUDPServices = append(*newlyActiveUDPServices, svcPortName)
 		}
 	}

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -136,19 +136,6 @@ func newEndpointInfo(baseInfo *proxy.BaseEndpointInfo, svcPortName *proxy.Servic
 	}
 }
 
-// Equal overrides the Equal() function implemented by proxy.BaseEndpointInfo.
-func (e *endpointsInfo) Equal(other proxy.Endpoint) bool {
-	o, ok := other.(*endpointsInfo)
-	if !ok {
-		klog.ErrorS(nil, "Failed to cast endpointsInfo")
-		return false
-	}
-	return e.Endpoint == o.Endpoint &&
-		e.IsLocal == o.IsLocal &&
-		e.ChainName == o.ChainName &&
-		e.Ready == o.Ready
-}
-
 // Proxier is an iptables based proxy for connections between a localhost:lport
 // and services that provide the actual backends.
 type Proxier struct {

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -5268,7 +5268,7 @@ func TestProxierDeleteNodePortStaleUDP(t *testing.T) {
 			eps.Endpoints = []discovery.Endpoint{{
 				Addresses: []string{epIP},
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(false),
+					Serving: pointer.Bool(false),
 				},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
@@ -5291,7 +5291,7 @@ func TestProxierDeleteNodePortStaleUDP(t *testing.T) {
 			eps.Endpoints = []discovery.Endpoint{{
 				Addresses: []string{epIP},
 				Conditions: discovery.EndpointConditions{
-					Ready: pointer.Bool(true),
+					Serving: pointer.Bool(true),
 				},
 			}}
 			eps.Ports = []discovery.EndpointPort{{

--- a/pkg/proxy/types.go
+++ b/pkg/proxy/types.go
@@ -131,8 +131,6 @@ type Endpoint interface {
 	IP() string
 	// Port returns the Port part of the endpoint.
 	Port() (int, error)
-	// Equal checks if two endpoints are equal.
-	Equal(Endpoint) bool
 	// GetNodeName returns the node name for the endpoint
 	GetNodeName() string
 	// GetZone returns the zone for the endpoint


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes a small bug in stale conntrack entries detection  for UDP connections.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119249

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
