### PR TITLE
cleanup: add defaulting for job manual selector

### DIFF
--- a/pkg/apis/batch/fuzzer/fuzzer.go
+++ b/pkg/apis/batch/fuzzer/fuzzer.go
@@ -48,7 +48,7 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 			if c.Rand.Int31()%2 == 0 {
 				j.ManualSelector = pointer.Bool(true)
 			} else {
-				j.ManualSelector = nil
+				j.ManualSelector = pointer.Bool(false)
 			}
 			mode := batch.NonIndexedCompletion
 			if c.RandBool() {

--- a/pkg/apis/batch/fuzzer/fuzzer.go
+++ b/pkg/apis/batch/fuzzer/fuzzer.go
@@ -45,11 +45,7 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 			j.Completions = &completions
 			j.Parallelism = &parallelism
 			j.BackoffLimit = &backoffLimit
-			if c.Rand.Int31()%2 == 0 {
-				j.ManualSelector = pointer.Bool(true)
-			} else {
-				j.ManualSelector = pointer.Bool(false)
-			}
+			j.ManualSelector = pointer.Bool(c.RandBool())
 			mode := batch.NonIndexedCompletion
 			if c.RandBool() {
 				mode = batch.IndexedCompletion

--- a/pkg/apis/batch/v1/defaults.go
+++ b/pkg/apis/batch/v1/defaults.go
@@ -79,6 +79,9 @@ func SetDefaults_Job(obj *batchv1.Job) {
 			}
 		}
 	}
+	if obj.Spec.ManualSelector == nil {
+		obj.Spec.ManualSelector = utilpointer.Bool(false)
+	}
 }
 
 func SetDefaults_CronJob(obj *batchv1.CronJob) {

--- a/pkg/apis/batch/v1/defaults_test.go
+++ b/pkg/apis/batch/v1/defaults_test.go
@@ -98,6 +98,7 @@ func TestSetDefaultJob(t *testing.T) {
 					BackoffLimit:   pointer.Int32(6),
 					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
 					Suspend:        pointer.Bool(false),
+					ManualSelector: pointer.Bool(false),
 					PodFailurePolicy: &batchv1.PodFailurePolicy{
 						Rules: []batchv1.PodFailurePolicyRule{
 							{
@@ -166,6 +167,7 @@ func TestSetDefaultJob(t *testing.T) {
 					CompletionMode:       completionModePtr(batchv1.NonIndexedCompletion),
 					Suspend:              pointer.Bool(false),
 					PodReplacementPolicy: podReplacementPtr(batchv1.Failed),
+					ManualSelector:       pointer.Bool(false),
 					PodFailurePolicy: &batchv1.PodFailurePolicy{
 						Rules: []batchv1.PodFailurePolicyRule{
 							{
@@ -198,6 +200,7 @@ func TestSetDefaultJob(t *testing.T) {
 					CompletionMode:       completionModePtr(batchv1.NonIndexedCompletion),
 					Suspend:              pointer.Bool(false),
 					PodReplacementPolicy: podReplacementPtr(batchv1.TerminatingOrFailed),
+					ManualSelector:       pointer.Bool(false),
 				},
 			},
 			expectLabels:               true,
@@ -218,6 +221,7 @@ func TestSetDefaultJob(t *testing.T) {
 					BackoffLimit:   pointer.Int32(6),
 					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
 					Suspend:        pointer.Bool(false),
+					ManualSelector: pointer.Bool(false),
 				},
 			},
 			expectLabels: true,
@@ -237,6 +241,7 @@ func TestSetDefaultJob(t *testing.T) {
 					BackoffLimit:   pointer.Int32(6),
 					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
 					Suspend:        pointer.Bool(false),
+					ManualSelector: pointer.Bool(false),
 				},
 			},
 			expectLabels: true,
@@ -279,6 +284,7 @@ func TestSetDefaultJob(t *testing.T) {
 					BackoffLimit:   pointer.Int32(6),
 					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
 					Suspend:        pointer.Bool(false),
+					ManualSelector: pointer.Bool(false),
 				},
 			},
 		},
@@ -369,6 +375,7 @@ func TestSetDefaultJob(t *testing.T) {
 					CompletionMode:       completionModePtr(batchv1.NonIndexedCompletion),
 					Suspend:              pointer.Bool(false),
 					PodReplacementPolicy: podReplacementPtr(batchv1.TerminatingOrFailed),
+					ManualSelector:       pointer.Bool(false),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -382,6 +389,7 @@ func TestSetDefaultJob(t *testing.T) {
 					CompletionMode:       completionModePtr(batchv1.NonIndexedCompletion),
 					Suspend:              pointer.Bool(false),
 					PodReplacementPolicy: podReplacementPtr(batchv1.TerminatingOrFailed),
+					ManualSelector:       pointer.Bool(false),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -398,6 +406,7 @@ func TestSetDefaultJob(t *testing.T) {
 					CompletionMode:       completionModePtr(batchv1.IndexedCompletion),
 					Suspend:              pointer.Bool(true),
 					PodReplacementPolicy: podReplacementPtr(batchv1.Failed),
+					ManualSelector:       pointer.Bool(true),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -411,6 +420,7 @@ func TestSetDefaultJob(t *testing.T) {
 					CompletionMode:       completionModePtr(batchv1.IndexedCompletion),
 					Suspend:              pointer.Bool(true),
 					PodReplacementPolicy: podReplacementPtr(batchv1.Failed),
+					ManualSelector:       pointer.Bool(true),
 				},
 			},
 			expectLabels: true,
@@ -449,6 +459,7 @@ func TestSetDefaultJob(t *testing.T) {
 					CompletionMode:       completionModePtr(batchv1.IndexedCompletion),
 					Template:             validPodTemplateSpec,
 					Suspend:              pointer.Bool(true),
+					ManualSelector:       pointer.Bool(true),
 				},
 			},
 			expected: &batchv1.Job{
@@ -460,6 +471,7 @@ func TestSetDefaultJob(t *testing.T) {
 					CompletionMode:       completionModePtr(batchv1.IndexedCompletion),
 					Template:             validPodTemplateSpec,
 					Suspend:              pointer.Bool(true),
+					ManualSelector:       pointer.Bool(false),
 				},
 			},
 			expectLabels: true,

--- a/pkg/apis/batch/v1/defaults_test.go
+++ b/pkg/apis/batch/v1/defaults_test.go
@@ -262,6 +262,7 @@ func TestSetDefaultJob(t *testing.T) {
 					BackoffLimit:   pointer.Int32(6),
 					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
 					Suspend:        pointer.Bool(true),
+					ManualSelector: pointer.Bool(false),
 				},
 			},
 			expectLabels: true,
@@ -303,6 +304,7 @@ func TestSetDefaultJob(t *testing.T) {
 					BackoffLimit:   pointer.Int32(6),
 					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
 					Suspend:        pointer.Bool(false),
+					ManualSelector: pointer.Bool(false),
 				},
 			},
 			expectLabels: true,
@@ -322,6 +324,7 @@ func TestSetDefaultJob(t *testing.T) {
 					BackoffLimit:   pointer.Int32(6),
 					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
 					Suspend:        pointer.Bool(false),
+					ManualSelector: pointer.Bool(false),
 				},
 			},
 			expectLabels: true,
@@ -342,6 +345,7 @@ func TestSetDefaultJob(t *testing.T) {
 					BackoffLimit:   pointer.Int32(6),
 					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
 					Suspend:        pointer.Bool(false),
+					ManualSelector: pointer.Bool(false),
 				},
 			},
 			expectLabels: true,
@@ -362,6 +366,7 @@ func TestSetDefaultJob(t *testing.T) {
 					BackoffLimit:   pointer.Int32(5),
 					CompletionMode: completionModePtr(batchv1.NonIndexedCompletion),
 					Suspend:        pointer.Bool(false),
+					ManualSelector: pointer.Bool(false),
 				},
 			},
 			expectLabels: true,
@@ -434,6 +439,7 @@ func TestSetDefaultJob(t *testing.T) {
 					CompletionMode:       completionModePtr(batchv1.IndexedCompletion),
 					Template:             validPodTemplateSpec,
 					Suspend:              pointer.Bool(true),
+					ManualSelector:       pointer.Bool(false),
 				},
 			},
 			expected: &batchv1.Job{
@@ -445,6 +451,7 @@ func TestSetDefaultJob(t *testing.T) {
 					CompletionMode:       completionModePtr(batchv1.IndexedCompletion),
 					Template:             validPodTemplateSpec,
 					Suspend:              pointer.Bool(true),
+					ManualSelector:       pointer.Bool(false),
 				},
 			},
 			expectLabels: true,
@@ -471,7 +478,7 @@ func TestSetDefaultJob(t *testing.T) {
 					CompletionMode:       completionModePtr(batchv1.IndexedCompletion),
 					Template:             validPodTemplateSpec,
 					Suspend:              pointer.Bool(true),
-					ManualSelector:       pointer.Bool(false),
+					ManualSelector:       pointer.Bool(true),
 				},
 			},
 			expectLabels: true,
