### PR TITLE
Automated cherry pick of #118549: fix 'pod' in kubelet prober metrics

### DIFF
--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -18,9 +18,7 @@ package prober
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
-	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -28,7 +26,6 @@ import (
 	"k8s.io/component-base/metrics"
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
-	"k8s.io/kubernetes/pkg/apis/apps"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
 )
@@ -115,12 +112,10 @@ func newWorker(
 		w.initialValue = results.Unknown
 	}
 
-	podName := getPodLabelName(w.pod)
-
 	basicMetricLabels := metrics.Labels{
 		"probe_type": w.probeType.String(),
 		"container":  w.container.Name,
-		"pod":        podName,
+		"pod":        w.pod.Name,
 		"namespace":  w.pod.Namespace,
 		"pod_uid":    string(w.pod.UID),
 	}
@@ -128,7 +123,7 @@ func newWorker(
 	proberDurationLabels := metrics.Labels{
 		"probe_type": w.probeType.String(),
 		"container":  w.container.Name,
-		"pod":        podName,
+		"pod":        w.pod.Name,
 		"namespace":  w.pod.Namespace,
 	}
 
@@ -336,16 +331,4 @@ func deepCopyPrometheusLabels(m metrics.Labels) metrics.Labels {
 		ret[k] = v
 	}
 	return ret
-}
-
-func getPodLabelName(pod *v1.Pod) string {
-	podName := pod.Name
-	if pod.GenerateName != "" {
-		podNameSlice := strings.Split(pod.Name, "-")
-		podName = strings.Join(podNameSlice[:len(podNameSlice)-1], "-")
-		if label, ok := pod.GetLabels()[apps.DefaultDeploymentUniqueLabelKey]; ok {
-			podName = strings.ReplaceAll(podName, fmt.Sprintf("-%s", label), "")
-		}
-	}
-	return podName
 }

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/kubernetes/pkg/apis/apps"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/pkg/kubelet/status"
@@ -492,51 +491,4 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 	msg = "Started, probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
-}
-
-func TestGetPodLabelName(t *testing.T) {
-	testCases := []struct {
-		name   string
-		pod    *v1.Pod
-		result string
-	}{
-		{
-			name: "Static pod",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "kube-controller-manager-k8s-master-21385161-0",
-				},
-			},
-			result: "kube-controller-manager-k8s-master-21385161-0",
-		},
-		{
-			name: "Deployment pod",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:         "coredns-845757d86-ccqpf",
-					GenerateName: "coredns-845757d86-",
-					Labels: map[string]string{
-						apps.DefaultDeploymentUniqueLabelKey: "845757d86",
-					},
-				},
-			},
-			result: "coredns",
-		},
-		{
-			name: "ReplicaSet pod",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:         "kube-proxy-2gmqn",
-					GenerateName: "kube-proxy-",
-				},
-			},
-			result: "kube-proxy",
-		},
-	}
-	for _, test := range testCases {
-		ret := getPodLabelName(test.pod)
-		if ret != test.result {
-			t.Errorf("Expected %s, got %s", test.result, ret)
-		}
-	}
 }


### PR DESCRIPTION
Cherry pick of #118549 on release-1.27.

#118549: fix 'pod' in kubelet prober metrics

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.25 regression to revert kubelet prober metrics `pod` tag to include actual pod name
```
