### PR TITLE
[KEP-3085] Promote PodReadyToStartContainers to beta in 1.29

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -674,8 +674,9 @@ const (
 	// Set pod completion index as a pod label for Indexed Jobs.
 	PodIndexLabel featuregate.Feature = "PodIndexLabel"
 
-	// owner: @ddebroy
+	// owner: @ddebroy, @kannon92
 	// alpha: v1.25
+	// beta: v1.29
 	//
 	// Enables reporting of PodReadyToStartContainersCondition condition in pod status after pod
 	// sandbox creation and network configuration completes successfully
@@ -1132,7 +1133,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	PodDisruptionConditions: {Default: true, PreRelease: featuregate.Beta},
 
-	PodReadyToStartContainersCondition: {Default: false, PreRelease: featuregate.Alpha},
+	PodReadyToStartContainersCondition: {Default: true, PreRelease: featuregate.Beta},
 
 	PodHostIPs: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -3367,7 +3367,7 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				LastTransitionTime: normalized_now,
 			},
 			expectedPodReadyToStartContainersCondition: v1.PodCondition{
-				Type:   kubetypes.PodReadyToStartContainers,
+				Type:   v1.PodReadyToStartContainers,
 				Status: v1.ConditionTrue,
 			},
 		},
@@ -3408,7 +3408,7 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				},
 			},
 			expectedPodReadyToStartContainersCondition: v1.PodCondition{
-				Type:   kubetypes.PodReadyToStartContainers,
+				Type:   v1.PodReadyToStartContainers,
 				Status: v1.ConditionTrue,
 			},
 		},
@@ -3448,7 +3448,7 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				},
 			},
 			expectedPodReadyToStartContainersCondition: v1.PodCondition{
-				Type:   kubetypes.PodReadyToStartContainers,
+				Type:   v1.PodReadyToStartContainers,
 				Status: v1.ConditionTrue,
 			},
 		},
@@ -3489,7 +3489,7 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				},
 			},
 			expectedPodReadyToStartContainersCondition: v1.PodCondition{
-				Type:   kubetypes.PodReadyToStartContainers,
+				Type:   v1.PodReadyToStartContainers,
 				Status: v1.ConditionFalse,
 			},
 		},
@@ -3536,7 +3536,7 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				Message: "test",
 			},
 			expectedPodReadyToStartContainersCondition: v1.PodCondition{
-				Type:   kubetypes.PodReadyToStartContainers,
+				Type:   v1.PodReadyToStartContainers,
 				Status: v1.ConditionFalse,
 			},
 		},
@@ -3590,7 +3590,7 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				Message: "test",
 			},
 			expectedPodReadyToStartContainersCondition: v1.PodCondition{
-				Type:   kubetypes.PodReadyToStartContainers,
+				Type:   v1.PodReadyToStartContainers,
 				Status: v1.ConditionFalse,
 			},
 		},
@@ -3631,7 +3631,7 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				},
 			},
 			expectedPodReadyToStartContainersCondition: v1.PodCondition{
-				Type:   kubetypes.PodReadyToStartContainers,
+				Type:   v1.PodReadyToStartContainers,
 				Status: v1.ConditionTrue,
 			},
 		},
@@ -3687,7 +3687,7 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				},
 			},
 			expectedPodReadyToStartContainersCondition: v1.PodCondition{
-				Type:   kubetypes.PodReadyToStartContainers,
+				Type:   v1.PodReadyToStartContainers,
 				Status: v1.ConditionTrue,
 			},
 		},
@@ -3747,7 +3747,7 @@ func Test_generateAPIPodStatus(t *testing.T) {
 				},
 			},
 			expectedPodReadyToStartContainersCondition: v1.PodCondition{
-				Type:   kubetypes.PodReadyToStartContainers,
+				Type:   v1.PodReadyToStartContainers,
 				Status: v1.ConditionTrue,
 			},
 		},

