### PR TITLE
Fix: null jsonpath serialization

### DIFF
--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -573,6 +573,9 @@ func (j *JSONPath) evalToText(v reflect.Value) ([]byte, error) {
 	if !ok {
 		return nil, fmt.Errorf("can't print type %s", v.Type())
 	}
+	if iface == nil {
+		return []byte("null"), nil
+	}
 	var buffer bytes.Buffer
 	fmt.Fprint(&buffer, iface)
 	return buffer.Bytes(), nil

--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
@@ -301,7 +301,8 @@ func TestJSONInput(t *testing.T) {
 		{"id": "i3", "x":  8, "y":  3 },
 		{"id": "i4", "x": -6, "y": -1 },
 		{"id": "i5", "x":  0, "y":  2, "z": 1 },
-		{"id": "i6", "x":  1, "y":  4 }
+		{"id": "i6", "x":  1, "y":  4 },
+		{"id": "i7", "x":  null, "y":  4 }
 	]`)
 	var pointsData interface{}
 	err := json.Unmarshal(pointsJSON, &pointsData)
@@ -311,6 +312,7 @@ func TestJSONInput(t *testing.T) {
 	pointsTests := []jsonpathTest{
 		{"exists filter", "{[?(@.z)].id}", pointsData, "i2 i5", false},
 		{"bracket key", "{[0]['id']}", pointsData, "i1", false},
+		{"nil value", "{[-1]['x']}", pointsData, "null", false},
 	}
 	testJSONPath(pointsTests, false, t)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
 
#### Which issue(s) this PR fixes: 
`When we extract a null value from a json string, the current code extracts an <nil>; The string. But it should be null, and this pr fixes the problem. All unit tests passed.
 `
  
#### Special notes for your reviewer:
@jiahuif 
