### PR TITLE
dynamically provision the PVs for cloud provider e2e tests

### DIFF
--- a/test/e2e/storage/framework/testdriver.go
+++ b/test/e2e/storage/framework/testdriver.go
@@ -54,10 +54,15 @@ type TestDriver interface {
 }
 
 // TestVolume is the result of PreprovisionedVolumeTestDriver.CreateVolume.
-// The only common functionality is to delete it. Individual driver interfaces
-// have additional methods that work with volumes created by them.
+// The usual function is to delete it, but for the driver of the cloud provider,
+// it provides a method to obtain their VolumeClaim.
+// Individual driver interfaces have additional methods that work with volumes created by them.
 type TestVolume interface {
 	DeleteVolume(ctx context.Context)
+	// GetVolumeClaim is used to get the VolumeClaim of the cloud provider,
+	// we removed the dependency on the cloud provider,
+	// and need to dynamically provision the PVs to preserve test coverage.
+	GetVolumeClaim(ctx context.Context) *v1.PersistentVolumeClaim
 }
 
 // PreprovisionedVolumeTestDriver represents an interface for a TestDriver that has pre-provisioned volume


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We need to remove cloud provider dependencies from our vendor, which will lose some tests that don't use dynamically provision PVCs and volume creation/deletion is out of scope for Kubernetes.

We need to use Dynamic provision PVs and then copy the fields to Pod/PV objects to simulate importing these objects outside.

For a more detailed discussion refer to: https://github.com/kubernetes/kubernetes/issues/118360#issuecomment-1570750797
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #118360

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
