### PR TITLE
Update prune's behaviour for namespaces

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -905,17 +905,14 @@ func TestApplyPruneObjectsWithAllowlist(t *testing.T) {
 				"namespace/test-apply pruned",
 			},
 		},
-		// Deprecated: kubectl apply will no longer prune non-namespaced resources by default when used with the --namespace flag in a future release
-		// namespace is a non-namespaced resource and will not be pruned in the future
 		"prune with namespace and without allowlist should delete resources that are not in the specified file": {
 			currentResources:        []runtime.Object{rc, rc2, cm, ns},
 			namespace:               "test",
-			expectedPrunedResources: []string{"test/test-cm", "test/test-rc2", "/test-apply"},
+			expectedPrunedResources: []string{"test/test-cm", "test/test-rc2"},
 			expectedOutputs: []string{
 				"replicationcontroller/test-rc unchanged",
 				"configmap/test-cm pruned",
 				"replicationcontroller/test-rc2 pruned",
-				"namespace/test-apply pruned",
 			},
 		},
 		// Even namespace is a non-namespaced resource, it will be pruned if specified in pruneAllowList in the future

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -1121,7 +1121,6 @@ func TestApplyPruneObjectsWithoutNamespace(t *testing.T) {
 	testCases := map[string]struct {
 		currentResources        []runtime.Object
 		pruneAllowlist          []string
-		namespace               string
 		expectedPrunedResources []string
 		expectedOutputs         []string
 	}{
@@ -1172,12 +1171,19 @@ func TestApplyPruneObjectsWithoutNamespace(t *testing.T) {
 
 				ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 				cmd := NewCmdApply("kubectl", tf, ioStreams)
-				cmd.Flags().Set("filename", filenameRC)
-				cmd.Flags().Set("prune", "true")
-				cmd.Flags().Set("namespace", tc.namespace)
-				cmd.Flags().Set("all", "true")
+				if err := cmd.Flags().Set("filename", filenameRC); err != nil {
+					t.Fatal(err)
+				}
+				if err = cmd.Flags().Set("prune", "true"); err != nil {
+					t.Fatal(err)
+				}
+				if err = cmd.Flags().Set("all", "true"); err != nil {
+					t.Fatal(err)
+				}
 				for _, allow := range tc.pruneAllowlist {
-					cmd.Flags().Set("prune-allowlist", allow)
+					if err = cmd.Flags().Set("prune-allowlist", allow); err != nil {
+						t.Fatal(err)
+					}
 				}
 				cmd.Run(cmd, []string{})
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -71,7 +71,7 @@ func newPruner(o *ApplyOptions) pruner {
 
 func (p *pruner) pruneAll(o *ApplyOptions) error {
 
-	namespacedRESTMappings, nonNamespacedRESTMappings, err := prune.GetRESTMappings(o.Mapper, o.PruneResources, o.Namespace != "")
+	namespacedRESTMappings, nonNamespacedRESTMappings, err := prune.GetRESTMappings(o.Mapper, o.PruneResources, o.Namespace != "default")
 	if err != nil {
 		return fmt.Errorf("error retrieving RESTMappings to prune: %v", err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/util/prune/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/prune/prune.go
@@ -22,7 +22,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/klog/v2"
 )
 
 // default allowlist of namespaced resources
@@ -64,11 +63,11 @@ func (pr Resource) String() string {
 // if pruneResources is specified by user, respect the user setting.
 func GetRESTMappings(mapper meta.RESTMapper, pruneResources []Resource, namespaceSpecified bool) (namespaced, nonNamespaced []*meta.RESTMapping, err error) {
 	if len(pruneResources) == 0 {
-		pruneResources = defaultNamespacedPruneResources
-		// TODO in kubectl v1.29, add back non-namespaced resource only if namespace is not specified
-		pruneResources = append(pruneResources, defaultNonNamespacedPruneResources...)
 		if namespaceSpecified {
-			klog.Warning("Deprecated: kubectl apply will no longer prune non-namespaced resources by default when used with the --namespace flag in a future release. To preserve the current behaviour, list the resources you want to target explicitly in the --prune-allowlist flag.")
+			pruneResources = defaultNamespacedPruneResources
+		} else {
+			pruneResources = defaultNamespacedPruneResources
+			pruneResources = append(pruneResources, defaultNonNamespacedPruneResources...)
 		}
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/prune/prune_test.go
@@ -68,10 +68,8 @@ func TestGetRESTMappings(t *testing.T) {
 			pr:                 []Resource{},
 			namespaceSpecified: true,
 			expectedns:         14,
-			// it will be 0 non-namespaced resources after the deprecation period has passed.
-			// for details, refer to https://github.com/kubernetes/kubernetes/pull/110907/.
-			expectednns: 2,
-			expectederr: nil,
+			expectednns:        0,
+			expectederr:        nil,
 		},
 		{
 			mapper: &testRESTMapper{},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind deprecation

#### What this PR does / why we need it:

This PR changes the behaviour of `--prune` flag of `kubectl apply`.

Previously if you use `--prune` with a namespace flag like ` -n sandbox` it also prunes other non-namespaced items as described in #110905.

>Run `kubectl apply --prune --dry-run=server --all -n sandbox -f a.yaml`, this results in
>service/nginx created (dry run)
>namespace/cattle-system pruned (dry run)

After this PR, the `--prune` flag no longer prunes non-namespaced items if used with a namesapce falg like `-n sandbox`.

>Run `kubectl apply --prune --dry-run=server --all -n sandbox -f a.yaml`, this results in
>service/nginx created (dry run)

(It still prunes the non-namespaced items if namespace is not sepcifed )

>Run `kubectl apply --prune --dry-run=server --all -f b.yaml`, this results in
>service/nginx created (dry run)
>namespace/cattle-system pruned (dry run)

#### Which issue(s) this PR fixes:
Fixes #110905

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Action Required: kubectl apply will no longer prune non-namespaced resources by default when used with the --namespace flag. To preserve the current behaviour, list the resources you want to target explicitly in the --prune-allowlist flag.
```