### PR TITLE
Automated cherry pick of #120204: Mark Job onPodConditions as optional in pod failure policy

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4455,8 +4455,7 @@
         }
       },
       "required": [
-        "action",
-        "onPodConditions"
+        "action"
       ],
       "type": "object"
     },

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -608,8 +608,7 @@
           }
         },
         "required": [
-          "action",
-          "onPodConditions"
+          "action"
         ],
         "type": "object"
       },

--- a/pkg/apis/batch/types.go
+++ b/pkg/apis/batch/types.go
@@ -241,6 +241,7 @@ type PodFailurePolicyRule struct {
 	// as a list of pod condition patterns. The requirement is satisfied if at
 	// least one pattern matches an actual pod condition. At most 20 elements are allowed.
 	// +listType=atomic
+	// +optional
 	OnPodConditions []PodFailurePolicyOnPodConditionsPattern
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -15948,7 +15948,7 @@ func schema_k8sio_api_batch_v1_PodFailurePolicyRule(ref common.ReferenceCallback
 						},
 					},
 				},
-				Required: []string{"action", "onPodConditions"},
+				Required: []string{"action"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/batch/v1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1/generated.proto
@@ -530,6 +530,7 @@ message PodFailurePolicyRule {
   // as a list of pod condition patterns. The requirement is satisfied if at
   // least one pattern matches an actual pod condition. At most 20 elements are allowed.
   // +listType=atomic
+  // +optional
   repeated PodFailurePolicyOnPodConditionsPattern onPodConditions = 3;
 }
 

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -236,6 +236,7 @@ type PodFailurePolicyRule struct {
 	// as a list of pod condition patterns. The requirement is satisfied if at
 	// least one pattern matches an actual pod condition. At most 20 elements are allowed.
 	// +listType=atomic
+	// +optional
 	OnPodConditions []PodFailurePolicyOnPodConditionsPattern `json:"onPodConditions" protobuf:"bytes,3,opt,name=onPodConditions"`
 }
 


### PR DESCRIPTION
Cherry pick of #120204 on release-1.28.

#120204: Mark Job onPodConditions as optional in pod failure policy

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Mark Job onPodConditions as optional in pod failure policy
```