### PR TITLE
[1.25] Automated cherry pick of #119027: prep for go1.21: use -e in go list

### DIFF
--- a/hack/update-vendor.sh
+++ b/hack/update-vendor.sh
@@ -288,7 +288,7 @@ while IFS= read -r repo; do
       echo "=== computing imports for ${repo}"
       go list all
       echo "=== computing tools imports for ${repo}"
-      go list -tags=tools all
+      go list -e -tags=tools all
     } >> "${LOG_FILE}" 2>&1
 
     # capture module dependencies


### PR DESCRIPTION
Cherry pick of #119027 on release-1.25.

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
For some reason, in go1.21, go list does not allow importing main packages anymore, even if it is for the sake of tracking dependencies (which is a valid use case).

A suggestion to work around this is to use -e flag to permit processing of erroneous packages. However, this doesn't seem prudent.

#### Which issue(s) this PR fixes:
Ref https://github.com/kubernetes/kubernetes/pull/118996#issuecomment-1617386511
Ref: https://github.com/golang/go/issues/59186

#### Special notes for your reviewer:
I'm not sure if we should be doing `-e` since that allows processing of ALL erroneous packages.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig architecture