### PR TITLE
Fix e2e tests for kubectl proxy cannot get cluster url

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -498,11 +498,11 @@ func LoadConfig() (config *restclient.Config, err error) {
 		return nil, err
 	}
 	// In case Host is not set in TestContext, sets it as
-	// CurrentContext Server for k8s API client to connect to.
+	// CurrentServer for k8s API client to connect to.
 	if TestContext.Host == "" && c.Clusters != nil {
-		currentContext, ok := c.Clusters[c.CurrentContext]
+		currentCluster, ok := c.Clusters[c.Contexts[c.CurrentContext].Cluster]
 		if ok {
-			TestContext.Host = currentContext.Server
+			TestContext.Host = currentCluster.Server
 		}
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119419

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
