### PR TITLE
Added Kind/ResourceScope support in APIService model

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/types.go
@@ -86,7 +86,7 @@ type APIServiceSpec struct {
 
 	// ScopedResources declares a range of scoped resources to tell what resources to provide by the APIService. there can be more resources provided
 	// by the servicebackend. k8s aggregator focuses on the resources declared by ScopedResources, if it is defined.
-	ScopedResources []ScopedResource `json:"scopedResources,omitempty" protobuf:"bytes,7,opt,name=scopedResources"`
+	ScopedResources []ScopedResource 
 }
 
 type ResourceScope string
@@ -97,18 +97,18 @@ const (
 )
 
 type ScopedResource struct {
-	ResourceScope ResourceScope `json:"resourceScope" protobuf:"bytes,2,name=resourceScope"`
+	ResourceScope ResourceScope 
 	// plural is the plural name of the resource to serve.
 	// The custom resources are served under `/apis/<group>/<version>/.../<plural>`.
 	// Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
 	// Must be all lowercase.
-	Plural string `json:"plural" protobuf:"bytes,1,opt,name=plural"`
+	Plural string 
 	// singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
 	// +optional
-	Singular string `json:"singular,omitempty" protobuf:"bytes,2,opt,name=singular"`
+	Singular string 
 	// kind is the serialized kind of the resource. It is normally CamelCase and singular.
 	// kube aggregator will use this value as the `kind` attribute in API calls.
-	Kind string `json:"kind" protobuf:"bytes,4,opt,name=kind"`
+	Kind string 
 }
 
 // ConditionStatus indicates the status of a condition (true, false, or unknown).

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/types.go
@@ -83,6 +83,32 @@ type APIServiceSpec struct {
 	// version, then minor version. An example sorted list of versions:
 	// v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
 	VersionPriority int32
+
+	// ScopedResources declares a range of scoped resources to tell what resources to provide by the APIService. there can be more resources provided
+	// by the servicebackend. k8s aggregator focuses on the resources declared by ScopedResources, if it is defined.
+	ScopedResources []ScopedResource `json:"scopedResources,omitempty" protobuf:"bytes,7,opt,name=scopedResources"`
+}
+
+type ResourceScope string
+
+const (
+	ResourceScopeCluster   ResourceScope = "Cluster"
+	ResourceScopeNamespace ResourceScope = "Namespace"
+)
+
+type ScopedResource struct {
+	ResourceScope ResourceScope `json:"resourceScope" protobuf:"bytes,2,name=resourceScope"`
+	// plural is the plural name of the resource to serve.
+	// The custom resources are served under `/apis/<group>/<version>/.../<plural>`.
+	// Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
+	// Must be all lowercase.
+	Plural string `json:"plural" protobuf:"bytes,1,opt,name=plural"`
+	// singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+	// +optional
+	Singular string `json:"singular,omitempty" protobuf:"bytes,2,opt,name=singular"`
+	// kind is the serialized kind of the resource. It is normally CamelCase and singular.
+	// kube aggregator will use this value as the `kind` attribute in API calls.
+	Kind string `json:"kind" protobuf:"bytes,4,opt,name=kind"`
 }
 
 // ConditionStatus indicates the status of a condition (true, false, or unknown).

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/types.go
@@ -90,6 +90,32 @@ type APIServiceSpec struct {
 
 	// leaving this here so everyone remembers why proto index 6 is skipped
 	// Priority int64 `json:"priority" protobuf:"varint,6,opt,name=priority"`
+
+	// ScopedResources declares a range of scoped resources to tell what resources to provide by the APIService. there can be more resources provided
+	// by the servicebackend. k8s aggregator focuses on the resources declared by ScopedResources, if it is defined.
+	ScopedResources []ScopedResource `json:"scopedResources,omitempty" protobuf:"bytes,7,opt,name=scopedResources"`
+}
+
+type ResourceScope string
+
+const (
+	ResourceScopeCluster   ResourceScope = "Cluster"
+	ResourceScopeNamespace ResourceScope = "Namespace"
+)
+
+type ScopedResource struct {
+	ResourceScope ResourceScope `json:"resourceScope" protobuf:"bytes,2,name=resourceScope"`
+	// plural is the plural name of the resource to serve.
+	// The custom resources are served under `/apis/<group>/<version>/.../<plural>`.
+	// Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
+	// Must be all lowercase.
+	Plural string `json:"plural" protobuf:"bytes,1,opt,name=plural"`
+	// singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+	// +optional
+	Singular string `json:"singular,omitempty" protobuf:"bytes,2,opt,name=singular"`
+	// kind is the serialized kind of the resource. It is normally CamelCase and singular.
+	// kube aggregator will use this value as the `kind` attribute in API calls.
+	Kind string `json:"kind" protobuf:"bytes,4,opt,name=kind"`
 }
 
 // ConditionStatus indicates the status of a condition (true, false, or unknown).

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/types.go
@@ -90,32 +90,6 @@ type APIServiceSpec struct {
 
 	// leaving this here so everyone remembers why proto index 6 is skipped
 	// Priority int64 `json:"priority" protobuf:"varint,6,opt,name=priority"`
-
-	// ScopedResources declares a range of scoped resources to tell what resources to provide by the APIService. there can be more resources provided
-	// by the servicebackend. k8s aggregator focuses on the resources declared by ScopedResources, if it is defined.
-	ScopedResources []ScopedResource `json:"scopedResources,omitempty" protobuf:"bytes,7,opt,name=scopedResources"`
-}
-
-type ResourceScope string
-
-const (
-	ResourceScopeCluster   ResourceScope = "Cluster"
-	ResourceScopeNamespace ResourceScope = "Namespace"
-)
-
-type ScopedResource struct {
-	ResourceScope ResourceScope `json:"resourceScope" protobuf:"bytes,2,name=resourceScope"`
-	// plural is the plural name of the resource to serve.
-	// The custom resources are served under `/apis/<group>/<version>/.../<plural>`.
-	// Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
-	// Must be all lowercase.
-	Plural string `json:"plural" protobuf:"bytes,1,opt,name=plural"`
-	// singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
-	// +optional
-	Singular string `json:"singular,omitempty" protobuf:"bytes,2,opt,name=singular"`
-	// kind is the serialized kind of the resource. It is normally CamelCase and singular.
-	// kube aggregator will use this value as the `kind` attribute in API calls.
-	Kind string `json:"kind" protobuf:"bytes,4,opt,name=kind"`
 }
 
 // ConditionStatus indicates the status of a condition (true, false, or unknown).

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/types.go
@@ -93,6 +93,32 @@ type APIServiceSpec struct {
 
 	// leaving this here so everyone remembers why proto index 6 is skipped
 	// Priority int64 `json:"priority" protobuf:"varint,6,opt,name=priority"`
+
+	// ScopedResources declares a range of scoped resources to tell what resources to provide by the APIService. there can be more resources provided
+	// by the servicebackend. k8s aggregator focuses on the resources declared by ScopedResources, if it is defined.
+	ScopedResources []ScopedResource `json:"scopedResources,omitempty" protobuf:"bytes,7,opt,name=scopedResources"`
+}
+
+type ResourceScope string
+
+const (
+	ResourceScopeCluster   ResourceScope = "Cluster"
+	ResourceScopeNamespace ResourceScope = "Namespace"
+)
+
+type ScopedResource struct {
+	ResourceScope ResourceScope `json:"resourceScope" protobuf:"bytes,2,name=resourceScope"`
+	// plural is the plural name of the resource to serve.
+	// The custom resources are served under `/apis/<group>/<version>/.../<plural>`.
+	// Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
+	// Must be all lowercase.
+	Plural string `json:"plural" protobuf:"bytes,1,opt,name=plural"`
+	// singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+	// +optional
+	Singular string `json:"singular,omitempty" protobuf:"bytes,2,opt,name=singular"`
+	// kind is the serialized kind of the resource. It is normally CamelCase and singular.
+	// kube aggregator will use this value as the `kind` attribute in API calls.
+	Kind string `json:"kind" protobuf:"bytes,4,opt,name=kind"`
 }
 
 // ConditionStatus indicates the status of a condition (true, false, or unknown).

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/types.go
@@ -107,7 +107,7 @@ const (
 )
 
 type ScopedResource struct {
-	ResourceScope ResourceScope `json:"resourceScope" protobuf:"bytes,2,name=resourceScope"`
+	ResourceScope ResourceScope `json:"resourceScope" protobuf:"bytes,2,2,name=resourceScope"`
 	// plural is the plural name of the resource to serve.
 	// The custom resources are served under `/apis/<group>/<version>/.../<plural>`.
 	// Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/types.go
@@ -107,7 +107,7 @@ const (
 )
 
 type ScopedResource struct {
-	ResourceScope ResourceScope `json:"resourceScope" protobuf:"bytes,2,2,name=resourceScope"`
+	ResourceScope ResourceScope `json:"resourceScope" protobuf:"bytes,2,name=resourceScope"`
 	// plural is the plural name of the resource to serve.
 	// The custom resources are served under `/apis/<group>/<version>/.../<plural>`.
 	// Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
@@ -115,7 +115,7 @@ type ScopedResource struct {
 	Plural string `json:"plural" protobuf:"bytes,1,opt,name=plural"`
 	// singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
 	// +optional
-	Singular string `json:"singular,omitempty" protobuf:"bytes,2,opt,name=singular"`
+	Singular string `json:"singular,omitempty" protobuf:"bytes,3,opt,name=singular"`
 	// kind is the serialized kind of the resource. It is normally CamelCase and singular.
 	// kube aggregator will use this value as the `kind` attribute in API calls.
 	Kind string `json:"kind" protobuf:"bytes,4,opt,name=kind"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This pull request (PR) adds support for defining scoped resources in the `APIService model`. It introduces the `ResourceScope type and the `ScopedResource` struct, allowing resources to be grouped based on their scope (Cluster or Namespace).

The changes in this PR enhance resource management, alleviate backend pressure, and facilitate seamless migrations for a more efficient and scalable Kubernetes cluster.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119738

