### PR TITLE
Added test file for kubernetes/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/expansion.go

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/expansion_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/expansion_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generators
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/gengo/generator"
+	"k8s.io/gengo/namer"
+	"k8s.io/gengo/types"
+)
+
+var mockType = &types.Type{
+	Name: types.Name{
+		Package: "kubernetes/staging/src/k8s.io/code-generator/cmd/lister-gen/generators",
+		Name: "generators",
+	},
+	CommentLines: []string{
+		"RandomType defines a random structure in Kubernetes",
+		"It should be used just when you need something different than 42",
+	},
+	SecondClosestCommentLines: []string{},
+}
+
+func TestFilter(t *testing.T) {
+	g := &expansionGenerator{
+		types: []*types.Type{
+			mockType,
+		},
+	}
+	tests := []struct {
+		name	string
+		context *generator.Context
+		input 	*types.Type
+		want 	bool
+	}{
+		{
+			name: "ContextTest",
+			context: &generator.Context{
+				Namers: make(namer.NameSystems),
+				Universe: types.Universe{},
+				Inputs: []string{"package1", "package2"},
+				Verify: true,
+			},
+			input: &types.Type{},
+			want: true,
+		},
+		{
+			name: "No Inputs",
+			context: &generator.Context{
+				Namers: make(namer.NameSystems),
+				Universe: types.Universe{},
+				Verify: true,
+			},
+			input: &types.Type{},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name , func(t *testing.T) {
+			got := g.Filter(tt.context, mockType)
+			if !reflect.DeepEqual(tt.want, got) {
+				t.Errorf("Filter(%v %v) = %v, want %v",tt.context, tt.input, got, tt.want)
+			}
+			if tt.context.Namers == nil {
+				t.Errorf("Namers is nil, expected a map")
+			}
+			if tt.context.Universe == nil {
+				t.Errorf("Universe is nil, expected a Universe instance")
+			}
+			if tt.context.Inputs != nil {
+				expectedInput := []string{"package1", "package2"}
+				if !reflect.DeepEqual(expectedInput, tt.context.Inputs) {
+					t.Errorf("Received mismatched inputs")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Unit test to improve code coverage of code-generators
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Improves code coverage
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119289 
Improves test coverage of code-generators
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
