### PR TITLE
Fix CSINode object recreation logic after Node object recreation

### DIFF
--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -17,6 +17,7 @@ limitations under the License.
 package volume
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -333,6 +334,8 @@ type KubeletVolumeHost interface {
 	WaitForCacheSync() error
 	// Returns hostutil.HostUtils
 	GetHostUtil() hostutil.HostUtils
+	// WaitForNodeRegistrationCompleted is a helper function that waits for node is in registrationCompleted state
+	WaitForNodeRegistrationCompleted(ctx context.Context) error
 }
 
 // AttachDetachVolumeHost is a AttachDetach Controller specific interface that plugins can use

--- a/pkg/volume/testing/volume_host.go
+++ b/pkg/volume/testing/volume_host.go
@@ -234,6 +234,10 @@ func (f *fakeVolumeHost) GetNodeName() types.NodeName {
 	return types.NodeName(f.nodeName)
 }
 
+func (f *fakeVolumeHost) WaitForNodeRegistrationCompleted(ctx context.Context) error {
+	return nil
+}
+
 func (f *fakeVolumeHost) GetEventRecorder() record.EventRecorder {
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A preemptible Node got deleted and recreated with the same name, however during csi driver registration the CSINode object was updated while it still had an ownerReference to the old Node uid. The fix here wait for [registrationCompleted](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet.go#L1042) in the Kubelet, and then compare the node UID in ownerReference, if the UID is different we will delete the csinote and recreate a new one.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/120063

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix CSINode object recreation logic after Node object recreation
```
