### PR TITLE
client-go: workqueue: Add IsAdded() method to the workqueue interface

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -2815,6 +2815,10 @@ func (t *trackingWorkqueue) Get() (interface{}, bool) {
 	t.dequeue(item)
 	return item, shutdown
 }
+func (t *trackingWorkqueue) IsQueued(item interface{}) bool {
+	_, ok := t.pendingMap[item]
+	return ok
+}
 func (t *trackingWorkqueue) Done(item interface{}) {
 	t.limiter.Done(item)
 }

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -2815,7 +2815,7 @@ func (t *trackingWorkqueue) Get() (interface{}, bool) {
 	t.dequeue(item)
 	return item, shutdown
 }
-func (t *trackingWorkqueue) IsQueued(item interface{}) bool {
+func (t *trackingWorkqueue) IsAdded(item interface{}) bool {
 	_, ok := t.pendingMap[item]
 	return ok
 }

--- a/staging/src/k8s.io/client-go/util/workqueue/queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue.go
@@ -26,7 +26,7 @@ import (
 // Interface defines the minimal requirements to implement a workqueue.
 type Interface interface {
 	Add(item interface{})
-	IsQueued(item interface{}) bool
+	IsAdded(item interface{}) bool
 	Len() int
 	Get() (item interface{}, shutdown bool)
 	Done(item interface{})
@@ -183,10 +183,10 @@ func (q *Type) Add(item interface{}) {
 	q.cond.Signal()
 }
 
-// IsQueued returns a bool to indicate whether `item` is actively queued.
-// It returns true if the item is in the dirty set which means it is
-// queued or about to be queued once processing completes.
-func (q *Type) IsQueued(item interface{}) bool {
+// IsAdded returns a bool to indicate whether `item` is added to the queue and ready to be processed.
+// The result is only valid for the moment of call, i.e. the item could subsequently be processed and
+// removed from the queue before the client acts on the result.
+func (q *Type) IsAdded(item interface{}) bool {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
 	return q.dirty.has(item)

--- a/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
@@ -167,6 +167,31 @@ func TestLen(t *testing.T) {
 	}
 }
 
+// TestIsQueued ensures that we can check the active queue for specific objects.
+func TestIsQueued(t *testing.T) {
+	q := workqueue.New()
+
+	q.Add("foo")
+	q.Add("bar")
+	if !q.IsQueued("foo") {
+		t.Errorf("Expected foo to be reported as queued")
+	}
+	if !q.IsQueued("bar") {
+		t.Errorf("Expected bar to be reported as queued")
+	}
+	if q.IsQueued("baz") {
+		t.Errorf("baz should not be reported as queued")
+	}
+	_, _ = q.Get()
+	if q.IsQueued("foo") {
+		t.Errorf("foo should no longer be reported as queued")
+	}
+	q.Add("foo")
+	if !q.IsQueued("foo") {
+		t.Errorf("foo should be queued whilst it is processing but not done")
+	}
+}
+
 func TestReinsert(t *testing.T) {
 	q := workqueue.New()
 	q.Add("foo")

--- a/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
@@ -186,9 +186,15 @@ func TestIsQueued(t *testing.T) {
 	if q.IsQueued("foo") {
 		t.Errorf("foo should no longer be reported as queued")
 	}
+	if !q.IsQueued("bar") {
+		t.Errorf("Expected bar to be reported as queued")
+	}
 	q.Add("foo")
 	if !q.IsQueued("foo") {
 		t.Errorf("foo should be queued whilst it is processing but not done")
+	}
+	if !q.IsQueued("bar") {
+		t.Errorf("Expected bar to be reported as queued")
 	}
 }
 

--- a/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
@@ -167,33 +167,33 @@ func TestLen(t *testing.T) {
 	}
 }
 
-// TestIsQueued ensures that we can check the active queue for specific objects.
-func TestIsQueued(t *testing.T) {
+// TestIsAdded ensures that we can check the active queue for specific objects.
+func TestIsAdded(t *testing.T) {
 	q := workqueue.New()
 
 	q.Add("foo")
 	q.Add("bar")
-	if !q.IsQueued("foo") {
+	if !q.IsAdded("foo") {
 		t.Errorf("Expected foo to be reported as queued")
 	}
-	if !q.IsQueued("bar") {
+	if !q.IsAdded("bar") {
 		t.Errorf("Expected bar to be reported as queued")
 	}
-	if q.IsQueued("baz") {
+	if q.IsAdded("baz") {
 		t.Errorf("baz should not be reported as queued")
 	}
 	_, _ = q.Get()
-	if q.IsQueued("foo") {
+	if q.IsAdded("foo") {
 		t.Errorf("foo should no longer be reported as queued")
 	}
-	if !q.IsQueued("bar") {
+	if !q.IsAdded("bar") {
 		t.Errorf("Expected bar to be reported as queued")
 	}
 	q.Add("foo")
-	if !q.IsQueued("foo") {
+	if !q.IsAdded("foo") {
 		t.Errorf("foo should be queued whilst it is processing but not done")
 	}
-	if !q.IsQueued("bar") {
+	if !q.IsAdded("bar") {
 		t.Errorf("Expected bar to be reported as queued")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind api-change

#### What this PR does / why we need it:

Breakout from XXL PR https://github.com/kubernetes/kubernetes/pull/112328

This PR adds an `IsAdded()` method to the workqueue Interface type (basic active workqueue).
This is needed so that we can add features into the delaying queue which allow more intelligent decisions to be made about the queuing of items based on whether they are already actively queued or not.  We want to be able to do this in a non-destructive way, i.e. we want an answer if the item is queued without having to wait and pop it out of the queue.
It is also useful to clients of the workqueue, particularly in test suites.

#### Special notes for your reviewer:

Whilst this change is simple and adds a modest capability to clients, it is essential in order to implement the more advanced features detailed in https://github.com/kubernetes/kubernetes/pull/112328
The intention is that `IsAdded()` will be joined by an `IsWaiting()` method on the delaying interface so that clients can find out whether their item is actively queued or in the 'waiting' (delayed) queue.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
