### PR TITLE
Automated cherry pick of #117143: wait: fix incorrect suggested method

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/poll.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/poll.go
@@ -41,7 +41,7 @@ func PollUntilContextCancel(ctx context.Context, interval time.Duration, immedia
 //	err := PollUntilContextCancel(ctx, interval, immediate, condition)
 //
 // The deadline context will be cancelled if the Poll succeeds before the timeout, simplifying
-// inline usage. All other behavior is identical to PollWithContextTimeout.
+// inline usage. All other behavior is identical to PollUntilContextTimeout.
 func PollUntilContextTimeout(ctx context.Context, interval, timeout time.Duration, immediate bool, condition ConditionWithContextFunc) error {
 	deadlineCtx, deadlineCancel := context.WithTimeout(ctx, timeout)
 	defer deadlineCancel()
@@ -59,7 +59,7 @@ func PollUntilContextTimeout(ctx context.Context, interval, timeout time.Duratio
 //
 // If you want to Poll something forever, see PollInfinite.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextTimeout.
+// Deprecated: This method does not return errors from context, use PollUntilContextTimeout.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func Poll(interval, timeout time.Duration, condition ConditionFunc) error {
@@ -78,7 +78,7 @@ func Poll(interval, timeout time.Duration, condition ConditionFunc) error {
 //
 // If you want to Poll something forever, see PollInfinite.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextTimeout.
+// Deprecated: This method does not return errors from context, use PollUntilContextTimeout.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollWithContext(ctx context.Context, interval, timeout time.Duration, condition ConditionWithContextFunc) error {
@@ -91,7 +91,7 @@ func PollWithContext(ctx context.Context, interval, timeout time.Duration, condi
 // PollUntil always waits interval before the first run of 'condition'.
 // 'condition' will always be invoked at least once.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollUntil(interval time.Duration, condition ConditionFunc, stopCh <-chan struct{}) error {
@@ -104,7 +104,7 @@ func PollUntil(interval time.Duration, condition ConditionFunc, stopCh <-chan st
 // PollUntilWithContext always waits interval before the first run of 'condition'.
 // 'condition' will always be invoked at least once.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollUntilWithContext(ctx context.Context, interval time.Duration, condition ConditionWithContextFunc) error {
@@ -118,7 +118,7 @@ func PollUntilWithContext(ctx context.Context, interval time.Duration, condition
 // Some intervals may be missed if the condition takes too long or the time
 // window is too short.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollInfinite(interval time.Duration, condition ConditionFunc) error {
@@ -132,7 +132,7 @@ func PollInfinite(interval time.Duration, condition ConditionFunc) error {
 // Some intervals may be missed if the condition takes too long or the time
 // window is too short.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollInfiniteWithContext(ctx context.Context, interval time.Duration, condition ConditionWithContextFunc) error {
@@ -150,7 +150,7 @@ func PollInfiniteWithContext(ctx context.Context, interval time.Duration, condit
 //
 // If you want to immediately Poll something forever, see PollImmediateInfinite.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextTimeout.
+// Deprecated: This method does not return errors from context, use PollUntilContextTimeout.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollImmediate(interval, timeout time.Duration, condition ConditionFunc) error {
@@ -168,7 +168,7 @@ func PollImmediate(interval, timeout time.Duration, condition ConditionFunc) err
 //
 // If you want to immediately Poll something forever, see PollImmediateInfinite.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextTimeout.
+// Deprecated: This method does not return errors from context, use PollUntilContextTimeout.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollImmediateWithContext(ctx context.Context, interval, timeout time.Duration, condition ConditionWithContextFunc) error {
@@ -180,7 +180,7 @@ func PollImmediateWithContext(ctx context.Context, interval, timeout time.Durati
 // PollImmediateUntil runs the 'condition' before waiting for the interval.
 // 'condition' will always be invoked at least once.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollImmediateUntil(interval time.Duration, condition ConditionFunc, stopCh <-chan struct{}) error {
@@ -193,7 +193,7 @@ func PollImmediateUntil(interval time.Duration, condition ConditionFunc, stopCh 
 // PollImmediateUntilWithContext runs the 'condition' before waiting for the interval.
 // 'condition' will always be invoked at least once.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollImmediateUntilWithContext(ctx context.Context, interval time.Duration, condition ConditionWithContextFunc) error {
@@ -207,7 +207,7 @@ func PollImmediateUntilWithContext(ctx context.Context, interval time.Duration, 
 // Some intervals may be missed if the condition takes too long or the time
 // window is too short.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollImmediateInfinite(interval time.Duration, condition ConditionFunc) error {
@@ -222,7 +222,7 @@ func PollImmediateInfinite(interval time.Duration, condition ConditionFunc) erro
 // Some intervals may be missed if the condition takes too long or the time
 // window is too short.
 //
-// Deprecated: This method does not return errors from context, use PollWithContextCancel.
+// Deprecated: This method does not return errors from context, use PollUntilContextCancel.
 // Note that the new method will no longer return ErrWaitTimeout and instead return errors
 // defined by the context package. Will be removed in a future release.
 func PollImmediateInfiniteWithContext(ctx context.Context, interval time.Duration, condition ConditionWithContextFunc) error {


### PR DESCRIPTION
Cherry pick of #117143 on release-1.27.

#117143: wait: fix incorrect suggested method

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```