### PR TITLE
Replace ErrorType struct with Interface in errors.go

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
@@ -284,7 +284,7 @@ func NewInvalid(qualifiedKind schema.GroupKind, name string, errs field.ErrorLis
 	for i := range errs {
 		err := errs[i]
 		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseType(err.Type),
+			Type:    metav1.CauseType(err.Type.Type()),
 			Message: err.ErrorBody(),
 			Field:   err.Field,
 		})

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -29,7 +29,7 @@ import (
 // Error is an implementation of the 'error' interface, which represents a
 // field-level validation error.
 type Error struct {
-	Type     ErrorType
+	Type     ErrorTypeInterface
 	Field    string
 	BadValue interface{}
 	Detail   string
@@ -96,6 +96,14 @@ func (v *Error) ErrorBody() string {
 	return s
 }
 
+// ErrorTypeInterface is an interface for representing an error type and detail message.
+type ErrorTypeInterface interface {
+	Type() string
+	String() string
+}
+
+var _ ErrorTypeInterface = (*ErrorType)(nil)
+
 // ErrorType is a machine readable value providing more detail about why
 // a field is invalid.  These values are expected to match 1-1 with
 // CauseType in api/types.go.
@@ -138,6 +146,11 @@ const (
 	// ErrorTypeTypeInvalid is for the value did not match the schema type for that field
 	ErrorTypeTypeInvalid ErrorType = "FieldValueTypeInvalid"
 )
+
+// Type returns the ErrorType string value.
+func (t ErrorType) Type() string {
+	return string(t)
+}
 
 // String converts a ErrorType into its corresponding canonical error message.
 func (t ErrorType) String() string {
@@ -278,7 +291,7 @@ type ErrorList []*Error
 
 // NewErrorTypeMatcher returns an errors.Matcher that returns true
 // if the provided error is a Error and has the provided ErrorType.
-func NewErrorTypeMatcher(t ErrorType) utilerrors.Matcher {
+func NewErrorTypeMatcher(t ErrorTypeInterface) utilerrors.Matcher {
 	return func(err error) bool {
 		if e, ok := err.(*Error); ok {
 			return e.Type == t


### PR DESCRIPTION
Replaced plain ErrorType with the newly introduced ErrorTypeInterface in errors.go. The modification is intended to improve flexibility as now it allows the ErrorType to have custom implementations through the interface, enhancing code maintainability and extensibility.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Replace ErrorType struct with Interface in errors.go

For example, in the past, if we want to use the `apimachinery/util` package, and want to add a new ErrorType `MyErrorType`, the `String()` method will panic.

```
// String converts a ErrorType into its corresponding canonical error message.
func (t ErrorType) String() string {
	switch t {
	case ErrorTypeNotFound:
		return "Not found"
        ...
        ...
        ...
	default:
		panic(fmt.Sprintf("unrecognized validation error: %q", string(t)))
	}
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Replace ErrorType struct with Interface in errors.go
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
