### PR TITLE
allow freebsd as a host os

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -144,11 +144,14 @@ kube::util::host_os() {
     Darwin)
       host_os=darwin
       ;;
+    FreeBSD)
+      host_os=freebsd
+      ;;
     Linux)
       host_os=linux
       ;;
     *)
-      kube::log::error "Unsupported host OS.  Must be Linux or Mac OS X."
+      kube::log::error "Unsupported host OS.  Must be Linux, Mac OS X or FreeBSD."
       exit 1
       ;;
   esac


### PR DESCRIPTION
Control plane components build and work on FreeBSD. This change just removes a confusing error message when building on FreeBSD.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This simply allows kubernetes components to build on a FreeBSD host OS without confusing error messages.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
