### PR TITLE
Increase timeout for DRA kubelet plugin client

### DIFF
--- a/pkg/kubelet/cm/dra/plugin/client.go
+++ b/pkg/kubelet/cm/dra/plugin/client.go
@@ -34,7 +34,7 @@ import (
 	drapb "k8s.io/kubelet/pkg/apis/dra/v1alpha3"
 )
 
-const PluginClientTimeout = 10 * time.Second
+const PluginClientTimeout = 45 * time.Second
 
 // Strongly typed address.
 type draAddr string


### PR DESCRIPTION
The 10 second timeout was too low. Given that the retry loop for the kubelet itself is 90s, increasing the timeout to half of this seems reasonable. Ideally we would pull in the variable that sets the retry timeout to 90s and then just set our local timeout to half of that. Unfortunately, this is not exported, so we settle (for now) with just explicitly setting it to 45s.