### PR TITLE
add trace for kubelet eviction manager

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -617,6 +617,11 @@ func (m *managerImpl) evictPod(ctx context.Context, pod *v1.Pod, gracePeriodOver
 		attribute.String("k8s.pod.name", pod.Name),
 		attribute.String("k8s.namespace.name", pod.Namespace),
 	))
+	otelSpan.AddEvent("Evicting pod", trace.WithAttributes(
+		attribute.String("pod", klog.KObj(pod).String()),
+		attribute.String("podUID", string(pod.UID)),
+		attribute.String("message", evictMsg),
+	))
 	defer otelSpan.End()
 	err := m.killPodFunc(pod, true, &gracePeriodOverride, func(status *v1.PodStatus) {
 		status.Phase = v1.PodFailed

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -613,13 +613,11 @@ func (m *managerImpl) evictPod(ctx context.Context, pod *v1.Pod, gracePeriodOver
 	klog.V(3).InfoS("Evicting pod", "pod", klog.KObj(pod), "podUID", pod.UID, "message", evictMsg)
 	_, otelSpan := m.tracer.Start(ctx, "Eviction/EvictPod", trace.WithAttributes(
 		attribute.String("k8s.pod.uid", string(pod.UID)),
-		attribute.String("k8s.pod", klog.KObj(pod).String()),
 		attribute.String("k8s.pod.name", pod.Name),
 		attribute.String("k8s.namespace.name", pod.Namespace),
 	))
 	otelSpan.AddEvent("Evicting pod", trace.WithAttributes(
 		attribute.String("k8s.pod.uid", string(pod.UID)),
-		attribute.String("pod", klog.KObj(pod).String()),
 		attribute.String("k8s.pod.name", pod.Name),
 		attribute.String("k8s.namespace.name", pod.Namespace),
 		attribute.String("k8s.eviction.message", evictMsg),
@@ -636,9 +634,7 @@ func (m *managerImpl) evictPod(ctx context.Context, pod *v1.Pod, gracePeriodOver
 	if err != nil {
 		klog.ErrorS(err, "Eviction manager: pod failed to evict", "pod", klog.KObj(pod))
 		otelSpan.RecordError(fmt.Errorf("pod failed to evict: %w", err), trace.WithAttributes(
-			attribute.String("err", err.Error()),
 			attribute.String("k8s.pod.uid", string(pod.UID)),
-			attribute.String("pod", klog.KObj(pod).String()),
 			attribute.String("k8s.pod.name", pod.Name),
 			attribute.String("k8s.namespace.name", pod.Namespace),
 		))
@@ -646,7 +642,6 @@ func (m *managerImpl) evictPod(ctx context.Context, pod *v1.Pod, gracePeriodOver
 		klog.InfoS("Eviction manager: pod is evicted successfully", "pod", klog.KObj(pod))
 		otelSpan.AddEvent("pod is evicted successfully", trace.WithAttributes(
 			attribute.String("k8s.pod.uid", string(pod.UID)),
-			attribute.String("pod", klog.KObj(pod).String()),
 			attribute.String("k8s.pod.name", pod.Name),
 			attribute.String("k8s.namespace.name", pod.Namespace),
 		))

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/klog/v2"
 
@@ -612,14 +613,14 @@ func (m *managerImpl) evictPod(ctx context.Context, pod *v1.Pod, gracePeriodOver
 	// this is a blocking call and should only return when the pod and its containers are killed.
 	klog.V(3).InfoS("Evicting pod", "pod", klog.KObj(pod), "podUID", pod.UID, "message", evictMsg)
 	_, otelSpan := m.tracer.Start(ctx, "Eviction/EvictPod", trace.WithAttributes(
-		attribute.String("k8s.pod.uid", string(pod.UID)),
-		attribute.String("k8s.pod.name", pod.Name),
-		attribute.String("k8s.namespace.name", pod.Namespace),
+		semconv.K8SPodUIDKey.String(string(pod.UID)),
+		semconv.K8SPodNameKey.String(pod.Name),
+		semconv.K8SNamespaceNameKey.String(pod.Namespace),
 	))
 	otelSpan.AddEvent("Evicting pod", trace.WithAttributes(
-		attribute.String("k8s.pod.uid", string(pod.UID)),
-		attribute.String("k8s.pod.name", pod.Name),
-		attribute.String("k8s.namespace.name", pod.Namespace),
+		semconv.K8SPodUIDKey.String(string(pod.UID)),
+		semconv.K8SPodNameKey.String(pod.Name),
+		semconv.K8SNamespaceNameKey.String(pod.Namespace),
 		attribute.String("k8s.eviction.message", evictMsg),
 	))
 	defer otelSpan.End()
@@ -634,16 +635,16 @@ func (m *managerImpl) evictPod(ctx context.Context, pod *v1.Pod, gracePeriodOver
 	if err != nil {
 		klog.ErrorS(err, "Eviction manager: pod failed to evict", "pod", klog.KObj(pod))
 		otelSpan.RecordError(fmt.Errorf("pod failed to evict: %w", err), trace.WithAttributes(
-			attribute.String("k8s.pod.uid", string(pod.UID)),
-			attribute.String("k8s.pod.name", pod.Name),
-			attribute.String("k8s.namespace.name", pod.Namespace),
+			semconv.K8SPodUIDKey.String(string(pod.UID)),
+			semconv.K8SPodNameKey.String(pod.Name),
+			semconv.K8SNamespaceNameKey.String(pod.Namespace),
 		))
 	} else {
 		klog.InfoS("Eviction manager: pod is evicted successfully", "pod", klog.KObj(pod))
 		otelSpan.AddEvent("pod is evicted successfully", trace.WithAttributes(
-			attribute.String("k8s.pod.uid", string(pod.UID)),
-			attribute.String("k8s.pod.name", pod.Name),
-			attribute.String("k8s.namespace.name", pod.Namespace),
+			semconv.K8SPodUIDKey.String(string(pod.UID)),
+			semconv.K8SPodNameKey.String(pod.Name),
+			semconv.K8SNamespaceNameKey.String(pod.Namespace),
 		))
 	}
 	return true

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -618,9 +618,11 @@ func (m *managerImpl) evictPod(ctx context.Context, pod *v1.Pod, gracePeriodOver
 		attribute.String("k8s.namespace.name", pod.Namespace),
 	))
 	otelSpan.AddEvent("Evicting pod", trace.WithAttributes(
+		attribute.String("k8s.pod.uid", string(pod.UID)),
 		attribute.String("pod", klog.KObj(pod).String()),
-		attribute.String("podUID", string(pod.UID)),
-		attribute.String("message", evictMsg),
+		attribute.String("k8s.pod.name", pod.Name),
+		attribute.String("k8s.namespace.name", pod.Namespace),
+		attribute.String("k8s.eviction.message", evictMsg),
 	))
 	defer otelSpan.End()
 	err := m.killPodFunc(pod, true, &gracePeriodOverride, func(status *v1.PodStatus) {
@@ -635,12 +637,18 @@ func (m *managerImpl) evictPod(ctx context.Context, pod *v1.Pod, gracePeriodOver
 		klog.ErrorS(err, "Eviction manager: pod failed to evict", "pod", klog.KObj(pod))
 		otelSpan.RecordError(fmt.Errorf("pod failed to evict: %w", err), trace.WithAttributes(
 			attribute.String("err", err.Error()),
+			attribute.String("k8s.pod.uid", string(pod.UID)),
 			attribute.String("pod", klog.KObj(pod).String()),
+			attribute.String("k8s.pod.name", pod.Name),
+			attribute.String("k8s.namespace.name", pod.Namespace),
 		))
 	} else {
 		klog.InfoS("Eviction manager: pod is evicted successfully", "pod", klog.KObj(pod))
 		otelSpan.AddEvent("pod is evicted successfully", trace.WithAttributes(
+			attribute.String("k8s.pod.uid", string(pod.UID)),
 			attribute.String("pod", klog.KObj(pod).String()),
+			attribute.String("k8s.pod.name", pod.Name),
+			attribute.String("k8s.namespace.name", pod.Namespace),
 		))
 	}
 	return true

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -633,7 +633,7 @@ func (m *managerImpl) evictPod(ctx context.Context, pod *v1.Pod, gracePeriodOver
 	})
 	if err != nil {
 		klog.ErrorS(err, "Eviction manager: pod failed to evict", "pod", klog.KObj(pod))
-		otelSpan.AddEvent("pod failed to evict", trace.WithAttributes(
+		otelSpan.RecordError(fmt.Errorf("pod failed to evict: %w", err), trace.WithAttributes(
 			attribute.String("err", err.Error()),
 			attribute.String("pod", klog.KObj(pod).String()),
 		))

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/klog/v2"
 
@@ -616,11 +616,6 @@ func (m *managerImpl) evictPod(ctx context.Context, pod *v1.Pod, gracePeriodOver
 		semconv.K8SPodUIDKey.String(string(pod.UID)),
 		semconv.K8SPodNameKey.String(pod.Name),
 		semconv.K8SNamespaceNameKey.String(pod.Namespace),
-	))
-	otelSpan.AddEvent("Evicting pod", trace.WithAttributes(
-		semconv.K8SPodUIDKey.String(string(pod.UID)),
-		semconv.K8SPodNameKey.String(pod.Name),
-		semconv.K8SNamespaceNameKey.String(pod.Namespace),
 		attribute.String("k8s.eviction.message", evictMsg),
 	))
 	defer otelSpan.End()
@@ -641,11 +636,6 @@ func (m *managerImpl) evictPod(ctx context.Context, pod *v1.Pod, gracePeriodOver
 		))
 	} else {
 		klog.InfoS("Eviction manager: pod is evicted successfully", "pod", klog.KObj(pod))
-		otelSpan.AddEvent("pod is evicted successfully", trace.WithAttributes(
-			semconv.K8SPodUIDKey.String(string(pod.UID)),
-			semconv.K8SPodNameKey.String(pod.Name),
-			semconv.K8SNamespaceNameKey.String(pod.Namespace),
-		))
 	}
 	return true
 }

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -25,6 +25,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
@@ -298,6 +299,7 @@ func TestMemoryPressure_VerifyPodStatus(t *testing.T) {
 					},
 				}
 				summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker("1500Mi", podStats)}
+
 				manager := &managerImpl{
 					clock:                        fakeClock,
 					killPodFunc:                  podKiller.killPodNow,
@@ -309,6 +311,7 @@ func TestMemoryPressure_VerifyPodStatus(t *testing.T) {
 					nodeRef:                      nodeRef,
 					nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 					thresholdsFirstObservedAt:    thresholdsObservedAt{},
+					tracer:                       oteltrace.NewNoopTracerProvider().Tracer(instrumentationScope),
 				}
 
 				// synchronize to detect the memory pressure
@@ -491,6 +494,7 @@ func TestDiskPressureNodeFs_VerifyPodStatus(t *testing.T) {
 					nodeRef:                      nodeRef,
 					nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 					thresholdsFirstObservedAt:    thresholdsObservedAt{},
+					tracer:                       oteltrace.NewNoopTracerProvider().Tracer(instrumentationScope),
 				}
 
 				// synchronize
@@ -595,6 +599,7 @@ func TestMemoryPressure(t *testing.T) {
 		nodeRef:                      nodeRef,
 		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 		thresholdsFirstObservedAt:    thresholdsObservedAt{},
+		tracer:                       oteltrace.NewNoopTracerProvider().Tracer(instrumentationScope),
 	}
 
 	// create a best effort pod to test admission
@@ -994,6 +999,7 @@ func TestDiskPressureNodeFs(t *testing.T) {
 				nodeRef:                      nodeRef,
 				nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 				thresholdsFirstObservedAt:    thresholdsObservedAt{},
+				tracer:                       oteltrace.NewNoopTracerProvider().Tracer(instrumentationScope),
 			}
 
 			// create a best effort pod to test admission
@@ -1231,6 +1237,7 @@ func TestMinReclaim(t *testing.T) {
 		nodeRef:                      nodeRef,
 		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 		thresholdsFirstObservedAt:    thresholdsObservedAt{},
+		tracer:                       oteltrace.NewNoopTracerProvider().Tracer(instrumentationScope),
 	}
 
 	// synchronize
@@ -1516,6 +1523,7 @@ func TestNodeReclaimFuncs(t *testing.T) {
 				nodeRef:                      nodeRef,
 				nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 				thresholdsFirstObservedAt:    thresholdsObservedAt{},
+				tracer:                       oteltrace.NewNoopTracerProvider().Tracer(instrumentationScope),
 			}
 
 			// synchronize
@@ -1973,6 +1981,7 @@ func TestInodePressureFsInodes(t *testing.T) {
 				nodeRef:                      nodeRef,
 				nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 				thresholdsFirstObservedAt:    thresholdsObservedAt{},
+				tracer:                       oteltrace.NewNoopTracerProvider().Tracer(instrumentationScope),
 			}
 
 			// create a best effort pod to test admission
@@ -2207,6 +2216,7 @@ func TestStaticCriticalPodsAreNotEvicted(t *testing.T) {
 		nodeRef:                      nodeRef,
 		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 		thresholdsFirstObservedAt:    thresholdsObservedAt{},
+		tracer:                       oteltrace.NewNoopTracerProvider().Tracer(instrumentationScope),
 	}
 
 	fakeClock.Step(1 * time.Minute)
@@ -2338,6 +2348,7 @@ func TestAllocatableMemoryPressure(t *testing.T) {
 		nodeRef:                      nodeRef,
 		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 		thresholdsFirstObservedAt:    thresholdsObservedAt{},
+		tracer:                       oteltrace.NewNoopTracerProvider().Tracer(instrumentationScope),
 	}
 
 	// create a best effort pod to test admission
@@ -2507,6 +2518,7 @@ func TestUpdateMemcgThreshold(t *testing.T) {
 		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 		thresholdsFirstObservedAt:    thresholdsObservedAt{},
 		thresholdNotifiers:           []ThresholdNotifier{thresholdNotifier},
+		tracer:                       oteltrace.NewNoopTracerProvider().Tracer(instrumentationScope),
 	}
 
 	// The UpdateThreshold method should have been called once, since this is the first run.
@@ -2602,6 +2614,7 @@ func TestManagerWithLocalStorageCapacityIsolationOpen(t *testing.T) {
 		nodeRef:                       nodeRef,
 		localStorageCapacityIsolation: true,
 		dedicatedImageFs:              diskInfoProvider.dedicatedImageFs,
+		tracer:                        oteltrace.NewNoopTracerProvider().Tracer(instrumentationScope),
 	}
 
 	activePodsFunc := func() []*v1.Pod {

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -18,6 +18,7 @@ package eviction
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -2699,7 +2699,10 @@ func TestEvictionSuccessSpan(t *testing.T) {
 	}
 
 	// synchronize to detect the memory pressure
-	manager.synchronize(diskInfoProvider, activePodsFunc)
+	_, err := manager.synchronize(diskInfoProvider, activePodsFunc)
+	if err != nil {
+		t.Fatalf("Manager should not have error but got %v", err)
+	}
 
 	output := fakeRecorder.Ended()
 
@@ -2767,7 +2770,10 @@ func TestEvictionFailSpan(t *testing.T) {
 	}
 
 	// synchronize to detect the memory pressure
-	manager.synchronize(diskInfoProvider, activePodsFunc)
+	_, err := manager.synchronize(diskInfoProvider, activePodsFunc)
+	if err != nil {
+		t.Fatalf("Manager should not have error but got %v", err)
+	}
 
 	output := fakeRecorder.Ended()
 

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -25,6 +25,9 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -55,6 +58,7 @@ type mockPodKiller struct {
 	evict               bool
 	statusFn            func(*v1.PodStatus)
 	gracePeriodOverride *int64
+	evictFailed         bool
 }
 
 // killPodNow records the pod that was killed
@@ -63,6 +67,9 @@ func (m *mockPodKiller) killPodNow(pod *v1.Pod, evict bool, gracePeriodOverride 
 	m.statusFn = statusFn
 	m.evict = evict
 	m.gracePeriodOverride = gracePeriodOverride
+	if m.evictFailed {
+		return fmt.Errorf("kill pod failed")
+	}
 	return nil
 }
 
@@ -2557,6 +2564,144 @@ func TestUpdateMemcgThreshold(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Manager should not have an error %v", err)
 	}
+}
+
+func TestEvictionSuccessSpan(t *testing.T) {
+	podMaker := makePodWithMemoryStats
+	summaryStatsMaker := makeMemoryStats
+	podsToMake := []podToMake{
+		{name: "below-requests", requests: newResourceList("", "1Gi", ""), limits: newResourceList("", "1Gi", ""), memoryWorkingSet: "900Mi"},
+		{name: "above-requests", requests: newResourceList("", "100Mi", ""), limits: newResourceList("", "1Gi", ""), memoryWorkingSet: "700Mi"},
+	}
+	pods := []*v1.Pod{}
+	podStats := map[*v1.Pod]statsapi.PodStats{}
+	for _, podToMake := range podsToMake {
+		pod, podStat := podMaker(podToMake.name, podToMake.priority, podToMake.requests, podToMake.limits, podToMake.memoryWorkingSet)
+		pods = append(pods, pod)
+		podStats[pod] = podStat
+	}
+	activePodsFunc := func() []*v1.Pod {
+		return pods
+	}
+
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	podKiller := &mockPodKiller{}
+	diskInfoProvider := &mockDiskInfoProvider{dedicatedImageFs: false}
+	diskGC := &mockDiskGC{err: nil}
+	nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
+
+	config := Config{
+		PressureTransitionPeriod: time.Minute * 5,
+		Thresholds: []evictionapi.Threshold{
+			{
+				Signal:   evictionapi.SignalMemoryAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("2Gi"),
+				},
+			},
+		},
+	}
+	summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker("1500Mi", podStats)}
+
+	fakeRecorder := tracetest.NewSpanRecorder()
+	oteltracer := trace.NewTracerProvider(trace.WithSpanProcessor(fakeRecorder)).Tracer(instrumentationScope)
+
+	manager := &managerImpl{
+		clock:                        fakeClock,
+		killPodFunc:                  podKiller.killPodNow,
+		imageGC:                      diskGC,
+		containerGC:                  diskGC,
+		config:                       config,
+		recorder:                     &record.FakeRecorder{},
+		summaryProvider:              summaryProvider,
+		nodeRef:                      nodeRef,
+		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
+		thresholdsFirstObservedAt:    thresholdsObservedAt{},
+		tracer:                       oteltracer,
+	}
+
+	// synchronize to detect the memory pressure
+	manager.synchronize(diskInfoProvider, activePodsFunc)
+
+	output := fakeRecorder.Ended()
+
+	assert.Equal(t, 1, len(output), "Manager should output 1 span")
+	assert.Equal(t, "Eviction/EvictPod", output[0].Name(), "Manager should output 1 span with name 'Eviction/EvictPod'")
+	assert.Equal(t, 3, len(output[0].Attributes()), "Manager should output 1 span with 3 attributes, k8s.pod.id, k8s.pod.name, k8s.namespace.name")
+	assert.Equal(t, 2, len(output[0].Events()), "Manager should output 1 span with 2 events")
+	assert.Equal(t, 4, len(output[0].Events()[0].Attributes), "Manager should output first event with 4 attributes, k8s.pod.id, k8s.pod.name, k8s.namespace.name, k8s.eviction.message")
+	assert.Equal(t, 3, len(output[0].Events()[1].Attributes), "Manager should output second event with 3 attributes, if eviction is successful, k8s.pod.id, k8s.pod.name, k8s.namespace.name")
+}
+
+func TestEvictionFailSpan(t *testing.T) {
+	podMaker := makePodWithMemoryStats
+	summaryStatsMaker := makeMemoryStats
+	podsToMake := []podToMake{
+		{name: "below-requests", requests: newResourceList("", "1Gi", ""), limits: newResourceList("", "1Gi", ""), memoryWorkingSet: "900Mi"},
+		{name: "above-requests", requests: newResourceList("", "100Mi", ""), limits: newResourceList("", "1Gi", ""), memoryWorkingSet: "700Mi"},
+	}
+	pods := []*v1.Pod{}
+	podStats := map[*v1.Pod]statsapi.PodStats{}
+	for _, podToMake := range podsToMake {
+		pod, podStat := podMaker(podToMake.name, podToMake.priority, podToMake.requests, podToMake.limits, podToMake.memoryWorkingSet)
+		pods = append(pods, pod)
+		podStats[pod] = podStat
+	}
+	activePodsFunc := func() []*v1.Pod {
+		return pods
+	}
+
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	podKiller := &mockPodKiller{
+		evictFailed: true,
+	}
+	diskInfoProvider := &mockDiskInfoProvider{dedicatedImageFs: false}
+	diskGC := &mockDiskGC{err: nil}
+	nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
+
+	config := Config{
+		PressureTransitionPeriod: time.Minute * 5,
+		Thresholds: []evictionapi.Threshold{
+			{
+				Signal:   evictionapi.SignalMemoryAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("2Gi"),
+				},
+			},
+		},
+	}
+	summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker("1500Mi", podStats)}
+
+	fakeRecorder := tracetest.NewSpanRecorder()
+	oteltracer := trace.NewTracerProvider(trace.WithSpanProcessor(fakeRecorder)).Tracer(instrumentationScope)
+
+	manager := &managerImpl{
+		clock:                        fakeClock,
+		killPodFunc:                  podKiller.killPodNow,
+		imageGC:                      diskGC,
+		containerGC:                  diskGC,
+		config:                       config,
+		recorder:                     &record.FakeRecorder{},
+		summaryProvider:              summaryProvider,
+		nodeRef:                      nodeRef,
+		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
+		thresholdsFirstObservedAt:    thresholdsObservedAt{},
+		tracer:                       oteltracer,
+	}
+
+	// synchronize to detect the memory pressure
+	manager.synchronize(diskInfoProvider, activePodsFunc)
+
+	output := fakeRecorder.Ended()
+
+	assert.Equal(t, 1, len(output), "Manager should output 1 span")
+	assert.Equal(t, "Eviction/EvictPod", output[0].Name(), "Manager should output 1 span with name 'Eviction/EvictPod'")
+	assert.Equal(t, 3, len(output[0].Attributes()), "Manager should output 1 span with 3 attributes, k8s.pod.id, k8s.pod.name, k8s.namespace.name")
+	assert.Equal(t, 2, len(output[0].Events()), "Manager should output 1 span with 2 events")
+	assert.Equal(t, 4, len(output[0].Events()[0].Attributes), "Manager should output first event with 4 attributes, k8s.pod.id, k8s.pod.name, k8s.namespace.name, k8s.eviction.message")
+	assert.Equal(t, 5, len(output[0].Events()[1].Attributes), "Manager should output second event with 5 attributes, if eviction is failed, k8s.pod.id, k8s.pod.name, k8s.namespace.name, exception.type, exception.message")
 }
 
 func TestManagerWithLocalStorageCapacityIsolationOpen(t *testing.T) {

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -68,7 +68,7 @@ func (m *mockPodKiller) killPodNow(pod *v1.Pod, evict bool, gracePeriodOverride 
 	m.evict = evict
 	m.gracePeriodOverride = gracePeriodOverride
 	if m.evictFailed {
-		return fmt.Errorf("kill pod failed")
+		return errors.New("kill pod failed")
 	}
 	return nil
 }

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -2705,10 +2705,8 @@ func TestEvictionSuccessSpan(t *testing.T) {
 
 	assert.Equal(t, 1, len(output), "Manager should output 1 span")
 	assert.Equal(t, "Eviction/EvictPod", output[0].Name(), "Manager should output 1 span with name 'Eviction/EvictPod'")
-	assert.Equal(t, 3, len(output[0].Attributes()), "Manager should output 1 span with 3 attributes, k8s.pod.id, k8s.pod.name, k8s.namespace.name")
-	assert.Equal(t, 2, len(output[0].Events()), "Manager should output 1 span with 2 events")
-	assert.Equal(t, 4, len(output[0].Events()[0].Attributes), "Manager should output first event with 4 attributes, k8s.pod.id, k8s.pod.name, k8s.namespace.name, k8s.eviction.message")
-	assert.Equal(t, 3, len(output[0].Events()[1].Attributes), "Manager should output second event with 3 attributes, if eviction is successful, k8s.pod.id, k8s.pod.name, k8s.namespace.name")
+	assert.Equal(t, 4, len(output[0].Attributes()), "Manager should output 1 span with 3 attributes, k8s.pod.id, k8s.pod.name, k8s.namespace.name, k8s.eviction.message")
+	assert.Equal(t, 0, len(output[0].Events()), "Manager should output 1 span with 0 events")
 }
 
 func TestEvictionFailSpan(t *testing.T) {
@@ -2775,8 +2773,7 @@ func TestEvictionFailSpan(t *testing.T) {
 
 	assert.Equal(t, 1, len(output), "Manager should output 1 span")
 	assert.Equal(t, "Eviction/EvictPod", output[0].Name(), "Manager should output 1 span with name 'Eviction/EvictPod'")
-	assert.Equal(t, 3, len(output[0].Attributes()), "Manager should output 1 span with 3 attributes, k8s.pod.id, k8s.pod.name, k8s.namespace.name")
-	assert.Equal(t, 2, len(output[0].Events()), "Manager should output 1 span with 2 events")
-	assert.Equal(t, 4, len(output[0].Events()[0].Attributes), "Manager should output first event with 4 attributes, k8s.pod.id, k8s.pod.name, k8s.namespace.name, k8s.eviction.message")
-	assert.Equal(t, 5, len(output[0].Events()[1].Attributes), "Manager should output second event with 5 attributes, if eviction is failed, k8s.pod.id, k8s.pod.name, k8s.namespace.name, exception.type, exception.message")
+	assert.Equal(t, 4, len(output[0].Attributes()), "Manager should output 1 span with 3 attributes, k8s.pod.id, k8s.pod.name, k8s.namespace.name, k8s.eviction.message")
+	assert.Equal(t, 1, len(output[0].Events()), "Manager should output 1 span with 2 events")
+	assert.Equal(t, 5, len(output[0].Events()[0].Attributes), "Manager should output second event with 5 attributes, if eviction is failed, k8s.pod.id, k8s.pod.name, k8s.namespace.name, exception.type, exception.message")
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -850,7 +850,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 
 	// setup eviction manager
 	evictionManager, evictionAdmitHandler := eviction.NewManager(klet.resourceAnalyzer, evictionConfig,
-		killPodNow(klet.podWorkers, kubeDeps.Recorder), klet.imageManager, klet.containerGC, kubeDeps.Recorder, nodeRef, klet.clock, kubeCfg.LocalStorageCapacityIsolation)
+		killPodNow(klet.podWorkers, kubeDeps.Recorder), klet.imageManager, klet.containerGC, kubeDeps.Recorder, nodeRef, klet.clock, kubeCfg.LocalStorageCapacityIsolation, kubeDeps.TracerProvider)
 
 	klet.evictionManager = evictionManager
 	klet.admitHandlers.AddPodAdmitHandler(evictionAdmitHandler)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -347,7 +347,7 @@ func newTestKubeletWithImageList(
 	}
 	// setup eviction manager
 	evictionManager, evictionAdmitHandler := eviction.NewManager(kubelet.resourceAnalyzer, eviction.Config{},
-		killPodNow(kubelet.podWorkers, fakeRecorder), kubelet.imageManager, kubelet.containerGC, fakeRecorder, nodeRef, kubelet.clock, kubelet.supportLocalStorageCapacityIsolation())
+		killPodNow(kubelet.podWorkers, fakeRecorder), kubelet.imageManager, kubelet.containerGC, fakeRecorder, nodeRef, kubelet.clock, kubelet.supportLocalStorageCapacityIsolation(), oteltrace.NewNoopTracerProvider())
 
 	kubelet.evictionManager = evictionManager
 	kubelet.admitHandlers.AddPodAdmitHandler(evictionAdmitHandler)

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/mock/gomock"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"k8s.io/mount-utils"
 
 	v1 "k8s.io/api/core/v1"
@@ -136,7 +137,7 @@ func TestRunOnce(t *testing.T) {
 	fakeKillPodFunc := func(pod *v1.Pod, evict bool, gracePeriodOverride *int64, fn func(*v1.PodStatus)) error {
 		return nil
 	}
-	evictionManager, evictionAdmitHandler := eviction.NewManager(kb.resourceAnalyzer, eviction.Config{}, fakeKillPodFunc, nil, nil, kb.recorder, nodeRef, kb.clock, kb.supportLocalStorageCapacityIsolation())
+	evictionManager, evictionAdmitHandler := eviction.NewManager(kb.resourceAnalyzer, eviction.Config{}, fakeKillPodFunc, nil, nil, kb.recorder, nodeRef, kb.clock, kb.supportLocalStorageCapacityIsolation(), oteltrace.NewNoopTracerProvider())
 
 	kb.evictionManager = evictionManager
 	kb.admitHandlers.AddPodAdmitHandler(evictionAdmitHandler)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add trace support for kubelet eviction manager.

I also use local test environment to demo this feature, following is the span in demo 

![image](https://github.com/kubernetes/kubernetes/assets/11855957/f47fa827-a7cf-4bd1-b2da-7d15dfbbd3c1)


#### Which issue(s) this PR fixes:

Fixes part of #113414

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: [<link>](https://github.com/kubernetes/enhancements/issues/2831)
- [Usage]: <link>
- [Other doc]: <link>
```
