### PR TITLE
Add wait for cache sync to OpenAPI controller test

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller_test.go
@@ -332,6 +332,7 @@ func setup(t *testing.T) (*testEnv, context.Context) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	factory.Start(ctx.Done())
+	factory.WaitForCacheSync(ctx.Done())
 
 	env.mux = http.NewServeMux()
 	h := handler.NewOpenAPIService(&spec.Swagger{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:

Fixes flake when testing the openapi controller.

```
jying@jefftree ~/w/k/s/s/k/a/p/c/openapi ❯❯❯ stress ./openapi.test -test.run TestTwoCRDsSameGroup                                                                                                 
5s: 48 runs so far, 0 failures
10s: 96 runs so far, 0 failures
15s: 144 runs so far, 0 failures
20s: 216 runs so far, 0 failures
25s: 264 runs so far, 0 failures
30s: 312 runs so far, 0 failures
35s: 375 runs so far, 0 failures
40s: 432 runs so far, 0 failures
45s: 480 runs so far, 0 failures
50s: 530 runs so far, 0 failures
55s: 600 runs so far, 0 failures
1m0s: 648 runs so far, 0 failures
1m5s: 696 runs so far, 0 failures
1m10s: 768 runs so far, 0 failures
1m15s: 816 runs so far, 0 failures
1m20s: 864 runs so far, 0 failures
1m25s: 925 runs so far, 0 failures
1m30s: 984 runs so far, 0 failures
1m35s: 1032 runs so far, 0 failures
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/119723

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @liggitt
/triage accepted
