### PR TITLE
kubectl: Replace `--user` with `--user-to-bind` in role/clusterrole, old flag marked for deprecation.

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -608,7 +608,7 @@ EOF
         AUTH_ARGS="--client-key=${CERT_DIR}/client-admin.key --client-certificate=${CERT_DIR}/client-admin.crt"
     fi
     # Grant apiserver permission to speak to the kubelet
-    ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" create clusterrolebinding kube-apiserver-kubelet-admin --clusterrole=system:kubelet-api-admin --user=kube-apiserver
+    ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" create clusterrolebinding kube-apiserver-kubelet-admin --clusterrole=system:kubelet-api-admin --user-to-bind=kube-apiserver
 
     # Grant kubelets permission to request client certificates
     ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" create clusterrolebinding kubelet-csr --clusterrole=system:certificates.k8s.io:certificatesigningrequests:selfnodeclient --group=system:nodes

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
@@ -43,7 +43,7 @@ var (
 
 	clusterRoleBindingExample = templates.Examples(i18n.T(`
 		  # Create a cluster role binding for user1, user2, and group1 using the cluster-admin cluster role
-		  kubectl create clusterrolebinding cluster-admin --clusterrole=cluster-admin --user=user1 --user=user2 --group=group1`))
+		  kubectl create clusterrolebinding cluster-admin --clusterrole=cluster-admin --user-to-bind=user1 --user-to-bind=user2 --group=group1`))
 )
 
 // ClusterRoleBindingOptions is returned by NewCmdCreateClusterRoleBinding
@@ -82,7 +82,7 @@ func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, ioStreams genericiooption
 	o := NewClusterRoleBindingOptions(ioStreams)
 
 	cmd := &cobra.Command{
-		Use:                   "clusterrolebinding NAME --clusterrole=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run=server|client|none]",
+		Use:                   "clusterrolebinding NAME --clusterrole=NAME [--user-to-bind=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Create a cluster role binding for a particular cluster role"),
 		Long:                  clusterRoleBindingLong,
@@ -101,6 +101,8 @@ func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, ioStreams genericiooption
 	cmd.Flags().StringVar(&o.ClusterRole, "clusterrole", "", i18n.T("ClusterRole this ClusterRoleBinding should reference"))
 	cmd.MarkFlagRequired("clusterrole")
 	cmd.Flags().StringArrayVar(&o.Users, "user", o.Users, "Usernames to bind to the clusterrole. The flag can be repeated to add multiple users.")
+	cmd.Flags().MarkDeprecated("user", "due to the conflict with global options. Will be deleted in 1.31. Use --user-to-bind.")
+	cmd.Flags().StringArrayVar(&o.Users, "user-to-bind", o.Users, "Usernames to bind to the clusterrole. The flag can be repeated to add multiple users.")
 	cmd.Flags().StringArrayVar(&o.Groups, "group", o.Groups, "Groups to bind to the clusterrole. The flag can be repeated to add multiple groups.")
 	cmd.Flags().StringArrayVar(&o.ServiceAccounts, "serviceaccount", o.ServiceAccounts, "Service accounts to bind to the clusterrole, in the format <namespace>:<name>. The flag can be repeated to add multiple service accounts.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
@@ -42,7 +42,7 @@ var (
 
 	roleBindingExample = templates.Examples(i18n.T(`
 		# Create a role binding for user1, user2, and group1 using the admin cluster role
-		kubectl create rolebinding admin --clusterrole=admin --user=user1 --user=user2 --group=group1
+		kubectl create rolebinding admin --clusterrole=admin --user-to-bind=user1 --user-to-bind=user2 --group=group1
 
 		# Create a role binding for serviceaccount monitoring:sa-dev using the admin role
 		kubectl create rolebinding admin-binding --role=admin --serviceaccount=monitoring:sa-dev`))
@@ -87,7 +87,7 @@ func NewCmdCreateRoleBinding(f cmdutil.Factory, ioStreams genericiooptions.IOStr
 	o := NewRoleBindingOptions(ioStreams)
 
 	cmd := &cobra.Command{
-		Use:                   "rolebinding NAME --clusterrole=NAME|--role=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run=server|client|none]",
+		Use:                   "rolebinding NAME --clusterrole=NAME|--role=NAME [--user-to-bind=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Create a role binding for a particular role or cluster role"),
 		Long:                  roleBindingLong,
@@ -107,6 +107,8 @@ func NewCmdCreateRoleBinding(f cmdutil.Factory, ioStreams genericiooptions.IOStr
 	cmd.Flags().StringVar(&o.ClusterRole, "clusterrole", "", i18n.T("ClusterRole this RoleBinding should reference"))
 	cmd.Flags().StringVar(&o.Role, "role", "", i18n.T("Role this RoleBinding should reference"))
 	cmd.Flags().StringArrayVar(&o.Users, "user", o.Users, "Usernames to bind to the role. The flag can be repeated to add multiple users.")
+	cmd.Flags().MarkDeprecated("user", "due to the conflict with global options. Will be deleted in 1.31. Use --user-to-bind.")
+	cmd.Flags().StringArrayVar(&o.Users, "user-to-bind", o.Users, "Usernames to bind to the role. The flag can be repeated to add multiple users.")
 	cmd.Flags().StringArrayVar(&o.Groups, "group", o.Groups, "Groups to bind to the role. The flag can be repeated to add multiple groups.")
 	cmd.Flags().StringArrayVar(&o.ServiceAccounts, "serviceaccount", o.ServiceAccounts, "Service accounts to bind to the role, in the format <namespace>:<name>. The flag can be repeated to add multiple service accounts.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
@@ -46,10 +46,10 @@ var (
 	kubectl set subject clusterrolebinding admin --serviceaccount=namespace:serviceaccount1
 
 	# Update a role binding for user1, user2, and group1
-	kubectl set subject rolebinding admin --user=user1 --user=user2 --group=group1
+	kubectl set subject rolebinding admin --user-to-bind=user1 --user-to-bind=user2 --group=group1
 
 	# Print the result (in YAML format) of updating rolebinding subjects from a local, without hitting the server
-	kubectl create rolebinding admin --role=admin --user=admin -o yaml --dry-run=client | kubectl set subject --local -f - --user=foo -o yaml`)
+	kubectl create rolebinding admin --role=admin --user-to-bind=admin -o yaml --dry-run=client | kubectl set subject --local -f - --user-to-bind=foo -o yaml`)
 )
 
 type updateSubjects func(existings []rbacv1.Subject, targets []rbacv1.Subject) (bool, []rbacv1.Subject)
@@ -94,7 +94,7 @@ func NewSubjectOptions(streams genericiooptions.IOStreams) *SubjectOptions {
 func NewCmdSubject(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := NewSubjectOptions(streams)
 	cmd := &cobra.Command{
-		Use:                   "subject (-f FILENAME | TYPE NAME) [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run=server|client|none]",
+		Use:                   "subject (-f FILENAME | TYPE NAME) [--user-to-bind=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Update the user, group, or service account in a role binding or cluster role binding"),
 		Long:                  subjectLong,
@@ -114,6 +114,8 @@ func NewCmdSubject(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra
 	cmd.Flags().BoolVar(&o.Local, "local", o.Local, "If true, set subject will NOT contact api-server but run locally.")
 	cmdutil.AddDryRunFlag(cmd)
 	cmd.Flags().StringArrayVar(&o.Users, "user", o.Users, "Usernames to bind to the role")
+	cmd.Flags().MarkDeprecated("user", "due to the conflict with global options. Will be deleted in 1.31. Use --user-to-bind.")
+	cmd.Flags().StringArrayVar(&o.Users, "user-to-bind", o.Users, "Usernames to bind to the role")
 	cmd.Flags().StringArrayVar(&o.Groups, "group", o.Groups, "Groups to bind to the role")
 	cmd.Flags().StringArrayVar(&o.ServiceAccounts, "serviceaccount", o.ServiceAccounts, "Service accounts to bind to the role")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-set")

--- a/test/cmd/rbac.sh
+++ b/test/cmd/rbac.sh
@@ -67,20 +67,20 @@ run_clusterroles_tests() {
   output_message=$(! kubectl get clusterrolebinding super-admin 2>&1 "${kube_flags[@]}")
   kube::test::if_has_string "${output_message}" 'clusterrolebindings.rbac.authorization.k8s.io "super-admin" not found'
   # Dry-run test `kubectl create clusterrolebinding`
-  kubectl create "${kube_flags[@]}" clusterrolebinding super-admin --dry-run=client --clusterrole=admin --user=super-admin
-  kubectl create "${kube_flags[@]}" clusterrolebinding super-admin --dry-run=server --clusterrole=admin --user=super-admin
+  kubectl create "${kube_flags[@]}" clusterrolebinding super-admin --dry-run=client --clusterrole=admin --user-to-bind=super-admin
+  kubectl create "${kube_flags[@]}" clusterrolebinding super-admin --dry-run=server --clusterrole=admin --user-to-bind=super-admin
   output_message=$(! kubectl get clusterrolebinding super-admin 2>&1 "${kube_flags[@]}")
   kube::test::if_has_string "${output_message}" 'clusterrolebindings.rbac.authorization.k8s.io "super-admin" not found'
   # test `kubectl create clusterrolebinding`
   # test `kubectl set subject clusterrolebinding`
-  kubectl create "${kube_flags[@]}" clusterrolebinding super-admin --clusterrole=admin --user=super-admin
+  kubectl create "${kube_flags[@]}" clusterrolebinding super-admin --clusterrole=admin --user-to-bind=super-admin
   kube::test::get_object_assert clusterrolebinding/super-admin "{{range.subjects}}{{.name}}:{{end}}" 'super-admin:'
-  kubectl set subject --dry-run=client "${kube_flags[@]}" clusterrolebinding super-admin --user=foo
-  kubectl set subject --dry-run=server "${kube_flags[@]}" clusterrolebinding super-admin --user=foo
+  kubectl set subject --dry-run=client "${kube_flags[@]}" clusterrolebinding super-admin --user-to-bind=foo
+  kubectl set subject --dry-run=server "${kube_flags[@]}" clusterrolebinding super-admin --user-to-bind=foo
   kube::test::get_object_assert clusterrolebinding/super-admin "{{range.subjects}}{{.name}}:{{end}}" 'super-admin:'
-  kubectl set subject "${kube_flags[@]}" clusterrolebinding super-admin --user=foo
+  kubectl set subject "${kube_flags[@]}" clusterrolebinding super-admin --user-to-bind=foo
   kube::test::get_object_assert clusterrolebinding/super-admin "{{range.subjects}}{{.name}}:{{end}}" 'super-admin:foo:'
-  kubectl create "${kube_flags[@]}" clusterrolebinding multi-users --clusterrole=admin --user=user-1 --user=user-2
+  kubectl create "${kube_flags[@]}" clusterrolebinding multi-users --clusterrole=admin --user-to-bind=user-1 --user-to-bind=user-2
   kube::test::get_object_assert clusterrolebinding/multi-users "{{range.subjects}}{{.name}}:{{end}}" 'user-1:user-2:'
 
   kubectl create "${kube_flags[@]}" clusterrolebinding super-group --clusterrole=admin --group=the-group
@@ -98,21 +98,21 @@ run_clusterroles_tests() {
   kube::test::get_object_assert clusterrolebinding/super-sa "{{range.subjects}}{{.name}}:{{end}}" 'sa-name:foo:'
 
   # test `kubectl set subject clusterrolebinding --all`
-  kubectl set subject "${kube_flags[@]}" clusterrolebinding --all --user=test-all-user
+  kubectl set subject "${kube_flags[@]}" clusterrolebinding --all --user-to-bind=test-all-user
   kube::test::get_object_assert clusterrolebinding/super-admin "{{range.subjects}}{{.name}}:{{end}}" 'super-admin:foo:test-all-user:'
   kube::test::get_object_assert clusterrolebinding/super-group "{{range.subjects}}{{.name}}:{{end}}" 'the-group:foo:test-all-user:'
   kube::test::get_object_assert clusterrolebinding/super-sa "{{range.subjects}}{{.name}}:{{end}}" 'sa-name:foo:test-all-user:'
 
   # test `kubectl create rolebinding`
   # test `kubectl set subject rolebinding`
-  kubectl create "${kube_flags[@]}" rolebinding admin --dry-run=client --clusterrole=admin --user=default-admin
-  kubectl create "${kube_flags[@]}" rolebinding admin --dry-run=server --clusterrole=admin --user=default-admin
+  kubectl create "${kube_flags[@]}" rolebinding admin --dry-run=client --clusterrole=admin --user-to-bind=default-admin
+  kubectl create "${kube_flags[@]}" rolebinding admin --dry-run=server --clusterrole=admin --user-to-bind=default-admin
   output_message=$(! kubectl get rolebinding/admin 2>&1 "${kube_flags[@]}")
   kube::test::if_has_string "${output_message}" ' not found'
-  kubectl create "${kube_flags[@]}" rolebinding admin --clusterrole=admin --user=default-admin
+  kubectl create "${kube_flags[@]}" rolebinding admin --clusterrole=admin --user-to-bind=default-admin
   kube::test::get_object_assert rolebinding/admin "{{.roleRef.kind}}" 'ClusterRole'
   kube::test::get_object_assert rolebinding/admin "{{range.subjects}}{{.name}}:{{end}}" 'default-admin:'
-  kubectl set subject "${kube_flags[@]}" rolebinding admin --user=foo
+  kubectl set subject "${kube_flags[@]}" rolebinding admin --user-to-bind=foo
   kube::test::get_object_assert rolebinding/admin "{{range.subjects}}{{.name}}:{{end}}" 'default-admin:foo:'
 
   kubectl create "${kube_flags[@]}" rolebinding localrole --role=localrole --group=the-group
@@ -129,7 +129,7 @@ run_clusterroles_tests() {
   kube::test::get_object_assert rolebinding/sarole "{{range.subjects}}{{.name}}:{{end}}" 'sa-name:foo:'
 
   # test `kubectl set subject rolebinding --all`
-  kubectl set subject "${kube_flags[@]}" rolebinding --all --user=test-all-user
+  kubectl set subject "${kube_flags[@]}" rolebinding --all --user-to-bind=test-all-user
   kube::test::get_object_assert rolebinding/admin "{{range.subjects}}{{.name}}:{{end}}" 'default-admin:foo:test-all-user:'
   kube::test::get_object_assert rolebinding/localrole "{{range.subjects}}{{.name}}:{{end}}" 'the-group:foo:test-all-user:'
   kube::test::get_object_assert rolebinding/sarole "{{range.subjects}}{{.name}}:{{end}}" 'sa-name:foo:test-all-user:'

--- a/test/cmd/template-output.sh
+++ b/test/cmd/template-output.sh
@@ -170,7 +170,7 @@ EOF
   kube::test::if_has_string "${output_message}" 'valid-pod:'
 
   # check that "set subject" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" set subject clusterrolebinding/foo --user=foo --dry-run=client --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" set subject clusterrolebinding/foo --user-to-bind=foo --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "create secret docker-registry" command supports --template output

--- a/test/e2e/instrumentation/monitoring/custom_metrics_deployments.go
+++ b/test/e2e/instrumentation/monitoring/custom_metrics_deployments.go
@@ -248,7 +248,7 @@ func createClusterAdminBinding() error {
 	}
 	serviceAccount := strings.TrimSpace(stdout)
 	framework.Logf("current service account: %q", serviceAccount)
-	stat, err := e2ekubectl.RunKubectl("", "create", "clusterrolebinding", ClusterAdminBinding, "--clusterrole=cluster-admin", "--user="+serviceAccount)
+	stat, err := e2ekubectl.RunKubectl("", "create", "clusterrolebinding", ClusterAdminBinding, "--clusterrole=cluster-admin", "--user-to-bind="+serviceAccount)
 	framework.Logf(stat)
 	return err
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Conflict of `--user` flag between global options (represents kubeconfig user) and in following subcommands (adds user to role or clusterrole):
1. `kubectl create role`
2. `kubectl create clusterrole`
3. `kubectl set subject`

To fix this, the flag `--user` is replaced with a new flag `--user-to-bind` in the 3 subcommands. The old flag `--user` is marked for **deprecation**. The global flag `--user` stays as is for minimal impact.

If this PR gets merged into `v1.28`, the depracated flag should be removed in `v1.31` (1 year later).

#### Which issue(s) this PR fixes:

Fixes #113334

#### Special notes for your reviewer:

Due to the conflict of flags, the flag inputs were only going to subcommands and not to global option. This behaviour, i.e., the kubeconfig user cannot be specified with `create role`, `create clusterrole` and `set subject`, will continue to be until the deprecated flag `--user` is fully removed in `v1.31`.

#### Does this PR introduce a user-facing change?

```release-note
Added new flag `--user-to-bind` for binding the user with role/clusterrole in `kubectl create role`, `kubectl create clusterrole` and `kubectl set subject`.
Deprecated flag `--user` in  `kubectl create role`, `kubectl create clusterrole` and `kubectl set subject` due to its conflict with global option `--user` (represents the kubeconfig user). For binding the user with role/clusterrole, use the flag `--user-to-bind` instead.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
