### PR TITLE
add UT for storageclass

### DIFF
--- a/pkg/volume/util/storageclass_test.go
+++ b/pkg/volume/util/storageclass_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+	"time"
+
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/kubernetes/pkg/controller"
+)
+
+func TestGetDefaultClass(t *testing.T) {
+
+	var (
+		t1 = time.Now()
+		t2 = time.Now().Add(1 * time.Hour)
+
+		sc1 = &storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-storage-class1",
+				Annotations: map[string]string{
+					"a": "b",
+				},
+			},
+		}
+		sc2 = &storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-storage-class2",
+				Annotations: map[string]string{
+					"a": "b",
+				},
+			},
+		}
+
+		sc3 = &storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-storage-class3",
+				Annotations: map[string]string{
+					IsDefaultStorageClassAnnotation: "true",
+				},
+				CreationTimestamp: metav1.Time{Time: t1},
+			},
+		}
+
+		sc4 = &storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-storage-class4",
+				Annotations: map[string]string{
+					IsDefaultStorageClassAnnotation: "true",
+				},
+				CreationTimestamp: metav1.Time{Time: t2},
+			},
+		}
+
+		sc5 = &storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-storage-class5",
+				Annotations: map[string]string{
+					IsDefaultStorageClassAnnotation: "true",
+				},
+				CreationTimestamp: metav1.Time{Time: t2},
+			},
+		}
+	)
+
+	testCases := []struct {
+		name    string
+		classes []*storagev1.StorageClass
+		expect  *storagev1.StorageClass
+	}{
+
+		{
+			name: "no storage class",
+		},
+
+		{
+			name:    "no default storage class",
+			classes: []*storagev1.StorageClass{sc1, sc2},
+			expect:  nil,
+		},
+
+		{
+			name:    "one default storage class",
+			classes: []*storagev1.StorageClass{sc1, sc2, sc3},
+			expect:  sc3,
+		},
+
+		{
+			name:    "two default storage class with different creation timestamp",
+			classes: []*storagev1.StorageClass{sc3, sc4},
+			expect:  sc4,
+		},
+
+		{
+			name:    "two default storage class with same creation timestamp",
+			classes: []*storagev1.StorageClass{sc4, sc5},
+			expect:  sc4,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
+			for _, c := range tc.classes {
+				informerFactory.Storage().V1().StorageClasses().Informer().GetStore().Add(c)
+			}
+			lister := informerFactory.Storage().V1().StorageClasses().Lister()
+			actual, err := GetDefaultClass(lister)
+			if err != nil {
+				t.Errorf("Expected no error, got %v", err)
+				return
+			}
+			if tc.expect != actual {
+				t.Errorf("Expected %v, got %v", tc.expect, actual)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

add UT for kubernetes/pkg/volume/util/storageclass, UT coverage can increase from 30.1% to 32.7%

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # NONE

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```
NONE
```
