### PR TITLE
client-go workqueue: fix shutdown race / test flake

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue.go
@@ -238,8 +238,12 @@ func (q *Type) Done(item interface{}) {
 // ShutDown will cause q to ignore all new items added to it and
 // immediately instruct the worker goroutines to exit.
 func (q *Type) ShutDown() {
-	q.setDrain(false)
-	q.shutdown()
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+
+	q.drain = false
+	q.shuttingDown = true
+	q.cond.Broadcast()
 }
 
 // ShutDownWithDrain will cause q to ignore all new items added to it. As soon
@@ -252,53 +256,16 @@ func (q *Type) ShutDown() {
 // ShutDownWithDrain, as to force the queue shut down to terminate immediately
 // without waiting for the drainage.
 func (q *Type) ShutDownWithDrain() {
-	q.setDrain(true)
-	q.shutdown()
-	for q.isProcessing() && q.shouldDrain() {
-		q.waitForProcessing()
-	}
-}
-
-// isProcessing indicates if there are still items on the work queue being
-// processed. It's used to drain the work queue on an eventual shutdown.
-func (q *Type) isProcessing() bool {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
-	return q.processing.len() != 0
-}
 
-// waitForProcessing waits for the worker goroutines to finish processing items
-// and call Done on them.
-func (q *Type) waitForProcessing() {
-	q.cond.L.Lock()
-	defer q.cond.L.Unlock()
-	// Ensure that we do not wait on a queue which is already empty, as that
-	// could result in waiting for Done to be called on items in an empty queue
-	// which has already been shut down, which will result in waiting
-	// indefinitely.
-	if q.processing.len() == 0 {
-		return
-	}
-	q.cond.Wait()
-}
-
-func (q *Type) setDrain(shouldDrain bool) {
-	q.cond.L.Lock()
-	defer q.cond.L.Unlock()
-	q.drain = shouldDrain
-}
-
-func (q *Type) shouldDrain() bool {
-	q.cond.L.Lock()
-	defer q.cond.L.Unlock()
-	return q.drain
-}
-
-func (q *Type) shutdown() {
-	q.cond.L.Lock()
-	defer q.cond.L.Unlock()
+	q.drain = true
 	q.shuttingDown = true
 	q.cond.Broadcast()
+
+	for q.processing.len() != 0 && q.drain {
+		q.cond.Wait()
+	}
 }
 
 func (q *Type) ShuttingDown() bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

Optionally add one or more of the following kinds if applicable:
/kind flake

#### What this PR does / why we need it:

There is a race the present implementation of the workqueue:

1. `ShutDownWithDrain()` does not lock `cond`.
1. `ShutDownWithDrain()`  runs a loop testing the condition that `cond` protects which it does through methods: `q.isProcessing() && q.shouldDrain()`.
1. Both `q.isProcessing()` and `q.shouldDrain()` independently lock `cond`.
1. The job of performing a `Wait()` is outsourced into a method `waitForProcessing()`
1. The method `waitForProcessing()` again gets a lock of `cond` but only tests one of the conditions (that the queue is not empty) before entering a `cond.Wait()`.
1. Because of all the individual locking it is possible to occasionally slip through the condition check in `ShutDownWithDrain()` and then have another process come along with an immediate `ShutDown()`.  Which is subsequently not checked in `waitForProcessing()` and so it is possible to get a deadlock.

This deadlock can be observed when running the workqueue tests via stress:

```
$ cd staging/src/k8s.io/client-go/util/workqueue
$ go test --race -v -c .
$ stress ./workqueue.test -test.run TestForceQueueShutdownUsingShutDown
```

This is the occasional flake:

```
/var/folders/6p/9btck9zj67l_5b6mg30s3fv00000gn/T/go-stress-20230724T101200-4177657046
fatal error: all goroutines are asleep - deadlock!

goroutine 1 [chan receive]:
testing.(*T).Run(0xc000003ba0, {0x10291cdac, 0x23}, 0x102a32908)
	/opt/homebrew/Cellar/go/1.20.6/libexec/src/testing/testing.go:1630 +0x604
testing.runTests.func1(0x0?)
	/opt/homebrew/Cellar/go/1.20.6/libexec/src/testing/testing.go:2036 +0x84
testing.tRunner(0xc000003ba0, 0xc000159a88)
	/opt/homebrew/Cellar/go/1.20.6/libexec/src/testing/testing.go:1576 +0x18c
testing.runTests(0xc00010ebe0?, {0x102c2e060, 0x1f, 0x1f}, {0xc000159ae8?, 0xc00001a53c?, 0x0?})
	/opt/homebrew/Cellar/go/1.20.6/libexec/src/testing/testing.go:2034 +0x704
testing.(*M).Run(0xc00010ebe0)
	/opt/homebrew/Cellar/go/1.20.6/libexec/src/testing/testing.go:1906 +0x954
k8s.io/client-go/util/workqueue.TestMain(0x0?)
	/Users/d_mccormick/go/src/github.xxx/kubernetes/kubernetes/staging/src/k8s.io/client-go/util/workqueue/main_test.go:28 +0xc8
main.main()
	_testmain.go:115 +0x308

goroutine 6 [semacquire]:
sync.runtime_Semacquire(0xc00001a5e8?)
	/opt/homebrew/Cellar/go/1.20.6/libexec/src/runtime/sema.go:62 +0x2c
sync.(*WaitGroup).Wait(0xc00001a5e0)
	/opt/homebrew/Cellar/go/1.20.6/libexec/src/sync/waitgroup.go:116 +0x7c
k8s.io/client-go/util/workqueue_test.TestForceQueueShutdownUsingShutDown(0x0?)
	/Users/d_mccormick/go/src/github.xxx/kubernetes/kubernetes/staging/src/k8s.io/client-go/util/workqueue/queue_test.go:310 +0x190
testing.tRunner(0xc000003d40, 0x102a32908)
	/opt/homebrew/Cellar/go/1.20.6/libexec/src/testing/testing.go:1576 +0x18c
created by testing.(*T).Run
	/opt/homebrew/Cellar/go/1.20.6/libexec/src/testing/testing.go:1629 +0x5e8

goroutine 7 [sync.Cond.Wait]:
sync.runtime_notifyListWait(0xc000100e50, 0x1)
	/opt/homebrew/Cellar/go/1.20.6/libexec/src/runtime/sema.go:527 +0x16c
sync.(*Cond).Wait(0xc000100e40)
	/opt/homebrew/Cellar/go/1.20.6/libexec/src/sync/cond.go:70 +0xb0
k8s.io/client-go/util/workqueue.(*Type).waitForProcessing(0xc00006c240)
	/Users/d_mccormick/go/src/github.xxx/kubernetes/kubernetes/staging/src/k8s.io/client-go/util/wo
```

The issue can be resolved by simply adding the missing check (for the request to drain having been rescinded) within `waitForProcessing()` but then we still have a tight loop checking the conditions before calling a method which then again checks the conditions.  There are a few things I don't like:

1. We are checking the same conditions twice
2. We make 3 method calls on each iteration of the loop.
3. We don't get a lock on the `ShutDownWithDrain()` method but then everything we do afterwards then gets its own lock.
4. There's quite a lot of code to do something fairly simple.

It is common practice to enclose a `Wait()` within a loop.  Because `Wait()` automatically unlocks the `cond` when it waits and locks again before it returns, it is safe to run in a method where we lock `cond` before checking the conditions.  So by moving the locking of the `cond` up into the `ShutDown()` and `ShutDownWithDrain()` methods, we no longer need a number of the separate methods that perform a lock and then check a condition.

After making the change:

```
go test --race -v -c .
stress ./workqueue.test -test.run TestForceQueueShutdownUsingShutDown
8h27m25s: 9868947 runs so far, 0 failures
```

#### Which issue(s) this PR fixes:

Flake

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
