### PR TITLE
[node-e2e]: Support checking if a feature gate is enabled during functional tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate.go
@@ -25,6 +25,9 @@ var (
 	// Only top-level commands/options setup and the k8s.io/component-base/featuregate/testing package should make use of this.
 	// Tests that need to modify feature gates for the duration of their test should use:
 	//   defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.<FeatureName>, <value>)()
+	//
+	// When used in tests, it must be used for feature gates that are enabled at test start time.
+	// It will not work if the feature gate is being enabled during the test.
 	DefaultMutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
 
 	// DefaultFeatureGate is a shared global FeatureGate.

--- a/test/e2e/framework/skipper/skipper.go
+++ b/test/e2e/framework/skipper/skipper.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/component-base/featuregate"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
@@ -53,50 +52,6 @@ func Skipf(format string, args ...interface{}) {
 func SkipUnlessAtLeast(value int, minValue int, message string) {
 	if value < minValue {
 		skipInternalf(1, message)
-	}
-}
-
-var featureGate featuregate.FeatureGate
-
-// InitFeatureGates must be called in test suites that have a --feature-gates parameter.
-// If not called, SkipUnlessFeatureGateEnabled and SkipIfFeatureGateEnabled will
-// record a test failure.
-func InitFeatureGates(defaults featuregate.FeatureGate, overrides map[string]bool) error {
-	clone := defaults.DeepCopy()
-	if err := clone.SetFromMap(overrides); err != nil {
-		return err
-	}
-	featureGate = clone
-	return nil
-}
-
-// SkipUnlessFeatureGateEnabled skips if the feature is disabled.
-//
-// Beware that this only works in test suites that have a --feature-gate
-// parameter and call InitFeatureGates. In test/e2e, the `Feature: XYZ` tag
-// has to be used instead and invocations have to make sure that they
-// only run tests that work with the given test cluster.
-func SkipUnlessFeatureGateEnabled(gate featuregate.Feature) {
-	if featureGate == nil {
-		framework.Failf("Feature gate checking is not enabled, don't use SkipUnlessFeatureGateEnabled(%v). Instead use the Feature tag.", gate)
-	}
-	if !featureGate.Enabled(gate) {
-		skipInternalf(1, "Only supported when %v feature is enabled", gate)
-	}
-}
-
-// SkipIfFeatureGateEnabled skips if the feature is enabled.
-//
-// Beware that this only works in test suites that have a --feature-gate
-// parameter and call InitFeatureGates. In test/e2e, the `Feature: XYZ` tag
-// has to be used instead and invocations have to make sure that they
-// only run tests that work with the given test cluster.
-func SkipIfFeatureGateEnabled(gate featuregate.Feature) {
-	if featureGate == nil {
-		framework.Failf("Feature gate checking is not enabled, don't use SkipFeatureGateEnabled(%v). Instead use the Feature tag.", gate)
-	}
-	if featureGate.Enabled(gate) {
-		skipInternalf(1, "Only supported when %v feature is disabled", gate)
 	}
 }
 

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -135,6 +135,10 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	framework.AfterReadingAllFlags(&framework.TestContext)
+	if err := initFeatureGates(utilfeature.DefaultFeatureGate, featureGates); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: initialize feature gates: %v", err)
+		os.Exit(1)
+	}
 	if err := e2eskipper.InitFeatureGates(utilfeature.DefaultFeatureGate, featureGates); err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: initialize feature gates: %v", err)
 		os.Exit(1)

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -46,7 +46,6 @@ import (
 	commontest "k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2econfig "k8s.io/kubernetes/test/e2e/framework/config"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2etestfiles "k8s.io/kubernetes/test/e2e/framework/testfiles"
 	e2etestingmanifests "k8s.io/kubernetes/test/e2e/testing-manifests"
 	"k8s.io/kubernetes/test/e2e_node/services"
@@ -136,10 +135,6 @@ func TestMain(m *testing.M) {
 	}
 	framework.AfterReadingAllFlags(&framework.TestContext)
 	if err := initFeatureGates(utilfeature.DefaultFeatureGate, featureGates); err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: initialize feature gates: %v", err)
-		os.Exit(1)
-	}
-	if err := e2eskipper.InitFeatureGates(utilfeature.DefaultFeatureGate, featureGates); err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: initialize feature gates: %v", err)
 		os.Exit(1)
 	}

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -134,7 +134,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	framework.AfterReadingAllFlags(&framework.TestContext)
-	if err := initFeatureGates(utilfeature.DefaultFeatureGate, featureGates); err != nil {
+	if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(featureGates); err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: initialize feature gates: %v", err)
 		os.Exit(1)
 	}

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -27,7 +27,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -133,12 +133,9 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	framework.AfterReadingAllFlags(&framework.TestContext)
-	initFeatureGates(featureGates)
 
