### PR TITLE
[waiting for kep-3673 ga]kubelet: deprecate registry-qps and registry-burst

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -421,7 +421,10 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 	fs.BoolVar(&c.RotateCertificates, "rotate-certificates", c.RotateCertificates, "Auto rotate the kubelet client certificates by requesting new certificates from the kube-apiserver when the certificate expiration approaches.")
 
 	fs.Int32Var(&c.RegistryPullQPS, "registry-qps", c.RegistryPullQPS, "If > 0, limit registry pull QPS to this value.  If 0, unlimited.")
+	fs.MarkDeprecated("registry-qps", "will be removed in 1.32 or later. Use MaxParallelImagePulls instead.") //nolint:errcheck
 	fs.Int32Var(&c.RegistryBurst, "registry-burst", c.RegistryBurst, "Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry-qps. Only used if --registry-qps > 0")
+	fs.MarkDeprecated("registry-burst", "will be removed in 1.32 or later. Use MaxParallelImagePulls instead.") //nolint:errcheck
+
 	fs.Int32Var(&c.EventRecordQPS, "event-qps", c.EventRecordQPS, "QPS to limit event creations. The number must be >= 0. If 0 will use DefaultQPS: 5.")
 	fs.Int32Var(&c.EventBurst, "event-burst", c.EventBurst, "Maximum size of a bursty event records, temporarily allows event records to burst to this number, while still not exceeding event-qps. The number must be >= 0. If 0 will use DefaultBurst: 10.")
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -56641,14 +56641,14 @@ func schema_k8sio_kubelet_config_v1beta1_KubeletConfiguration(ref common.Referen
 					},
 					"registryPullQPS": {
 						SchemaProps: spec.SchemaProps{
-							Description: "registryPullQPS is the limit of registry pulls per second. The value must not be a negative number. Setting it to 0 means no limit. Default: 5",
+							Description: "registryPullQPS is the limit of registry pulls per second. The value must not be a negative number. Setting it to 0 means no limit. Deprecated: use MaxParallelImagePulls instead. It will has no effect after v1.32. Default: 5",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
 					},
 					"registryBurst": {
 						SchemaProps: spec.SchemaProps{
-							Description: "registryBurst is the maximum size of bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registryPullQPS. The value must not be a negative number. Only used if registryPullQPS is greater than 0. Default: 10",
+							Description: "registryBurst is the maximum size of bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registryPullQPS. The value must not be a negative number. Only used if registryPullQPS is greater than 0. Deprecated: use MaxParallelImagePulls instead. It will has no effect after v1.32. Default: 10",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -145,10 +145,12 @@ type KubeletConfiguration struct {
 	Authorization KubeletAuthorization
 	// registryPullQPS is the limit of registry pulls per second.
 	// Set to 0 for no limit.
+	// Deprecated: use MaxParallelImagePulls instead
 	RegistryPullQPS int32
 	// registryBurst is the maximum size of bursty pulls, temporarily allows
 	// pulls to burst to this number, while still not exceeding registryPullQPS.
 	// Only used if registryPullQPS > 0.
+	// Deprecated: use MaxParallelImagePulls instead
 	RegistryBurst int32
 	// eventRecordQPS is the maximum event creations per second. If 0, there
 	// is no limit enforced.

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -194,6 +194,7 @@ type KubeletConfiguration struct {
 	// registryPullQPS is the limit of registry pulls per second.
 	// The value must not be a negative number.
 	// Setting it to 0 means no limit.
+	// Deprecated: use MaxParallelImagePulls instead. It will has no effect after v1.32.
 	// Default: 5
 	// +optional
 	RegistryPullQPS *int32 `json:"registryPullQPS,omitempty"`
@@ -201,6 +202,7 @@ type KubeletConfiguration struct {
 	// pulls to burst to this number, while still not exceeding registryPullQPS.
 	// The value must not be a negative number.
 	// Only used if registryPullQPS is greater than 0.
+	// Deprecated: use MaxParallelImagePulls instead. It will has no effect after v1.32.
 	// Default: 10
 	// +optional
 	RegistryBurst int32 `json:"registryBurst,omitempty"`


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup
/kind deprecation

#### What this PR does / why we need it:
https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3673-kubelet-parallel-image-pull-limit#beta

Since kep-3673 is beta, we suggest users use MaxParallelImagePulls instead. So we can start the deprecation process for these two and encourage users to use the added one above in future releases.

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/kubernetes/issues/112044#issuecomment-1411244321

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kubelet: deprecate flags "registry-qps" and "registry-burst", use MaxParallelImagePulls instead.
```
