### PR TITLE
Limit intstr.Parse() to 32-bit integer parsing

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr_test.go
@@ -264,3 +264,63 @@ func TestGetValueFromIntOrPercentNil(t *testing.T) {
 		t.Errorf("expected error got none")
 	}
 }
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		input  string
+		output IntOrString
+	}{
+		{
+			input:  "0",
+			output: IntOrString{Type: Int, IntVal: 0},
+		},
+		{
+			input:  "2147483647", // math.MaxInt32
+			output: IntOrString{Type: Int, IntVal: 2147483647},
+		},
+		{
+			input:  "-2147483648", // math.MinInt32
+			output: IntOrString{Type: Int, IntVal: -2147483648},
+		},
+		{
+			input:  "2147483648", // math.MaxInt32+1
+			output: IntOrString{Type: String, StrVal: "2147483648"},
+		},
+		{
+			input:  "-2147483649", // math.MinInt32-1
+			output: IntOrString{Type: String, StrVal: "-2147483649"},
+		},
+		{
+			input:  "9223372036854775807", // math.MaxInt64
+			output: IntOrString{Type: String, StrVal: "9223372036854775807"},
+		},
+		{
+			input:  "-9223372036854775808", // math.MinInt64
+			output: IntOrString{Type: String, StrVal: "-9223372036854775808"},
+		},
+		{
+			input:  "9223372036854775808", // math.MaxInt64+1
+			output: IntOrString{Type: String, StrVal: "9223372036854775808"},
+		},
+		{
+			input:  "-9223372036854775809", // math.MinInt64-1
+			output: IntOrString{Type: String, StrVal: "-9223372036854775809"},
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("test case %d", i)
+		value := Parse(test.input)
+		if test.output.Type != value.Type {
+			t.Errorf("expected type %d (%v), but got %d (%v)", test.output.Type, test.output, value.Type, value)
+			continue
+		}
+		if value.Type == Int && test.output.IntVal != value.IntVal {
+			t.Errorf("expected int value %d (%v), but got %d (%v)", test.output.IntVal, test.output, value.IntVal, value)
+			continue
+		}
+		if value.Type == String && test.output.StrVal != value.StrVal {
+			t.Errorf("expected string value %q (%v), but got %q (%v)", test.output.StrVal, test.output, value.StrVal, value)
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently, intstr.Parse() attempts to parse its input using strconv.Atoi(); if that succeeds, it stores the result using FromInt(). This means that integer values which fit in int but not in int32 end up corrupted, even though IntOrString can store them correctly (as a string).

This changes intstr.Parse() to use strconv.ParseInt(), limiting the input size to 32 bits. Thus values larger than that are stored correctly using a string.

This is extracted from #119285, with unit tests added. See #119370 for further context.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @thockin