### PR TITLE
scheduler: fix data race after binding failure

### DIFF
--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -121,6 +121,7 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 		status := sched.bindingCycle(bindingCycleCtx, state, fwk, scheduleResult, assumedPodInfo, start, podsToActivate)
 		if !status.IsSuccess() {
 			sched.handleBindingCycleError(bindingCycleCtx, state, fwk, assumedPodInfo, start, scheduleResult, status)
+			return
 		}
 		// Usually, DonePod is called inside the scheduling queue,
 		// but in this case, we need to call it here because this Pod won't go back to the scheduling queue.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When binding has failed, `Done` gets called by
`handleBindingCycleError`. Calling it again is at best redundant and worse, suffers from a data race:
- the `assumedPodInfo` is placed in the backoff queue
- an event causes the `Pod` pointer to get updated in it
- reading `assumedPodInfo.Pod.UID` races with that write

This race was found with`go test -race`.

#### Which issue(s) this PR fixes:
Fixes #119712

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kube-scheduler: Fine-grained tracking of events (introduced in 1.28) suffered from a data race when binding fails.
```
