### PR TITLE
WIP: Add heartbeat tests for remotecommand/websocket package

### DIFF
--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -25,7 +25,6 @@
       "github.com/gorilla/mux": "unmaintained, archive mode",
       "github.com/gorilla/rpc": "unmaintained, archive mode",
       "github.com/gorilla/schema": "unmaintained, archive mode",
-      "github.com/gorilla/websocket": "unmaintained, archive mode",
       "github.com/grpc-ecosystem/grpc-gateway": "use github.com/grpc-ecosystem/grpc-gateway/v2",
       "github.com/hashicorp/consul": "MPL license not in CNCF allowlist",
       "github.com/hashicorp/errwrap": "MPL license not in CNCF allowlist",
@@ -119,11 +118,6 @@
         "cloud.google.com/go/bigquery",
         "cloud.google.com/go/compute",
         "cloud.google.com/go/storage"
-      ],
-      "github.com/gorilla/websocket": [
-        "github.com/moby/spdystream",
-        "github.com/tmc/grpc-websocket-proxy",
-        "go.etcd.io/etcd/server/v3"
       ],
       "github.com/grpc-ecosystem/grpc-gateway": [
         "go.etcd.io/etcd/api/v3",

--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
@@ -855,3 +855,38 @@ func (r *ErrorReporter) AsObject(err error) runtime.Object {
 	})
 	return &status.ErrStatus
 }
