### PR TITLE
Wait for volumes to be unmounted between node shutdown Pod group terminators

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -876,6 +876,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	shutdownManager, shutdownAdmitHandler := nodeshutdown.NewManager(&nodeshutdown.Config{
 		Logger:                           logger,
 		ProbeManager:                     klet.probeManager,
+		VolumeManager:                    klet.volumeManager,
 		Recorder:                         kubeDeps.Recorder,
 		NodeRef:                          nodeRef,
 		GetPodsFunc:                      klet.GetActivePods,

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/eviction"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/prober"
+	"k8s.io/kubernetes/pkg/kubelet/volumemanager"
 	"k8s.io/utils/clock"
 )
 
@@ -40,6 +41,7 @@ type Manager interface {
 type Config struct {
 	Logger                           klog.Logger
 	ProbeManager                     prober.Manager
+	VolumeManager                    volumemanager.VolumeManager
 	Recorder                         record.EventRecorder
 	NodeRef                          *v1.ObjectReference
 	GetPodsFunc                      eviction.ActivePodsFunc

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
@@ -21,6 +21,7 @@ limitations under the License.
 package nodeshutdown
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -41,6 +42,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/nodeshutdown/systemd"
 	"k8s.io/kubernetes/pkg/kubelet/prober"
+	"k8s.io/kubernetes/pkg/kubelet/volumemanager"
 	"k8s.io/utils/clock"
 )
 
@@ -72,6 +74,8 @@ type managerImpl struct {
 	recorder     record.EventRecorder
 	nodeRef      *v1.ObjectReference
 	probeManager prober.Manager
+
+	volumeManager volumemanager.VolumeManager
 
 	shutdownGracePeriodByPodPriority []kubeletconfig.ShutdownGracePeriodByPodPriority
 
@@ -123,6 +127,7 @@ func NewManager(conf *Config) (Manager, lifecycle.PodAdmitHandler) {
 		logger:                           conf.Logger,
 		probeManager:                     conf.ProbeManager,
 		recorder:                         conf.Recorder,
+		volumeManager:                    conf.VolumeManager,
 		nodeRef:                          conf.NodeRef,
 		getPods:                          conf.GetPodsFunc,
 		killPodFunc:                      conf.KillPodFunc,
@@ -394,22 +399,47 @@ func (m *managerImpl) processShutdownEvent() error {
 				} else {
 					m.logger.V(1).Info("Shutdown manager finished killing pod", "pod", klog.KObj(pod))
 				}
+
 			}(pod, group)
 		}
 
+		var groupTerminationWaitDuration = time.Duration(group.ShutdownGracePeriodSeconds) * time.Second
 		var (
-			doneCh = make(chan struct{})
-			timer  = m.clock.NewTimer(time.Duration(group.ShutdownGracePeriodSeconds) * time.Second)
+			doneCh         = make(chan struct{})
+			timer          = m.clock.NewTimer(groupTerminationWaitDuration)
+			ctx, ctxCancel = context.WithDeadline(context.Background(), time.Now().Add(groupTerminationWaitDuration))
 		)
 		go func() {
 			defer close(doneCh)
+			defer ctxCancel()
 			wg.Wait()
+
+			// The signal to kill a Pod was sent successfully to all the pods,
+			// let's wait until all the volumes are unmounted from all the pods before
+			// continuing to the next group. This is done so that the CSI Driver (assuming
+			// that it's part of the highest group) has a chance to perform unmounts.
+			if err := m.volumeManager.WaitForAllPodsUnmount(ctx, group.Pods); err != nil {
+				var podNames []string
+				for _, pod := range group.Pods {
+					podNames = append(podNames, pod.Name)
+				}
+
+				// Waiting for volume teardown is done on a best basis effort,
+				// report an error and continue.
+				//
+				// Depending on the user provided kubelet configuration value
+				// either the `timer` will tick and we'll continue to shutdown the next group, or,
+				// WaitForAllPodsUnmount will timeout, therefore this goroutine
+				// will close doneCh and we'll continue to shutdown the next group.
+				m.logger.V(1).Error(err, "Failed while waiting for all the volumes belonging to Pods in this group to unmount", "pods", podNames)
+			}
 		}()
 
 		select {
 		case <-doneCh:
 			timer.Stop()
 		case <-timer.C():
+			ctxCancel()
 			m.logger.V(1).Info("Shutdown manager pod killing time out", "gracePeriod", group.ShutdownGracePeriodSeconds, "priority", group.Priority)
 		}
 	}

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -31,6 +32,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -105,6 +107,12 @@ type VolumeManager interface {
 	// An error is returned if all volumes are not unmounted within
 	// the duration defined in podAttachAndMountTimeout.
 	WaitForUnmount(ctx context.Context, pod *v1.Pod) error
+
+	// WaitForAllPodsUnmount is a version of WaitForUnmount that blocks and
+	// waits until all the volumes belonging to all the pods are unmounted.
+	// An error is returned if there's at least one Pod with volumes not unmounted
+	// within the duration defined in podAttachAndMountTimeout
+	WaitForAllPodsUnmount(ctx context.Context, pods []*v1.Pod) error
 
 	// GetMountedVolumesForPod returns a VolumeMap containing the volumes
 	// referenced by the specified pod that are successfully attached and
@@ -479,6 +487,23 @@ func (vm *volumeManager) WaitForUnmount(ctx context.Context, pod *v1.Pod) error 
 
 	klog.V(3).InfoS("All volumes are unmounted for pod", "pod", klog.KObj(pod))
 	return nil
+}
+
+func (vm *volumeManager) WaitForAllPodsUnmount(ctx context.Context, pods []*v1.Pod) error {
+	var errors []error
+	var wg sync.WaitGroup
+	wg.Add(len(pods))
+	for _, pod := range pods {
+		go func(pod *v1.Pod) {
+			defer wg.Done()
+			if err := vm.WaitForUnmount(ctx, pod); err != nil {
+				klog.V(5).ErrorS(err, "Failed to wait for Pod to unmount its volumes", "pod", klog.KObj(pod))
+				errors = append(errors, err)
+			}
+		}(pod)
+	}
+	wg.Wait()
+	return utilerrors.NewAggregate(errors)
 }
 
 func (vm *volumeManager) getVolumesNotInDSW(uniquePodName types.UniquePodName, expectedVolumes []string) []string {

--- a/pkg/kubelet/volumemanager/volume_manager_fake.go
+++ b/pkg/kubelet/volumemanager/volume_manager_fake.go
@@ -31,6 +31,8 @@ type FakeVolumeManager struct {
 	reportedInUse map[v1.UniqueVolumeName]bool
 }
 
+var _ VolumeManager = &FakeVolumeManager{}
+
 // NewFakeVolumeManager creates a new VolumeManager test instance
 func NewFakeVolumeManager(initialVolumes []v1.UniqueVolumeName) *FakeVolumeManager {
 	volumes := map[v1.UniqueVolumeName]bool{}
@@ -54,6 +56,11 @@ func (f *FakeVolumeManager) WaitForAttachAndMount(ctx context.Context, pod *v1.P
 
 // WaitForUnmount is not implemented
 func (f *FakeVolumeManager) WaitForUnmount(ctx context.Context, pod *v1.Pod) error {
+	return nil
+}
+
+// WaitForAllPodsUnmount is not implemented
+func (f *FakeVolumeManager) WaitForAllPodsUnmount(ctx context.Context, pods []*v1.Pod) error {
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

For more background read #115148.

nodeshutdown acknowledging the SIGTERM signal sent to the Pods is not enough because nodeshutdown will immediately try to terminate Pods in next groups and it might be possible that one of those Pods is the CSI Driver which is needed to safely terminate a Pod (so that the CSI Driver has a chance to perform volume teardown).

This PR adds the volumemanager as a dependency of the nodeshutdown controller in the kubelet, nodeshutdown will use volumanager querying its knowledge about the status of mounts for Pods in the current group, when all the Pods are safely unmounted then nodeshutdown will proceed terminating the next group.

Note that this approach relies on the component that perform the unmount (the CSI Driver) to have the highest priority so that it's terminated last, in practice this means adding the `pod.spec.priorityClassName: system-cluster-critical` to the CSI Driver Pods.

TODO: e2e test with the hostpath CSI Driver

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Node shutdown controller makes a best effort to wait for CSI Drivers to complete the volume teardown process between the different Pod priority groups defined the kubelet config.
```
