### PR TITLE
[e2e] stop using deprecated framework.ExpectNotEqual in test derictory

### DIFF
--- a/test/e2e/apimachinery/chunking.go
+++ b/test/e2e/apimachinery/chunking.go
@@ -166,7 +166,7 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 		opts.Continue = inconsistentToken
 		list, err = client.List(ctx, opts)
 		framework.ExpectNoError(err, "failed to list pod templates in namespace: %s, given inconsistent continue token %s and limit: %d", ns, opts.Continue, opts.Limit)
-		framework.ExpectNotEqual(list.ResourceVersion, firstRV)
+		gomega.Expect(list.ResourceVersion).NotTo(gomega.Equal(firstRV))
 		gomega.Expect(len(list.Items)).To(gomega.BeNumerically("==", opts.Limit))
 		found := int(oneTenth)
 

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -122,7 +123,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 						expected = e
 					}
 				}
-				framework.ExpectNotEqual(expected, nil)
+				gomega.Expect(expected).NotTo(gomega.BeNil())
 				if !equality.Semantic.DeepEqual(actual.Spec, expected.Spec) {
 					framework.Failf("Expected CustomResourceDefinition in list with name %s to match crd created with same name, but got different specs:\n%s",
 						actual.Name, cmp.Diff(expected.Spec, actual.Spec))
@@ -210,7 +211,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 					break
 				}
 			}
-			framework.ExpectNotEqual(group, nil, "apiextensions.k8s.io API group not found in /apis discovery document")
+			gomega.Expect(group).NotTo(gomega.BeNil(), "apiextensions.k8s.io API group not found in /apis discovery document")
 
 			ginkgo.By("finding the apiextensions.k8s.io/v1 API group/version in the /apis discovery document")
 			var version *metav1.GroupVersionForDiscovery
@@ -220,7 +221,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 					break
 				}
 			}
-			framework.ExpectNotEqual(version, nil, "apiextensions.k8s.io/v1 API group version not found in /apis discovery document")
+			gomega.Expect(version).NotTo(gomega.BeNil(), "apiextensions.k8s.io/v1 API group version not found in /apis discovery document")
 		}
 
 		{
@@ -238,7 +239,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 					break
 				}
 			}
-			framework.ExpectNotEqual(version, nil, "apiextensions.k8s.io/v1 API group version not found in /apis/apiextensions.k8s.io discovery document")
+			gomega.Expect(version).NotTo(gomega.BeNil(), "apiextensions.k8s.io/v1 API group version not found in /apis/apiextensions.k8s.io discovery document")
 		}
 
 		{
@@ -255,7 +256,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 					crdResource = &apiResourceList.APIResources[i]
 				}
 			}
-			framework.ExpectNotEqual(crdResource, nil, "customresourcedefinitions resource not found in /apis/apiextensions.k8s.io/v1 discovery document")
+			gomega.Expect(crdResource).NotTo(gomega.BeNil(), "customresourcedefinitions resource not found in /apis/apiextensions.k8s.io/v1 discovery document")
 		}
 	})
 

--- a/test/e2e/apimachinery/discovery.go
+++ b/test/e2e/apimachinery/discovery.go
@@ -128,8 +128,7 @@ var _ = SIGDescribe("Discovery", func() {
 		list := &metav1.APIGroupList{}
 		err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/").Do(ctx).Into(list)
 		framework.ExpectNoError(err, "Failed to find /apis/")
-		framework.ExpectNotEqual(len(list.Groups), 0, "Missing APIGroups")
-
+		gomega.Expect(list.Groups).NotTo(gomega.BeEmpty(), "Missing APIGroups")
 		for _, group := range list.Groups {
 			if strings.HasSuffix(group.Name, ".example.com") {
 				// ignore known example dynamic API groups that are added/removed during the e2e test run
@@ -142,7 +141,7 @@ var _ = SIGDescribe("Discovery", func() {
 			apiPath := "/apis/" + group.Name + "/"
 			err = f.ClientSet.Discovery().RESTClient().Get().AbsPath(apiPath).Do(ctx).Into(checkGroup)
 			framework.ExpectNoError(err, "Fail to access: %s", apiPath)
-			framework.ExpectNotEqual(len(checkGroup.Versions), 0, "No version found for %v", group.Name)
+			gomega.Expect(checkGroup.Versions).NotTo(gomega.BeEmpty(), "No version found for %v", group.Name)
 			framework.Logf("PreferredVersion.GroupVersion: %s", checkGroup.PreferredVersion.GroupVersion)
 			framework.Logf("Versions found %v", checkGroup.Versions)
 

--- a/test/e2e/apimachinery/table_conversion.go
+++ b/test/e2e/apimachinery/table_conversion.go
@@ -112,8 +112,8 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 			Do(ctx).Into(pagedTable)
 		framework.ExpectNoError(err, "failed to get pod templates in Table form in namespace: %s", ns)
 		framework.ExpectEqual(len(pagedTable.Rows), 2)
-		framework.ExpectNotEqual(pagedTable.ResourceVersion, "")
-		framework.ExpectNotEqual(pagedTable.Continue, "")
+		gomega.Expect(pagedTable.ResourceVersion).NotTo(gomega.BeEmpty())
+		gomega.Expect(pagedTable.Continue).NotTo(gomega.BeEmpty())
 		framework.ExpectEqual(pagedTable.Rows[0].Cells[0], "template-0000")
 		framework.ExpectEqual(pagedTable.Rows[1].Cells[0], "template-0001")
 
@@ -138,7 +138,7 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 		gomega.Expect(table.Rows).ToNot(gomega.BeEmpty())
 		framework.ExpectEqual(len(table.Rows[0].Cells), len(table.ColumnDefinitions))
 		framework.ExpectEqual(table.ColumnDefinitions[0].Name, "Name")
-		framework.ExpectNotEqual(table.ResourceVersion, "")
+		gomega.Expect(table.ResourceVersion).NotTo(gomega.BeEmpty())
 
 		out := printTable(table)
 		gomega.Expect(out).To(gomega.MatchRegexp("^NAME\\s"))

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -131,7 +131,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 					break
 				}
 			}
-			framework.ExpectNotEqual(group, nil, "admissionregistration.k8s.io API group not found in /apis discovery document")
+			gomega.Expect(group).NotTo(gomega.BeNil(), "admissionregistration.k8s.io API group not found in /apis discovery document")
 
 			ginkgo.By("finding the admissionregistration.k8s.io/v1 API group/version in the /apis discovery document")
 			var version *metav1.GroupVersionForDiscovery
@@ -141,7 +141,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 					break
 				}
 			}
-			framework.ExpectNotEqual(version, nil, "admissionregistration.k8s.io/v1 API group version not found in /apis discovery document")
+			gomega.Expect(version).NotTo(gomega.BeNil(), "admissionregistration.k8s.io/v1 API group version not found in /apis discovery document")
 		}
 
 		{
@@ -159,7 +159,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 					break
 				}
 			}
