### PR TITLE
Fix the flaky TestJobApiBackoffReset test

### DIFF
--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -4602,10 +4602,11 @@ func TestJobApiBackoffReset(t *testing.T) {
 	if retries != 1 {
 		t.Fatalf("%s: expected exactly 1 retry, got %d", job.Name, retries)
 	}
+	// await for the actual requeue after processing of the pending queue is done
+	awaitForQueueLen(ctx, t, manager, 1)
 
 	// the queue is emptied on success
 	fakePodControl.Err = nil
-	manager.clock.Sleep(fastJobApiBackoff)
 	manager.processNextWorkItem(context.TODO())
 	verifyEmptyQueue(ctx, t, manager)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119480

#### Special notes for your reviewer:

More details on the issue: https://github.com/kubernetes/kubernetes/issues/119480#issuecomment-1645385338

The first commit introduced sleeps (https://github.com/kubernetes/kubernetes/commit/cd563d8c285ba73379cc9680e57b614e98c8e10b) to induce the failure: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/119506/pull-kubernetes-unit/1682339022472482816.

In the second commit https://github.com/kubernetes/kubernetes/pull/119506/commits/70678337c9cda525ca551e4c7b4c4901b5f219bf (still keeping the sleep in the delaying queue) the job controller does not fail: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/119506/pull-kubernetes-unit/1682351835106512896

The next commit(s) will fix the issue.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
