### PR TITLE
add metrics about statefulset rolling update durations

### DIFF
--- a/pkg/controller/statefulset/metrics/metrics.go
+++ b/pkg/controller/statefulset/metrics/metrics.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package metrics
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const StatefulSetControllerSubsystem = "statefulset_controller"
+
+var StsRollingUpdateDuratationSeconds = metrics.NewHistogram(
+	&metrics.HistogramOpts{
+		Subsystem:      StatefulSetControllerSubsystem,
+		Name:           "statefulset_rolling_update_duration_seconds",
+		Help:           "Time between when a statefulset finishes rolling update, and when the corresponding statefulset started to do rolling update",
+		Buckets:        metrics.ExponentialBuckets(0.001, 2, 16), // 1ms ~ 32.768s
+		StabilityLevel: metrics.ALPHA,
+	},
+)
+
+var registerMetrics sync.Once
+
+// Register registers ReplicaSet controller metrics.
+func Register() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(StsRollingUpdateDuratationSeconds)
+	})
+}

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -42,6 +42,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/history"
+	"k8s.io/kubernetes/pkg/controller/statefulset/metrics"
 
 	"k8s.io/klog/v2"
 )
@@ -141,6 +142,8 @@ func NewStatefulSetController(
 	)
 	ssc.setLister = setInformer.Lister()
 	ssc.setListerSynced = setInformer.Informer().HasSynced
+
+	metrics.Register()
 
 	// TODO: Watch volumes
 	return ssc


### PR DESCRIPTION


#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #117928

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
statefulset_rolling_update_duration_seconds: record time between when a statefulset finishes rolling update, and when the corresponding statefulset started to do rolling update
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
