### PR TITLE
added comment for clarifying steps related to kubernetes mutual (2-wa…

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -260,7 +260,39 @@ func (s *SecureServingOptions) ApplyTo(config **server.SecureServingInfo) error 
 	c := *config
 
 	serverCertFile, serverKeyFile := s.ServerCert.CertKey.CertFile, s.ServerCert.CertKey.KeyFile
-	// load main cert
+	// load main cert *original description until 2023-08-18*
+
+	/*
+		kubernetes mutual (2-way) x509 between client and apiserver:
+
+			>1. apiserver sending its apiserver certificate along with its publickey to client
+			2. client verifies the apiserver certificate sent against its cluster certificate authority data
+			3. client sending its client certificate along with its public key to the apiserver
+			4. apiserver verifies the client certificate sent against its cluster certificate authority data
+
+			description:
+				here, with this block,
+				apiserver certificate and pub key data (along with priv key)get loaded into server.SecureServingInfo
+				for client to later in the step 2 verify the apiserver certificate during the handshake
+				when making a request
+
+			normal args related to this stage:
+				--tls-cert-file string  File containing the default x509 Certificate for HTTPS.
+					(CA cert, if any, concatenated after server cert). If HTTPS serving is enabled, and
+					--tls-cert-file and --tls-private-key-file are not provided, a self-signed certificate
+					and key are generated for the public address and saved to the directory specified by
+					--cert-dir
+				--tls-private-key-file string  File containing the default x509 private key matching --tls-cert-file.
+
+				(retrievable from "kube-apiserver --help" command)
+				(suggested by @deads2k)
+
+			see also:
+				- for the step 2, see: staging/src/k8s.io/client-go/transport/transport.go
+				- for the step 3, see: staging/src/k8s.io/client-go/transport/transport.go
+				- for the step 4, see: staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+	*/
+
 	if len(serverCertFile) != 0 || len(serverKeyFile) != 0 {
 		var err error
 		c.Cert, err = dynamiccertificates.NewDynamicServingContentFromFiles("serving-cert", serverCertFile, serverKeyFile)

--- a/staging/src/k8s.io/client-go/transport/transport.go
+++ b/staging/src/k8s.io/client-go/transport/transport.go
@@ -96,6 +96,32 @@ func TLSConfigFor(c *Config) (*tls.Config, error) {
 	}
 
 	if c.HasCA() {
+		/*
+			kubernetes mutual (2-way) x509 between client and apiserver:
+
+				1. apiserver sending its apiserver certificate along with its publickey to client
+				>2. client verifies the apiserver certificate sent against its cluster certificate authority data
+				3. client sending its client certificate along with its public key to the apiserver
+				4. apiserver verifies the client certificate sent against its cluster certificate authority data
+
+				description:
+					here, with this block,
+					cluster certificate authority data gets loaded into TLS before the handshake process
+					for client to later during the handshake verify the apiserver certificate
+
+				normal args related to this stage:
+					--certificate-authority='':
+						Path to a cert file for the certificate authority
+
+					(retrievable from "kubectl options" command)
+					(suggested by @deads2k)
+
+				see also:
+					- for the step 1, see: staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+					- for the step 3, see: a few lines below in this file
+					- for the step 4, see: staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+		*/
+
 		rootCAs, err := rootCertPool(c.TLS.CAData)
 		if err != nil {
 			return nil, fmt.Errorf("unable to load root certificates: %w", err)
@@ -121,6 +147,35 @@ func TLSConfigFor(c *Config) (*tls.Config, error) {
 	}
 
 	if c.HasCertAuth() || c.HasCertCallback() {
+
+		/*
+			    kubernetes mutual (2-way) x509 between client and apiserver:
+
+					1. apiserver sending its apiserver certificate along with its publickey to client
+					2. client verifies the apiserver certificate sent against its cluster certificate authority data
+					>3. client sending its client certificate along with its public key to the apiserver
+					4. apiserver verifies the client certificate sent against its cluster certificate authority data
+
+					description:
+						here, with this callback function,
+						client certificate and pub key get loaded into TLS during the handshake process
+						for apiserver to later in the step 4 verify the client certificate
+
+					normal args related to this stage:
+						--client-certificate='':
+							Path to a client certificate file for TLS
+						--client-key='':
+							Path to a client key file for TLS
+
+						(retrievable from "kubectl options" command)
+						(suggested by @deads2k)
+
+					see also:
+						- for the step 1, see: staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+						- for the step 2, see: a few lines above in this file
+						- for the step 4, see: staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+		*/
+
 		tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			// Note: static key/cert data always take precedence over cert
 			// callback.


### PR DESCRIPTION
added comment for clarifying steps related to kubernetes mutual (2-way) x509

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR is related to clarifying the documentation for the kubernetes mutual (2-way) x509 protocol between
client and apiserver.
Since mutual (2-way) x509 is supported by kubernetes and run virtually everytime a client makes a request to apiserver, and itself is one of the core underpinnings of the whole kubernetes security architecture, I think
it is important to keep the documentation within the code base not only for the clarification, but also for further indexing and ease of search if any of interested users come to identify the process.
Currently, "mutual (or 2-way) x509 in kubernetes" query into Google or Github or even ChatGPT and Bard doesn't give back anything meaningful.

#### Which issue(s) this PR fixes:

Not regarding any code fixing

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
