### PR TITLE
add support for ExponentialBucketsRange

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/buckets.go
+++ b/staging/src/k8s.io/component-base/metrics/buckets.go
@@ -33,6 +33,16 @@ func ExponentialBuckets(start, factor float64, count int) []float64 {
 	return prometheus.ExponentialBuckets(start, factor, count)
 }
 
+// ExponentialBucketsRange creates 'count' buckets, where the lowest bucket is
+// 'min' and the highest bucket is 'max'. The final +Inf bucket is not counted
+// and not included in the returned slice. The returned slice is meant to be
+// used for the Buckets field of HistogramOpts.
+//
+// The function panics if 'count' is 0 or negative, if 'min' is 0 or negative.
+func ExponentialBucketsRange(min, max float64, count int) []float64 {
+	return prometheus.ExponentialBucketsRange(min, max, count)
+}
+
 // MergeBuckets merges buckets together
 func MergeBuckets(buckets ...[]float64) []float64 {
 	result := make([]float64, 1)

--- a/test/instrumentation/decode_metric.go
+++ b/test/instrumentation/decode_metric.go
@@ -484,7 +484,9 @@ func (c *metricDecoder) decodeBucketFunctionCall(v *ast.CallExpr) ([]float64, er
 					case "LinearBuckets":
 						merged = append(merged, metrics.LinearBuckets(firstArg, secondArg, thirdArg)...)
 					case "ExponentialBuckets":
-						merged = append(merged, metrics.LinearBuckets(firstArg, secondArg, thirdArg)...)
+						merged = append(merged, metrics.ExponentialBuckets(firstArg, secondArg, thirdArg)...)
+					case "ExponentialBucketsRange":
+						merged = append(merged, metrics.ExponentialBucketsRange(firstArg, secondArg, thirdArg)...)
 					}
 				}
 			}
@@ -513,6 +515,12 @@ func (c *metricDecoder) decodeBucketFunctionCall(v *ast.CallExpr) ([]float64, er
 			return nil, err, true
 		}
 		return metrics.ExponentialBuckets(firstArg, secondArg, thirdArg), nil, true
+	case "ExponentialBucketsRange":
+		firstArg, secondArg, thirdArg, err := decodeBucketArguments(v)
+		if err != nil {
+			return nil, err, true
+		}
+		return metrics.ExponentialBucketsRange(firstArg, secondArg, thirdArg), nil, true
 	case "MergeBuckets":
 		merged := []float64{}
 		for _, arg := range v.Args {

--- a/test/instrumentation/testdata/pkg/kubelet/metrics/metrics.go
+++ b/test/instrumentation/testdata/pkg/kubelet/metrics/metrics.go
@@ -193,8 +193,8 @@ var (
 			Subsystem:      KubeletSubsystem,
 			Name:           CgroupManagerOperationsKey,
 			Help:           "Duration in seconds for cgroup manager operations. Broken down by method.",
-			Buckets:        metrics.DefBuckets,
-			StabilityLevel: metrics.ALPHA,
+			Buckets:        metrics.ExponentialBucketsRange(0.01, 10, 10),
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"operation_type"},
 	)

--- a/test/instrumentation/testdata/test-stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/test-stable-metrics-list.yaml
@@ -122,6 +122,24 @@
     certificate is invalid or unused, the value will be +INF.
   type: Gauge
   stabilityLevel: BETA
+- name: cgroup_manager_duration_seconds
+  subsystem: kubelet
+  help: Duration in seconds for cgroup manager operations. Broken down by method.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - operation_type
+  buckets:
+  - 0.01
+  - 0.02154434690031884
+  - 0.046415888336127795
+  - 0.10000000000000002
+  - 0.21544346900318842
+  - 0.46415888336127803
+  - 1.0000000000000002
+  - 2.1544346900318847
+  - 4.641588833612781
+  - 10.000000000000005
 - name: device_plugin_alloc_duration_seconds
   subsystem: kubelet
   help: Duration in seconds to serve a device plugin Allocation request. Broken down


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

Adds support to the metrics stability framework for `ExponentialBucketsRange`. This allows you to specify a start and end bucket value and the convenience function will autogenerate exponentially increasing buckets in between.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
