### PR TITLE
fix(api/resource): fix quantity parse with max scale size value

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/amount.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/amount.go
@@ -43,6 +43,8 @@ const (
 	Tera  Scale = 12
 	Peta  Scale = 15
 	Exa   Scale = 18
+
+	maxScale = Exa
 )
 
 var (
@@ -279,8 +281,8 @@ func (a infDecAmount) AsCanonicalBytes(out []byte) (result []byte, exponent int3
 	amount, times := removeBigIntFactors(amount, bigTen)
 	exponent += times
 
-	// make sure exponent is a multiple of 3
-	for exponent%3 != 0 {
+	// make sure exponent is a multiple of 3 and less then or equal 18(E)
+	for exponent%3 != 0 || exponent > int32(maxScale) {
 		amount.Mul(amount, bigTen)
 		exponent--
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -337,6 +337,10 @@ func ParseQuantity(str string) (Quantity, error) {
 						return Quantity{i: int64Amount{value: result, scale: Scale(scale)}, Format: format, s: str}, nil
 					}
 				}
+				// keep canonical string for no shift needed
+				if scale >= int32(maxScale) {
+					return Quantity{i: int64Amount{value: result, scale: Scale(scale)}, Format: format, s: str}, nil
+				}
 				return Quantity{i: int64Amount{value: result, scale: Scale(scale)}, Format: format}, nil
 			}
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -341,6 +341,10 @@ func TestQuantityParse(t *testing.T) {
 		{".0001k", decQuantity(100, -3, DecimalSI)},
 		{"1.", decQuantity(1, 0, DecimalSI)},
 		{"1.G", decQuantity(1, 9, DecimalSI)},
+
+		// no shift for max scale size(E)
+		{"1000E", decQuantity(1, 21, DecimalSI)},
+		{"10000E", decQuantity(10000, 18, DecimalSI)},
 	}
 
 	for _, asDec := range []bool{false, true} {
@@ -692,6 +696,9 @@ func TestQuantityString(t *testing.T) {
 		{decQuantity(1, -6, DecimalSI), "1u", ""},
 		{decQuantity(80, -6, DecimalSI), "80u", ""},
 		{decQuantity(1080, -6, DecimalSI), "1080u", ""},
+		{decQuantity(1001, 18, DecimalSI), "1001E", ""},
+		{decQuantity(1000, 18, DecimalSI), "1000E", ""},
+		{decQuantity(1, 21, DecimalSI), "1000E", ""},
 	}
 	for _, item := range table {
 		got := item.in.String()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
fix a bug in reosurce package. 
when we try to parse a "2000E" to  resource quantity and convert it back by calling String(), it return an unexpected result "2", it is supposed to "2000E"

```go
import  "k8s.io/apimachinery/pkg/api/resource"

q, _ := resource.ParseQuantity("2000E")
q.String() // -> "2"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix resource quantity parse when it reaches the max scale size "E"
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
