### PR TITLE
e2e_apps:stop using deprecated framework.ExpectError

### DIFF
--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -681,10 +681,7 @@ func stopDeployment(ctx context.Context, c clientset.Interface, ns, deploymentNa
 
 	framework.Logf("Ensuring deployment %s was deleted", deploymentName)
 	_, err = c.AppsV1().Deployments(ns).Get(ctx, deployment.Name, metav1.GetOptions{})
-	framework.ExpectError(err)
-	if !apierrors.IsNotFound(err) {
-		framework.Failf("Expected deployment %s to be deleted", deploymentName)
-	}
+	gomega.Expect(err).To(gomega.MatchError(apierrors.IsNotFound, fmt.Sprintf("Expected deployment %s to be deleted", deploymentName)))
 	framework.Logf("Ensuring deployment %s's RSes were deleted", deploymentName)
 	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
 	framework.ExpectNoError(err)

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -317,10 +317,9 @@ var _ = SIGDescribe("DisruptionController", func() {
 
 			if c.shouldDeny {
 				err = cs.CoreV1().Pods(ns).EvictV1(ctx, e)
-				framework.ExpectError(err, "pod eviction should fail")
-				if !apierrors.HasStatusCause(err, policyv1.DisruptionBudgetCause) {
-					framework.Fail("pod eviction should fail with DisruptionBudget cause")
-				}
+				gomega.Expect(err).To(gomega.MatchError(func(err error) bool {
+					return apierrors.HasStatusCause(err, policyv1.DisruptionBudgetCause)
+				}, "pod eviction should fail with DisruptionBudget cause"))
 			} else {
 				// Only wait for running pods in the "allow" case
 				// because one of shouldDeny cases relies on the
@@ -363,10 +362,9 @@ var _ = SIGDescribe("DisruptionController", func() {
 			},
 		}
 		err = cs.CoreV1().Pods(ns).EvictV1(ctx, e)
-		framework.ExpectError(err, "pod eviction should fail")
-		if !apierrors.HasStatusCause(err, policyv1.DisruptionBudgetCause) {
-			framework.Failf("pod eviction should fail with DisruptionBudget cause. The error was \"%v\"", err)
-		}
+		gomega.Expect(err).To(gomega.MatchError(func(err error) bool {
+			return apierrors.HasStatusCause(err, policyv1.DisruptionBudgetCause)
+		}, fmt.Sprintf("pod eviction should fail with DisruptionBudget cause. The error was \"%v\"\n", err)))
 
 		ginkgo.By("Updating the pdb to allow a pod to be evicted")
 		updatePDBOrDie(ctx, cs, ns, defaultName, func(pdb *policyv1.PodDisruptionBudget) *policyv1.PodDisruptionBudget {
@@ -403,10 +401,9 @@ var _ = SIGDescribe("DisruptionController", func() {
 			},
 		}
 		err = cs.CoreV1().Pods(ns).EvictV1(ctx, e)
-		framework.ExpectError(err, "pod eviction should fail")
-		if !apierrors.HasStatusCause(err, policyv1.DisruptionBudgetCause) {
-			framework.Failf("pod eviction should fail with DisruptionBudget cause. The error was \"%v\"", err)
-		}
+		gomega.Expect(err).To(gomega.MatchError(func(err error) bool {
+			return apierrors.HasStatusCause(err, policyv1.DisruptionBudgetCause)
+		}, fmt.Sprintf("pod eviction should fail with DisruptionBudget cause. The error was \"%v\"\n", err)))
 
 		ginkgo.By("Deleting the pdb to allow a pod to be evicted")
 		deletePDBOrDie(ctx, cs, ns, defaultName)

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -684,10 +684,7 @@ done`}
 
 		ginkgo.By("Ensuring job was deleted")
 		_, err = e2ejob.GetJob(ctx, f.ClientSet, f.Namespace.Name, job.Name)
-		framework.ExpectError(err, "failed to ensure job %s was deleted in namespace: %s", job.Name, f.Namespace.Name)
-		if !apierrors.IsNotFound(err) {
-			framework.Failf("failed to ensure job %s was deleted in namespace: %s", job.Name, f.Namespace.Name)
-		}
+		gomega.Expect(err).To(gomega.MatchError(apierrors.IsNotFound, fmt.Sprintf("failed to ensure job %s was deleted in namespace: %s", job.Name, f.Namespace.Name)))
 	})
 
 	/*


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

est/e2e/apps stop using deprecated framework.ExpectError

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref # https://github.com/kubernetes/kubernetes/pull/115961

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```
NONE
```
