### PR TITLE
Fix kubectl apply secret does not remove key

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -711,6 +711,9 @@ See https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts`
 		annotationMap := metadata.GetAnnotations()
 		if _, ok := annotationMap[corev1.LastAppliedConfigAnnotation]; !ok {
 			fmt.Fprintf(o.ErrOut, warningNoLastAppliedConfigAnnotation, info.ObjectName(), corev1.LastAppliedConfigAnnotation, o.cmdBaseName)
+			if err := util.CreateApplyAnnotation(info.Object, unstructured.UnstructuredJSONScheme); err != nil {
+				return err
+			}
 		}
 
 		patcher, err := newPatcher(o, info, helper)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

What type of PR is this?
/kind bug

What this PR does / why we need it:
I have created a secret using:
`kubectl create secret generic data-secret --from-literal=firstEntry=first --from-literal=secondEntry=second` 
and get the yaml representation:
 `kubectl get secret data-secret -o yaml > 1.yaml`
This is 1.yaml:
```
apiVersion: v1
data:
  firstEntry: Zmlyc3Q=
  secondEntry: c2Vjb25k
kind: Secret
metadata:
  creationTimestamp: "2023-07-26T01:59:26Z"
  name: data-secret
  namespace: default
  resourceVersion: "617"
  uid: 673b58a0-6879-4ec1-8314-aa24765368a2
type: Opaque
```
Then edit this yaml,remove "secondEntry: c2Vjb25k" and run `kubectl apply -f 1.yaml`
And run  `kubectl get secret data-secret -o yaml > 2.yaml`
This is 2.yaml:
```
apiVersion: v1
data:
  firstEntry: Zmlyc3Q=
  secondEntry: c2Vjb25k
kind: Secret
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{"firstEntry":"Zmlyc3Q="},"kind":"Secret","metadata":{"annotations":{},"creationTimestamp":"2023-07-26T01:59:26Z","name":"data-secret","namespace":"default","resourceVersion":"617","uid":"673b58a0-6879-4ec1-8314-aa24765368a2"},"type":"Opaque"}
  creationTimestamp: "2023-07-26T01:59:26Z"
  name: data-secret
  namespace: default
  resourceVersion: "737"
  uid: 673b58a0-6879-4ec1-8314-aa24765368a2
type: Opaque
```
I found that the data from annotations are different from the actual data.
I tried using util.CreateApplyAnnotation() to add annotations to resources that were not created using the 'kubectl apply' , and it resolved the issue. However, it still needs to be confirmed by someone with more experience."
Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1453

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