-	if err := services.SetFeatureGatesForInProcessComponents(serviceFeatureGates); err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: initialize process feature gates for API service: %v", err)
-		os.Exit(1)
-	}
+	initFeatureGates(utilfeature.DefaultMutableFeatureGate, featureGates)
+	initFeatureGates(defaultMutableServiceGate, serviceFeatureGates)
 
 	setExtraEnvs()
 	os.Exit(m.Run())

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -38,7 +38,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
@@ -134,10 +133,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	framework.AfterReadingAllFlags(&framework.TestContext)
-	if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(featureGates); err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: initialize feature gates: %v", err)
-		os.Exit(1)
-	}
+	initFeatureGates(featureGates)
 
 	if err := services.SetFeatureGatesForInProcessComponents(serviceFeatureGates); err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: initialize process feature gates for API service: %v", err)

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -134,8 +133,7 @@ func TestMain(m *testing.M) {
 	}
 	framework.AfterReadingAllFlags(&framework.TestContext)
 
-	initFeatureGates(utilfeature.DefaultMutableFeatureGate, featureGates)
-	initFeatureGates(defaultMutableServiceGate, serviceFeatureGates)
+	initFeatureGates(featureGates, serviceFeatureGates)
 
 	setExtraEnvs()
 	os.Exit(m.Run())