+
+// ExitError is an interface that presents an API similar to os.ProcessState, which is
+// what ExitError from os/exec is.  This is designed to make testing a bit easier and
+// probably loses some of the cross-platform properties of the underlying library.
+type ExitError interface {
+	String() string
+	Error() string
+	Exited() bool
+	ExitStatus() int
+}
+
+// CodeExitError is an implementation of ExitError consisting of an error object
+// and an exit code (the upper bits of os.exec.ExitStatus).
+type CodeExitError struct {
+	Err  error
+	Code int
+}
+
+var _ ExitError = CodeExitError{}
+
+func (e CodeExitError) Error() string {
+	return e.Err.Error()
+}
+
+func (e CodeExitError) String() string {
+	return e.Err.Error()
+}
+
+func (e CodeExitError) Exited() bool {
+	return true
+}
+
+func (e CodeExitError) ExitStatus() int {
+	return e.Code
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/doc.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/doc.go
@@ -16,6 +16,54 @@ limitations under the License.
 
 // Package wsstream contains utilities for streaming content over WebSockets.
 // The Conn type allows callers to multiplex multiple read/write channels over
-// a single websocket. The Reader type allows an io.Reader to be copied over
-// a websocket channel as binary content.
+// a single websocket.
+//
+// "channel.k8s.io"
+//
+// The Websocket RemoteCommand subprotocol "channel.k8s.io" prepends each binary message with a
+// byte indicating the channel number (zero indexed) the message was sent on. Messages in both
+// directions should prefix their messages with this channel byte. Used for remote execution,
+// the channel numbers are by convention defined to match the POSIX file-descriptors assigned
+// to STDIN, STDOUT, and STDERR (0, 1, and 2). No other conversion is performed on the raw
+// subprotocol - writes are sent as they are received by the server.
+//
+// Example client session:
+//
+//	CONNECT http://server.com with subprotocol "channel.k8s.io"
+//	WRITE []byte{0, 102, 111, 111, 10} # send "foo\n" on channel 0 (STDIN)
+//	READ  []byte{1, 10}                # receive "\n" on channel 1 (STDOUT)
+//	CLOSE
+//
+// "v2.channel.k8s.io"
+//
+// The second Websocket subprotocol version "v2.channel.k8s.io" is the same as version 1,
+// but it is the first "versioned" subprotocol.
+//
+// "v3.channel.k8s.io"
+//
+// The third version of the Websocket RemoteCommand subprotocol adds another channel
+// for terminal resizing events. This channel is prepended with the byte '3', and it
+// transmits two window sizes (encoding TerminalSize struct) with integers in the range
+// (0,65536].
+//
+// "v4.channel.k8s.io"
+//
+// The fourth version of the Websocket RemoteCommand subprotocol adds a channel for
+// errors. This channel returns structured errors containing process exit codes. The
+// error is "apierrors.StatusError{}".
+//
+// "v5.channel.k8s.io"
+//
+// The fifth version of the Websocket RemoteCommand subprotocol adds a CLOSE signal,
+// which is sent as the first byte of the message. The second byte is the channel
+// id. This CLOSE signal is handled by the websocket server by closing the stream,
+// allowing the other streams to complete transmission if necessary, and gracefully
+// shutdown the connection.
+//
+// Example client session:
+//
+//	CONNECT http://server.com with subprotocol "v5.channel.k8s.io"
+//	WRITE []byte{0, 102, 111, 111, 10} # send "foo\n" on channel 0 (STDIN)
+//	WRITE []byte{255, 0}               # send CLOSE signal (STDIN)
+//	CLOSE
 package wsstream // import "k8s.io/apimachinery/pkg/util/httpstream/wsstream"

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/doc.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package remotecommand
-
-import apimachinery "k8s.io/apimachinery/pkg/util/remotecommand"
-
-// TODO: move all imports of these types to use the new package.
-// Deprecated: Use types in "k8s.io/apimachinery/pkg/util/remotecommand" instead.
-type TerminalSize = apimachinery.TerminalSize
-
-type TerminalSizeQueue = apimachinery.TerminalSizeQueue
+// This temporary package replicates SPDY client functionality for use in the
+// StreamTranslator proxy in the parent "proxy" package. This isolated
+// functionality is necessary to transition Kubernetes bi-directional streaming
+// protocol from SPDY to the more modern WebSockets. This effort is described
+// in the following KEP:
+//
+//	https://github.com/kubernetes/enhancements/issues/4006
+//
+// This package should not be imported anywhere except the parent "proxy" package.
+package spdy

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/errorstream.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/errorstream.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// errorStreamDecoder interprets the data on the error channel and creates a go error object from it.
+type errorStreamDecoder interface {
+	decode(message []byte) error
+}
+
+// watchErrorStream watches the errorStream for remote command error data,
+// decodes it with the given errorStreamDecoder, sends the decoded error (or nil if the remote
+// command exited successfully) to the returned error channel, and closes it.
+// This function returns immediately.
+func watchErrorStream(errorStream io.Reader, d errorStreamDecoder) chan error {
+	errorChan := make(chan error)
+
+	go func() {
+		defer runtime.HandleCrash()
+
+		message, err := io.ReadAll(errorStream)
+		switch {
+		case err != nil && err != io.EOF:
+			errorChan <- fmt.Errorf("error reading from error stream: %s", err)
+		case len(message) > 0:
+			errorChan <- d.decode(message)
+		default:
+			errorChan <- nil
+		}
+		close(errorChan)
+	}()
+
+	return errorChan
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/reader.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/reader.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"io"
+)
+
+// readerWrapper delegates to an io.Reader so that only the io.Reader interface is implemented,
+// to keep io.Copy from doing things we don't want when copying from the reader to the data stream.
+//
+// If the Stdin io.Reader provided to remotecommand implements a WriteTo function (like bytes.Buffer does[1]),
+// io.Copy calls that method[2] to attempt to write the entire buffer to the stream in one call.
+// That results in an oversized call to spdystream.Stream#Write [3],
+// which results in a single oversized data frame[4] that is too large.
+//
+// [1] https://golang.org/pkg/bytes/#Buffer.WriteTo
+// [2] https://golang.org/pkg/io/#Copy
+// [3] https://github.com/kubernetes/kubernetes/blob/90295640ef87db9daa0144c5617afe889e7992b2/vendor/github.com/docker/spdystream/stream.go#L66-L73
+// [4] https://github.com/kubernetes/kubernetes/blob/90295640ef87db9daa0144c5617afe889e7992b2/vendor/github.com/docker/spdystream/spdy/write.go#L302-L304
+type readerWrapper struct {
+	reader io.Reader
+}
+
+func (r readerWrapper) Read(p []byte) (int, error) {
+	return r.reader.Read(p)
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/remotecommand.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/remotecommand.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/remotecommand"
+)
+
+const (
+	// Name of header that specifies stream type
+	StreamType = "streamType"
+	// Value for streamType header for stdin stream
+	StreamTypeStdin = "stdin"
+	// Value for streamType header for stdout stream
+	StreamTypeStdout = "stdout"
+	// Value for streamType header for stderr stream
+	StreamTypeStderr = "stderr"
+	// Value for streamType header for data stream
+	StreamTypeData = "data"
+	// Value for streamType header for error stream
+	StreamTypeError = "error"
+	// Value for streamType header for terminal resize stream
+	StreamTypeResize = "resize"
+)
+
+// StreamOptions holds information pertaining to the current streaming session:
+// input/output streams, if the client is requesting a TTY, and a terminal size queue to
+// support terminal resizing.
+type StreamOptions struct {
+	Stdin             io.Reader
+	Stdout            io.Writer
+	Stderr            io.Writer
+	Tty               bool
+	TerminalSizeQueue remotecommand.TerminalSizeQueue
+}
+
+// Executor is an interface for transporting shell-style streams.
+type Executor interface {
+	// Deprecated: use StreamWithContext instead to avoid possible resource leaks.
+	// See https://github.com/kubernetes/kubernetes/pull/103177 for details.
+	Stream(options StreamOptions) error
+
+	// StreamWithContext initiates the transport of the standard shell streams. It will
+	// transport any non-nil stream to a remote system, and return an error if a problem
+	// occurs. If tty is set, the stderr stream is not used (raw TTY manages stdout and
+	// stderr over the stdout stream).
+	// The context controls the entire lifetime of stream execution.
+	StreamWithContext(ctx context.Context, options StreamOptions) error
+}
+
+type streamCreator interface {
+	CreateStream(headers http.Header) (httpstream.Stream, error)
+}
+
+type streamProtocolHandler interface {
+	stream(conn streamCreator) error
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/transport.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/transport.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+)
+
+// Upgrader validates a response from the server after a SPDY upgrade.
+type Upgrader interface {
+	// NewConnection validates the response and creates a new Connection.
+	NewConnection(resp *http.Response) (httpstream.Connection, error)
+}
+
+// dialer implements the httpstream.Dialer interface.
+type dialer struct {
+	client   *http.Client
+	upgrader Upgrader
+	method   string
+	url      *url.URL
+}
+
+var _ httpstream.Dialer = &dialer{}
+
+// NewDialer will create a dialer that connects to the provided URL and upgrades the connection to SPDY.
+func NewDialer(upgrader Upgrader, client *http.Client, method string, url *url.URL) httpstream.Dialer {
+	return &dialer{
+		client:   client,
+		upgrader: upgrader,
+		method:   method,
+		url:      url,
+	}
+}
+
+func (d *dialer) Dial(protocols ...string) (httpstream.Connection, string, error) {
+	req, err := http.NewRequest(d.method, d.url.String(), nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("error creating request: %v", err)
+	}
+	return Negotiate(d.upgrader, d.client, req, protocols...)
+}
+
+// Negotiate opens a connection to a remote server and attempts to negotiate
+// a SPDY connection. Upon success, it returns the connection and the protocol selected by
+// the server. The client transport must use the upgradeRoundTripper - see RoundTripperFor.
+func Negotiate(upgrader Upgrader, client *http.Client, req *http.Request, protocols ...string) (httpstream.Connection, string, error) {
+	for i := range protocols {
+		req.Header.Add(httpstream.HeaderProtocolVersion, protocols[i])
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("error sending request: %v", err)
+	}
+	defer resp.Body.Close()
+	conn, err := upgrader.NewConnection(resp)
+	if err != nil {
+		return nil, "", err
+	}
+	return conn, resp.Header.Get(httpstream.HeaderProtocolVersion), nil
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/v2.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/v2.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// streamProtocolV2 implements version 2 of the streaming protocol for attach
+// and exec. The original streaming protocol was metav1. As a result, this
+// version is referred to as version 2, even though it is the first actual
+// numbered version.
+type streamProtocolV2 struct {
+	StreamOptions
+
+	errorStream  io.Reader
+	remoteStdin  io.ReadWriteCloser
+	remoteStdout io.Reader
+	remoteStderr io.Reader
+}
+
+var _ streamProtocolHandler = &streamProtocolV2{}
+
+func newStreamProtocolV2(options StreamOptions) streamProtocolHandler {
+	return &streamProtocolV2{
+		StreamOptions: options,
+	}
+}
+
+func (p *streamProtocolV2) createStreams(conn streamCreator) error {
+	var err error
+	headers := http.Header{}
+
+	// set up error stream
+	headers.Set(StreamType, StreamTypeError)
+	p.errorStream, err = conn.CreateStream(headers)
+	if err != nil {
+		return err
+	}
+
+	// set up stdin stream
+	if p.Stdin != nil {
+		headers.Set(StreamType, StreamTypeStdin)
+		p.remoteStdin, err = conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+	}
+
+	// set up stdout stream
+	if p.Stdout != nil {
+		headers.Set(StreamType, StreamTypeStdout)
+		p.remoteStdout, err = conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+	}
+
+	// set up stderr stream
+	if p.Stderr != nil && !p.Tty {
+		headers.Set(StreamType, StreamTypeStderr)
+		p.remoteStderr, err = conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *streamProtocolV2) copyStdin() {
+	if p.Stdin != nil {
+		var once sync.Once
+
+		// copy from client's stdin to container's stdin
+		go func() {
+			defer runtime.HandleCrash()
+
+			// if p.stdin is noninteractive, p.g. `echo abc | kubectl exec -i <pod> -- cat`, make sure
+			// we close remoteStdin as soon as the copy from p.stdin to remoteStdin finishes. Otherwise
+			// the executed command will remain running.
+			defer once.Do(func() { p.remoteStdin.Close() })
+
+			if _, err := io.Copy(p.remoteStdin, readerWrapper{p.Stdin}); err != nil {
+				runtime.HandleError(err)
+			}
+		}()
+
+		// read from remoteStdin until the stream is closed. this is essential to
+		// be able to exit interactive sessions cleanly and not leak goroutines or
+		// hang the client's terminal.
+		//
+		// TODO we aren't using go-dockerclient any more; revisit this to determine if it's still
+		// required by engine-api.
+		//
+		// go-dockerclient's current hijack implementation
+		// (https://github.com/fsouza/go-dockerclient/blob/89f3d56d93788dfe85f864a44f85d9738fca0670/client.go#L564)
+		// waits for all three streams (stdin/stdout/stderr) to finish copying
+		// before returning. When hijack finishes copying stdout/stderr, it calls
+		// Close() on its side of remoteStdin, which allows this copy to complete.
+		// When that happens, we must Close() on our side of remoteStdin, to
+		// allow the copy in hijack to complete, and hijack to return.
+		go func() {
+			defer runtime.HandleCrash()
+			defer once.Do(func() { p.remoteStdin.Close() })
+
+			// this "copy" doesn't actually read anything - it's just here to wait for
+			// the server to close remoteStdin.
+			if _, err := io.Copy(io.Discard, p.remoteStdin); err != nil {
+				runtime.HandleError(err)
+			}
+		}()
+	}
+}
+
+func (p *streamProtocolV2) copyStdout(wg *sync.WaitGroup) {
+	if p.Stdout == nil {
+		return
+	}
+
+	wg.Add(1)
+	go func() {
+		defer runtime.HandleCrash()
+		defer wg.Done()
+		// make sure, packet in queue can be consumed.
+		// block in queue may lead to deadlock in conn.server
+		// issue: https://github.com/kubernetes/kubernetes/issues/96339
+		defer io.Copy(io.Discard, p.remoteStdout)
+
+		if _, err := io.Copy(p.Stdout, p.remoteStdout); err != nil {
+			runtime.HandleError(err)
+		}
+	}()
+}
+
+func (p *streamProtocolV2) copyStderr(wg *sync.WaitGroup) {
+	if p.Stderr == nil || p.Tty {
+		return
+	}
+
+	wg.Add(1)
+	go func() {
+		defer runtime.HandleCrash()
+		defer wg.Done()
+		defer io.Copy(io.Discard, p.remoteStderr)
+
+		if _, err := io.Copy(p.Stderr, p.remoteStderr); err != nil {
+			runtime.HandleError(err)
+		}
+	}()
+}
+
+func (p *streamProtocolV2) stream(conn streamCreator) error {
+	if err := p.createStreams(conn); err != nil {
+		return err
+	}
+
+	// now that all the streams have been created, proceed with reading & copying
+
+	errorChan := watchErrorStream(p.errorStream, &errorDecoderV2{})
+
+	p.copyStdin()
+
+	var wg sync.WaitGroup
+	p.copyStdout(&wg)
+	p.copyStderr(&wg)
+
+	// we're waiting for stdout/stderr to finish copying
+	wg.Wait()
+
+	// waits for errorStream to finish reading with an error or nil
+	return <-errorChan
+}
+
+// errorDecoderV2 interprets the error channel data as plain text.
+type errorDecoderV2 struct{}
+
+func (d *errorDecoderV2) decode(message []byte) error {
+	return fmt.Errorf("error executing remote command: %s", message)
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/v3.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/v3.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// streamProtocolV3 implements version 3 of the streaming protocol for attach
+// and exec. This version adds support for resizing the container's terminal.
+type streamProtocolV3 struct {
+	*streamProtocolV2
+
+	resizeStream io.Writer
+}
+
+var _ streamProtocolHandler = &streamProtocolV3{}
+
+func newStreamProtocolV3(options StreamOptions) streamProtocolHandler {
+	return &streamProtocolV3{
+		streamProtocolV2: newStreamProtocolV2(options).(*streamProtocolV2),
+	}
+}
+
+func (p *streamProtocolV3) createStreams(conn streamCreator) error {
+	// set up the streams from v2
+	if err := p.streamProtocolV2.createStreams(conn); err != nil {
+		return err
+	}
+
+	// set up resize stream
+	if p.Tty {
+		headers := http.Header{}
+		headers.Set(StreamType, StreamTypeResize)
+		var err error
+		p.resizeStream, err = conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *streamProtocolV3) handleResizes() {
+	if p.resizeStream == nil || p.TerminalSizeQueue == nil {
+		return
+	}
+	go func() {
+		defer runtime.HandleCrash()
+
+		encoder := json.NewEncoder(p.resizeStream)
+		for {
+			size := p.TerminalSizeQueue.Next()
+			if size == nil {
+				return
+			}
+			if err := encoder.Encode(&size); err != nil {
+				runtime.HandleError(err)
+			}
+		}
+	}()
+}
+
+func (p *streamProtocolV3) stream(conn streamCreator) error {
+	if err := p.createStreams(conn); err != nil {
+		return err
+	}
+
+	// now that all the streams have been created, proceed with reading & copying
+
+	errorChan := watchErrorStream(p.errorStream, &errorDecoderV3{})
+
+	p.handleResizes()
+
+	p.copyStdin()
+
+	var wg sync.WaitGroup
+	p.copyStdout(&wg)
+	p.copyStderr(&wg)
+
+	// we're waiting for stdout/stderr to finish copying
+	wg.Wait()
+
+	// waits for errorStream to finish reading with an error or nil
+	return <-errorChan
+}
+
+type errorDecoderV3 struct {
+	errorDecoderV2
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/v4.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/v4.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/remotecommand"
+)
+
+// streamProtocolV4 implements version 4 of the streaming protocol for attach
+// and exec. This version adds support for exit codes on the error stream through
+// the use of metav1.Status instead of plain text messages.
+type streamProtocolV4 struct {
+	*streamProtocolV3
+}
+
+var _ streamProtocolHandler = &streamProtocolV4{}
+
+func newStreamProtocolV4(options StreamOptions) streamProtocolHandler {
+	return &streamProtocolV4{
+		streamProtocolV3: newStreamProtocolV3(options).(*streamProtocolV3),
+	}
+}
+
+func (p *streamProtocolV4) createStreams(conn streamCreator) error {
+	return p.streamProtocolV3.createStreams(conn)
+}
+
+func (p *streamProtocolV4) handleResizes() {
+	p.streamProtocolV3.handleResizes()
+}
+
+func (p *streamProtocolV4) stream(conn streamCreator) error {
+	if err := p.createStreams(conn); err != nil {
+		return err
+	}
+
+	// now that all the streams have been created, proceed with reading & copying
+	errorChan := watchErrorStream(p.errorStream, &errorDecoderV4{})
+
+	p.handleResizes()
+
+	p.copyStdin()
+
+	var wg sync.WaitGroup
+	p.copyStdout(&wg)
+	p.copyStderr(&wg)
+
+	// we're waiting for stdout/stderr to finish copying
+	wg.Wait()
+
+	// waits for errorStream to finish reading with an error or nil
+	return <-errorChan
+}
+
+// errorDecoderV4 interprets the json-marshaled metav1.Status on the error channel
+// and creates an exec.ExitError from it.
+type errorDecoderV4 struct{}
+
+func (d *errorDecoderV4) decode(message []byte) error {
+	status := metav1.Status{}
+	err := json.Unmarshal(message, &status)
+	if err != nil {
+		return fmt.Errorf("error stream protocol error: %v in %q", err, string(message))
+	}
+	switch status.Status {
+	case metav1.StatusSuccess:
+		return nil
+	case metav1.StatusFailure:
+		if status.Reason == remotecommand.NonZeroExitCodeReason {
+			if status.Details == nil {
+				return errors.New("error stream protocol error: details must be set")
+			}
+			for i := range status.Details.Causes {
+				c := &status.Details.Causes[i]
+				if c.Type != remotecommand.ExitCodeCauseType {
+					continue
+				}
+
+				rc, err := strconv.ParseUint(c.Message, 10, 8)
+				if err != nil {
+					return fmt.Errorf("error stream protocol error: invalid exit code value %q", c.Message)
+				}
+				return apierrors.CodeExitError{
+					Err:  fmt.Errorf("command terminated with exit code %d", rc),
+					Code: int(rc),
+				}
+			}
+
+			return fmt.Errorf("error stream protocol error: no %s cause given", remotecommand.ExitCodeCauseType)
+		}
+	default:
+		return errors.New("error stream protocol error: unknown error")
+	}
+
+	return fmt.Errorf(status.Message)
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/v5.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/spdy/v5.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+// streamProtocolV5 add support for V5 of the remote command subprotocol.
+// For the streamProtocolHandler, this version is the same as V4.
+type streamProtocolV5 struct {
+	*streamProtocolV4
+}
+
+var _ streamProtocolHandler = &streamProtocolV5{}
+
+func newStreamProtocolV5(options StreamOptions) streamProtocolHandler {
+	return &streamProtocolV5{
+		streamProtocolV4: newStreamProtocolV4(options).(*streamProtocolV4),
+	}
+}
+
+func (p *streamProtocolV5) stream(conn streamCreator) error {
+	return p.streamProtocolV4.stream(conn)
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/streamtranslator.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/streamtranslator.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream/spdy"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	spdyproxy "k8s.io/apimachinery/pkg/util/proxy/spdy"
+	"k8s.io/apimachinery/pkg/util/remotecommand"
+	"k8s.io/klog/v2"
+)
+
+// StreamTranslatorHandler is a handler which translates WebSocket stream data
+// to SPDY to proxy to kubelet (and ContainerRuntime).
+type StreamTranslatorHandler struct {
+	// Location is the location of the upstream proxy. It is used as the location to Dial on the upstream server
+	// for upgrade requests.
+	Location *url.URL
+	// Transport provides an optional round tripper to use to proxy. If nil, the default proxy transport is used
+	Transport http.RoundTripper
+	// Responder is passed errors that occur while setting up proxying.
+	Responder ErrorResponder
+	// Options define the requested streams (e.g. stdin, stdout).
+	Options Options
+}
+
+// NewStreamTranslatorHandler creates a new proxy handler. Responder is required for returning
+// errors to the caller.
+func NewStreamTranslatorHandler(location *url.URL, transport http.RoundTripper, responder ErrorResponder, opts Options) *StreamTranslatorHandler {
+	return &StreamTranslatorHandler{
+		Location:  normalizeLocation(location),
+		Transport: transport,
+		Responder: responder,
+		Options:   opts,
+	}
+}
+
+func (h *StreamTranslatorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// Create WebSocket server, including particular streams requested.
+	websocketStreams, err := webSocketServerStreams(req, w, h.Options)
+	if err != nil {
+		klog.Errorf("websocket createStreams error: %v", err)
+		h.Responder.Error(w, req, err)
+		return
+	}
+	defer websocketStreams.conn.Close()
+
+	// Create the SPDY client connection proxied through kubelet.
+	tlsConfig, err := utilnet.TLSClientConfig(h.Transport)
+	if tlsConfig != nil && err == nil {
+		// Manually set NextProtos to "http/1.1", since http/2.0 will NOT upgrade a connection.
+		tlsConfig.NextProtos = []string{"http/1.1"}
+	} else {
+		klog.Infof("Unable to unwrap transport %T to get at TLS config: %v", h.Transport, err)
+	}
+	spdyRoundTripper := spdy.NewRoundTripper(tlsConfig)
+	spdyExecutor, err := spdyproxy.NewSPDYExecutorForTransports(spdyRoundTripper, spdyRoundTripper, "POST", h.Location)
+	if err != nil {
+		klog.Errorf("websocket createStreams error: %v", err)
+		h.Responder.Error(w, req, err)
+		return
+	}
+
+	// Wire the WebSocket server streams output to the SPDY client input.
+	opts := spdyproxy.StreamOptions{}
+	if h.Options.Stdin {
+		opts.Stdin = websocketStreams.stdinStream
+	}
+	if h.Options.Stdout {
+		opts.Stdout = websocketStreams.stdoutStream
+	}
+	if h.Options.Stderr {
+		opts.Stderr = websocketStreams.stderrStream
+	}
+	if h.Options.Tty {
+		opts.Tty = true
+		opts.TerminalSizeQueue = &translatorSizeQueue{resizeChan: websocketStreams.resizeChan}
+	}
+	// Start the SPDY client with connected streams. Output from the WebSocket server
+	// streams will be forwarded into the SPDY client.
+	err = spdyExecutor.StreamWithContext(req.Context(), opts)
+	if err != nil {
+		klog.Errorf("spdyExecutor StreamWithContext() error: %v", err)
+		// Report error back to the WebSocket client.
+		if exitErr, ok := err.(apierrors.CodeExitError); ok && exitErr.Exited() {
+			rc := exitErr.ExitStatus()
+			websocketStreams.writeStatus(&apierrors.StatusError{ErrStatus: metav1.Status{
+				Status: metav1.StatusFailure,
+				Reason: remotecommand.NonZeroExitCodeReason,
+				Details: &metav1.StatusDetails{
+					Causes: []metav1.StatusCause{
+						{
+							Type:    remotecommand.ExitCodeCauseType,
+							Message: fmt.Sprintf("%d", rc),
+						},
+					},
+				},
+				Message: fmt.Sprintf("command terminated with non-zero exit code: %v", exitErr),
+			}})
+		} else {
+			websocketStreams.writeStatus(apierrors.NewInternalError(err))
+		}
+		return
+	}
+
+	// Write the success status back to the WebSocket client.
+	websocketStreams.writeStatus(&apierrors.StatusError{ErrStatus: metav1.Status{
+		Status: metav1.StatusSuccess,
+	}})
+}
+
+// translatorSizeQueue feeds the size events from the WebSocket
+// resizeChan into the SPDY client input. Implements TerminalSizeQueue
+// interface.
+type translatorSizeQueue struct {
+	resizeChan chan remotecommand.TerminalSize
+}
+
+func (t *translatorSizeQueue) Next() *remotecommand.TerminalSize {
+	size, ok := <-t.resizeChan
+	if !ok {
+		return nil
+	}
+	return &size
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/translatinghandler.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/translatinghandler.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/util/httpstream/wsstream"
+	"k8s.io/apimachinery/pkg/util/remotecommand"
+	"k8s.io/klog/v2"
+)
+
+// translatingHandler wraps the delegate handler, implementing the
+// http.Handler interface. The delegate handles all requests unless
+// the request is a WebSocket/V5 request, in which case the translator
+// handles the request.
+type translatingHandler struct {
+	delegate   http.Handler
+	translator http.Handler
+}
+
+func NewTranslatingHandler(delegate http.Handler, translator http.Handler) http.Handler {
+	return &translatingHandler{
+		delegate:   delegate,
+		translator: translator,
+	}
+}
+
+func (t *translatingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if wsstream.IsWebSocketRequest(req) &&
+		wsstream.IsWebSocketRequestedProtocol(req, remotecommand.StreamProtocolV5Name) {
+		klog.V(4).Infof("WebSocket/V5 upgrade request handled by StreamTranslator proxy")
+		t.translator.ServeHTTP(w, req)
+		return
+	}
+	t.delegate.ServeHTTP(w, req)
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/websocket_server.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/websocket_server.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/httpstream/wsstream"
+	"k8s.io/apimachinery/pkg/util/remotecommand"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
+)
+
+const defaultIdleConnectionTimeout = 4 * time.Hour
+
+// Options contains details about which streams are required for
+// remote command execution.
+type Options struct {
+	Stdin  bool
+	Stdout bool
+	Stderr bool
+	Tty    bool
+}
+
+// ValidationOptions returns an error for invalid combinations of
+// requested streams.
+func ValidateOptions(opts Options) error {
+	if opts.Tty && opts.Stderr {
+		return fmt.Errorf("specifying both TTY and stderr is invalid")
+	}
+	if !opts.Stdin && !opts.Stdout && !opts.Stderr {
+		return fmt.Errorf("you must specify at least 1 of stdin, stdout, stderr")
+	}
+	return nil
+}
+
+// conns contains the connection and streams used when
+// forwarding an attach or execute session into a container.
+type conns struct {
+	conn         io.Closer
+	stdinStream  io.ReadCloser
+	stdoutStream io.WriteCloser
+	stderrStream io.WriteCloser
+	writeStatus  func(status *apierrors.StatusError) error
+	resizeStream io.ReadCloser
+	resizeChan   chan remotecommand.TerminalSize
+	tty          bool
+}
+
+// Create WebSocket server streams to respond to a WebSocket client. Creates the streams passed
+// in the stream options.
+func webSocketServerStreams(req *http.Request, w http.ResponseWriter, opts Options) (*conns, error) {
+	ctx, err := createWebSocketStreams(req, w, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if ctx.resizeStream != nil {
+		ctx.resizeChan = make(chan remotecommand.TerminalSize)
+		go handleResizeEvents(req.Context(), ctx.resizeStream, ctx.resizeChan)
+	}
+
+	return ctx, nil
+}
+
+// Read terminal resize events off of passed stream and queue into passed channel.
+func handleResizeEvents(ctx context.Context, stream io.Reader, channel chan<- remotecommand.TerminalSize) {
+	defer runtime.HandleCrash()
+	defer close(channel)
+
+	decoder := json.NewDecoder(stream)
+	for {
+		size := remotecommand.TerminalSize{}
+		if err := decoder.Decode(&size); err != nil {
+			break
+		}
+
+		select {
+		case channel <- size:
+		case <-ctx.Done():
+			// To avoid leaking this routine, exit if the http request finishes. This path
+			// would generally be hit if starting the process fails and nothing is started to
+			// ingest these resize events.
+			return
+		}
+	}
+}
+
+// createChannels returns the standard channel types for a shell connection (STDIN 0, STDOUT 1, STDERR 2)
+// along with the approximate duplex value. It also creates the error (3) and resize (4) channels.
+func createChannels(opts Options) []wsstream.ChannelType {
+	// open the requested channels, and always open the error channel
+	channels := make([]wsstream.ChannelType, 5)
+	channels[remotecommand.StreamStdIn] = readChannel(opts.Stdin)
+	channels[remotecommand.StreamStdOut] = writeChannel(opts.Stdout)
+	channels[remotecommand.StreamStdErr] = writeChannel(opts.Stderr)
+	channels[remotecommand.StreamErr] = wsstream.WriteChannel
+	channels[remotecommand.StreamResize] = wsstream.ReadChannel
+	return channels
+}
+
+// readChannel returns wsstream.ReadChannel if real is true, or wsstream.IgnoreChannel.
+func readChannel(real bool) wsstream.ChannelType {
+	if real {
+		return wsstream.ReadChannel
+	}
+	return wsstream.IgnoreChannel
+}
+
+// writeChannel returns wsstream.WriteChannel if real is true, or wsstream.IgnoreChannel.
+func writeChannel(real bool) wsstream.ChannelType {
+	if real {
+		return wsstream.WriteChannel
+	}
+	return wsstream.IgnoreChannel
+}
+
+// createWebSocketStreams returns a "conns" struct containing the websocket connection and
+// streams needed to perform an exec or an attach.
+func createWebSocketStreams(req *http.Request, w http.ResponseWriter, opts Options) (*conns, error) {
+	channels := createChannels(opts)
+	conn := wsstream.NewConn(map[string]wsstream.ChannelProtocolConfig{
+		// WebSocket server only supports remote command version 5.
+		remotecommand.StreamProtocolV5Name: {
+			Binary:   true,
+			Channels: channels,
+		},
+	})
+	conn.SetIdleTimeout(defaultIdleConnectionTimeout)
+	// Opening the connection responds to WebSocket client, negotiating
+	// the WebSocket upgrade connection and the subprotocol.
+	negotiatedProtocol, streams, err := conn.Open(w, req)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("unable to upgrade websocket connection: %v", err))
+		return nil, err
+	}
+	klog.V(4).Infof("websocket server negotiated sub-protocol: %s", negotiatedProtocol)
+
+	// Send an empty message to the lowest writable channel to notify the client the connection is established
+	switch {
+	case opts.Stdout:
+		streams[remotecommand.StreamStdOut].Write([]byte{})
+	case opts.Stderr:
+		streams[remotecommand.StreamStdErr].Write([]byte{})
+	default:
+		streams[remotecommand.StreamErr].Write([]byte{})
+	}
+
+	ctx := &conns{
+		conn:         conn,
+		stdinStream:  streams[remotecommand.StreamStdIn],
+		stdoutStream: streams[remotecommand.StreamStdOut],
+		stderrStream: streams[remotecommand.StreamStdErr],
+		tty:          opts.Tty,
+		resizeStream: streams[remotecommand.StreamResize],
+	}
+
+	ctx.writeStatus = v4WriteStatusFunc(streams[remotecommand.StreamErr])
+
+	return ctx, nil
+}
+
+// v4WriteStatusFunc returns a WriteStatusFunc that marshals a given api Status
+// as json in the error channel.
+func v4WriteStatusFunc(stream io.Writer) func(status *apierrors.StatusError) error {
+	return func(status *apierrors.StatusError) error {
+		bs, err := json.Marshal(status.Status())
+		if err != nil {
+			return err
+		}
+		_, err = stream.Write(bs)
+		return err
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/remotecommand/constants.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/remotecommand/constants.go
@@ -46,8 +46,22 @@ const (
 	// adds support for exit codes.
 	StreamProtocolV4Name = "v4.channel.k8s.io"
 
+	// The subprotocol "v5.channel.k8s.io" is used for remote command
+	// attachment/execution. It is the 5th version of the subprotocol and
+	// adds support for a CLOSE signal.
+	StreamProtocolV5Name = "v5.channel.k8s.io"
+
 	NonZeroExitCodeReason = metav1.StatusReason("NonZeroExitCode")
 	ExitCodeCauseType     = metav1.CauseType("ExitCode")
+
+	// RemoteCommand stream identifiers. The first three identifiers (for STDIN,
+	// STDOUT, STDERR) are the same as their file descriptors.
+	StreamStdIn  = 0
+	StreamStdOut = 1
+	StreamStdErr = 2
+	StreamErr    = 3
+	StreamResize = 4
+	StreamClose  = 255
 )
 
 var SupportedStreamingProtocols = []string{StreamProtocolV4Name, StreamProtocolV3Name, StreamProtocolV2Name, StreamProtocolV1Name}

--- a/staging/src/k8s.io/apimachinery/pkg/util/remotecommand/resize.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/remotecommand/resize.go
@@ -16,10 +16,18 @@ limitations under the License.
 
 package remotecommand
 
-import apimachinery "k8s.io/apimachinery/pkg/util/remotecommand"
+// TerminalSize and TerminalSizeQueue was a part of k8s.io/kubernetes/pkg/util/term
+// and were moved in order to decouple client from other term dependencies
 
-// TODO: move all imports of these types to use the new package.
-// Deprecated: Use types in "k8s.io/apimachinery/pkg/util/remotecommand" instead.
-type TerminalSize = apimachinery.TerminalSize
+// TerminalSize represents the width and height of a terminal.
+type TerminalSize struct {
+	Width  uint16
+	Height uint16
+}
 
-type TerminalSizeQueue = apimachinery.TerminalSizeQueue
+// TerminalSizeQueue is capable of returning terminal resize events as they occur.
+type TerminalSizeQueue interface {
+	// Next returns the new terminal size after the terminal has been resized. It returns nil when
+	// monitoring has been stopped.
+	Next() *TerminalSize
+}

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -87,6 +87,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect

--- a/staging/src/k8s.io/apiserver/go.sum
+++ b/staging/src/k8s.io/apiserver/go.sum
@@ -163,6 +163,7 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8V
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -372,6 +373,7 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -88,6 +88,14 @@ const (
 	// Add support for distributed tracing in the API Server
 	APIServerTracing featuregate.Feature = "APIServerTracing"
 
+	// owner: @seans3
+	// kep: http://kep.k8s.io/4006
+	// alpha: v1.28
+	//
+	// Enables StreamTranslator proxy to handle WebSockets RemoteCommand/V5
+	// upgrade requests.
+	ClientRemoteCommandWebsockets featuregate.Feature = "ClientRemoteCommandWebsockets"
+
 	// owner: @cici37 @jpbetz
 	// kep: http://kep.k8s.io/3488
 	// alpha: v1.26
@@ -240,6 +248,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	APIServerIdentity: {Default: true, PreRelease: featuregate.Beta},
 
 	APIServerTracing: {Default: true, PreRelease: featuregate.Beta},
+
+	ClientRemoteCommandWebsockets: {Default: false, PreRelease: featuregate.Alpha},
 
 	ValidatingAdmissionPolicy: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/staging/src/k8s.io/cli-runtime/go.sum
+++ b/staging/src/k8s.io/cli-runtime/go.sum
@@ -72,6 +72,7 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.3.0
+	github.com/gorilla/websocket v1.4.2
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
 	github.com/imdario/mergo v0.3.6
 	github.com/peterbourgon/diskv v2.0.1+incompatible

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/onsi/gomega v1.27.6 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/staging/src/k8s.io/client-go/go.sum
+++ b/staging/src/k8s.io/client-go/go.sum
@@ -44,6 +44,7 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJY
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/staging/src/k8s.io/client-go/go.sum
+++ b/staging/src/k8s.io/client-go/go.sum
@@ -74,6 +74,7 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=
 github.com/onsi/ginkgo/v2 v2.9.4/go.mod h1:gCQYp2Q+kSoIj7ykSVb9nskRSsR6PUj4AiLywzIhbKM=

--- a/staging/src/k8s.io/client-go/tools/remotecommand/fallback.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/fallback.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"context"
+	"net/url"
+
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/transport/websocket"
+)
+
+var _ Executor = &fallbackExecutor{}
+
+type fallbackExecutor struct {
+	primary   Executor
+	secondary Executor
+}
+
+// NewFallbackExecutor creates an Executor that first attempts to use the
+// WebSocketExecutor, falling back to the legacy SPDYExecutor if the initial
+// websocket "StreamWithContext" call fails.
+func NewFallbackExecutor(config *restclient.Config, method string, url *url.URL) (Executor, error) {
+	primary, err := NewWebSocketExecutor(config, method, url.String())
+	if err != nil {
+		return nil, err
+	}
+	secondary, err := NewSPDYExecutor(config, method, url)
+	if err != nil {
+		return nil, err
+	}
+	return &fallbackExecutor{
+		primary:   primary,
+		secondary: secondary,
+	}, nil
+}
+
+// Stream is deprecated. Please use "StreamWithContext".
+func (f *fallbackExecutor) Stream(options StreamOptions) error {
+	return f.StreamWithContext(context.Background(), options)
+}
+
+// StreamWithContext initially attempts to call "StreamWithContext" using the
+// primary executor, falling back to calling the secondary executor if the
+// initial primary call to upgrade to a websocket connection fails.
+func (f *fallbackExecutor) StreamWithContext(ctx context.Context, options StreamOptions) error {
+	err := f.primary.StreamWithContext(ctx, options)
+	if _, isErr := err.(*websocket.UpgradeFailureError); isErr {
+		return f.secondary.StreamWithContext(ctx, options)
+	}
+	return err
+}

--- a/staging/src/k8s.io/client-go/tools/remotecommand/fallback_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/fallback_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/remotecommand"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+)
+
+func TestFallbackClient_WebSocketPrimarySucceeds(t *testing.T) {
+	// Create fake WebSocket server. Copy received STDIN data back onto STDOUT stream.
+	websocketServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conns, err := webSocketServerStreams(req, w, streamOptionsFromRequest(req))
+		if err != nil {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		defer conns.conn.Close()
+		// Loopback the STDIN stream onto the STDOUT stream.
+		_, err = io.Copy(conns.stdoutStream, conns.stdinStream)
+		require.NoError(t, err)
+	}))
+	defer websocketServer.Close()
+
+	// Now create the fallback client (executor), and point it to the "websocketServer".
+	// Must add STDIN and STDOUT query params for the client request.
+	websocketServer.URL = websocketServer.URL + "?" + "stdin=true" + "&" + "stdout=true"
+	websocketLocation, err := url.Parse(websocketServer.URL)
+	require.NoError(t, err)
+	exec, err := NewFallbackExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketLocation)
+	require.NoError(t, err)
+	// Generate random data, and set it up to stream on STDIN. The data will be
+	// returned on the STDOUT buffer.
+	randomSize := 1024 * 1024
+	randomData := make([]byte, randomSize)
+	if _, err := rand.Read(randomData); err != nil {
+		t.Errorf("unexpected error reading random data: %v", err)
+	}
+	var stdout bytes.Buffer
+	options := &StreamOptions{
+		Stdin:  bytes.NewReader(randomData),
+		Stdout: &stdout,
+	}
+	errorChan := make(chan error)
+	go func() {
+		// Start the streaming on the WebSocket "exec" client.
+		errorChan <- exec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		if err != nil {
+			t.Errorf("unexpected error")
+		}
+	}
+
+	data, err := ioutil.ReadAll(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		t.Errorf("error reading the stream: %v", err)
+		return
+	}
+	// Check the random data sent on STDIN was the same returned on STDOUT.
+	if !bytes.Equal(randomData, data) {
+		t.Errorf("unexpected data received: %d sent: %d", len(data), len(randomData))
+	}
+}
+
+func TestFallbackClient_SPDYSecondarySucceeds(t *testing.T) {
+	// Create fake SPDY server. Copy received STDIN data back onto STDOUT stream.
+	spdyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var stdin, stdout bytes.Buffer
+		ctx, err := createHTTPStreams(w, req, &StreamOptions{
+			Stdin:  &stdin,
+			Stdout: &stdout,
+		})
+		if err != nil {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		defer ctx.conn.Close()
+		io.Copy(ctx.stdoutStream, ctx.stdinStream)
+	}))
+	defer spdyServer.Close()
+
+	spdyLocation, err := url.Parse(spdyServer.URL)
+	require.NoError(t, err)
+	exec, err := NewFallbackExecutor(&rest.Config{Host: spdyLocation.Host}, "POST", spdyLocation)
+	require.NoError(t, err)
+	// Generate random data, and set it up to stream on STDIN. The data will be
+	// returned on the STDOUT buffer.
+	randomSize := 1024 * 1024
+	randomData := make([]byte, randomSize)
+	if _, err := rand.Read(randomData); err != nil {
+		t.Errorf("unexpected error reading random data: %v", err)
+	}
+	var stdout bytes.Buffer
+	options := &StreamOptions{
+		Stdin:  bytes.NewReader(randomData),
+		Stdout: &stdout,
+	}
+	errorChan := make(chan error)
+	go func() {
+		errorChan <- exec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		if err != nil {
+			t.Errorf("unexpected error")
+		}
+	}
+
+	data, err := ioutil.ReadAll(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		t.Errorf("error reading the stream: %v", err)
+		return
+	}
+	// Check the random data sent on STDIN was the same returned on STDOUT.
+	if !bytes.Equal(randomData, data) {
+		t.Errorf("unexpected data received: %d sent: %d", len(data), len(randomData))
+	}
+}
+
+func TestFallbackClient_PrimaryAndSecondaryFail(t *testing.T) {
+	// Create fake WebSocket server. Copy received STDIN data back onto STDOUT stream.
+	websocketServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conns, err := webSocketServerStreams(req, w, streamOptionsFromRequest(req))
+		if err != nil {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		defer conns.conn.Close()
+		// Loopback the STDIN stream onto the STDOUT stream.
+		_, err = io.Copy(conns.stdoutStream, conns.stdinStream)
+		require.NoError(t, err)
+	}))
+	defer websocketServer.Close()
+
+	// Now create the fallback client (executor), and point it to the "websocketServer".
+	// Must add STDIN and STDOUT query params for the client request.
+	websocketServer.URL = websocketServer.URL + "?" + "stdin=true" + "&" + "stdout=true"
+	websocketLocation, err := url.Parse(websocketServer.URL)
+	require.NoError(t, err)
+	exec, err := NewFallbackExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketLocation)
+	require.NoError(t, err)
+	// Update the websocket executor to request remote command v4, which is unsupported.
+	fallbackExec, ok := exec.(*fallbackExecutor)
+	assert.True(t, ok, "error casting executor as fallbackExecutor")
+	websocketExec, ok := fallbackExec.primary.(*wsStreamExecutor)
+	assert.True(t, ok, "error casting executor as websocket executor")
+	// Set the attempted subprotocol version to V4; websocket server only accepts V5.
+	websocketExec.protocols = []string{remotecommand.StreamProtocolV4Name}
+
+	// Generate random data, and set it up to stream on STDIN. The data will be
+	// returned on the STDOUT buffer.
+	randomSize := 1024 * 1024
+	randomData := make([]byte, randomSize)
+	if _, err := rand.Read(randomData); err != nil {
+		t.Errorf("unexpected error reading random data: %v", err)
+	}
+	var stdout bytes.Buffer
+	options := &StreamOptions{
+		Stdin:  bytes.NewReader(randomData),
+		Stdout: &stdout,
+	}
+	errorChan := make(chan error)
+	go func() {
+		errorChan <- exec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		// Ensure secondary executor returned an error.
+		require.Error(t, err)
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/remotecommand/spdy.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/spdy.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/remotecommand"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/transport/spdy"
+	"k8s.io/klog/v2"
+)
+
+// spdyStreamExecutor handles transporting standard shell streams over an httpstream connection.
+type spdyStreamExecutor struct {
+	upgrader  spdy.Upgrader
+	transport http.RoundTripper
+
+	method    string
+	url       *url.URL
+	protocols []string
+}
+
+// NewSPDYExecutor connects to the provided server and upgrades the connection to
+// multiplexed bidirectional streams.
+func NewSPDYExecutor(config *restclient.Config, method string, url *url.URL) (Executor, error) {
+	wrapper, upgradeRoundTripper, err := spdy.RoundTripperFor(config)
+	if err != nil {
+		return nil, err
+	}
+	return NewSPDYExecutorForTransports(wrapper, upgradeRoundTripper, method, url)
+}
+
+// NewSPDYExecutorForTransports connects to the provided server using the given transport,
+// upgrades the response using the given upgrader to multiplexed bidirectional streams.
+func NewSPDYExecutorForTransports(transport http.RoundTripper, upgrader spdy.Upgrader, method string, url *url.URL) (Executor, error) {
+	return NewSPDYExecutorForProtocols(
+		transport, upgrader, method, url,
+		remotecommand.StreamProtocolV5Name,
+		remotecommand.StreamProtocolV4Name,
+		remotecommand.StreamProtocolV3Name,
+		remotecommand.StreamProtocolV2Name,
+		remotecommand.StreamProtocolV1Name,
+	)
+}
+
+// NewSPDYExecutorForProtocols connects to the provided server and upgrades the connection to
+// multiplexed bidirectional streams using only the provided protocols. Exposed for testing, most
+// callers should use NewSPDYExecutor or NewSPDYExecutorForTransports.
+func NewSPDYExecutorForProtocols(transport http.RoundTripper, upgrader spdy.Upgrader, method string, url *url.URL, protocols ...string) (Executor, error) {
+	return &spdyStreamExecutor{
+		upgrader:  upgrader,
+		transport: transport,
+		method:    method,
+		url:       url,
+		protocols: protocols,
+	}, nil
+}
+
+// Stream opens a protocol streamer to the server and streams until a client closes
+// the connection or the server disconnects.
+func (e *spdyStreamExecutor) Stream(options StreamOptions) error {
+	return e.StreamWithContext(context.Background(), options)
+}
+
+// newConnectionAndStream creates a new SPDY connection and a stream protocol handler upon it.
+func (e *spdyStreamExecutor) newConnectionAndStream(ctx context.Context, options StreamOptions) (httpstream.Connection, streamProtocolHandler, error) {
+	req, err := http.NewRequestWithContext(ctx, e.method, e.url.String(), nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating request: %v", err)
+	}
+
+	conn, protocol, err := spdy.Negotiate(
+		e.upgrader,
+		&http.Client{Transport: e.transport},
+		req,
+		e.protocols...,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var streamer streamProtocolHandler
+
+	switch protocol {
+	case remotecommand.StreamProtocolV5Name:
+		streamer = newStreamProtocolV5(options)
+	case remotecommand.StreamProtocolV4Name:
+		streamer = newStreamProtocolV4(options)
+	case remotecommand.StreamProtocolV3Name:
+		streamer = newStreamProtocolV3(options)
+	case remotecommand.StreamProtocolV2Name:
+		streamer = newStreamProtocolV2(options)
+	case "":
+		klog.V(4).Infof("The server did not negotiate a streaming protocol version. Falling back to %s", remotecommand.StreamProtocolV1Name)
+		fallthrough
+	case remotecommand.StreamProtocolV1Name:
+		streamer = newStreamProtocolV1(options)
+	}
+
+	return conn, streamer, nil
+}
+
+// StreamWithContext opens a protocol streamer to the server and streams until a client closes
+// the connection or the server disconnects or the context is done.
+func (e *spdyStreamExecutor) StreamWithContext(ctx context.Context, options StreamOptions) error {
+	conn, streamer, err := e.newConnectionAndStream(ctx, options)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	panicChan := make(chan any, 1)
+	errorChan := make(chan error, 1)
+	go func() {
+		defer func() {
+			if p := recover(); p != nil {
+				panicChan <- p
+			}
+		}()
+		errorChan <- streamer.stream(conn)
+	}()
+
+	select {
+	case p := <-panicChan:
+		panic(p)
+	case err := <-errorChan:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+

--- a/staging/src/k8s.io/client-go/tools/remotecommand/spdy_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/spdy_test.go
@@ -343,7 +343,7 @@ func TestStreamExitsAfterConnectionIsClosed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	streamExec := exec.(*streamExecutor)
+	streamExec := exec.(*spdyStreamExecutor)
 
 	conn, streamer, err := streamExec.newConnectionAndStream(ctx, options)
 	if err != nil {
@@ -352,7 +352,7 @@ func TestStreamExitsAfterConnectionIsClosed(t *testing.T) {
 
 	errorChan := make(chan error)
 	go func() {
-		errorChan <- streamer.stream(conn)
+		errorChan <- streamer.stream(spdyStreamCreator{Connection: conn})
 	}()
 
 	// Wait until stream goroutine starts.

--- a/staging/src/k8s.io/client-go/tools/remotecommand/spdy_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/spdy_test.go
@@ -352,7 +352,7 @@ func TestStreamExitsAfterConnectionIsClosed(t *testing.T) {
 
 	errorChan := make(chan error)
 	go func() {
-		errorChan <- streamer.stream(spdyStreamCreator{Connection: conn})
+		errorChan <- streamer.stream(conn)
 	}()
 
 	// Wait until stream goroutine starts.

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v2_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v2_test.go
@@ -52,6 +52,8 @@ func (f *fakeStreamCreator) CreateStream(headers http.Header) (httpstream.Stream
 	return nil, f.errors[streamType]
 }
 
+func (f *fakeStreamCreator) Run() {}
+
 func TestV2CreateStreams(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v5.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v5.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+// streamProtocolV5 add support for V5 of the remote command subprotocol.
+// For the streamProtocolHandler, this version is the same as V4.
+type streamProtocolV5 struct {
+	*streamProtocolV4
+}
+
+var _ streamProtocolHandler = &streamProtocolV5{}
+
+func newStreamProtocolV5(options StreamOptions) streamProtocolHandler {
+	return &streamProtocolV5{
+		streamProtocolV4: newStreamProtocolV4(options).(*streamProtocolV4),
+	}
+}
+
+func (p *streamProtocolV5) stream(conn streamCreator) error {
+	return p.streamProtocolV4.stream(conn)
+}

--- a/staging/src/k8s.io/client-go/tools/remotecommand/websocket.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/websocket.go
@@ -1,0 +1,388 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	gwebsocket "github.com/gorilla/websocket"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/remotecommand"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/transport/websocket"
+	"k8s.io/klog/v2"
+)
+
+const (
+	pingReadDeadline = 60 * time.Second
+	// should be less than pingReadDeadline
+	pingWriteDeadline = 10 * time.Second
+	PingPeriod        = 5 * time.Second
+)
+
+var (
+	_ Executor          = &wsStreamExecutor{}
+	_ streamCreator     = &wsStreamCreator{}
+	_ httpstream.Stream = &stream{}
+
+	streamType2streamID = map[string]byte{
+		v1.StreamTypeStdin:  remotecommand.StreamStdIn,
+		v1.StreamTypeStdout: remotecommand.StreamStdOut,
+		v1.StreamTypeStderr: remotecommand.StreamStdErr,
+		v1.StreamTypeError:  remotecommand.StreamErr,
+		v1.StreamTypeResize: remotecommand.StreamResize,
+	}
+)
+
+// wsStreamExecutor handles transporting standard shell streams over an httpstream connection.
+type wsStreamExecutor struct {
+	transport http.RoundTripper
+	upgrader  websocket.ConnectionHolder
+	method    string
+	url       string
+	protocols []string
+}
+
+// NewWebSocketExecutor allows to execute commands via a WebSocket connection.
+func NewWebSocketExecutor(config *restclient.Config, method, url string) (Executor, error) {
+	transport, upgrader, err := websocket.RoundTripperFor(config)
+	if err != nil {
+		return nil, fmt.Errorf("error creating websocket transports: %v", err)
+	}
+	return &wsStreamExecutor{
+		transport: transport,
+		upgrader:  upgrader,
+		method:    method,
+		url:       url,
+		// Only supports V5 protocol for correct version skew functionality.
+		// Previous api servers will proxy upgrade requests to legacy websocket
+		// servers on container runtimes which support V1-V4. These legacy
+		// websocket servers will not handle the new CLOSE signal.
+		protocols: []string{remotecommand.StreamProtocolV5Name},
+	}, nil
+}
+
+// Deprecated: use StreamWithContext instead to avoid possible resource leaks.
+// See https://github.com/kubernetes/kubernetes/pull/103177 for details.
+func (e *wsStreamExecutor) Stream(options StreamOptions) error {
+	return e.StreamWithContext(context.Background(), options)
+}
+
+func (e *wsStreamExecutor) StreamWithContext(ctx context.Context, options StreamOptions) error {
+	req, err := http.NewRequestWithContext(ctx, e.method, e.url, nil)
+	if err != nil {
+		return err
+	}
+	conn, err := websocket.Negotiate(e.transport, e.upgrader, req, e.protocols...)
+	if err != nil {
+		return err
+	}
+	if conn == nil {
+		panic(fmt.Errorf("websocket connection is nil"))
+	}
+	defer conn.Close()
+	protocol := conn.Subprotocol()
+	klog.V(4).Infof("The subprotocol is %s", protocol)
+
+	var streamer streamProtocolHandler
+	switch protocol {
+	case remotecommand.StreamProtocolV5Name:
+		streamer = newStreamProtocolV5(options)
+	case remotecommand.StreamProtocolV4Name:
+		streamer = newStreamProtocolV4(options)
+	case remotecommand.StreamProtocolV3Name:
+		streamer = newStreamProtocolV3(options)
+	case remotecommand.StreamProtocolV2Name:
+		streamer = newStreamProtocolV2(options)
+	case "":
+		klog.V(4).Infof("The server did not negotiate a streaming protocol version. Falling back to %s", remotecommand.StreamProtocolV1Name)
+		fallthrough
+	case remotecommand.StreamProtocolV1Name:
+		streamer = newStreamProtocolV1(options)
+	}
+
+	panicChan := make(chan any, 1)
+	errorChan := make(chan error, 1)
+	go func() {
+		defer func() {
+			if p := recover(); p != nil {
+				panicChan <- p
+			}
+		}()
+		creator := newWSStreamCreator(conn)
+		go creator.run(e.upgrader.DataBufferSize()) // connection read/stream write loop in its own goroutine.
+		errorChan <- streamer.stream(creator)
+	}()
+
+	select {
+	case p := <-panicChan:
+		panic(p)
+	case err := <-errorChan:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type wsStreamCreator struct {
+	conn      *gwebsocket.Conn
+	connMu    sync.Mutex
+	streams   map[byte]*stream
+	streamsMu sync.Mutex
+}
+
+func newWSStreamCreator(conn *gwebsocket.Conn) *wsStreamCreator {
+	ws := wsStreamCreator{
+		conn:    conn,
+		streams: map[byte]*stream{},
+	}
+
+	go ws.sendPings(PingPeriod) // start heartbeat
+
+	return &ws
+}
+
+func (c *wsStreamCreator) getStream(id byte) *stream {
+	c.streamsMu.Lock()
+	defer c.streamsMu.Unlock()
+	return c.streams[id]
+}
+
+func (c *wsStreamCreator) setStream(id byte, s *stream) {
+	c.streamsMu.Lock()
+	defer c.streamsMu.Unlock()
+	c.streams[id] = s
+}
+
+// CreateStream uses id from passed headers to create a stream over "c.conn" connection.
+// Returns a Stream structure or nil and an error if one occurred.
+func (c *wsStreamCreator) CreateStream(headers http.Header) (httpstream.Stream, error) {
+	streamType := headers.Get(v1.StreamType)
+	id, ok := streamType2streamID[streamType]
+	if !ok {
+		return nil, fmt.Errorf("unknown stream type: %s", streamType)
+	}
+	if s := c.getStream(id); s != nil {
+		return nil, fmt.Errorf("duplicate stream for type %s", streamType)
+	}
+	reader, writer := io.Pipe()
+	s := &stream{
+		headers:   headers,
+		readPipe:  reader,
+		writePipe: writer,
+		conn:      c.conn,
+		connMu:    &c.connMu,
+		id:        id,
+	}
+	c.setStream(id, s)
+	return s, nil
+}
+
+// sendPings starts heartbeat sending a "ping" from the endpoint every "period".
+func (c *wsStreamCreator) sendPings(period time.Duration) {
+	c.connMu.Lock()
+	closedCh := make(chan struct{})
+	closeHandler := c.conn.CloseHandler()
+	c.conn.SetCloseHandler(func(code int, text string) error {
+		close(closedCh)
+		return closeHandler(code, text)
+	})
+	c.connMu.Unlock()
+	t := time.NewTicker(period)
+	defer t.Stop()
+	for {
+		select {
+		case <-closedCh:
+			return
+		case <-t.C:
+			c.connMu.Lock()
+			if err := c.conn.WriteControl(gwebsocket.PingMessage, nil, time.Now().Add(period)); err != nil {
+				klog.V(7).Infof("Websocket Ping failed: %v", err)
+				// Continue, in case this is a transient failure.
+				// c.conn.CloseChan above will tell us when the connection is
+				// actually closed.
+			} else {
+				klog.V(7).Infof("Websocket Ping succeeeded")
+			}
+			c.connMu.Unlock()
+		}
+	}
+}
+
+// run is executed in its own goroutine, reading the connection and demultiplexing
+// the data messages into individual streams.
+func (c *wsStreamCreator) run(bufferSize int) {
+	// Buffer size must correspond to the same size allocated
+	// for the read buffer during websocket client creation. A
+	// difference can cause incomplete connection reads.
+	readBuffer := make([]byte, bufferSize)
+	// Set up handler for ping/pong heartbeat.
+	if err := c.conn.SetReadDeadline(time.Now().Add(pingReadDeadline)); err != nil {
+		klog.V(7).Infof("Websocket setting read deadline failed %v", err)
+	}
+	c.conn.SetPongHandler(func(string) error {
+		err := c.conn.SetReadDeadline(time.Now().Add(pingReadDeadline))
+		if err != nil {
+			klog.V(7).Infof("Websocket setting read deadline failed %v", err)
+		}
+		return nil
+	})
+	for {
+		messageType, r, err := c.conn.NextReader()
+		if err != nil {
+			websocketErr, ok := err.(*gwebsocket.CloseError)
+			if ok && websocketErr.Code == gwebsocket.CloseNormalClosure {
+				err = nil // readers will get io.EOF as it's a normal closure
+			} else {
+				err = fmt.Errorf("next reader: %w", err)
+			}
+			c.closeAllStreamReaders(err)
+			return
+		}
+		if messageType != gwebsocket.BinaryMessage {
+			c.closeAllStreamReaders(fmt.Errorf("unexpected message type: %d", messageType))
+			return
+		}
+		// it's ok to read just a single byte because the underlying library wraps the actual connection with
+		// a buffered reader anyway.
+		_, err = io.ReadFull(r, readBuffer[:1])
+		if err != nil {
+			c.closeAllStreamReaders(fmt.Errorf("read stream id: %w", err))
+			return
+		}
+		streamID := readBuffer[0]
+		s := c.getStream(streamID)
+		if s == nil {
+			klog.Errorf("Unknown stream id %d, discarding message", streamID)
+			continue
+		}
+		for {
+			nr, errRead := r.Read(readBuffer)
+			if nr > 0 {
+				_, errWrite := s.writePipe.Write(readBuffer[:nr])
+				if errWrite != nil {
+					// Pipe must have been closed by the stream user. Nothing to do, discard the message.
+					break
+				}
+			}
+			if errRead != nil {
+				if errRead == io.EOF {
+					break
+				}
+				c.closeAllStreamReaders(fmt.Errorf("read message: %w", err))
+				return
+			}
+		}
+	}
+}
+
+// closeAllStreamReaders closes readers in all streams.
+// This unblocks all stream.Read() calls.
+func (c *wsStreamCreator) closeAllStreamReaders(err error) {
+	c.streamsMu.Lock()
+	defer c.streamsMu.Unlock()
+	for _, s := range c.streams {
+		// Closing writePipe unblocks all readPipe.Read() callers and prevents any future writes.
+		_ = s.writePipe.CloseWithError(err)
+	}
+}
+
+type stream struct {
+	headers   http.Header
+	readPipe  *io.PipeReader
+	writePipe *io.PipeWriter
+	// conn is used for writing directly into the connection.
+	// Is nil after Close() / Reset() to prevent future writes.
+	conn *gwebsocket.Conn
+	// connMu protects conn against concurrent write operations. There must be a single writer and a single reader only.
+	// The mutex is shared across all streams because the underlying connection is shared.
+	connMu *sync.Mutex
+	id     byte
+}
+
+func (s *stream) Read(p []byte) (n int, err error) {
+	return s.readPipe.Read(p)
+}
+
+// Write writes directly to the underlying WebSocket connection.
+func (s *stream) Write(p []byte) (n int, err error) {
+	klog.V(4).Infof("Write() on stream %d", s.id)
+	defer klog.V(4).Infof("Write() done on stream %d", s.id)
+	s.connMu.Lock()
+	defer s.connMu.Unlock()
+	if s.conn == nil {
+		return 0, fmt.Errorf("write on closed stream %d", s.id)
+	}
+	err = s.conn.SetWriteDeadline(time.Now().Add(pingWriteDeadline))
+	if err != nil {
+		klog.V(7).Infof("Websocket setting write deadline failed %v", err)
+		return 0, err
+	}
+	// Message writer buffers the message data, so we don't need to do that ourselves.
+	// Just write id and the data as two separate writes to avoid allocating an intermediate buffer.
+	w, err := s.conn.NextWriter(gwebsocket.BinaryMessage)
+	if err != nil {
+		return 0, err
+	}
+	_, err = w.Write([]byte{s.id})
+	if err != nil {
+		_ = w.Close()
+		return 0, err
+	}
+	n, err = w.Write(p)
+	if err != nil {
+		_ = w.Close()
+		return n, err
+	}
+	return n, w.Close()
+}
+
+// Close half-closes the stream, indicating this side is finished with the stream.
+func (s *stream) Close() error {
+	klog.V(4).Infof("Close() on stream %d", s.id)
+	defer klog.V(4).Infof("Close() done on stream %d", s.id)
+	s.connMu.Lock()
+	defer s.connMu.Unlock()
+	if s.conn == nil {
+		return fmt.Errorf("Close() on already closed stream %d", s.id)
+	}
+	s.conn.WriteMessage(gwebsocket.BinaryMessage, []byte{remotecommand.StreamClose, s.id})
+	s.conn = nil
+	return nil
+}
+
+func (s *stream) Reset() error {
+	klog.V(4).Infof("Reset() on stream %d", s.id)
+	defer klog.V(4).Infof("Reset() done on stream %d", s.id)
+	s.Close()
+	return s.writePipe.Close()
+}
+
+func (s *stream) Headers() http.Header {
+	return s.headers
+}
+
+func (s *stream) Identifier() uint32 {
+	return uint32(s.id)
+}

--- a/staging/src/k8s.io/client-go/tools/remotecommand/websocket_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/websocket_test.go
@@ -1,0 +1,536 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	mrand "math/rand"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream/wsstream"
+	"k8s.io/apimachinery/pkg/util/remotecommand"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+)
+
+// TestWebSocketClient_LoopbackStdinToStdout returns random data sent on the STDIN channel
+// back down the STDOUT channel. A subsequent comparison checks if the data
+// sent on the STDIN channel is the same as the data returned on the STDOUT
+// channel. This test can be run many times by the "stress" tool to check
+// if there is any data which would cause problems with the WebSocket streams.
+func TestWebSocketClient_LoopbackStdinToStdout(t *testing.T) {
+	// Create fake WebSocket server. Copy received STDIN data back onto STDOUT stream.
+	websocketServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conns, err := webSocketServerStreams(req, w, streamOptionsFromRequest(req))
+		if err != nil {
+			t.Fatalf("error on webSocketServerStreams: %v", err)
+		}
+		defer conns.conn.Close()
+		// Loopback the STDIN stream onto the STDOUT stream.
+		_, err = io.Copy(conns.stdoutStream, conns.stdinStream)
+		if err != nil {
+			t.Fatalf("error copying STDIN to STDOUT: %v", err)
+		}
+	}))
+	defer websocketServer.Close()
+
+	// Now create the WebSocket client (executor), and point it to the "websocketServer".
+	// Must add STDIN and STDOUT query params for the WebSocket client request.
+	websocketServer.URL = websocketServer.URL + "?" + "stdin=true" + "&" + "stdout=true"
+	websocketLocation, err := url.Parse(websocketServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
+	}
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	if err != nil {
+		t.Errorf("unexpected error creating websocket executor: %v", err)
+	}
+	// Generate random data, and set it up to stream on STDIN. The data will be
+	// returned on the STDOUT buffer.
+	randomSize := 1024 * 1024
+	randomData := make([]byte, randomSize)
+	if _, err := rand.Read(randomData); err != nil {
+		t.Errorf("unexpected error reading random data: %v", err)
+	}
+	var stdout bytes.Buffer
+	options := &StreamOptions{
+		Stdin:  bytes.NewReader(randomData),
+		Stdout: &stdout,
+	}
+	errorChan := make(chan error)
+	go func() {
+		// Start the streaming on the WebSocket "exec" client.
+		errorChan <- exec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		if err != nil {
+			t.Errorf("unexpected error")
+		}
+	}
+	data, err := ioutil.ReadAll(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		t.Errorf("error reading the stream: %v", err)
+		return
+	}
+	// Check the random data sent on STDIN was the same returned on STDOUT.
+	if !bytes.Equal(randomData, data) {
+		t.Errorf("unexpected data received: %d sent: %d", len(data), len(randomData))
+	}
+}
+
+// TestWebSocketClient_LoopbackStdinToStderr returns random data sent on the STDIN channel
+// back down the STDERR channel. A subsequent comparison checks if the data
+// sent on the STDIN channel is the same as the data returned on the STDERR
+// channel. This test can be run many times by the "stress" tool to check
+// if there is any data which would cause problems with the WebSocket streams.
+func TestWebSocketClient_LoopbackStdinToStderr(t *testing.T) {
+	// Create fake WebSocket server. Copy received STDIN data back onto STDERR stream.
+	websocketServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conns, err := webSocketServerStreams(req, w, streamOptionsFromRequest(req))
+		if err != nil {
+			t.Fatalf("error on webSocketServerStreams: %v", err)
+		}
+		defer conns.conn.Close()
+		// Loopback the STDIN stream onto the STDERR stream.
+		_, err = io.Copy(conns.stderrStream, conns.stdinStream)
+		if err != nil {
+			t.Fatalf("error copying STDIN to STDERR: %v", err)
+		}
+	}))
+	defer websocketServer.Close()
+
+	// Now create the WebSocket client (executor), and point it to the "websocketServer".
+	// Must add STDIN and STDERR query params for the WebSocket client request.
+	websocketServer.URL = websocketServer.URL + "?" + "stdin=true" + "&" + "stderr=true"
+	websocketLocation, err := url.Parse(websocketServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
+	}
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	if err != nil {
+		t.Errorf("unexpected error creating websocket executor: %v", err)
+	}
+	// Generate random data, and set it up to stream on STDIN. The data will be
+	// returned on the STDERR buffer.
+	randomSize := 1024 * 1024
+	randomData := make([]byte, randomSize)
+	if _, err := rand.Read(randomData); err != nil {
+		t.Errorf("unexpected error reading random data: %v", err)
+	}
+	var stderr bytes.Buffer
+	options := &StreamOptions{
+		Stdin:  bytes.NewReader(randomData),
+		Stderr: &stderr,
+	}
+	errorChan := make(chan error)
+	go func() {
+		// Start the streaming on the WebSocket "exec" client.
+		errorChan <- exec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		if err != nil {
+			t.Errorf("unexpected error")
+		}
+	}
+	data, err := ioutil.ReadAll(bytes.NewReader(stderr.Bytes()))
+	if err != nil {
+		t.Errorf("error reading the stream: %v", err)
+		return
+	}
+	// Check the random data sent on STDIN was the same returned on STDERR.
+	if !bytes.Equal(randomData, data) {
+		t.Errorf("unexpected data received: %d sent: %d", len(data), len(randomData))
+	}
+}
+
+// Returns a random exit code in the range(1-127).
+func randomExitCode() int {
+	errorCode := mrand.Intn(128)
+	if errorCode == 0 {
+		errorCode = 1
+	}
+	return errorCode
+}
+
+// TestWebSocketClient_ErrorStream tests the websocket error stream by hard-coding a
+// structured non-zero exit code error from the websocket server to the websocket client.
+func TestWebSocketClient_ErrorStream(t *testing.T) {
+	expectedExitCode := randomExitCode()
+	// Create fake WebSocket server. Returns structured exit code error on error stream.
+	websocketServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conns, err := webSocketServerStreams(req, w, streamOptionsFromRequest(req))
+		if err != nil {
+			t.Fatalf("error on webSocketServerStreams: %v", err)
+		}
+		defer conns.conn.Close()
+		_, err = io.Copy(conns.stderrStream, conns.stdinStream)
+		if err != nil {
+			t.Fatalf("error copying STDIN to STDERR: %v", err)
+		}
+		// Force an non-zero exit code error returned on the error stream.
+		conns.writeStatus(&apierrors.StatusError{ErrStatus: metav1.Status{
+			Status: metav1.StatusFailure,
+			Reason: remotecommand.NonZeroExitCodeReason,
+			Details: &metav1.StatusDetails{
+				Causes: []metav1.StatusCause{
+					{
+						Type:    remotecommand.ExitCodeCauseType,
+						Message: fmt.Sprintf("%d", expectedExitCode),
+					},
+				},
+			},
+		}})
+	}))
+	defer websocketServer.Close()
+
+	// Now create the WebSocket client (executor), and point it to the "websocketServer".
+	websocketServer.URL = websocketServer.URL + "?" + "stdin=true" + "&" + "stderr=true"
+	websocketLocation, err := url.Parse(websocketServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
+	}
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	if err != nil {
+		t.Errorf("unexpected error creating websocket executor: %v", err)
+	}
+	randomData := make([]byte, 256)
+	if _, err := rand.Read(randomData); err != nil {
+		t.Errorf("unexpected error reading random data: %v", err)
+	}
+	var stderr bytes.Buffer
+	options := &StreamOptions{
+		Stdin:  bytes.NewReader(randomData),
+		Stderr: &stderr,
+	}
+	errorChan := make(chan error)
+	go func() {
+		// Start the streaming on the WebSocket "exec" client.
+		errorChan <- exec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		// Expect exit code error on error stream.
+		if err == nil {
+			t.Errorf("expected error, but received none")
+		}
+		expectedError := fmt.Sprintf("command terminated with exit code %d", expectedExitCode)
+		// Compare expected error with exit code to actual error.
+		if expectedError != err.Error() {
+			t.Errorf("expected error (%s), got (%s)", expectedError, err)
+		}
+	}
+}
+
+// fakeTerminalSizeQueue implements the TerminalSizeQueue interface, hard-coded to
+// return the "size" only once.
+type fakeTerminalSizeQueue struct {
+	served bool
+	size   TerminalSize
+}
+
+// Next returns a pointer to "size" the first time, nil every other time.
+func (f *fakeTerminalSizeQueue) Next() *TerminalSize {
+	if f.served {
+		return nil
+	}
+	f.served = true
+	return &f.size
+}
+
+// randomTerminalSize returns a TerminalSize with random values in the
+// range (0-65535) for the fields Width and Height.
+func randomTerminalSize() TerminalSize {
+	randWidth := uint16(mrand.Intn(int(math.Pow(2, 16))))
+	randHeight := uint16(mrand.Intn(int(math.Pow(2, 16))))
+	return TerminalSize{
+		Width:  randWidth,
+		Height: randHeight,
+	}
+}
+
+// TestWebSocketClient_TTYResizeChannel tests the websocket terminal resize stream by hard-coding a
+// a random terminal size to be sent on the resize stream, then comparing the received terminal
+// size to the one sent.
+func TestWebSocketClient_TTYResizeChannel(t *testing.T) {
+	expectedTerminalSize := randomTerminalSize()
+	// Create fake WebSocket server, which will read and compare the sent terminal resize.
+	websocketServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conns, err := webSocketServerStreams(req, w, streamOptionsFromRequest(req))
+		if err != nil {
+			t.Fatalf("error on webSocketServerStreams: %v", err)
+		}
+		defer conns.conn.Close()
+		// Read the terminal resize request from the websocket client and compare.
+		actualTerminalSize := <-conns.resizeChan
+		if !reflect.DeepEqual(expectedTerminalSize, actualTerminalSize) {
+			t.Errorf("expected terminal size (%v), got (%v)", expectedTerminalSize, actualTerminalSize)
+		}
+	}))
+	defer websocketServer.Close()
+
+	// Now create the WebSocket client (executor), and point it to the "websocketServer".
+	// Must add TTY query param for the WebSocket client request.
+	websocketServer.URL = websocketServer.URL + "?" + "tty=true" + "&" + "stdout=true"
+	websocketLocation, err := url.Parse(websocketServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
+	}
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	if err != nil {
+		t.Errorf("unexpected error creating websocket executor: %v", err)
+	}
+	errorChan := make(chan error)
+	go func() {
+		// Start the streaming on the WebSocket "exec" client. Hard-code the WebSocket client
+		// to send the expected terminal resize request.
+		errorChan <- exec.StreamWithContext(context.Background(), StreamOptions{
+			Tty:               true,
+			TerminalSizeQueue: &fakeTerminalSizeQueue{served: false, size: expectedTerminalSize},
+		})
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+}
+
+// TestWebSocketClient_BadHandshake tests that a "bad handshake" error occurs when
+// the WebSocketExecutor attempts to upgrade the connection to a subprotocol version
+// (V4) that is not supported by the websocket server (only supports V5).
+func TestWebSocketClient_BadHandshake(t *testing.T) {
+	// Create fake WebSocket server (supports V5 subprotocol).
+	websocketServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conns, err := webSocketServerStreams(req, w, streamOptionsFromRequest(req))
+		if err != nil {
+			t.Fatalf("error on webSocketServerStreams: %v", err)
+		}
+		defer conns.conn.Close()
+	}))
+	defer websocketServer.Close()
+
+	websocketServer.URL = websocketServer.URL + "?" + "stdout=true"
+	websocketLocation, err := url.Parse(websocketServer.URL)
+	if err != nil {
+		t.Fatalf("Unable to parse WebSocket server URL: %s", websocketServer.URL)
+	}
+	exec, err := NewWebSocketExecutor(&rest.Config{Host: websocketLocation.Host}, "POST", websocketServer.URL)
+	if err != nil {
+		t.Errorf("unexpected error creating websocket executor: %v", err)
+	}
+	streamExec := exec.(*wsStreamExecutor)
+	// Set the attempted subprotocol version to V4; websocket server only accepts V5.
+	streamExec.protocols = []string{remotecommand.StreamProtocolV4Name}
+
+	var stdout bytes.Buffer
+	options := &StreamOptions{
+		Stdout: &stdout,
+	}
+	errorChan := make(chan error)
+	go func() {
+		// Start the streaming on the WebSocket "exec" client.
+		errorChan <- streamExec.StreamWithContext(context.Background(), *options)
+	}()
+
+	select {
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("expect stream to be closed after connection is closed.")
+	case err := <-errorChan:
+		// Expecting unable to upgrade connection -- "bad handshake" error.
+		if err == nil {
+			t.Errorf("expected error but received none")
+		}
+		if !strings.Contains(err.Error(), "bad handshake") {
+			t.Errorf("expected bad handshake error, got (%s)", err)
+		}
+	}
+}
+
+// options contains details about which streams are required for
+// remote command execution.
+type options struct {
+	stdin  bool
+	stdout bool
+	stderr bool
+	tty    bool
+}
+
+// Translates query params in request into options struct.
+func streamOptionsFromRequest(req *http.Request) *options {
+	query := req.URL.Query()
+	tty := query.Get("tty") == "true"
+	stdin := query.Get("stdin") == "true"
+	stdout := query.Get("stdout") == "true"
+	stderr := query.Get("stderr") == "true"
+	return &options{
+		stdin:  stdin,
+		stdout: stdout,
+		stderr: stderr,
+		tty:    tty,
+	}
+}
+
+// websocketStreams contains the WebSocket connection and streams from a server.
+type websocketStreams struct {
+	conn         io.Closer
+	stdinStream  io.ReadCloser
+	stdoutStream io.WriteCloser
+	stderrStream io.WriteCloser
+	writeStatus  func(status *apierrors.StatusError) error
+	resizeStream io.ReadCloser
+	resizeChan   chan TerminalSize
+	tty          bool
+}
+
+// Create WebSocket server streams to respond to a WebSocket client. Creates the streams passed
+// in the stream options.
+func webSocketServerStreams(req *http.Request, w http.ResponseWriter, opts *options) (*websocketStreams, error) {
+	conn, err := createWebSocketStreams(req, w, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if conn.resizeStream != nil {
+		conn.resizeChan = make(chan TerminalSize)
+		go handleResizeEvents(req.Context(), conn.resizeStream, conn.resizeChan)
+	}
+
+	return conn, nil
+}
+
+// Read terminal resize events off of passed stream and queue into passed channel.
+func handleResizeEvents(ctx context.Context, stream io.Reader, channel chan<- TerminalSize) {
+	defer close(channel)
+
+	decoder := json.NewDecoder(stream)
+	for {
+		size := TerminalSize{}
+		if err := decoder.Decode(&size); err != nil {
+			break
+		}
+
+		select {
+		case channel <- size:
+		case <-ctx.Done():
+			// To avoid leaking this routine, exit if the http request finishes. This path
+			// would generally be hit if starting the process fails and nothing is started to
+			// ingest these resize events.
+			return
+		}
+	}
+}
+
+// createChannels returns the standard channel types for a shell connection (STDIN 0, STDOUT 1, STDERR 2)
+// along with the approximate duplex value. It also creates the error (3) and resize (4) channels.
+func createChannels(opts *options) []wsstream.ChannelType {
+	// open the requested channels, and always open the error channel
+	channels := make([]wsstream.ChannelType, 5)
+	channels[remotecommand.StreamStdIn] = readChannel(opts.stdin)
+	channels[remotecommand.StreamStdOut] = writeChannel(opts.stdout)
+	channels[remotecommand.StreamStdErr] = writeChannel(opts.stderr)
+	channels[remotecommand.StreamErr] = wsstream.WriteChannel
+	channels[remotecommand.StreamResize] = wsstream.ReadChannel
+	return channels
+}
+
+// readChannel returns wsstream.ReadChannel if real is true, or wsstream.IgnoreChannel.
+func readChannel(real bool) wsstream.ChannelType {
+	if real {
+		return wsstream.ReadChannel
+	}
+	return wsstream.IgnoreChannel
+}
+
+// writeChannel returns wsstream.WriteChannel if real is true, or wsstream.IgnoreChannel.
+func writeChannel(real bool) wsstream.ChannelType {
+	if real {
+		return wsstream.WriteChannel
+	}
+	return wsstream.IgnoreChannel
+}
+
+// createWebSocketStreams returns a "channels" struct containing the websocket connection and
+// streams needed to perform an exec or an attach.
+func createWebSocketStreams(req *http.Request, w http.ResponseWriter, opts *options) (*websocketStreams, error) {
+	channels := createChannels(opts)
+	conn := wsstream.NewConn(map[string]wsstream.ChannelProtocolConfig{
+		remotecommand.StreamProtocolV5Name: {
+			Binary:   true,
+			Channels: channels,
+		},
+	})
+	conn.SetIdleTimeout(4 * time.Hour)
+	// Opening the connection responds to WebSocket client, negotiating
+	// the WebSocket upgrade connection and the subprotocol.
+	_, streams, err := conn.Open(w, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Send an empty message to the lowest writable channel to notify the client the connection is established
+	switch {
+	case opts.stdout:
+		streams[remotecommand.StreamStdOut].Write([]byte{})
+	case opts.stderr:
+		streams[remotecommand.StreamStdErr].Write([]byte{})
+	default:
+		streams[remotecommand.StreamErr].Write([]byte{})
+	}
+
+	wsStreams := &websocketStreams{
+		conn:         conn,
+		stdinStream:  streams[remotecommand.StreamStdIn],
+		stdoutStream: streams[remotecommand.StreamStdOut],
+		stderrStream: streams[remotecommand.StreamStdErr],
+		tty:          opts.tty,
+		resizeStream: streams[remotecommand.StreamResize],
+	}
+
+	wsStreams.writeStatus = v4WriteStatusFunc(streams[remotecommand.StreamErr])
+
+	return wsStreams, nil
+}

--- a/staging/src/k8s.io/client-go/transport/websocket/roundtripper.go
+++ b/staging/src/k8s.io/client-go/transport/websocket/roundtripper.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package websocket
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	gwebsocket "github.com/gorilla/websocket"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+)
+
+var (
+	_ utilnet.TLSClientConfigHolder = &RoundTripper{}
+	_ http.RoundTripper             = &RoundTripper{}
+)
+
+// ConnectionHolder defines functions for structure providing
+// access to the websocket connection.
+type ConnectionHolder interface {
+	DataBufferSize() int
+	Connection() *gwebsocket.Conn
+}
+
+// RoundTripper knows how to establish a connection to a remote WebSocket endpoint and make it available for use.
+// RoundTripper must not be reused.
+type RoundTripper struct {
+	// TLSConfig holds the TLS configuration settings to use when connecting
+	// to the remote server.
+	TLSConfig *tls.Config
+
+	// Proxier specifies a function to return a proxy for a given
+	// Request. If the function returns a non-nil error, the
+	// request is aborted with the provided error.
+	// If Proxy is nil or returns a nil *URL, no proxy is used.
+	Proxier func(req *http.Request) (*url.URL, error)
+
+	// Conn holds the WebSocket connection after a round trip.
+	Conn *gwebsocket.Conn
+}
+
+// Connection returns the stored websocket connection.
+func (rt *RoundTripper) Connection() *gwebsocket.Conn {
+	return rt.Conn
+}
+
+// DataBufferSize returns the size of buffers for the
+// websocket connection.
+func (rt *RoundTripper) DataBufferSize() int {
+	return 32 * 1024
+}
+
+// TLSClientConfig implements pkg/util/net.TLSClientConfigHolder.
+func (rt *RoundTripper) TLSClientConfig() *tls.Config {
+	return rt.TLSConfig
+}
+
+// RoundTrip connects to the remote websocket using the headers in the request and the TLS
+// configuration from the config
+func (rt *RoundTripper) RoundTrip(request *http.Request) (retResp *http.Response, retErr error) {
+	defer func() {
+		if request.Body != nil {
+			err := request.Body.Close()
+			if retErr == nil {
+				retErr = err
+			}
+		}
+	}()
+
+	// set the protocol version directly on the dialer from the header
+	protocolVersions := request.Header[httpstream.HeaderProtocolVersion]
+	delete(request.Header, httpstream.HeaderProtocolVersion)
+
+	dialer := gwebsocket.Dialer{
+		Proxy:           rt.Proxier,
+		TLSClientConfig: rt.TLSConfig,
+		Subprotocols:    protocolVersions,
+		ReadBufferSize:  rt.DataBufferSize() + 1024, // add space for the protocol byte indicating which channel the data is for
+		WriteBufferSize: rt.DataBufferSize() + 1024, // add space for the protocol byte indicating which channel the data is for
+	}
+	switch request.URL.Scheme {
+	case "https":
+		request.URL.Scheme = "wss"
+	case "http":
+		request.URL.Scheme = "ws"
+	default:
+		return nil, fmt.Errorf("unknown url scheme: %s", request.URL.Scheme)
+	}
+	wsConn, resp, err := dialer.DialContext(request.Context(), request.URL.String(), request.Header)
+	if err != nil {
+		if err != gwebsocket.ErrBadHandshake {
+			return nil, err
+		}
+		return nil, fmt.Errorf("unable to upgrade connection: %v", err)
+	}
+
+	rt.Conn = wsConn
+
+	return resp, nil
+}
+
+// RoundTripperFor transforms the passed rest config into a wrapped roundtripper, as well
+// as a pointer to the websocket RoundTripper. The websocket RoundTripper contains the
+// websocket connection after RoundTrip() on the wrapper. Returns an error if there is
+// a problem creating the round trippers.
+func RoundTripperFor(config *restclient.Config) (http.RoundTripper, ConnectionHolder, error) {
+	transportCfg, err := config.TransportConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+	tlsConfig, err := transport.TLSConfigFor(transportCfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	proxy := config.Proxy
+	if proxy == nil {
+		proxy = utilnet.NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment)
+	}
+
+	upgradeRoundTripper := &RoundTripper{
+		TLSConfig: tlsConfig,
+		Proxier:   proxy,
+	}
+	wrapper, err := transport.HTTPWrappersForConfig(transportCfg, upgradeRoundTripper)
+	if err != nil {
+		return nil, nil, err
+	}
+	return wrapper, upgradeRoundTripper, nil
+}
+
+// Negotiate opens a connection to a remote server and attempts to negotiate
+// a WebSocket connection. Upon success, it returns the negotiated connection.
+// The round tripper rt must use the WebSocket round tripper wsRt - see RoundTripperFor.
+func Negotiate(rt http.RoundTripper, connectionInfo ConnectionHolder, req *http.Request, protocols ...string) (*gwebsocket.Conn, error) {
+	req.Header[httpstream.HeaderProtocolVersion] = protocols
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		return nil, fmt.Errorf("error sending request: %v", err)
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		connectionInfo.Connection().Close()
+		return nil, fmt.Errorf("error closing response body: %v", err)
+	}
+	return connectionInfo.Connection(), nil
+}

