### PR TITLE
Automated cherry pick of #119341: Ignore context canceled from validate and mutate webhook

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -147,6 +147,10 @@ func (a *mutatingDispatcher) Dispatch(ctx context.Context, attr admission.Attrib
 		if err != nil {
 			switch err := err.(type) {
 			case *webhookutil.ErrCallingWebhook:
+				if ctx.Err() == context.Canceled {
+					klog.Warningf("Context Canceled when calling webhook %v", hook.Name)
+					return err
+				}
 				if !ignoreClientCallFailures {
 					rejected = true
 					admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "admit", string(versionedAttr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionCallingWebhookError, int(err.Status.ErrStatus.Code))
@@ -177,10 +181,6 @@ func (a *mutatingDispatcher) Dispatch(ctx context.Context, attr admission.Attrib
 		}
 
 		if callErr, ok := err.(*webhookutil.ErrCallingWebhook); ok {
-			if ctx.Err() == context.Canceled {
-				klog.Warningf("Context Canceled when calling webhook %v", hook.Name)
-				return err
-			}
 			if ignoreClientCallFailures {
 				klog.Warningf("Failed calling webhook, failing open %v: %v", hook.Name, callErr)
 				admissionmetrics.Metrics.ObserveWebhookFailOpen(ctx, hook.Name, "admit")

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -20,6 +20,7 @@ package mutating
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -147,13 +148,12 @@ func (a *mutatingDispatcher) Dispatch(ctx context.Context, attr admission.Attrib
 		if err != nil {
 			switch err := err.(type) {
 			case *webhookutil.ErrCallingWebhook:
-				if ctx.Err() == context.Canceled {
-					klog.Warningf("Context Canceled when calling webhook %v", hook.Name)
-					return err
-				}
 				if !ignoreClientCallFailures {
 					rejected = true
-					admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "admit", string(versionedAttr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionCallingWebhookError, int(err.Status.ErrStatus.Code))
+					// Ignore context cancelled from webhook metrics
+					if !errors.Is(err.Reason, context.Canceled) {
+						admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "admit", string(versionedAttr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionCallingWebhookError, int(err.Status.ErrStatus.Code))
+					}
 				}
 				admissionmetrics.Metrics.ObserveWebhook(ctx, hook.Name, time.Since(t), rejected, versionedAttr.Attributes, "admit", int(err.Status.ErrStatus.Code))
 			case *webhookutil.ErrWebhookRejection:
@@ -182,10 +182,14 @@ func (a *mutatingDispatcher) Dispatch(ctx context.Context, attr admission.Attrib
 
 		if callErr, ok := err.(*webhookutil.ErrCallingWebhook); ok {
 			if ignoreClientCallFailures {
-				klog.Warningf("Failed calling webhook, failing open %v: %v", hook.Name, callErr)
-				admissionmetrics.Metrics.ObserveWebhookFailOpen(ctx, hook.Name, "admit")
-				annotator.addFailedOpenAnnotation()
-
+				// Ignore context cancelled from webhook metrics
+				if errors.Is(callErr.Reason, context.Canceled) {
+					klog.Warningf("Context canceled when calling webhook %v", hook.Name)
+				} else {
+					klog.Warningf("Failed calling webhook, failing open %v: %v", hook.Name, callErr)
+					admissionmetrics.Metrics.ObserveWebhookFailOpen(ctx, hook.Name, "admit")
+					annotator.addFailedOpenAnnotation()
+				}
 				utilruntime.HandleError(callErr)
 
 				select {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -177,6 +177,10 @@ func (a *mutatingDispatcher) Dispatch(ctx context.Context, attr admission.Attrib
 		}
 
 		if callErr, ok := err.(*webhookutil.ErrCallingWebhook); ok {
+			if ctx.Err() == context.Canceled {
+				klog.Warningf("Context Canceled when calling webhook %v", hook.Name)
+				return err
+			}
 			if ignoreClientCallFailures {
 				klog.Warningf("Failed calling webhook, failing open %v: %v", hook.Name, callErr)
 				admissionmetrics.Metrics.ObserveWebhookFailOpen(ctx, hook.Name, "admit")

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -18,6 +18,7 @@ package validating
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -152,13 +153,12 @@ func (d *validatingDispatcher) Dispatch(ctx context.Context, attr admission.Attr
 			if err != nil {
 				switch err := err.(type) {
 				case *webhookutil.ErrCallingWebhook:
-					if ctx.Err() == context.Canceled {
-						klog.Warningf("Context Canceled when calling webhook %v", hook.Name)
-						return
-					}
 					if !ignoreClientCallFailures {
 						rejected = true
-						admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "validating", string(versionedAttr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionCallingWebhookError, int(err.Status.ErrStatus.Code))
+						// Ignore context cancelled from webhook metrics
+						if !errors.Is(err.Reason, context.Canceled) {
+							admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "validating", string(versionedAttr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionCallingWebhookError, int(err.Status.ErrStatus.Code))
+						}
 					}
 					admissionmetrics.Metrics.ObserveWebhook(ctx, hook.Name, time.Since(t), rejected, versionedAttr.Attributes, "validating", int(err.Status.ErrStatus.Code))
 				case *webhookutil.ErrWebhookRejection:
@@ -177,12 +177,17 @@ func (d *validatingDispatcher) Dispatch(ctx context.Context, attr admission.Attr
 
 			if callErr, ok := err.(*webhookutil.ErrCallingWebhook); ok {
 				if ignoreClientCallFailures {
-					klog.Warningf("Failed calling webhook, failing open %v: %v", hook.Name, callErr)
-					admissionmetrics.Metrics.ObserveWebhookFailOpen(ctx, hook.Name, "validating")
-					key := fmt.Sprintf("%sround_0_index_%d", ValidatingAuditAnnotationFailedOpenKeyPrefix, idx)
-					value := hook.Name
-					if err := versionedAttr.Attributes.AddAnnotation(key, value); err != nil {
-						klog.Warningf("Failed to set admission audit annotation %s to %s for validating webhook %s: %v", key, value, hook.Name, err)
+					// Ignore context cancelled from webhook metrics
+					if errors.Is(callErr.Reason, context.Canceled) {
+						klog.Warningf("Context canceled when calling webhook %v", hook.Name)
+					} else {
+						klog.Warningf("Failed calling webhook, failing open %v: %v", hook.Name, callErr)
+						admissionmetrics.Metrics.ObserveWebhookFailOpen(ctx, hook.Name, "validating")
+						key := fmt.Sprintf("%sround_0_index_%d", ValidatingAuditAnnotationFailedOpenKeyPrefix, idx)
+						value := hook.Name
+						if err := versionedAttr.Attributes.AddAnnotation(key, value); err != nil {
+							klog.Warningf("Failed to set admission audit annotation %s to %s for validating webhook %s: %v", key, value, hook.Name, err)
+						}
 					}
 					utilruntime.HandleError(callErr)
 					return

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -172,6 +172,10 @@ func (d *validatingDispatcher) Dispatch(ctx context.Context, attr admission.Attr
 			}
 
 			if callErr, ok := err.(*webhookutil.ErrCallingWebhook); ok {
+				if ctx.Err() == context.Canceled {
+					klog.Warningf("Context Canceled when calling webhook %v", hook.Name)
+					return
+				}
 				if ignoreClientCallFailures {
 					klog.Warningf("Failed calling webhook, failing open %v: %v", hook.Name, callErr)
 					admissionmetrics.Metrics.ObserveWebhookFailOpen(ctx, hook.Name, "validating")

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -152,6 +152,10 @@ func (d *validatingDispatcher) Dispatch(ctx context.Context, attr admission.Attr
 			if err != nil {
 				switch err := err.(type) {
 				case *webhookutil.ErrCallingWebhook:
+					if ctx.Err() == context.Canceled {
+						klog.Warningf("Context Canceled when calling webhook %v", hook.Name)
+						return
+					}
 					if !ignoreClientCallFailures {
 						rejected = true
 						admissionmetrics.Metrics.ObserveWebhookRejection(ctx, hook.Name, "validating", string(versionedAttr.Attributes.GetOperation()), admissionmetrics.WebhookRejectionCallingWebhookError, int(err.Status.ErrStatus.Code))
@@ -172,10 +176,6 @@ func (d *validatingDispatcher) Dispatch(ctx context.Context, attr admission.Attr
 			}
 
 			if callErr, ok := err.(*webhookutil.ErrCallingWebhook); ok {
-				if ctx.Err() == context.Canceled {
-					klog.Warningf("Context Canceled when calling webhook %v", hook.Name)
-					return
-				}
 				if ignoreClientCallFailures {
 					klog.Warningf("Failed calling webhook, failing open %v: %v", hook.Name, callErr)
 					admissionmetrics.Metrics.ObserveWebhookFailOpen(ctx, hook.Name, "validating")


### PR DESCRIPTION
Cherry pick of #119341 on release-1.26.

#119341: Ignore context canceled from validate and mutate webhook

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Ignore context canceled from validate and mutate webhook
```