### PR TITLE
apf: refactor promise to use a context

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/promise/promise_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/promise/promise_test.go
@@ -28,7 +28,7 @@ func TestWriteOnceSet(t *testing.T) {
 	oldTime := time.Now()
 	cval := &oldTime
 	ctx, cancel := context.WithCancel(context.Background())
-	wr := NewWriteOnce(nil, ctx.Done(), cval)
+	wr := NewWriteOnce(nil, ctx, cval)
 	gots := make(chan interface{})
 	goGetExpectNotYet(t, wr, gots, "Set")
 	now := time.Now()
@@ -53,7 +53,7 @@ func TestWriteOnceCancel(t *testing.T) {
 	oldTime := time.Now()
 	cval := &oldTime
 	ctx, cancel := context.WithCancel(context.Background())
-	wr := NewWriteOnce(nil, ctx.Done(), cval)
+	wr := NewWriteOnce(nil, ctx, cval)
 	gots := make(chan interface{})
 	goGetExpectNotYet(t, wr, gots, "cancel")
 	cancel()
@@ -73,7 +73,7 @@ func TestWriteOnceInitial(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	now := time.Now()
 	aval := &now
-	wr := NewWriteOnce(aval, ctx.Done(), cval)
+	wr := NewWriteOnce(aval, ctx, cval)
 	gots := make(chan interface{})
 	goGetAndExpect(t, wr, gots, aval)
 	later := time.Now()

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -53,7 +53,7 @@ type queueSetFactory struct {
 // - whose Set method is invoked with the queueSet locked, and
 // - whose Get method is invoked with the queueSet not locked.
 // The parameters are the same as for `promise.NewWriteOnce`.
-type promiseFactory func(initial interface{}, doneCh <-chan struct{}, doneVal interface{}) promise.WriteOnce
+type promiseFactory func(initial interface{}, doneCtx context.Context, doneVal interface{}) promise.WriteOnce
 
 // promiseFactoryFactory returns the promiseFactory to use for the given queueSet
 type promiseFactoryFactory func(*queueSet) promiseFactory
@@ -584,7 +584,7 @@ func (qs *queueSet) timeoutOldRequestsAndRejectOrEnqueueLocked(ctx context.Conte
 		fsName:            fsName,
 		flowDistinguisher: flowDistinguisher,
 		ctx:               ctx,
-		decision:          qs.promiseFactory(nil, ctx.Done(), decisionCancel),
+		decision:          qs.promiseFactory(nil, ctx, decisionCancel),
 		arrivalTime:       qs.clock.Now(),
 		arrivalR:          qs.currentR,
 		queue:             queue,
@@ -725,7 +725,7 @@ func (qs *queueSet) dispatchSansQueueLocked(ctx context.Context, workEstimate *f
 		flowDistinguisher: flowDistinguisher,
 		ctx:               ctx,
 		startTime:         now,
-		decision:          qs.promiseFactory(decisionExecute, ctx.Done(), decisionCancel),
+		decision:          qs.promiseFactory(decisionExecute, ctx, decisionCancel),
 		arrivalTime:       now,
 		arrivalR:          qs.currentR,
 		descr1:            descr1,

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -1223,8 +1223,8 @@ func TestContextCancel(t *testing.T) {
 
 func countingPromiseFactoryFactory(activeCounter counter.GoRoutineCounter) promiseFactoryFactory {
 	return func(qs *queueSet) promiseFactory {
-		return func(initial interface{}, doneCh <-chan struct{}, doneVal interface{}) promise.WriteOnce {
-			return testpromise.NewCountingWriteOnce(activeCounter, &qs.lock, initial, doneCh, doneVal)
+		return func(initial interface{}, doneCtx context.Context, doneVal interface{}) promise.WriteOnce {
+			return testpromise.NewCountingWriteOnce(activeCounter, &qs.lock, initial, doneCtx.Done(), doneVal)
 		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
refactor promise to take a `context` instead of channel

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), 
```docs

```
