### PR TITLE
refactor: expose default kubectl config

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -92,14 +92,14 @@ type KubectlOptions struct {
 	genericiooptions.IOStreams
 }
 
-var defaultConfigFlags = genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag().WithDiscoveryBurst(300).WithDiscoveryQPS(50.0)
+var DefaultConfigFlags = genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag().WithDiscoveryBurst(300).WithDiscoveryQPS(50.0)
 
 // NewDefaultKubectlCommand creates the `kubectl` command with default arguments
 func NewDefaultKubectlCommand() *cobra.Command {
 	return NewDefaultKubectlCommandWithArgs(KubectlOptions{
 		PluginHandler: NewDefaultPluginHandler(plugin.ValidPluginFilenamePrefixes),
 		Arguments:     os.Args,
-		ConfigFlags:   defaultConfigFlags,
+		ConfigFlags:   DefaultConfigFlags,
 		IOStreams:     genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
 	})
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -364,7 +364,7 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 
 	kubeConfigFlags := o.ConfigFlags
 	if kubeConfigFlags == nil {
-		kubeConfigFlags = defaultConfigFlags
+		kubeConfigFlags = DefaultConfigFlags
 	}
 	kubeConfigFlags.AddFlags(flags)
 	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)


### PR DESCRIPTION
- so that it can be imported in other libraries

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind cleanup
/sig cli

#### What this PR does / why we need it:
**Context**
We increased the discovery burst and QPS for `kubectl` in https://github.com/kubernetes/kubernetes/pull/105520 (new burst: 300, new QPS is 50.0). This is to fix issues like https://github.com/kubernetes/kubectl/issues/1126

The new discovery burst and QPS is defined on line 95 and used on line 102. `NewDefaultKubectlCommand` [is used by `kubectl`](https://github.com/kubernetes/kubernetes/blob/a5d2d6fec3a1a9538255d796eaf58e0777940135/cmd/kubectl/kubectl.go#L29)
https://github.com/kubernetes/kubernetes/blob/2c56321398485e514313186cc880f026c32e5073/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go#L95-L105

**Problem**
Argo workflows [import `kubectl` as a package](https://github.com/argoproj/argo-workflows/blob/a0fd61941f22d0d38128830ecdabaf81b54f1c0c/go.mod#L74). 
https://github.com/argoproj/argo-workflows/blob/256ff72816b4314f59fe39f0a458644af0075ebe/workflow/executor/resource.go#L374-L376

But it doesn't use the same function as the `kubectl` binary (i.e.,  `NewDefaultKubectlCommand`). It instead uses `NewKubectlCommand` (so that some options can be tweaked). `NewKubectlCommand` function does not use the new discovery burst and QPS unless both the values are passed to the function as parameters. 

Argo workflows as of now does not pass the new discovery burst and QPS to the `NewKubectlCommand` [in its code](https://github.com/argoproj/argo-workflows/blob/256ff72816b4314f59fe39f0a458644af0075ebe/workflow/executor/resource.go#L374-L376). 

There is a PR out to fix this: https://github.com/argoproj/argo-workflows/pull/11603

The problem is every time there is an update in the default values, the hardcoded values in argo workflows would have to be updated as well. Having `defaultConfigFlags` exposed as a `DefaultConfigFlags` would help because users of `NewKubectlCommand` won't have to hardcode the default discovery burst and QPS in their code. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
