### PR TITLE
kubectl debug: Introduce customizable AttachFunc instead static one

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -213,6 +213,11 @@ func (o *DebugOptions) Complete(restClientGetter genericclioptions.RESTClientGet
 	attachFlag := cmd.Flags().Lookup("attach")
 	if !attachFlag.Changed && o.Interactive {
 		o.Attach = true
+		// Downstream tools may want to use their own customized
+		// attach function to do extra work or use attach command
+		// with different flags instead of the static one defined in
+		// handleAttachPod. But if this function is not set explicitly,
+		// we fall back to default.
 		if o.AttachFunc == nil {
 			o.AttachFunc = o.handleAttachPod
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -2104,7 +2104,7 @@ func TestCompleteAndValidate(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.wantOpts, opts, cmpFilter, cmpopts.IgnoreFields(DebugOptions{},
-				"attachChanged", "shareProcessedChanged", "podClient", "WarningPrinter", "Applier", "explicitNamespace", "Builder")); diff != "" {
+				"attachChanged", "shareProcessedChanged", "podClient", "WarningPrinter", "Applier", "explicitNamespace", "Builder", "AttachFunc")); diff != "" {
 				t.Error("CompleteAndValidate unexpected diff in generated object: (-want +got):\n", diff)
 			}
 		})


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Currently, kubectl debug statically relies on handleAttachPod function
in order to attach to the pod.
However, external tools would want to set their own customized attach
function and this PR introduces generic `AttachFunc` function interface
which can also be overriden by external tools.
From the point of kubectl debug, there is no functionality change.

In addition to that legacy server support for ephemeral containers were added in kubectl
debug in 1.22(with this commit https://github.com/kubernetes/kubernetes/commit/06124c1d1c68ec4a30406bf585df2ec83231cb65). Since now we are in 1.29, we can safely remove ephemeral
container legacy server support because 1.22 is already far away from
supported version skew boundary.

#### Does this PR introduce a user-facing change?
```release-note
Remove ephemeral container legacy server support for the server versions prior to 1.22
```