### PR TITLE
Treat empty string as nil in fuzzer for CEL Reason field

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer/fuzzer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer/fuzzer.go
@@ -181,5 +181,11 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			// JSON only supports 53 bits because everything is a float
 			*obj = int64(c.Uint64()) & ((int64(1) << 53) - 1)
 		},
+		func(obj *apiextensions.ValidationRule, c fuzz.Continue) {
+			c.FuzzNoCustom(obj)
+			if obj.Reason != nil && *(obj.Reason) == "" {
+				obj.Reason = nil
+			}
+		},
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

In CRD schemas, x-kubernetes-validations[].reason is an pointer to a string with omitempty enabled. When the fuzzer sets the field to an empty string it deserializes back as nil, which is semantically safe but fails TestRoundTrip:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-unit/1683444240597651456

This modifies the fuzzer to always use nil instead of a pointer to an empty string to avoid this flake.

#### Special notes for your reviewer:

Reproduction case passes with this fix in place:

```
TEST_RAND_SEED=859509990 go test ./pkg/apiserver/validation -run "TestRoundTrip" -count 1
ok  	k8s.io/apiextensions-apiserver/pkg/apiserver/validation	0.099s
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig api-machinery
/priority critically-urgent
/cc @liggitt @cici37 
