### PR TITLE
fix: Mount point may become local without calling `NodePublishVolume` after node rebooting

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconstruct.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct.go
@@ -78,6 +78,7 @@ func (rc *reconciler) syncStates(kubeletPodDir string) {
 			devicePath:        reconstructedVolume.devicePath,
 			deviceMounter:     reconstructedVolume.deviceMounter,
 			blockVolumeMapper: reconstructedVolume.blockVolumeMapper,
+			mounter:           reconstructedVolume.mounter,
 		}
 		if volumeInDSW {
 			// Some pod needs the volume. And it exists on disk. Some previous

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct.go
@@ -83,7 +83,6 @@ func (rc *reconciler) syncStates(kubeletPodDir string) {
 		if cachedInfo, ok := volumesNeedUpdate[reconstructedVolume.volumeName]; ok {
 			gvl = cachedInfo
 		}
-		gvl.addPodVolume(reconstructedVolume)
 		if volumeInDSW {
 			// Some pod needs the volume. And it exists on disk. Some previous
 			// kubelet must have created the directory, therefore it must have
@@ -95,6 +94,7 @@ func (rc *reconciler) syncStates(kubeletPodDir string) {
 			klog.V(4).InfoS("Volume exists in desired state, marking as InUse", "podName", volume.podName, "volumeSpecName", volume.volumeSpecName)
 			continue
 		}
+		gvl.addPodVolume(reconstructedVolume)
 		// There is no pod that uses the volume.
 		if rc.operationExecutor.IsOperationPending(reconstructedVolume.volumeName, nestedpendingoperations.EmptyUniquePodName, nestedpendingoperations.EmptyNodeName) {
 			klog.InfoS("Volume is in pending operation, skip cleaning up mounts")

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct.go
@@ -78,10 +78,6 @@ func (rc *reconciler) syncStates(kubeletPodDir string) {
 			devicePath:        reconstructedVolume.devicePath,
 			deviceMounter:     reconstructedVolume.deviceMounter,
 			blockVolumeMapper: reconstructedVolume.blockVolumeMapper,
-			mounter:           reconstructedVolume.mounter,
-		}
-		if cachedInfo, ok := volumesNeedUpdate[reconstructedVolume.volumeName]; ok {
-			gvl = cachedInfo
 		}
 		if volumeInDSW {
 			// Some pod needs the volume. And it exists on disk. Some previous
@@ -90,16 +86,23 @@ func (rc *reconciler) syncStates(kubeletPodDir string) {
 			// this new kubelet so reconcile() calls SetUp and re-mounts the
 			// volume if it's necessary.
 			volumeNeedReport = append(volumeNeedReport, reconstructedVolume.volumeName)
+			if cachedInfo, ok := rc.skippedDuringReconstruction[reconstructedVolume.volumeName]; ok {
+				gvl = cachedInfo
+			}
+			gvl.addPodVolume(reconstructedVolume)
 			rc.skippedDuringReconstruction[reconstructedVolume.volumeName] = gvl
 			klog.V(4).InfoS("Volume exists in desired state, marking as InUse", "podName", volume.podName, "volumeSpecName", volume.volumeSpecName)
 			continue
 		}
-		gvl.addPodVolume(reconstructedVolume)
 		// There is no pod that uses the volume.
 		if rc.operationExecutor.IsOperationPending(reconstructedVolume.volumeName, nestedpendingoperations.EmptyUniquePodName, nestedpendingoperations.EmptyNodeName) {
 			klog.InfoS("Volume is in pending operation, skip cleaning up mounts")
 		}
 		klog.V(2).InfoS("Reconciler sync states: could not find pod information in desired state, update it in actual state", "reconstructedVolume", reconstructedVolume)
+		if cachedInfo, ok := volumesNeedUpdate[reconstructedVolume.volumeName]; ok {
+			gvl = cachedInfo
+		}
+		gvl.addPodVolume(reconstructedVolume)
 		volumesNeedUpdate[reconstructedVolume.volumeName] = gvl
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
After Node rebooting and kubelet restarting, volume manger will execute [syncStates](https://github.com/kubernetes/kubernetes/blob/release-1.27/pkg/kubelet/volumemanager/reconciler/reconstruct.go#L45): get volumes from pod dir, and reconstruct the volume and [add it to ASW and mark the volume as `volume mounted`](https://github.com/kubernetes/kubernetes/blob/release-1.27/pkg/kubelet/volumemanager/reconciler/reconstruct.go#L107) if it is not in DSW.

If multiple Pods use the same volume, and one of the pods is deleted but left over the volume in pod dir. After rebooting, only the pod deleted (that is to say, not in DSW during reconstruction) and volume left should [be added to ASW and marked as `volume mounted`](https://github.com/kubernetes/kubernetes/blob/release-1.27/pkg/kubelet/volumemanager/reconciler/reconstruct.go#L107) . 

However, since the reconstructed volume has been [added to `gvl`](https://github.com/kubernetes/kubernetes/blob/release-1.27/pkg/kubelet/volumemanager/reconciler/reconstruct.go#L86) before [judging whether it is in DSW](https://github.com/kubernetes/kubernetes/blob/release-1.27/pkg/kubelet/volumemanager/reconciler/reconstruct.go#L87-L97), and `gvl` is a pointer variable, so the volume in DSW will also [be added to ASW and marked as `volume mounted`](https://github.com/kubernetes/kubernetes/blob/release-1.27/pkg/kubelet/volumemanager/reconciler/reconstruct.go#L107) , which makes the pods running w/o calling `NodePublishVolume`.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119921

add pod volume to gvl after judging whether the volume is in DSW, that is to say, only add volumes not in DSW to gvl, so only the volumes that not in DSW will be added to ASW and marked as `volume mounted` .

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: Mount point may become local without calling NodePublishVolume after node rebooting.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
