### PR TITLE
Revert "Add node-env and instance-type flags to node-e2e tests"

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -95,11 +95,9 @@ if [ "${remote}" = true ] && [ "${remote_mode}" = gce ] ; then
   image_project=${IMAGE_PROJECT:-"cos-cloud"}
   metadata=${INSTANCE_METADATA:-""}
   gubernator=${GUBERNATOR:-"false"}
-  instance_type=${INSTANCE_TYPE:-""}
-  node_env="${NODE_ENV:-""}"
   image_config_file=${IMAGE_CONFIG_FILE:-""}
   image_config_dir=${IMAGE_CONFIG_DIR:-""}
-  use_dockerized_build=${USE_DOCKERIZED_BUILD:-"false"}
+  use_dockerized_build=${USE_DOCKERIZED_BUILD:-""}
   target_build_arch=${TARGET_BUILD_ARCH:-""}
   runtime_config=${RUNTIME_CONFIG:-""}
   if [[ ${hosts} == "" && ${images} == "" && ${image_config_file} == "" ]]; then
@@ -161,26 +159,11 @@ if [ "${remote}" = true ] && [ "${remote_mode}" = gce ] ; then
   echo "Project: ${project}"
   echo "Image Project: ${image_project}"
   echo "Compute/Zone: ${zone}"
-  if [[ -n ${images} ]]; then
-    echo "Images: ${images}"
-  fi
-  if [[ -n ${hosts} ]]; then
-    echo "Hosts: ${hosts}"
-  fi
-  echo "Test Args: ${test_args}"
+  echo "Images: ${images}"
+  echo "Hosts: ${hosts}"
   echo "Ginkgo Flags: ${ginkgoflags}"
-  if [[ -n ${metadata} ]]; then
-    echo "Instance Metadata: ${metadata}"
-  fi
-  if [[ -n ${node_env} ]]; then
-    echo "Node-env: \"${node_env}\""
-  fi
-  if [[ -n ${image_config_file} ]]; then
-    echo "Image Config File: ${image_config_dir}/${image_config_file}"
-  fi
-  if [[ -n ${instance_type} ]]; then
-    echo "Instance Type: ${instance_type}"
-  fi
+  echo "Instance Metadata: ${metadata}"
+  echo "Image Config File: ${image_config_file}"
   echo "Kubelet Config File: ${kubelet_config_file}"
 
   # Invoke the runner
@@ -193,8 +176,8 @@ if [ "${remote}" = true ] && [ "${remote_mode}" = gce ] ; then
     --image-config-file="${image_config_file}" --system-spec-name="${system_spec_name}" \
     --runtime-config="${runtime_config}" --preemptible-instances="${preemptible_instances}" \
     --ssh-user="${ssh_user}" --ssh-key="${ssh_key}" --ssh-options="${ssh_options}" \
-    --image-config-dir="${image_config_dir}" --node-env="${node_env}" \
-    --use-dockerized-build="${use_dockerized_build}" --instance-type="${instance_type}" \
+    --image-config-dir="${image_config_dir}" \
+    --use-dockerized-build="${use_dockerized_build}" \
     --target-build-arch="${target_build_arch}" \
     --extra-envs="${extra_envs}" --kubelet-config-file="${kubelet_config_file}"  --test-suite="${test_suite}" \
     "${timeout_arg}" \

--- a/test/e2e_node/remote/gce/gce_runner.go
+++ b/test/e2e_node/remote/gce/gce_runner.go
@@ -74,7 +74,6 @@ var project = flag.String("project", "", "gce project the hosts live in (gce)")
 var zone = flag.String("zone", "", "gce zone that the hosts live in (gce)")
 var instanceMetadata = flag.String("instance-metadata", "", "key/value metadata for instances separated by '=' or '<', 'k=v' means the key is 'k' and the value is 'v'; 'k<p' means the key is 'k' and the value is extracted from the local path 'p', e.g. k1=v1,k2<p2  (gce)")
 var imageProject = flag.String("image-project", "", "gce project the hosts live in  (gce)")
-var instanceType = flag.String("instance-type", "e2-medium", "GCP Machine type to use for test")
 var preemptibleInstances = flag.Bool("preemptible-instances", false, "If true, gce instances will be configured to be preemptible  (gce)")
 
 func init() {
@@ -83,7 +82,7 @@ func init() {
 
 const (
 	defaultGCEMachine             = "n1-standard-1"
-	acceleratorTypeResourceFormat = "https://www.googleapis.com/compute/v1/projects/%s/zones/%s/acceleratorTypes/%s"
+	acceleratorTypeResourceFormat = "https://www.googleapis.com/compute/beta/projects/%s/zones/%s/acceleratorTypes/%s"
 )
 
 type GCERunner struct {
@@ -765,9 +764,7 @@ func (g *GCERunner) updateKernelArguments(instance *compute.Instance, image stri
 }
 
 func (g *GCERunner) machineType(machine string) string {
-	if machine == "" && *instanceType != "" {
-		machine = *instanceType
-	} else {
+	if machine == "" {
 		machine = defaultGCEMachine
 	}
 	return fmt.Sprintf("zones/%s/machineTypes/%s", *zone, machine)


### PR DESCRIPTION
Reverts kubernetes/kubernetes#119513


This change causes all the `kubetest2` related CI jobs abort due to `node-env` is not set correctly, pls see [here](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-node-arm64-ubuntu-serial/1682651510309130240/artifacts/build-log.txt).

The failure starts from 22/7 when the pr is merged, check it out from here: https://testgrid.k8s.io/sig-node-kubelet#kubelet-gce-e2e-arm64-ubuntu-serial&width=90&show-stale-tests=

> Kubelet Config File: test/e2e_node/jenkins/default-kubelet-config.yaml
invalid value "" for flag -node-env: invalid env string 

/assign @dims @upodroid 