### PR TITLE
Fix empty table when sorting on nonexistent field

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package get
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -52,9 +53,17 @@ func (s *SortingPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 			parsedField = s.SortField
 		}
 
-		if sorter, err := NewTableSorter(table, parsedField); err != nil {
+		sorter, err := NewTableSorter(table, parsedField)
+		if sorter != nil && errors.Is(err, ErrNoFieldMatch{}) {
+			klog.Warningf(err.Error())
+		} else if sorter == nil {
+			if err == nil {
+				return fmt.Errorf("unknown sorting error")
+			}
 			return err
-		} else if err := sorter.Sort(); err != nil {
+		}
+
+		if err := sorter.Sort(); err != nil {
 			return err
 		}
 		return s.Delegate.PrintObj(table, out)
@@ -385,6 +394,26 @@ func (t *TableSorter) Sort() error {
 	return nil
 }
 
+// ErrNoFieldMatch is a structured error indicating the provided JSONPath did not
+// match any row in the table.
+type ErrNoFieldMatch struct {
+	field string
+}
+
+// Error implements the error interface.
+func (e ErrNoFieldMatch) Error() string {
+	return fmt.Sprintf("couldn't find any field with path %q in the list of objects", e.field)
+}
+
+func (e ErrNoFieldMatch) Is(target error) bool {
+	_, ok := target.(*ErrNoFieldMatch)
+	return ok
+}
+
+// NewTableSorter creates a new table sorter with a given JSONPath field.
+// - If no rows match the JSONPath, returns a sorter and a warning.
+// - On other error, returns nil and the error.
+// - If successful, returns the sorter and nil.
 func NewTableSorter(table *metav1.Table, field string) (*TableSorter, error) {
 	var parsedRows [][][]reflect.Value
 
@@ -406,15 +435,17 @@ func NewTableSorter(table *metav1.Table, field string) (*TableSorter, error) {
 		}
 	}
 
-	if len(table.Rows) > 0 && !fieldFoundOnce {
-		return nil, fmt.Errorf("couldn't find any field with path %q in the list of objects", field)
-	}
-
-	return &TableSorter{
+	sorter := &TableSorter{
 		obj:        table,
 		field:      field,
 		parsedRows: parsedRows,
-	}, nil
+	}
+
+	if len(table.Rows) > 0 && !fieldFoundOnce {
+		return sorter, ErrNoFieldMatch{field: field}
+	}
+
+	return sorter, nil
 }
 func findJSONPathResults(parser *jsonpath.JSONPath, from runtime.Object) ([][]reflect.Value, error) {
 	if unstructuredObj, ok := from.(*unstructured.Unstructured); ok {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
@@ -54,9 +54,9 @@ func (s *SortingPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 		}
 
 		sorter, err := NewTableSorter(table, parsedField)
-		if sorter != nil && errors.Is(err, ErrNoFieldMatch{}) {
+		if sorter != nil && errors.As(err, &ErrNoFieldMatch{}) {
 			klog.Warningln(err.Error())
-		} else if sorter == nil {
+		} else if sorter == nil || err != nil {
 			if err == nil {
 				return fmt.Errorf("unknown sorting error")
 			}
@@ -403,11 +403,6 @@ type ErrNoFieldMatch struct {
 // Error implements the error interface.
 func (e ErrNoFieldMatch) Error() string {
 	return fmt.Sprintf("couldn't find any field with path %q in the list of objects", e.field)
-}
-
-func (e ErrNoFieldMatch) Is(target error) bool {
-	_, ok := target.(*ErrNoFieldMatch)
-	return ok
 }
 
 // NewTableSorter creates a new table sorter with a given JSONPath field.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
@@ -55,7 +55,7 @@ func (s *SortingPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 
 		sorter, err := NewTableSorter(table, parsedField)
 		if sorter != nil && errors.As(err, &ErrNoFieldMatch{}) {
-			klog.Warningln(err.Error())
+			klog.Warningf("WARNING: %v", err.Error())
 		} else if sorter == nil || err != nil {
 			if err == nil {
 				return fmt.Errorf("unknown sorting error")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
@@ -55,7 +55,7 @@ func (s *SortingPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 
 		sorter, err := NewTableSorter(table, parsedField)
 		if sorter != nil && errors.Is(err, ErrNoFieldMatch{}) {
-			klog.Warningf(err.Error())
+			klog.Warningln(err.Error())
 		} else if sorter == nil {
 			if err == nil {
 				return fmt.Errorf("unknown sorting error")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If a the JSONPath specified by `kubectl get ... --sort-by [json-path]` matches no rows, falls back to displaying every row and a warning indicating that no row matched, instead of zero rows.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1343

#### Special notes for your reviewer:
I wasn't too sure about the `errors.Is` vs `errors.As` stuff. It seems to work but not super clear on if it's correct.

#### Does this PR introduce a user-facing change?
```release-note
The --sort-by flag will no longer cause zero rows to display when set to a JSONPath which matches zero rows.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: