### PR TITLE
kubeadm: fix nil pointer when etcd member is already removed

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -362,8 +362,11 @@ func (c *Client) RemoveMember(id uint64) ([]Member, error) {
 
 	// Returns the updated list of etcd members
 	ret := []Member{}
-	for _, m := range resp.Members {
-		ret = append(ret, Member{Name: m.Name, PeerURL: m.PeerURLs[0]})
+	if resp != nil {
+		for _, m := range resp.Members {
+			ret = append(ret, Member{Name: m.Name, PeerURL: m.PeerURLs[0]})
+		}
+
 	}
 
 	return ret, nil


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
- Code was added in https://github.com/kubernetes/kubernetes/pull/117724

https://github.com/kubernetes/kubernetes/blob/2c6c4566eff972d6c1320b5f8ad795f88c822d09/cmd/kubeadm/app/util/etcd/etcd.go#L351-L354


#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubeadm/issues/2912

#### Special notes for your reviewer:

- [ ] TODO: this may need cherry-picks to old versions

#### Does this PR introduce a user-facing change?

```release-note
kubeadm: fix nil pointer when etcd member is already removed
```
