### PR TITLE
[releng] Update publishing-bot rules for release branches to Go 1.20.7

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -11,22 +11,22 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/code-generator
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/code-generator
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/code-generator
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.27
       dir: staging/src/k8s.io/code-generator
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.28
       dir: staging/src/k8s.io/code-generator
@@ -42,22 +42,22 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.27
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.28
       dir: staging/src/k8s.io/apimachinery
@@ -80,7 +80,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/api
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -88,7 +88,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/api
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -96,7 +96,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/api
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -104,7 +104,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/api
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -142,7 +142,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -156,7 +156,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -170,7 +170,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -184,7 +184,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -224,7 +224,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-base
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -236,7 +236,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-base
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -248,7 +248,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/component-base
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -260,7 +260,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/component-base
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -298,7 +298,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -310,7 +310,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -322,7 +322,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -334,7 +334,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -360,12 +360,12 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kms
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/kms
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -377,7 +377,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/kms
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -421,7 +421,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/apiserver
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -435,7 +435,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/apiserver
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -451,7 +451,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/apiserver
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -467,7 +467,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/apiserver
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -523,7 +523,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -541,7 +541,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -561,7 +561,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -581,7 +581,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -650,7 +650,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -673,7 +673,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -698,7 +698,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -723,7 +723,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -787,7 +787,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -806,7 +806,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -825,7 +825,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -844,7 +844,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -906,7 +906,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -926,7 +926,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -948,7 +948,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -970,7 +970,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1021,7 +1021,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/metrics
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1035,7 +1035,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/metrics
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1049,7 +1049,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/metrics
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1063,7 +1063,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/metrics
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1103,7 +1103,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1115,7 +1115,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1127,7 +1127,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1139,7 +1139,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1181,7 +1181,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1195,7 +1195,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1209,7 +1209,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1223,7 +1223,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1266,7 +1266,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1280,7 +1280,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1294,7 +1294,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1308,7 +1308,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1334,22 +1334,22 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cri-api
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/cri-api
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/cri-api
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.27
       dir: staging/src/k8s.io/cri-api
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.28
       dir: staging/src/k8s.io/cri-api
@@ -1390,7 +1390,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubelet
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1404,7 +1404,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubelet
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1418,7 +1418,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kubelet
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1432,7 +1432,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/kubelet
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1482,7 +1482,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1496,7 +1496,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1510,7 +1510,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1524,7 +1524,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1574,7 +1574,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1590,7 +1590,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1608,7 +1608,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1626,7 +1626,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1688,7 +1688,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1708,7 +1708,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1730,7 +1730,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1752,7 +1752,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1822,7 +1822,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1844,7 +1844,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1868,7 +1868,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1892,7 +1892,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1938,7 +1938,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1948,7 +1948,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1958,7 +1958,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1968,7 +1968,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2000,7 +2000,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -2010,7 +2010,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2020,7 +2020,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2030,7 +2030,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2052,22 +2052,22 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.27
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.28
       dir: staging/src/k8s.io/mount-utils
@@ -2124,7 +2124,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -2150,7 +2150,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2178,7 +2178,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2202,7 +2202,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2272,7 +2272,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/kubectl
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -2294,7 +2294,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubectl
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2316,7 +2316,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kubectl
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2338,7 +2338,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/kubectl
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2396,7 +2396,7 @@ rules:
       branch: release-1.24
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.25
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.25
@@ -2412,7 +2412,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2430,7 +2430,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2448,7 +2448,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2488,7 +2488,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2504,7 +2504,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.27
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2520,7 +2520,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2555,7 +2555,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/endpointslice
   - name: release-1.28
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.28


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Update publishing-bot rules for release branches to Go 1.20.7 for the supported release branches (1.25+). 

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3181

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

/hold for cherry picks to merge

/assign @saschagrunert @cpanato @liggitt @nikhita 
cc @kubernetes/release-engineering 