### PR TITLE
Fixing the "Service Account Token" broken link in above readme 

### DIFF
--- a/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/README.md
+++ b/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/README.md
@@ -54,5 +54,5 @@ the `kubectl run` command and then run:
 
     kubectl delete deployment demo
 
-[sa]: https://kubernetes.io/docs/admin/authentication/#service-account-tokens
+[sa]: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens
 [mk]: https://kubernetes.io/docs/getting-started-guides/minikube/


### PR DESCRIPTION
In this PR, I am fixing a broken link ("Service Account Token" link) in the readme.
