### PR TITLE
client-go: log proper 'caches populated' message, with type and source and only once

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -337,7 +337,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 			if !apierrors.IsInvalid(err) {
 				return err
 			}
-			klog.Warning("the watch-list feature is not supported by the server, falling back to the previous LIST/WATCH semantic")
+			klog.Warning("The watch-list feature is not supported by the server, falling back to the previous LIST/WATCH semantics")
 			fallbackToList = true
 			// Ensure that we won't accidentally pass some garbage down the watch.
 			w = nil
@@ -350,6 +350,8 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 			return err
 		}
 	}
+
+	klog.V(2).Infof("Caches populated for %v from %s", r.typeDescription, r.name)
 
 	resyncerrc := make(chan error, 1)
 	cancelCh := make(chan struct{})

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -334,11 +334,9 @@ func WaitForCacheSync(stopCh <-chan struct{}, cacheSyncs ...InformerSynced) bool
 		},
 		stopCh)
 	if err != nil {
-		klog.V(2).Infof("stop requested")
 		return false
 	}
 
-	klog.V(4).Infof("caches populated")
 	return true
 }
 


### PR DESCRIPTION
From `caches populated` to `Caches populated for *v1.RoleBinding from k8s.io/client-go/informers/factory.go:150`

/kind cleanup

```release-note
Add context to "caches populated" log messages.
```