### PR TITLE
Exclude mounts from mount refs that don't share a parent

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -691,6 +691,7 @@ func SearchMountPoints(hostSource, mountInfoPath string) ([]string, error) {
 	}
 
 	mountID := 0
+	parentID := -1
 	rootPath := ""
 	major := -1
 	minor := -1
@@ -702,6 +703,7 @@ func SearchMountPoints(hostSource, mountInfoPath string) ([]string, error) {
 		if hostSource == mis[i].MountPoint || PathWithinBase(hostSource, mis[i].MountPoint) {
 			// If it's a mount point or path under a mount point.
 			mountID = mis[i].ID
+			parentID = mis[i].ParentID
 			rootPath = filepath.Join(mis[i].Root, strings.TrimPrefix(hostSource, mis[i].MountPoint))
 			major = mis[i].Major
 			minor = mis[i].Minor
@@ -715,8 +717,8 @@ func SearchMountPoints(hostSource, mountInfoPath string) ([]string, error) {
 
 	var refs []string
 	for i := range mis {
-		if mis[i].ID == mountID {
-			// Ignore mount entry for mount source itself.
+		if mis[i].ID == mountID || (mis[i].ParentID != parentID && mountID != mis[i].ParentID) {
+			// Ignore mount entry for mount source itself, or if they don't share the same parent and the mount source isn't its parent.
 			continue
 		}
 		if mis[i].Root == rootPath && mis[i].Major == major && mis[i].Minor == minor {

--- a/staging/src/k8s.io/mount-utils/mount_linux_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux_test.go
@@ -324,6 +324,7 @@ func TestSearchMountPoints(t *testing.T) {
 40 29 0:34 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:21 - cgroup cgroup rw,cpuset
 41 29 0:35 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:22 - cgroup cgroup rw,net_cls,net_prio
 58 25 7:1 / /mnt/disks/blkvol1 rw,relatime shared:38 - ext4 /dev/loop1 rw,data=ordere
+90 30 0:100 / /var/lib/test-mounts/test1 rw,relatime shared:100 - tmpfs tmpfs rw,size=5120k
 `
 
 	testcases := []struct {
@@ -427,6 +428,13 @@ func TestSearchMountPoints(t *testing.T) {
 				"/var/lib/kubelet/pods/f19fe4e2-5a63-11e8-962f-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-test",
 				"/var/lib/kubelet/pods/4854a48b-5a64-11e8-962f-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-test",
 			},
+			nil,
+		},
+		{
+			"dir-bindmounted-ignore-diff-parent",
+			"/var/lib/test-mounts/test1",
+			base + `91 42 0:100 / /mnt/lib/test-mounts/test1 rw,relatime shared:100 - tmpfs tmpfs rw,size=5120k`,
+			nil,
 			nil,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This fixes an issue where when something like `/var/lib/kubelet` is bindmounted to somewhere else on disk. When this happens things like staging volumes for `ReadWriteMany` volumes will always return a reference even when there are none.

This causes tons of staging volumes to exist on the hosts that will never be cleaned up.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119752

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where bind mounting the staging volume path would cause Kubelet to never tell the CSI to unstage a volume on a node.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None.