### PR TITLE
remove GAed FG DownwardAPIHugePages

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -5613,7 +5613,6 @@ func TestHugePagesEnv(t *testing.T) {
 	// enable gate
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DownwardAPIHugePages, true)()
 			opts := PodValidationOptions{}
 			if errs := validateEnvVarValueFrom(testCase, field.NewPath("field"), opts); len(errs) != 0 {
 				t.Errorf("expected success, got: %v", errs)

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -238,14 +238,6 @@ const (
 	// Disable in-tree functionality in kubelet to authenticate to cloud provider container registries for image pull credentials.
 	DisableKubeletCloudCredentialProviders featuregate.Feature = "DisableKubeletCloudCredentialProviders"
 
-	// owner: @derekwaynecarr
-	// alpha: v1.20
-	// beta: v1.21 (off by default until 1.22)
-	// ga: v1.27
-	//
-	// Enables usage of hugepages-<size> in downward API.
-	DownwardAPIHugePages featuregate.Feature = "DownwardAPIHugePages"
-
 	// owner: @pohly
 	// kep: http://kep.k8s.io/3063
 	// alpha: v1.26
@@ -1015,8 +1007,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	DisableKubeletCloudCredentialProviders: {Default: false, PreRelease: featuregate.Alpha},
 
 	DevicePluginCDIDevices: {Default: false, PreRelease: featuregate.Alpha},
-
-	DownwardAPIHugePages: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in v1.29
 
 	DynamicResourceAllocation: {Default: false, PreRelease: featuregate.Alpha},
 


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:

> 	// owner: @derekwaynecarr
> 	// alpha: v1.20
> 	// beta: v1.21 (off by default until 1.22)
> 	// ga: v1.27
> 	//
> 	// Enables usage of hugepages-<size> in downward API.

#### Which issue(s) this PR fixes:
ref https://github.com/kubernetes/kubernetes/pull/115721 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Removed the `DownwardAPIHugePages` feature gate (the feature is stable and always enabled)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
https://github.com/kubernetes/enhancements/issues/2053

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/b5b3585/keps/sig-node/2053-downward-api-hugepages/README.md
```
