### PR TITLE
Make seccomp status checks in e2e tests more robust

### DIFF
--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -40,6 +40,12 @@ import (
 	"github.com/onsi/gomega"
 )
 
+// SeccompProcStatusField is the field of /proc/$PID/status referencing the seccomp filter type.
+const SeccompProcStatusField = "Seccomp:"
+
+// ProcSelfStatusPath is the path to /proc/self/status.
+const ProcSelfStatusPath = "/proc/self/status"
+
 func scTestPod(hostIPC bool, hostPID bool) *v1.Pod {
 	podName := "security-context-" + string(uuid.NewUUID())
 	pod := &v1.Pod{
@@ -196,27 +202,27 @@ var _ = SIGDescribe("Security Context", func() {
 		pod := scTestPod(false, false)
 		pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeUnconfined}}
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeRuntimeDefault}}
-		pod.Spec.Containers[0].Command = []string{"grep", "ecc", "/proc/self/status"}
+		pod.Spec.Containers[0].Command = []string{"grep", SeccompProcStatusField, ProcSelfStatusPath}
 		e2eoutput.TestContainerOutput(ctx, f, "seccomp unconfined container", pod, 0, []string{"0"}) // seccomp disabled
 	})
 
 	ginkgo.It("should support seccomp unconfined on the pod [LinuxOnly]", func(ctx context.Context) {
 		pod := scTestPod(false, false)
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeUnconfined}}
-		pod.Spec.Containers[0].Command = []string{"grep", "ecc", "/proc/self/status"}
+		pod.Spec.Containers[0].Command = []string{"grep", SeccompProcStatusField, ProcSelfStatusPath}
 		e2eoutput.TestContainerOutput(ctx, f, "seccomp unconfined pod", pod, 0, []string{"0"}) // seccomp disabled
 	})
 
 	ginkgo.It("should support seccomp runtime/default [LinuxOnly]", func(ctx context.Context) {
 		pod := scTestPod(false, false)
 		pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{SeccompProfile: &v1.SeccompProfile{Type: v1.SeccompProfileTypeRuntimeDefault}}
-		pod.Spec.Containers[0].Command = []string{"grep", "ecc", "/proc/self/status"}
+		pod.Spec.Containers[0].Command = []string{"grep", SeccompProcStatusField, ProcSelfStatusPath}
 		e2eoutput.TestContainerOutput(ctx, f, "seccomp runtime/default", pod, 0, []string{"2"}) // seccomp filtered
 	})
 
 	ginkgo.It("should support seccomp default which is unconfined [LinuxOnly]", func(ctx context.Context) {
 		pod := scTestPod(false, false)
-		pod.Spec.Containers[0].Command = []string{"grep", "ecc", "/proc/self/status"}
+		pod.Spec.Containers[0].Command = []string{"grep", SeccompProcStatusField, ProcSelfStatusPath}
 		e2eoutput.TestContainerOutput(ctx, f, "seccomp default unconfined", pod, 0, []string{"0"}) // seccomp disabled
 	})
 })

--- a/test/e2e_node/seccompdefault_test.go
+++ b/test/e2e_node/seccompdefault_test.go
@@ -30,6 +30,7 @@ import (
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+	"k8s.io/kubernetes/test/e2e/node"
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
@@ -53,7 +54,7 @@ var _ = SIGDescribe("SeccompDefault [Serial] [Feature:SeccompDefault] [LinuxOnly
 						{
 							Name:            name,
 							Image:           busyboxImage,
-							Command:         []string{"grep", "Seccomp:", "/proc/self/status"},
+							Command:         []string{"grep", node.SeccompProcStatusField, node.ProcSelfStatusPath},
 							SecurityContext: securityContext,
 						},
 					},


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
The tests have been introduced in https://github.com/kubernetes/kubernetes/pull/26710/commits/ca7be7dc6d566980f5bfc85add965d40d55a269c and checked for `ecc` in `/proc/self/status` since its creation.

We got a new field `Seccomp_filters:` with the Linux commit https://github.com/torvalds/linux/commit/c818c03b661cd769e035e41673d5543ba2ebda64, means that `ecc` would now match both and interfere with possible test results depending on the host.

The field `Seccomp:` got introduced in https://github.com/torvalds/linux/commit/2f4b3bf6b2318cfaa177ec5a802f4d8d6afbd816 and has never changed since then, means we can use it directly to make the tests more strict.


#### Which issue(s) this PR fixes:
Refers to https://github.com/kubernetes-sigs/cri-tools/pull/1236


#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
