### PR TITLE
Fix nil pointer dereference in addCRIPodContainerStats to resolve runtime panic in TestListPodStatsStrictlyFromCRIChanges test

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider_windows.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows.go
@@ -87,6 +87,11 @@ func (p *criStatsProvider) addCRIPodContainerStats(criSandboxStat *runtimeapi.Po
 	podSandbox *runtimeapi.PodSandbox,
 	rootFsInfo *cadvisorapiv2.FsInfo,
 	updateCPUNanoCoreUsage bool) {
+	// Check if criSandboxStat or criSandboxStat.Windows is nil before proceeding
+    	if criSandboxStat == nil || criSandboxStat.Windows == nil {
+        log.Println("Error: criSandboxStat or criSandboxStat.Windows is nil, skipping container processing.")
+        return
+    	}
 	for _, criContainerStat := range criSandboxStat.Windows.Containers {
 		container, found := containerMap[criContainerStat.Attributes.Id]
 		if !found {


### PR DESCRIPTION
What type of PR is this?
Bug Fix

What this PR does / why we need it:
This PR addresses a runtime panic caused by a nil pointer dereference in the `addCRIPodContainerStats` function. The issue occurs when `criSandboxStat` or `criSandboxStat.Windows` is nil during container processing. This PR adds a check to ensure that these values are not nil before proceeding, avoiding the panic.

Which issue(s) this PR fixes:
Fixes  #119565

Special notes for your reviewer:
Please review the changes in `cri_stats_provider_windows.go`. The fix has been verified locally by running the affected test case "TestListPodStatsStrictlyFromCRIChanges," and it no longer encounters the panic.

Does this PR introduce a user-facing change?
No

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A