### PR TITLE
kubeadm: update swap warning for v1.28 change

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -653,7 +653,7 @@ func (swc SwapCheck) Check() (warnings, errorList []error) {
 	}
 
 	if len(buf) > 1 {
-		return []error{errors.New("swap is enabled; production deployments should disable swap unless testing the NodeSwap feature gate of the kubelet")}, nil
+		return []error{errors.New("swap is supported for cgroup v2 only; the NodeSwap feature gate of the kubelet is beta but disabled by default")}, nil
 	}
 
 	return nil, nil


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

We have mentioned the steps to enable Swap with kubeadm in the blog: https://kubernetes.io/blog/2023/08/24/swap-linux-beta/#set-up-a-kubernetes-cluster-that-uses-swap-enabled-nodes.
- A special note here is that `Note that NodeSwap is supported for cgroup v2 only. For Kubernetes v1.28, using swap along with cgroup v1 is no longer supported.`

Since 1.28, the FG is beta but disabled by default. I prefer to keep the warning and update it accordingly.

#### Which issue(s) this PR fixes:
xref https://github.com/kubernetes/kubeadm/issues/2563

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
kubeadm: updated warning message when swap space is detected. When swap is active on Linux, kubeadm explains that swap is supported for cgroup v2 only and is beta but disabled by default.
```