-			framework.ExpectNotEqual(version, nil, "admissionregistration.k8s.io/v1 API group version not found in /apis/admissionregistration.k8s.io discovery document")
+			gomega.Expect(version).NotTo(gomega.BeNil(), "admissionregistration.k8s.io/v1 API group version not found in /apis/admissionregistration.k8s.io discovery document")
 		}
 
 		{
@@ -182,8 +182,8 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 					validatingWebhookResource = &apiResourceList.APIResources[i]
 				}
 			}
-			framework.ExpectNotEqual(mutatingWebhookResource, nil, "mutatingwebhookconfigurations resource not found in /apis/admissionregistration.k8s.io/v1 discovery document")
-			framework.ExpectNotEqual(validatingWebhookResource, nil, "validatingwebhookconfigurations resource not found in /apis/admissionregistration.k8s.io/v1 discovery document")
+			gomega.Expect(mutatingWebhookResource).NotTo(gomega.BeNil(), "mutatingwebhookconfigurations resource not found in /apis/admissionregistration.k8s.io/v1 discovery document")
+			gomega.Expect(validatingWebhookResource).NotTo(gomega.BeNil(), "validatingwebhookconfigurations resource not found in /apis/admissionregistration.k8s.io/v1 discovery document")
 		}
 	})
 

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -121,7 +121,7 @@ var _ = SIGDescribe("Cluster size autoscaling [Slow]", func() {
 		framework.ExpectNoError(err)
 		nodeCount = len(nodes.Items)
 		ginkgo.By(fmt.Sprintf("Initial number of schedulable nodes: %v", nodeCount))
-		framework.ExpectNotEqual(nodeCount, 0)
+		gomega.Expect(nodeCount).NotTo(gomega.HaveValue(gomega.Equal(0)))
 		mem := nodes.Items[0].Status.Allocatable[v1.ResourceMemory]
 		memAllocatableMb = int((&mem).Value() / 1024 / 1024)
 

--- a/test/e2e/cloud/gcp/addon_update.go
+++ b/test/e2e/cloud/gcp/addon_update.go
@@ -251,7 +251,7 @@ var _ = SIGDescribe("Addon update", func() {
 		e2eskipper.SkipUnlessProviderIs("gce")
 
 		//these tests are long, so I squeezed several cases in one scenario
-		framework.ExpectNotEqual(sshClient, nil)
+		gomega.Expect(sshClient).NotTo(gomega.BeNil())
 		dir = f.Namespace.Name // we use it only to give a unique string for each test execution
 
 		temporaryRemotePathPrefix := "addon-test-dir"

--- a/test/e2e/cloud/gcp/kubelet_security.go
+++ b/test/e2e/cloud/gcp/kubelet_security.go
@@ -31,6 +31,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 var _ = SIGDescribe("Ports Security Check [Feature:KubeletSecurity]", func() {
@@ -54,7 +55,8 @@ var _ = SIGDescribe("Ports Security Check [Feature:KubeletSecurity]", func() {
 
 		var statusCode int
 		result.StatusCode(&statusCode)
-		framework.ExpectNotEqual(statusCode, http.StatusOK)
+		gomega.Expect(statusCode).NotTo(gomega.Equal(http.StatusOK))
+
 	})
 	ginkgo.It("should not be able to proxy to cadvisor port 4194 using proxy subresource", func(ctx context.Context) {
 		result, err := e2ekubelet.ProxyRequest(ctx, f.ClientSet, nodeName, "containers/", 4194)
@@ -62,7 +64,7 @@ var _ = SIGDescribe("Ports Security Check [Feature:KubeletSecurity]", func() {
 
 		var statusCode int
 		result.StatusCode(&statusCode)
-		framework.ExpectNotEqual(statusCode, http.StatusOK)
+		gomega.Expect(statusCode).NotTo(gomega.Equal(http.StatusOK))
 	})
 
 	// make sure kubelet readonly (10255) and cadvisor (4194) ports are closed on the public IP address
@@ -78,7 +80,7 @@ var _ = SIGDescribe("Ports Security Check [Feature:KubeletSecurity]", func() {
 // checks whether the target port is closed
 func portClosedTest(f *framework.Framework, pickNode *v1.Node, port int) {
 	nodeAddrs := e2enode.GetAddresses(pickNode, v1.NodeExternalIP)
-	framework.ExpectNotEqual(len(nodeAddrs), 0)
+	gomega.Expect(nodeAddrs).NotTo(gomega.BeEmpty())
 
 	for _, addr := range nodeAddrs {
 		conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", addr, port), 1*time.Minute)

--- a/test/e2e/cloud/gcp/node_lease.go
+++ b/test/e2e/cloud/gcp/node_lease.go
@@ -149,7 +149,7 @@ var _ = SIGDescribe("[Disruptive]NodeLease", func() {
 				deletedNodeName = originalNodeName
 				break
 			}
-			framework.ExpectNotEqual(deletedNodeName, "")
+			gomega.Expect(deletedNodeName).NotTo(gomega.BeEmpty())
 			gomega.Eventually(ctx, func() error {
 				if _, err := leaseClient.Get(ctx, deletedNodeName, metav1.GetOptions{}); err == nil {
 					return fmt.Errorf("node lease is not deleted yet for node %q", deletedNodeName)

--- a/test/e2e/common/node/secrets.go
+++ b/test/e2e/common/node/secrets.go
@@ -178,7 +178,7 @@ var _ = SIGDescribe("Secrets", func() {
 			LabelSelector: "testsecret-constant=true",
 		})
 		framework.ExpectNoError(err, "failed to list secrets")
-		framework.ExpectNotEqual(len(secretsList.Items), 0, "no secrets found")
+		gomega.Expect(secretsList.Items).NotTo(gomega.BeEmpty(), "no secrets found")
 
 		foundCreatedSecret := false
 		var secretCreatedName string

--- a/test/e2e/instrumentation/logging/generic_soak.go
+++ b/test/e2e/instrumentation/logging/generic_soak.go
@@ -34,6 +34,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 var loggingSoak struct {
@@ -85,7 +86,7 @@ func RunLogPodsWithSleepOf(ctx context.Context, f *framework.Framework, sleep ti
 	nodes, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
 	framework.ExpectNoError(err)
 	totalPods := len(nodes.Items)
-	framework.ExpectNotEqual(totalPods, 0)
+	gomega.Expect(totalPods).NotTo(gomega.HaveValue(gomega.Equal(0)))
 
 	kilobyte := strings.Repeat("logs-123", 128) // 8*128=1024 = 1KB of text.
 

--- a/test/e2e/network/conntrack.go
+++ b/test/e2e/network/conntrack.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -113,7 +114,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		}
 
 		ips := e2enode.GetAddressesByTypeAndFamily(&nodes.Items[0], v1.NodeInternalIP, family)
-		framework.ExpectNotEqual(len(ips), 0)
+		gomega.Expect(ips).NotTo(gomega.BeEmpty())
 
 		clientNodeInfo = nodeInfo{
 			name:   nodes.Items[0].Name,
@@ -121,7 +122,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		}
 
 		ips = e2enode.GetAddressesByTypeAndFamily(&nodes.Items[1], v1.NodeInternalIP, family)
-		framework.ExpectNotEqual(len(ips), 0)
+		gomega.Expect(ips).NotTo(gomega.BeEmpty())
 
 		serverNodeInfo = nodeInfo{
 			name:   nodes.Items[1].Name,

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -786,7 +786,7 @@ var _ = common.SIGDescribe("Ingress API", func() {
 		ginkgo.By("deleting")
 
 		expectFinalizer := func(ing *networkingv1.Ingress, msg string) {
-			framework.ExpectNotEqual(ing.DeletionTimestamp, nil, fmt.Sprintf("expected deletionTimestamp, got nil on step: %q, ingress: %+v", msg, ing))
+			gomega.Expect(ing.DeletionTimestamp).NotTo(gomega.BeNil(), fmt.Sprintf("expected deletionTimestamp, got nil on step: %q, ingress: %+v", msg, ing))
 			if len(ing.Finalizers) == 0 {
 				framework.Failf("expected finalizers on ingress, got none on step: %q, ingress: %+v", msg, ing)
 			}

--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -40,6 +40,7 @@ import (
 	netutils "k8s.io/utils/net"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 var kubeProxyE2eImage = imageutils.GetE2EImage(imageutils.Agnhost)
@@ -76,7 +77,7 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 		}
 
 		ips := e2enode.GetAddressesByTypeAndFamily(&nodes.Items[0], v1.NodeInternalIP, family)
-		framework.ExpectNotEqual(len(ips), 0)
+		gomega.Expect(ips).NotTo(gomega.BeEmpty())
 
 		clientNodeInfo := NodeInfo{
 			node:   &nodes.Items[0],
@@ -85,7 +86,7 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 		}
 
 		ips = e2enode.GetAddressesByTypeAndFamily(&nodes.Items[1], v1.NodeInternalIP, family)
-		framework.ExpectNotEqual(len(ips), 0)
+		gomega.Expect(ips).NotTo(gomega.BeEmpty())
 
 		serverNodeInfo := NodeInfo{
 			node:   &nodes.Items[1],

--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -551,7 +551,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 		acceptPod, err = cs.CoreV1().Pods(namespace).Get(ctx, acceptPod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "Unable to get pod %s", acceptPod.Name)
 		gomega.Expect(acceptPod.Status.Phase).To(gomega.Equal(v1.PodRunning))
-		framework.ExpectNotEqual(acceptPod.Status.PodIP, "")
+		gomega.Expect(acceptPod.Status.PodIP).NotTo(gomega.BeEmpty())
 
 		// Create loadbalancer service with source range from node[0] and podAccept
 		svc, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
@@ -581,7 +581,7 @@ var _ = common.SIGDescribe("LoadBalancers", func() {
 		dropPod, err = cs.CoreV1().Pods(namespace).Get(ctx, dropPod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "Unable to get pod %s", dropPod.Name)
 		gomega.Expect(acceptPod.Status.Phase).To(gomega.Equal(v1.PodRunning))
-		framework.ExpectNotEqual(acceptPod.Status.PodIP, "")
+		gomega.Expect(acceptPod.Status.PodIP).NotTo(gomega.BeEmpty())
 
 		ginkgo.By("Update service LoadBalancerSourceRange and check reachability")
 		_, err = jig.UpdateService(ctx, func(svc *v1.Service) {
@@ -1602,8 +1602,8 @@ var _ = common.SIGDescribe("LoadBalancers ESIPP [Slow]", func() {
 				noEndpointNodeMap[n.Name] = ips[0]
 			}
 		}
-		framework.ExpectNotEqual(len(endpointNodeMap), 0)
-		framework.ExpectNotEqual(len(noEndpointNodeMap), 0)
+		gomega.Expect(endpointNodeMap).NotTo(gomega.BeEmpty())
+		gomega.Expect(noEndpointNodeMap).NotTo(gomega.BeEmpty())
 
 		svcTCPPort := int(svc.Spec.Ports[0].Port)
 		svcNodePort := int(svc.Spec.Ports[0].NodePort)

--- a/test/e2e/network/no_snat.go
+++ b/test/e2e/network/no_snat.go
@@ -73,7 +73,7 @@ var _ = common.SIGDescribe("NoSNAT [Feature:NoSNAT] [Slow]", func() {
 		ginkgo.By("creating a test pod on each Node")
 		nodes, err := e2enode.GetReadySchedulableNodes(ctx, cs)
 		framework.ExpectNoError(err)
-		framework.ExpectNotEqual(len(nodes.Items), 0, "no Nodes in the cluster")
+		gomega.Expect(nodes.Items).NotTo(gomega.BeEmpty(), "no Nodes in the cluster")
 
 		for _, node := range nodes.Items {
 			// target Pod at Node

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1073,7 +1073,7 @@ var _ = common.SIGDescribe("Services", func() {
 		pausePods, err := cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: labelSelector.String()})
 		framework.ExpectNoError(err, "Error in listing pods associated with pause pod deployments")
 
-		framework.ExpectNotEqual(pausePods.Items[0].Spec.NodeName, pausePods.Items[1].Spec.NodeName)
+		gomega.Expect(pausePods.Items[0].Spec.NodeName).NotTo(gomega.Equal(pausePods.Items[1].Spec.NodeName))
 
 		serviceAddress := net.JoinHostPort(serviceIP, strconv.Itoa(servicePort))
 
@@ -1401,7 +1401,7 @@ var _ = common.SIGDescribe("Services", func() {
 		gomega.Expect(nodePortCounts).To(gomega.Equal(2), "updated service should have two Ports but found %d Ports", nodePortCounts)
 
 		for _, port := range nodePortService.Spec.Ports {
-			framework.ExpectNotEqual(port.NodePort, 0, "NodePort service failed to allocate NodePort for Port %s", port.Name)
+			gomega.Expect(port.NodePort).NotTo(gomega.Equal(0), "NodePort service failed to allocate NodePort for Port %s", port.Name)
 			framework.Logf("NodePort service allocates NodePort: %d for Port: %s over Protocol: %s", port.NodePort, port.Name, port.Protocol)
 		}
 	})
@@ -3903,7 +3903,7 @@ func execAffinityTestForSessionAffinityTimeout(ctx context.Context, f *framework
 			family = v1.IPv6Protocol
 		}
 		svcIP = e2enode.FirstAddressByTypeAndFamily(nodes, v1.NodeInternalIP, family)
-		framework.ExpectNotEqual(svcIP, "", "failed to get Node internal IP for family: %s", family)
+		gomega.Expect(svcIP).NotTo(gomega.BeEmpty(), "failed to get Node internal IP for family: %s", family)
 		servicePort = int(svc.Spec.Ports[0].NodePort)
 	} else {
 		svcIP = svc.Spec.ClusterIP
@@ -3986,7 +3986,7 @@ func execAffinityTestForNonLBServiceWithOptionalTransition(ctx context.Context, 
 			family = v1.IPv6Protocol
 		}
 		svcIP = e2enode.FirstAddressByTypeAndFamily(nodes, v1.NodeInternalIP, family)
-		framework.ExpectNotEqual(svcIP, "", "failed to get Node internal IP for family: %s", family)
+		gomega.Expect(svcIP).NotTo(gomega.BeEmpty(), "failed to get Node internal IP for family: %s", family)
 		servicePort = int(svc.Spec.Ports[0].NodePort)
 	} else {
 		svcIP = svc.Spec.ClusterIP

--- a/test/e2e/node/mount_propagation.go
+++ b/test/e2e/node/mount_propagation.go
@@ -101,7 +101,7 @@ var _ = SIGDescribe("Mount propagation", func() {
 		// Fail the test if the namespace is not set. We expect that the
 		// namespace is unique and we might delete user data if it's not.
 		if len(f.Namespace.Name) == 0 {
-			framework.ExpectNotEqual(f.Namespace.Name, "")
+			gomega.Expect(f.Namespace.Name).NotTo(gomega.BeEmpty())
 			return
 		}
 

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -138,8 +138,8 @@ var _ = SIGDescribe("Pods Extended", func() {
 			})
 			framework.ExpectNoError(err, "kubelet never observed the termination notice")
 
-			framework.ExpectNotEqual(lastPod.DeletionTimestamp, nil)
-			framework.ExpectNotEqual(lastPod.Spec.TerminationGracePeriodSeconds, 0)
+			gomega.Expect(lastPod.DeletionTimestamp).NotTo(gomega.BeNil())
+			gomega.Expect(lastPod.Spec.TerminationGracePeriodSeconds).NotTo(gomega.HaveValue(gomega.Equal(0)))
 
 			selector = labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
 			options = metav1.ListOptions{LabelSelector: selector.String()}

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -1183,6 +1183,6 @@ func getNodeHostIP(ctx context.Context, f *framework.Framework, nodeName string)
 	node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	ips := e2enode.GetAddressesByTypeAndFamily(node, v1.NodeInternalIP, family)
-	framework.ExpectNotEqual(len(ips), 0)
+	gomega.Expect(ips).NotTo(gomega.BeEmpty())
 	return ips[0]
 }

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -328,7 +328,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		podRes := v1.ResourceList{testExtendedResource: resource.MustParse("1")}
 
 		ginkgo.By("Select a node to run the lower and higher priority pods")
-		framework.ExpectNotEqual(len(nodeList.Items), 0, "We need at least one node for the test to run")
+		gomega.Expect(nodeList.Items).NotTo(gomega.BeEmpty(), "We need at least one node for the test to run")
 		node := nodeList.Items[0]
 		nodeCopy := node.DeepCopy()
 		nodeCopy.Status.Capacity[testExtendedResource] = resource.MustParse("1")

--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -199,7 +199,7 @@ var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 		labelPod, err := cs.CoreV1().Pods(ns).Get(ctx, labelPodName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		ginkgo.By("Verify the pod was scheduled to the expected node.")
-		framework.ExpectNotEqual(labelPod.Spec.NodeName, nodeName)
+		gomega.Expect(labelPod.Spec.NodeName).NotTo(gomega.Equal(nodeName))
 	})
 
 	ginkgo.It("Pod should be preferably scheduled to nodes pod can tolerate", func(ctx context.Context) {

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -298,7 +298,7 @@ func (d *driverDefinition) GetDynamicProvisionStorageClass(ctx context.Context, 
 		}
 	}
 
-	framework.ExpectNotEqual(sc, nil, "storage class is unexpectantly nil")
+	gomega.Expect(sc).NotTo(gomega.BeNil(), "storage class is unexpectantly nil")
 
 	if fsType != "" {
 		if sc.Parameters == nil {

--- a/test/e2e/storage/pv_protection.go
+++ b/test/e2e/storage/pv_protection.go
@@ -124,7 +124,7 @@ var _ = utils.SIGDescribe("PV Protection", func() {
 		ginkgo.By("Checking that the PV status is Terminating")
 		pv, err = client.CoreV1().PersistentVolumes().Get(ctx, pv.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While checking PV status")
-		framework.ExpectNotEqual(pv.ObjectMeta.DeletionTimestamp, nil)
+		gomega.Expect(pv.ObjectMeta.DeletionTimestamp).NotTo(gomega.BeNil())
 
 		ginkgo.By("Deleting the PVC that is bound to the PV")
 		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(ctx, pvc.Name, *metav1.NewDeleteOptions(0))

--- a/test/e2e/storage/pvc_protection.go
+++ b/test/e2e/storage/pvc_protection.go
@@ -134,7 +134,7 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 		ginkgo.By("Checking that the PVC status is Terminating")
 		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While checking PVC status")
-		framework.ExpectNotEqual(pvc.ObjectMeta.DeletionTimestamp, nil)
+		gomega.Expect(pvc.ObjectMeta.DeletionTimestamp).NotTo(gomega.BeNil())
 
 		ginkgo.By("Deleting the pod that uses the PVC")
 		err = e2epod.DeletePodWithWait(ctx, client, pod)
@@ -153,7 +153,7 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 		ginkgo.By("Checking that the PVC status is Terminating")
 		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While checking PVC status")
-		framework.ExpectNotEqual(pvc.ObjectMeta.DeletionTimestamp, nil)
+		gomega.Expect(pvc.ObjectMeta.DeletionTimestamp).NotTo(gomega.BeNil())
 
 		ginkgo.By("Creating second Pod whose scheduling fails because it uses a PVC that is being deleted")
 		secondPod, err2 := e2epod.CreateUnschedulablePod(ctx, client, nameSpace, nil, []*v1.PersistentVolumeClaim{pvc}, f.NamespacePodSecurityLevel, "")
@@ -166,7 +166,7 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 		ginkgo.By("Checking again that the PVC status is Terminating")
 		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While checking PVC status")
-		framework.ExpectNotEqual(pvc.ObjectMeta.DeletionTimestamp, nil)
+		gomega.Expect(pvc.ObjectMeta.DeletionTimestamp).NotTo(gomega.BeNil())
 
 		ginkgo.By("Deleting the first pod that uses the PVC")
 		err = e2epod.DeletePodWithWait(ctx, client, pod)

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -965,7 +965,7 @@ func PVMultiNodeCheck(ctx context.Context, client clientset.Interface, timeouts 
 	framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, client, pod.Name, pod.Namespace, timeouts.PodStartSlow))
 	runningPod, err = client.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err, "get pod")
-	framework.ExpectNotEqual(runningPod.Spec.NodeName, actualNodeName, "second pod should have run on a different node")
+	gomega.Expect(runningPod.Spec.NodeName).NotTo(gomega.Equal(actualNodeName), "second pod should have run on a different node")
 	StopPod(ctx, client, pod)
 	pod = nil
 }
@@ -973,7 +973,7 @@ func PVMultiNodeCheck(ctx context.Context, client clientset.Interface, timeouts 
 // TestBindingWaitForFirstConsumerMultiPVC tests the binding with WaitForFirstConsumer mode
 func (t StorageClassTest) TestBindingWaitForFirstConsumerMultiPVC(ctx context.Context, claims []*v1.PersistentVolumeClaim, nodeSelector map[string]string, expectUnschedulable bool) ([]*v1.PersistentVolume, *v1.Node) {
 	var err error
-	framework.ExpectNotEqual(len(claims), 0)
+	gomega.Expect(claims).NotTo(gomega.BeEmpty())
 	namespace := claims[0].Namespace
 
 	ginkgo.By("creating claims")

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -998,7 +998,7 @@ func testSubpathReconstruction(ctx context.Context, f *framework.Framework, host
 			podNode = &nodeList.Items[i]
 		}
 	}
-	framework.ExpectNotEqual(podNode, nil, "pod node should exist in schedulable nodes")
+	gomega.Expect(podNode).NotTo(gomega.BeNil(), "pod node should exist in schedulable nodes")
 
 	storageutils.TestVolumeUnmountsFromDeletedPodWithForceOption(ctx, f.ClientSet, f, pod, forceDelete, true, nil, volumePath)
 

--- a/test/e2e/storage/testsuites/topology.go
+++ b/test/e2e/storage/testsuites/topology.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 
+	"github.com/onsi/gomega"
+
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,7 +140,8 @@ func (t *topologyTestSuite) DefineTests(driver storageframework.TestDriver, patt
 		}
 
 		l.resource.Sc = dDriver.GetDynamicProvisionStorageClass(ctx, l.config, pattern.FsType)
-		framework.ExpectNotEqual(l.resource.Sc, nil, "driver failed to provide a StorageClass")
+		gomega.Expect(l.resource.Sc).NotTo(gomega.BeNil(), "driver failed to provide a StorageClass")
+
 		l.resource.Sc.VolumeBindingMode = &pattern.BindingMode
 
 		testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange

--- a/test/e2e/storage/testsuites/volumemode.go
+++ b/test/e2e/storage/testsuites/volumemode.go
@@ -389,7 +389,7 @@ func (t *volumeModeTestSuite) DefineTests(driver storageframework.TestDriver, pa
 		// Reload the pod to get its node
 		pod, err = l.cs.CoreV1().Pods(l.ns.Name).Get(ctx, pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
-		framework.ExpectNotEqual(pod.Spec.NodeName, "", "pod should be scheduled to a node")
+		gomega.Expect(pod.Spec.NodeName).NotTo(gomega.BeEmpty(), "pod should be scheduled to a node")
 		node, err := l.cs.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -136,7 +136,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		if !ephemeral {
 			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
-			framework.ExpectNotEqual(pvc, nil)
+			gomega.Expect(pvc).NotTo(gomega.BeNil())
 		}
 
 		pod := makePod(f, pvc, ephemeral)
@@ -150,8 +150,8 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 
 		updatedStorageMetrics := waitForDetachAndGrabMetrics(ctx, storageOpMetrics, metricsGrabber, pluginName)
 
-		framework.ExpectNotEqual(len(updatedStorageMetrics.latencyMetrics), 0, "Error fetching c-m updated storage metrics")
-		framework.ExpectNotEqual(len(updatedStorageMetrics.statusMetrics), 0, "Error fetching c-m updated storage metrics")
+		gomega.Expect(updatedStorageMetrics.latencyMetrics).NotTo(gomega.BeEmpty(), "Error fetching c-m updated storage metrics")
+		gomega.Expect(updatedStorageMetrics.statusMetrics).NotTo(gomega.BeEmpty(), "Error fetching c-m updated storage metrics")
 
 		volumeOperations := []string{"volume_detach", "volume_attach"}
 
@@ -186,7 +186,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		if !ephemeral {
 			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "failed to create PVC %s/%s", pvc.Namespace, pvc.Name)
-			framework.ExpectNotEqual(pvc, nil)
+			gomega.Expect(pvc).NotTo(gomega.BeNil())
 		}
 
 		ginkgo.By("Creating a pod and expecting it to fail")
@@ -205,14 +205,14 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		framework.ExpectNoError(err, "failed to get controller manager metrics")
 		updatedStorageMetrics := getControllerStorageMetrics(updatedControllerMetrics, pluginName)
 
-		framework.ExpectNotEqual(len(updatedStorageMetrics.statusMetrics), 0, "Error fetching c-m updated storage metrics")
+		gomega.Expect(updatedStorageMetrics.statusMetrics).NotTo(gomega.BeEmpty(), "Error fetching c-m updated storage metrics")
 	}
 
 	filesystemMode := func(ctx context.Context, isEphemeral bool) {
 		if !isEphemeral {
 			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
-			framework.ExpectNotEqual(pvc, nil)
+			gomega.Expect(pvc).NotTo(gomega.BeNil())
 		}
 
 		pod := makePod(f, pvc, isEphemeral)
@@ -277,7 +277,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		if !isEphemeral {
 			pvcBlock, err = c.CoreV1().PersistentVolumeClaims(pvcBlock.Namespace).Create(ctx, pvcBlock, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
-			framework.ExpectNotEqual(pvcBlock, nil)
+			gomega.Expect(pvcBlock).NotTo(gomega.BeNil())
 		}
 
 		pod := makePod(f, pvcBlock, isEphemeral)
@@ -343,7 +343,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		if !isEphemeral {
 			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
-			framework.ExpectNotEqual(pvc, nil)
+			gomega.Expect(pvc).NotTo(gomega.BeNil())
 		}
 
 		pod := makePod(f, pvc, isEphemeral)
@@ -374,7 +374,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		if !isEphemeral {
 			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
-			framework.ExpectNotEqual(pvc, nil)
+			gomega.Expect(pvc).NotTo(gomega.BeNil())
 		}
 
 		pod := makePod(f, pvc, isEphemeral)
@@ -404,7 +404,7 @@ var _ = utils.SIGDescribe("[Serial] Volume metrics", func() {
 		if !isEphemeral {
 			pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
-			framework.ExpectNotEqual(pvc, nil)
+			gomega.Expect(pvc).NotTo(gomega.BeNil())
 		}
 
 		pod := makePod(f, pvc, isEphemeral)

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -275,7 +275,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				}
 
 				if zone, ok := test.Parameters["zone"]; ok {
-					framework.ExpectNotEqual(len(zone), 0, "expect at least one zone")
+					gomega.Expect(zone).NotTo(gomega.BeEmpty(), "expect at least one zone")
 				}
 
 				ginkgo.By("Testing " + test.Name)

--- a/test/e2e/upgrades/node/sysctl.go
+++ b/test/e2e/upgrades/node/sysctl.go
@@ -69,7 +69,7 @@ func (t *SysctlUpgradeTest) Test(ctx context.Context, f *framework.Framework, do
 		framework.ExpectNoError(err)
 	}
 	if err == nil {
-		framework.ExpectNotEqual(pod.Status.Phase, v1.PodRunning)
+		gomega.Expect(pod.Status.Phase).NotTo(gomega.Equal(v1.PodRunning))
 	}
 
 	t.verifySafeSysctlWork(ctx, f)

--- a/test/e2e/windows/security_context.go
+++ b/test/e2e/windows/security_context.go
@@ -167,7 +167,7 @@ var _ = SIGDescribe("[Feature:Windows] SecurityContext", func() {
 		ginkgo.By("Waiting for pod to finish")
 		event, err := e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(ctx, podInvalid)
 		framework.ExpectNoError(err)
-		framework.ExpectNotEqual(event, nil, "event should not be empty")
+		gomega.Expect(event).NotTo(gomega.BeNil(), "event should not be empty")
 		framework.Logf("Got event: %v", event)
 		expectedEventError := "container's runAsUserName (ContainerAdministrator) which will be regarded as root identity and will break non-root policy"
 		gomega.Expect(event.Message).Should(gomega.ContainSubstring(expectedEventError), "Event error should indicate non-root policy caused container to not start")
@@ -185,7 +185,7 @@ var _ = SIGDescribe("[Feature:Windows] SecurityContext", func() {
 		ginkgo.By("Waiting for pod to finish")
 		event, err := e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(ctx, podInvalid)
 		framework.ExpectNoError(err)
-		framework.ExpectNotEqual(event, nil, "event should not be empty")
+		gomega.Expect(event).NotTo(gomega.BeNil(), "event should not be empty")
 		framework.Logf("Got event: %v", event)
 		expectedEventError := "container's runAsUserName (CONTAINERADMINISTRATOR) which will be regarded as root identity and will break non-root policy"
 		gomega.Expect(event.Message).Should(gomega.ContainSubstring(expectedEventError), "Event error should indicate non-root policy caused container to not start")

--- a/test/e2e_node/eviction_test.go
+++ b/test/e2e_node/eviction_test.go
@@ -711,7 +711,7 @@ func verifyEvictionOrdering(ctx context.Context, f *framework.Framework, testSpe
 			}
 		}
 		gomega.Expect(priorityPod).NotTo(gomega.BeNil())
-		framework.ExpectNotEqual(priorityPod.Status.Phase, v1.PodSucceeded,
+		gomega.Expect(priorityPod.Status.Phase).NotTo(gomega.Equal(v1.PodSucceeded),
 			fmt.Sprintf("pod: %s succeeded unexpectedly", priorityPod.Name))
 
 		// Check eviction ordering.
@@ -726,7 +726,7 @@ func verifyEvictionOrdering(ctx context.Context, f *framework.Framework, testSpe
 			}
 			gomega.Expect(lowPriorityPod).NotTo(gomega.BeNil())
 			if priorityPodSpec.evictionPriority < lowPriorityPodSpec.evictionPriority && lowPriorityPod.Status.Phase == v1.PodRunning {
-				framework.ExpectNotEqual(priorityPod.Status.Phase, v1.PodFailed,
+				gomega.Expect(priorityPod.Status.Phase).NotTo(gomega.Equal(v1.PodFailed),
 					fmt.Sprintf("priority %d pod: %s failed before priority %d pod: %s",
 						priorityPodSpec.evictionPriority, priorityPodSpec.pod.Name, lowPriorityPodSpec.evictionPriority, lowPriorityPodSpec.pod.Name))
 			}
@@ -739,7 +739,7 @@ func verifyEvictionOrdering(ctx context.Context, f *framework.Framework, testSpe
 
 		// EvictionPriority 0 pods should not fail
 		if priorityPodSpec.evictionPriority == 0 {
-			framework.ExpectNotEqual(priorityPod.Status.Phase, v1.PodFailed,
+			gomega.Expect(&priorityPod.Status.Phase).NotTo(gomega.Equal(v1.PodFailed),
 				fmt.Sprintf("priority 0 pod: %s failed", priorityPod.Name))
 		}
 

--- a/test/e2e_node/pod_conditions_test.go
+++ b/test/e2e_node/pod_conditions_test.go
@@ -41,6 +41,7 @@ import (
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 var _ = SIGDescribe("Pod conditions managed by Kubelet", func() {
@@ -125,7 +126,7 @@ func runPodFailingConditionsTest(f *framework.Framework, hasInitContainers, chec
 			// Verify PodInitialized is set if init containers are not present (since without init containers, it gets set very early)
 			initializedTime, err := getTransitionTimeForPodConditionWithStatus(p, v1.PodInitialized, true)
 			framework.ExpectNoError(err)
-			framework.ExpectNotEqual(initializedTime.Before(scheduledTime), true, fmt.Sprintf("pod without init containers is initialized at: %v which is before pod scheduled at: %v", initializedTime, scheduledTime))
+			gomega.Expect(initializedTime.Before(scheduledTime)).NotTo(gomega.BeTrue(), fmt.Sprintf("pod without init containers is initialized at: %v which is before pod scheduled at: %v", initializedTime, scheduledTime))
 		}
 
 		// Verify ContainersReady is not set (since sandboxcreation is blocked)
@@ -165,28 +166,28 @@ func runPodReadyConditionsTest(f *framework.Framework, hasInitContainers, checkP
 
 			if hasInitContainers {
 				// With init containers, verify the sequence of conditions is: Scheduled => PodReadyToStartContainers => Initialized
-				framework.ExpectNotEqual(readyToStartContainersTime.Before(scheduledTime), true, fmt.Sprintf("pod with init containers is initialized at: %v which is before pod has ready to start at: %v", initializedTime, readyToStartContainersTime))
-				framework.ExpectNotEqual(initializedTime.Before(readyToStartContainersTime), true, fmt.Sprintf("pod with init containers is initialized at: %v which is before pod has ready to start at: %v", initializedTime, readyToStartContainersTime))
+				gomega.Expect(readyToStartContainersTime.Before(scheduledTime)).NotTo(gomega.BeTrue(), fmt.Sprintf("pod with init containers is initialized at: %v which is before pod has ready to start at: %v", initializedTime, readyToStartContainersTime))
+				gomega.Expect(initializedTime.Before(readyToStartContainersTime)).NotTo(gomega.BeTrue(), fmt.Sprintf("pod with init containers is initialized at: %v which is before pod has ready to start at: %v", initializedTime, readyToStartContainersTime))
 			} else {
 				// Without init containers, verify the sequence of conditions is: Scheduled => Initialized => PodReadyToStartContainers
 				condBeforeContainersReadyTransitionTime = readyToStartContainersTime
 				errSubstrIfContainersReadyTooEarly = "ready to start"
-				framework.ExpectNotEqual(initializedTime.Before(scheduledTime), true, fmt.Sprintf("pod without init containers initialized at: %v which is before pod scheduled at: %v", initializedTime, scheduledTime))
-				framework.ExpectNotEqual(readyToStartContainersTime.Before(initializedTime), true, fmt.Sprintf("pod without init containers has ready to start at: %v which is before pod is initialized at: %v", readyToStartContainersTime, initializedTime))
+				gomega.Expect(initializedTime.Before(scheduledTime)).NotTo(gomega.BeTrue(), fmt.Sprintf("pod without init containers initialized at: %v which is before pod scheduled at: %v", initializedTime, scheduledTime))
+				gomega.Expect(readyToStartContainersTime.Before(initializedTime)).NotTo(gomega.BeTrue(), fmt.Sprintf("pod without init containers has ready to start at: %v which is before pod is initialized at: %v", readyToStartContainersTime, initializedTime))
 			}
 		} else {
 			// In the absence of PodHasReadyToStartContainers feature disabled, verify the sequence is: Scheduled => Initialized
-			framework.ExpectNotEqual(initializedTime.Before(scheduledTime), true, fmt.Sprintf("pod initialized at: %v which is before pod scheduled at: %v", initializedTime, scheduledTime))
+			gomega.Expect(initializedTime.Before(scheduledTime)).NotTo(gomega.BeTrue(), fmt.Sprintf("pod initialized at: %v which is before pod scheduled at: %v", initializedTime, scheduledTime))
 		}
 		// Verify the next condition to get set is ContainersReady
 		containersReadyTime, err := getTransitionTimeForPodConditionWithStatus(p, v1.ContainersReady, true)
 		framework.ExpectNoError(err)
-		framework.ExpectNotEqual(containersReadyTime.Before(condBeforeContainersReadyTransitionTime), true, fmt.Sprintf("containers ready at: %v which is before pod %s: %v", containersReadyTime, errSubstrIfContainersReadyTooEarly, initializedTime))
+		gomega.Expect(containersReadyTime.Before(condBeforeContainersReadyTransitionTime)).NotTo(gomega.BeTrue(), fmt.Sprintf("containers ready at: %v which is before pod %s: %v", containersReadyTime, errSubstrIfContainersReadyTooEarly, initializedTime))
 
 		// Verify ContainersReady => PodReady
 		podReadyTime, err := getTransitionTimeForPodConditionWithStatus(p, v1.PodReady, true)
 		framework.ExpectNoError(err)
-		framework.ExpectNotEqual(podReadyTime.Before(containersReadyTime), true, fmt.Sprintf("pod ready at: %v which is before pod containers ready at: %v", podReadyTime, containersReadyTime))
+		gomega.Expect(podReadyTime.Before(containersReadyTime)).NotTo(gomega.BeTrue(), fmt.Sprintf("pod ready at: %v which is before pod containers ready at: %v", podReadyTime, containersReadyTime))
 	}
 }
 

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -359,7 +359,7 @@ func findKubeletServiceName(running bool) string {
 	framework.ExpectNoError(err)
 	regex := regexp.MustCompile("(kubelet-\\w+)")
 	matches := regex.FindStringSubmatch(string(stdout))
-	framework.ExpectNotEqual(len(matches), 0, "Found more than one kubelet service running: %q", stdout)
+	gomega.Expect(matches).NotTo(gomega.BeEmpty(), "Found more than one kubelet service running: %q", stdout)
 	kubeletServiceName := matches[0]
 	framework.Logf("Get running kubelet with systemctl: %v, %v", string(stdout), kubeletServiceName)
 	return kubeletServiceName


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
stop using deprecated framework.ExpectNotEqual in test derictory


#### Which issue(s) this PR fixes:

Ref https://github.com/kubernetes/kubernetes/pull/115961