--- a/staging/src/k8s.io/client-go/transport/websocket/roundtripper_test.go
+++ b/staging/src/k8s.io/client-go/transport/websocket/roundtripper_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package websocket
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/httpstream/wsstream"
+	"k8s.io/apimachinery/pkg/util/remotecommand"
+	restclient "k8s.io/client-go/rest"
+)
+
+func TestWebSocketRoundTripper_RoundTripperSucceeds(t *testing.T) {
+	// Create fake WebSocket server.
+	websocketServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conns, err := webSocketServerStreams(req, w)
+		if err != nil {
+			t.Fatalf("error on webSocketServerStreams: %v", err)
+		}
+		defer conns.conn.Close()
+	}))
+	defer websocketServer.Close()
+
+	// Create the wrapped roundtripper and websocket upgrade roundtripper and call "RoundTrip()".
+	websocketLocation, err := url.Parse(websocketServer.URL)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), "POST", websocketServer.URL, nil)
+	require.NoError(t, err)
+	rt, wsRt, err := RoundTripperFor(&restclient.Config{Host: websocketLocation.Host})
+	require.NoError(t, err)
+	requestedProtocol := remotecommand.StreamProtocolV5Name
+	req.Header[httpstream.HeaderProtocolVersion] = []string{requestedProtocol}
+	_, err = rt.RoundTrip(req)
+	require.NoError(t, err)
+	// WebSocket Connection is stored in websocket RoundTripper.
+	// Compare the expected negotiated subprotocol with the actual subprotocol.
+	actualProtocol := wsRt.Connection().Subprotocol()
+	assert.Equal(t, requestedProtocol, actualProtocol)
+
+}
+
+func TestWebSocketRoundTripper_RoundTripperFails(t *testing.T) {
+	// Create fake WebSocket server.
+	websocketServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conns, err := webSocketServerStreams(req, w)
+		if err != nil {
+			t.Fatalf("error on webSocketServerStreams: %v", err)
+		}
+		defer conns.conn.Close()
+	}))
+	defer websocketServer.Close()
+
+	// Create the wrapped roundtripper and websocket upgrade roundtripper and call "RoundTrip()".
+	websocketLocation, err := url.Parse(websocketServer.URL)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), "POST", websocketServer.URL, nil)
+	require.NoError(t, err)
+	rt, _, err := RoundTripperFor(&restclient.Config{Host: websocketLocation.Host})
+	require.NoError(t, err)
+	// Requested subprotocol version 1 is not supported by test websocket server.
+	requestedProtocol := remotecommand.StreamProtocolV1Name
+	req.Header[httpstream.HeaderProtocolVersion] = []string{requestedProtocol}
+	_, err = rt.RoundTrip(req)
+	// Ensure a "bad handshake" error is returned, since requested protocol is not supported.
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "bad handshake"))
+}
+
+func TestWebSocketRoundTripper_NegotiateCreatesConnection(t *testing.T) {
+	// Create fake WebSocket server.
+	websocketServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conns, err := webSocketServerStreams(req, w)
+		if err != nil {
+			t.Fatalf("error on webSocketServerStreams: %v", err)
+		}
+		defer conns.conn.Close()
+	}))
+	defer websocketServer.Close()
+
+	// Create the websocket roundtripper and call "Negotiate" to create websocket connection.
+	websocketLocation, err := url.Parse(websocketServer.URL)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(context.Background(), "POST", websocketServer.URL, nil)
+	require.NoError(t, err)
+	rt, wsRt, err := RoundTripperFor(&restclient.Config{Host: websocketLocation.Host})
+	require.NoError(t, err)
+	requestedProtocol := remotecommand.StreamProtocolV5Name
+	conn, err := Negotiate(rt, wsRt, req, requestedProtocol)
+	require.NoError(t, err)
+	// Compare the expected negotiated subprotocol with the actual subprotocol.
+	actualProtocol := conn.Subprotocol()
+	assert.Equal(t, requestedProtocol, actualProtocol)
+}
+
+// websocketStreams contains the WebSocket connection and streams from a server.
+type websocketStreams struct {
+	conn io.Closer
+}
+
+func webSocketServerStreams(req *http.Request, w http.ResponseWriter) (*websocketStreams, error) {
+	conn := wsstream.NewConn(map[string]wsstream.ChannelProtocolConfig{
+		remotecommand.StreamProtocolV5Name: {
+			Binary:   true,
+			Channels: []wsstream.ChannelType{},
+		},
+	})
+	conn.SetIdleTimeout(4 * time.Hour)
+	// Opening the connection responds to WebSocket client, negotiating
+	// the WebSocket upgrade connection and the subprotocol.
+	_, _, err := conn.Open(w, req)
+	if err != nil {
+		return nil, err
+	}
+	return &websocketStreams{conn: conn}, nil
+}

