### PR TITLE
Use debian-base instead of distroless for conformance image

### DIFF
--- a/test/conformance/image/Dockerfile
+++ b/test/conformance/image/Dockerfile
@@ -12,18 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE
 ARG RUNNERIMAGE
-
-FROM ${BASEIMAGE} as debbase
-
 FROM ${RUNNERIMAGE}
-
-# This is a dependency for `kubectl diff` tests
-COPY --from=debbase /usr/bin/diff /usr/local/bin/
-COPY --from=debbase /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu
-COPY --from=debbase /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu
-COPY --from=debbase /lib64/ld-linux-x86-64.so.2 /lib64
 
 COPY cluster /kubernetes/cluster
 COPY ginkgo /usr/local/bin/

--- a/test/conformance/image/Makefile
+++ b/test/conformance/image/Makefile
@@ -34,12 +34,7 @@ CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 # This is defined in root Makefile, but some build contexts do not refer to them
 KUBE_BASE_IMAGE_REGISTRY?=registry.k8s.io
 BASE_IMAGE_VERSION?=bookworm-v1.0.0
-BASEIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base-${ARCH}:${BASE_IMAGE_VERSION}
-
-# Keep debian releases (e.g. debian 11 == bullseye) consistent 
-# between BASE_IMAGE_VERSION and DISTROLESS_IMAGE images
-DISTROLESS_IMAGE?=base-debian11
-RUNNERIMAGE?=gcr.io/distroless/${DISTROLESS_IMAGE}:latest
+RUNNERIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base-${ARCH}:${BASE_IMAGE_VERSION}
 
 TEMP_DIR:=$(shell mktemp -d -t conformance-XXXXXX)
 
@@ -68,7 +63,6 @@ endif
 		--load \
 		--pull \
 		-t ${REGISTRY}/conformance-${ARCH}:${VERSION} \
-		--build-arg BASEIMAGE=$(BASEIMAGE) \
 		--build-arg RUNNERIMAGE=$(RUNNERIMAGE) \
 		${TEMP_DIR}
 	rm -rf "${TEMP_DIR}"


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
The `diff` binary (required by the `kubectl diff` e2e test) gets statically or dynamically linked based on the used glibc version. We cannot really predict that behavior for the various platforms of debian-base and therefore cannot copy the binary around. This means that distroless is not a great choice for the conformance image unless we stop relying on `diff`.

This means we now switch back to `debian-base` for the conformance image to simplify the build process and reduce the amount of moving parts.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119411

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Switched back to debian-base instead of distroless for conformance image.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
