### PR TITLE
Refactor apiserver endpoint transformers to more natively use Encoders

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/helper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/helper.go
@@ -257,3 +257,26 @@ func (d WithoutVersionDecoder) Decode(data []byte, defaults *schema.GroupVersion
 	}
 	return obj, gvk, err
 }
+
+type encoderWithAllocator struct {
+	encoder      EncoderWithAllocator
+	memAllocator MemoryAllocator
+}
+
+// NewEncoderWithAllocator returns a new encoder
+func NewEncoderWithAllocator(e EncoderWithAllocator, a MemoryAllocator) Encoder {
+	return &encoderWithAllocator{
+		encoder:      e,
+		memAllocator: a,
+	}
+}
+
+// Encode writes the provided object to the nested writer
+func (e *encoderWithAllocator) Encode(obj Object, w io.Writer) error {
+	return e.encoder.EncodeWithAllocator(obj, w, e.memAllocator)
+}
+
+// Identifier returns identifier of this encoder.
+func (e *encoderWithAllocator) Identifier() Identifier {
+	return e.encoder.Identifier()
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go
@@ -134,23 +134,3 @@ func (e *encoder) Encode(obj runtime.Object) error {
 	e.buf.Reset()
 	return err
 }
-
-type encoderWithAllocator struct {
-	writer       io.Writer
-	encoder      runtime.EncoderWithAllocator
-	memAllocator runtime.MemoryAllocator
-}
-
-// NewEncoderWithAllocator returns a new streaming encoder
-func NewEncoderWithAllocator(w io.Writer, e runtime.EncoderWithAllocator, a runtime.MemoryAllocator) Encoder {
-	return &encoderWithAllocator{
-		writer:       w,
-		encoder:      e,
-		memAllocator: a,
-	}
-}
-
-// Encode writes the provided object to the nested writer
-func (e *encoderWithAllocator) Encode(obj runtime.Object) error {
-	return e.encoder.EncodeWithAllocator(obj, e.writer, e.memAllocator)
-}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -143,7 +143,7 @@ func serveWatch(watcher watch.Interface, scope *RequestScope, mediaTypeOptions n
 		EmbeddedEncoder: embeddedEncoder,
 
 		Fixup: func(obj runtime.Object) runtime.Object {
-			result, err := transformObject(ctx, obj, options, mediaTypeOptions, scope, req)
+			result, err := transformObject(ctx, obj, options, mediaTypeOptions.Convert, scope)
 			if err != nil {
 				utilruntime.HandleError(fmt.Errorf("failed to transform object %v: %v", reflect.TypeOf(obj), err))
 				return obj

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
@@ -647,7 +647,6 @@ func TestWatchHTTPErrors(t *testing.T) {
 		Encoder:         newCodec,
 		EmbeddedEncoder: newCodec,
 
-		Fixup:          func(obj runtime.Object) runtime.Object { return obj },
 		TimeoutFactory: &fakeTimeoutFactory{timeoutCh, done},
 	}
 
@@ -712,7 +711,6 @@ func TestWatchHTTPErrorsBeforeServe(t *testing.T) {
 		Encoder:         newCodec,
 		EmbeddedEncoder: newCodec,
 
-		Fixup:          func(obj runtime.Object) runtime.Object { return obj },
 		TimeoutFactory: &fakeTimeoutFactory{timeoutCh, done},
 	}
 
@@ -771,7 +769,6 @@ func TestWatchHTTPDynamicClientErrors(t *testing.T) {
 		Encoder:         newCodec,
 		EmbeddedEncoder: newCodec,
 
-		Fixup:          func(obj runtime.Object) runtime.Object { return obj },
 		TimeoutFactory: &fakeTimeoutFactory{timeoutCh, done},
 	}
 
@@ -814,7 +811,6 @@ func TestWatchHTTPTimeout(t *testing.T) {
 		Encoder:         newCodec,
 		EmbeddedEncoder: newCodec,
 
-		Fixup:          func(obj runtime.Object) runtime.Object { return obj },
 		TimeoutFactory: &fakeTimeoutFactory{timeoutCh, done},
 	}
 


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/83898

This PR on its own addresses the above issue.
But its main purpose is to enable a large memory allocation optimization:
- in https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1152-less-object-serializations we created a framework and avoided serializing the same object multiple times
- however, there is one big piece that I missed:
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go#L274-L290
- even though the serialization of watch-event is simple [we just copy bytes around], we're allocating quite a bit of memory there and optimizing that can bring non-negligible savings
- this PR [in addition to being a nice cleanup on its own] enables that improvement in a clear way

```release-note
NONE
```

To reviewers: I recommend reviewing commit-by-commit - commits are self-contained and build on top of each other.

/kind cleanup
/priority important-longterm
/sig api-machinery