### PR TITLE
cleanup: extract generateSelector from Validate method in job strategy

### DIFF
--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -92,6 +92,7 @@ func (jobStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 // PrepareForCreate clears the status of a job before creation.
 func (jobStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	job := obj.(*batch.Job)
+	generateSelectorIfNeeded(job)
 	job.Status = batch.JobStatus{}
 
 	job.Generation = 1
@@ -163,9 +164,6 @@ func (jobStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object
 // Validate validates a new job.
 func (jobStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	job := obj.(*batch.Job)
-	if !*job.Spec.ManualSelector {
-		generateSelector(job)
-	}
 	opts := validationOptionsForJob(job, nil)
 	return batchvalidation.ValidateJob(job, opts)
 }
@@ -210,6 +208,13 @@ func (jobStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []s
 	}
 	warnings = append(warnings, job.WarningsForJobSpec(ctx, field.NewPath("spec"), &newJob.Spec, nil)...)
 	return warnings
+}
+
+// generateSelectorIfNeeded checks the job's manual selector flag and generates selector labels if the flag is true.
+func generateSelectorIfNeeded(obj *batch.Job) {
+	if !*obj.Spec.ManualSelector {
+		generateSelector(obj)
+	}
 }
 
 // generateSelector adds a selector to a job and labels to its template

--- a/pkg/registry/batch/job/strategy_test.go
+++ b/pkg/registry/batch/job/strategy_test.go
@@ -487,15 +487,17 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 			job: batch.Job{
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
-					Selector: validSelector,
-					Template: validPodTemplateSpec,
+					Selector:       validSelector,
+					ManualSelector: pointer.Bool(false),
+					Template:       validPodTemplateSpec,
 				},
 			},
 			wantJob: batch.Job{
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
-					Selector: validSelector,
-					Template: expectedPodTemplateSpec,
+					Selector:       validSelector,
+					ManualSelector: pointer.Bool(false),
+					Template:       expectedPodTemplateSpec,
 				},
 			},
 		},
@@ -505,6 +507,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
+					ManualSelector:       pointer.Bool(false),
 					Template:             validPodTemplateSpec,
 					BackoffLimitPerIndex: pointer.Int32(1),
 					MaxFailedIndexes:     pointer.Int32(1),
@@ -514,6 +517,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
+					ManualSelector:       pointer.Bool(false),
 					Template:             expectedPodTemplateSpec,
 					BackoffLimitPerIndex: pointer.Int32(1),
 					MaxFailedIndexes:     pointer.Int32(1),
@@ -526,6 +530,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
+					ManualSelector:       pointer.Bool(false),
 					Template:             validPodTemplateSpec,
 					BackoffLimitPerIndex: pointer.Int32(1),
 					MaxFailedIndexes:     pointer.Int32(1),
@@ -535,6 +540,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
+					ManualSelector:       pointer.Bool(false),
 					Template:             expectedPodTemplateSpec,
 					BackoffLimitPerIndex: nil,
 					MaxFailedIndexes:     nil,
@@ -547,6 +553,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:         validSelector,
+					ManualSelector:   pointer.Bool(false),
 					Template:         validPodTemplateSpec,
 					PodFailurePolicy: podFailurePolicy,
 				},
@@ -555,6 +562,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:         validSelector,
+					ManualSelector:   pointer.Bool(false),
 					Template:         expectedPodTemplateSpec,
 					PodFailurePolicy: podFailurePolicy,
 				},
@@ -566,6 +574,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
+					ManualSelector:       pointer.Bool(false),
 					Template:             validPodTemplateSpec,
 					PodReplacementPolicy: podReplacementPolicy(batch.Failed),
 				},
@@ -574,6 +583,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
+					ManualSelector:       pointer.Bool(false),
 					Template:             expectedPodTemplateSpec,
 					PodReplacementPolicy: podReplacementPolicy(batch.Failed),
 				},
@@ -585,6 +595,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
+					ManualSelector:       pointer.Bool(false),
 					Template:             validPodTemplateSpec,
 					PodReplacementPolicy: podReplacementPolicy(batch.Failed),
 				},
@@ -593,6 +604,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
+					ManualSelector:       pointer.Bool(false),
 					Template:             expectedPodTemplateSpec,
 					PodReplacementPolicy: nil,
 				},
@@ -604,6 +616,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:         validSelector,
+					ManualSelector:   pointer.Bool(false),
 					Template:         validPodTemplateSpec,
 					PodFailurePolicy: podFailurePolicy,
 				},
@@ -612,6 +625,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:         validSelector,
+					ManualSelector:   pointer.Bool(false),
 					Template:         expectedPodTemplateSpec,
 					PodFailurePolicy: nil,
 				},
@@ -621,8 +635,9 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 			job: batch.Job{
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
-					Selector: validSelector,
-					Template: validPodTemplateSpec,
+					Selector:       validSelector,
+					ManualSelector: pointer.Bool(false),
+					Template:       validPodTemplateSpec,
 				},
 				Status: batch.JobStatus{
 					Active: 1,
@@ -631,8 +646,9 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 			wantJob: batch.Job{
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
-					Selector: validSelector,
-					Template: expectedPodTemplateSpec,
+					Selector:       validSelector,
+					ManualSelector: pointer.Bool(false),
+					Template:       expectedPodTemplateSpec,
 				},
 			},
 		},