--- a/pkg/kubelet/status/generate.go
+++ b/pkg/kubelet/status/generate.go
@@ -247,12 +247,12 @@ func GeneratePodReadyToStartContainersCondition(pod *v1.Pod, podStatus *kubecont
 	// fresh sandbox and configure networking for the sandbox.
 	if !newSandboxNeeded {
 		return v1.PodCondition{
-			Type:   kubetypes.PodReadyToStartContainers,
+			Type:   v1.PodReadyToStartContainers,
 			Status: v1.ConditionTrue,
 		}
 	}
 	return v1.PodCondition{
-		Type:   kubetypes.PodReadyToStartContainers,
+		Type:   v1.PodReadyToStartContainers,
 		Status: v1.ConditionFalse,
 	}
 }

--- a/pkg/kubelet/status/generate_test.go
+++ b/pkg/kubelet/status/generate_test.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/utils/pointer"
 )
 
@@ -615,7 +614,7 @@ func TestGeneratePodReadyToStartContainersCondition(t *testing.T) {
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			test.expected.Type = kubetypes.PodReadyToStartContainers
+			test.expected.Type = v1.PodReadyToStartContainers
 			condition := GeneratePodReadyToStartContainersCondition(test.pod, test.status)
 			require.Equal(t, test.expected.Type, condition.Type)
 			require.Equal(t, test.expected.Status, condition.Status)

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -634,7 +634,7 @@ func (m *manager) updateStatusInternal(pod *v1.Pod, status v1.PodStatus, forceUp
 	updateLastTransitionTime(&status, &oldStatus, v1.PodInitialized)
 
 	// Set PodReadyToStartContainersCondition.LastTransitionTime.
-	updateLastTransitionTime(&status, &oldStatus, kubetypes.PodReadyToStartContainers)
+	updateLastTransitionTime(&status, &oldStatus, v1.PodReadyToStartContainers)
 
 	// Set PodScheduledCondition.LastTransitionTime.
 	updateLastTransitionTime(&status, &oldStatus, v1.PodScheduled)

--- a/pkg/kubelet/types/constants.go
+++ b/pkg/kubelet/types/constants.go
@@ -38,12 +38,3 @@ const (
 	LimitedSwap   = "LimitedSwap"
 	UnlimitedSwap = "UnlimitedSwap"
 )
-
-// Alpha conditions managed by Kubelet that are not yet part of the API. The
-// entries here should be moved to staging/src/k8s.io.api/core/v1/types.go
-// once the feature managing the condition graduates to Beta.
-const (
-	// PodReadyToStartContainers pod sandbox is successfully configured and
-	// the pod is ready to launch containers.
-	PodReadyToStartContainers = "PodReadyToStartContainers"
-)

--- a/pkg/kubelet/types/pod_status.go
+++ b/pkg/kubelet/types/pod_status.go
@@ -38,7 +38,7 @@ func PodConditionByKubelet(conditionType v1.PodConditionType) bool {
 		}
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodReadyToStartContainersCondition) {
-		if conditionType == PodReadyToStartContainers {
+		if conditionType == v1.PodReadyToStartContainers {
 			return true
 		}
 	}

--- a/pkg/kubelet/types/pod_status_test.go
+++ b/pkg/kubelet/types/pod_status_test.go
@@ -34,7 +34,7 @@ func TestPodConditionByKubelet(t *testing.T) {
 		v1.PodReady,
 		v1.PodInitialized,
 		v1.ContainersReady,
-		PodReadyToStartContainers,
+		v1.PodReadyToStartContainers,
 	}
 
 	for _, tc := range trueCases {

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2866,6 +2866,9 @@ const (
 	// DisruptionTarget indicates the pod is about to be terminated due to a
 	// disruption (such as preemption, eviction API or garbage-collection).
 	DisruptionTarget PodConditionType = "DisruptionTarget"
+	// PodReadyToStartContainers pod sandbox is successfully configured and
+	// the pod is ready to launch containers.
+	PodReadyToStartContainers PodConditionType = "PodReadyToStartContainers"
 )
 
 // These are reasons for a pod's transition to a condition.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
As part of the beta promotion for PodReadyToStartContainers (KEP 3085), we need to move the API from a kubelet constant to a api versioned condition.  

This also changes the feature gate to beta and cleans up some deprecation in the pod_conditions_test.go

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promote PodReadyToStartContainers condition to beta.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3085-pod-conditions-for-starting-completition-of-sandbox-creation
```
