### PR TITLE
Automated cherry pick of #117710: e2e_node: move getSampleDevicePluginPod to

### DIFF
--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -779,3 +779,26 @@ func matchContainerDevices(ident string, contDevs []*kubeletpodresourcesv1.Conta
 	}
 	return nil
 }
+
+// getSampleDevicePluginPod returns the Sample Device Plugin pod to be used e2e tests.
+func getSampleDevicePluginPod(pluginSockDir string) *v1.Pod {
+	data, err := e2etestfiles.Read(SampleDevicePluginDSYAML)
+	if err != nil {
+		framework.Fail(err.Error())
+	}
+
+	ds := readDaemonSetV1OrDie(data)
+	dp := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: SampleDevicePluginName,
+		},
+		Spec: ds.Spec.Template.Spec,
+	}
+	for i := range dp.Spec.Containers[0].Env {
+		if dp.Spec.Containers[0].Env[i].Name == SampleDeviceEnvVarNamePluginSockDir {
+			dp.Spec.Containers[0].Env[i].Value = pluginSockDir
+		}
+	}
+
+	return dp
+}

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -24,10 +24,8 @@ import (
 	"sync"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	internalapi "k8s.io/cri-api/pkg/apis"
@@ -246,29 +244,6 @@ func getContainerImageFromE2ETestDaemonset(dsYamlPath string) (string, error) {
 		return "", fmt.Errorf("failed to parse the container image: cannot extract the container from YAML")
 	}
 	return ds.Spec.Template.Spec.Containers[0].Image, nil
-}
-
-// getSampleDevicePluginPod returns the Sample Device Plugin pod to be used e2e tests.
-func getSampleDevicePluginPod(pluginSockDir string) *v1.Pod {
-	data, err := e2etestfiles.Read(SampleDevicePluginDSYAML)
-	if err != nil {
-		framework.Fail(err.Error())
-	}
-
-	ds := readDaemonSetV1OrDie(data)
-	dp := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: SampleDevicePluginName,
-		},
-		Spec: ds.Spec.Template.Spec,
-	}
-	for i := range dp.Spec.Containers[0].Env {
-		if dp.Spec.Containers[0].Env[i].Name == SampleDeviceEnvVarNamePluginSockDir {
-			dp.Spec.Containers[0].Env[i].Value = pluginSockDir
-		}
-	}
-
-	return dp
 }
 
 // getSRIOVDevicePluginImage returns the image of SRIOV device plugin.


### PR DESCRIPTION
Cherry pick of #117710 on release-1.25.

#117710: e2e_node: move getSampleDevicePluginPod to

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```