### PR TITLE
[e2e_cloud] stop using deprecated framework.ExpectNotEqual

### DIFF
--- a/test/e2e/cloud/gcp/addon_update.go
+++ b/test/e2e/cloud/gcp/addon_update.go
@@ -38,6 +38,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 // TODO: it would probably be slightly better to build up the objects
@@ -250,7 +251,7 @@ var _ = SIGDescribe("Addon update", func() {
 		e2eskipper.SkipUnlessProviderIs("gce")
 
 		//these tests are long, so I squeezed several cases in one scenario
-		framework.ExpectNotEqual(sshClient, nil)
+		gomega.Expect(sshClient).NotTo(gomega.BeNil())
 		dir = f.Namespace.Name // we use it only to give a unique string for each test execution
 
 		temporaryRemotePathPrefix := "addon-test-dir"

--- a/test/e2e/cloud/gcp/kubelet_security.go
+++ b/test/e2e/cloud/gcp/kubelet_security.go
@@ -19,6 +19,7 @@ package gcp
 import (
 	"context"
 	"fmt"
+	"github.com/onsi/gomega"
 	"net"
 	"net/http"
 	"time"
@@ -54,7 +55,7 @@ var _ = SIGDescribe("Ports Security Check [Feature:KubeletSecurity]", func() {
 
 		var statusCode int
 		result.StatusCode(&statusCode)
-		framework.ExpectNotEqual(statusCode, http.StatusOK)
+		gomega.Expect(statusCode).NotTo(gomega.Equal(http.StatusOK))
 	})
 	ginkgo.It("should not be able to proxy to cadvisor port 4194 using proxy subresource", func(ctx context.Context) {
 		result, err := e2ekubelet.ProxyRequest(ctx, f.ClientSet, nodeName, "containers/", 4194)
@@ -62,7 +63,7 @@ var _ = SIGDescribe("Ports Security Check [Feature:KubeletSecurity]", func() {
 
 		var statusCode int
 		result.StatusCode(&statusCode)
-		framework.ExpectNotEqual(statusCode, http.StatusOK)
+		gomega.Expect(statusCode).NotTo(gomega.Equal(http.StatusOK))
 	})
 
 	// make sure kubelet readonly (10255) and cadvisor (4194) ports are closed on the public IP address
@@ -78,7 +79,7 @@ var _ = SIGDescribe("Ports Security Check [Feature:KubeletSecurity]", func() {
 // checks whether the target port is closed
 func portClosedTest(f *framework.Framework, pickNode *v1.Node, port int) {
 	nodeAddrs := e2enode.GetAddresses(pickNode, v1.NodeExternalIP)
-	framework.ExpectNotEqual(len(nodeAddrs), 0)
+	gomega.Expect(nodeAddrs).NotTo(gomega.BeEmpty())
 
 	for _, addr := range nodeAddrs {
 		conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", addr, port), 1*time.Minute)

--- a/test/e2e/cloud/gcp/node_lease.go
+++ b/test/e2e/cloud/gcp/node_lease.go
@@ -149,7 +149,7 @@ var _ = SIGDescribe("[Disruptive]NodeLease", func() {
 				deletedNodeName = originalNodeName
 				break
 			}
-			framework.ExpectNotEqual(deletedNodeName, "")
+			gomega.Expect(deletedNodeName).NotTo(gomega.BeEmpty())
 			gomega.Eventually(ctx, func() error {
 				if _, err := leaseClient.Get(ctx, deletedNodeName, metav1.GetOptions{}); err == nil {
 					return fmt.Errorf("node lease is not deleted yet for node %q", deletedNodeName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
[e2e_cloud] stop using deprecated framework.ExpectNotEqual

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref https://github.com/kubernetes/kubernetes/pull/115961