### PR TITLE
fix(kubectl): kubectl events doesn't filter events by GroupVersion fo…

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/events/events.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/events/events.go
@@ -229,6 +229,7 @@ func (o *EventsOptions) Run() error {
 	if o.forName != "" {
 		listOptions.FieldSelector = fields.AndSelectors(
 			fields.OneTermEqualSelector("involvedObject.kind", o.forGVK.Kind),
+			fields.OneTermEqualSelector("involvedObject.apiVersion", o.forGVK.GroupVersion().String()),
 			fields.OneTermEqualSelector("involvedObject.name", o.forName)).String()
 	}
 	if o.Watch {

--- a/test/cmd/events.sh
+++ b/test/cmd/events.sh
@@ -56,8 +56,7 @@ run_kubectl_events_tests() {
     "names": {
       "plural": "cronjobs",
       "singular": "cronjob",
-      "kind": "Cronjob",
-      "shortNames": ["mycj"]
+      "kind": "Cronjob"
     },
     "versions": [
       {

--- a/test/cmd/events.sh
+++ b/test/cmd/events.sh
@@ -151,7 +151,7 @@ __EOF__
 
     #Clean up
     kubectl delete cronjob pi --namespace=test-events
-    kubectl delete mycj pi --namespace=test-events
+    kubectl delete cronjobs.v1.example.com pi --namespace=test-events
     kubectl delete crd cronjobs.example.com
     kubectl delete namespace test-events
 

--- a/test/cmd/events.sh
+++ b/test/cmd/events.sh
@@ -42,6 +42,62 @@ run_kubectl_events_tests() {
     kube::test::get_object_assert 'cronjob --namespace=test-events' "{{range.items}}{{ if eq $id_field \"pi\" }}found{{end}}{{end}}:" ':'
     ### Create a cronjob in a specific namespace
     kubectl create cronjob pi --schedule="59 23 31 2 *" --namespace=test-events "--image=$IMAGE_PERL" -- perl -Mbignum=bpi -wle 'print bpi(20)' "${kube_flags[@]:?}"
+    ### Create a crd
+    kubectl create -f - << __EOF__
+{
+  "kind": "CustomResourceDefinition",
+  "apiVersion": "apiextensions.k8s.io/v1",
+  "metadata": {
+    "name": "cronjobs.example.com"
+  },
+  "spec": {
+    "group": "example.com",
+    "scope": "Namespaced",
+    "names": {
+      "plural": "cronjobs",
+      "singular": "cronjob",
+      "kind": "Cronjob",
+      "shortNames": ["mycj"]
+    },
+    "versions": [
+      {
+        "name": "v1",
+        "served": true,
+        "storage": true,
+        "schema": {
+          "openAPIV3Schema": {
+            "type": "object",
+            "properties": {
+              "spec": {
+                "type": "object",
+                "properties": {
+                  "image": {"type": "string"}
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+__EOF__
+
+    ### Create a example.com/v1 Cronjob in a specific namespace
+    kubectl create -f - << __EOF__
+{
+  "kind": "Cronjob",
+  "apiVersion": "example.com/v1",
+  "metadata": {
+    "name": "pi",
+    "namespace": "test-events"
+  },
+  "spec": {
+    "image": "test"
+  }
+}
+__EOF__
+
     # Post-Condition: assertion object exists
     kube::test::get_object_assert 'cronjob/pi --namespace=test-events' "{{$id_field}}" 'pi'
 
@@ -60,6 +116,10 @@ run_kubectl_events_tests() {
     # Post-Condition: events returns event for fully qualified Cronjob.v1.batch/pi when --for flag is used
     output_message=$(kubectl events -n test-events --for Cronjob.v1.batch/pi "${kube_flags[@]:?}" 2>&1)
     kube::test::if_has_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
+
+    # Post-Condition: events not returns event for fully qualified Cronjob.v1.example.com/pi when --for flag is used
+    output_message=$(kubectl events -n test-events --for Cronjob.v1.example.com/pi "${kube_flags[@]:?}" 2>&1)
+    kube::test::if_has_not_string "${output_message}" "Warning" "InvalidSchedule" "Cronjob/pi"
 
     # Post-Condition: events returns event for fully qualified without version Cronjob.batch/pi when --for flag is used
     output_message=$(kubectl events -n test-events --for=Cronjob.batch/pi "${kube_flags[@]:?}" 2>&1)
@@ -92,6 +152,8 @@ run_kubectl_events_tests() {
 
     #Clean up
     kubectl delete cronjob pi --namespace=test-events
+    kubectl delete mycj pi --namespace=test-events
+    kubectl delete crd cronjobs.example.com
     kubectl delete namespace test-events
 
     set +o nounset


### PR DESCRIPTION
…r resource with full name

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
Fix kubectl events doesn't filter events by group and version for resource with full name

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #   https://github.com/kubernetes/kubectl/issues/1470

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix kubectl events doesn't filter events by GroupVersion for resource with full name.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
