### PR TITLE
apiserver/httplog: pretty up impersonation output

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
@@ -164,7 +164,7 @@ func WithImpersonation(handler http.Handler, a authorizer.Authorizer, s runtime.
 		req = req.WithContext(request.WithUser(ctx, newUser))
 
 		oldUser, _ := request.UserFrom(ctx)
-		httplog.LogOf(req, w).Addf("%v is acting as %v", oldUser, newUser)
+		httplog.LogOf(req, w).Addf("%v is impersonating %v", userString(oldUser), userString(newUser))
 
 		ae := audit.AuditEventFrom(ctx)
 		audit.LogImpersonatedUser(ae, newUser)
@@ -181,6 +181,24 @@ func WithImpersonation(handler http.Handler, a authorizer.Authorizer, s runtime.
 
 		handler.ServeHTTP(w, req)
 	})
+}
+
+func userString(u user.Info) string {
+	if u == nil {
+		return "<none>"
+	}
+	b := strings.Builder{}
+	if name := u.GetName(); name == "" {
+		b.WriteString("<empty>")
+	} else {
+		b.WriteString(name)
+	}
+	if groups := u.GetGroups(); len(groups) > 0 {
+		b.WriteString("[")
+		b.WriteString(strings.Join(groups, ","))
+		b.WriteString("]")
+	}
+	return b.String()
 }
 
 func unescapeExtraKey(encodedKey string) string {

--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
@@ -205,7 +205,6 @@ func StatusIsNot(statuses ...int) StacktracePred {
 func (rl *respLogger) Addf(format string, data ...interface{}) {
 	rl.mutex.Lock()
 	defer rl.mutex.Unlock()
-	rl.addedInfo.WriteString("\n")
 	rl.addedInfo.WriteString(fmt.Sprintf(format, data...))
 }
 


### PR DESCRIPTION
```
I0807 09:09:16.419239       1 httplog.go:132] "HTTP" verb="GET" URI="/apis/batch/v1?timeout=32s" latency="214.666µs" userAgent="kubernetes-provider/v0.0.0 (linux/arm64) kubernetes/$Format" audit-ID="948ef6b2-474d-45a7-ad5f-894ce93d05f7" srcIP="192.168.139.202:35542" apf_pl="exempt" apf_fs="exempt" apf_execution_time="129.5µs" resp=200 addedInfo=<

      &{kubernetes-admin  [system:masters system:authenticated] map[]} is acting as &{foo  [system:authenticated] map[]}
       >
```

to

```
I0807 09:09:16.419239       1 httplog.go:132] "HTTP" verb="GET" URI="/apis/batch/v1?timeout=32s" latency="214.666µs" userAgent="kubernetes-provider/v0.0.0 (linux/arm64) kubernetes/$Format" audit-ID="948ef6b2-474d-45a7-ad5f-894ce93d05f7" srcIP="192.168.139.202:35542" apf_pl="exempt" apf_fs="exempt" apf_execution_time="129.5µs" resp=200 addedInfo="kubernetes-admin[system:masters system:authenticated] is impersonating foo[system:authenticated]"
```

#### What type of PR is this?

/kind cleanup

```release-note
Clean up kube-apiserver http logs for impersonated requests.
```