### PR TITLE
Automated cherry pick of #118601: priority & fairness: support dynamic max seats

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -901,7 +901,7 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	if c.FlowControl != nil {
 		workEstimatorCfg := flowcontrolrequest.DefaultWorkEstimatorConfig()
 		requestWorkEstimator := flowcontrolrequest.NewWorkEstimator(
-			c.StorageObjectCountTracker.Get, c.FlowControl.GetInterestedWatchCount, workEstimatorCfg)
+			c.StorageObjectCountTracker.Get, c.FlowControl.GetInterestedWatchCount, workEstimatorCfg, c.FlowControl.GetMaxSeats)
 		handler = filterlatency.TrackCompleted(handler)
 		handler = genericfilters.WithPriorityAndFairness(handler, c.LongRunningFunc, c.FlowControl, requestWorkEstimator)
 		handler = filterlatency.TrackStarted(handler, c.TracerProvider, "priorityandfairness")

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -80,6 +80,7 @@ type fakeApfFilter struct {
 	postDequeue  func()
 
 	utilflowcontrol.WatchTracker
+	utilflowcontrol.MaxSeatsTracker
 }
 
 func (t fakeApfFilter) Handle(ctx context.Context,
@@ -146,10 +147,11 @@ func newApfServerWithSingleRequest(t *testing.T, decision mockDecision) *httptes
 
 func newApfServerWithHooks(t *testing.T, decision mockDecision, onExecute, postExecute, postEnqueue, postDequeue func()) *httptest.Server {
 	fakeFilter := fakeApfFilter{
-		mockDecision: decision,
-		postEnqueue:  postEnqueue,
-		postDequeue:  postDequeue,
-		WatchTracker: utilflowcontrol.NewWatchTracker(),
+		mockDecision:    decision,
+		postEnqueue:     postEnqueue,
+		postDequeue:     postDequeue,
+		WatchTracker:    utilflowcontrol.NewWatchTracker(),
+		MaxSeatsTracker: utilflowcontrol.NewMaxSeatsTracker(),
 	}
 	return newApfServerWithFilter(t, fakeFilter, onExecute, postExecute)
 }
@@ -349,12 +351,14 @@ type fakeWatchApfFilter struct {
 	preExecutePanic  bool
 
 	utilflowcontrol.WatchTracker
+	utilflowcontrol.MaxSeatsTracker
 }
 
 func newFakeWatchApfFilter(capacity int) *fakeWatchApfFilter {
 	return &fakeWatchApfFilter{
-		capacity:     capacity,
-		WatchTracker: utilflowcontrol.NewWatchTracker(),
+		capacity:        capacity,
+		WatchTracker:    utilflowcontrol.NewWatchTracker(),
+		MaxSeatsTracker: utilflowcontrol.NewMaxSeatsTracker(),
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go
@@ -77,6 +77,10 @@ type Interface interface {
 
 	// WatchTracker provides the WatchTracker interface.
 	WatchTracker
+
+	// MaxSeatsTracker is invoked from the work estimator to track max seats
+	// that can be occupied by a request for a priority level.
+	MaxSeatsTracker
 }
 
 // This request filter implements https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/1040-priority-and-fairness/README.md

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/max_seats.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/max_seats.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"sync"
+)
+
+// MaxSeatsTracker is used to track max seats allocatable per priority level from the work estimator
+type MaxSeatsTracker interface {
+	// GetMaxSeats returns the maximum seats a request should occupy for a given priority level.
+	GetMaxSeats(priorityLevelName string) uint64
+
+	// SetMaxSeats configures max seats for a priority level.
+	SetMaxSeats(priorityLevelName string, maxSeats uint64)
+
+	// ForgetPriorityLevel removes max seats tracking for a priority level.
+	ForgetPriorityLevel(priorityLevelName string)
+}
+
+type maxSeatsTracker struct {
+	sync.RWMutex
+
+	maxSeats map[string]uint64
+}
+
+func NewMaxSeatsTracker() MaxSeatsTracker {
+	return &maxSeatsTracker{
+		maxSeats: make(map[string]uint64),
+	}
+}
+
+func (m *maxSeatsTracker) GetMaxSeats(plName string) uint64 {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.maxSeats[plName]
+}
+
+func (m *maxSeatsTracker) SetMaxSeats(plName string, maxSeats uint64) {
+	m.Lock()
+	defer m.Unlock()
+
+	m.maxSeats[plName] = maxSeats
+}
+
+func (m *maxSeatsTracker) ForgetPriorityLevel(plName string) {
+	m.Lock()
+	defer m.Unlock()
+
+	delete(m.maxSeats, plName)
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/max_seats_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/max_seats_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/api/flowcontrol/v1beta3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fqs "k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset"
+	"k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/eventclock"
+	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"
+	"k8s.io/client-go/informers"
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// Test_GetMaxSeats tests max seats retrieved from MaxSeatsTracker
+func Test_GetMaxSeats(t *testing.T) {
+	testcases := []struct {
+		name             string
+		nominalCL        int
+		handSize         int32
+		expectedMaxSeats uint64
+	}{
+		{
+			name:             "nominalCL=5, handSize=6",
+			nominalCL:        5,
+			handSize:         6,
+			expectedMaxSeats: 1,
+		},
+		{
+			name:             "nominalCL=10, handSize=6",
+			nominalCL:        10,
+			handSize:         6,
+			expectedMaxSeats: 1,
+		},
+		{
+			name:             "nominalCL=15, handSize=6",
+			nominalCL:        15,
+			handSize:         6,
+			expectedMaxSeats: 2,
+		},
+		{
+			name:             "nominalCL=20, handSize=6",
+			nominalCL:        20,
+			handSize:         6,
+			expectedMaxSeats: 3,
+		},
+		{
+			name:             "nominalCL=35, handSize=6",
+			nominalCL:        35,
+			handSize:         6,
+			expectedMaxSeats: 5,
+		},
+		{
+			name:             "nominalCL=100, handSize=6",
+			nominalCL:        100,
+			handSize:         6,
+			expectedMaxSeats: 15,
+		},
+		{
+			name:             "nominalCL=200, handSize=6",
+			nominalCL:        200,
+			handSize:         6,
+			expectedMaxSeats: 30,
+		},
+		{
+			name:             "nominalCL=10, handSize=1",
+			nominalCL:        10,
+			handSize:         1,
+			expectedMaxSeats: 2,
+		},
+		{
+			name:             "nominalCL=100, handSize=20",
+			nominalCL:        100,
+			handSize:         20,
+			expectedMaxSeats: 5,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			clientset := clientsetfake.NewSimpleClientset()
+			informerFactory := informers.NewSharedInformerFactory(clientset, time.Second)
+			flowcontrolClient := clientset.FlowcontrolV1beta3()
+			startTime := time.Now()
+			clk, _ := eventclock.NewFake(startTime, 0, nil)
+			c := newTestableController(TestableConfig{
+				Name:              "Controller",
+				Clock:             clk,
+				InformerFactory:   informerFactory,
+				FlowcontrolClient: flowcontrolClient,
+				// for the purposes of this test, serverCL ~= nominalCL since there is
+				// only 1 PL with large concurrency shares, making mandatory PLs negligible.
+				ServerConcurrencyLimit: testcase.nominalCL,
+				RequestWaitLimit:       time.Minute,
+				ReqsGaugeVec:           metrics.PriorityLevelConcurrencyGaugeVec,
+				ExecSeatsGaugeVec:      metrics.PriorityLevelExecutionSeatsGaugeVec,
+				QueueSetFactory:        fqs.NewQueueSetFactory(clk),
+			})
+
+			testPriorityLevel := &v1beta3.PriorityLevelConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pl",
+				},
+				Spec: v1beta3.PriorityLevelConfigurationSpec{
+					Type: v1beta3.PriorityLevelEnablementLimited,
+					Limited: &v1beta3.LimitedPriorityLevelConfiguration{
+						NominalConcurrencyShares: 10000,
+						LimitResponse: v1beta3.LimitResponse{
+							Queuing: &v1beta3.QueuingConfiguration{
+								HandSize: testcase.handSize,
+							},
+						},
+					},
+				},
+			}
+			c.digestConfigObjects([]*v1beta3.PriorityLevelConfiguration{testPriorityLevel}, nil)
+			maxSeats := c.GetMaxSeats("test-pl")
+			if maxSeats != testcase.expectedMaxSeats {
+				t.Errorf("unexpected max seats, got=%d, want=%d", maxSeats, testcase.expectedMaxSeats)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/config.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	minimumSeats                = 1
-	maximumSeats                = 10
+	maximumSeatsLimit           = 10
 	objectsPerSeat              = 100.0
 	watchesPerSeat              = 10.0
 	enableMutatingWorkEstimator = true
@@ -39,12 +39,13 @@ type WorkEstimatorConfig struct {
 
 	// MinimumSeats is the minimum number of seats a request must occupy.
 	MinimumSeats uint64 `json:"minimumSeats,omitempty"`
-	// MaximumSeats is the maximum number of seats a request can occupy
+
+	// MaximumSeatsLimit is an upper limit on the max seats a request can occupy.
 	//
 	// NOTE: work_estimate_seats_samples metric uses the value of maximumSeats
 	// as the upper bound, so when we change maximumSeats we should also
 	// update the buckets of the metric.
-	MaximumSeats uint64 `json:"maximumSeats,omitempty"`
+	MaximumSeatsLimit uint64 `json:"maximumSeatsLimit,omitempty"`
 }
 
 // ListWorkEstimatorConfig holds work estimator parameters related to list requests.
@@ -66,7 +67,7 @@ type MutatingWorkEstimatorConfig struct {
 func DefaultWorkEstimatorConfig() *WorkEstimatorConfig {
 	return &WorkEstimatorConfig{
 		MinimumSeats:                minimumSeats,
-		MaximumSeats:                maximumSeats,
+		MaximumSeatsLimit:           maximumSeatsLimit,
 		ListWorkEstimatorConfig:     defaultListWorkEstimatorConfig(),
 		MutatingWorkEstimatorConfig: defaultMutatingWorkEstimatorConfig(),
 	}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/mutating_work_estimator.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/mutating_work_estimator.go
@@ -25,25 +25,33 @@ import (
 	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"
 )
 
-func newMutatingWorkEstimator(countFn watchCountGetterFunc, config *WorkEstimatorConfig) WorkEstimatorFunc {
+func newMutatingWorkEstimator(countFn watchCountGetterFunc, config *WorkEstimatorConfig, maxSeatsFn maxSeatsFunc) WorkEstimatorFunc {
 	estimator := &mutatingWorkEstimator{
-		config:  config,
-		countFn: countFn,
+		config:     config,
+		countFn:    countFn,
+		maxSeatsFn: maxSeatsFn,
 	}
 	return estimator.estimate
 }
 
 type mutatingWorkEstimator struct {
-	config  *WorkEstimatorConfig
-	countFn watchCountGetterFunc
+	config     *WorkEstimatorConfig
+	countFn    watchCountGetterFunc
+	maxSeatsFn maxSeatsFunc
 }
 
 func (e *mutatingWorkEstimator) estimate(r *http.Request, flowSchemaName, priorityLevelName string) WorkEstimate {
+	minSeats := e.config.MinimumSeats
+	maxSeats := e.maxSeatsFn(priorityLevelName)
+	if maxSeats == 0 || maxSeats > e.config.MaximumSeatsLimit {
+		maxSeats = e.config.MaximumSeatsLimit
+	}
+
 	// TODO(wojtekt): Remove once we tune the algorithm to not fail
 	// scalability tests.
 	if !e.config.Enabled {
 		return WorkEstimate{
-			InitialSeats: 1,
+			InitialSeats: minSeats,
 		}
 	}
 
@@ -52,15 +60,15 @@ func (e *mutatingWorkEstimator) estimate(r *http.Request, flowSchemaName, priori
 		// no RequestInfo should never happen, but to be on the safe side
 		// let's return a large value.
 		return WorkEstimate{
-			InitialSeats:      1,
-			FinalSeats:        e.config.MaximumSeats,
+			InitialSeats:      minSeats,
+			FinalSeats:        maxSeats,
 			AdditionalLatency: e.config.eventAdditionalDuration(),
 		}
 	}
 
 	if isRequestExemptFromWatchEvents(requestInfo) {
 		return WorkEstimate{
-			InitialSeats:      e.config.MinimumSeats,
+			InitialSeats:      minSeats,
 			FinalSeats:        0,
 			AdditionalLatency: time.Duration(0),
 		}
@@ -126,8 +134,8 @@ func (e *mutatingWorkEstimator) estimate(r *http.Request, flowSchemaName, priori
 		//
 		// TODO: Confirm that the current cap of maximumSeats allow us to
 		//   achieve the above.
-		if finalSeats > e.config.MaximumSeats {
-			finalSeats = e.config.MaximumSeats
+		if finalSeats > maxSeats {
+			finalSeats = maxSeats
 		}
 		additionalLatency = finalWork.DurationPerSeat(float64(finalSeats))
 	}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/width_test.go
@@ -27,8 +27,6 @@ import (
 
 func TestWorkEstimator(t *testing.T) {
 	defaultCfg := DefaultWorkEstimatorConfig()
-	minimumSeats := defaultCfg.MinimumSeats
-	maximumSeats := defaultCfg.MaximumSeats
 
 	tests := []struct {
 		name                      string
@@ -37,6 +35,7 @@ func TestWorkEstimator(t *testing.T) {
 		counts                    map[string]int64
 		countErr                  error
 		watchCount                int
+		maxSeats                  uint64
 		initialSeatsExpected      uint64
 		finalSeatsExpected        uint64
 		additionalLatencyExpected time.Duration
@@ -45,7 +44,8 @@ func TestWorkEstimator(t *testing.T) {
 			name:                 "request has no RequestInfo",
 			requestURI:           "http://server/apis/",
 			requestInfo:          nil,
-			initialSeatsExpected: maximumSeats,
+			maxSeats:             10,
+			initialSeatsExpected: 10,
 		},
 		{
 			name:       "request verb is not list",
@@ -53,7 +53,8 @@ func TestWorkEstimator(t *testing.T) {
 			requestInfo: &apirequest.RequestInfo{
 				Verb: "get",
 			},
-			initialSeatsExpected: minimumSeats,
+			maxSeats:             10,
+			initialSeatsExpected: 1,
 		},
 		{
 			name:       "request verb is list, conversion to ListOptions returns error",
@@ -66,7 +67,8 @@ func TestWorkEstimator(t *testing.T) {
 			counts: map[string]int64{
 				"events.foo.bar": 799,
 			},
-			initialSeatsExpected: maximumSeats,
+			maxSeats:             10,
+			initialSeatsExpected: 10,
 		},
 		{
 			name:       "request verb is list, has limit and resource version is 1",
@@ -79,6 +81,7 @@ func TestWorkEstimator(t *testing.T) {
 			counts: map[string]int64{
 				"events.foo.bar": 699,
 			},
+			maxSeats:             10,
 			initialSeatsExpected: 8,
 		},
 		{
@@ -92,6 +95,7 @@ func TestWorkEstimator(t *testing.T) {
 			counts: map[string]int64{
 				"events.foo.bar": 699,
 			},
+			maxSeats:             10,
 			initialSeatsExpected: 7,
 		},
 		{
@@ -105,6 +109,7 @@ func TestWorkEstimator(t *testing.T) {
 			counts: map[string]int64{
 				"events.foo.bar": 699,
 			},
+			maxSeats:             10,
 			initialSeatsExpected: 8,
 		},
 		{
@@ -118,6 +123,7 @@ func TestWorkEstimator(t *testing.T) {
 			counts: map[string]int64{
 				"events.foo.bar": 399,
 			},
+			maxSeats:             10,
 			initialSeatsExpected: 8,
 		},
 		{
@@ -129,7 +135,8 @@ func TestWorkEstimator(t *testing.T) {
 				Resource: "events",
 			},
 			countErr:             ObjectCountNotFoundErr,
-			initialSeatsExpected: minimumSeats,
+			maxSeats:             10,
+			initialSeatsExpected: 1,
 		},
 		{
 			name:       "request verb is list, continuation is set",
@@ -142,6 +149,7 @@ func TestWorkEstimator(t *testing.T) {
 			counts: map[string]int64{
 				"events.foo.bar": 699,
 			},
+			maxSeats:             10,
 			initialSeatsExpected: 8,
 		},
 		{
@@ -155,6 +163,7 @@ func TestWorkEstimator(t *testing.T) {
 			counts: map[string]int64{
 				"events.foo.bar": 399,
 			},
+			maxSeats:             10,
 			initialSeatsExpected: 4,
 		},
 		{
@@ -181,6 +190,7 @@ func TestWorkEstimator(t *testing.T) {
 			counts: map[string]int64{
 				"events.foo.bar": 699,
 			},
+			maxSeats:             10,
 			initialSeatsExpected: 8,
 		},
 		{
@@ -194,6 +204,7 @@ func TestWorkEstimator(t *testing.T) {
 			counts: map[string]int64{
 				"events.foo.bar": 799,
 			},
+			maxSeats:             10,
 			initialSeatsExpected: 8,
 		},
 		{
@@ -207,7 +218,22 @@ func TestWorkEstimator(t *testing.T) {
 			counts: map[string]int64{
 				"events.foo.bar": 1999,
 			},
-			initialSeatsExpected: maximumSeats,
+			maxSeats:             10,
+			initialSeatsExpected: 10,
+		},
+		{
+			name:       "request verb is list, maximum is capped, lower max seats",
+			requestURI: "http://server/apis/foo.bar/v1/events?resourceVersion=foo",
+			requestInfo: &apirequest.RequestInfo{
+				Verb:     "list",
+				APIGroup: "foo.bar",
+				Resource: "events",
+			},
+			counts: map[string]int64{
+				"events.foo.bar": 1999,
+			},
+			maxSeats:             5,
+			initialSeatsExpected: 5,
 		},
 		{
 			name:       "request verb is list, list from cache, count not known",
@@ -218,7 +244,8 @@ func TestWorkEstimator(t *testing.T) {
 				Resource: "events",
 			},
 			countErr:             ObjectCountNotFoundErr,
-			initialSeatsExpected: minimumSeats,
+			maxSeats:             10,
+			initialSeatsExpected: 1,
 		},
 		{
 			name:       "request verb is list, object count is stale",
@@ -232,7 +259,8 @@ func TestWorkEstimator(t *testing.T) {
 				"events.foo.bar": 799,
 			},
 			countErr:             ObjectCountStaleErr,
-			initialSeatsExpected: maximumSeats,
+			maxSeats:             10,
+			initialSeatsExpected: 10,
 		},
 		{
 			name:       "request verb is list, object count is not found",
@@ -243,7 +271,8 @@ func TestWorkEstimator(t *testing.T) {
 				Resource: "events",
 			},
 			countErr:             ObjectCountNotFoundErr,
-			initialSeatsExpected: minimumSeats,
+			maxSeats:             10,
+			initialSeatsExpected: 1,
 		},
 		{
 			name:       "request verb is list, count getter throws unknown error",
@@ -254,7 +283,8 @@ func TestWorkEstimator(t *testing.T) {
 				Resource: "events",
 			},
 			countErr:             errors.New("unknown error"),
-			initialSeatsExpected: maximumSeats,
+			maxSeats:             10,
+			initialSeatsExpected: 10,
 		},
 		{
 			name:       "request verb is list, metadata.name specified",
@@ -268,7 +298,8 @@ func TestWorkEstimator(t *testing.T) {
 			counts: map[string]int64{
 				"events.foo.bar": 799,
 			},
-			initialSeatsExpected: minimumSeats,
+			maxSeats:             10,
+			initialSeatsExpected: 1,
 		},
 		{
 			name:       "request verb is list, metadata.name, resourceVersion and limit specified",
@@ -282,7 +313,8 @@ func TestWorkEstimator(t *testing.T) {
 			counts: map[string]int64{
 				"events.foo.bar": 799,
 			},
-			initialSeatsExpected: minimumSeats,
+			maxSeats:             10,
+			initialSeatsExpected: 1,
 		},
 		{
 			name:       "request verb is create, no watches",
@@ -292,6 +324,7 @@ func TestWorkEstimator(t *testing.T) {
 				APIGroup: "foo.bar",
 				Resource: "foos",
 			},
+			maxSeats:                  10,
 			initialSeatsExpected:      1,
 			finalSeatsExpected:        0,
 			additionalLatencyExpected: 0,
@@ -305,6 +338,7 @@ func TestWorkEstimator(t *testing.T) {
 				Resource: "foos",
 			},
 			watchCount:                29,
+			maxSeats:                  10,
 			initialSeatsExpected:      1,
 			finalSeatsExpected:        3,
 			additionalLatencyExpected: 5 * time.Millisecond,
@@ -318,6 +352,7 @@ func TestWorkEstimator(t *testing.T) {
 				Resource: "foos",
 			},
 			watchCount:                5,
+			maxSeats:                  10,
 			initialSeatsExpected:      1,
 			finalSeatsExpected:        0,
 			additionalLatencyExpected: 0,
@@ -331,6 +366,7 @@ func TestWorkEstimator(t *testing.T) {
 				Resource: "foos",
 			},
 			watchCount:                199,
+			maxSeats:                  10,
 			initialSeatsExpected:      1,
 			finalSeatsExpected:        10,
 			additionalLatencyExpected: 10 * time.Millisecond,
@@ -343,6 +379,7 @@ func TestWorkEstimator(t *testing.T) {
 				APIGroup: "foo.bar",
 				Resource: "foos",
 			},
+			maxSeats:                  10,
 			initialSeatsExpected:      1,
 			finalSeatsExpected:        0,
 			additionalLatencyExpected: 0,
@@ -356,6 +393,7 @@ func TestWorkEstimator(t *testing.T) {
 				Resource: "foos",
 			},
 			watchCount:                29,
+			maxSeats:                  10,
 			initialSeatsExpected:      1,
 			finalSeatsExpected:        3,
 			additionalLatencyExpected: 5 * time.Millisecond,
@@ -368,6 +406,7 @@ func TestWorkEstimator(t *testing.T) {
 				APIGroup: "foo.bar",
 				Resource: "foos",
 			},
+			maxSeats:                  10,
 			initialSeatsExpected:      1,
 			finalSeatsExpected:        0,
 			additionalLatencyExpected: 0,
@@ -381,9 +420,24 @@ func TestWorkEstimator(t *testing.T) {
 				Resource: "foos",
 			},
 			watchCount:                29,
+			maxSeats:                  10,
 			initialSeatsExpected:      1,
 			finalSeatsExpected:        3,
 			additionalLatencyExpected: 5 * time.Millisecond,
+		},
+		{
+			name:       "request verb is patch, watches registered, lower max seats",
+			requestURI: "http://server/apis/foo.bar/v1/foos/myfoo",
+			requestInfo: &apirequest.RequestInfo{
+				Verb:     "patch",
+				APIGroup: "foo.bar",
+				Resource: "foos",
+			},
+			watchCount:                100,
+			maxSeats:                  5,
+			initialSeatsExpected:      1,
+			finalSeatsExpected:        5,
+			additionalLatencyExpected: 10 * time.Millisecond,
 		},
 		{
 			name:       "request verb is delete, no watches",
@@ -393,6 +447,7 @@ func TestWorkEstimator(t *testing.T) {
 				APIGroup: "foo.bar",
 				Resource: "foos",
 			},
+			maxSeats:                  10,
 			initialSeatsExpected:      1,
 			finalSeatsExpected:        0,
 			additionalLatencyExpected: 0,
@@ -406,6 +461,7 @@ func TestWorkEstimator(t *testing.T) {
 				Resource: "foos",
 			},
 			watchCount:                29,
+			maxSeats:                  10,
 			initialSeatsExpected:      1,
 			finalSeatsExpected:        3,
 			additionalLatencyExpected: 5 * time.Millisecond,
@@ -420,7 +476,8 @@ func TestWorkEstimator(t *testing.T) {
 				Subresource: "token",
 			},
 			watchCount:                5777,
-			initialSeatsExpected:      minimumSeats,
+			maxSeats:                  10,
+			initialSeatsExpected:      1,
 			finalSeatsExpected:        0,
 			additionalLatencyExpected: 0,
 		},
@@ -433,8 +490,9 @@ func TestWorkEstimator(t *testing.T) {
 				Resource: "serviceaccounts",
 			},
 			watchCount:                1000,
+			maxSeats:                  10,
 			initialSeatsExpected:      1,
-			finalSeatsExpected:        maximumSeats,
+			finalSeatsExpected:        10,
 			additionalLatencyExpected: 50 * time.Millisecond,
 		},
 	}
@@ -451,8 +509,11 @@ func TestWorkEstimator(t *testing.T) {
 			watchCountsFn := func(_ *apirequest.RequestInfo) int {
 				return test.watchCount
 			}
+			maxSeatsFn := func(_ string) uint64 {
+				return test.maxSeats
+			}
 
-			estimator := NewWorkEstimator(countsFn, watchCountsFn, defaultCfg)
+			estimator := NewWorkEstimator(countsFn, watchCountsFn, defaultCfg, maxSeatsFn)
 
 			req, err := http.NewRequest("GET", test.requestURI, nil)
 			if err != nil {


### PR DESCRIPTION
Cherry pick of #118601 on release-1.27.

#118601: priority & fairness: support dynamically configuring work

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```