--- a/test/e2e_node/services/internal_services.go
+++ b/test/e2e_node/services/internal_services.go
@@ -23,7 +23,6 @@ import (
 
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/test/e2e/framework"
 
@@ -139,8 +138,4 @@ func getServicesHealthCheckURLs() []string {
 	return []string{
 		getAPIServerHealthCheckURL(),
 	}
-}
-
-func SetFeatureGatesForInProcessComponents(featureGates map[string]bool) error {
-	return utilfeature.DefaultMutableFeatureGate.SetFromMap(featureGates)
 }

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -91,21 +91,8 @@ var (
 	kubeletHealthCheckURL    = fmt.Sprintf("http://127.0.0.1:%d/healthz", ports.KubeletHealthzPort)
 	containerRuntimeUnitName = ""
 	// KubeletConfig is the kubelet configuration the test is running against.
-	kubeletCfg  *kubeletconfig.KubeletConfiguration
-	featureGate featuregate.FeatureGate
+	kubeletCfg *kubeletconfig.KubeletConfiguration
 )
-
-// InitFeatureGates must be called in test suites that have a --feature-gates parameter.
-// If not called, SkipUnlessFeatureGateEnabled and SkipIfFeatureGateEnabled will
-// record a test failure.
-func initFeatureGates(defaults featuregate.FeatureGate, overrides map[string]bool) error {
-	clone := defaults.DeepCopy()
-	if err := clone.SetFromMap(overrides); err != nil {
-		return err
-	}
-	featureGate = clone
-	return nil
-}
 
 func getNodeSummary(ctx context.Context) (*stats.Summary, error) {
 	kubeletConfig, err := getCurrentKubeletConfig(ctx)

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -94,6 +94,15 @@ var (
 	kubeletCfg *kubeletconfig.KubeletConfiguration
 )
 
+func initFeatureGates(featureGates map[string]bool) {
+	err := utilfeature.DefaultMutableFeatureGate.SetFromMap(featureGates)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: initialize feature gates: %v", err)
+		os.Exit(1)
+	}
+}
+
 func getNodeSummary(ctx context.Context) (*stats.Summary, error) {
 	kubeletConfig, err := getCurrentKubeletConfig(ctx)
 	if err != nil {

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -97,13 +97,18 @@ var (
 	kubeletCfg *kubeletconfig.KubeletConfiguration
 )
 
-func initFeatureGates(featureGateObj featuregate.MutableFeatureGate, featureGatesToSet map[string]bool) {
+func initFeatureGate(featureGateObj featuregate.MutableFeatureGate, featureGatesToSet map[string]bool) {
 	err := featureGateObj.SetFromMap(featureGatesToSet)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: initialize feature gates: %v", err)
 		os.Exit(1)
 	}
+}
+
+func initFeatureGates(featureGates, serviceFeatureGates map[string]bool) {
+	initFeatureGate(utilfeature.DefaultMutableFeatureGate, featureGates)
+	initFeatureGate(defaultMutableServiceGate, serviceFeatureGates)
 }
 
 func getNodeSummary(ctx context.Context) (*stats.Summary, error) {

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -75,6 +75,9 @@ var startServices = flag.Bool("start-services", true, "If true, start local node
 var stopServices = flag.Bool("stop-services", true, "If true, stop local node services after running tests")
 var busyboxImage = imageutils.GetE2EImage(imageutils.BusyBox)
 
+// defaultMutableServiceGate is similar to DefaultMutableFeatureGate, but is intended for API server feature gates.
+var defaultMutableServiceGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+
 const (
 	// Kubelet internal cgroup name for node allocatable cgroup.
 	defaultNodeAllocatableCgroup = "kubepods"
@@ -94,8 +97,8 @@ var (
 	kubeletCfg *kubeletconfig.KubeletConfiguration
 )
 
-func initFeatureGates(featureGates map[string]bool) {
-	err := utilfeature.DefaultMutableFeatureGate.SetFromMap(featureGates)
+func initFeatureGates(featureGateObj featuregate.MutableFeatureGate, featureGatesToSet map[string]bool) {
+	err := featureGateObj.SetFromMap(featureGatesToSet)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: initialize feature gates: %v", err)

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -91,8 +91,21 @@ var (
 	kubeletHealthCheckURL    = fmt.Sprintf("http://127.0.0.1:%d/healthz", ports.KubeletHealthzPort)
 	containerRuntimeUnitName = ""
 	// KubeletConfig is the kubelet configuration the test is running against.
-	kubeletCfg *kubeletconfig.KubeletConfiguration
+	kubeletCfg  *kubeletconfig.KubeletConfiguration
+	featureGate featuregate.FeatureGate
 )
+
+// InitFeatureGates must be called in test suites that have a --feature-gates parameter.
+// If not called, SkipUnlessFeatureGateEnabled and SkipIfFeatureGateEnabled will
+// record a test failure.
+func initFeatureGates(defaults featuregate.FeatureGate, overrides map[string]bool) error {
+	clone := defaults.DeepCopy()
+	if err := clone.SetFromMap(overrides); err != nil {
+		return err
+	}
+	featureGate = clone
+	return nil
+}
 
 func getNodeSummary(ctx context.Context) (*stats.Summary, error) {
 	kubeletConfig, err := getCurrentKubeletConfig(ctx)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Today it isn't possible to check whether a feature gate is enabled or not during node e2e testing. Such a capability is important in certain cases, for example for [swap tests](https://github.com/kubernetes/kubernetes/blob/v1.29.0-alpha.0/test/e2e_node/swap_test.go#L145) [1]. However, the current way to check if this feature gate is enabled does not work and always returns false.

This PR introduces an `isFeatureGateEnabled()` function to determine if a feature gate is enabled or not in a reliable manner. For more info read below.

[1] https://github.com/kubernetes/kubernetes/blob/v1.29.0-alpha.0/test/e2e_node/swap_test.go#L145

#### Special notes for your reviewer:
Turns out that the `skipper` package introduced this very logic [here](https://github.com/kubernetes/kubernetes/blob/v1.29.0-alpha.0/test/e2e/framework/skipper/skipper.go#L61) [1], explaining that it `must be called in test suites that have a --feature-gates parameter`. However, the `featureGate` object, although [initialized](https://github.com/kubernetes/kubernetes/blob/v1.29.0-alpha.0/test/e2e_node/e2e_node_suite_test.go#L138) [2], is never actually used.

What I did in this PR is introduce this object in the `e2enode` package, initialized it, and created an `isFeatureGateEnabled()` function that uses it. Then, I've cleaned up the unused code from the skipper package.

[1] https://github.com/kubernetes/kubernetes/blob/v1.29.0-alpha.0/test/e2e/framework/skipper/skipper.go#L61
[2] https://github.com/kubernetes/kubernetes/blob/v1.29.0-alpha.0/test/e2e_node/e2e_node_suite_test.go#L138

#### Does this PR introduce a user-facing change?
```release-note
NONE
```