### PR TITLE
Automated cherry pick of #120204: Mark Job onPodConditions as optional in pod failure policy

### DIFF
--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -585,8 +585,7 @@
           }
         },
         "required": [
-          "action",
-          "onPodConditions"
+          "action"
         ],
         "type": "object"
       },

--- a/pkg/apis/batch/types.go
+++ b/pkg/apis/batch/types.go
@@ -211,6 +211,7 @@ type PodFailurePolicyRule struct {
 	// as a list of pod condition patterns. The requirement is satisfied if at
 	// least one pattern matches an actual pod condition. At most 20 elements are allowed.
 	// +listType=atomic
+	// +optional
 	OnPodConditions []PodFailurePolicyOnPodConditionsPattern
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -14882,7 +14882,7 @@ func schema_k8sio_api_batch_v1_PodFailurePolicyRule(ref common.ReferenceCallback
 						},
 					},
 				},
-				Required: []string{"action", "onPodConditions"},
+				Required: []string{"action"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/batch/v1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1/generated.proto
@@ -468,6 +468,7 @@ message PodFailurePolicyRule {
   // as a list of pod condition patterns. The requirement is satisfied if at
   // least one pattern matches an actual pod condition. At most 20 elements are allowed.
   // +listType=atomic
+  // +optional
   repeated PodFailurePolicyOnPodConditionsPattern onPodConditions = 3;
 }
 

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -202,6 +202,7 @@ type PodFailurePolicyRule struct {
 	// as a list of pod condition patterns. The requirement is satisfied if at
 	// least one pattern matches an actual pod condition. At most 20 elements are allowed.
 	// +listType=atomic
+	// +optional
 	OnPodConditions []PodFailurePolicyOnPodConditionsPattern `json:"onPodConditions" protobuf:"bytes,3,opt,name=onPodConditions"`
 }
 


### PR DESCRIPTION
Cherry pick of #120204 on release-1.27.

#120204: Mark Job onPodConditions as optional in pod failure policy

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Mark Job onPodConditions as optional in pod failure policy
```