### PR TITLE
api: change list type for node lists in PodSchedulingContext

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14045,7 +14045,7 @@
             "type": "string"
           },
           "type": "array",
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "selectedNode": {
           "description": "SelectedNode is the node for which allocation of ResourceClaims that are referenced by the Pod and that use \"WaitForFirstConsumer\" allocation is to be attempted.",
@@ -14204,7 +14204,7 @@
             "type": "string"
           },
           "type": "array",
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         }
       },
       "type": "object"

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha2_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha2_openapi.json
@@ -219,7 +219,7 @@
               "type": "string"
             },
             "type": "array",
-            "x-kubernetes-list-type": "set"
+            "x-kubernetes-list-type": "atomic"
           },
           "selectedNode": {
             "description": "SelectedNode is the node for which allocation of ResourceClaims that are referenced by the Pod and that use \"WaitForFirstConsumer\" allocation is to be attempted.",
@@ -414,7 +414,7 @@
               "type": "string"
             },
             "type": "array",
-            "x-kubernetes-list-type": "set"
+            "x-kubernetes-list-type": "atomic"
           }
         },
         "type": "object"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -43041,7 +43041,7 @@ func schema_k8sio_api_resource_v1alpha2_PodSchedulingContextSpec(ref common.Refe
 					"potentialNodes": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -43302,7 +43302,7 @@ func schema_k8sio_api_resource_v1alpha2_ResourceClaimSchedulingStatus(ref common
 					"unsuitableNodes": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{

--- a/staging/src/k8s.io/api/resource/v1alpha2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1alpha2/generated.proto
@@ -107,7 +107,7 @@ message PodSchedulingContextSpec {
   // that suits all pending resources. This may get increased in the
   // future, but not reduced.
   //
-  // +listType=set
+  // +listType=atomic
   // +optional
   repeated string potentialNodes = 2;
 }
@@ -208,7 +208,7 @@ message ResourceClaimSchedulingStatus {
   // PodSchedulingSpec.PotentialNodes. This may get increased in the
   // future, but not reduced.
   //
-  // +listType=set
+  // +listType=atomic
   // +optional
   repeated string unsuitableNodes = 2;
 }

--- a/staging/src/k8s.io/api/resource/v1alpha2/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha2/types.go
@@ -248,7 +248,7 @@ type PodSchedulingContextSpec struct {
 	// that suits all pending resources. This may get increased in the
 	// future, but not reduced.
 	//
-	// +listType=set
+	// +listType=atomic
 	// +optional
 	PotentialNodes []string `json:"potentialNodes,omitempty" protobuf:"bytes,2,opt,name=potentialNodes"`
 }
@@ -283,7 +283,7 @@ type ResourceClaimSchedulingStatus struct {
 	// PodSchedulingSpec.PotentialNodes. This may get increased in the
 	// future, but not reduced.
 	//
-	// +listType=set
+	// +listType=atomic
 	// +optional
 	UnsuitableNodes []string `json:"unsuitableNodes,omitempty" protobuf:"bytes,2,opt,name=unsuitableNodes"`
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -11923,7 +11923,7 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             scalar: string
-          elementRelationship: associative
+          elementRelationship: atomic
     - name: selectedNode
       type:
         scalar: string
@@ -12002,7 +12002,7 @@ var schemaYAML = typed.YAMLObject(`types:
         list:
           elementType:
             scalar: string
-          elementRelationship: associative
+          elementRelationship: atomic
 - name: io.k8s.api.resource.v1alpha2.ResourceClaimSpec
   map:
     fields:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

The "set" list type was chosen because it seemed appropriate (no duplicates!) but that made tracking of managed fields more expensive (each entry in the list is tracked, not the entire field) and for no good reason (one client is responsible for the entire list).

Therefore the type gets changed to "atomic". Server-side-apply has not been used in the past and PodSchedulingContext objects are short-lived and still in alpha, so any potential compatibility issues should be minor.

The scheduling throughput in scheduler_perf increases:

    name                                                                      old SchedulingThroughput/Average     new SchedulingThroughput/Average
    PerfScheduling/SchedulingWithResourceClaimTemplate/2000pods_100nodes-36   18.8 ± 8%                            24.0 ±37%
    PerfScheduling/SchedulingWithMultipleResourceClaims/2000pods_100nodes-36  13.7 ±81%                            18.5 ±40%


#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/issues/113701

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
