### PR TITLE
kube-proxy: fix combination of --config and logging command line flags

### DIFF
--- a/cmd/kube-proxy/app/server_others_test.go
+++ b/cmd/kube-proxy/app/server_others_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -563,7 +564,7 @@ detectLocalMode: "BridgeInterface"`)
 
 		opt := NewOptions()
 		opt.ConfigFile = file.Name()
-		err = opt.Complete()
+		err = opt.Complete(new(pflag.FlagSet))
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

When parsing a config file, all settings derived from command line flags are discarded because only the config settings are used. That has been the traditional behavior for non-logging flags.

But `--config ... -v=4` used to work until
71ef0dafa72ca8cf2aa26fe1a75d3379a551771a added logging to the configuration. To restore the original behavior, kube-proxy now:
- parses flags
- reads the config file
- applies logging settings from the flags to the config loaded from file
- uses that merged config

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/119864

#### Special notes for your reviewer:

Needs more tests...

#### Does this PR introduce a user-facing change?
```release-note
kube-proxy in Kubernetes >= 1.28 up until v1.28.0-beta.0 ignored the `-v` command line flag when combined with `--config`.
```
