### PR TITLE
Allow disabling both listened-on ports in cloud-provider

### DIFF
--- a/staging/src/k8s.io/cloud-provider/options/options.go
+++ b/staging/src/k8s.io/cloud-provider/options/options.go
@@ -263,7 +263,7 @@ func (o *CloudControllerManagerOptions) Validate(allControllers []string, disabl
 	if o.WebhookServing != nil {
 		errors = append(errors, o.WebhookServing.Validate()...)
 
-		if o.WebhookServing.BindPort == o.SecureServing.BindPort {
+		if o.WebhookServing.BindPort == o.SecureServing.BindPort && o.WebhookServing.BindPort != 0 {
 			errors = append(errors, fmt.Errorf("--webhook-secure-port cannot be the same value as --secure-port"))
 		}
 	}

--- a/staging/src/k8s.io/cloud-provider/options/webhook.go
+++ b/staging/src/k8s.io/cloud-provider/options/webhook.go
@@ -122,7 +122,7 @@ func (o *WebhookServingOptions) AddFlags(fs *pflag.FlagSet) {
 		"associated interface(s) must be reachable by the rest of the cluster, and by CLI/web "+
 		fmt.Sprintf("clients. If set to an unspecified address (0.0.0.0 or ::), all interfaces will be used. If unset, defaults to %v.", o.BindAddress))
 
-	fs.IntVar(&o.BindPort, "webhook-secure-port", o.BindPort, fmt.Sprintf("Secure port to serve cloud provider webhooks. If unset, defaults to %d.", o.BindPort))
+	fs.IntVar(&o.BindPort, "webhook-secure-port", o.BindPort, "Secure port to serve cloud provider webhooks. If 0, don't serve webhooks at all.")
 
 	fs.StringVar(&o.ServerCert.CertDirectory, "webhook-cert-dir", o.ServerCert.CertDirectory, ""+
 		"The directory where the TLS certs are located. "+


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

Setting the port to `0` indicates that the port should not be registered. In that case, there is no conflict by setting both ports to disabled/`0`.

I have also updated the cli flag help description to inform users about disabling the port.

#### Which issue(s) this PR fixes:
Related to #120043

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
