### PR TITLE
Automated cherry pick of #120018: Store validating admission policies and bindings as

### DIFF
--- a/api/discovery/apis__admissionregistration.k8s.io__v1alpha1.json
+++ b/api/discovery/apis__admissionregistration.k8s.io__v1alpha1.json
@@ -11,7 +11,7 @@
       "name": "validatingadmissionpolicies",
       "namespaced": false,
       "singularName": "validatingadmissionpolicy",
-      "storageVersionHash": "Vd+hadMG3gs=",
+      "storageVersionHash": "P/h9c6yIbaY=",
       "verbs": [
         "create",
         "delete",
@@ -42,7 +42,7 @@
       "name": "validatingadmissionpolicybindings",
       "namespaced": false,
       "singularName": "validatingadmissionpolicybinding",
-      "storageVersionHash": "Yc3M4GKADk4=",
+      "storageVersionHash": "XYju31JKYek=",
       "verbs": [
         "create",
         "delete",

--- a/api/discovery/apis__admissionregistration.k8s.io__v1beta1.json
+++ b/api/discovery/apis__admissionregistration.k8s.io__v1beta1.json
@@ -11,7 +11,7 @@
       "name": "validatingadmissionpolicies",
       "namespaced": false,
       "singularName": "validatingadmissionpolicy",
-      "storageVersionHash": "Vd+hadMG3gs=",
+      "storageVersionHash": "P/h9c6yIbaY=",
       "verbs": [
         "create",
         "delete",
@@ -42,7 +42,7 @@
       "name": "validatingadmissionpolicybindings",
       "namespaced": false,
       "singularName": "validatingadmissionpolicybinding",
-      "storageVersionHash": "Yc3M4GKADk4=",
+      "storageVersionHash": "XYju31JKYek=",
       "verbs": [
         "create",
         "delete",

--- a/pkg/kubeapiserver/default_storage_factory_builder.go
+++ b/pkg/kubeapiserver/default_storage_factory_builder.go
@@ -69,8 +69,8 @@ func NewStorageFactoryConfig() *StorageFactoryConfig {
 		//
 		// TODO (https://github.com/kubernetes/kubernetes/issues/108451): remove the override in 1.25.
 		// apisstorage.Resource("csistoragecapacities").WithVersion("v1beta1"),
-		admissionregistration.Resource("validatingadmissionpolicies").WithVersion("v1alpha1"),
-		admissionregistration.Resource("validatingadmissionpolicybindings").WithVersion("v1alpha1"),
+		admissionregistration.Resource("validatingadmissionpolicies").WithVersion("v1beta1"),
+		admissionregistration.Resource("validatingadmissionpolicybindings").WithVersion("v1beta1"),
 		networking.Resource("clustercidrs").WithVersion("v1alpha1"),
 		networking.Resource("ipaddresses").WithVersion("v1alpha1"),
 		certificates.Resource("clustertrustbundles").WithVersion("v1alpha1"),

--- a/test/integration/etcd/data.go
+++ b/test/integration/etcd/data.go
@@ -354,12 +354,10 @@ func GetEtcdStorageDataForNamespace(namespace string) map[schema.GroupVersionRes
 		gvr("admissionregistration.k8s.io", "v1beta1", "validatingadmissionpolicies"): {
 			Stub:             `{"metadata":{"name":"vap1b1","creationTimestamp":null},"spec":{"paramKind":{"apiVersion":"test.example.com/v1","kind":"Example"},"matchConstraints":{"resourceRules": [{"resourceNames": ["fakeName"], "apiGroups":["apps"],"apiVersions":["v1"],"operations":["CREATE", "UPDATE"], "resources":["deployments"]}]},"validations":[{"expression":"object.spec.replicas <= params.maxReplicas","message":"Too many replicas"}]}}`,
 			ExpectedEtcdPath: "/registry/validatingadmissionpolicies/vap1b1",
-			ExpectedGVK:      gvkP("admissionregistration.k8s.io", "v1alpha1", "ValidatingAdmissionPolicy"),
 		},
 		gvr("admissionregistration.k8s.io", "v1beta1", "validatingadmissionpolicybindings"): {
 			Stub:             `{"metadata":{"name":"pb1b1","creationTimestamp":null},"spec":{"policyName":"replicalimit-policy.example.com","paramRef":{"name":"replica-limit-test.example.com","parameterNotFoundAction":"Deny"},"validationActions":["Deny"]}}`,
 			ExpectedEtcdPath: "/registry/validatingadmissionpolicybindings/pb1b1",
-			ExpectedGVK:      gvkP("admissionregistration.k8s.io", "v1alpha1", "ValidatingAdmissionPolicyBinding"),
 		},
 		// --
 
@@ -367,10 +365,12 @@ func GetEtcdStorageDataForNamespace(namespace string) map[schema.GroupVersionRes
 		gvr("admissionregistration.k8s.io", "v1alpha1", "validatingadmissionpolicies"): {
 			Stub:             `{"metadata":{"name":"vap1","creationTimestamp":null},"spec":{"paramKind":{"apiVersion":"test.example.com/v1","kind":"Example"},"matchConstraints":{"resourceRules": [{"resourceNames": ["fakeName"], "apiGroups":["apps"],"apiVersions":["v1"],"operations":["CREATE", "UPDATE"], "resources":["deployments"]}]},"validations":[{"expression":"object.spec.replicas <= params.maxReplicas","message":"Too many replicas"}]}}`,
 			ExpectedEtcdPath: "/registry/validatingadmissionpolicies/vap1",
+			ExpectedGVK:      gvkP("admissionregistration.k8s.io", "v1beta1", "ValidatingAdmissionPolicy"),
 		},
 		gvr("admissionregistration.k8s.io", "v1alpha1", "validatingadmissionpolicybindings"): {
 			Stub:             `{"metadata":{"name":"pb1","creationTimestamp":null},"spec":{"policyName":"replicalimit-policy.example.com","paramRef":{"name":"replica-limit-test.example.com"},"validationActions":["Deny"]}}`,
 			ExpectedEtcdPath: "/registry/validatingadmissionpolicybindings/pb1",
+			ExpectedGVK:      gvkP("admissionregistration.k8s.io", "v1beta1", "ValidatingAdmissionPolicyBinding"),
 		},
 		// --
 

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -169,28 +169,37 @@ func TestEtcdStoragePath(t *testing.T) {
 				fixtureFilenameGroup = "core"
 			}
 			// find all versions of this group/kind in all versions of the serialization fixture testdata
-			previousReleaseGroupKindFiles, err := filepath.Glob("../../../staging/src/k8s.io/api/testdata/*/" + fixtureFilenameGroup + ".*." + expectedGVK.Kind + ".yaml")
+			releaseGroupKindFiles, err := filepath.Glob("../../../staging/src/k8s.io/api/testdata/*/" + fixtureFilenameGroup + ".*." + expectedGVK.Kind + ".yaml")
 			if err != nil {
 				t.Error(err)
 			}
-			if len(previousReleaseGroupKindFiles) == 0 && !allowMissingTestdataFixtures[expectedGVK] {
+			if len(releaseGroupKindFiles) == 0 && !allowMissingTestdataFixtures[expectedGVK] {
 				// We should at least find the HEAD fixtures
 				t.Errorf("No testdata serialization files found for %#v, cannot determine if previous releases could read this group/kind. Add this group-version to k8s.io/api/roundtrip_test.go", expectedGVK)
 			}
-			// find non-alpha versions of this group/kind understood by previous releases
+
+			// find non-alpha versions of this group/kind understood by current and previous releases
+			currentNonAlphaVersions := sets.NewString()
 			previousNonAlphaVersions := sets.NewString()
-			for _, previousReleaseGroupKindFile := range previousReleaseGroupKindFiles {
-				if serverVersion := filepath.Base(filepath.Dir(previousReleaseGroupKindFile)); serverVersion == "HEAD" {
-					continue
-				}
+			for _, previousReleaseGroupKindFile := range releaseGroupKindFiles {
 				parts := strings.Split(filepath.Base(previousReleaseGroupKindFile), ".")
 				version := parts[len(parts)-3]
 				if !strings.Contains(version, "alpha") {
-					previousNonAlphaVersions.Insert(version)
+					if serverVersion := filepath.Base(filepath.Dir(previousReleaseGroupKindFile)); serverVersion == "HEAD" {
+						currentNonAlphaVersions.Insert(version)
+					} else {
+						previousNonAlphaVersions.Insert(version)
+					}
 				}
 			}
-			if len(previousNonAlphaVersions) > 0 && !previousNonAlphaVersions.Has(expectedGVK.Version) {
-				t.Errorf("Previous releases understand non-alpha versions %q, but do not understand the expected current storage version %q. "+
+			if len(currentNonAlphaVersions) > 0 && strings.Contains(expectedGVK.Version, "alpha") {
+				t.Errorf("Non-alpha versions %q exist, but the expected storage version is %q. Prefer beta or GA storage versions over alpha.",
+					currentNonAlphaVersions.List(),
+					expectedGVK.Version,
+				)
+			}
+			if !strings.Contains(expectedGVK.Version, "alpha") && len(previousNonAlphaVersions) > 0 && !previousNonAlphaVersions.Has(expectedGVK.Version) {
+				t.Errorf("Previous releases understand non-alpha versions %q, but do not understand the expected current non-alpha storage version %q. "+
 					"This means a current server will store data in etcd that is not understood by a previous version.",
 					previousNonAlphaVersions.List(),
 					expectedGVK.Version,


### PR DESCRIPTION
Cherry pick of #120018 on release-1.28.

#120018: Store validating admission policies and bindings as

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```