### PR TITLE
Replace stat syscall with statx

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -442,7 +442,7 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 			return mounter.isLikelyNotMountPoint(file)
 		}
 
-		return false, err
+		return true, err
 	}
 
 	if stat.Attributes_mask != 0 {
@@ -459,10 +459,10 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 
 	root := filepath.Dir(strings.TrimSuffix(file, "/"))
 	if rootStat, err = statx(root); err != nil {
-		return false, err
+		return true, err
 	}
 
-	return !(stat.Dev_major == rootStat.Dev_major && stat.Dev_minor == rootStat.Dev_minor), nil
+	return (stat.Dev_major == rootStat.Dev_major && stat.Dev_minor == rootStat.Dev_minor), nil
 }
 
 // CanSafelySkipMountPointCheck relies on the detected behavior of umount when given a target that is not a mount point.


### PR DESCRIPTION
statx with AT_STATX_DONT_SYNC will not stuck kubelet syncLoop.

stat will stuck in syscall when nfs server not responding, replace stat with statx to fix it.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #101622

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


