### PR TITLE
hack: add extractcheck into golangci-lint

### DIFF
--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -29,6 +29,7 @@ issues:
 linters:
   disable-all: false # in contrast to golangci.yaml, the default set of linters remains enabled
   enable: # please keep this alphabetized and in sync with golangci.yaml
+    - extractcheck
     - ginkgolinter
     - gocritic
     - govet
@@ -45,6 +46,10 @@ linters-settings: # please keep this alphabetized
       path: ../_output/local/bin/logcheck.so
       description: structured logging checker
       original-url: k8s.io/logtools/logcheck
+    extractcheck:
+      # Installed there by hack/verify-golangci-lint.sh.
+      path: ../_output/local/bin/extractcheck.so
+      description: SSA extract checker
   gocritic:
   staticcheck:
     checks:

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -30,6 +30,7 @@ issues:
 linters:
   disable-all: true # not disabled in golangci-strict.yaml
   enable: # please keep this alphabetized and in sync with golangci-strict.yaml
+    - extractcheck
     - ginkgolinter
     - gocritic
     - govet
@@ -46,6 +47,10 @@ linters-settings: # please keep this alphabetized
       path: ../_output/local/bin/logcheck.so
       description: structured logging checker
       original-url: k8s.io/logtools/logcheck
+    extractcheck:
+      # Installed there by hack/verify-golangci-lint.sh.
+      path: ../_output/local/bin/extractcheck.so
+      description: SSA extract checker
   gocritic:
     enabled-checks:             # not limited in golangci-strict.yaml
       - equalFold               # not limited in golangci-strict.yaml

--- a/hack/tools/extractcheck/README.md
+++ b/hack/tools/extractcheck/README.md
@@ -1,0 +1,5 @@
+This directory contains a linter for checking SSA Extract calls.
+
+Please refer to
+https://kubernetes.io/blog/2021/08/06/server-side-apply-ga/#using-server-side-apply-in-a-controller
+for SSA Extract model.

