### PR TITLE
Adding backup code for removing finalizers to more Job End States.

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -469,7 +469,8 @@ func (jm *Controller) updateJob(logger klog.Logger, old, cur interface{}) {
 		jm.enqueueSyncJobImmediately(logger, curJob)
 	}
 
-	// if curJob is finished, remove the finalizer as a backup check.
+	// The job shouldn't be marked as finished until all pod finalizers are removed.
+	// This is a backup operation
 	if IsJobFinished(curJob) {
 		jm.backupRemovePodFinalizers(curJob)
 	}

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -470,9 +470,9 @@ func (jm *Controller) updateJob(logger klog.Logger, old, cur interface{}) {
 	}
 
 	// The job shouldn't be marked as finished until all pod finalizers are removed.
-	// This is a backup operation
+	// This is a backup operation in this case.
 	if IsJobFinished(curJob) {
-		jm.backupRemovePodFinalizers(curJob)
+		jm.cleanupPodFinalizers(curJob)
 	}
 
 	// check if need to add a new rsync for ActiveDeadlineSeconds
@@ -509,7 +509,7 @@ func (jm *Controller) deleteJob(logger klog.Logger, obj interface{}) {
 			return
 		}
 	}
-	jm.backupRemovePodFinalizers(jobObj)
+	jm.cleanupPodFinalizers(jobObj)
 }
 
 // enqueueSyncJobImmediately tells the Job controller to invoke syncJob
@@ -1874,7 +1874,7 @@ func onlyReplaceFailedPods(job *batch.Job) bool {
 	return feature.DefaultFeatureGate.Enabled(features.JobPodFailurePolicy) && job.Spec.PodFailurePolicy != nil
 }
 
