### PR TITLE
Don't reuse CPU set of a restartable init container

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
+	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/utils/cpuset"
 )
 
@@ -277,6 +278,12 @@ func (p *staticPolicy) updateCPUsToReuse(pod *v1.Pod, container *v1.Container, c
 	// If so, add its cpuset to the cpuset of reusable CPUs for any new allocations.
 	for _, initContainer := range pod.Spec.InitContainers {
 		if container.Name == initContainer.Name {
+			if types.IsRestartableInitContainer(&initContainer) {
+				// If the container is a restartable init container, we should not
+				// reuse its cpuset, as a restartable init container can run with
+				// regular containers.
+				break
+			}
 			p.cpusToReuse[string(pod.UID)] = p.cpusToReuse[string(pod.UID)].Union(cset)
 			return
 		}
@@ -444,15 +451,21 @@ func (p *staticPolicy) guaranteedCPUs(pod *v1.Pod, container *v1.Container) int 
 func (p *staticPolicy) podGuaranteedCPUs(pod *v1.Pod) int {
 	// The maximum of requested CPUs by init containers.
 	requestedByInitContainers := 0
+	requestedByRestartableInitContainers := 0
 	for _, container := range pod.Spec.InitContainers {
 		if _, ok := container.Resources.Requests[v1.ResourceCPU]; !ok {
 			continue
 		}
 		requestedCPU := p.guaranteedCPUs(pod, &container)
-		if requestedCPU > requestedByInitContainers {
-			requestedByInitContainers = requestedCPU
+		// See https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers#resources-calculation-for-scheduling-and-pod-admission
+		// for the detail.
+		if types.IsRestartableInitContainer(&container) {
+			requestedByRestartableInitContainers += requestedCPU
+		} else if requestedByRestartableInitContainers+requestedCPU > requestedByInitContainers {
+			requestedByInitContainers = requestedByRestartableInitContainers + requestedCPU
 		}
 	}
+
 	// The sum of requested CPUs by app containers.
 	requestedByAppContainers := 0
 	for _, container := range pod.Spec.Containers {
@@ -462,10 +475,11 @@ func (p *staticPolicy) podGuaranteedCPUs(pod *v1.Pod) int {
 		requestedByAppContainers += p.guaranteedCPUs(pod, &container)
 	}
 
-	if requestedByInitContainers > requestedByAppContainers {
+	requestedByLongRunningContainers := requestedByAppContainers + requestedByRestartableInitContainers
+	if requestedByInitContainers > requestedByLongRunningContainers {
 		return requestedByInitContainers
 	}
-	return requestedByAppContainers
+	return requestedByLongRunningContainers
 }
 
 func (p *staticPolicy) takeByTopology(availableCPUs cpuset.CPUSet, numCPUs int) (cpuset.CPUSet, error) {

--- a/pkg/kubelet/cm/cpumanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology_hints_test.go
@@ -65,11 +65,14 @@ func returnMachineInfo() cadvisorapi.MachineInfo {
 	}
 }
 
+type containerOptions struct {
+	request       string
+	limit         string
+	restartPolicy v1.ContainerRestartPolicy
+}
+
 func TestPodGuaranteedCPUs(t *testing.T) {
-	CPUs := [][]struct {
-		request string
-		limit   string
-	}{
+	options := [][]*containerOptions{
 		{
 			{request: "0", limit: "0"},
 		},
@@ -85,17 +88,46 @@ func TestPodGuaranteedCPUs(t *testing.T) {
 		},
 	}
 	// tc for not guaranteed Pod
-	testPod1 := makeMultiContainerPod(CPUs[0], CPUs[0])
-	testPod2 := makeMultiContainerPod(CPUs[0], CPUs[1])
-	testPod3 := makeMultiContainerPod(CPUs[1], CPUs[0])
+	testPod1 := makeMultiContainerPodWithOptions(options[0], options[0])
+	testPod2 := makeMultiContainerPodWithOptions(options[0], options[1])
+	testPod3 := makeMultiContainerPodWithOptions(options[1], options[0])
 	// tc for guaranteed Pod
-	testPod4 := makeMultiContainerPod(CPUs[1], CPUs[1])
-	testPod5 := makeMultiContainerPod(CPUs[2], CPUs[2])
+	testPod4 := makeMultiContainerPodWithOptions(options[1], options[1])
+	testPod5 := makeMultiContainerPodWithOptions(options[2], options[2])
 	// tc for comparing init containers and user containers
-	testPod6 := makeMultiContainerPod(CPUs[1], CPUs[2])
-	testPod7 := makeMultiContainerPod(CPUs[2], CPUs[1])
+	testPod6 := makeMultiContainerPodWithOptions(options[1], options[2])
+	testPod7 := makeMultiContainerPodWithOptions(options[2], options[1])
 	// tc for multi containers
-	testPod8 := makeMultiContainerPod(CPUs[3], CPUs[3])
+	testPod8 := makeMultiContainerPodWithOptions(options[3], options[3])
+	// tc for restartable init containers
+	testPod9 := makeMultiContainerPodWithOptions([]*containerOptions{
+		{request: "1", limit: "1", restartPolicy: v1.ContainerRestartPolicyAlways},
+	}, []*containerOptions{
+		{request: "1", limit: "1"},
+	})
+	testPod10 := makeMultiContainerPodWithOptions([]*containerOptions{
+		{request: "5", limit: "5"},
+		{request: "1", limit: "1", restartPolicy: v1.ContainerRestartPolicyAlways},
+		{request: "2", limit: "2", restartPolicy: v1.ContainerRestartPolicyAlways},
+		{request: "3", limit: "3", restartPolicy: v1.ContainerRestartPolicyAlways},
+	}, []*containerOptions{
+		{request: "1", limit: "1"},
+	})
+	testPod11 := makeMultiContainerPodWithOptions([]*containerOptions{
+		{request: "5", limit: "5"},
+		{request: "1", limit: "1", restartPolicy: v1.ContainerRestartPolicyAlways},
+		{request: "2", limit: "2", restartPolicy: v1.ContainerRestartPolicyAlways},
+		{request: "5", limit: "5"},
+		{request: "3", limit: "3", restartPolicy: v1.ContainerRestartPolicyAlways},
+	}, []*containerOptions{
+		{request: "1", limit: "1"},
+	})
+	testPod12 := makeMultiContainerPodWithOptions([]*containerOptions{
+		{request: "10", limit: "10", restartPolicy: v1.ContainerRestartPolicyAlways},
+		{request: "200", limit: "200"},
+	}, []*containerOptions{
+		{request: "100", limit: "100"},
+	})
 
 	p := staticPolicy{}
 
@@ -144,13 +176,35 @@ func TestPodGuaranteedCPUs(t *testing.T) {
 			pod:         testPod8,
 			expectedCPU: 6,
 		},
+		{
+			name:        "TestCase09: restartable init container + regular container",
+			pod:         testPod9,
+			expectedCPU: 2,
+		},
+		{
+			name:        "TestCase09: multiple restartable init containers",
+			pod:         testPod10,
+			expectedCPU: 7,
+		},
+		{
+			name:        "TestCase11: multiple restartable and regular init containers",
+			pod:         testPod11,
+			expectedCPU: 8,
+		},
+		{
+			name:        "TestCase12: restartable init, regular init and regular container",
+			pod:         testPod12,
+			expectedCPU: 210,
+		},
 	}
 	for _, tc := range tcases {
-		requestedCPU := p.podGuaranteedCPUs(tc.pod)
+		t.Run(tc.name, func(t *testing.T) {
+			requestedCPU := p.podGuaranteedCPUs(tc.pod)
 
-		if requestedCPU != tc.expectedCPU {
-			t.Errorf("Expected in result to be %v , got %v", tc.expectedCPU, requestedCPU)
-		}
+			if requestedCPU != tc.expectedCPU {
+				t.Errorf("Expected in result to be %v , got %v", tc.expectedCPU, requestedCPU)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When cpu-manager-policy is static and you create a guaranteed pod with a restartable init container,
a restartable init container shares its CPU set with a regular container.

This PR makes sure that a restartable init container does not share its CPU set with regular containers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
xref: #119442 

#### Special notes for your reviewer:

##### Before this PR
```
$ cat <<EOF | kubectl apply -f - 
apiVersion: v1
kind: Pod
metadata:
  name: test
spec:
  initContainers:
  - name: init-1
    image: ubuntu
    command:
    - sh
    - -c
    - |
      grep Cpus_allowed_list /proc/self/status | cut -f2
    volumeMounts:
    - name: shared
      mountPath: /tmp/shared
    resources:
      limits:
        cpu: 8
        memory: 100Mi
  - name: restartable-init-2
    image: ubuntu
    command:
    - sh
    - -c
    - |
      grep Cpus_allowed_list /proc/self/status | cut -f2
      sleep 300s
    volumeMounts:
    - name: shared
      mountPath: /tmp/shared
    resources:
      limits:
        cpu: 4
        memory: 200Mi
    restartPolicy: Always
  containers:
  - name: regular-3
    image: ubuntu
    command:
    - sh
    - -c
    - |
      grep Cpus_allowed_list /proc/self/status | cut -f2
      sleep 300s
    resources:
      limits:
        cpu: 4
        memory: 300Mi
    volumeMounts:
    - name: shared
      mountPath: /tmp/shared
  terminationGracePeriodSeconds: 1
  volumes:
  - name: shared
    emptyDir: {}
  restartPolicy: Never
EOF
pod/test created
...
$ kubectl logs test -c init-1
0-3,6-9
$ kubectl logs test -c restartable-init-2
0-1,6-7  # init container and restartalbe init container can share the CPUs, as "init-1" is already terminated and will not restart.
$ kubectl logs test -c regular-3         
0-1,6-7  # restartable init container and regular container should not share the CPUs, as they should run together.
```

##### After this PR
```
$ cat <<EOF | kubectl apply -f - 
apiVersion: v1
kind: Pod
metadata:
  name: test
spec:
  initContainers:
  - name: init-1
    image: ubuntu
    command:
    - sh
    - -c
    - |
      grep Cpus_allowed_list /proc/self/status | cut -f2
    volumeMounts:
    - name: shared
      mountPath: /tmp/shared
    resources:
      limits:
        cpu: 8
        memory: 100Mi
  - name: restartable-init-2
    image: ubuntu
    command:
    - sh
    - -c
    - |
      grep Cpus_allowed_list /proc/self/status | cut -f2
      sleep 300s
    volumeMounts:
    - name: shared
      mountPath: /tmp/shared
    resources:
      limits:
        cpu: 4
        memory: 200Mi
    restartPolicy: Always
  containers:
  - name: regular-3
    image: ubuntu
    command:
    - sh
    - -c
    - |
      grep Cpus_allowed_list /proc/self/status | cut -f2
      sleep 300s
    resources:
      limits:
        cpu: 4
        memory: 300Mi
    volumeMounts:
    - name: shared
      mountPath: /tmp/shared
  terminationGracePeriodSeconds: 1
  volumes:
  - name: shared
    emptyDir: {}
  restartPolicy: Never
EOF
pod/test created
...
$ kubectl logs test -c init-1
0-3,6-9
$ kubectl logs test -c restartable-init-2
0-1,6-7
$ kubectl logs test -c regular-3
2-3,8-9
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where the CPU set allocated to an init container, with containerRestartPolicy of `Always`, were erroneously reused by a regular container.
```
wrote "none", as we already added a release note in https://github.com/kubernetes/kubernetes/pull/116429.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers
```

/cc @SergeyKanzhelev @tzneal @klueska 
/assign @mrunalp 
/priority important-soon