### PR TITLE
SSA: prevent usage of Extract calls via forbidigo

### DIFF
--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -25,10 +25,16 @@ issues:
     - linters:
        - ginkgolinter
       text: use a function call in (Eventually|Consistently)
+    # SSA Extract calls are allowed in tests.
+    - linters:
+       - forbidigo
+      text: should not be used because managedFields was removed
+      path: _test.go$
 
 linters:
   disable-all: false # in contrast to golangci.yaml, the default set of linters remains enabled
   enable: # please keep this alphabetized and in sync with golangci.yaml
+    - forbidigo
     - ginkgolinter
     - gocritic
     - govet
@@ -45,6 +51,15 @@ linters-settings: # please keep this alphabetized
       path: ../_output/local/bin/logcheck.so
       description: structured logging checker
       original-url: k8s.io/logtools/logcheck
+  forbidigo:
+    analyze-types: true
+    forbid:
+    - p: ^managedfields\.ExtractInto$
+      pkg: ^k8s\.io/apimachinery/pkg/util/managedfields$
+      msg: should not be used because managedFields was removed
+    - p: \.Extract
+      pkg: ^k8s\.io/client-go/applyconfigurations/
+      msg: should not be used because managedFields was removed
   gocritic:
   staticcheck:
     checks:

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -26,10 +26,16 @@ issues:
     - linters:
        - ginkgolinter
       text: use a function call in (Eventually|Consistently)
+    # SSA Extract calls are allowed in tests.
+    - linters:
+       - forbidigo
+      text: should not be used because managedFields was removed
+      path: _test.go$
 
 linters:
   disable-all: true # not disabled in golangci-strict.yaml
   enable: # please keep this alphabetized and in sync with golangci-strict.yaml
+    - forbidigo
     - ginkgolinter
     - gocritic
     - govet
@@ -46,6 +52,15 @@ linters-settings: # please keep this alphabetized
       path: ../_output/local/bin/logcheck.so
       description: structured logging checker
       original-url: k8s.io/logtools/logcheck
+  forbidigo:
+    analyze-types: true
+    forbid:
+    - p: ^managedfields\.ExtractInto$
+      pkg: ^k8s\.io/apimachinery/pkg/util/managedfields$
+      msg: should not be used because managedFields was removed
+    - p: \.Extract
+      pkg: ^k8s\.io/client-go/applyconfigurations/
+      msg: should not be used because managedFields was removed
   gocritic:
     enabled-checks:             # not limited in golangci-strict.yaml
       - equalFold               # not limited in golangci-strict.yaml

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/unstructured.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/unstructured.go
@@ -125,7 +125,7 @@ func (e *extractor) extractUnstructured(object *unstructured.Unstructured, field
 		return nil, fmt.Errorf("failed to fetch the objectType: %v", err)
 	}
 	result := &unstructured.Unstructured{}
-	err = managedfields.ExtractInto(object, *objectType, fieldManager, result, subresource)
+	err = managedfields.ExtractInto(object, *objectType, fieldManager, result, subresource) //nolint:forbidigo
 	if err != nil {
 		return nil, fmt.Errorf("failed calling ExtractInto for unstructured: %v", err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Client-side extract calls depend on `managedFields`, which might not be available. Therefore they should not be used in production code.

They are okay in test files (because the API has to be tested), in the generated code (because the various type specific APIs still need to be provided) and in unstructured.go (same reason).

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/119658

#### Special notes for your reviewer:

This is an alternative for writing [custom linter](https://github.com/kubernetes/kubernetes/pull/119672).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
