### PR TITLE
when kubelet restarts pid/memory/disk pressure taints will not be wiped

### DIFF
--- a/pkg/kubelet/eviction/mock_threshold_notifier_test.go
+++ b/pkg/kubelet/eviction/mock_threshold_notifier_test.go
@@ -52,6 +52,20 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
+// HasSynced mocks base method.
+func (m *MockManager) HasSynced() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasSynced")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasSynced indicates an expected call of HasSynced.
+func (mr *MockManagerMockRecorder) HasSynced() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasSynced", reflect.TypeOf((*MockManager)(nil).HasSynced))
+}
+
 // IsUnderDiskPressure mocks base method.
 func (m *MockManager) IsUnderDiskPressure() bool {
 	m.ctrl.T.Helper()

--- a/pkg/kubelet/eviction/types.go
+++ b/pkg/kubelet/eviction/types.go
@@ -67,6 +67,9 @@ type Manager interface {
 
 	// IsUnderPIDPressure returns true if the node is under PID pressure.
 	IsUnderPIDPressure() bool
+
+	// HasSynced returns true if eviction manager has executed synchronize method.
+	HasSynced() bool
 }
 
 // DiskInfoProvider is responsible for informing the manager how disk is configured.

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -740,9 +740,9 @@ func (kl *Kubelet) defaultNodeStatusFuncs() []func(context.Context, *v1.Node) er
 	setters = append(setters, nodestatus.VolumeLimits(kl.volumePluginMgr.ListVolumePluginWithLimits))
 
 	setters = append(setters,
-		nodestatus.MemoryPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderMemoryPressure, kl.recordNodeStatusEvent),
-		nodestatus.DiskPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderDiskPressure, kl.recordNodeStatusEvent),
-		nodestatus.PIDPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderPIDPressure, kl.recordNodeStatusEvent),
+		nodestatus.MemoryPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderMemoryPressure, kl.evictionManager.HasSynced, kl.recordNodeStatusEvent),
+		nodestatus.DiskPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderDiskPressure, kl.evictionManager.HasSynced, kl.recordNodeStatusEvent),
+		nodestatus.PIDPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderPIDPressure, kl.evictionManager.HasSynced, kl.recordNodeStatusEvent),
 		nodestatus.ReadyCondition(kl.clock.Now, kl.runtimeState.runtimeErrors, kl.runtimeState.networkErrors, kl.runtimeState.storageErrors,
 			validateHostFunc, kl.containerManager.Status, kl.shutdownManager.ShutdownStatus, kl.recordNodeStatusEvent, kl.supportLocalStorageCapacityIsolation()),
 		nodestatus.VolumesInUse(kl.volumeManager.ReconcilerStatesHasBeenSynced, kl.volumeManager.GetVolumesInUse),

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -1697,8 +1697,11 @@ func TestMemoryPressureCondition(t *testing.T) {
 			pressureFunc := func() bool {
 				return tc.pressure
 			}
+			hasSynced := func() bool {
+				return true
+			}
 			// construct setter
-			setter := MemoryPressureCondition(nowFunc, pressureFunc, recordEventFunc)
+			setter := MemoryPressureCondition(nowFunc, pressureFunc, hasSynced, recordEventFunc)
 			// call setter on node
 			if err := setter(ctx, tc.node); err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -1819,8 +1822,11 @@ func TestPIDPressureCondition(t *testing.T) {
 			pressureFunc := func() bool {
 				return tc.pressure
 			}
+			hasSynced := func() bool {
+				return true
+			}
 			// construct setter
-			setter := PIDPressureCondition(nowFunc, pressureFunc, recordEventFunc)
+			setter := PIDPressureCondition(nowFunc, pressureFunc, hasSynced, recordEventFunc)
 			// call setter on node
 			if err := setter(ctx, tc.node); err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -1941,8 +1947,11 @@ func TestDiskPressureCondition(t *testing.T) {
 			pressureFunc := func() bool {
 				return tc.pressure
 			}
+			hasSynced := func() bool {
+				return true
+			}
 			// construct setter
-			setter := DiskPressureCondition(nowFunc, pressureFunc, recordEventFunc)
+			setter := DiskPressureCondition(nowFunc, pressureFunc, hasSynced, recordEventFunc)
 			// call setter on node
 			if err := setter(ctx, tc.node); err != nil {
 				t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119645

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
when kubelet restarts pid/memory/disk pressure taints will not be wiped
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
