### PR TITLE
feature(scheduler): simplify QueueingHintFn by introducing new status `Pending`

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -180,7 +180,7 @@ type Status struct {
 	reasons []string
 	err     error
 	// failedPlugin is an optional field that records the plugin name a Pod failed by.
-	// It's set by the framework when code is Unschedulable or UnschedulableAndUnresolvable.
+	// It's set by the framework when code is Unschedulable, UnschedulableAndUnresolvable or Pending.
 	failedPlugin string
 }
 

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -77,18 +77,30 @@ const (
 	// Success means that plugin ran correctly and found pod schedulable.
 	// NOTE: A nil status is also considered as "Success".
 	Success Code = iota
-	// Error is used for internal plugin errors, unexpected input, etc.
+	// Error is one of the failures, used for internal plugin errors, unexpected input, etc.
+	// Plugin shouldn't return this code for expected failures, like Unschedulable.
+	// Since it's the unexpected failure, the scheduling queue registers the pod without unschedulable plugins.
+	// Meaning, the Pod will be requeued to activeQ/backoffQ soon.
 	Error
-	// Unschedulable is used when a plugin finds a pod unschedulable. The scheduler might attempt to
+	// Unschedulable is one of the failures, used when a plugin finds a pod unschedulable.
+	// If it's returned from PreFilter or Filter, the scheduler might attempt to
 	// run other postFilter plugins like preemption to get this pod scheduled.
 	// Use UnschedulableAndUnresolvable to make the scheduler skipping other postFilter plugins.
 	// The accompanying status message should explain why the pod is unschedulable.
+	//
+	// We regard the backoff as a penalty of wasting the scheduling cycle.
+	// When the scheduling queue requeues Pods, which was rejected with Unschedulable in the last scheduling,
+	// the Pod goes through backoff.
 	Unschedulable
 	// UnschedulableAndUnresolvable is used when a plugin finds a pod unschedulable and
 	// other postFilter plugins like preemption would not change anything.
 	// Plugins should return Unschedulable if it is possible that the pod can get scheduled
 	// after running other postFilter plugins.
 	// The accompanying status message should explain why the pod is unschedulable.
+	//
+	// We regard the backoff as a penalty of wasting the scheduling cycle.
+	// When the scheduling queue requeues Pods, which was rejected with Unschedulable in the last scheduling,
+	// the Pod goes through backoff.
 	UnschedulableAndUnresolvable
 	// Wait is used when a Permit plugin finds a pod scheduling should wait.
 	Wait
@@ -97,10 +109,27 @@ const (
 	// - when a PreFilter plugin returns Skip so that coupled Filter plugin/PreFilterExtensions() will be skipped.
 	// - when a PreScore plugin returns Skip so that coupled Score plugin will be skipped.
 	Skip
+	// Pending means that the scheduling process is finished successfully,
+	// but the plugin wants to abort the scheduling cycle/binding cycle here.
+	//
+	// For example, the DRA plugin sometimes needs to wait for the external device driver
+	// to provision the resource for the Pod.
+	// It's different from when to return Unschedulable/UnschedulableAndUnresolvable,
+	// because in this case, the scheduler decides where the Pod can go successfully,
+	// but we need to wait for the external component to do something based on that scheduling result.
+	//
+	// We regard the backoff as a penalty of wasting the scheduling cycle.
+	// In the case of returning Pending, we cannot say the scheduling cycle is wasted
+	// because the scheduling result is used to proceed the Pod's scheduling forward,
+	// that particular scheduling cycle is failed though.
+	// So, Pods rejected by such reasons don't need to suffer a penalty (backoff).
+	// When the scheduling queue requeues Pods, which was rejected with Pending in the last scheduling,
+	// the Pod goes to activeQ directly ignoring backoff.
+	Pending
 )
 
 // This list should be exactly the same as the codes iota defined above in the same order.
-var codes = []string{"Success", "Error", "Unschedulable", "UnschedulableAndUnresolvable", "Wait", "Skip"}
+var codes = []string{"Success", "Error", "Unschedulable", "UnschedulableAndUnresolvable", "Wait", "Skip", "Pending"}
 
 func (c Code) String() string {
 	return codes[c]
@@ -151,7 +180,7 @@ type Status struct {
 	reasons []string
 	err     error
 	// failedPlugin is an optional field that records the plugin name a Pod failed by.
-	// It's set by the framework when code is Error, Unschedulable or UnschedulableAndUnresolvable.
+	// It's set by the framework when code is Unschedulable or UnschedulableAndUnresolvable.
 	failedPlugin string
 }
 

--- a/pkg/scheduler/framework/interface_test.go
+++ b/pkg/scheduler/framework/interface_test.go
@@ -131,6 +131,7 @@ func TestStatusCodes(t *testing.T) {
 	assertStatusCode(t, UnschedulableAndUnresolvable, 3)
 	assertStatusCode(t, Wait, 4)
 	assertStatusCode(t, Skip, 5)
+	assertStatusCode(t, Pending, 6)
 }
 
 func assertStatusCode(t *testing.T, code Code, value int) {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -346,7 +346,7 @@ func TestPlugin(t *testing.T) {
 			classes: []*resourcev1alpha2.ResourceClass{resourceClass},
 			want: want{
 				reserve: result{
-					status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `waiting for resource driver to allocate resource`),
+					status: framework.NewStatus(framework.Pending, `waiting for resource driver to allocate resource`),
 					added:  []metav1.Object{schedulingSelectedPotential},
 				},
 			},
@@ -360,7 +360,7 @@ func TestPlugin(t *testing.T) {
 			classes: []*resourcev1alpha2.ResourceClass{resourceClass},
 			want: want{
 				reserve: result{
-					status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `waiting for resource driver to provide information`),
+					status: framework.NewStatus(framework.Pending, `waiting for resource driver to provide information`),
 					added:  []metav1.Object{schedulingPotential},
 				},
 			},
@@ -374,7 +374,7 @@ func TestPlugin(t *testing.T) {
 			classes:     []*resourcev1alpha2.ResourceClass{resourceClass},
 			want: want{
 				reserve: result{
-					status: framework.NewStatus(framework.UnschedulableAndUnresolvable, `waiting for resource driver to allocate resource`),
+					status: framework.NewStatus(framework.Pending, `waiting for resource driver to allocate resource`),
 					changes: change{
 						scheduling: func(in *resourcev1alpha2.PodSchedulingContext) *resourcev1alpha2.PodSchedulingContext {
 							return st.FromPodSchedulingContexts(in).
@@ -925,7 +925,7 @@ func Test_isSchedulableAfterClaimChange(t *testing.T) {
 		"queue-on-add": {
 			pod:          podWithClaimName,
 			newObj:       pendingImmediateClaim,
-			expectedHint: framework.QueueImmediately,
+			expectedHint: framework.Queue,
 		},
 		"backoff-wrong-old-object": {
 			pod:         podWithClaimName,
@@ -953,7 +953,7 @@ func Test_isSchedulableAfterClaimChange(t *testing.T) {
 				claim.Status.Allocation = &resourcev1alpha2.AllocationResult{}
 				return claim
 			}(),
-			expectedHint: framework.QueueImmediately,
+			expectedHint: framework.Queue,
 		},
 	}
 
@@ -1051,7 +1051,7 @@ func Test_isSchedulableAfterPodSchedulingContextChange(t *testing.T) {
 			claims:       []*resourcev1alpha2.ResourceClaim{pendingDelayedClaim},
 			oldObj:       scheduling,
 			newObj:       schedulingInfo,
-			expectedHint: framework.QueueImmediately,
+			expectedHint: framework.Queue,
 		},
 		"queue-bad-selected-node": {
 			pod:    podWithClaimTemplateInStatus,
@@ -1067,7 +1067,7 @@ func Test_isSchedulableAfterPodSchedulingContextChange(t *testing.T) {
 				scheduling.Status.ResourceClaims[0].UnsuitableNodes = append(scheduling.Status.ResourceClaims[0].UnsuitableNodes, scheduling.Spec.SelectedNode)
 				return scheduling
 			}(),
-			expectedHint: framework.QueueImmediately,
+			expectedHint: framework.Queue,
 		},
 		"skip-spec-changes": {
 			pod:    podWithClaimTemplateInStatus,
@@ -1089,7 +1089,7 @@ func Test_isSchedulableAfterPodSchedulingContextChange(t *testing.T) {
 				scheduling.Finalizers = append(scheduling.Finalizers, "foo")
 				return scheduling
 			}(),
-			expectedHint: framework.QueueAfterBackoff,
+			expectedHint: framework.Queue,
 		},
 	}
 

--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity.go
@@ -94,7 +94,7 @@ func (pl *NodeAffinity) EventsToRegister() []framework.ClusterEventWithHint {
 func (pl *NodeAffinity) isSchedulableAfterNodeChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
 	originalNode, modifiedNode, err := util.As[*v1.Node](oldObj, newObj)
 	if err != nil {
-		return framework.QueueAfterBackoff, err
+		return framework.Queue, err
 	}
 
 	if pl.addedNodeSelector != nil && !pl.addedNodeSelector.Match(modifiedNode) {
@@ -105,7 +105,7 @@ func (pl *NodeAffinity) isSchedulableAfterNodeChange(logger klog.Logger, pod *v1
 	requiredNodeAffinity := nodeaffinity.GetRequiredNodeAffinity(pod)
 	isMatched, err := requiredNodeAffinity.Match(modifiedNode)
 	if err != nil {
-		return framework.QueueAfterBackoff, err
+		return framework.Queue, err
 	}
 	if !isMatched {
 		logger.V(4).Info("node was created or updated, but doesn't matches with the pod's NodeAffinity", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
@@ -116,14 +116,14 @@ func (pl *NodeAffinity) isSchedulableAfterNodeChange(logger klog.Logger, pod *v1
 	if originalNode != nil {
 		wasMatched, err = requiredNodeAffinity.Match(originalNode)
 		if err != nil {
-			return framework.QueueAfterBackoff, err
+			return framework.Queue, err
 		}
 	}
 
 	if !wasMatched {
 		// This modification makes this Node match with Pod's NodeAffinity.
 		logger.V(4).Info("node was created or updated, and matches with the pod's NodeAffinity", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
-		return framework.QueueAfterBackoff, nil
+		return framework.Queue, nil
 	}
 
 	logger.V(4).Info("node was created or updated, but it doesn't make this pod schedulable", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))

--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
@@ -1189,7 +1189,7 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 			args:         &config.NodeAffinityArgs{},
 			pod:          podWithNodeAffinity.Obj(),
 			newObj:       "not-a-node",
-			expectedHint: framework.QueueAfterBackoff,
+			expectedHint: framework.Queue,
 			expectedErr:  true,
 		},
 		"backoff-wrong-old-object": {
@@ -1197,7 +1197,7 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 			pod:          podWithNodeAffinity.Obj(),
 			oldObj:       "not-a-node",
 			newObj:       st.MakeNode().Obj(),
-			expectedHint: framework.QueueAfterBackoff,
+			expectedHint: framework.Queue,
 			expectedErr:  true,
 		},
 		"skip-queue-on-add": {
@@ -1210,7 +1210,7 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 			args:         &config.NodeAffinityArgs{},
 			pod:          podWithNodeAffinity.Obj(),
 			newObj:       st.MakeNode().Label("foo", "bar").Obj(),
-			expectedHint: framework.QueueAfterBackoff,
+			expectedHint: framework.Queue,
 		},
 		"skip-unrelated-changes": {
 			args:         &config.NodeAffinityArgs{},
@@ -1245,7 +1245,7 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 			pod:          podWithNodeAffinity.Obj(),
 			oldObj:       st.MakeNode().Obj(),
 			newObj:       st.MakeNode().Label("foo", "bar").Obj(),
-			expectedHint: framework.QueueAfterBackoff,
+			expectedHint: framework.Queue,
 		},
 		"skip-queue-on-add-scheduler-enforced-node-affinity": {
 			args: &config.NodeAffinityArgs{
@@ -1289,7 +1289,7 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 			},
 			pod:          podWithNodeAffinity.Obj(),
 			newObj:       st.MakeNode().Label("foo", "bar").Obj(),
-			expectedHint: framework.QueueAfterBackoff,
+			expectedHint: framework.Queue,
 		},
 	}
 

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -120,7 +120,7 @@ func (pl *NodePorts) EventsToRegister() []framework.ClusterEventWithHint {
 		// See: https://github.com/kubernetes/kubernetes/issues/109437
 		// And, we can remove NodeUpdated event once https://github.com/kubernetes/kubernetes/issues/110175 is solved.
 		// We don't need the QueueingHintFn here because the scheduling of Pods will be always retried with backoff when this Event happens.
-		// (the same as QueueAfterBackoff)
+		// (the same as Queue)
 		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add | framework.Update}},
 	}
 }
@@ -130,7 +130,7 @@ func (pl *NodePorts) EventsToRegister() []framework.ClusterEventWithHint {
 func (pl *NodePorts) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
 	deletedPod, _, err := util.As[*v1.Pod](oldObj, nil)
 	if err != nil {
-		return framework.QueueAfterBackoff, err
+		return framework.Queue, err
 	}
 
 	// If the deleted pod is unscheduled, it doesn't make the target pod schedulable.
@@ -163,8 +163,8 @@ func (pl *NodePorts) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Po
 		return framework.QueueSkip, nil
 	}
 
-	logger.V(4).Info("the deleted pod and the target pod have any common port(s), returning QueueAfterBackoff as deleting this Pod may make the Pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
-	return framework.QueueAfterBackoff, nil
+	logger.V(4).Info("the deleted pod and the target pod have any common port(s), returning Queue as deleting this Pod may make the Pod schedulable", "pod", klog.KObj(pod), "deletedPod", klog.KObj(deletedPod))
+	return framework.Queue, nil
 }
 
 // Filter invoked at the filter extension point.

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
@@ -313,7 +313,7 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 		"backoff-wrong-old-object": {
 			pod:          podWithHostPort.Obj(),
 			oldObj:       "not-a-pod",
-			expectedHint: framework.QueueAfterBackoff,
+			expectedHint: framework.Queue,
 			expectedErr:  true,
 		},
 		"skip-queue-on-unscheduled": {
@@ -334,7 +334,7 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 		"queue-on-released-hostport": {
 			pod:          podWithHostPort.Obj(),
 			oldObj:       st.MakePod().Node("fake-node").HostPort(8080).Obj(),
-			expectedHint: framework.QueueAfterBackoff,
+			expectedHint: framework.Queue,
 		},
 	}
 

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
@@ -61,7 +61,7 @@ func (pl *NodeUnschedulable) isSchedulableAfterNodeChange(logger klog.Logger, po
 	originalNode, modifiedNode, err := util.As[*v1.Node](oldObj, newObj)
 	if err != nil {
 		logger.Error(err, "unexpected objects in isSchedulableAfterNodeChange", "oldObj", oldObj, "newObj", newObj)
-		return framework.QueueAfterBackoff, err
+		return framework.Queue, err
 	}
 
 	originalNodeSchedulable, modifiedNodeSchedulable := false, !modifiedNode.Spec.Unschedulable
@@ -71,7 +71,7 @@ func (pl *NodeUnschedulable) isSchedulableAfterNodeChange(logger klog.Logger, po
 
 	if !originalNodeSchedulable && modifiedNodeSchedulable {
 		logger.V(4).Info("node was created or updated, pod may be schedulable now", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
-		return framework.QueueAfterBackoff, nil
+		return framework.Queue, nil
 	}
 
 	logger.V(4).Info("node was created or updated, but it doesn't make this pod schedulable", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
@@ -98,7 +98,7 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 			name:         "backoff-wrong-new-object",
 			pod:          &v1.Pod{},
 			newObj:       "not-a-node",
-			expectedHint: framework.QueueAfterBackoff,
+			expectedHint: framework.Queue,
 			expectedErr:  true,
 		},
 		{
@@ -110,7 +110,7 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 				},
 			},
 			oldObj:       "not-a-node",
-			expectedHint: framework.QueueAfterBackoff,
+			expectedHint: framework.Queue,
 			expectedErr:  true,
 		},
 		{
@@ -131,7 +131,7 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 					Unschedulable: false,
 				},
 			},
-			expectedHint: framework.QueueAfterBackoff,
+			expectedHint: framework.Queue,
 		},
 		{
 			name: "skip-unrelated-change",
@@ -167,7 +167,7 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 					Unschedulable: true,
 				},
 			},
-			expectedHint: framework.QueueAfterBackoff,
+			expectedHint: framework.Queue,
 		},
 	}
 

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -304,7 +304,7 @@ const (
 	NoNodeAvailableMsg = "0/%v nodes are available"
 )
 
-func (d *Diagnosis) SetFailedPlugin(sts *Status) {
+func (d *Diagnosis) AddPluginStatus(sts *Status) {
 	if sts.FailedPlugin() == "" {
 		return
 	}

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -85,15 +85,15 @@ type ClusterEventWithHint struct {
 	// and filters out events to reduce useless retry of Pod's scheduling.
 	// It's an optional field. If not set,
 	// the scheduling of Pods will be always retried with backoff when this Event happens.
-	// (the same as QueueAfterBackoff)
+	// (the same as Queue)
 	QueueingHintFn QueueingHintFn
 }
 
 // QueueingHintFn returns a hint that signals whether the event can make a Pod,
 // which was rejected by this plugin in the past scheduling cycle, schedulable or not.
 // It's called before a Pod gets moved from unschedulableQ to backoffQ or activeQ.
-// If it returns an error, we'll take the returned QueueingHint as `QueueAfterBackoff` at the caller whatever we returned here so that
-// we can prevent the Pod from stucking in the unschedulable pod pool.
+// If it returns an error, we'll take the returned QueueingHint as `Queue` at the caller whatever we returned here so that
+// we can prevent the Pod from being stuck in the unschedulable pod pool.
 //
 // - `pod`: the Pod to be enqueued, which is rejected by this plugin in the past.
 // - `oldObj` `newObj`: the object involved in that event.
@@ -109,29 +109,16 @@ const (
 	// scheduling of the pod.
 	QueueSkip QueueingHint = iota
 
-	// QueueAfterBackoff implies that the Pod may be schedulable by the event,
-	// and worth retrying the scheduling again after backoff.
-	QueueAfterBackoff
-
-	// QueueImmediately is returned only when it is highly possible that the Pod gets scheduled in the next scheduling.
-	// You should only return QueueImmediately when there is a high chance that the Pod gets scheduled in the next scheduling.
-	// Otherwise, it's detrimental to scheduling throughput.
-	// For example, when the Pod was rejected as waiting for an external resource to be provisioned, that is directly tied to the Pod,
-	// and the event is that the resource is provisioned, then you can return QueueImmediately.
-	// As a counterexample, when the Pod was rejected due to insufficient memory resource,
-	// and the event is that more memory on Node is available, then you should return QueueAfterBackoff instead of QueueImmediately
-	// because other Pods may be waiting for the same resources and only a few of them would schedule in the next scheduling cycle.
-	QueueImmediately
+	// Queue implies that the Pod may be schedulable by the event.
+	Queue
 )
 
 func (s QueueingHint) String() string {
 	switch s {
 	case QueueSkip:
 		return "QueueSkip"
-	case QueueAfterBackoff:
-		return "QueueAfterBackoff"
-	case QueueImmediately:
-		return "QueueImmediately"
+	case Queue:
+		return "Queue"
 	}
 	return ""
 }
@@ -179,9 +166,11 @@ type QueuedPodInfo struct {
 	// It shouldn't be updated once initialized. It's used to record the e2e scheduling
 	// latency for a pod.
 	InitialAttemptTimestamp *time.Time
-	// If a Pod failed in a scheduling cycle, record the plugin names it failed by.
+	// UnschedulablePlugins records the plugin names that the Pod failed with Unschedulable or UnschedulableAndUnresolvable status.
 	// It's registered only when the Pod is rejected in PreFilter, Filter, Reserve, or Permit (WaitOnPermit).
 	UnschedulablePlugins sets.Set[string]
+	// PendingPlugins records the plugin names that the Pod failed with Pending status.
+	PendingPlugins sets.Set[string]
 	// Whether the Pod is scheduling gated (by PreEnqueuePlugins) or not.
 	Gated bool
 }
@@ -292,8 +281,11 @@ type WeightedAffinityTerm struct {
 
 // Diagnosis records the details to diagnose a scheduling failure.
 type Diagnosis struct {
-	NodeToStatusMap      NodeToStatusMap
+	NodeToStatusMap NodeToStatusMap
+	// UnschedulablePlugins are plugins that returns Unschedulable or UnschedulableAndUnresolvable.
 	UnschedulablePlugins sets.Set[string]
+	// UnschedulablePlugins are plugins that returns Pending.
+	PendingPlugins sets.Set[string]
 	// PreFilterMsg records the messages returned from PreFilter plugins.
 	PreFilterMsg string
 	// PostFilterMsg records the messages returned from PostFilter plugins.
@@ -311,6 +303,24 @@ const (
 	// NoNodeAvailableMsg is used to format message when no nodes available.
 	NoNodeAvailableMsg = "0/%v nodes are available"
 )
+
+func (d *Diagnosis) SetFailedPlugin(sts *Status) {
+	if sts.FailedPlugin() == "" {
+		return
+	}
+	if sts.IsUnschedulable() {
+		if d.UnschedulablePlugins == nil {
+			d.UnschedulablePlugins = sets.New[string]()
+		}
+		d.UnschedulablePlugins.Insert(sts.FailedPlugin())
+	}
+	if sts.Code() == Pending {
+		if d.PendingPlugins == nil {
+			d.PendingPlugins = sets.New[string]()
+		}
+		d.PendingPlugins.Insert(sts.FailedPlugin())
+	}
+}
 
 // Error returns detailed information of why the pod failed to fit on each node.
 // A message format is "0/X nodes are available: <PreFilterMsg>. <FilterMsg>. <PostFilterMsg>."

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -451,7 +451,7 @@ func (p *PriorityQueue) isPodWorthRequeuing(logger klog.Logger, pInfo *framework
 				continue
 			}
 
-			h, err := hintfn.QueueingHintFn(logger, pod, oldObj, newObj)
+			hint, err := hintfn.QueueingHintFn(logger, pod, oldObj, newObj)
 			if err != nil {
 				// If the QueueingHintFn returned an error, we should treat the event as Queue so that we can prevent
 				// the Pod from being stuck in the unschedulable pod pool.
@@ -461,9 +461,9 @@ func (p *PriorityQueue) isPodWorthRequeuing(logger klog.Logger, pInfo *framework
 				} else {
 					logger.Error(err, "QueueingHintFn returns error", "event", event, "plugin", hintfn.PluginName, "pod", klog.KObj(pod), "oldObj", klog.KObj(oldObjMeta), "newObj", klog.KObj(newObjMeta))
 				}
-				h = framework.Queue
+				hint = framework.Queue
 			}
-			if h == framework.QueueSkip {
+			if hint == framework.QueueSkip {
 				continue
 			}
 

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -397,72 +397,97 @@ func (p *PriorityQueue) Run(logger klog.Logger) {
 	}, 30*time.Second, p.stop)
 }
 
-// isPodWorthRequeuing calls QueueingHintFn of only plugins registered in pInfo.unschedulablePlugins.
-// If any QueueingHintFn returns QueueImmediately, the scheduling queue is supposed to enqueue this Pod to activeQ.
-// If no QueueingHintFn returns QueueImmediately, but some return QueueAfterBackoff,
+// queueingStrategy indicates how the scheduling queue should enqueue the Pod from unschedulable pod pool.
+type queueingStrategy int
+
+const (
+	// queueSkip indicates that the scheduling queue should skip requeuing the Pod to activeQ/backoffQ.
+	queueSkip queueingStrategy = iota
+	// queueAfterBackoff indicates that the scheduling queue should requeue the Pod after backoff is completed.
+	queueAfterBackoff
+	// queueImmediately indicates that the scheduling queue should skip backoff and requeue the Pod immediately to activeQ.
+	queueImmediately
+)
+
+// isPodWorthRequeuing calls QueueingHintFn of only plugins registered in pInfo.unschedulablePlugins and pInfo.PendingPlugins.
+//
+// If any of pInfo.PendingPlugins return Queue,
+// the scheduling queue is supposed to enqueue this Pod to activeQ, skipping backoffQ.
+// If any of pInfo.unschedulablePlugins return Queue,
 // the scheduling queue is supposed to enqueue this Pod to activeQ/backoffQ depending on the remaining backoff time of the Pod.
-// If all QueueingHintFn returns QueueSkip, the scheduling queue enqueues the Pod back to unschedulable Pod pool
+// If all QueueingHintFns returns Skip, the scheduling queue enqueues the Pod back to unschedulable Pod pool
 // because no plugin changes the scheduling result via the event.
-func (p *PriorityQueue) isPodWorthRequeuing(logger klog.Logger, pInfo *framework.QueuedPodInfo, event framework.ClusterEvent, oldObj, newObj interface{}) framework.QueueingHint {
-	if pInfo.UnschedulablePlugins.Len() == 0 {
-		logger.V(6).Info("Worth requeuing because no unschedulable plugins", "pod", klog.KObj(pInfo.Pod))
-		return framework.QueueAfterBackoff
+func (p *PriorityQueue) isPodWorthRequeuing(logger klog.Logger, pInfo *framework.QueuedPodInfo, event framework.ClusterEvent, oldObj, newObj interface{}) queueingStrategy {
+	failedPlugins := pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins)
+	if failedPlugins.Len() == 0 {
+		logger.V(6).Info("Worth requeuing because no failed plugins", "pod", klog.KObj(pInfo.Pod))
+		return queueAfterBackoff
 	}
 
 	if event.IsWildCard() {
+		// If the wildcard event is special one as someone wants to force all Pods to move to activeQ/backoffQ.
+		// We return queueAfterBackoff in this case, while resetting all blocked plugins.
 		logger.V(6).Info("Worth requeuing because the event is wildcard", "pod", klog.KObj(pInfo.Pod))
-		return framework.QueueAfterBackoff
+		return queueAfterBackoff
 	}
 
 	hintMap, ok := p.queueingHintMap[pInfo.Pod.Spec.SchedulerName]
 	if !ok {
 		// shouldn't reach here unless bug.
 		logger.Error(nil, "No QueueingHintMap is registered for this profile", "profile", pInfo.Pod.Spec.SchedulerName, "pod", klog.KObj(pInfo.Pod))
-		return framework.QueueAfterBackoff
+		return queueAfterBackoff
 	}
 
 	pod := pInfo.Pod
-	queueHint := framework.QueueSkip
+	queueStrategy := queueSkip
 	for eventToMatch, hintfns := range hintMap {
 		if eventToMatch.Resource != event.Resource || eventToMatch.ActionType&event.ActionType == 0 {
 			continue
 		}
 
 		for _, hintfn := range hintfns {
-			if !pInfo.UnschedulablePlugins.Has(hintfn.PluginName) {
+			if !failedPlugins.Has(hintfn.PluginName) {
+				// skip if it's not hintfn from failedPlugins.
 				continue
 			}
 
 			h, err := hintfn.QueueingHintFn(logger, pod, oldObj, newObj)
 			if err != nil {
-				// If the QueueingHintFn returned an error, we should treat the event as QueueAfterBackoff so that we can prevent
-				// the Pod from stucking in the unschedulable pod pool.
+				// If the QueueingHintFn returned an error, we should treat the event as Queue so that we can prevent
+				// the Pod from being stuck in the unschedulable pod pool.
 				oldObjMeta, newObjMeta, asErr := util.As[klog.KMetadata](oldObj, newObj)
 				if asErr != nil {
 					logger.Error(err, "QueueingHintFn returns error", "event", event, "plugin", hintfn.PluginName, "pod", klog.KObj(pod))
 				} else {
 					logger.Error(err, "QueueingHintFn returns error", "event", event, "plugin", hintfn.PluginName, "pod", klog.KObj(pod), "oldObj", klog.KObj(oldObjMeta), "newObj", klog.KObj(newObjMeta))
 				}
-				h = framework.QueueAfterBackoff
+				h = framework.Queue
 			}
-
-			switch h {
-			case framework.QueueSkip:
+			if h == framework.QueueSkip {
 				continue
-			case framework.QueueImmediately:
-				return h
-			case framework.QueueAfterBackoff:
-				// replace queueHint with the returned value,
-				// but continue to other queueHintFn to check because other plugins may want to return QueueImmediately.
-				queueHint = h
 			}
 
+			if pInfo.PendingPlugins.Has(hintfn.PluginName) {
+				// interprets Queue from the Pending plugin as queueImmediately.
+				// We can return immediately because queueImmediately is the highest priority.
+				return queueImmediately
+			}
+
+			// interprets Queue from the unschedulable plugin as queueAfterBackoff.
+
+			if pInfo.PendingPlugins.Len() == 0 {
+				// We can return immediately because no Pending plugins, which only can make queueImmediately, registered in this Pod,
+				// and queueAfterBackoff is the second highest priority.
+				return queueAfterBackoff
+			}
+
+			// We can't return immediately because there are some Pending plugins registered in this Pod.
+			// We need to check if those plugins return Queue or not and if they do, we return queueImmediately.
+			queueStrategy = queueAfterBackoff
 		}
 	}
 
-	// No queueing hint function is registered for this event
-	// or no queueing hint fn returns the value other than QueueSkip.
-	return queueHint
+	return queueStrategy
 }
 
 // runPreEnqueuePlugins iterates PreEnqueue function in each registered PreEnqueuePlugin.
@@ -626,7 +651,7 @@ func (p *PriorityQueue) SchedulingCycle() int64 {
 
 // determineSchedulingHintForInFlightPod looks at the unschedulable plugins of the given Pod
 // and determines the scheduling hint for this Pod while checking the events that happened during in-flight.
-func (p *PriorityQueue) determineSchedulingHintForInFlightPod(logger klog.Logger, pInfo *framework.QueuedPodInfo) framework.QueueingHint {
+func (p *PriorityQueue) determineSchedulingHintForInFlightPod(logger klog.Logger, pInfo *framework.QueuedPodInfo) queueingStrategy {
 	logger.V(5).Info("Checking events for in-flight pod", "pod", klog.KObj(pInfo.Pod), "unschedulablePlugins", pInfo.UnschedulablePlugins, "inFlightEventsSize", p.inFlightEvents.Len(), "inFlightPodsSize", len(p.inFlightPods))
 
 	// AddUnschedulableIfNotPresent is called with the Pod at the end of scheduling or binding.
@@ -638,48 +663,50 @@ func (p *PriorityQueue) determineSchedulingHintForInFlightPod(logger klog.Logger
 		// be empty. If it is not, we may have a problem.
 		if len(pInfo.UnschedulablePlugins) != 0 {
 			logger.Error(nil, "In flight Pod isn't found in the scheduling queue. If you see this error log, it's likely a bug in the scheduler.", "pod", klog.KObj(pInfo.Pod))
-			return framework.QueueAfterBackoff
+			return queueAfterBackoff
 		}
 		if p.inFlightEvents.Len() > len(p.inFlightPods) {
-			return framework.QueueAfterBackoff
+			return queueAfterBackoff
 		}
-		return framework.QueueSkip
+		return queueSkip
 	}
 
-	if len(pInfo.UnschedulablePlugins) == 0 {
-		// No unschedulable plugins are associated with this Pod.
+	failedPlugins := pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins)
+	if len(failedPlugins) == 0 {
+		// No failed plugins are associated with this Pod.
 		// Meaning something unusual (a temporal failure on kube-apiserver, etc) happened and this Pod gets moved back to the queue.
 		// In this case, we should retry scheduling it because this Pod may not be retried until the next flush.
-		return framework.QueueAfterBackoff
+		return queueAfterBackoff
 	}
 
 	// check if there is an event that makes this Pod schedulable based on pInfo.UnschedulablePlugins.
-	schedulingHint := framework.QueueSkip
+	queueingStrategy := queueSkip
 	for event := inFlightPod.Next(); event != nil; event = event.Next() {
 		e, ok := event.Value.(*clusterEvent)
 		if !ok {
-			// Must be another pod. Can be ignored.
+			// Must be another in-flight Pod (*v1.Pod). Can be ignored.
 			continue
 		}
 		logger.V(5).Info("Checking event for in-flight pod", "pod", klog.KObj(pInfo.Pod), "event", e.event.Label)
 
-		hint := p.isPodWorthRequeuing(logger, pInfo, e.event, e.oldObj, e.newObj)
-		if hint == framework.QueueSkip {
+		switch p.isPodWorthRequeuing(logger, pInfo, e.event, e.oldObj, e.newObj) {
+		case queueSkip:
 			continue
-		}
-
-		if hint == framework.QueueImmediately {
-			// QueueImmediately is the strongest opinion, we don't need to check other events.
-			schedulingHint = framework.QueueImmediately
-			break
-		}
-		if hint == framework.QueueAfterBackoff {
-			// replace schedulingHint with QueueAfterBackoff,
-			// but continue to check other events because we may find it QueueImmediately with other events.
-			schedulingHint = framework.QueueAfterBackoff
+		case queueImmediately:
+			// queueImmediately is the highest priority.
+			// No need to go through the rest of the events.
+			return queueImmediately
+		case queueAfterBackoff:
+			// replace schedulingHint with queueAfterBackoff
+			queueingStrategy = queueAfterBackoff
+			if pInfo.PendingPlugins.Len() == 0 {
+				// We can return immediately because no Pending plugins, which only can make queueImmediately, registered in this Pod,
+				// and queueAfterBackoff is the second highest priority.
+				return queueAfterBackoff
+			}
 		}
 	}
-	return schedulingHint
+	return queueingStrategy
 }
 
 // addUnschedulableIfNotPresentWithoutQueueingHint inserts a pod that cannot be scheduled into
@@ -693,12 +720,16 @@ func (p *PriorityQueue) addUnschedulableWithoutQueueingHint(logger klog.Logger, 
 	// Refresh the timestamp since the pod is re-added.
 	pInfo.Timestamp = p.clock.Now()
 
+	// When the queueing hint is enabled, they are used differently.
+	// But, we use all of them as UnschedulablePlugins when the queueing hint isn't enabled so that we don't break the old behaviour.
+	failedPlugins := pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins)
+
 	// If a move request has been received, move it to the BackoffQ, otherwise move
 	// it to unschedulablePods.
-	for plugin := range pInfo.UnschedulablePlugins {
+	for plugin := range failedPlugins {
 		metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Inc()
 	}
-	if p.moveRequestCycle >= podSchedulingCycle || len(pInfo.UnschedulablePlugins) == 0 {
+	if p.moveRequestCycle >= podSchedulingCycle || len(failedPlugins) == 0 {
 		// Two cases to move a Pod to the active/backoff queue:
 		// - The Pod is rejected by some plugins, but a move request is received after this Pod's scheduling cycle is started.
 		//   In this case, the received event may be make Pod schedulable and we should retry scheduling it.
@@ -753,7 +784,8 @@ func (p *PriorityQueue) AddUnschedulableIfNotPresent(logger klog.Logger, pInfo *
 
 	// If a move request has been received, move it to the BackoffQ, otherwise move
 	// it to unschedulablePods.
-	for plugin := range pInfo.UnschedulablePlugins {
+	failedPlugins := pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins)
+	for plugin := range failedPlugins {
 		metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Inc()
 	}
 
@@ -762,7 +794,7 @@ func (p *PriorityQueue) AddUnschedulableIfNotPresent(logger klog.Logger, pInfo *
 
 	// In this case, we try to requeue this Pod to activeQ/backoffQ.
 	queue := p.requeuePodViaQueueingHint(logger, pInfo, schedulingHint, ScheduleAttemptFailure)
-	logger.V(3).Info("Pod moved to an internal scheduling queue", "pod", klog.KObj(pod), "event", ScheduleAttemptFailure, "queue", queue, "schedulingCycle", podSchedulingCycle, "hint", schedulingHint)
+	logger.V(3).Info("Pod moved to an internal scheduling queue", "pod", klog.KObj(pod), "event", ScheduleAttemptFailure, "queue", queue, "schedulingCycle", podSchedulingCycle, "hint", schedulingHint, "unschedulable plugins", failedPlugins)
 	if queue == activeQ {
 		// When the Pod is moved to activeQ, need to let p.cond know so that the Pod will be pop()ed out.
 		p.cond.Broadcast()
@@ -853,10 +885,11 @@ func (p *PriorityQueue) Pop() (*framework.QueuedPodInfo, error) {
 	}
 
 	// Update metrics and reset the set of unschedulable plugins for the next attempt.
-	for plugin := range pInfo.UnschedulablePlugins {
+	for plugin := range pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins) {
 		metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Dec()
 	}
 	pInfo.UnschedulablePlugins.Clear()
+	pInfo.PendingPlugins.Clear()
 
 	return pInfo, nil
 }
@@ -1067,15 +1100,15 @@ func (p *PriorityQueue) MoveAllToActiveOrBackoffQueue(logger klog.Logger, event 
 // It returns the queue name Pod goes.
 //
 // NOTE: this function assumes lock has been acquired in caller
-func (p *PriorityQueue) requeuePodViaQueueingHint(logger klog.Logger, pInfo *framework.QueuedPodInfo, schedulingHint framework.QueueingHint, event string) string {
-	if schedulingHint == framework.QueueSkip {
+func (p *PriorityQueue) requeuePodViaQueueingHint(logger klog.Logger, pInfo *framework.QueuedPodInfo, strategy queueingStrategy, event string) string {
+	if strategy == queueSkip {
 		p.unschedulablePods.addOrUpdate(pInfo)
 		metrics.SchedulerQueueIncomingPods.WithLabelValues("unschedulable", event).Inc()
 		return unschedulablePods
 	}
 
 	pod := pInfo.Pod
-	if schedulingHint == framework.QueueAfterBackoff && p.isPodBackingoff(pInfo) {
+	if strategy == queueAfterBackoff && p.isPodBackingoff(pInfo) {
 		if err := p.podBackoffQ.Add(pInfo); err != nil {
 			logger.Error(err, "Error adding pod to the backoff queue, queue this Pod to unschedulable pod pool", "pod", klog.KObj(pod))
 			p.unschedulablePods.addOrUpdate(pInfo)
@@ -1086,7 +1119,7 @@ func (p *PriorityQueue) requeuePodViaQueueingHint(logger klog.Logger, pInfo *fra
 		return backoffQ
 	}
 
-	// Reach here if schedulingHint is QueueImmediately, or schedulingHint is QueueAfterBackoff but the pod is not backing off.
+	// Reach here if schedulingHint is QueueImmediately, or schedulingHint is Queue but the pod is not backing off.
 
 	added, err := p.addToActiveQ(logger, pInfo)
 	if err != nil {
@@ -1111,7 +1144,7 @@ func (p *PriorityQueue) movePodsToActiveOrBackoffQueue(logger klog.Logger, podIn
 	activated := false
 	for _, pInfo := range podInfoList {
 		schedulingHint := p.isPodWorthRequeuing(logger, pInfo, event, oldObj, newObj)
-		if schedulingHint == framework.QueueSkip {
+		if schedulingHint == queueSkip {
 			// QueueingHintFn determined that this Pod isn't worth putting to activeQ or backoffQ by this event.
 			logger.V(5).Info("Event is not making pod schedulable", "pod", klog.KObj(pInfo.Pod), "event", event.Label)
 			continue

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -214,7 +214,7 @@ func (sched *Scheduler) schedulingCycle(
 					NodeToStatusMap: framework.NodeToStatusMap{scheduleResult.SuggestedHost: sts},
 				},
 			}
-			fitErr.Diagnosis.SetFailedPlugin(sts)
+			fitErr.Diagnosis.AddPluginStatus(sts)
 			return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, framework.NewStatus(sts.Code()).WithError(fitErr)
 		}
 		return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, sts
@@ -237,7 +237,7 @@ func (sched *Scheduler) schedulingCycle(
 					NodeToStatusMap: framework.NodeToStatusMap{scheduleResult.SuggestedHost: runPermitStatus},
 				},
 			}
-			fitErr.Diagnosis.SetFailedPlugin(runPermitStatus)
+			fitErr.Diagnosis.AddPluginStatus(runPermitStatus)
 			return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, framework.NewStatus(runPermitStatus.Code()).WithError(fitErr)
 		}
 
@@ -458,7 +458,7 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, fwk framework.F
 		msg := s.Message()
 		diagnosis.PreFilterMsg = msg
 		logger.V(5).Info("Status after running PreFilter plugins for pod", "pod", klog.KObj(pod), "status", msg)
-		diagnosis.SetFailedPlugin(s)
+		diagnosis.AddPluginStatus(s)
 		return nil, diagnosis, nil
 	}
 
@@ -569,7 +569,7 @@ func (sched *Scheduler) findNodesThatPassFilters(
 		} else {
 			statusesLock.Lock()
 			diagnosis.NodeToStatusMap[nodeInfo.Node().Name] = status
-			diagnosis.SetFailedPlugin(status)
+			diagnosis.AddPluginStatus(status)
 			statusesLock.Unlock()
 		}
 	}

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -211,10 +211,10 @@ func (sched *Scheduler) schedulingCycle(
 				NumAllNodes: 1,
 				Pod:         pod,
 				Diagnosis: framework.Diagnosis{
-					NodeToStatusMap:      framework.NodeToStatusMap{scheduleResult.SuggestedHost: sts},
-					UnschedulablePlugins: sets.New(sts.FailedPlugin()),
+					NodeToStatusMap: framework.NodeToStatusMap{scheduleResult.SuggestedHost: sts},
 				},
 			}
+			fitErr.Diagnosis.SetFailedPlugin(sts)
 			return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, framework.NewStatus(sts.Code()).WithError(fitErr)
 		}
 		return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, sts
@@ -234,10 +234,10 @@ func (sched *Scheduler) schedulingCycle(
 				NumAllNodes: 1,
 				Pod:         pod,
 				Diagnosis: framework.Diagnosis{
-					NodeToStatusMap:      framework.NodeToStatusMap{scheduleResult.SuggestedHost: runPermitStatus},
-					UnschedulablePlugins: sets.New(runPermitStatus.FailedPlugin()),
+					NodeToStatusMap: framework.NodeToStatusMap{scheduleResult.SuggestedHost: runPermitStatus},
 				},
 			}
+			fitErr.Diagnosis.SetFailedPlugin(runPermitStatus)
 			return ScheduleResult{nominatingInfo: clearNominatedNode}, assumedPodInfo, framework.NewStatus(runPermitStatus.Code()).WithError(fitErr)
 		}
 
@@ -435,8 +435,7 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, fwk framework.Framework, state *framework.CycleState, pod *v1.Pod) ([]*v1.Node, framework.Diagnosis, error) {
 	logger := klog.FromContext(ctx)
 	diagnosis := framework.Diagnosis{
-		NodeToStatusMap:      make(framework.NodeToStatusMap),
-		UnschedulablePlugins: sets.New[string](),
+		NodeToStatusMap: make(framework.NodeToStatusMap),
 	}
 
 	allNodes, err := sched.nodeInfoSnapshot.NodeInfos().List()
@@ -459,10 +458,7 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, fwk framework.F
 		msg := s.Message()
 		diagnosis.PreFilterMsg = msg
 		logger.V(5).Info("Status after running PreFilter plugins for pod", "pod", klog.KObj(pod), "status", msg)
-		// Status satisfying IsUnschedulable() gets injected into diagnosis.UnschedulablePlugins.
-		if s.FailedPlugin() != "" {
-			diagnosis.UnschedulablePlugins.Insert(s.FailedPlugin())
-		}
+		diagnosis.SetFailedPlugin(s)
 		return nil, diagnosis, nil
 	}
 
@@ -490,7 +486,7 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, fwk framework.F
 			nodes = append(nodes, nInfo)
 		}
 	}
-	feasibleNodes, err := sched.findNodesThatPassFilters(ctx, fwk, state, pod, diagnosis, nodes)
+	feasibleNodes, err := sched.findNodesThatPassFilters(ctx, fwk, state, pod, &diagnosis, nodes)
 	// always try to update the sched.nextStartNodeIndex regardless of whether an error has occurred
 	// this is helpful to make sure that all the nodes have a chance to be searched
 	processedNodes := len(feasibleNodes) + len(diagnosis.NodeToStatusMap)
@@ -513,7 +509,7 @@ func (sched *Scheduler) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, 
 		return nil, err
 	}
 	node := []*framework.NodeInfo{nodeInfo}
-	feasibleNodes, err := sched.findNodesThatPassFilters(ctx, fwk, state, pod, diagnosis, node)
+	feasibleNodes, err := sched.findNodesThatPassFilters(ctx, fwk, state, pod, &diagnosis, node)
 	if err != nil {
 		return nil, err
 	}
@@ -532,7 +528,7 @@ func (sched *Scheduler) findNodesThatPassFilters(
 	fwk framework.Framework,
 	state *framework.CycleState,
 	pod *v1.Pod,
-	diagnosis framework.Diagnosis,
+	diagnosis *framework.Diagnosis,
 	nodes []*framework.NodeInfo) ([]*v1.Node, error) {
 	numAllNodes := len(nodes)
 	numNodesToFind := sched.numFeasibleNodesToFind(fwk.PercentageOfNodesToScore(), int32(numAllNodes))
@@ -573,7 +569,7 @@ func (sched *Scheduler) findNodesThatPassFilters(
 		} else {
 			statusesLock.Lock()
 			diagnosis.NodeToStatusMap[nodeInfo.Node().Name] = status
-			diagnosis.UnschedulablePlugins.Insert(status.FailedPlugin())
+			diagnosis.SetFailedPlugin(status)
 			statusesLock.Unlock()
 		}
 	}
@@ -982,6 +978,7 @@ func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, fwk framewo
 		logger.V(2).Info("Unable to schedule pod; no nodes are registered to the cluster; waiting", "pod", klog.KObj(pod))
 	} else if fitError, ok := err.(*framework.FitError); ok { // Inject UnschedulablePlugins to PodInfo, which will be used later for moving Pods between queues efficiently.
 		podInfo.UnschedulablePlugins = fitError.Diagnosis.UnschedulablePlugins
+		podInfo.PendingPlugins = fitError.Diagnosis.PendingPlugins
 		logger.V(2).Info("Unable to schedule pod; no fit; waiting", "pod", klog.KObj(pod), "err", errMsg)
 	} else if apierrors.IsNotFound(err) {
 		logger.V(2).Info("Unable to schedule pod, possibly due to node not found; waiting", "pod", klog.KObj(pod), "err", errMsg)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -363,9 +363,9 @@ func New(ctx context.Context,
 }
 
 // defaultQueueingHintFn is the default queueing hint function.
-// It always returns QueueAfterBackoff as the queueing hint.
+// It always returns Queue as the queueing hint.
 var defaultQueueingHintFn = func(_ klog.Logger, _ *v1.Pod, _, _ interface{}) (framework.QueueingHint, error) {
-	return framework.QueueAfterBackoff, nil
+	return framework.Queue, nil
 }
 
 func buildQueueingHintMap(es []framework.EnqueueExtensions) internalqueue.QueueingHintMap {

--- a/test/integration/scheduler/queue_test.go
+++ b/test/integration/scheduler/queue_test.go
@@ -544,7 +544,7 @@ func TestRequeueByPermitRejection(t *testing.T) {
 				frameworkHandler: fh,
 				schedulingHint: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
 					queueingHintCalledCounter++
-					return framework.QueueImmediately, nil
+					return framework.Queue, nil
 				},
 			}
 			return fakePermit, nil

--- a/test/integration/scheduler/rescheduling_test.go
+++ b/test/integration/scheduler/rescheduling_test.go
@@ -71,7 +71,7 @@ func (rp *ReservePlugin) EventsToRegister() []framework.ClusterEventWithHint {
 		{
 			Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add},
 			QueueingHintFn: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
-				return framework.QueueImmediately, nil
+				return framework.Queue, nil
 			},
 		},
 	}
@@ -108,7 +108,7 @@ func (pp *PermitPlugin) EventsToRegister() []framework.ClusterEventWithHint {
 		{
 			Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add},
 			QueueingHintFn: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
-				return framework.QueueImmediately, nil
+				return framework.Queue, nil
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

QueueingHintFn returns three values, QueueSkip, QueueAfterBackoff, and QueueImmediately.
https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/types.go#L109-L121
QueueSkip is OK as it's pretty clear, but it's unclear when to return QueueAfterBackoff and when to return QueueImmediately. Then, the current unclear situation results in different opinions from different people about which value we should return like [this](https://github.com/kubernetes/kubernetes/pull/119155#discussion_r1260207009).

https://github.com/kubernetes/kubernetes/pull/118551#discussion_r1267676030 is the thread which I wanted to clarify that point.
In the thread, https://github.com/kubernetes/kubernetes/pull/118551#discussion_r1269193782 is one idea to clarify this. 
BackoffQ is a light way of keeping throughput high by preventing pods that are "permanently unschedulable" from blocking the queue. (quote from https://github.com/kubernetes/kubernetes/pull/117561#discussion_r1189061873). 
So, the backoff delay is a penalty of wasting the scheduling cycle -- the more rejection the Pod has gotten at the scheduling cycle, the more delay that Pod should get in backoffQ as a penalty for wasting scheduling cycles.

And based on that concept, we split the failure into two reasons:
- scheduling failure: common scheduling failures like PodAffinity rejects Pod in Filter, NodeResourceFit rejects Pod in Filter, etc. Almost all scheduling failure are in this group.
- other rejections: There are some rejections that are **must** for the scheduling. Like DRA needs to wait for the claim to be provisioned from its design - After the scheduling cycle is finished successfully, DRA needs to reject Pod once anyways in order to wait for schedulingcontext to be updated by the driver based on that scheduling result.
  - Note that the scheduling cycle, used to decide the Node in this example, isn't a vain effort, considering DRA can proceed the scheduling further by the scheduling result.

And, we consider they equal when to return QueueAfterBackoff (the former) and when to return QueueImmediately (the latter). 

---

Based on the above thoughts from the discussion, it feels like we shouldn't control how to requeue Pods via the returning values (QueueAfterBackoff/QueueImmediately). Rather, I believe we should control it how the Pod is rejected (with which status the Pod is rejected).
That's more natural than QueueAfterBackoff/QueueImmediately because we define when to return QueueAfterBackoff/QueueImmediately is tightly coupled with the reason the Pod was rejected.

This PR proposes to simplify QueueingHintFn's returning value.
QueueingHint will have only two values, Queue or QueueSkip.

And instead, introduce a new status, SuccessButReject.
SuccessButReject is used when the scheduler succeeds everything in the scheduling cycle but needs to reject Pod once, for example, in order to wait for the external component to do something.
For example, as said earlier, the DRA plugin sometimes needs to wait for the external device driver to provision the resource for the Pod based on the scheduling result.
It's different from when to return Unschedulable/UnschedulableAndUnresolvable, because in this case, the scheduling cycle, used to decide the Node in this example, isn't a vain effort, considering DRA can proceed the scheduling further by the scheduling result.

When the plugin rejectes a pod with this code, the scheduler remembers the pod and the plugin name, and when the appropriate event happens, which the plugin's QueueingHintFn returns Queue, the scheduler retries the scheduling immediately without waiting for the backoff. (Yes! it's a same behaviour as QueueImmediately that we now have)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Part of: https://github.com/kubernetes/kubernetes/issues/114297

#### Special notes for your reviewer:

/cc @alculquicondor @kerthcet 

There might be another better name instead of `SuccessButReject`. Please propose if any 😅 
EDIT: Per discussion in KEP, we use the word `Pending`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note 
The scheduler gets new statuses Pending, which are used to achieve efficient enqueueing in the scheduling queue.
QueueingHintFn interface gets simplified by introducing a new status Pending - the returning value is changed to have only Queue and QueueSkip. The scheduling queue determines whether it should treat Queue as QueueAfterBackoff or QueueImmediately via the reason why the Pod was rejected. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: http://kep.k8s.io/4247
```
