### PR TITLE
e2e framework util subtle bug checking endpoints

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -478,7 +478,7 @@ func isIPv6Endpoint(e *v1.Endpoints) bool {
 				continue
 			}
 			// Endpoints are single family, so it is enough to check only one address
-			return netutils.IsIPv6String(sub.Addresses[0].IP)
+			return netutils.IsIPv6String(addr.IP)
 		}
 	}
 	// default to IPv4 an Endpoint without IP addresses


### PR DESCRIPTION

/kind bug
```release-note
NONE
```

We canonalize the Endpoints generated so this is relatively safe but incorrect, so we make it right