### PR TITLE
fix: mount point may become local volume without calling `NodeStageVolume` after node rebooting.

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -2312,7 +2312,7 @@ func TestSyncStates(t *testing.T) {
 			createMountPoint: true,
 			podInfos:         []podInfo{},
 			verifyFunc: func(rcInstance *reconciler, fakePlugin *volumetesting.FakeVolumePlugin) error {
-				mountedPods := rcInstance.actualStateOfWorld.GetMountedVolumes()
+				mountedPods := rcInstance.actualStateOfWorld.GetAllMountedVolumes()
 				if len(mountedPods) != 2 {
 					return fmt.Errorf("expected 2 pods to in asw got %d", len(mountedPods))
 				}
@@ -2329,7 +2329,7 @@ func TestSyncStates(t *testing.T) {
 			podInfos:         []podInfo{defaultPodInfo},
 			verifyFunc: func(rcInstance *reconciler, fakePlugin *volumetesting.FakeVolumePlugin) error {
 				// for pod that is deleted, volume is considered as mounted
-				mountedPods := rcInstance.actualStateOfWorld.GetMountedVolumes()
+				mountedPods := rcInstance.actualStateOfWorld.GetAllMountedVolumes()
 				if len(mountedPods) != 1 {
 					return fmt.Errorf("expected 1 pods to in asw got %d", len(mountedPods))
 				}
@@ -2364,7 +2364,7 @@ func TestSyncStates(t *testing.T) {
 			createMountPoint: false,
 			podInfos:         []podInfo{},
 			verifyFunc: func(rcInstance *reconciler, fakePlugin *volumetesting.FakeVolumePlugin) error {
-				mountedPods := rcInstance.actualStateOfWorld.GetMountedVolumes()
+				mountedPods := rcInstance.actualStateOfWorld.GetAllMountedVolumes()
 				if len(mountedPods) != 1 {
 					return fmt.Errorf("expected 1 pods to in asw got %d", len(mountedPods))
 				}

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -2316,6 +2316,9 @@ func TestSyncStates(t *testing.T) {
 				if len(mountedPods) != 2 {
 					return fmt.Errorf("expected 2 pods to in asw got %d", len(mountedPods))
 				}
+				if len(rcInstance.actualStateOfWorld.GetMountedVolumes()) != 0 {
+					return fmt.Errorf("expected 0 pod to in asw got %d", len(mountedPods))
+				}
 				return nil
 			},
 		},

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct.go
@@ -146,12 +146,12 @@ func (rc *reconciler) updateStates(volumesNeedUpdate map[v1.UniqueVolumeName]*gl
 			continue
 		}
 		for _, volume := range gvl.podVolumes {
-			err = rc.markVolumeState(volume, operationexecutor.VolumeMounted)
+			err = rc.markVolumeState(volume, operationexecutor.VolumeMountUncertain)
 			if err != nil {
 				klog.ErrorS(err, "Could not add pod to volume information to actual state of world", "pod", klog.KObj(volume.pod))
 				continue
 			}
-			klog.V(2).InfoS("Volume is marked as mounted and added into the actual state", "pod", klog.KObj(volume.pod), "podName", volume.podName, "volumeName", volume.volumeName)
+			klog.V(2).InfoS("Volume is marked as uncertain and added into the actual state", "pod", klog.KObj(volume.pod), "podName", volume.podName, "volumeName", volume.volumeName)
 		}
 		// If the volume has device to mount, we mark its device as mounted.
 		if gvl.deviceMounter != nil || gvl.blockVolumeMapper != nil {
@@ -160,12 +160,12 @@ func (rc *reconciler) updateStates(volumesNeedUpdate map[v1.UniqueVolumeName]*gl
 				klog.ErrorS(err, "Could not find device mount path for volume", "volumeName", gvl.volumeName)
 				continue
 			}
-			err = rc.actualStateOfWorld.MarkDeviceAsMounted(gvl.volumeName, gvl.devicePath, deviceMountPath, "")
+			err = rc.actualStateOfWorld.MarkDeviceAsUncertain(gvl.volumeName, gvl.devicePath, deviceMountPath, "")
 			if err != nil {
 				klog.ErrorS(err, "Could not mark device is mounted to actual state of world", "volume", gvl.volumeName)
 				continue
 			}
-			klog.V(2).InfoS("Volume is marked device as mounted and added into the actual state", "volumeName", gvl.volumeName)
+			klog.V(2).InfoS("Volume is marked device as uncertain and added into the actual state", "volumeName", gvl.volumeName)
 		}
 	}
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix [mount point may become local volume after node rebooting](https://github.com/kubernetes/kubernetes/issues/117513) under old volume reconstruction implementation.

During reconstruction, we should not mark volume and device as mounted in ASW, because if there are Pods that use the same volume exist in DSW, they won't get mounted anymore. 

Instead, we should mark the volume state as Uncertain, which meas it will be unmounted for the deleted Pods and mounted for the running Pods during the following reconcile process.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #117513

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix mount point may become local volume after node rebooting in old volume reconstruction implementation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
