### PR TITLE
fix ephemeral volume test suite failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.2
 	github.com/cyphar/filepath-securejoin v0.2.3
+	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/emicklei/go-restful/v3 v3.9.0
@@ -155,7 +156,6 @@ require (
 	github.com/containerd/ttrpc v1.2.2 // indirect
 	github.com/coredns/caddy v1.1.1 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/daviddengcn/go-colortext v1.0.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect

--- a/test/e2e/storage/testsuites/ephemeral.go
+++ b/test/e2e/storage/testsuites/ephemeral.go
@@ -35,6 +35,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
@@ -114,9 +115,14 @@ func (p *ephemeralTestSuite) DefineTests(driver storageframework.TestDriver, pat
 		l       local
 	)
 
+	// The base name is used to generate a unique name for the resources created by this test.
+	// In order to avoid name collisions when we run this test in parallel with other ephemeral
+	// tests, we use a hash of the test suite as the suffix of the base name.
+	baseName := fmt.Sprintf("ephemeral-%s", utils.DeepHashObjectToString(p))
+
 	// Beware that it also registers an AfterEach which renders f unusable. Any code using
 	// f must run inside an It or Context callback.
-	f := framework.NewFrameworkWithCustomTimeouts("ephemeral", storageframework.GetDriverTimeouts(driver))
+	f := framework.NewFrameworkWithCustomTimeouts(baseName, storageframework.GetDriverTimeouts(driver))
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	init := func(ctx context.Context) {

--- a/test/e2e/storage/utils/hash.go
+++ b/test/e2e/storage/utils/hash.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"hash"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// DeepHashObjectToString creates a unique hash string from a go object.
+// copied from k8s.io/endpointslice/util/controller_utils.go
+func DeepHashObjectToString(objectToWrite interface{}) string {
+	hasher := md5.New()
+	deepHashObject(hasher, objectToWrite)
+	return hex.EncodeToString(hasher.Sum(nil)[0:])
+}
+
+// DeepHashObject writes specified object to hash using the spew library
+// which follows pointers and prints actual values of the nested objects
+// ensuring the hash does not change when a pointer changes.
+// copied from k8s.io/endpointslice/util/controller_utils.go
+func deepHashObject(hasher hash.Hash, objectToWrite interface{}) {
+	hasher.Reset()
+	printer := spew.ConfigState{
+		Indent:         " ",
+		SortKeys:       true,
+		DisableMethods: true,
+		SpewKeys:       true,
+	}
+	printer.Fprintf(hasher, "%#v", objectToWrite)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #118037 

#### Special notes for your reviewer:

grep psp-csi-hostpath-role-ephemeral-9424 [kube-apiserver-audit.log](https://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cos-k8sstable1-default/1653651043134738432/artifacts/test-359c739436-master/)

```
{"kind":"Event","verb":"create","apiVersion":"audit.k8s.io/v1","level":"RequestResponse","auditID":"6a9f1e33-3b02-4766-8061-46f09c9803fe","stage":"ResponseComplete","requestURI":"/apis/rbac.authorization.k8s.io/v1/clusterrolebindings","user":{"username":"kubecfg","groups":["system:masters","system:authenticated"]},"sourceIPs":["34.66.240.149"],"userAgent":"e2e.test/v1.27.1 (linux/amd64) kubernetes/7d93cc6 -- [sig-storage] CSI Volumes [Driver: csi-hostpath] [Testpattern: Generic Ephemeral-volume (block volmode) (late-binding)] ephemeral should create read/write inline ephemeral volume","objectRef":{"resource":"clusterrolebindings","name":"psp-csi-hostpath-role-ephemeral-9424","apiGroup":"rbac.authorization.k8s.io","apiVersion":"v1"},"responseStatus":{"metadata":{},"code":201},"requestObject":{"kind":"ClusterRoleBinding","apiVersion":"rbac.authorization.k8s.io/v1","metadata":{"name":"psp-csi-hostpath-role-ephemeral-9424","creationTimestamp":null},"subjects":[{"kind":"ServiceAccount","name":"csi-attacher","namespace":"ephemeral-9424-26"},{"kind":"ServiceAccount","name":"csi-provisioner","namespace":"ephemeral-9424-26"},{"kind":"ServiceAccount","name":"csi-snapshotter","namespace":"ephemeral-9424-26"},{"kind":"ServiceAccount","name":"csi-resizer","namespace":"ephemeral-9424-26"},{"kind":"ServiceAccount","name":"csi-external-health-monitor-controller","namespace":"ephemeral-9424-26"},{"kind":"ServiceAccount","name":"csi-hostpathplugin-sa","namespace":"ephemeral-9424-26"}],"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"e2e-test-privileged-psp"}},"responseObject":{"kind":"ClusterRoleBinding","apiVersion":"rbac.authorization.k8s.io/v1","metadata":{"name":"psp-csi-hostpath-role-ephemeral-9424","uid":"99630f42-cac7-42b1-8e64-f9de491cd85c","resourceVersion":"24062","creationTimestamp":"2023-05-03T06:59:36Z","managedFields":[{"manager":"e2e.test","operation":"Update","apiVersion":"rbac.authorization.k8s.io/v1","time":"2023-05-03T06:59:36Z","fieldsType":"FieldsV1","fieldsV1":{"f:roleRef":{},"f:subjects":{}}}]},"subjects":[{"kind":"ServiceAccount","name":"csi-attacher","namespace":"ephemeral-9424-26"},{"kind":"ServiceAccount","name":"csi-provisioner","namespace":"ephemeral-9424-26"},{"kind":"ServiceAccount","name":"csi-snapshotter","namespace":"ephemeral-9424-26"},{"kind":"ServiceAccount","name":"csi-resizer","namespace":"ephemeral-9424-26"},{"kind":"ServiceAccount","name":"csi-external-health-monitor-controller","namespace":"ephemeral-9424-26"},{"kind":"ServiceAccount","name":"csi-hostpathplugin-sa","namespace":"ephemeral-9424-26"}],"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"e2e-test-privileged-psp"}},"requestReceivedTimestamp":"2023-05-03T06:59:36.929529Z","stageTimestamp":"2023-05-03T06:59:36.954099Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":""}}
{"kind":"Event","verb":"create","apiVersion":"audit.k8s.io/v1","level":"RequestResponse","auditID":"b536462c-54c9-4f02-945c-ca6bcb3c8291","stage":"ResponseComplete","requestURI":"/apis/rbac.authorization.k8s.io/v1/clusterrolebindings","user":{"username":"kubecfg","groups":["system:masters","system:authenticated"]},"sourceIPs":["34.66.240.149"],"userAgent":"e2e.test/v1.27.1 (linux/amd64) kubernetes/7d93cc6 -- [sig-storage] CSI Volumes [Driver: csi-hostpath] [Testpattern: CSI Ephemeral-volume (default fs)] ephemeral should create read/write inline ephemeral volume","objectRef":{"resource":"clusterrolebindings","name":"psp-csi-hostpath-role-ephemeral-9424","apiGroup":"rbac.authorization.k8s.io","apiVersion":"v1"},"responseStatus":{"metadata":{},"status":"Failure","message":"clusterrolebindings.rbac.authorization.k8s.io \"psp-csi-hostpath-role-ephemeral-9424\" already exists","reason":"AlreadyExists","details":{"name":"psp-csi-hostpath-role-ephemeral-9424","group":"rbac.authorization.k8s.io","kind":"clusterrolebindings"},"code":409},"requestObject":{"kind":"ClusterRoleBinding","apiVersion":"rbac.authorization.k8s.io/v1","metadata":{"name":"psp-csi-hostpath-role-ephemeral-9424","creationTimestamp":null},"subjects":[{"kind":"ServiceAccount","name":"csi-attacher","namespace":"ephemeral-9424-1906"},{"kind":"ServiceAccount","name":"csi-provisioner","namespace":"ephemeral-9424-1906"},{"kind":"ServiceAccount","name":"csi-snapshotter","namespace":"ephemeral-9424-1906"},{"kind":"ServiceAccount","name":"csi-resizer","namespace":"ephemeral-9424-1906"},{"kind":"ServiceAccount","name":"csi-external-health-monitor-controller","namespace":"ephemeral-9424-1906"},{"kind":"ServiceAccount","name":"csi-hostpathplugin-sa","namespace":"ephemeral-9424-1906"}],"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"e2e-test-privileged-psp"}},"responseObject":{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"clusterrolebindings.rbac.authorization.k8s.io \"psp-csi-hostpath-role-ephemeral-9424\" already exists","reason":"AlreadyExists","details":{"name":"psp-csi-hostpath-role-ephemeral-9424","group":"rbac.authorization.k8s.io","kind":"clusterrolebindings"},"code":409},"requestReceivedTimestamp":"2023-05-03T07:02:07.063637Z","stageTimestamp":"2023-05-03T07:02:07.099918Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":""}}
{"kind":"Event","verb":"delete","apiVersion":"audit.k8s.io/v1","level":"RequestResponse","auditID":"394df0b9-f6fb-426c-bbea-70fdeb6efaa9","stage":"ResponseComplete","requestURI":"/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/psp-csi-hostpath-role-ephemeral-9424","user":{"username":"kubecfg","groups":["system:masters","system:authenticated"]},"sourceIPs":["34.66.240.149"],"userAgent":"e2e.test/v1.27.1 (linux/amd64) kubernetes/7d93cc6 -- [sig-storage] CSI Volumes [Driver: csi-hostpath] [Testpattern: Generic Ephemeral-volume (block volmode) (late-binding)] ephemeral should create read/write inline ephemeral volume","objectRef":{"resource":"clusterrolebindings","name":"psp-csi-hostpath-role-ephemeral-9424","apiGroup":"rbac.authorization.k8s.io","apiVersion":"v1"},"responseStatus":{"metadata":{},"status":"Success","details":{"name":"psp-csi-hostpath-role-ephemeral-9424","group":"rbac.authorization.k8s.io","kind":"clusterrolebindings","uid":"99630f42-cac7-42b1-8e64-f9de491cd85c"},"code":200},"requestObject":{"kind":"DeleteOptions","apiVersion":"meta.k8s.io/__internal"},"responseObject":{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"psp-csi-hostpath-role-ephemeral-9424","group":"rbac.authorization.k8s.io","kind":"clusterrolebindings","uid":"99630f42-cac7-42b1-8e64-f9de491cd85c"}},"requestReceivedTimestamp":"2023-05-03T07:02:48.149279Z","stageTimestamp":"2023-05-03T07:02:48.508367Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":""}}

```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
