### PR TITLE
introduce generic funcs for nested unstructured

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
@@ -225,3 +225,80 @@ func TestSetNestedMap(t *testing.T) {
 	assert.Len(t, obj["x"].(map[string]interface{})["z"], 1)
 	assert.Equal(t, obj["x"].(map[string]interface{})["z"].(map[string]interface{})["b"], "bar")
 }
+
+func TestNestedValueNoCopy(t *testing.T) {
+	type fooStruct struct {
+		Foo int
+		Bar bool
+	}
+
+	obj := map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": 1,
+			"c": "c",
+			"d": []any{1, 2, 3},
+			"e": map[string]any{"foo": "bar"},
+			"f": fooStruct{Foo: 1, Bar: false},
+		},
+	}
+
+	var res any
+
+	res, exists, err := NestedValueNoCopy[int](obj, "a", "b")
+	assert.True(t, exists)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, res)
+
+	res, exists, err = NestedValueNoCopy[string](obj, "a", "c")
+	assert.True(t, exists)
+	assert.NoError(t, err)
+	assert.Equal(t, "c", res)
+
+	res, exists, err = NestedValueNoCopy[[]any](obj, "a", "d")
+	assert.True(t, exists)
+	assert.NoError(t, err)
+	assert.Equal(t, []any{1, 2, 3}, res)
+
+	res, exists, err = NestedValueNoCopy[map[string]any](obj, "a", "e")
+	assert.True(t, exists)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]any{"foo": "bar"}, res)
+
+	res, exists, err = NestedValueNoCopy[fooStruct](obj, "a", "f")
+	assert.True(t, exists)
+	assert.NoError(t, err)
+	assert.Equal(t, fooStruct{Foo: 1, Bar: false}, res)
+}
+
+func TestNestedValueCopy(t *testing.T) {
+	obj := map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": int64(1),
+			"c": "c",
+			"d": []any{int64(1), int64(2), int64(3)},
+			"e": map[string]any{"foo": "bar"},
+		},
+	}
+
+	var res any
+
+	res, exists, err := NestedValueCopy[int64](obj, "a", "b")
+	assert.True(t, exists)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), res)
+
+	res, exists, err = NestedValueCopy[string](obj, "a", "c")
+	assert.True(t, exists)
+	assert.NoError(t, err)
+	assert.Equal(t, "c", res)
+
+	res, exists, err = NestedValueCopy[[]any](obj, "a", "d")
+	assert.True(t, exists)
+	assert.NoError(t, err)
+	assert.Equal(t, []any{int64(1), int64(2), int64(3)}, res)
+
+	res, exists, err = NestedValueCopy[map[string]any](obj, "a", "e")
+	assert.True(t, exists)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]any{"foo": "bar"}, res)
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -608,6 +608,13 @@ func DeepCopyJSON(x map[string]interface{}) map[string]interface{} {
 	return DeepCopyJSONValue(x).(map[string]interface{})
 }
 
+// JSONCopyable represents valid value type for json deep copy.
+//
+// NOTE: actual elems type of Slice and Map might not comply with this constraint.
+type JSONCopyable interface {
+	string | int64 | bool | float64 | encodingjson.Number | []any | map[string]any
+}
+
 // DeepCopyJSONValue deep copies the passed value, assuming it is a valid JSON representation i.e. only contains
 // types produced by json.Unmarshal() and also int64.
 // bool, int64, float64, string, []interface{}, map[string]interface{}, json.Number and nil


### PR DESCRIPTION
#### What type of PR is this?

<!--
/kind feature
-->

#### What this PR does / why we need it:

Introduce generic funcs for nested unstructured.

`func NestedValueNoCopy[T any](obj map[string]any, fields ...string) (val T, found bool, err error)`

`func NestedValueCopy[T runtime.JSONCopyable](obj map[string]any, fields ...string) (val T, found bool, err error)`

`func NestedTypedMap[T any](obj map[string]any, fields ...string) (map[string]T, bool, error) `

`func NestedTypedSlice[T any](obj map[string]any, fields ...string) ([]T, bool, error)`

`func SetNestedTypedSlice[T any](obj map[string]any, value []T, fields ...string) error `

`func SetNestedTypedMap[T any](obj map[string]any, value map[string]T, fields ...string) error`

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE
