### PR TITLE
remove docker/distribution to 2.8.1

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -334,7 +334,6 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
-github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v20.10.21+incompatible h1:UTLdBmHk3bEY+w8qeO5KttOhy6OmXWsl/FEet9Uswog=


### PR DESCRIPTION
2.8.1 is identified as affected by https://github.com/advisories/GHSA-h8c3-8522-vxc6 and https://github.com/advisories/GHSA-hqxw-f8mx-cpmw; bumping to 2.8.2 avoids k/k triggering scanners on those CVEs.

When this PR was merged, an subsequent entry for 2.8.1 was left in go.sum which needs to be removed.

https://github.com/kubernetes/kubernetes/pull/118036 

Fixes https://github.com/kubernetes/kubernetes/issues/120178