### PR TITLE
bring the existing test image repo binding up to parity with the list

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -195,6 +195,9 @@ type TestContextType struct {
 	// KubeTestRepoConfigFile is a yaml file used for overriding registries for test images.
 	KubeTestRepoList string
 
+	// KubeTestImageRepository is the image repository where the test images are hosted, like "quay.io/openshift/community-e2e-images"
+	KubeTestImageRepository string
+
 	// SnapshotControllerPodName is the name used for identifying the snapshot controller pod.
 	SnapshotControllerPodName string
 
@@ -364,6 +367,7 @@ func RegisterCommonFlags(flags *flag.FlagSet) {
 
 	flags.StringVar(&TestContext.E2EDockerConfigFile, "e2e-docker-config-file", "", "A docker credentials configuration file used which contains authorization token that can be used to pull images from certain private registries provided by the users. For more details refer https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#log-in-to-docker-hub")
 	flags.StringVar(&TestContext.KubeTestRepoList, "kube-test-repo-list", "", "A yaml file used for overriding registries for test images. Alternatively, the KUBE_TEST_REPO_LIST env variable can be set.")
+	flags.StringVar(&TestContext.KubeTestImageRepository, "kube-test-repo", "", "The image repository where the test images are hosted, like \"quay.io/openshift/community-e2e-images\". Alternatively, the KUBE_TEST_REPO env variable can be set.")
 
 	flags.StringVar(&TestContext.SnapshotControllerPodName, "snapshot-controller-pod-name", "", "The pod name to use for identifying the snapshot controller in the kube-system namespace.")
 	flags.IntVar(&TestContext.SnapshotControllerHTTPPort, "snapshot-controller-http-port", 0, "The port to use for snapshot controller HTTP communication.")
@@ -467,8 +471,8 @@ func AfterReadingAllFlags(t *TestContextType) {
 
 	// These flags are not exposed via the normal command line flag set,
 	// therefore we have to use our own private one here.
-	if t.KubeTestRepoList != "" {
-		image.Init(t.KubeTestRepoList)
+	if len(t.KubeTestRepoList) > 0 || len(t.KubeTestImageRepository) > 0 {
+		image.Init(t.KubeTestRepoList, t.KubeTestImageRepository)
 	}
 	var fs flag.FlagSet
 	klog.InitFlags(&fs)

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -68,15 +68,15 @@ func (i *Config) SetVersion(version string) {
 	i.version = version
 }
 
-func Init(repoList string) {
-	registry, imageConfigs, originalImageConfigs = readRepoList(repoList)
+func Init(repoList, imageRepository string) {
+	registry, imageConfigs, originalImageConfigs = readRepoList(repoList, imageRepository)
 }
 
-func readRepoList(repoList string) (RegistryList, map[ImageID]Config, map[ImageID]Config) {
+func readRepoList(repoList, imageRepository string) (RegistryList, map[ImageID]Config, map[ImageID]Config) {
 	registry := initRegistry
 
 	if repoList == "" {
-		imageConfigs, originalImageConfigs := initImageConfigs(registry)
+		imageConfigs, originalImageConfigs := initImageConfigs(registry, imageRepository)
 		return registry, imageConfigs, originalImageConfigs
 	}
 
@@ -101,7 +101,7 @@ func readRepoList(repoList string) (RegistryList, map[ImageID]Config, map[ImageI
 		panic(fmt.Errorf("error unmarshalling '%v' YAML file: %v", repoList, err))
 	}
 
-	imageConfigs, originalImageConfigs := initImageConfigs(registry)
+	imageConfigs, originalImageConfigs := initImageConfigs(registry, imageRepository)
 
 	return registry, imageConfigs, originalImageConfigs
 
@@ -143,7 +143,7 @@ var (
 		CloudProviderGcpRegistry: "registry.k8s.io/cloud-provider-gcp",
 	}
 
-	registry, imageConfigs, originalImageConfigs = readRepoList(os.Getenv("KUBE_TEST_REPO_LIST"))
+	registry, imageConfigs, originalImageConfigs = readRepoList(os.Getenv("KUBE_TEST_REPO_LIST"), os.Getenv("KUBE_TEST_REPO"))
 )
 
 type ImageID int
@@ -230,7 +230,7 @@ const (
 	WindowsServer
 )
 
-func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
+func initImageConfigs(list RegistryList, imageRepository string) (map[ImageID]Config, map[ImageID]Config) {
 	configs := map[ImageID]Config{}
 	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.45"}
 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
@@ -279,8 +279,8 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 
 	// if requested, map all the SHAs into a known format based on the input
 	originalImageConfigs := configs
-	if repo := os.Getenv("KUBE_TEST_REPO"); len(repo) > 0 {
-		configs = GetMappedImageConfigs(originalImageConfigs, repo)
+	if len(imageRepository) > 0 {
+		configs = GetMappedImageConfigs(originalImageConfigs, imageRepository)
 	}
 
 	return configs, originalImageConfigs


### PR DESCRIPTION
`KUBE_TEST_REPO` and `KUBE_TEST_REPO_LIST` are currently  used to configure where test images are pulled from.  This PR makes `KUBE_TEST_REPO` have parity with `KUBE_TEST_REPO_LIST` to reevaluate after an explicit choice via flag versus an env var only. 

/kind cleanup
/priority important-soon
/sig testing

```release-note
NONE
```