### PR TITLE
Fix XValidations deepcopy to copy contents of nested pointers

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/deepcopy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/deepcopy.go
@@ -291,9 +291,11 @@ func (in *JSONSchemaProps) DeepCopy() *JSONSchemaProps {
 	}
 
 	if in.XValidations != nil {
-		in, out := &in.XValidations, &out.XValidations
-		*out = make([]ValidationRule, len(*in))
-		copy(*out, *in)
+		inValidations, outValidations := &in.XValidations, &out.XValidations
+		*outValidations = make([]ValidationRule, len(*inValidations))
+		for i := range *inValidations {
+			in.XValidations[i].DeepCopyInto(&out.XValidations[i])
+		}
 	}
 
 	return out

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/deepcopy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/deepcopy.go
@@ -251,9 +251,11 @@ func (in *JSONSchemaProps) DeepCopy() *JSONSchemaProps {
 	}
 
 	if in.XValidations != nil {
-		in, out := &in.XValidations, &out.XValidations
-		*out = make([]ValidationRule, len(*in))
-		copy(*out, *in)
+		inValidations, outValidations := &in.XValidations, &out.XValidations
+		*outValidations = make([]ValidationRule, len(*inValidations))
+		for i := range *inValidations {
+			in.XValidations[i].DeepCopyInto(&out.XValidations[i])
+		}
 	}
 
 	return out

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/deepcopy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/deepcopy.go
@@ -267,9 +267,11 @@ func (in *JSONSchemaProps) DeepCopy() *JSONSchemaProps {
 	}
 
 	if in.XValidations != nil {
-		in, out := &in.XValidations, &out.XValidations
-		*out = make([]ValidationRule, len(*in))
-		copy(*out, *in)
+		inValidations, outValidations := &in.XValidations, &out.XValidations
+		*outValidations = make([]ValidationRule, len(*inValidations))
+		for i := range *inValidations {
+			in.XValidations[i].DeepCopyInto(&out.XValidations[i])
+		}
 	}
 
 	return out


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

This is the cause of a very high flake rate.

#### Which issue(s) this PR fixes:

Fixes #119493

#### Special notes for your reviewer:

As [noted](https://github.com/kubernetes/kubernetes/issues/119493#issuecomment-1645979409) by @liggitt the last time a field was added here, the same thing happened - https://github.com/kubernetes/kubernetes/issues/107954

#### Does this PR introduce a user-facing change?

No, this is a bug in a field added in 1.28

```release-note
NONE
```

/priority critically-urgent
/sig api-machinery
/cc @liggitt @cici37 @pacoxu 