### PR TITLE
fix unusable secret manifest for type docker-registry

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -58,7 +59,7 @@ var (
 		  kubectl create secret docker-registry my-secret --docker-server=DOCKER_REGISTRY_SERVER --docker-username=DOCKER_USER --docker-password=DOCKER_PASSWORD --docker-email=DOCKER_EMAIL
 
 		  # Create a new secret named my-secret from ~/.docker/config.json
-		  kubectl create secret docker-registry my-secret --from-file=.dockerconfigjson=path/to/.docker/config.json`))
+		  kubectl create secret docker-registry my-secret --from-file=path/to/.docker/config.json`))
 )
 
 // DockerConfigJSON represents a local docker auth config file
@@ -152,7 +153,11 @@ func NewCmdCreateSecretDockerRegistry(f cmdutil.Factory, ioStreams genericioopti
 	cmd.Flags().StringVar(&o.Email, "docker-email", o.Email, i18n.T("Email for Docker registry"))
 	cmd.Flags().StringVar(&o.Server, "docker-server", o.Server, i18n.T("Server location for Docker registry"))
 	cmd.Flags().BoolVar(&o.AppendHash, "append-hash", o.AppendHash, "Append a hash of the secret to its name.")
-	cmd.Flags().StringSliceVar(&o.FileSources, "from-file", o.FileSources, "Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid secret key.")
+	cmd.Flags().StringSliceVar(&o.FileSources, "from-file", o.FileSources, "Key files can be specified using their file path, "+
+		"in which case a default name of "+corev1.DockerConfigJsonKey+" will be given to them, "+
+		"or optionally with a name and file path, in which case the given name will be used. "+
+		"Specifying a directory will iterate each named file in the directory that is a valid secret key. "+
+		"For this command, the key should always be "+corev1.DockerConfigJsonKey+".")
 
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 
@@ -204,6 +209,11 @@ func (o *CreateSecretDockerRegistryOptions) Complete(f cmdutil.Factory, cmd *cob
 		return err
 	}
 
+	for i := range o.FileSources {
+		if !strings.Contains(o.FileSources[i], "=") {
+			o.FileSources[i] = corev1.DockerConfigJsonKey + "=" + o.FileSources[i]
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

```shell
(⎈|kind-firefly:N/A)➜  kubernetes git:(fix-kubectl-1439) ✗ kubectl create secret docker-registry demo --from-file=/Users/kiki/.docker/config.json
error: failed to create secret Secret "demo" is invalid: data[.dockerconfigjson]: Required value
(⎈|kind-firefly:N/A)➜  kubernetes git:(fix-kubectl-1439) ✗ ./_output/bin/kubectl create secret docker-registry demo --from-file=/Users/kiki/.docker/config.json
secret/demo created
(⎈|kind-firefly:N/A)➜  kubernetes git:(fix-kubectl-1439) ✗ kubectl get secret
NAME   TYPE                             DATA   AGE
demo   kubernetes.io/dockerconfigjson   1      6s
(⎈|kind-firefly:N/A)➜  kubernetes git:(fix-kubectl-1439) ✗ kubectl get secret demo -ojsonpath='{.data.\.dockerconfigjson}' | base64 -D
{
  "auths": {
    "daocloud.io": {},
    "ghcr.io": {},
    "https://index.docker.io/v1/": {},
    "registry.redhat.io": {}
  },
  "credsStore": "desktop"
}
(⎈|kind-firefly:N/A)➜  kubernetes git:(fix-kubectl-1439) ✗ cat /Users/kiki/.docker/config.json
{
  "auths": {
    "daocloud.io": {},
    "ghcr.io": {},
    "https://index.docker.io/v1/": {},
    "registry.redhat.io": {}
  },
  "credsStore": "desktop"
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1439

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl support both:
- kubectl create secret docker-registry <NAME> --from-file=<path/to/.docker/config.json>
- kubectl create secret docker-registry <NAME> --from-file=.dockerconfigjson=<path/to/.docker/config.json>
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
