### PR TITLE
Fix NCC-E003660-R44: Authentication Source Not Shown in Audit Logs

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/interfaces.go
@@ -23,6 +23,20 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
+const (
+	// AuthenticatorAnnotationKey is the key used to indicate which authenticator
+	// was used to authenticate a request.
+	AuthenticatorAnnotationKey = "authentication.k8s.io/authenticator"
+	// the following are the names of the authenticators that are supported
+	// by the apiserver.  These are the values that should be used in the
+	// AuthenticatorAnnotationKey.
+	AnonymousAuthenticator     = "anonymous"
+	BearerTokenAuthenticator   = "bearerToken"
+	RequestHeaderAuthenticator = "requestHeader"
+	WebsocketAuthenticator     = "websocket"
+	X509Authenticator          = "x509"
+)
+
 // Token checks a string value against a backing authentication store and
 // returns a Response or an error if the token could not be checked.
 type Token interface {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous.go
@@ -19,6 +19,7 @@ package anonymous
 import (
 	"net/http"
 
+	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
@@ -32,6 +33,7 @@ const (
 func NewAuthenticator() authenticator.Request {
 	return authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
 		auds, _ := authenticator.AudiencesFrom(req.Context())
+		audit.AddAuditAnnotation(req.Context(), authenticator.AuthenticatorAnnotationKey, authenticator.AnonymousAuthenticator)
 		return &authenticator.Response{
 			User: &user.DefaultInfo{
 				Name:   anonymousUser,

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"strings"
 
+	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/warning"
 )
@@ -72,5 +73,6 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.R
 		err = invalidToken
 	}
 
+	audit.AddAuditAnnotation(req.Context(), authenticator.AuthenticatorAnnotationKey, authenticator.BearerTokenAuthenticator)
 	return resp, ok, err
 }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"strings"
 
+	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	x509request "k8s.io/apiserver/pkg/authentication/request/x509"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -165,6 +166,7 @@ func (a *requestHeaderAuthRequestHandler) AuthenticateRequest(req *http.Request)
 	// clear headers used for authentication
 	ClearAuthenticationHeaders(req.Header, a.nameHeaders, a.groupHeaders, a.extraHeaderPrefixes)
 
+	audit.AddAuditAnnotation(req.Context(), authenticator.AuthenticatorAnnotationKey, authenticator.RequestHeaderAuthenticator)
 	return &authenticator.Response{
 		User: &user.DefaultInfo{
 			Name:   name,

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/websocket/protocol.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/websocket/protocol.go
@@ -25,6 +25,7 @@ import (
 	"unicode/utf8"
 
 	"k8s.io/apimachinery/pkg/util/httpstream/wsstream"
+	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 )
 
@@ -97,6 +98,7 @@ func (a *ProtocolAuthenticator) AuthenticateRequest(req *http.Request) (*authent
 		// https://tools.ietf.org/html/rfc6455#section-11.3.4 indicates the Sec-WebSocket-Protocol header may appear multiple times
 		// in a request, and is logically the same as a single Sec-WebSocket-Protocol header field that contains all values
 		req.Header.Set(protocolHeader, strings.Join(filteredProtocols, ","))
+		audit.AddAuditAnnotation(req.Context(), authenticator.AuthenticatorAnnotationKey, authenticator.WebsocketAuthenticator)
 	}
 
 	// If the token authenticator didn't error, provide a default error

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
@@ -27,6 +27,7 @@ import (
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/component-base/metrics"
@@ -168,6 +169,7 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.R
 		}
 
 		if ok {
+			audit.AddAuditAnnotation(req.Context(), authenticator.AuthenticatorAnnotationKey, authenticator.X509Authenticator)
 			return user, ok, err
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119626 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Include the authentication source in audit logging, allowing administrators to clearly
identify which authentication method was used for a given request.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
