### PR TITLE
implement Stringer for podActions

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -514,6 +514,11 @@ type podActions struct {
 	UpdatePodResources bool
 }
 
+func (p podActions) String() string {
+	return fmt.Sprintf("KillPod: %t, CreateSandbox: %t, UpdatePodResources: %t, Attempt: %d, InitContainersToStart: %v, ContainersToStart: %v, EphemeralContainersToStart: %v,ContainersToUpdate: %v, ContainersToKill: %v",
+		p.KillPod, p.CreateSandbox, p.UpdatePodResources, p.Attempt, p.InitContainersToStart, p.ContainersToStart, p.EphemeralContainersToStart, p.ContainersToUpdate, p.ContainersToKill)
+}
+
 func containerChanged(container *v1.Container, containerStatus *kubecontainer.Status) (uint64, uint64, bool) {
 	expectedHash := kubecontainer.HashContainer(container)
 	return expectedHash, containerStatus.Hash, containerStatus.Hash != expectedHash


### PR DESCRIPTION
klog prints an internal error when trying to log the podActions struct.

> I0505 14:12:12.827065  190662 kuberuntime_manager.go:1014] "computePodActions got for pod" podActions="<internal error: json: unsupported type: map[container.ContainerID]kuberuntime.containerToKillInfo>" pod="kube-system/coredns-8f5847b64-mzw46"

Implement the stringer interface on the struct to avoid the json error.

> I0807 08:49:24.108882 1569814 kuberuntime_manager.go:1010] "computePodActions got for pod" podActions="KillPod: true, CreateSandbox: true, UpdatePodResources: false, Attempt: 0, InitContainersToStart: [], ContainersToStart: [0 1], EphemeralContainersToStart: [], ContainersToKill: map[], ContainersToUpdate: map[]" pod="new/foo"

/kind bug
/kind cleanup

Related to #117809

```release-note
NONE
```

