### PR TITLE
Update the container images used in cloudbuild to their latest version

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -250,7 +250,7 @@ dependencies:
 
   # GCB docker gcloud image
   - name: "gcb-docker-gcloud: dependents"
-    version: v20221007-69e0da97ef
+    version: v20230623-56e06d7c18
     refPaths:
     - path: build/pause/cloudbuild.yaml
       match: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud

--- a/build/pause/cloudbuild.yaml
+++ b/build/pause/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221007-69e0da97ef'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230623-56e06d7c18'
     entrypoint: 'bash'
     dir: ./build/pause
     env:

--- a/cluster/images/etcd/cloudbuild.yaml
+++ b/cluster/images/etcd/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221007-69e0da97ef'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230623-56e06d7c18'
     entrypoint: 'bash'
     dir: ./cluster/images/etcd
     env:

--- a/test/images/cloudbuild.yaml
+++ b/test/images/cloudbuild.yaml
@@ -9,7 +9,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221007-69e0da97ef'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230623-56e06d7c18'
     entrypoint: 'bash'
     dir: ./test/images/
     env:


### PR DESCRIPTION
This carry below GOLLANG_VERSION which got many CVE fixes:

/workspace # echo $GOLANG_VERSION
1.20.5
/workspace #

CVE-2023-29403 and Go issue https://go.dev/issue/60272. CVE-2023-29404 and CVE-2023-29405:
  Go issues https://go.dev/issue/60305 and https://go.dev/issue/60306
CVE-2023-29402 and Go issue https://go.dev/issue/60167



/kind cleanup



-->
```release-note
NONE
```

