### PR TITLE
Automated cherry pick of #120109: Add wait for cache sync

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller_test.go
@@ -332,6 +332,7 @@ func setup(t *testing.T) (*testEnv, context.Context) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	factory.Start(ctx.Done())
+	factory.WaitForCacheSync(ctx.Done())
 
 	env.mux = http.NewServeMux()
 	h := handler.NewOpenAPIService(&spec.Swagger{})


### PR DESCRIPTION
Cherry pick of #120109 on release-1.28.

#120109: Add wait for cache sync

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```