### PR TITLE
fix: implement MarshalLog for structures in volumemanager for structured-logging.

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconstruct_common.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct_common.go
@@ -38,6 +38,8 @@ import (
 	utilstrings "k8s.io/utils/strings"
 )
 
+// these interfaces are necessary to keep the structures private
+// and at the same time log them correctly in structured logs.
 var _ logr.Marshaler = podVolume{}
 var _ logr.Marshaler = reconstructedVolume{}
 var _ logr.Marshaler = globalVolumeInfo{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Before fix:
```shell
I0808 16:02:25.857797  350699 reconstruct_common.go:184] "Get volumes from pod directory" path="/var/lib/kubelet/pods" volumes=[{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}]
```
After fix:
```shell
I0808 16:09:42.118411  358937 reconstruct_common.go:184] "Get volumes from pod directory" path="/var/lib/kubelet/pods" volumes="[{podName:1ace5d05-5cfc-4642-8c29-6b47200e041a volumeSpecName:kube-api-access-gctfp volumePath:/var/lib/kubelet/pods/1ace5d05-5cfc-4642-8c29-6b47200e041a/volumes/kubernetes.io~projected/kube-api-access-gctfp pluginName:kubernetes.io/projected volumeMode:Filesystem} ..........
```

This is because `klog` rely on `encoding/json` lib to encode the structure and print out, so it can't print un-exported fields.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
