### PR TITLE
Update CHANGELOG OWNERS to reflect 1.28 Release Notes team

### DIFF
--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -11,13 +11,15 @@ approvers:
   - csantanapr # 1.25 Release Notes Lead
   - harshanarayana # 1.27 Release Notes Lead
   - ramrodo # 1.26 Release Notes Lead
+  - sanchita-07 # 1.28 Release Notes Lead
 reviewers:
   - release-managers
-  - AnaMMedina21 # 1.27 Release Notes Shadow
-  - harshanarayana # 1.27 Release Notes Lead
-  - rjsadow # 1.27 Release Notes Shadow
-  - sanchita-07 # 1.27 Release Notes Shadow
-  - yrs147 # 1.27 Release Notes Shadow
+  - AnaMMedina21 # 1.28 Release Notes Shadow
+  - sanchita-07 # 1.28 Release Notes Lead
+  - fsmunoz # 1.28 Release Notes Shadow
+  - michaelfromyeg # 1.28 Release Notes Shadow
+  - muddapu # 1.28 Release Notes Shadow
+  - rashansmith # 1.28 Release Notes Shadow
 labels:
   - sig/release
   - area/release-eng

--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -15,11 +15,11 @@ approvers:
 reviewers:
   - release-managers
   - AnaMMedina21 # 1.28 Release Notes Shadow
-  - sanchita-07 # 1.28 Release Notes Lead
   - fsmunoz # 1.28 Release Notes Shadow
   - michaelfromyeg # 1.28 Release Notes Shadow
   - muddapu # 1.28 Release Notes Shadow
   - rashansmith # 1.28 Release Notes Shadow
+  - sanchita-07 # 1.28 Release Notes Lead
 labels:
   - sig/release
   - area/release-eng


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:
This PR updates the OWNERS file and adds 1.28 release-notes team as approver and reviewers.

/assign @gracenng @leonardpahlke 