### PR TITLE
fix race creating etcd client for healthchecks

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -157,10 +157,10 @@ func newETCD3Check(c storagebackend.Config, timeout time.Duration, stopCh <-chan
 	var prober *etcd3ProberMonitor
 	clientErr := fmt.Errorf("etcd client connection not yet established")
 
-	go wait.PollUntil(time.Second, func() (bool, error) {
-		newProber, err := newETCD3ProberMonitor(c)
+	go wait.PollImmediateUntil(time.Second, func() (bool, error) {
 		lock.Lock()
 		defer lock.Unlock()
+		newProber, err := newETCD3ProberMonitor(c)
 		// Ensure that server is already not shutting down.
 		select {
 		case <-stopCh:


### PR DESCRIPTION
Lock the entire process to create a new etcd client to avoid races.

The unit tests assert on the return error, since we didn't lock on the client creation, the return error could be checked before this function returned causing a flake

```
stress ./factory.test 
5s: 0 runs so far, 0 failures
10s: 0 runs so far, 0 failures
15s: 0 runs so far, 0 failures
20s: 0 runs so far, 0 failures
25s: 0 runs so far, 0 failures
30s: 0 runs so far, 0 failures
35s: 48 runs so far, 0 failures
40s: 48 runs so far, 0 failures
45s: 48 runs so far, 0 failures
50s: 48 runs so far, 0 failures
55s: 48 runs so far, 0 failures
1m0s: 48 runs so far, 0 failures
1m5s: 96 runs so far, 0 failures
1m10s: 96 runs so far, 0 failures
1m15s: 96 runs so far, 0 failures
1m20s: 96 runs so far, 0 failures
1m25s: 96 runs so far, 0 failures
1m30s: 96 runs so far, 0 failures
1m35s: 127 runs so far, 0 failures
1m40s: 144 runs so far, 0 failures
```

/kind bug
/kind flake
Fixes #119702, #114852

```release-note
NONE
```
