### PR TITLE
Automated cherry pick of #119753: kubeadm: fix nil pointer when etcd member is already removed

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -362,8 +362,11 @@ func (c *Client) RemoveMember(id uint64) ([]Member, error) {
 
 	// Returns the updated list of etcd members
 	ret := []Member{}
-	for _, m := range resp.Members {
-		ret = append(ret, Member{Name: m.Name, PeerURL: m.PeerURLs[0]})
+	if resp != nil {
+		for _, m := range resp.Members {
+			ret = append(ret, Member{Name: m.Name, PeerURL: m.PeerURLs[0]})
+		}
+
 	}
 
 	return ret, nil


### PR DESCRIPTION
Cherry pick of #119753 on release-1.27.

#119753: kubeadm: fix nil pointer when etcd member is already removed

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: fix nil pointer when etcd member is already removed
```