### PR TITLE
Make gomaxprocs install optional, limit to tests

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -18,6 +18,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
+kube::golang::setup_gomaxprocs
 
 # start the cache mutation detector by default so that cache mutators will be found
 KUBE_CACHE_MUTATION_DETECTOR="${KUBE_CACHE_MUTATION_DETECTOR:-true}"

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -22,6 +22,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
+kube::golang::setup_gomaxprocs
 
 # start the cache mutation detector by default so that cache mutators will be found
 KUBE_CACHE_MUTATION_DETECTOR="${KUBE_CACHE_MUTATION_DETECTOR:-true}"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Avoids the install of the ncpu dependencies if GOMAXPROCS is already set explicitly, and limits the auto-set to test targets

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/119768

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @dims

Easier to review ignoring whitespace changes - https://github.com/kubernetes/kubernetes/pull/119977/files?diff=split&w=1