### PR TITLE
implement secret empty string value integration test

### DIFF
--- a/test/integration/secrets/secrets_test.go
+++ b/test/integration/secrets/secrets_test.go
@@ -22,8 +22,11 @@ import (
 	"context"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	"encoding/json"
+
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration"
@@ -48,6 +51,57 @@ func TestSecrets(t *testing.T) {
 	defer framework.DeleteNamespaceOrDie(client, ns, t)
 
 	DoTestSecrets(t, client, ns)
+	DoTestSecretsImmutableWithEmptyValue(t, client, ns)
+}
+
+// DoTestSecretsImmutableWithEmptyValue Test whether apiserver will judge the secret data inconsistency
+// if the value of map in secret data is the empty string when patch secret,
+// and if the Immutable value of secret is true, the patch request is rejected.
+func DoTestSecretsImmutableWithEmptyValue(t *testing.T, client clientset.Interface, ns *v1.Namespace) {
+	// Make a secret object. Make a secret object. the map in the secret data contains the value of the empty string
+	// make Immutable true, so that if the apiserver judge that the patch secret is inconsistent, it will refuse the patch
+	trueVal := true
+	s := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret",
+			Namespace: ns.Name,
+		},
+		Immutable: &trueVal,
+		Data: map[string][]byte{
+			"emptyData": {},
+		},
+	}
+
+	if _, err := client.CoreV1().Secrets(s.Namespace).Create(context.TODO(), &s, metav1.CreateOptions{}); err != nil {
+		t.Errorf("unable to create test secret: %v", err)
+	}
+	defer deleteSecretOrErrorf(t, client, s.Namespace, s.Name)
+
+	// Make a patch secret object
+	patchSecret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret",
+			Namespace: ns.Name,
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		Immutable: &trueVal,
+		Data: map[string][]byte{
+			"emptyData": {},
+		},
+	}
+
+	secretPatch, err := json.Marshal(patchSecret)
+	if err != nil {
+		t.Errorf("unable to marshal test secret: %v", err)
+	}
+
+	// Patch secret object, expect patch to succeed,
+	// more detailed discussion is at #119229
+	if _, err := client.CoreV1().Secrets(s.Namespace).Patch(context.TODO(), patchSecret.Name, types.StrategicMergePatchType, secretPatch, metav1.PatchOptions{}); err != nil {
+		t.Errorf("unable to patch test secret: %v", err)
+	}
 }
 
 // DoTestSecrets test secrets for one api version.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Test whether apiserver will judge the secret data inconsistency if the value of map in secret data is the empty string when patch secret, ref: https://github.com/kubernetes/kubernetes/pull/118605#issuecomment-1632846924
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
