### PR TITLE
Skip `kubectl diff` test if binary is not found in `$PATH`

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -154,8 +154,6 @@ dependencies:
       match: BASEIMAGE\?\=registry\.k8s\.io\/build-image\/debian-base-ppc64le:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
     - path: cluster/images/etcd/Makefile
       match: BASEIMAGE\?\=registry\.k8s\.io\/build-image\/debian-base-s390x:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
-    - path: test/conformance/image/Makefile
-      match: BASE_IMAGE_VERSION\?=
 
   - name: "registry.k8s.io/distroless-iptables: dependents"
     version: v0.2.6

--- a/test/conformance/image/Dockerfile
+++ b/test/conformance/image/Dockerfile
@@ -12,18 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE
 ARG RUNNERIMAGE
 
-FROM ${BASEIMAGE} as debbase
-
 FROM ${RUNNERIMAGE}
-
-# This is a dependency for `kubectl diff` tests
-COPY --from=debbase /usr/bin/diff /usr/local/bin/
-COPY --from=debbase /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu
-COPY --from=debbase /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu
-COPY --from=debbase /lib64/ld-linux-x86-64.so.2 /lib64
 
 COPY cluster /kubernetes/cluster
 COPY ginkgo /usr/local/bin/

--- a/test/conformance/image/Makefile
+++ b/test/conformance/image/Makefile
@@ -31,13 +31,6 @@ E2E_GO_RUNNER_BIN?=$(shell test -f $(LOCAL_OUTPUT_PATH)/go-runner && echo $(LOCA
 
 CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
-# This is defined in root Makefile, but some build contexts do not refer to them
-KUBE_BASE_IMAGE_REGISTRY?=registry.k8s.io
-BASE_IMAGE_VERSION?=bookworm-v1.0.0
-BASEIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base-${ARCH}:${BASE_IMAGE_VERSION}
-
-# Keep debian releases (e.g. debian 11 == bullseye) consistent 
-# between BASE_IMAGE_VERSION and DISTROLESS_IMAGE images
 DISTROLESS_IMAGE?=base-debian11
 RUNNERIMAGE?=gcr.io/distroless/${DISTROLESS_IMAGE}:latest
 
@@ -68,7 +61,6 @@ endif
 		--load \
 		--pull \
 		-t ${REGISTRY}/conformance-${ARCH}:${VERSION} \
-		--build-arg BASEIMAGE=$(BASEIMAGE) \
 		--build-arg RUNNERIMAGE=$(RUNNERIMAGE) \
 		${TEMP_DIR}
 	rm -rf "${TEMP_DIR}"

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1221,14 +1221,6 @@
     proper information.
   release: v1.9
   file: test/e2e/kubectl/kubectl.go
-- testname: Kubectl, diff Deployment
-  codename: '[sig-cli] Kubectl client Kubectl diff should check if kubectl diff finds
-    a difference for Deployments [Conformance]'
-  description: Create a Deployment with httpd image. Declare the same Deployment with
-    a different image, busybox. Diff of live Deployment with declared Deployment MUST
-    include the difference between live and declared image.
-  release: v1.19
-  file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, create service, replication controller
   codename: '[sig-cli] Kubectl client Kubectl expose should create services for rc  [Conformance]'
   description: Create a Pod running agnhost listening to port 6379. Using kubectl

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -993,7 +993,11 @@ metadata:
 			Testname: Kubectl, diff Deployment
 			Description: Create a Deployment with httpd image. Declare the same Deployment with a different image, busybox. Diff of live Deployment with declared Deployment MUST include the difference between live and declared image.
 		*/
-		framework.ConformanceIt("should check if kubectl diff finds a difference for Deployments", func(ctx context.Context) {
+		ginkgo.It("should check if kubectl diff finds a difference for Deployments", func(ctx context.Context) {
+			if _, err := exec.LookPath("diff"); err != nil {
+				ginkgo.Skip("diff binary not available in $PATH")
+			}
+
 			ginkgo.By("create deployment with httpd image")
 			deployment := commonutils.SubstituteImageName(string(readTestFileOrDie(httpdDeployment3Filename)))
 			e2ekubectl.RunKubectlOrDieInput(ns, deployment, "create", "-f", "-")


### PR DESCRIPTION



#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
As an alternative to
https://github.com/kubernetes/kubernetes/pull/119422, we now skip the conformance test and therefore do not rely on `diff` any more.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/119411

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Skipping `kubectl diff` test for conformance image since we do not ship the `diff` utility any more.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
