### PR TITLE
Tolerate more api types.go files to generate code

### DIFF
--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -538,7 +538,7 @@ function kube::codegen::gen_client() {
     done < <(
         ( kube::codegen::internal::git_grep -l \
             -e '+genclient' \
-            ":(glob)${in_root}"/'**/types.go' \
+            ":(glob)${in_root}"/'**/*types.go' \
             || true \
         ) | LC_ALL=C sort -u
     )


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
Can not generator with kube_codegen.sh when i have *_types.go rather hen types.go in api project.

Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/119930