### PR TITLE
Kubeadm: check health status of all control plane components in wait-control-plane phase for inti 

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/controlplane"
+
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
 )
@@ -103,6 +104,11 @@ func runWaitControlPlanePhase(c workflow.RunData) error {
 	clusterConfig := data.Cfg().ClusterConfiguration
 	if features.Enabled(clusterConfig.FeatureGates, features.WaitForAllControlPlaneComponents) {
 		waitForControlPlaneComponentsFunc = func() error {
+			if data.DryRun() {
+				fmt.Println("[dryrun] Would wait for the control plane components to be ready")
+				return nil
+			}
+
 			return controlplane.WaitForControlPlaneComponents(
 				controlplane.ControlPlaneComponents,
 				data.Cfg().Timeouts.ControlPlaneComponentHealthCheck.Duration,

--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -38,8 +38,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
-	"k8s.io/kubernetes/cmd/kubeadm/app/phases/controlplane"
 	kubeletphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubelet"
 	patchnodephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/patchnode"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
@@ -218,21 +216,6 @@ func runKubeletStartJoinPhase(c workflow.RunData) (returnErr error) {
 	if err := waitForTLSBootstrappedClient(cfg.Timeouts.TLSBootstrap.Duration); err != nil {
 		fmt.Printf(kubeadmJoinFailMsg, err)
 		return err
-	}
-
-	if cfg.ControlPlane != nil && features.Enabled(initCfg.FeatureGates, features.WaitForAllControlPlaneComponents) {
-		fmt.Println("[kubelet-start] Wait for control plane components")
-		timeout := 40 * time.Second
-		err := controlplane.WaitForControlPlaneComponents(
-			controlplane.ControlPlaneComponents,
-			timeout,
-			data.ManifestDir(),
-			data.KubeletDir(),
-			initCfg.CertificatesDir)
-		if err != nil {
-			return err
-		}
-
 	}
 
 	// When we know the /etc/kubernetes/kubelet.conf file is available, get the client

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -38,6 +38,8 @@ const (
 	EtcdLearnerMode = "EtcdLearnerMode"
 	// UpgradeAddonsBeforeControlPlane is expected to be in deprecated in v1.28 and will be removed in future release
 	UpgradeAddonsBeforeControlPlane = "UpgradeAddonsBeforeControlPlane"
+	// WaitForAllControlPlaneComponents is expected to be in v1.29
+	WaitForAllControlPlaneComponents = "WaitForAllControlPlaneComponents"
 )
 
 // InitFeatureGates are the default feature gates for the init command
@@ -52,6 +54,7 @@ var InitFeatureGates = FeatureList{
 		FeatureSpec:        featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Deprecated},
 		DeprecationMessage: "The UpgradeAddonsBeforeControlPlane feature gate is deprecated and will be removed in a future release.",
 	},
+	WaitForAllControlPlaneComponents: {FeatureSpec: featuregate.FeatureSpec{Default: false}},
 }
 
 // Feature represents a feature being gated

--- a/cmd/kubeadm/app/phases/controlplane/components.go
+++ b/cmd/kubeadm/app/phases/controlplane/components.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	kubeletconfig "k8s.io/kubelet/config/v1beta1"
+
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
+)
+
+var ControlPlaneComponents = []string{
+	kubeadmconstants.KubeAPIServer,
+	kubeadmconstants.KubeControllerManager,
+	kubeadmconstants.KubeScheduler,
+}
+
+type component struct {
+	name    string
+	labels  map[string]string
+	touched bool
+}
+
+// WaitForControlPlaneComponent wait for control plane component to be ready by check pod status returned by kubelet
+func WaitForControlPlaneComponents(componentNames []string, timeout time.Duration, manifestDir, kubeletDir, certificatesDir string) error {
+	certFile := filepath.Join(certificatesDir, kubeadmconstants.APIServerKubeletClientCertName)
+	keyFile := filepath.Join(certificatesDir, kubeadmconstants.APIServerKubeletClientKeyName)
+
+	client, err := rest.HTTPClientFor(&rest.Config{
+		TLSClientConfig: rest.TLSClientConfig{
+			CertFile: certFile,
+			KeyFile:  keyFile,
+			Insecure: true,
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to create kubelet client")
+	}
+
+	kubeletEndpoint, err := getKubeletEndpoint(filepath.Join(kubeletDir, kubeadmconstants.KubeletConfigurationFileName))
+	if err != nil {
+		return errors.Wrap(err, "failed to get kubelet endpoint")
+	}
+
+	components := make([]*component, len(componentNames))
+	for i, name := range componentNames {
+		labels, err := getComponentLabels(name, manifestDir)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get pod labels of %s component", name)
+		}
+
+		components[i] = &component{name, labels, false}
+	}
+
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
+		klog.V(1).Infoln("[control-plane] polling status of control plane components...")
+
+		resp, err := client.Get(kubeletEndpoint)
+		if err != nil {
+			fmt.Printf("[kubelet client] Error getting pods [%v]\n", err)
+			return false, nil
+		}
+
+		defer resp.Body.Close()
+
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Printf("[kubelet client] Error reading pods from response body [%v]\n", err)
+			return false, nil
+		}
+
+		pods := &v1.PodList{}
+		if err := json.Unmarshal(data, pods); err != nil {
+			fmt.Printf("[kubelet client] Error parsing pods from response body [%v]\n", err)
+			return false, nil
+		}
+
+		for _, comp := range components {
+			labels := comp.labels
+		match_pod:
+			for _, pod := range pods.Items {
+				podLabels := pod.ObjectMeta.Labels
+				for key, value := range labels {
+					if podLabels[key] != value {
+						continue match_pod
+					}
+				}
+
+				comp.touched = true
+
+				for _, status := range pod.Status.ContainerStatuses {
+					if !status.Ready {
+						klog.V(1).Infof("[control-plane] component: %s is not ready\n", comp.name)
+						return false, nil
+					}
+				}
+
+				klog.V(1).Infof("[control-plane] component: %s is ready\n", comp.name)
+			}
+		}
+
+		for _, comp := range components {
+			if !comp.touched {
+				fmt.Printf("[kubelet client] Couldn`t find pod for component: %s with labels: [%v]\n", comp.name, comp.labels)
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+}
+
+func getKubeletEndpoint(configFile string) (string, error) {
+	config := &kubeletconfig.KubeletConfiguration{}
+
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		return "", err
+	}
+
+	if err := yaml.Unmarshal(data, config); err != nil {
+		return "", err
+	}
+
+	kubeletPort := config.Port
+	if kubeletPort == 0 {
+		kubeletPort = kubeadmconstants.KubeletPort
+	}
+
+	return fmt.Sprintf("https://127.0.0.1:%d/pods", kubeletPort), nil
+}
+
+func getComponentLabels(component string, manifestDir string) (map[string]string, error) {
+	pod, err := staticpod.ReadStaticPodFromDisk(kubeadmconstants.GetStaticPodFilepath(component, manifestDir))
+	if err != nil {
+		return nil, err
+	}
+
+	labels := pod.ObjectMeta.Labels
+	if labels == nil {
+		return nil, errors.New("Empty labels")
+	}
+
+	return labels, nil
+}

--- a/cmd/kubeadm/app/phases/controlplane/components.go
+++ b/cmd/kubeadm/app/phases/controlplane/components.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
 )
 
+// ControlPlaneComponents contains all components in control plane
 var ControlPlaneComponents = []string{
 	kubeadmconstants.KubeAPIServer,
 	kubeadmconstants.KubeControllerManager,
@@ -50,7 +51,7 @@ type component struct {
 	touched bool
 }
 
-// WaitForControlPlaneComponent wait for control plane component to be ready by check pod status returned by kubelet
+// WaitForControlPlaneComponents wait for control plane component to be ready by check pod status returned by kubelet
 func WaitForControlPlaneComponents(componentNames []string, timeout time.Duration, manifestDir, kubeletDir, certificatesDir string) error {
 	certFile := filepath.Join(certificatesDir, kubeadmconstants.APIServerKubeletClientCertName)
 	keyFile := filepath.Join(certificatesDir, kubeadmconstants.APIServerKubeletClientKeyName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixed kubeadm init command of wait-control-plane phase dose not check health status of all control plane components

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [kubernetes/kubeadm#2907](https://github.com/kubernetes/kubeadm/issues/2907)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```docs
kubeadm: 
Introduce a new feature: `WaitForAllControlPlaneComponents` to support waiting for all control plane components  to be ready, when creating a control plane node with `init` or `join` sub command
```
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
