### PR TITLE
Add namespace to NotFound error for kubectl logs command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -276,6 +277,9 @@ func (o *LogsOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []str
 		}
 		infos, err := builder.Do().Infos()
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				err = fmt.Errorf("error from server (NotFound): %w in namespace %q", err, o.Namespace)
+			}
 			return err
 		}
 		if o.Selector == "" && len(infos) != 1 {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes [#1459](https://github.com/kubernetes/kubectl/issues/1459)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Adds the namespace when using 'kubectl logs <pod-name>' and the pod is not found. Previously the message returned would be 'Error from server (NotFound): pods "my-pod-name" not found'. This has been updated to reflect the namespace in the message as follows: 'Error from server (NotFound): pods "my-pod-name" not found in namespace "default"'
```