### PR TITLE
make job.status.active and job.status.failed be filtered in the server-side

### DIFF
--- a/pkg/apis/batch/v1/conversion.go
+++ b/pkg/apis/batch/v1/conversion.go
@@ -29,7 +29,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	return scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Job"),
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name", "metadata.namespace", "status.successful":
+			case "metadata.name", "metadata.namespace", "status.successful", "status.active", "status.failed":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label %q not supported for Job", label)

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -340,6 +340,8 @@ func JobToSelectableFields(job *batch.Job) fields.Set {
 	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(&job.ObjectMeta, true)
 	specificFieldsSet := fields.Set{
 		"status.successful": strconv.Itoa(int(job.Status.Succeeded)),
+		"status.active":     strconv.Itoa(int(job.Status.Active)),
+		"status.failed":     strconv.Itoa(int(job.Status.Failed)),
 	}
 	return generic.MergeFieldsSets(objectMetaFieldsSet, specificFieldsSet)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation


Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR aims to add `job.Status.Active` and `job.Status.Failed` as possible filters in FieldSelectors in the server-side.

Currently, it is possible to do:
```
listOpt := metav1.ListOptions{
    FieldSelector: "status.successful=1",
}
result, err := clientset.BatchV1().Jobs("").List(listOptions) 
```

This PR aims to make the following possible as well:
```
listOpt := metav1.ListOptions{
    FieldSelector: "status.active=1",
}
result, err := clientset.BatchV1().Jobs("").List(listOptions) 
```

```
listOpt := metav1.ListOptions{
    FieldSelector: "status.failed=1",
}
result, err := clientset.BatchV1().Jobs("").List(listOptions) 
```

With that, we could filter jobs by active and failed status as well.

#### Which issue(s) this PR fixes:
It doesn't fix any issue, but it's somehow related to #53459.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
