### PR TITLE
Automated cherry pick of #109676: Skip mount point checks when possible during mount

### DIFF
--- a/staging/src/k8s.io/mount-utils/fake_mounter.go
+++ b/staging/src/k8s.io/mount-utils/fake_mounter.go
@@ -218,7 +218,7 @@ func (f *FakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
-func (f *FakeMounter) CanSafelySkipMountPointCheck() bool {
+func (f *FakeMounter) canSafelySkipMountPointCheck() bool {
 	return f.skipMountPointCheck
 }
 

--- a/staging/src/k8s.io/mount-utils/fake_mounter.go
+++ b/staging/src/k8s.io/mount-utils/fake_mounter.go
@@ -218,16 +218,9 @@ func (f *FakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
-func (f *FakeMounter) canSafelySkipMountPointCheck() bool {
-	return f.skipMountPointCheck
-}
-
-func (f *FakeMounter) IsMountPoint(file string) (bool, error) {
-	notMnt, err := f.IsLikelyNotMountPoint(file)
-	if err != nil {
-		return false, err
-	}
-	return !notMnt, nil
+// CanSafelySkipMountPointCheck always returns false for FakeMounter.
+func (f *FakeMounter) CanSafelySkipMountPointCheck() bool {
+	return false
 }
 
 // GetMountRefs finds all mount references to the path, returns a

--- a/staging/src/k8s.io/mount-utils/fake_mounter.go
+++ b/staging/src/k8s.io/mount-utils/fake_mounter.go
@@ -218,9 +218,8 @@ func (f *FakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
-// CanSafelySkipMountPointCheck always returns false for FakeMounter.
 func (f *FakeMounter) CanSafelySkipMountPointCheck() bool {
-	return false
+	return f.skipMountPointCheck
 }
 
 // GetMountRefs finds all mount references to the path, returns a

--- a/staging/src/k8s.io/mount-utils/mount.go
+++ b/staging/src/k8s.io/mount-utils/mount.go
@@ -65,18 +65,10 @@ type Interface interface {
 	// care about such situations, this is a faster alternative to calling List()
 	// and scanning that output.
 	IsLikelyNotMountPoint(file string) (bool, error)
-	// canSafelySkipMountPointCheck indicates whether this mounter returns errors on
+	// CanSafelySkipMountPointCheck indicates whether this mounter returns errors on
 	// operations for targets that are not mount points. If this returns true, no such
 	// errors will be returned.
-	canSafelySkipMountPointCheck() bool
-	// IsMountPoint determines if a directory is a mountpoint.
-	// It should return ErrNotExist when the directory does not exist.
-	// IsMountPoint is more expensive than IsLikelyNotMountPoint.
-	// IsMountPoint detects bind mounts in linux.
-	// IsMountPoint may enumerate all the mountpoints using List() and
-	// the list of mountpoints may be large, then it uses
-	// isMountPointMatch to evaluate whether the directory is a mountpoint.
-	IsMountPoint(file string) (bool, error)
+	CanSafelySkipMountPointCheck() bool
 	// GetMountRefs finds all mount references to pathname, returning a slice of
 	// paths. Pathname can be a mountpoint path or a normal	directory
 	// (for bind mount). On Linux, pathname is excluded from the slice.

--- a/staging/src/k8s.io/mount-utils/mount.go
+++ b/staging/src/k8s.io/mount-utils/mount.go
@@ -65,10 +65,10 @@ type Interface interface {
 	// care about such situations, this is a faster alternative to calling List()
 	// and scanning that output.
 	IsLikelyNotMountPoint(file string) (bool, error)
-	// CanSafelySkipMountPointCheck indicates whether this mounter returns errors on
+	// canSafelySkipMountPointCheck indicates whether this mounter returns errors on
 	// operations for targets that are not mount points. If this returns true, no such
 	// errors will be returned.
-	CanSafelySkipMountPointCheck() bool
+	canSafelySkipMountPointCheck() bool
 	// GetMountRefs finds all mount references to pathname, returning a slice of
 	// paths. Pathname can be a mountpoint path or a normal	directory
 	// (for bind mount). On Linux, pathname is excluded from the slice.

--- a/staging/src/k8s.io/mount-utils/mount_helper_common.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_common.go
@@ -53,7 +53,8 @@ func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, exte
 	}
 
 	if corruptedMnt || mounter.canSafelySkipMountPointCheck() {
-		klog.V(4).Infof("unmounting %q", mountPath)
+		klog.V(4).Infof("unmounting %q (corruptedMount: %t, mounterCanSkipMountPointChecks: %t)",
+			mountPath, corruptedMnt, mounter.canSafelySkipMountPointCheck())
 		if err := mounter.UnmountWithForce(mountPath, umountTimeout); err != nil {
 			return err
 		}
@@ -89,7 +90,8 @@ func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, exte
 // will be skipped. The mount point check will also be skipped if the mounter supports it.
 func doCleanupMountPoint(mountPath string, mounter Interface, extensiveMountPointCheck bool, corruptedMnt bool) error {
 	if corruptedMnt || mounter.canSafelySkipMountPointCheck() {
-		klog.V(4).Infof("unmounting %q", mountPath)
+		klog.V(4).Infof("unmounting %q (corruptedMount: %t, mounterCanSkipMountPointChecks: %t)",
+			mountPath, corruptedMnt, mounter.canSafelySkipMountPointCheck())
 		if err := mounter.Unmount(mountPath); err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/mount-utils/mount_helper_common.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_common.go
@@ -95,12 +95,6 @@ func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, exte
 // if corruptedMnt is true, it means that the mountPath is a corrupted mountpoint, and the mount point check
 // will be skipped. The mount point check will also be skipped if the mounter supports it.
 func doCleanupMountPoint(mountPath string, mounter Interface, extensiveMountPointCheck bool, corruptedMnt bool) error {
-<<<<<<< HEAD
-	if corruptedMnt || mounter.canSafelySkipMountPointCheck() {
-		klog.V(4).Infof("unmounting %q (corruptedMount: %t, mounterCanSkipMountPointChecks: %t)",
-			mountPath, corruptedMnt, mounter.canSafelySkipMountPointCheck())
-		if err := mounter.Unmount(mountPath); err != nil {
-=======
 	var notMnt bool
 	var err error
 	if !mounter.CanSafelySkipMountPointCheck() && !corruptedMnt {
@@ -108,7 +102,6 @@ func doCleanupMountPoint(mountPath string, mounter Interface, extensiveMountPoin
 		// if mountPath was not a mount point - we would have attempted to remove mountPath
 		// and hence return errors if any.
 		if err != nil || notMnt {
->>>>>>> Skip mount point checks when possible during mount cleanup.
 			return err
 		}
 		return removePath(mountPath)
@@ -168,10 +161,14 @@ func removePathIfNotMountPoint(mountPath string, mounter Interface, extensiveMou
 // removePath attempts to remove the directory. Returns nil if the directory was removed or does not exist.
 func removePath(mountPath string) error {
 <<<<<<< HEAD
+<<<<<<< HEAD
 	klog.V(4).Infof("Warning: deleting path %q", mountPath)
 =======
 	klog.Warningf("Warning: deleting mount path %q", mountPath)
 >>>>>>> Skip mount point checks when possible during mount cleanup.
+=======
+	klog.Warningf("Warning: deleting path %q", mountPath)
+>>>>>>> Add test for detectSafeNotMountedBehavior.
 	err := os.Remove(mountPath)
 	if os.IsNotExist(err) {
 		klog.V(4).Infof("%q does not exist", mountPath)

--- a/staging/src/k8s.io/mount-utils/mount_helper_common.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_common.go
@@ -53,7 +53,7 @@ func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, exte
 	}
 	var notMnt bool
 	var err error
-	if !mounter.CanSafelySkipMountPointCheck() && !corruptedMnt {
+	if !mounter.canSafelySkipMountPointCheck() && !corruptedMnt {
 		notMnt, err = removePathIfNotMountPoint(mountPath, mounter, extensiveMountPointCheck)
 		// if mountPath was not a mount point - we would have attempted to remove mountPath
 		// and hence return errors if any.
@@ -74,7 +74,7 @@ func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, exte
 		return err
 	}
 
-	if mounter.CanSafelySkipMountPointCheck() {
+	if mounter.canSafelySkipMountPointCheck() {
 		return removePath(mountPath)
 	}
 
@@ -97,7 +97,7 @@ func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, exte
 func doCleanupMountPoint(mountPath string, mounter Interface, extensiveMountPointCheck bool, corruptedMnt bool) error {
 	var notMnt bool
 	var err error
-	if !mounter.CanSafelySkipMountPointCheck() && !corruptedMnt {
+	if !mounter.canSafelySkipMountPointCheck() && !corruptedMnt {
 		notMnt, err = removePathIfNotMountPoint(mountPath, mounter, extensiveMountPointCheck)
 		// if mountPath was not a mount point - we would have attempted to remove mountPath
 		// and hence return errors if any.
@@ -118,7 +118,7 @@ func doCleanupMountPoint(mountPath string, mounter Interface, extensiveMountPoin
 		return err
 	}
 
-	if mounter.CanSafelySkipMountPointCheck() {
+	if mounter.canSafelySkipMountPointCheck() {
 		return removePath(mountPath)
 	}
 
@@ -160,15 +160,7 @@ func removePathIfNotMountPoint(mountPath string, mounter Interface, extensiveMou
 
 // removePath attempts to remove the directory. Returns nil if the directory was removed or does not exist.
 func removePath(mountPath string) error {
-<<<<<<< HEAD
-<<<<<<< HEAD
 	klog.V(4).Infof("Warning: deleting path %q", mountPath)
-=======
-	klog.Warningf("Warning: deleting mount path %q", mountPath)
->>>>>>> Skip mount point checks when possible during mount cleanup.
-=======
-	klog.Warningf("Warning: deleting path %q", mountPath)
->>>>>>> Add test for detectSafeNotMountedBehavior.
 	err := os.Remove(mountPath)
 	if os.IsNotExist(err) {
 		klog.V(4).Infof("%q does not exist", mountPath)

--- a/staging/src/k8s.io/mount-utils/mount_helper_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_test.go
@@ -102,6 +102,20 @@ func TestDoCleanupMountPoint(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		"skip-mount-point-check": {
+			prepareMnt: func(base string) (MountPoint, error, error) {
+				path := filepath.Join(base, testMount)
+				if err := os.MkdirAll(path, defaultPerm); err != nil {
+					return MountPoint{Device: "/dev/sdb", Path: path}, nil, err
+				}
+				return MountPoint{Device: "/dev/sdb", Path: path}, nil, nil
+			},
+			prepareMntr: func(mntr *FakeMounter) error {
+				mntr.WithSkipMountPointCheck()
+				return nil
+			},
+			expectErr: false,
+		},
 	}
 
 	for name, tt := range tests {

--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -262,6 +262,11 @@ func detectSystemd() bool {
 // When possible, we will trust umount's message and avoid doing our own mount point checks.
 // More info: https://github.com/util-linux/util-linux/blob/v2.2/mount/umount.c#L179
 func detectSafeNotMountedBehavior() bool {
+	return detectSafeNotMountedBehaviorWithExec(utilexec.New())
+}
+
+// detectSafeNotMountedBehaviorWithExec is for testing with FakeExec.
+func detectSafeNotMountedBehaviorWithExec(exec utilexec.Interface) bool {
 	if _, err := exec.LookPath("umount"); err != nil {
 		klog.V(2).Infof("Failed to locate umount executable to detect safe 'not mounted' behavior")
 		return false

--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -276,16 +276,14 @@ func detectSafeNotMountedBehavior() bool {
 	cmd := exec.Command("umount", path)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		klog.V(2).Infof("Cannot run umount to detect safe 'not mounted' behavior: %v", err)
-		klog.V(4).Infof("'umount %s' output: %s, failed with: %v", path, string(output), err)
-		return false
+		if strings.Contains(string(output), errNotMounted) {
+			klog.V(2).Infof("Detected umount with safe 'not mounted' behavior")
+			return true
+		}
+		klog.V(4).Infof("'umount %s' failed with: %v, output: %s", path, err, string(output))
 	}
-	if !strings.Contains(string(output), errNotMounted) {
-		klog.V(2).Infof("Detected umount with unsafe 'not mounted' behavior")
-		return false
-	}
-	klog.V(2).Infof("Detected umount with safe 'not mounted' behavior")
-	return true
+	klog.V(2).Infof("Detected umount with unsafe 'not mounted' behavior")
+	return false
 }
 
 // MakeMountArgs makes the arguments to the mount(8) command.

--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -267,14 +267,10 @@ func detectSafeNotMountedBehavior() bool {
 
 // detectSafeNotMountedBehaviorWithExec is for testing with FakeExec.
 func detectSafeNotMountedBehaviorWithExec(exec utilexec.Interface) bool {
-	if _, err := exec.LookPath("umount"); err != nil {
-		klog.V(2).Infof("Failed to locate umount executable to detect safe 'not mounted' behavior")
-		return false
-	}
 	// create a temp dir and try to umount it
 	path, err := ioutil.TempDir("", "kubelet-detect-safe-umount")
 	if err != nil {
-		klog.V(2).Infof("Cannot create temp dir to detect safe 'not mounted' behavior: %v", err)
+		klog.V(4).Infof("Cannot create temp dir to detect safe 'not mounted' behavior: %v", err)
 		return false
 	}
 	defer os.RemoveAll(path)
@@ -282,12 +278,12 @@ func detectSafeNotMountedBehaviorWithExec(exec utilexec.Interface) bool {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(output), errNotMounted) {
-			klog.V(2).Infof("Detected umount with safe 'not mounted' behavior")
+			klog.V(4).Infof("Detected umount with safe 'not mounted' behavior")
 			return true
 		}
 		klog.V(4).Infof("'umount %s' failed with: %v, output: %s", path, err, string(output))
 	}
-	klog.V(2).Infof("Detected umount with unsafe 'not mounted' behavior")
+	klog.V(4).Infof("Detected umount with unsafe 'not mounted' behavior")
 	return false
 }
 
@@ -373,6 +369,7 @@ func (mounter *Mounter) Unmount(target string) error {
 			err = &exec.ExitError{ProcessState: command.ProcessState}
 		}
 		if mounter.withSafeNotMountedBehavior && strings.Contains(string(output), errNotMounted) {
+			klog.V(4).Infof("ignoring 'not mounted' error for %s", target)
 			return nil
 		}
 		return fmt.Errorf("unmount failed: %v\nUnmounting arguments: %s\nOutput: %s", err, target, string(output))

--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -423,8 +423,8 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
-// CanSafelySkipMountPointCheck relies on the detected behavior of umount when given a target that is not a mount point.
-func (mounter *Mounter) CanSafelySkipMountPointCheck() bool {
+// canSafelySkipMountPointCheck relies on the detected behavior of umount when given a target that is not a mount point.
+func (mounter *Mounter) canSafelySkipMountPointCheck() bool {
 	return mounter.withSafeNotMountedBehavior
 }
 

--- a/staging/src/k8s.io/mount-utils/mount_unsupported.go
+++ b/staging/src/k8s.io/mount-utils/mount_unsupported.go
@@ -74,8 +74,8 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, errUnsupported
 }
 
-// CanSafelySkipMountPointCheck always returns false on unsupported platforms
-func (mounter *Mounter) CanSafelySkipMountPointCheck() bool {
+// canSafelySkipMountPointCheck always returns false on unsupported platforms
+func (mounter *Mounter) canSafelySkipMountPointCheck() bool {
 	return false
 }
 

--- a/staging/src/k8s.io/mount-utils/mount_unsupported.go
+++ b/staging/src/k8s.io/mount-utils/mount_unsupported.go
@@ -74,15 +74,9 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, errUnsupported
 }
 
-// canSafelySkipMountPointCheck always returns false on unsupported platforms
-func (mounter *Mounter) canSafelySkipMountPointCheck() bool {
+// CanSafelySkipMountPointCheck always returns false on unsupported platforms
+func (mounter *Mounter) CanSafelySkipMountPointCheck() bool {
 	return false
-}
-
-// IsMountPoint determines if a directory is a mountpoint.
-// It always returns an error on unsupported platforms.
-func (mounter *Mounter) IsMountPoint(file string) (bool, error) {
-	return false, errUnsupported
 }
 
 // GetMountRefs always returns an error on unsupported platforms

--- a/staging/src/k8s.io/mount-utils/mount_windows.go
+++ b/staging/src/k8s.io/mount-utils/mount_windows.go
@@ -244,8 +244,8 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
-// CanSafelySkipMountPointCheck always returns false on Windows
-func (mounter *Mounter) CanSafelySkipMountPointCheck() bool {
+// canSafelySkipMountPointCheck always returns false on Windows
+func (mounter *Mounter) canSafelySkipMountPointCheck() bool {
 	return false
 }
 

--- a/staging/src/k8s.io/mount-utils/mount_windows.go
+++ b/staging/src/k8s.io/mount-utils/mount_windows.go
@@ -244,18 +244,9 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
-// canSafelySkipMountPointCheck always returns false on Windows
-func (mounter *Mounter) canSafelySkipMountPointCheck() bool {
+// CanSafelySkipMountPointCheck always returns false on Windows
+func (mounter *Mounter) CanSafelySkipMountPointCheck() bool {
 	return false
-}
-
-// IsMountPoint: determines if a directory is a mountpoint.
-func (mounter *Mounter) IsMountPoint(file string) (bool, error) {
-	isNotMnt, err := mounter.IsLikelyNotMountPoint(file)
-	if err != nil {
-		return false, err
-	}
-	return !isNotMnt, nil
 }
 
 // GetMountRefs : empty implementation here since there is no place to query all mount points on Windows


### PR DESCRIPTION
Cherry pick of #109676 on release-1.26.

#109676: Skip mount point checks when possible during mount

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

**Note to reviewers**: This cherry-pick is a step toward my goal of cherry-picking a fix for https://github.com/kubernetes/kubernetes/issues/114546 to release-1.26.

We need to cherry pick a fix to 1.26 : https://github.com/kubernetes/kubernetes/pull/114605. These changes were made on top of the changes in https://github.com/kubernetes/kubernetes/pull/109676, I cherry picked the change in 1.26 : https://github.com/kubernetes/kubernetes/pull/119087 but some of the unit tests are failing so I'd like to cherry-pick this before I cherry-pick https://github.com/kubernetes/kubernetes/pull/114605.

**Does this PR introduce a user-facing change?**

```release-notes
Cherry picked #109676 - Skip mount point checks when possible during mount
```