### PR TITLE
Fix segfault during storage size metric collection

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -85,7 +85,7 @@ var (
 		[]string{"endpoint"},
 	)
 	storageSizeDescription   = compbasemetrics.NewDesc("apiserver_storage_size_bytes", "Size of the storage database file physically allocated in bytes.", []string{"cluster"}, nil, compbasemetrics.ALPHA, "")
-	storageMonitor           = &monitorCollector{}
+	storageMonitor           = &monitorCollector{monitorGetter: func() ([]Monitor, error) { return nil, nil }}
 	etcdEventsReceivedCounts = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
 			Subsystem:      "apiserver",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fix a segfault when collecting the storage size metrics when the getters used to collect the data on etcd haven't been initialized properly. This happens when the EtcdOptions are not applied which is the case for aggregated apiservers that don't care about storage.

From a downstream CI run:

```go
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x20351f5]

goroutine 301 [running]:
k8s.io/apiserver/pkg/storage/etcd3/metrics.(*monitorCollector).CollectWithStability(0x99ae0a?, 0x0?)
	k8s.io/apiserver@v0.28.0-rc.0/pkg/storage/etcd3/metrics/metrics.go:271 +0x35
k8s.io/component-base/metrics.(*BaseStableCollector).Collect.func1()
	k8s.io/component-base@v0.28.0-rc.0/metrics/collector.go:83 +0x2f
created by k8s.io/component-base/metrics.(*BaseStableCollector).Collect
	k8s.io/component-base@v0.28.0-rc.0/metrics/collector.go:82 +0x8d
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
k8s.io/apiserver: Fixed a nil panic attempting to collect etcd metrics in aggregated API servers that don't initialize etcd storage
```
