### PR TITLE
Avoid pulling node-problem-detector through CDN

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -297,7 +297,7 @@ function install-node-problem-detector {
   fi
 
   echo "Downloading ${npd_tar}."
-  local -r npd_release_path="${NODE_PROBLEM_DETECTOR_RELEASE_PATH:-https://dl.k8s.io}"
+  local -r npd_release_path="${NODE_PROBLEM_DETECTOR_RELEASE_PATH:-https://storage.googleapis.com/kubernetes-release}"
   download-or-bust "${npd_hash}" "${npd_release_path}/node-problem-detector/${npd_tar}"
   local -r npd_dir="${KUBE_HOME}/node-problem-detector"
   mkdir -p "${npd_dir}"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Tests are failing with the following error:

```
[   48.754749] configure.sh[1004]: Downloading node-problem-detector-v0.8.9-linux_amd64.tar.gz.
[   48.893855] configure.sh[1145]: curl: (22) The requested URL returned error: 503
[   48.894189] configure.sh[1145]: Warning: Problem : HTTP error. Will retry in 10 seconds. 6 retries left.
```

See log: https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-alpha-features/1685581332681330688/artifacts/bootstrap-e2e-minion-group-w513/serial-1.log

Slack thread: https://kubernetes.slack.com/archives/CN0K3TE2C/p1690693604504739

Similar to #119663

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

/assign @dims @ameukam 