### PR TITLE
Add unit tests for subdomain match in keyring

### DIFF
--- a/pkg/credentialprovider/keyring_test.go
+++ b/pkg/credentialprovider/keyring_test.go
@@ -88,6 +88,22 @@ func TestURLsMatch(t *testing.T) {
 			targetURL:     "kubernetes.io",
 			matchExpected: false,
 		},
+		{
+			globURL:       "*kubernetes.io",
+			targetURL:     "a.kubernetes.io",
+			matchExpected: false,
+		},
+		// match when number of parts match
+		{
+			globURL:       "*kubernetes.io",
+			targetURL:     "kubernetes.io",
+			matchExpected: true,
+		},
+		{
+			globURL:       "*.*.*.kubernetes.io",
+			targetURL:     "a.b.c.kubernetes.io",
+			matchExpected: true,
+		},
 		// no match when some parts mismatch
 		{
 			globURL:       "kubernetes.io",


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
This ensures that the amount of subdomains should always match the glob+dot (`*.`) pattern.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refers to https://github.com/kubernetes/kubernetes/issues/119941

#### Special notes for your reviewer:
PTAL @njgibbon
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
