### PR TITLE
[KEP-2400] Add `pod_swap_usage_bytes` as an expected metric in resource metric e2e test

### DIFF
--- a/test/e2e_node/resource_metrics_test.go
+++ b/test/e2e_node/resource_metrics_test.go
@@ -165,3 +165,18 @@ func boundedSample(lower, upper interface{}) types.GomegaMatcher {
 		"Histogram": gstruct.Ignore(),
 	}))
 }
+
+func haveKeys(keys ...string) types.GomegaMatcher {
+	gomega.ExpectWithOffset(1, keys).ToNot(gomega.BeEmpty())
+	matcher := gomega.HaveKey(keys[0])
+
+	if len(keys) == 1 {
+		return matcher
+	}
+
+	for _, key := range keys[1:] {
+		matcher = gomega.And(matcher, gomega.HaveKey(key))
+	}
+
+	return matcher
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/kind failing-test

#### What this PR does / why we need it:
Recently, swap stats [were added](https://github.com/kubernetes/kubernetes/pull/118865) to `/stats/summary` and `/metrics/resource`.
These changes caused the `ResourceMetricsAPI` e2e test to fail at periodic jobs [1], that do not expect the `pod_swap_usage_bytes` metric.

This PR adds expectation for `pod_swap_usage_bytes` metric to the test, which will now cause it to pass.

[1] https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cgroupv1-node-e2e-features

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119400

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
<!--
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->
