### PR TITLE
add default IPMode for service status when IPMode FG is enabled

### DIFF
--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -156,6 +156,19 @@ func SetDefaults_Service(obj *v1.Service) {
 	}
 
 }
+
+func SetDefaults_ServiceStatus(status *v1.ServiceStatus) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.LoadBalancerIPMode) {
+		ipMode := v1.LoadBalancerIPModeVIP
+
+		for i, ing := range status.LoadBalancer.Ingress {
+			if ing.IP != "" && ing.IPMode == nil {
+				status.LoadBalancer.Ingress[i].IPMode = &ipMode
+			}
+		}
+	}
+}
+
 func SetDefaults_Pod(obj *v1.Pod) {
 	// If limits are specified, but requests are not, default requests to limits
 	// This is done here rather than a more specific defaulting pass on v1.ResourceRequirements

--- a/pkg/apis/core/v1/zz_generated.defaults.go
+++ b/pkg/apis/core/v1/zz_generated.defaults.go
@@ -61,6 +61,7 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 	scheme.AddTypeDefaultingFunc(&v1.SecretList{}, func(obj interface{}) { SetObjectDefaults_SecretList(obj.(*v1.SecretList)) })
 	scheme.AddTypeDefaultingFunc(&v1.Service{}, func(obj interface{}) { SetObjectDefaults_Service(obj.(*v1.Service)) })
 	scheme.AddTypeDefaultingFunc(&v1.ServiceList{}, func(obj interface{}) { SetObjectDefaults_ServiceList(obj.(*v1.ServiceList)) })
+	scheme.AddTypeDefaultingFunc(&v1.ServiceStatus{}, func(obj interface{}) { SetObjectDefaults_ServiceStatus(obj.(*v1.ServiceStatus)) })
 	return nil
 }
 
@@ -1089,4 +1090,8 @@ func SetObjectDefaults_ServiceList(in *v1.ServiceList) {
 		a := &in.Items[i]
 		SetObjectDefaults_Service(a)
 	}
+}
+
+func SetObjectDefaults_ServiceStatus(in *v1.ServiceStatus) {
+	SetDefaults_ServiceStatus(in)
 }


### PR DESCRIPTION


#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/119452

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
add default IPMode for service status when IPMode FG is enabled
```