@@ -643,6 +659,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
+					ManualSelector:       pointer.Bool(false),
 					Template:             validPodTemplateSpec,
 					BackoffLimitPerIndex: pointer.Int32(1),
 					PodFailurePolicy: &batch.PodFailurePolicy{
@@ -661,8 +678,9 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 			wantJob: batch.Job{
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
-					Selector: validSelector,
-					Template: expectedPodTemplateSpec,
+					Selector:       validSelector,
+					ManualSelector: pointer.Bool(false),
+					Template:       expectedPodTemplateSpec,
 					PodFailurePolicy: &batch.PodFailurePolicy{
 						Rules: []batch.PodFailurePolicyRule{},
 					},
@@ -676,6 +694,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
+					ManualSelector:       pointer.Bool(false),
 					Template:             validPodTemplateSpec,
 					BackoffLimitPerIndex: pointer.Int32(1),
 					PodFailurePolicy: &batch.PodFailurePolicy{
@@ -708,8 +727,9 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 			wantJob: batch.Job{
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
-					Selector: validSelector,
-					Template: expectedPodTemplateSpec,
+					Selector:       validSelector,
+					ManualSelector: pointer.Bool(false),
+					Template:       expectedPodTemplateSpec,
 					PodFailurePolicy: &batch.PodFailurePolicy{
 						Rules: []batch.PodFailurePolicyRule{
 							{
@@ -1333,7 +1353,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 			job: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector: defaultSelector,
+					Selector:       defaultSelector,
 					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1345,7 +1365,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 			wantJob: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector: defaultSelector,
+					Selector:       defaultSelector,
 					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1359,7 +1379,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 			job: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector: defaultSelector,
+					Selector:       defaultSelector,
 					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1371,7 +1391,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 			wantJob: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector: defaultSelector,
+					Selector:       defaultSelector,
 					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{

--- a/pkg/registry/batch/job/strategy_test.go
+++ b/pkg/registry/batch/job/strategy_test.go
@@ -1293,10 +1293,10 @@ func TestJobStrategy_Validate(t *testing.T) {
 
 	theUID := types.UID("1a2b3c4d5e6f7g8h9i0k")
 	validSelector := &metav1.LabelSelector{
-		MatchLabels: map[string]string{"a": "b"},
+		MatchLabels: map[string]string{"a": "b", batch.LegacyJobNameLabel: "myjob2", batch.JobNameLabel: "myjob2", batch.LegacyControllerUidLabel: string(theUID), batch.ControllerUidLabel: string(theUID)},
 	}
-	validLabels := map[string]string{batch.LegacyJobNameLabel: "myjob2", batch.JobNameLabel: "myjob2", batch.LegacyControllerUidLabel: string(theUID), batch.ControllerUidLabel: string(theUID)}
 	labelsWithNonBatch := map[string]string{"a": "b", batch.LegacyJobNameLabel: "myjob2", batch.JobNameLabel: "myjob2", batch.LegacyControllerUidLabel: string(theUID), batch.ControllerUidLabel: string(theUID)}
+	defaultSelector := &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}}
 	validPodSpec := api.PodSpec{
 		RestartPolicy: api.RestartPolicyOnFailure,
 		DNSPolicy:     api.DNSClusterFirst,
@@ -1320,7 +1320,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 			job: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector:       nil,
+					Selector: defaultSelector,
 					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1332,7 +1332,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 			wantJob: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}},
+					Selector: defaultSelector,
 					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1346,7 +1346,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 			job: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector:       nil,
+					Selector: defaultSelector,
 					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						Spec: validPodSpec,
@@ -1355,21 +1355,19 @@ func TestJobStrategy_Validate(t *testing.T) {
 			wantJob: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}},
+					Selector: defaultSelector,
 					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: validLabels,
-						},
 						Spec: validPodSpec,
 					}},
 			},
+			wantWarningCount: 5,
 		},
 		"labels exist": {
 			job: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector:       nil,
+					Selector:       defaultSelector,
 					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1381,7 +1379,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 			wantJob: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}},
+					Selector:       defaultSelector,
 					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1425,7 +1423,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 			job: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector:       nil,
+					Selector:       defaultSelector,
 					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1442,7 +1440,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 			wantJob: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}},
+					Selector:       defaultSelector,
 					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1461,7 +1459,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 			job: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector:       nil,
+					Selector:       defaultSelector,
 					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1479,7 +1477,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 			wantJob: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}},
+					Selector:       defaultSelector,
 					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`Validate` calls `generateSelector` which adds labels. This is wrong - `Validate` is not supposed to modify objects! This should be done from PrepareFor* hooks instead. A side-effect of this is that any update operation will set these labels, which seems like a benefit but is hidden in a place where nobody will NEVER think to look.

#### Which issue(s) this PR fixes:
Partially fixes https://github.com/kubernetes/kubernetes/issues/116137 as per @thockin comment https://github.com/kubernetes/kubernetes/issues/116137#issuecomment-1448520671

A followup PR will be created to address the second issue mentioned by @thockin.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

