### PR TITLE
fix typos for pod replacement policy

### DIFF
--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -78,7 +78,7 @@ var (
 		string(api.ConditionTrue),
 		string(api.ConditionUnknown))
 
-	supportedPodRecreationPolicy = sets.New(
+	supportedPodReplacementPolicy = sets.New(
 		string(batch.Failed),
 		string(batch.TerminatingOrFailed))
 )
@@ -295,9 +295,9 @@ func validatePodReplacementPolicy(spec *batch.JobSpec, fldPath *field.Path) fiel
 			if *spec.PodReplacementPolicy != batch.Failed {
 				allErrs = append(allErrs, field.NotSupported(fldPath, *spec.PodReplacementPolicy, []string{string(batch.Failed)}))
 			}
-			// If PodFailurePolicy not specified we allow values in supportedPodRecreationPolicy.
-		} else if !supportedPodRecreationPolicy.Has(string(*spec.PodReplacementPolicy)) {
-			allErrs = append(allErrs, field.NotSupported(fldPath, *spec.PodReplacementPolicy, sets.List(supportedPodRecreationPolicy)))
+			// If PodFailurePolicy not specified we allow values in supportedPodReplacementPolicy.
+		} else if !supportedPodReplacementPolicy.Has(string(*spec.PodReplacementPolicy)) {
+			allErrs = append(allErrs, field.NotSupported(fldPath, *spec.PodReplacementPolicy, sets.List(supportedPodReplacementPolicy)))
 		}
 	}
 	return allErrs

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1462,7 +1462,7 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 
 	var terminating int32 = 0
 	if onlyReplaceFailedPods(jobCtx.job) {
-		// For PodFailurePolicy specified but PodRecreationPolicy disabled
+		// For PodFailurePolicy specified but PodReplacementPolicy disabled
 		// we still need to count terminating pods for replica counts
 		// But we will not allow updates to status.
 		if jobCtx.terminating == nil {
@@ -1870,8 +1870,8 @@ func countReadyPods(pods []*v1.Pod) int32 {
 	return cnt
 }
 
-// This checks if we should apply PodRecreationPolicy.
-// PodRecreationPolicy controls when we recreate pods if they are marked as terminating
+// This checks if we should apply PodReplacementPolicy.
+// PodReplacementPolicy controls when we recreate pods if they are marked as terminating
 // Failed means that we recreate only once the pod has terminated.
 func onlyReplaceFailedPods(job *batch.Job) bool {
 	if feature.DefaultFeatureGate.Enabled(features.JobPodReplacementPolicy) && *job.Spec.PodReplacementPolicy == batch.Failed {

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -626,7 +626,7 @@ func TestControllerSyncJob(t *testing.T) {
 			expectedActive:         2,
 			expectedCreatedIndexes: sets.New(0, 1),
 		},
-		"indexed job with some pods deleted, podRecreationPolicy Failed": {
+		"indexed job with some pods deleted, podReplacementPolicy Failed": {
 			parallelism:             2,
 			completions:             5,
 			backoffLimit:            6,
@@ -639,7 +639,7 @@ func TestControllerSyncJob(t *testing.T) {
 			terminatingPods:         1,
 			expectedTerminating:     pointer.Int32(1),
 		},
-		"indexed job with some pods deleted, podRecreationPolicy TerminatingOrFailed": {
+		"indexed job with some pods deleted, podReplacementPolicy TerminatingOrFailed": {
 			parallelism:             2,
 			completions:             5,
 			backoffLimit:            6,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

There were a few typos for `podRecreationPolicy` rather than `podReplacementPolicy`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
