### PR TITLE
[StructuredAuthorizationConfiguration] Add --authorization-config flag and guard it using a Feature Gate

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -327,6 +327,13 @@ func TestAddFlags(t *testing.T) {
 	expected.Authentication.OIDC.UsernameClaim = "sub"
 	expected.Authentication.OIDC.SigningAlgs = []string{"RS256"}
 
+	if !s.Authorization.AreLegacyFlagsSet() {
+		t.Errorf("expected legacy authorization flags to be set")
+	}
+
+	// setting the method to nil since methods can't be compared with reflect.DeepEqual
+	s.Authorization.AreLegacyFlagsSet = nil
+
 	if !reflect.DeepEqual(expected, s) {
 		t.Errorf("Got different run options than expected.\nDifference detected on:\n%s", cmp.Diff(expected, s, cmpopts.IgnoreUnexported(admission.Plugins{}, kubeoptions.OIDCAuthenticationOptions{})))
 	}

--- a/pkg/controlplane/apiserver/options/options_test.go
+++ b/pkg/controlplane/apiserver/options/options_test.go
@@ -283,6 +283,12 @@ func TestAddFlags(t *testing.T) {
 	expected.Authentication.OIDC.UsernameClaim = "sub"
 	expected.Authentication.OIDC.SigningAlgs = []string{"RS256"}
 
+	if !s.Authorization.AreLegacyFlagsSet() {
+		t.Errorf("expected legacy authorization flags to be set")
+	}
+	// setting the method to nil since methods can't be compared with reflect.DeepEqual
+	s.Authorization.AreLegacyFlagsSet = nil
+
 	if !reflect.DeepEqual(expected, s) {
 		t.Errorf("Got different run options than expected.\nDifference detected on:\n%s", cmp.Diff(expected, s, cmpopts.IgnoreUnexported(admission.Plugins{}, kubeoptions.OIDCAuthenticationOptions{})))
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1145,6 +1145,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.ServerSideFieldValidation: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
 
+	genericfeatures.StructuredAuthorizationConfiguration: {Default: false, PreRelease: featuregate.Alpha},
+
 	genericfeatures.UnauthenticatedHTTP2DOSMitigation: {Default: true, PreRelease: featuregate.Beta},
 
 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed

--- a/pkg/kubeapiserver/options/authorization_test.go
+++ b/pkg/kubeapiserver/options/authorization_test.go
@@ -173,6 +173,13 @@ func TestBuiltInAuthorizationOptionsAddFlags(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if !opts.AreLegacyFlagsSet() {
+		t.Fatal("legacy flags should have been configured")
+	}
+
+	// setting the method to nil since methods can't be compared with reflect.DeepEqual
+	opts.AreLegacyFlagsSet = nil
+
 	if !reflect.DeepEqual(opts, expected) {
 		t.Error(cmp.Diff(opts, expected))
 	}

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/load/load.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/load/load.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package load
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	api "k8s.io/apiserver/pkg/apis/apiserver"
+	"k8s.io/apiserver/pkg/apis/apiserver/install"
+	externalapi "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
+)
+
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme, serializer.EnableStrict)
+)
+
+func init() {
+	install.Install(scheme)
+}
+
+func LoadFromFile(file string) (*api.AuthorizationConfiguration, error) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	return LoadFromData(data)
+}
+
+func LoadFromReader(reader io.Reader) (*api.AuthorizationConfiguration, error) {
+	if reader == nil {
+		// no reader specified, use default config
+		return LoadFromData(nil)
+	}
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	return LoadFromData(data)
+}
+
+func LoadFromData(data []byte) (*api.AuthorizationConfiguration, error) {
+	if len(data) == 0 {
+		// no config provided, return default
+		externalConfig := &externalapi.AuthorizationConfiguration{}
+		scheme.Default(externalConfig)
+		internalConfig := &api.AuthorizationConfiguration{}
+		if err := scheme.Convert(externalConfig, internalConfig, nil); err != nil {
+			return nil, err
+		}
+		return internalConfig, nil
+	}
+
+	decodedObj, err := runtime.Decode(codecs.UniversalDecoder(), data)
+	if err != nil {
+		return nil, err
+	}
+	configuration, ok := decodedObj.(*api.AuthorizationConfiguration)
+	if !ok {
+		return nil, fmt.Errorf("expected AuthorizationConfiguration, got %T", decodedObj)
+	}
+	return configuration, nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/load/load_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/load/load_test.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package load
+
+import (
+	"bytes"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api "k8s.io/apiserver/pkg/apis/apiserver"
+)
+
+var defaultConfig = &api.AuthorizationConfiguration{}
+
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+	file, err := os.CreateTemp("", "config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Remove(file.Name()); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if err := os.WriteFile(file.Name(), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return file.Name()
+}
+
+func TestLoadFromFile(t *testing.T) {
+	// no file
+	{
+		_, err := LoadFromFile("")
+		if err == nil {
+			t.Fatalf("expected err: %v", err)
+		}
+	}
+
+	// empty file
+	{
+		config, err := LoadFromFile(writeTempFile(t, ``))
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if !reflect.DeepEqual(config, defaultConfig) {
+			t.Fatalf("unexpected config:\n%s", cmp.Diff(defaultConfig, config))
+		}
+	}
+
+	// valid file
+	{
+		input := `{
+			"apiVersion":"apiserver.config.k8s.io/v1alpha1",
+			"kind":"AuthorizationConfiguration",
+			"authorizers":[{"type":"Webhook"}]}`
+		expect := &api.AuthorizationConfiguration{
+			Authorizers: []api.AuthorizerConfiguration{{Type: "Webhook"}},
+		}
+
+		config, err := LoadFromFile(writeTempFile(t, input))
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if !reflect.DeepEqual(config, expect) {
+			t.Fatalf("unexpected config:\n%s", cmp.Diff(expect, config))
+		}
+	}
+
+	// missing file
+	{
+		_, err := LoadFromFile(`bogus-missing-file`)
+		if err == nil {
+			t.Fatalf("expected err, got none")
+		}
+		if !strings.Contains(err.Error(), "bogus-missing-file") {
+			t.Fatalf("expected missing file error, got %v", err)
+		}
+	}
+
+	// invalid content file
+	{
+		input := `{
+			"apiVersion":"apiserver.config.k8s.io/v99",
+			"kind":"AuthorizationConfiguration",
+			"authorizers":{"type":"Webhook"}}`
+
+		_, err := LoadFromFile(writeTempFile(t, input))
+		if err == nil {
+			t.Fatalf("expected err, got none")
+		}
+		if !strings.Contains(err.Error(), "apiserver.config.k8s.io/v99") {
+			t.Fatalf("expected apiVersion error, got %v", err)
+		}
+	}
+}
+
+func TestLoadFromReader(t *testing.T) {
+	// no reader
+	{
+		config, err := LoadFromReader(nil)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if !reflect.DeepEqual(config, defaultConfig) {
+			t.Fatalf("unexpected config:\n%s", cmp.Diff(defaultConfig, config))
+		}
+	}
+
+	// empty reader
+	{
+		config, err := LoadFromReader(&bytes.Buffer{})
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if !reflect.DeepEqual(config, defaultConfig) {
+			t.Fatalf("unexpected config:\n%s", cmp.Diff(defaultConfig, config))
+		}
+	}
+
+	// valid reader
+	{
+		input := `{
+			"apiVersion":"apiserver.config.k8s.io/v1alpha1",
+			"kind":"AuthorizationConfiguration",
+			"authorizers":[{"type":"Webhook"}]}`
+		expect := &api.AuthorizationConfiguration{
+			Authorizers: []api.AuthorizerConfiguration{{Type: "Webhook"}},
+		}
+
+		config, err := LoadFromReader(bytes.NewBufferString(input))
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if !reflect.DeepEqual(config, expect) {
+			t.Fatalf("unexpected config:\n%s", cmp.Diff(expect, config))
+		}
+	}
+
+	// invalid reader
+	{
+		input := `{
+			"apiVersion":"apiserver.config.k8s.io/v99",
+			"kind":"AuthorizationConfiguration",
+			"authorizers":[{"type":"Webhook"}]}`
+
+		_, err := LoadFromReader(bytes.NewBufferString(input))
+		if err == nil {
+			t.Fatalf("expected err, got none")
+		}
+		if !strings.Contains(err.Error(), "apiserver.config.k8s.io/v99") {
+			t.Fatalf("expected apiVersion error, got %v", err)
+		}
+	}
+}
+
+func TestLoadFromData(t *testing.T) {
+	testcases := []struct {
+		name         string
+		data         []byte
+		expectErr    string
+		expectConfig *api.AuthorizationConfiguration
+	}{
+		{
+			name:         "nil",
+			data:         nil,
+			expectConfig: defaultConfig,
+		},
+		{
+			name:         "nil",
+			data:         []byte{},
+			expectConfig: defaultConfig,
+		},
+		{
+			name: "v1alpha1 - json",
+			data: []byte(`{
+"apiVersion":"apiserver.config.k8s.io/v1alpha1",
+"kind":"AuthorizationConfiguration",
+"authorizers":[{"type":"Webhook"}]}`),
+			expectConfig: &api.AuthorizationConfiguration{
+				Authorizers: []api.AuthorizerConfiguration{{Type: "Webhook"}},
+			},
+		},
+		{
+			name: "v1alpha1 - defaults",
+			data: []byte(`{
+"apiVersion":"apiserver.config.k8s.io/v1alpha1",
+"kind":"AuthorizationConfiguration",
+"authorizers":[{"type":"Webhook","name":"default","webhook":{}}]}`),
+			expectConfig: &api.AuthorizationConfiguration{
+				Authorizers: []api.AuthorizerConfiguration{{
+					Type: "Webhook",
+					Name: "default",
+					Webhook: &api.WebhookConfiguration{
+						AuthorizedTTL:   metav1.Duration{Duration: 5 * time.Minute},
+						UnauthorizedTTL: metav1.Duration{Duration: 30 * time.Second},
+					},
+				}},
+			},
+		},
+		{
+			name: "v1alpha1 - yaml",
+			data: []byte(`
+apiVersion: apiserver.config.k8s.io/v1alpha1
+kind: AuthorizationConfiguration
+authorizers:
+- type: Webhook
+`),
+			expectConfig: &api.AuthorizationConfiguration{
+				Authorizers: []api.AuthorizerConfiguration{{Type: "Webhook"}},
+			},
+		},
+		{
+			name:      "missing apiVersion",
+			data:      []byte(`{"kind":"AuthorizationConfiguration"}`),
+			expectErr: `'apiVersion' is missing`,
+		},
+		{
+			name:      "missing kind",
+			data:      []byte(`{"apiVersion":"apiserver.config.k8s.io/v1alpha1"}`),
+			expectErr: `'Kind' is missing`,
+		},
+		{
+			name:      "unknown group",
+			data:      []byte(`{"apiVersion":"apps/v1alpha1","kind":"AuthorizationConfiguration"}`),
+			expectErr: `apps/v1alpha1`,
+		},
+		{
+			name:      "unknown version",
+			data:      []byte(`{"apiVersion":"apiserver.config.k8s.io/v99","kind":"AuthorizationConfiguration"}`),
+			expectErr: `apiserver.config.k8s.io/v99`,
+		},
+		{
+			name:      "unknown kind",
+			data:      []byte(`{"apiVersion":"apiserver.config.k8s.io/v1alpha1","kind":"SomeConfiguration"}`),
+			expectErr: `SomeConfiguration`,
+		},
+		{
+			name: "unknown field",
+			data: []byte(`{
+"apiVersion":"apiserver.config.k8s.io/v1alpha1",
+"kind":"AuthorizationConfiguration",
+"authorzers":[{"type":"Webhook"}]}`),
+			expectErr: `unknown field "authorzers"`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			config, err := LoadFromData(tc.data)
+			if err != nil {
+				if len(tc.expectErr) == 0 {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !strings.Contains(err.Error(), tc.expectErr) {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if len(tc.expectErr) > 0 {
+				t.Fatalf("expected err, got none")
+			}
+
+			if !reflect.DeepEqual(config, tc.expectConfig) {
+				t.Fatalf("unexpected config:\n%s", cmp.Diff(tc.expectConfig, config))
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -223,6 +223,13 @@ const (
 	// Enables Structured Authentication Configuration
 	StructuredAuthenticationConfiguration featuregate.Feature = "StructuredAuthenticationConfiguration"
 
+	// owner: @palnabarun
+	// kep: https://kep.k8s.io/3221
+	// alpha: v1.29
+	//
+	// Enables Structured Authorization Configuration
+	StructuredAuthorizationConfiguration featuregate.Feature = "StructuredAuthorizationConfiguration"
+
 	// owner: @wojtek-t
 	// alpha: v1.15
 	// beta: v1.16
@@ -304,6 +311,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	StorageVersionHash: {Default: true, PreRelease: featuregate.Beta},
 
 	StructuredAuthenticationConfiguration: {Default: false, PreRelease: featuregate.Alpha},
+
+	StructuredAuthorizationConfiguration: {Default: false, PreRelease: featuregate.Alpha},
 
 	UnauthenticatedHTTP2DOSMitigation: {Default: true, PreRelease: featuregate.Beta},
 

--- a/test/integration/auth/authz_config_test.go
+++ b/test/integration/auth/authz_config_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	clientset "k8s.io/client-go/kubernetes"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/authutil"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestAuthzConfig(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StructuredAuthorizationConfiguration, true)()
+
+	dir := t.TempDir()
+	configFileName := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configFileName, []byte(`
+apiVersion: apiserver.config.k8s.io/v1alpha1
+kind: AuthorizationConfiguration
+authorizers:
+- type: RBAC
+  name: rbac
+`), os.FileMode(0644)); err != nil {
+		t.Fatal(err)
+	}
+
+	server := kubeapiservertesting.StartTestServerOrDie(
+		t,
+		nil,
+		[]string{"--authorization-config=" + configFileName},
+		framework.SharedEtcd(),
+	)
+	t.Cleanup(server.TearDownFn)
+
+	adminClient := clientset.NewForConfigOrDie(server.ClientConfig)
+
+	sar := &authorizationv1.SubjectAccessReview{Spec: authorizationv1.SubjectAccessReviewSpec{
+		User: "alice",
+		ResourceAttributes: &authorizationv1.ResourceAttributes{
+			Namespace: "foo",
+			Verb:      "create",
+			Group:     "",
+			Version:   "v1",
+			Resource:  "configmaps",
+		},
+	}}
+	result, err := adminClient.AuthorizationV1().SubjectAccessReviews().Create(context.TODO(), sar, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status.Allowed {
+		t.Fatal("expected denied, got allowed")
+	}
+
+	authutil.GrantUserAuthorization(t, context.TODO(), adminClient, "alice",
+		rbacv1.PolicyRule{
+			Verbs:     []string{"create"},
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+		},
+	)
+
+	result, err = adminClient.AuthorizationV1().SubjectAccessReviews().Create(context.TODO(), sar, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Status.Allowed {
+		t.Fatal("expected allowed, got denied")
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1457,6 +1457,7 @@ k8s.io/apiserver/pkg/admission/plugin/webhook/validating
 k8s.io/apiserver/pkg/admission/testing
 k8s.io/apiserver/pkg/apis/apiserver
 k8s.io/apiserver/pkg/apis/apiserver/install
+k8s.io/apiserver/pkg/apis/apiserver/load
 k8s.io/apiserver/pkg/apis/apiserver/v1
 k8s.io/apiserver/pkg/apis/apiserver/v1alpha1
 k8s.io/apiserver/pkg/apis/apiserver/v1beta1


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area apiserver

#### What this PR does / why we need it:

This is follow-up on https://github.com/kubernetes/kubernetes/pull/119099 and implements the following:

- kube-apiserver flag (`--authorization-config`) for authorization configuration file
- feature gate (`StructuredAuthorizationConfiguration`) for gating changes
- adds an integration test for reading authorizers from the configuration file

#### Which issue(s) this PR fixes:

Fixes #118872

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
kube-apiserver: adds --authorization-config flag for reading a configuration file containing an apiserver.config.k8s.io/v1alpha1 AuthorizationConfiguration object. --authorization-config flag is mutually exclusive with --authorization-modes and --authorization-webhook-* flags. The alpha StructuredAuthorizationConfiguration feature flag must be enabled for --authorization-config to be specified.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs
- [KEP]: https://kep.k8s.io/3221
- [Usage]: TBD
- [Other doc]: TBD
```