-func (jm *Controller) backupRemovePodFinalizers(job *batch.Job) {
+func (jm *Controller) cleanupPodFinalizers(job *batch.Job) {
 	// Listing pods shouldn't really fail, as we are just querying the informer cache.
 	selector, err := metav1.LabelSelectorAsSelector(job.Spec.Selector)
 	if err != nil {

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -4698,7 +4698,6 @@ func (f *fakeRateLimitingQueue) AddRateLimited(item interface{}) {}
 func (f *fakeRateLimitingQueue) Forget(item interface{}) {
 	f.requeues = 0
 }
-
 func (f *fakeRateLimitingQueue) NumRequeues(item interface{}) int {
 	return f.requeues
 }

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -5198,7 +5198,7 @@ func TestBackupFinalizerRemoval(t *testing.T) {
 	}
 
 	pod := newPod("test-pod", job)
-	// pod.Finalizers = append(pod.Finalizers, batch.JobTrackingFinalizer)
+	pod.Finalizers = append(pod.Finalizers, batch.JobTrackingFinalizer)
 
 	pod, err = clientset.CoreV1().Pods(pod.GetNamespace()).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -5190,7 +5190,7 @@ func TestBackupFinalizerRemoval(t *testing.T) {
 	// This is done above by initializing the manager and not calling manager.Run() yet.
 
 	// 2. Create a job.
-	job := newJob(2, 2, 6, batch.NonIndexedCompletion)
+	job := newJob(1, 1, 1, batch.NonIndexedCompletion)
 
 	// 3. Create the pods.
 	podBuilder := buildPod().name("test_pod").deletionTimestamp().trackingFinalizer().job(job)
@@ -5207,6 +5207,11 @@ func TestBackupFinalizerRemoval(t *testing.T) {
 
 	// 5. Start the workers.
 	go manager.Run(context.TODO(), 0)
+
+	err = manager.syncJob(context.TODO(), testutil.GetKey(job, t))
+	if err != nil {
+		t.Errorf("Unexpected error when syncing jobs %v", err)
+	}
 
 	// Check if the finalizer has been removed from the pod.
 	if err := wait.Poll(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -5192,7 +5192,7 @@ func TestBackupFinalizerRemoval(t *testing.T) {
 	// 2. Create a job.
 	job := newJob(1, 1, 1, batch.NonIndexedCompletion)
 
-	_, err := clientset.BatchV1().Jobs(job.GetNamespace()).Create(ctx, job, metav1.CreateOptions{})
+	job, err := clientset.BatchV1().Jobs(job.GetNamespace()).Create(ctx, job, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Creating job: %v", err)
 	}
@@ -5200,7 +5200,7 @@ func TestBackupFinalizerRemoval(t *testing.T) {
 	pod := newPod("test-pod", job)
 	// pod.Finalizers = append(pod.Finalizers, batch.JobTrackingFinalizer)
 
-	_, err = clientset.CoreV1().Pods(pod.GetNamespace()).Create(ctx, pod, metav1.CreateOptions{})
+	pod, err = clientset.CoreV1().Pods(pod.GetNamespace()).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Creating pod: %v", err)
 	}
@@ -5210,7 +5210,10 @@ func TestBackupFinalizerRemoval(t *testing.T) {
 		Status: v1.ConditionTrue,
 	})
 
-	clientset.BatchV1().Jobs(job.GetNamespace()).UpdateStatus(ctx, job, metav1.UpdateOptions{})
+	job, err = clientset.BatchV1().Jobs(job.GetNamespace()).UpdateStatus(ctx, job, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Updating job status: %v", err)
+	}
 
 	go manager.Run(context.TODO(), 0)
 

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -4706,6 +4706,7 @@ func (f *fakeRateLimitingQueue) AddAfter(item interface{}, duration time.Duratio
 	f.item = item
 	f.duration = duration
 }
+
 func TestJobBackoff(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	logger := klog.FromContext(ctx)
@@ -4787,47 +4788,58 @@ func TestJobBackoffForOnFailure(t *testing.T) {
 		expectedConditionReason string
 	}{
 		"backoffLimit 0 should have 1 pod active": {
-			1, 1, 0, false, []int32{0}, v1.PodRunning,
+			1, 1, 0,
+			false, []int32{0}, v1.PodRunning,
 			1, 0, 0, nil, "",
 		},
 		"backoffLimit 1 with restartCount 0 should have 1 pod active": {
-			1, 1, 1, false, []int32{0}, v1.PodRunning,
+			1, 1, 1,
+			false, []int32{0}, v1.PodRunning,
 			1, 0, 0, nil, "",
 		},
 		"backoffLimit 1 with restartCount 1 and podRunning should have 0 pod active": {
-			1, 1, 1, false, []int32{1}, v1.PodRunning,
+			1, 1, 1,
+			false, []int32{1}, v1.PodRunning,
 			0, 0, 1, &jobConditionFailed, "BackoffLimitExceeded",
 		},
 		"backoffLimit 1 with restartCount 1 and podPending should have 0 pod active": {
-			1, 1, 1, false, []int32{1}, v1.PodPending,
+			1, 1, 1,
+			false, []int32{1}, v1.PodPending,
 			0, 0, 1, &jobConditionFailed, "BackoffLimitExceeded",
 		},
 		"too many job failures with podRunning - single pod": {
-			1, 5, 2, false, []int32{2}, v1.PodRunning,
+			1, 5, 2,
+			false, []int32{2}, v1.PodRunning,
 			0, 0, 1, &jobConditionFailed, "BackoffLimitExceeded",
 		},
 		"too many job failures with podPending - single pod": {
-			1, 5, 2, false, []int32{2}, v1.PodPending,
+			1, 5, 2,
+			false, []int32{2}, v1.PodPending,
 			0, 0, 1, &jobConditionFailed, "BackoffLimitExceeded",
 		},
 		"too many job failures with podRunning - multiple pods": {
-			2, 5, 2, false, []int32{1, 1}, v1.PodRunning,
+			2, 5, 2,
+			false, []int32{1, 1}, v1.PodRunning,
 			0, 0, 2, &jobConditionFailed, "BackoffLimitExceeded",
 		},
 		"too many job failures with podPending - multiple pods": {
-			2, 5, 2, false, []int32{1, 1}, v1.PodPending,
+			2, 5, 2,
+			false, []int32{1, 1}, v1.PodPending,
 			0, 0, 2, &jobConditionFailed, "BackoffLimitExceeded",
 		},
 		"not enough failures": {
-			2, 5, 3, false, []int32{1, 1}, v1.PodRunning,
+			2, 5, 3,
+			false, []int32{1, 1}, v1.PodRunning,
 			2, 0, 0, nil, "",
 		},
 		"suspending a job": {
-			2, 4, 6, true, []int32{1, 1}, v1.PodRunning,
+			2, 4, 6,
+			true, []int32{1, 1}, v1.PodRunning,
 			0, 0, 0, &jobConditionSuspended, "JobSuspended",
 		},
 		"finshed job": {
-			2, 4, 6, true, []int32{1, 1, 2, 0}, v1.PodSucceeded,
+			2, 4, 6,
+			true, []int32{1, 1, 2, 0}, v1.PodSucceeded,
 			0, 4, 0, &jobConditionComplete, "",
 		},
 	}

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -5192,9 +5192,14 @@ func TestBackupFinalizerRemoval(t *testing.T) {
 	// 2. Create a job.
 	job := newJob(1, 1, 1, batch.NonIndexedCompletion)
 
+	_, err := clientset.BatchV1().Jobs(job.GetNamespace()).Create(ctx, job, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Creating job: %v", err)
+	}
+
 	// 3. Create the pods.
 	podBuilder := buildPod().name("test_pod").deletionTimestamp().trackingFinalizer().job(job)
-	pod, err := clientset.CoreV1().Pods("default").Create(context.Background(), podBuilder.Pod, metav1.CreateOptions{})
+	pod, err := clientset.CoreV1().Pods(podBuilder.Pod.GetNamespace()).Create(ctx, podBuilder.Pod, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Creating pod: %v", err)
 	}

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -4872,6 +4872,7 @@ func TestJobBackoffForOnFailure(t *testing.T) {
 
 			// run
 			err := manager.syncJob(context.TODO(), testutil.GetKey(job, t))
+
 			if err != nil {
 				t.Errorf("unexpected error syncing job.  Got %#v", err)
 			}

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -5210,7 +5210,7 @@ func TestBackupFinalizerRemoval(t *testing.T) {
 		Status: v1.ConditionTrue,
 	})
 
-	job, err = clientset.BatchV1().Jobs(job.GetNamespace()).UpdateStatus(ctx, job, metav1.UpdateOptions{})
+	_, err = clientset.BatchV1().Jobs(job.GetNamespace()).UpdateStatus(ctx, job, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("Updating job status: %v", err)
 	}

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -5172,7 +5172,7 @@ func TestFinalizersRemovedExpectations(t *testing.T) {
 	}
 }
 
-func TestBackupFinalizers(t *testing.T) {
+func TestBackupFinalizerRemoval(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	clientset := fake.NewSimpleClientset()
 	sharedInformers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
@@ -5206,7 +5206,7 @@ func TestBackupFinalizers(t *testing.T) {
 	})
 
 	// 5. Start the workers.
-	go manager.Run(context.TODO(), 1)
+	go manager.Run(context.TODO(), 0)
 
 	// Check if the finalizer has been removed from the pod.
 	if err := wait.Poll(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -5225,9 +5225,7 @@ func TestFinalizerCleanup(t *testing.T) {
 		}
 		return !hasJobTrackingFinalizer(p), nil
 	}); err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			t.Errorf("Waiting for Pod to get the finalizer removed: %v", err)
-		}
+		t.Errorf("Waiting for Pod to get the finalizer removed: %v", err)
 	}
 
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind bug

**What this PR does / why we need it:**

- Adds a new test for coverage of the pod finalizer cleanup code.

**Which issue(s) this PR fixes:**

Fixes https://github.com/kubernetes/kubernetes/issues/119833

**Does this PR introduce a user-facing change?**
```release-note
Added a redundant process to remove tracking finalizers from Pods that belong to Jobs. The process kicks in after the control plane marks a Job as finished
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```

```
