### PR TITLE
Do not fail volume attach or publish operation at kubelet if target path directory already exists on the node.

### DIFF
--- a/pkg/util/filesystem/defaultfs.go
+++ b/pkg/util/filesystem/defaultfs.go
@@ -17,8 +17,10 @@ limitations under the License.
 package filesystem
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -73,6 +75,32 @@ func (fs *DefaultFs) Rename(oldpath, newpath string) error {
 // MkdirAll via os.MkdirAll
 func (fs *DefaultFs) MkdirAll(path string, perm os.FileMode) error {
 	return os.MkdirAll(fs.prefix(path), perm)
+}
+
+// MkdirAllWithPathCheck checks if path exists already. If not, it creates a directory
+// named path, along with any necessary parents, and returns nil, or else returns an error.
+// Permission bits perm (before umask) are used for all directories that
+// MkdirAllWithPathCheck creates.
+// If path is already a directory, MkdirAllWithPathCheck does nothing and returns nil.
+// NOTE: In case of Windows NTFS, mount points are implemented as reparse-point
+// (similar to symlink) and do not represent actual directory. Hence Directory existence
+// check for windows NTFS will NOT check for dir, but for symlink presence.
+func MkdirAllWithPathCheck(path string, perm os.FileMode) error {
+	if dir, err := os.Lstat(path); err == nil {
+		// If the path exists already,
+		// 1. for Unix/Linux OS, check if the path is directory.
+		// 2. for windows NTFS, check if the path is symlink instead of directory.
+		if dir.IsDir() ||
+			(runtime.GOOS == "windows" && (dir.Mode()&os.ModeSymlink != 0)) {
+			return nil
+		}
+		return fmt.Errorf("path %v exists but is not a directory", path)
+	}
+	// If existence of path not known, attempt to create it.
+	if err := os.MkdirAll(path, perm); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Chtimes via os.Chtimes

--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/util/filesystem"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util"
 	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
@@ -341,9 +342,10 @@ func (c *csiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMo
 
 	// Store volume metadata for UnmountDevice. Keep it around even if the
 	// driver does not support NodeStage, UnmountDevice still needs it.
-	if err = os.MkdirAll(deviceMountPath, 0750); err != nil {
+	if err = filesystem.MkdirAllWithPathCheck(deviceMountPath, 0750); err != nil {
 		return errors.New(log("attacher.MountDevice failed to create dir %#v:  %v", deviceMountPath, err))
 	}
+
 	klog.V(4).Info(log("created target path successfully [%s]", deviceMountPath))
 	dataDir := filepath.Dir(deviceMountPath)
 	data := map[string]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR addresses issue reported at https://github.com/kubernetes/kubernetes/issues/119401. This allows kubelet to ignore if the staging target directory or parent publish directory already exists and let corresponding CSI driver handle the situation.

Testing done:
Reproduced original issue seen in the bug mentioned above and after replacing kubelet with this fix, control was successfully passed to CSI driver, instead of failing the volume attach at kubelet level.

#### Which issue(s) this PR fixes:
https://github.com/kubernetes/kubernetes/issues/119401

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Do not fail volume attach or publish operation at kubelet if target path directory already exists on the node.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
