### PR TITLE
Automated cherry pick of #119986: Pass Pinned field to kubecontainer.Image

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_image.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image.go
@@ -109,6 +109,7 @@ func (m *kubeGenericRuntimeManager) ListImages() ([]kubecontainer.Image, error) 
 			RepoTags:    img.RepoTags,
 			RepoDigests: img.RepoDigests,
 			Spec:        toKubeContainerImageSpec(img),
+			Pinned:      img.Pinned,
 		})
 	}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
@@ -77,6 +77,30 @@ func TestListImages(t *testing.T) {
 	assert.Equal(t, expected.List(), actual.List())
 }
 
+func TestListImagesPinnedField(t *testing.T) {
+	ctx := context.Background()
+	_, fakeImageService, fakeManager, err := createTestRuntimeManager()
+	assert.NoError(t, err)
+
+	imagesPinned := map[string]bool{
+		"1111": false,
+		"2222": true,
+		"3333": false,
+	}
+	imageList := []string{}
+	for image, pinned := range imagesPinned {
+		fakeImageService.SetFakeImagePinned(image, pinned)
+		imageList = append(imageList, image)
+	}
+	fakeImageService.SetFakeImages(imageList)
+
+	actualImages, err := fakeManager.ListImages(ctx)
+	assert.NoError(t, err)
+	for _, image := range actualImages {
+		assert.Equal(t, imagesPinned[image.ID], image.Pinned)
+	}
+}
+
 func TestListImagesWithError(t *testing.T) {
 	_, fakeImageService, fakeManager, err := createTestRuntimeManager()
 	assert.NoError(t, err)

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
@@ -33,6 +33,7 @@ type FakeImageService struct {
 	Called        []string
 	Errors        map[string][]error
 	Images        map[string]*runtimeapi.Image
+	Pinned        map[string]bool
 
 	pulledImages []*pulledImage
 
@@ -72,6 +73,17 @@ func (r *FakeImageService) SetFakeImageSize(size uint64) {
 	r.FakeImageSize = size
 }
 
+// SetFakeImagePinned sets the image Pinned field for one image.
+func (r *FakeImageService) SetFakeImagePinned(image string, pinned bool) {
+	r.Lock()
+	defer r.Unlock()
+
+	if r.Pinned == nil {
+		r.Pinned = make(map[string]bool)
+	}
+	r.Pinned[image] = pinned
+}
+
 // SetFakeFilesystemUsage sets the FilesystemUsage for FakeImageService.
 func (r *FakeImageService) SetFakeFilesystemUsage(usage []*runtimeapi.FilesystemUsage) {
 	r.Lock()
@@ -95,6 +107,7 @@ func (r *FakeImageService) makeFakeImage(image *runtimeapi.ImageSpec) *runtimeap
 		Size_:    r.FakeImageSize,
 		Spec:     image,
 		RepoTags: []string{image.Image},
+		Pinned:   r.Pinned[image.Image],
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #119986 on release-1.23.

#119986: Pass Pinned field to kubecontainer.Image

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```