### PR TITLE
e2e_apps: stop using deprecated framework.ExpectConsistOf

### DIFF
--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -506,7 +506,7 @@ func listPDBs(ctx context.Context, cs kubernetes.Interface, ns string, labelSele
 	for _, item := range pdbList.Items {
 		pdbNames = append(pdbNames, item.Name)
 	}
-	framework.ExpectConsistOf(pdbNames, expectedPDBNames, "Expecting returned PDBs '%s' in namespace %s", expectedPDBNames, ns)
+	gomega.Expect(pdbNames).To(gomega.ConsistOf(expectedPDBNames), "Expecting returned PDBs '%s' in namespace %s", expectedPDBNames, ns)
 }
 
 func deletePDBCollection(ctx context.Context, cs kubernetes.Interface, ns string) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
e2e_apps: stop using deprecated framework.ExpectConsistOf

**Which issue(s) this PR fixes:**
Ref https://github.com/kubernetes/kubernetes/pull/115961

**Special notes for your reviewer:**
Does this PR introduce a user-facing change?

```
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```

```