### PR TITLE
Allow disabling LoadBalancer HealthCheck port allocation

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -56,6 +56,8 @@ type Extra struct {
 	APIServerServiceIP net.IP
 
 	ServiceNodePortRange utilnet.PortRange
+	// EnableServiceHealthCheckPort enables health check port allocation for LoadBalancer services
+	EnableServiceHealthCheckPort bool
 
 	EndpointReconcilerType string
 
@@ -124,6 +126,9 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 	fs.Var(&s.ServiceNodePortRange, "service-node-port-range", ""+
 		"A port range to reserve for services with NodePort visibility.  This must not overlap with the ephemeral port range on nodes.  "+
 		"Example: '30000-32767'. Inclusive at both ends of the range.")
+
+	fs.BoolVar(&s.EnableServiceHealthCheckPort, "enable-service-health-check-port", true,
+		"If true, allocate health check ports for LoadBalancer services.")
 
 	// Kubelet related flags:
 	fs.StringSliceVar(&s.KubeletConfig.PreferredAddressTypes, "kubelet-preferred-address-types", s.KubeletConfig.PreferredAddressTypes,

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -298,10 +298,11 @@ func TestAddFlags(t *testing.T) {
 		},
 
 		Extra: Extra{
-			ServiceNodePortRange:   kubeoptions.DefaultServiceNodePortRange,
-			ServiceClusterIPRanges: (&net.IPNet{IP: netutils.ParseIPSloppy("192.168.128.0"), Mask: net.CIDRMask(17, 32)}).String(),
-			EndpointReconcilerType: string(reconcilers.LeaseEndpointReconcilerType),
-			AllowPrivileged:        false,
+			ServiceNodePortRange:         kubeoptions.DefaultServiceNodePortRange,
+			EnableServiceHealthCheckPort: true,
+			ServiceClusterIPRanges:       (&net.IPNet{IP: netutils.ParseIPSloppy("192.168.128.0"), Mask: net.CIDRMask(17, 32)}).String(),
+			EndpointReconcilerType:       string(reconcilers.LeaseEndpointReconcilerType),
+			AllowPrivileged:              false,
 			KubeletConfig: kubeletclient.KubeletClientConfig{
 				Port:         10250,
 				ReadOnlyPort: 10255,

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -245,8 +245,9 @@ func CreateKubeAPIServerConfig(opts options.CompletedOptions) (
 
 			APIServerServicePort: 443,
 
-			ServiceNodePortRange:      opts.ServiceNodePortRange,
-			KubernetesServiceNodePort: opts.KubernetesServiceNodePort,
+			ServiceNodePortRange:         opts.ServiceNodePortRange,
+			KubernetesServiceNodePort:    opts.KubernetesServiceNodePort,
+			EnableServiceHealthCheckPort: opts.EnableServiceHealthCheckPort,
 
 			EndpointReconcilerType: reconcilers.Type(opts.EndpointReconcilerType),
 			MasterCount:            opts.MasterCount,

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -209,6 +209,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.Var(&o.config.DetectLocalMode, "detect-local-mode", "Mode to use to detect local traffic. This parameter is ignored if a config file is specified by --config.")
 	fs.StringVar(&o.config.DetectLocal.BridgeInterface, "pod-bridge-interface", o.config.DetectLocal.BridgeInterface, "A bridge interface name in the cluster. Kube-proxy considers traffic as local if originating from an interface which matches the value. This argument should be set if DetectLocalMode is set to BridgeInterface.")
 	fs.StringVar(&o.config.DetectLocal.InterfaceNamePrefix, "pod-interface-name-prefix", o.config.DetectLocal.InterfaceNamePrefix, "An interface prefix in the cluster. Kube-proxy considers traffic as local if originating from interfaces that match the given prefix. This argument should be set if DetectLocalMode is set to InterfaceNamePrefix.")
+	fs.BoolVar(&o.config.EnableServiceHealthCheckPort, "enable-service-health-check-port", o.config.EnableServiceHealthCheckPort, "If true, kube-proxy will serve health check ports for LoadBalancer services.")
 	logsapi.AddFlags(&o.config.Logging, fs)
 }
 

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -209,7 +209,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.Var(&o.config.DetectLocalMode, "detect-local-mode", "Mode to use to detect local traffic. This parameter is ignored if a config file is specified by --config.")
 	fs.StringVar(&o.config.DetectLocal.BridgeInterface, "pod-bridge-interface", o.config.DetectLocal.BridgeInterface, "A bridge interface name in the cluster. Kube-proxy considers traffic as local if originating from an interface which matches the value. This argument should be set if DetectLocalMode is set to BridgeInterface.")
 	fs.StringVar(&o.config.DetectLocal.InterfaceNamePrefix, "pod-interface-name-prefix", o.config.DetectLocal.InterfaceNamePrefix, "An interface prefix in the cluster. Kube-proxy considers traffic as local if originating from interfaces that match the given prefix. This argument should be set if DetectLocalMode is set to InterfaceNamePrefix.")
-	fs.BoolVar(&o.config.EnableServiceHealthCheckPort, "enable-service-health-check-port", o.config.EnableServiceHealthCheckPort, "If true, kube-proxy will serve health check ports for LoadBalancer services.")
+	fs.BoolVar(o.config.EnableServiceHealthCheckPort, "enable-service-health-check-port", pointer.BoolDeref(o.config.EnableServiceHealthCheckPort, true), "If true, kube-proxy will serve health check ports for LoadBalancer services.")
 	logsapi.AddFlags(&o.config.Logging, fs)
 }
 

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -130,8 +130,8 @@ func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguratio
 	var proxier proxy.Provider
 	var err error
 
-	if !config.EnableServiceHealthCheckPort {
-		klog.InfoS("Disabling health check port serving", "EnableServiceHealthCheckPort", config.EnableServiceHealthCheckPort)
+	if !(*config.EnableServiceHealthCheckPort) {
+		klog.InfoS("Disabling health check port serving", "EnableServiceHealthCheckPort", *config.EnableServiceHealthCheckPort)
 		apiservice.DisableHealthCheckPortAllocation()
 	}
 

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/cadvisor/machine"
 	"github.com/google/cadvisor/utils/sysfs"
 	"k8s.io/apimachinery/pkg/watch"
+	apiservice "k8s.io/kubernetes/pkg/api/v1/service"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -128,6 +129,11 @@ func (s *ProxyServer) platformCheckSupported() (ipv4Supported, ipv6Supported, du
 func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguration, dualStack bool) (proxy.Provider, error) {
 	var proxier proxy.Provider
 	var err error
+
+	if !config.EnableServiceHealthCheckPort {
+		klog.InfoS("Disabling health check port serving", "EnableServiceHealthCheckPort", config.EnableServiceHealthCheckPort)
+		apiservice.DisableHealthCheckPortAllocation()
+	}
 
 	primaryProtocol := utiliptables.ProtocolIPv4
 	if s.PrimaryIPFamily == v1.IPv6Protocol {

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -78,6 +78,7 @@ detectLocal:
 nodePortAddresses:
   - "10.20.30.40/16"
   - "fd00:1::0/64"
+enableServiceHealthCheckPort: true
 `
 
 	testCases := []struct {
@@ -224,6 +225,7 @@ nodePortAddresses:
 				Format:         "text",
 				FlushFrequency: logsapi.TimeOrMetaDuration{Duration: metav1.Duration{Duration: 5 * time.Second}, SerializeAsString: true},
 			},
+			EnableServiceHealthCheckPort: pointer.Bool(true),
 		}
 
 		options := NewOptions()

--- a/pkg/api/service/util.go
+++ b/pkg/api/service/util.go
@@ -78,9 +78,13 @@ func RequestsOnlyLocalTraffic(service *api.Service) bool {
 }
 
 // NeedsHealthCheck checks if service needs health check.
-func NeedsHealthCheck(service *api.Service) bool {
+var NeedsHealthCheck = func(service *api.Service) bool {
 	if service.Spec.Type != api.ServiceTypeLoadBalancer {
 		return false
 	}
 	return RequestsOnlyLocalTraffic(service)
+}
+
+func DisableHealthCheckPortAllocation() {
+	NeedsHealthCheck = func(service *api.Service) bool { return false }
 }

--- a/pkg/api/service/util_test.go
+++ b/pkg/api/service/util_test.go
@@ -214,3 +214,25 @@ func TestNeedsHealthCheck(t *testing.T) {
 		},
 	})
 }
+
+func TestDisableHealthCheckPortAllocation(t *testing.T) {
+	// backup the check function for the disabling test
+	needsHealthCheckFnBackup := NeedsHealthCheck
+	neededService := &api.Service{
+		Spec: api.ServiceSpec{
+			Type:                  api.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: api.ServiceExternalTrafficPolicyLocal,
+		},
+	}
+	if res := NeedsHealthCheck(neededService); res != true {
+		t.Errorf("Expected needs health check = %v, got %v",
+			true, res)
+	}
+	DisableHealthCheckPortAllocation()
+	if res := NeedsHealthCheck(neededService); res != false {
+		t.Errorf("Expected needs health check = %v, got %v",
+			false, res)
+	}
+	// restore the check function
+	NeedsHealthCheck = needsHealthCheckFnBackup
+}

--- a/pkg/api/v1/service/util.go
+++ b/pkg/api/v1/service/util.go
@@ -85,9 +85,13 @@ func InternalPolicyLocal(service *v1.Service) bool {
 }
 
 // NeedsHealthCheck checks if service needs health check.
-func NeedsHealthCheck(service *v1.Service) bool {
+var NeedsHealthCheck = func(service *v1.Service) bool {
 	if service.Spec.Type != v1.ServiceTypeLoadBalancer {
 		return false
 	}
 	return ExternalPolicyLocal(service)
+}
+
+func DisableHealthCheckPortAllocation() {
+	NeedsHealthCheck = func(service *v1.Service) bool { return false }
 }

--- a/pkg/api/v1/service/util_test.go
+++ b/pkg/api/v1/service/util_test.go
@@ -241,3 +241,25 @@ func TestInternalPolicyLocal(t *testing.T) {
 		},
 	})
 }
+
+func TestDisableHealthCheckPortAllocation(t *testing.T) {
+	// backup the check function for the disabling test
+	needsHealthCheckFnBackup := NeedsHealthCheck
+	neededService := &v1.Service{
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
+		},
+	}
+	if res := NeedsHealthCheck(neededService); res != true {
+		t.Errorf("Expected needs health check = %v, got %v",
+			true, res)
+	}
+	DisableHealthCheckPortAllocation()
+	if res := NeedsHealthCheck(neededService); res != false {
+		t.Errorf("Expected needs health check = %v, got %v",
+			false, res)
+	}
+	// restore the check function
+	NeedsHealthCheck = needsHealthCheckFnBackup
+}

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -198,6 +198,10 @@ type ExtraConfig struct {
 
 	// The range of ports to be assigned to services with type=NodePort or greater
 	ServiceNodePortRange utilnet.PortRange
+
+	// EnableServiceHealthCheckPort enables health check port allocation for LoadBalancer services
+	EnableServiceHealthCheckPort bool
+
 	// If non-zero, the "kubernetes" services uses this port as NodePort.
 	KubernetesServiceNodePort int
 
@@ -439,10 +443,11 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 			KubeletClientConfig: c.ExtraConfig.KubeletClientConfig,
 		},
 		Services: corerest.ServicesConfig{
-			ClusterIPRange:          c.ExtraConfig.ServiceIPRange,
-			SecondaryClusterIPRange: c.ExtraConfig.SecondaryServiceIPRange,
-			NodePortRange:           c.ExtraConfig.ServiceNodePortRange,
-			IPRepairInterval:        c.ExtraConfig.RepairServicesInterval,
+			ClusterIPRange:               c.ExtraConfig.ServiceIPRange,
+			SecondaryClusterIPRange:      c.ExtraConfig.SecondaryServiceIPRange,
+			NodePortRange:                c.ExtraConfig.ServiceNodePortRange,
+			IPRepairInterval:             c.ExtraConfig.RepairServicesInterval,
+			EnableServiceHealthCheckPort: c.ExtraConfig.EnableServiceHealthCheckPort,
 		},
 	})
 	if err != nil {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -55246,8 +55246,15 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyConfiguration(ref common.R
 							Ref:         ref("k8s.io/component-base/logs/api/v1.LoggingConfiguration"),
 						},
 					},
+					"enableServiceHealthCheckPort": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EnableServiceHealthCheckPort enables health check port serving for LoadBalancer services",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
-				Required: []string{"bindAddress", "healthzBindAddress", "metricsBindAddress", "bindAddressHardFail", "enableProfiling", "clusterCIDR", "hostnameOverride", "clientConnection", "iptables", "ipvs", "oomScoreAdj", "mode", "portRange", "conntrack", "configSyncPeriod", "nodePortAddresses", "winkernel", "showHiddenMetricsForVersion", "detectLocalMode", "detectLocal"},
+				Required: []string{"bindAddress", "healthzBindAddress", "metricsBindAddress", "bindAddressHardFail", "enableProfiling", "clusterCIDR", "hostnameOverride", "clientConnection", "iptables", "ipvs", "oomScoreAdj", "mode", "portRange", "conntrack", "configSyncPeriod", "nodePortAddresses", "winkernel", "showHiddenMetricsForVersion", "detectLocalMode", "detectLocal", "enableServiceHealthCheckPort"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/proxy/apis/config/fuzzer/fuzzer.go
+++ b/pkg/proxy/apis/config/fuzzer/fuzzer.go
@@ -50,6 +50,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			if obj.Logging.Format == "" {
 				obj.Logging.Format = "text"
 			}
+			obj.EnableServiceHealthCheckPort = pointer.Bool(c.RandBool())
 		},
 	}
 }

--- a/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/after/v1alpha1.yaml
+++ b/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/after/v1alpha1.yaml
@@ -19,7 +19,7 @@ detectLocal:
   interfaceNamePrefix: ""
 detectLocalMode: ""
 enableProfiling: false
-enableServiceHealthCheckPort: null
+enableServiceHealthCheckPort: true
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""
 iptables:

--- a/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/after/v1alpha1.yaml
+++ b/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/after/v1alpha1.yaml
@@ -19,6 +19,7 @@ detectLocal:
   interfaceNamePrefix: ""
 detectLocalMode: ""
 enableProfiling: false
+enableServiceHealthCheckPort: null
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""
 iptables:

--- a/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/roundtrip/default/v1alpha1.yaml
+++ b/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/roundtrip/default/v1alpha1.yaml
@@ -19,7 +19,7 @@ detectLocal:
   interfaceNamePrefix: ""
 detectLocalMode: ""
 enableProfiling: false
-enableServiceHealthCheckPort: null
+enableServiceHealthCheckPort: true
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""
 iptables:

--- a/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/roundtrip/default/v1alpha1.yaml
+++ b/pkg/proxy/apis/config/scheme/testdata/KubeProxyConfiguration/roundtrip/default/v1alpha1.yaml
@@ -19,6 +19,7 @@ detectLocal:
   interfaceNamePrefix: ""
 detectLocalMode: ""
 enableProfiling: false
+enableServiceHealthCheckPort: null
 healthzBindAddress: 0.0.0.0:10256
 hostnameOverride: ""
 iptables:

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -193,7 +193,7 @@ type KubeProxyConfiguration struct {
 	// Refer to [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.
 	Logging logsapi.LoggingConfiguration
 	// EnableServiceHealthCheckPort enables health check port serving for LoadBalancer services
-	EnableServiceHealthCheckPort bool
+	EnableServiceHealthCheckPort *bool
 }
 
 // ProxyMode represents modes used by the Kubernetes proxy server.

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -192,6 +192,8 @@ type KubeProxyConfiguration struct {
 	// Logging specifies the options of logging.
 	// Refer to [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.
 	Logging logsapi.LoggingConfiguration
+	// EnableServiceHealthCheckPort enables health check port serving for LoadBalancer services
+	EnableServiceHealthCheckPort bool
 }
 
 // ProxyMode represents modes used by the Kubernetes proxy server.

--- a/pkg/proxy/apis/config/v1alpha1/defaults.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults.go
@@ -125,6 +125,9 @@ func SetDefaults_KubeProxyConfiguration(obj *kubeproxyconfigv1alpha1.KubeProxyCo
 	if obj.FeatureGates == nil {
 		obj.FeatureGates = make(map[string]bool)
 	}
+	if obj.EnableServiceHealthCheckPort == nil {
+		obj.EnableServiceHealthCheckPort = pointer.Bool(true)
+	}
 	// Use the Default LoggingConfiguration option
 	logsapi.SetRecommendedLoggingConfiguration(&obj.Logging)
 }

--- a/pkg/proxy/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults_test.go
@@ -74,6 +74,7 @@ func TestDefaultsKubeProxyConfiguration(t *testing.T) {
 					Format:         "text",
 					FlushFrequency: logsapi.TimeOrMetaDuration{Duration: metav1.Duration{Duration: 5 * time.Second}, SerializeAsString: true},
 				},
+				EnableServiceHealthCheckPort: pointer.Bool(true),
 			},
 		},
 		{
@@ -114,6 +115,7 @@ func TestDefaultsKubeProxyConfiguration(t *testing.T) {
 					Format:         "text",
 					FlushFrequency: logsapi.TimeOrMetaDuration{Duration: metav1.Duration{Duration: 5 * time.Second}, SerializeAsString: true},
 				},
+				EnableServiceHealthCheckPort: pointer.Bool(true),
 			},
 		},
 	}

--- a/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
@@ -159,6 +159,7 @@ func autoConvert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguratio
 		return err
 	}
 	out.Logging = in.Logging
+	out.EnableServiceHealthCheckPort = (*bool)(unsafe.Pointer(in.EnableServiceHealthCheckPort))
 	return nil
 }
 
@@ -202,6 +203,7 @@ func autoConvert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguratio
 		return err
 	}
 	out.Logging = in.Logging
+	out.EnableServiceHealthCheckPort = (*bool)(unsafe.Pointer(in.EnableServiceHealthCheckPort))
 	return nil
 }
 

--- a/pkg/proxy/apis/config/zz_generated.deepcopy.go
+++ b/pkg/proxy/apis/config/zz_generated.deepcopy.go
@@ -93,6 +93,11 @@ func (in *KubeProxyConfiguration) DeepCopyInto(out *KubeProxyConfiguration) {
 	out.Winkernel = in.Winkernel
 	out.DetectLocal = in.DetectLocal
 	in.Logging.DeepCopyInto(&out.Logging)
+	if in.EnableServiceHealthCheckPort != nil {
+		in, out := &in.EnableServiceHealthCheckPort, &out.EnableServiceHealthCheckPort
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -37,6 +37,7 @@ import (
 	networkingv1alpha1client "k8s.io/client-go/kubernetes/typed/networking/v1alpha1"
 	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	apiservice "k8s.io/kubernetes/pkg/api/service"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/cluster/ports"
 	"k8s.io/kubernetes/pkg/features"
@@ -78,9 +79,10 @@ type ProxyConfig struct {
 
 type ServicesConfig struct {
 	// Service IP ranges
-	ClusterIPRange          net.IPNet
-	SecondaryClusterIPRange net.IPNet
-	NodePortRange           utilnet.PortRange
+	ClusterIPRange               net.IPNet
+	SecondaryClusterIPRange      net.IPNet
+	NodePortRange                utilnet.PortRange
+	EnableServiceHealthCheckPort bool
 
 	IPRepairInterval time.Duration
 }
@@ -221,6 +223,10 @@ func (c *legacyProvider) NewRESTStorage(apiResourceConfigSource serverstorage.AP
 		if err != nil {
 			return genericapiserver.APIGroupInfo{}, err
 		}
+	}
+
+	if !c.Services.EnableServiceHealthCheckPort {
+		apiservice.DisableHealthCheckPortAllocation()
 	}
 
 	if resource := "pods"; apiResourceConfigSource.ResourceEnabled(corev1.SchemeGroupVersion.WithResource(resource)) {

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
@@ -189,6 +189,8 @@ type KubeProxyConfiguration struct {
 	// Refer to [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go)
 	// for more information.
 	Logging logsapi.LoggingConfiguration `json:"logging,omitempty"`
+	// EnableServiceHealthCheckPort enables health check port serving for LoadBalancer services
+	EnableServiceHealthCheckPort *bool `json:"enableServiceHealthCheckPort"`
 }
 
 // ProxyMode represents modes used by the Kubernetes proxy server.

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/zz_generated.deepcopy.go
@@ -71,6 +71,11 @@ func (in *KubeProxyConfiguration) DeepCopyInto(out *KubeProxyConfiguration) {
 	out.Winkernel = in.Winkernel
 	out.DetectLocal = in.DetectLocal
 	in.Logging.DeepCopyInto(&out.Logging)
+	if in.EnableServiceHealthCheckPort != nil {
+		in, out := &in.EnableServiceHealthCheckPort, &out.EnableServiceHealthCheckPort
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig network

#### What this PR does / why we need it:
Some LoadBalancer implementations choose to route traffic to pods (or nodes where the target pods are running), instead of attaching every node to the LoadBalancer's backend, e.g. [Alibaba Cloud](https://github.com/kubernetes/cloud-provider-alibaba-cloud/blob/v2.7.0/pkg/controller/service/clbv1/vgroups.go#L429-L437), [Huawei Cloud](https://github.com/kubernetes-sigs/cloud-provider-huaweicloud/blob/release-1.17/pkg/cloudprovider/huaweicloud/elb.go#L566-L607). In such cases, allocating a HealthCheck port would be unnecessary (node port is precious). This PR adds the `--enable-service-health-check-port` flag to allow disabling HealthCheck port allocation (for apiserver) and serving (for kube-proxy).

#### Special notes for your reviewer:
A similar case is the [spec.allocateLoadBalancerNodePorts](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation), where a kubernetes user can specify if a service should be allocated with a NodePort. However, since the LoadBalancer implementation in one cluster is not changing, I think a global flag for apiserver and kube-proxy is enough.

#### Does this PR introduce a user-facing change?
```release-note
Introduce the `--enable-service-health-check-port` flag to allow disabling HealthCheck port allocation (for apiserver) and serving (for kube-proxy).
```