@@ -511,6 +518,9 @@ func TestSetDefaultJob(t *testing.T) {
 			}
 			if diff := cmp.Diff(expected.Spec.PodReplacementPolicy, actual.Spec.PodReplacementPolicy); diff != "" {
 				t.Errorf("Unexpected PodReplacementPolicy (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(expected.Spec.ManualSelector, actual.Spec.ManualSelector); diff != "" {
+				t.Errorf("Unexpected ManualSelector (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/registry/batch/job/storage/storage_test.go
+++ b/pkg/registry/batch/job/storage/storage_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package storage
 
 import (
+	"k8s.io/utils/pointer"
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -137,9 +138,10 @@ func TestCreate(t *testing.T) {
 		// invalid (empty selector)
 		&batch.Job{
 			Spec: batch.JobSpec{
-				Completions: validJob.Spec.Completions,
-				Selector:    &metav1.LabelSelector{},
-				Template:    validJob.Spec.Template,
+				ManualSelector: pointer.Bool(false),
+				Completions:    validJob.Spec.Completions,
+				Selector:       &metav1.LabelSelector{},
+				Template:       validJob.Spec.Template,
 			},
 		},
 	)

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -164,7 +164,7 @@ func (jobStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object
 func (jobStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	job := obj.(*batch.Job)
 	// TODO: move UID generation earlier and do this in defaulting logic?
-	if *job.Spec.ManualSelector == false {
+	if !*job.Spec.ManualSelector {
 		generateSelector(job)
 	}
 	opts := validationOptionsForJob(job, nil)

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -164,7 +164,7 @@ func (jobStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object
 func (jobStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	job := obj.(*batch.Job)
 	// TODO: move UID generation earlier and do this in defaulting logic?
-	if job.Spec.ManualSelector == nil || *job.Spec.ManualSelector == false {
+	if *job.Spec.ManualSelector == false {
 		generateSelector(job)
 	}
 	opts := validationOptionsForJob(job, nil)

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -163,7 +163,6 @@ func (jobStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object
 // Validate validates a new job.
 func (jobStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	job := obj.(*batch.Job)
-	// TODO: move UID generation earlier and do this in defaulting logic?
 	if !*job.Spec.ManualSelector {
 		generateSelector(job)
 	}

--- a/pkg/registry/batch/job/strategy_test.go
+++ b/pkg/registry/batch/job/strategy_test.go
@@ -1320,7 +1320,8 @@ func TestJobStrategy_Validate(t *testing.T) {
 			job: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector: nil,
+					Selector:       nil,
+					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: validSelector.MatchLabels,
@@ -1331,7 +1332,8 @@ func TestJobStrategy_Validate(t *testing.T) {
 			wantJob: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}},
+					Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}},
+					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: validSelector.MatchLabels,
@@ -1344,7 +1346,8 @@ func TestJobStrategy_Validate(t *testing.T) {
 			job: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector: nil,
+					Selector:       nil,
+					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						Spec: validPodSpec,
 					}},
@@ -1352,7 +1355,8 @@ func TestJobStrategy_Validate(t *testing.T) {
 			wantJob: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}},
+					Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}},
+					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: validLabels,
@@ -1365,7 +1369,8 @@ func TestJobStrategy_Validate(t *testing.T) {
 			job: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector: nil,
+					Selector:       nil,
+					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: labelsWithNonBatch,
@@ -1376,7 +1381,8 @@ func TestJobStrategy_Validate(t *testing.T) {
 			wantJob: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}},
+					Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}},
+					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: labelsWithNonBatch,
@@ -1419,7 +1425,8 @@ func TestJobStrategy_Validate(t *testing.T) {
 			job: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector: nil,
+					Selector:       nil,
+					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: validSelector.MatchLabels,
@@ -1435,7 +1442,8 @@ func TestJobStrategy_Validate(t *testing.T) {
 			wantJob: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}},
+					Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}},
+					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: labelsWithNonBatch,
@@ -1453,7 +1461,8 @@ func TestJobStrategy_Validate(t *testing.T) {
 			job: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector: nil,
+					Selector:       nil,
+					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: validSelector.MatchLabels,
@@ -1470,7 +1479,8 @@ func TestJobStrategy_Validate(t *testing.T) {
 			wantJob: &batch.Job{
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
-					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}},
+					Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{batch.ControllerUidLabel: string(theUID)}},
+					ManualSelector: pointer.Bool(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: labelsWithNonBatch,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`Validate` says if `job.Spec.ManualSelector == nil || *job.Spec.ManualSelector == false` - this is wrong. That field should be recognized as `nil` in `pkg/apis/batch/v1/defaults.go` and assigned a value. You should not be nil-checking fields all over the place and inferring their default values. It seems innocuous on a bool, but imagine an int or string field - you'd have the default value sprinkled all over the codebase.

#### Which issue(s) this PR fixes:

Second fix for #116137 as per @thockin comment https://github.com/kubernetes/kubernetes/issues/116137#issuecomment-1448520671

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig apps