--- a/staging/src/k8s.io/client-go/util/exec/exec.go
+++ b/staging/src/k8s.io/client-go/util/exec/exec.go
@@ -14,39 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// TODO: Update imports of these error types to use newer apimachinery package.
+// Deprecated: Import these error types from "k8s.io/apimachinery/pkg/api/errors" instead.
 package exec
 
-// ExitError is an interface that presents an API similar to os.ProcessState, which is
-// what ExitError from os/exec is.  This is designed to make testing a bit easier and
-// probably loses some of the cross-platform properties of the underlying library.
-type ExitError interface {
-	String() string
-	Error() string
-	Exited() bool
-	ExitStatus() int
-}
+import apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-// CodeExitError is an implementation of ExitError consisting of an error object
-// and an exit code (the upper bits of os.exec.ExitStatus).
-type CodeExitError struct {
-	Err  error
-	Code int
-}
+type ExitError = apierrors.ExitError
 
-var _ ExitError = CodeExitError{}
-
-func (e CodeExitError) Error() string {
-	return e.Err.Error()
-}
-
-func (e CodeExitError) String() string {
-	return e.Err.Error()
-}
-
-func (e CodeExitError) Exited() bool {
-	return true
-}
-
-func (e CodeExitError) ExitStatus() int {
-	return e.Code
-}
+type CodeExitError = apierrors.CodeExitError

