### PR TITLE
Automated cherry pick of #118881: fix openapi/v3 non local apiservices aggregation

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator/aggregator.go
@@ -114,6 +114,7 @@ func (s *specProxier) AddUpdateAPIService(handler http.Handler, apiservice *v1.A
 	if apiServiceInfo, ok := s.apiServiceInfo[apiservice.Name]; ok {
 		apiServiceInfo.apiService = *apiservice
 		apiServiceInfo.handler = handler
+		return
 	}
 	s.apiServiceInfo[apiservice.Name] = &openAPIV3APIServiceInfo{
 		apiService: *apiservice,


### PR DESCRIPTION
Cherry pick of #118881 on release-1.27.

#118881: fix openapi/v3 non local apiservices aggregation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a regression exposed in 1.27 by kubectl switching to openapi v3 by resolving a flake in openapi v3 aggregation
```