### PR TITLE
component-base/tracing: set reconnection period to reasonable value

### DIFF
--- a/staging/src/k8s.io/component-base/tracing/utils.go
+++ b/staging/src/k8s.io/component-base/tracing/utils.go
@@ -19,6 +19,7 @@ package tracing
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -63,6 +64,7 @@ func NewProvider(ctx context.Context,
 		opts = append(opts, otlptracegrpc.WithEndpoint(*tracingConfig.Endpoint))
 	}
 	opts = append(opts, otlptracegrpc.WithInsecure())
+	opts = append(opts, otlptracegrpc.WithReconnectionPeriod(time.Second*10))
 	exporter, err := otlptracegrpc.New(ctx, opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Today, when the otel endpoint is not available the span exporter blocks on every request (hypothesis, @logicalhan or other might be able to confirm). This leads to degradation of the kube-apiserver effectively, showing up like this in the logs:

```
2023/07/26 22:02:31 max retry time elapsed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 10.96.182.143:4317: connect: connection refused"
```

Setting the reconnection period is supposed to change that:
```
// WithReconnectionPeriod set the minimum amount of time between connection
// attempts to the target endpoint.
```

```release-note
Backoff on connection attempts to an OpenTelemetry endpoint avoiding degradation of kube-apiserver when the endpoint is not available.
```