--- a/hack/tools/extractcheck/extractcheck.go
+++ b/hack/tools/extractcheck/extractcheck.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/types"
+	"path"
+	"regexp"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+type config struct {
+	matches []*regexp.Regexp
+}
+
+func newConfig() config {
+	var matches []*regexp.Regexp
+	excludeRegex := []string{
+		"k8s.io/kubernetes/test/integration/client/client_test.go",
+		"k8s.io/kubernetes/test/integration/client/dynamic_client_test.go",
+		"k8s.io/client-go/applyconfigurations/.*",
+	}
+
+	for _, f := range excludeRegex {
+		re, err := regexp.Compile(f)
+		if err != nil {
+			panic(err)
+		}
+		matches = append(matches, re)
+	}
+	return config{matches}
+}
+
+func (c config) isEnable(filename string) bool {
+	for _, r := range c.matches {
+		if matchFullString(filename, r) {
+			return false
+		}
+	}
+	return true
+}
+
+func Analyser() *analysis.Analyzer {
+	flags := flag.NewFlagSet("", flag.ExitOnError)
+	return &analysis.Analyzer{
+		Name: "extractcheck",
+		Doc:  "Tool to check SSA extract calls.",
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			return run(pass)
+		},
+		Flags: *flags,
+	}
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	c := newConfig()
+	for _, file := range pass.Files {
+		filename := pass.Pkg.Path() + "/" + path.Base(pass.Fset.Position(file.Package).Filename)
+		if !c.isEnable(filename) {
+			continue
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch n := n.(type) {
+			case *ast.CallExpr:
+				// We are interested in function calls, as we want to detect calls to
+				//   * k8s.io/apimachinery/pkg/util/managedfields.ExtractInto()
+				//   * k8s.io/client-go/applyconfigurations.Extract*()
+				checkForFunctionExpr(n, pass)
+			}
+
+			return true
+		})
+	}
+	return nil, nil
+}
+
+// checkForFunctionExpr checks if the call expression matches SSA Extract-model.
+func checkForFunctionExpr(fexpr *ast.CallExpr, pass *analysis.Pass) {
+	fun := fexpr.Fun
+
+	if selExpr, ok := fun.(*ast.SelectorExpr); ok {
+		if isExtractManagedFields(selExpr, pass) || isExtractApplyConfigrations(selExpr, pass) {
+			pass.Report(analysis.Diagnostic{
+				Pos:     fexpr.Pos(),
+				Message: fmt.Sprintf("Extract function %q should not be used because managedFields was removed in kube-controller-manager/kube-scheduler", selExpr.Sel.Name),
+			})
+		}
+	}
+}
+
+// isExtractManagedFields returns true if the type of the expression is
+// k8s.io/client-go/applyconfigurations.ExtractInto.
+func isExtractManagedFields(expr *ast.SelectorExpr, pass *analysis.Pass) bool {
+	fName := expr.Sel.Name
+	return strings.HasPrefix(fName, "ExtractInto") && fromPackage(expr.Sel, "k8s.io/apimachinery/pkg/util/managedfields", pass)
+}
+
+// isExtractApplyConfigrations returns true if the type of the expression is
+// k8s.io/client-go/applyconfigurations.Extract* (e.g. ExtractPod)
+func isExtractApplyConfigrations(expr *ast.SelectorExpr, pass *analysis.Pass) bool {
+	fName := expr.Sel.Name
+	return strings.HasPrefix(fName, "Extract") && fromPackage(expr.Sel, "k8s.io/client-go/applyconfigurations", pass)
+}
+
+// fromPackage checks whether an expression is an identifier that refers
+// to a package under target path.
+func fromPackage(expr ast.Expr, packagePath string, pass *analysis.Pass) bool {
+	if ident, ok := expr.(*ast.Ident); ok {
+		if object, ok := pass.TypesInfo.Uses[ident]; ok {
+			switch object := object.(type) {
+			case *types.Func:
+				pkg := object.Pkg()
+				if strings.HasPrefix(pkg.Path(), packagePath) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func matchFullString(str string, re *regexp.Regexp) bool {
+	loc := re.FindStringIndex(str)
+	if loc == nil {
+		// No match at all.
+		return false
+	}
+	if loc[1]-loc[0] < len(str) {
+		// Only matches a substring.
+		return false
+	}
+	return true
+}

--- a/hack/tools/extractcheck/main.go
+++ b/hack/tools/extractcheck/main.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "golang.org/x/tools/go/analysis/singlechecker"
+
+func main() {
+	singlechecker.Main(Analyser())
+}

--- a/hack/tools/extractcheck/plugin.go
+++ b/hack/tools/extractcheck/plugin.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"golang.org/x/tools/go/analysis"
+)
+
+type analyzerPlugin struct{}
+
+func (*analyzerPlugin) GetAnalyzers() []*analysis.Analyzer {
+	return []*analysis.Analyzer{
+		Analyser(),
+	}
+}
+
+// AnalyzerPlugin is the entry point for golangci-lint.
+var AnalyzerPlugin analyzerPlugin

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golangci/golangci-lint v1.53.3
 	github.com/google/go-flow-levee v0.1.5
 	go.uber.org/automaxprocs v1.5.2
+	golang.org/x/tools v0.9.3
 	gotest.tools/gotestsum v1.6.4
 	honnef.co/go/tools v0.4.3
 	sigs.k8s.io/logtools v0.5.0
@@ -187,7 +188,6 @@ require (
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/term v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
-	golang.org/x/tools v0.9.3 // indirect
 	golang.org/x/tools/go/pointer v0.1.0-deprecated // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -137,12 +137,13 @@ kube::golang::verify_go_version
 export GO111MODULE=on
 
 # Install golangci-lint
-echo "installing golangci-lint and logcheck plugin from hack/tools into ${GOBIN}"
+echo "installing golangci-lint and logcheck/extractcheck plugins from hack/tools into ${GOBIN}"
 pushd "${KUBE_ROOT}/hack/tools" >/dev/null
   go install github.com/golangci/golangci-lint/cmd/golangci-lint
   if [ "${golangci_config}" ]; then
     # This cannot be used without a config.
     go build -o "${GOBIN}/logcheck.so" -buildmode=plugin sigs.k8s.io/logtools/logcheck/plugin
+    go build -o "${GOBIN}/extractcheck.so" -buildmode=plugin ./extractcheck
   fi
 popd >/dev/null
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

The new added lint `extractcheck` checks if server-side-apply extract model is
used in kube-controller-manager and kube-scheduler code to prevent
silent failures after removal of managedFields as memory efficiency
optimizations (https://github.com/kubernetes/kubernetes/pull/119556 and https://github.com/kubernetes/kubernetes/pull/118455).


#### Which issue(s) this PR fixes:

Fixes #119658

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE