### PR TITLE
mark the OOM killer as serial to reduce flakes

### DIFF
--- a/test/e2e_node/oomkiller_linux_test.go
+++ b/test/e2e_node/oomkiller_linux_test.go
@@ -37,7 +37,10 @@ type testCase struct {
 	oomTargetContainerName string
 }
 
-var _ = SIGDescribe("OOMKiller [LinuxOnly] [NodeConformance]", func() {
+// Marked as [Serial] since currently the runtime can miss the OOM event if the pod is killed too quickly. This seems
+// to occur more often when the node is highly loaded.
+
+var _ = SIGDescribe("OOMKiller [LinuxOnly] [NodeConformance] [Serial]", func() {
 	f := framework.NewDefaultFramework("oomkiller-test")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In testing I could only reproduce the flake by running stress-ng to load the CPU. Running it as serial should reduce and hopefully eliminate the flakiness.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119600

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
