### PR TITLE
[releng] Update publishing-bot rules for release-1.24 to Go 1.20.7

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -6,7 +6,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/code-generator
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/code-generator
@@ -37,7 +37,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/apimachinery
@@ -72,7 +72,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/api
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -128,7 +128,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -212,7 +212,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/component-base
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -286,7 +286,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -407,7 +407,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apiserver
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -505,7 +505,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -627,7 +627,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -768,7 +768,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -886,7 +886,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1007,7 +1007,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/metrics
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1091,7 +1091,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1167,7 +1167,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1252,7 +1252,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1329,7 +1329,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cri-api
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/cri-api
@@ -1376,7 +1376,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kubelet
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1468,7 +1468,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1558,7 +1558,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1668,7 +1668,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -1800,7 +1800,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1928,7 +1928,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: apimachinery
       branch: release-1.24
@@ -1990,7 +1990,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -2047,7 +2047,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     source:
       branch: release-1.24
       dir: staging/src/k8s.io/mount-utils
@@ -2098,7 +2098,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -2250,7 +2250,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kubectl
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.24
@@ -2380,7 +2380,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.24
-    go: 1.20.6
+    go: 1.20.7
     dependencies:
     - repository: api
       branch: release-1.24


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Update publishing-bot rules for 1.24 release branch to Go 1.20.7 for the supported release branches . 

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3181

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

/hold for cherry picks to merge

/assign @saschagrunert @cpanato @liggitt @nikhita 
cc @kubernetes/release-engineering 