### PR TITLE
Fix NCC-E003660-B4Y: Dangerous File Path Construction

### DIFF
--- a/pkg/routes/logs_test.go
+++ b/pkg/routes/logs_test.go
@@ -17,17 +17,18 @@ limitations under the License.
 package routes
 
 import (
-	"fmt"
-	"github.com/emicklei/go-restful/v3"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/emicklei/go-restful/v3"
 )
 
 func TestLogFileHandler(t *testing.T) {
-	oversizeFileName := fmt.Sprintf("%032768s", "a")
+	oversizeFileName := strings.Repeat("a", 32768)
 	tests := []struct {
 		logpath      string
 		expectedCode int
@@ -77,8 +78,8 @@ func TestLogFileHandler(t *testing.T) {
 
 func TestPreCheckLogFileNameLength(t *testing.T) {
 	// In windows, with long file name support enabled, file names can have up to 32,767 characters.
-	oversizeFileName := fmt.Sprintf("%032768s", "a")
-	normalFileName := fmt.Sprintf("%0255s", "a")
+	oversizeFileName := strings.Repeat("a", 32768)
+	normalFileName := strings.Repeat("a", 255)
 
 	// check file with oversize name.
 	if !logFileNameIsTooLong(oversizeFileName) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
According to NCC-E003660-B4Y. Although http.Server explicitly sanitizes its input,before using the "actual" path, it should be ensured that it is within the logdir directory.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119641

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
