### PR TITLE
[e2e_auth] stop using deprecated framework.ExpectNotEqual

### DIFF
--- a/test/e2e/auth/node_authn.go
+++ b/test/e2e/auth/node_authn.go
@@ -53,7 +53,7 @@ var _ = SIGDescribe("[Feature:NodeAuthenticator]", func() {
 		}
 
 		nodeIPs := e2enode.GetAddressesByTypeAndFamily(&nodes.Items[0], v1.NodeInternalIP, family)
-		framework.ExpectNotEqual(len(nodeIPs), 0)
+		gomega.Expect(nodeIPs).NotTo(gomega.BeEmpty())
 	})
 
 	ginkgo.It("The kubelet's main port 10250 should reject requests with no credentials", func(ctx context.Context) {

--- a/test/e2e/auth/node_authz.go
+++ b/test/e2e/auth/node_authz.go
@@ -33,6 +33,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 const (
@@ -54,7 +55,7 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 
 		nodeList, err := f.ClientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err, "failed to list nodes in namespace: %s", ns)
-		framework.ExpectNotEqual(len(nodeList.Items), 0)
+		gomega.Expect(nodeList.Items).NotTo(gomega.BeEmpty())
 		nodeName = nodeList.Items[0].Name
 		asUser = nodeNamePrefix + nodeName
 		ginkgo.By("Creating a kubernetes client that impersonates a node")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
e2e_auth: stop using deprecated framework.ExpectNotEqual

#### Which issue(s) this PR fixes:
Ref https://github.com/kubernetes/kubernetes/pull/115961
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