--- a/staging/src/k8s.io/component-base/go.sum
+++ b/staging/src/k8s.io/component-base/go.sum
@@ -302,6 +302,7 @@ github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 h1:BZHcxBETFHIdVyhyEfOvn/RdU/QGdLI4y34qQGjGWO0=

--- a/staging/src/k8s.io/component-helpers/go.sum
+++ b/staging/src/k8s.io/component-helpers/go.sum
@@ -41,6 +41,7 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJY
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/staging/src/k8s.io/dynamic-resource-allocation/go.sum
+++ b/staging/src/k8s.io/dynamic-resource-allocation/go.sum
@@ -52,6 +52,7 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJY
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/staging/src/k8s.io/endpointslice/go.sum
+++ b/staging/src/k8s.io/endpointslice/go.sum
@@ -58,6 +58,7 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJY
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/staging/src/k8s.io/kms/go.sum
+++ b/staging/src/k8s.io/kms/go.sum
@@ -32,6 +32,7 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=

--- a/staging/src/k8s.io/kube-aggregator/go.mod
+++ b/staging/src/k8s.io/kube-aggregator/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/staging/src/k8s.io/kube-aggregator/go.sum
+++ b/staging/src/k8s.io/kube-aggregator/go.sum
@@ -163,6 +163,7 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8V
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -366,6 +367,7 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/staging/src/k8s.io/kubectl/go.sum
+++ b/staging/src/k8s.io/kubectl/go.sum
@@ -103,6 +103,7 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
@@ -157,9 +157,17 @@ type DefaultRemoteAttach struct{}
 
 // Attach executes attach to a running container
 func (*DefaultRemoteAttach) Attach(method string, url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool, terminalSizeQueue remotecommand.TerminalSizeQueue) error {
+	// Legacy SPDY executor is default. If feature gate enabled, fallback
+	// executor attempts websockets first--then SPDY.
 	exec, err := remotecommand.NewSPDYExecutor(config, method, url)
 	if err != nil {
 		return err
+	}
+	if cmdutil.RemoteCommandWebsockets.IsEnabled() {
+		exec, err = remotecommand.NewFallbackExecutor(config, method, url)
+		if err != nil {
+			return err
+		}
 	}
 	return exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{
 		Stdin:             stdin,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -425,9 +425,10 @@ func GetPodRunningTimeoutFlag(cmd *cobra.Command) (time.Duration, error) {
 type FeatureGate string
 
 const (
-	ApplySet              FeatureGate = "KUBECTL_APPLYSET"
-	CmdPluginAsSubcommand FeatureGate = "KUBECTL_ENABLE_CMD_SHADOW"
-	InteractiveDelete     FeatureGate = "KUBECTL_INTERACTIVE_DELETE"
+	ApplySet                FeatureGate = "KUBECTL_APPLYSET"
+	CmdPluginAsSubcommand   FeatureGate = "KUBECTL_ENABLE_CMD_SHADOW"
+	InteractiveDelete       FeatureGate = "KUBECTL_INTERACTIVE_DELETE"
+	RemoteCommandWebsockets FeatureGate = "KUBECTL_REMOTE_COMMAND_WEBSOCKETS"
 )
 
 func (f FeatureGate) IsEnabled() bool {

--- a/staging/src/k8s.io/kubelet/go.mod
+++ b/staging/src/k8s.io/kubelet/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect

--- a/staging/src/k8s.io/kubelet/go.sum
+++ b/staging/src/k8s.io/kubelet/go.sum
@@ -72,6 +72,7 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJY
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=

--- a/staging/src/k8s.io/kubelet/go.sum
+++ b/staging/src/k8s.io/kubelet/go.sum
@@ -110,6 +110,7 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=
 github.com/onsi/ginkgo/v2 v2.9.4/go.mod h1:gCQYp2Q+kSoIj7ykSVb9nskRSsR6PUj4AiLywzIhbKM=

--- a/staging/src/k8s.io/legacy-cloud-providers/go.sum
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.sum
@@ -250,6 +250,7 @@ github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pf
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
 github.com/googleapis/gax-go/v2 v2.7.1 h1:gF4c0zjUP2H/s/hEGyLA3I0fA2ZWjzYiONAD6cvPr8A=
 github.com/googleapis/gax-go/v2 v2.7.1/go.mod h1:4orTrqY6hXxxaUL4LHIPl6lGo8vAE38/qKbhSAKP6QI=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=

--- a/staging/src/k8s.io/metrics/go.sum
+++ b/staging/src/k8s.io/metrics/go.sum
@@ -44,6 +44,7 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJY
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/staging/src/k8s.io/sample-cli-plugin/go.sum
+++ b/staging/src/k8s.io/sample-cli-plugin/go.sum
@@ -72,6 +72,7 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=

--- a/staging/src/k8s.io/sample-controller/go.sum
+++ b/staging/src/k8s.io/sample-controller/go.sum
@@ -45,6 +45,7 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJY
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1927,6 +1927,7 @@ k8s.io/client-go/tools/remotecommand
 k8s.io/client-go/tools/watch
 k8s.io/client-go/transport
 k8s.io/client-go/transport/spdy
+k8s.io/client-go/transport/websocket
 k8s.io/client-go/util/cert
 k8s.io/client-go/util/certificate
 k8s.io/client-go/util/certificate/csr

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1399,6 +1399,7 @@ k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/net
 k8s.io/apimachinery/pkg/util/net/testing
 k8s.io/apimachinery/pkg/util/proxy
+k8s.io/apimachinery/pkg/util/proxy/spdy
 k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/remotecommand
 k8s.io/apimachinery/pkg/util/runtime


### PR DESCRIPTION
This PR adds heartbeat tests for remotecommand/websocket package on top of https://github.com/kubernetes/kubernetes/pull/119186.
This PR's motivation is to run these tests on CI and get signal about the results.