### PR TITLE
Now if GetPodStatus is not ok, it will record PodStartDuration and ignore the pod Phase

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1767,7 +1767,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	// Record the time it takes for the pod to become running
 	// since kubelet first saw the pod if firstSeenTime is set.
 	existingStatus, ok := kl.statusManager.GetPodStatus(pod.UID)
-	if !ok || existingStatus.Phase == v1.PodPending && apiPodStatus.Phase == v1.PodRunning &&
+	if (!ok || existingStatus.Phase == v1.PodPending) && apiPodStatus.Phase == v1.PodRunning &&
 		!firstSeenTime.IsZero() {
 		metrics.PodStartDuration.Observe(metrics.SinceInSeconds(firstSeenTime))
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1803,7 +1803,7 @@ func TestSyncPodStartMetrics(t *testing.T) {
 	pods := []*v1.Pod{podPending}
 	kl.podManager.SetPods(pods)
 
-	kl.SyncPod(context.Background(), kubetypes.SyncPodUpdate, podPending, nil, &kubecontainer.PodStatus{})
+	_, _ = kl.SyncPod(context.Background(), kubetypes.SyncPodUpdate, podPending, nil, &kubecontainer.PodStatus{})
 	metricsFamily, err := metrics.GetGather().Gather()
 	if err != nil {
 		t.Errorf("metrics gather error")
@@ -1821,13 +1821,13 @@ func TestSyncPodStartMetrics(t *testing.T) {
 			{Name: "1234", Image: "foo"},
 		},
 	})
-	podRunning.Status.ContainerStatuses = append(podRunning.Status.ContainerStatuses)
+
 	podRunning.Annotations[kubetypes.ConfigFirstSeenAnnotationKey] = kubetypes.NewTimestamp().GetString()
 	podRunning.Status.Phase = v1.PodRunning
 	pods = []*v1.Pod{podRunning}
 	kl.podManager.SetPods(pods)
 
-	kl.SyncPod(context.Background(), kubetypes.SyncPodUpdate, podRunning, nil, &kubecontainer.PodStatus{
+	_, _ = kl.SyncPod(context.Background(), kubetypes.SyncPodUpdate, podRunning, nil, &kubecontainer.PodStatus{
 		ID:        podRunning.UID,
 		Name:      podRunning.Name,
 		Namespace: podRunning.Namespace,
@@ -1844,7 +1844,6 @@ func TestSyncPodStartMetrics(t *testing.T) {
 	}
 	for _, mf := range metricsFamily {
 		if *mf.Name == "kubelet_pod_start_duration_seconds" {
-			t.Log(mf.Metric)
 			if *mf.Metric[0].Histogram.SampleCount == 0 {
 				t.Errorf("expected kubelet_pod_start_duration_seconds counter > 0")
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Now if GetPodStatus is not ok, it will record PodStartDuration and ignore the pod Phase.
``` go
if a || b && c{
    // if a == true, will fast pass, b&&c will be ignored.
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
