### PR TITLE
remove the legacy test dependency

### DIFF
--- a/test/e2e_node/seccompdefault_test.go
+++ b/test/e2e_node/seccompdefault_test.go
@@ -27,12 +27,18 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	admissionapi "k8s.io/pod-security-admission/api"
+
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
-	"k8s.io/kubernetes/test/e2e/node"
-	admissionapi "k8s.io/pod-security-admission/api"
 )
+
+// SeccompProcStatusField is the field of /proc/$PID/status referencing the seccomp filter type.
+const SeccompProcStatusField = "Seccomp:"
+
+// ProcSelfStatusPath is the path to /proc/self/status.
+const ProcSelfStatusPath = "/proc/self/status"
 
 // Serial because the test updates kubelet configuration.
 var _ = SIGDescribe("SeccompDefault [Serial] [Feature:SeccompDefault] [LinuxOnly]", func() {
@@ -54,7 +60,7 @@ var _ = SIGDescribe("SeccompDefault [Serial] [Feature:SeccompDefault] [LinuxOnly
 						{
 							Name:            name,
 							Image:           busyboxImage,
-							Command:         []string{"grep", node.SeccompProcStatusField, node.ProcSelfStatusPath},
+							Command:         []string{"grep", SeccompProcStatusField, ProcSelfStatusPath},
 							SecurityContext: securityContext,
 						},
 					},


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

This removes the import added in https://github.com/kubernetes/kubernetes/pull/119880 which added a bunch of apparently old failing tests. Example failing tests can be seen at https://testgrid.k8s.io/sig-node-release-blocking#node-kubelet-serial-containerd


dd44792cec916bdad65a87d76625a7aa3250cf05 - bad / 663 specs
aef70da2103fd0fbca079fb00dd69814c0255417 - good / 543 specs

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
