### PR TITLE
windows-tests: Add retries to Windows `assertConsistentConnectivity` …

### DIFF
--- a/test/e2e/windows/reboot_node.go
+++ b/test/e2e/windows/reboot_node.go
@@ -111,13 +111,13 @@ var _ = sigDescribe("[Feature:Windows] [Excluded:WindowsDocker] [MinimumKubeletV
 		nginxPod = e2epod.NewPodClient(f).CreateSync(ctx, nginxPod)
 
 		ginkgo.By("checking connectivity to 8.8.8.8 53 (google.com) from Linux")
-		assertConsistentConnectivity(ctx, f, nginxPod.ObjectMeta.Name, "linux", linuxCheck("8.8.8.8", 53))
+		assertConsistentConnectivity(ctx, f, nginxPod.ObjectMeta.Name, "linux", linuxCheck("8.8.8.8", 53), externalMaxTries)
 
 		ginkgo.By("checking connectivity to www.google.com from Windows")
-		assertConsistentConnectivity(ctx, f, agnPod.ObjectMeta.Name, "windows", windowsCheck("www.google.com"))
+		assertConsistentConnectivity(ctx, f, agnPod.ObjectMeta.Name, "windows", windowsCheck("www.google.com"), externalMaxTries)
 
 		ginkgo.By("checking connectivity from Linux to Windows for the first time")
-		assertConsistentConnectivity(ctx, f, nginxPod.ObjectMeta.Name, "linux", linuxCheck(agnPod.Status.PodIP, 80))
+		assertConsistentConnectivity(ctx, f, nginxPod.ObjectMeta.Name, "linux", linuxCheck(agnPod.Status.PodIP, 80), internalMaxTries)
 
 		initialRestartCount := podutil.GetExistingContainerStatus(agnPod.Status.ContainerStatuses, "windows-container").RestartCount
 
@@ -201,7 +201,7 @@ var _ = sigDescribe("[Feature:Windows] [Excluded:WindowsDocker] [MinimumKubeletV
 		agnPodOut, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, agnPod.Name, metav1.GetOptions{})
 		gomega.Expect(agnPodOut.Status.Phase).To(gomega.Equal(v1.PodRunning))
 		framework.ExpectNoError(err, "getting pod info after reboot")
-		assertConsistentConnectivity(ctx, f, nginxPod.ObjectMeta.Name, "linux", linuxCheck(agnPodOut.Status.PodIP, 80))
+		assertConsistentConnectivity(ctx, f, nginxPod.ObjectMeta.Name, "linux", linuxCheck(agnPodOut.Status.PodIP, 80), internalMaxTries)
 
 		// create another host process pod to check system boot time
 		checkPod := &v1.Pod{

--- a/test/e2e/windows/service.go
+++ b/test/e2e/windows/service.go
@@ -82,7 +82,7 @@ var _ = sigDescribe("Services", skipUnlessWindows(func() {
 		// Admission controllers may sometimes do the wrong thing
 		gomega.Expect(testPod.Spec.NodeSelector).To(gomega.HaveKeyWithValue("kubernetes.io/os", "windows"), "pod.spec.nodeSelector")
 		ginkgo.By(fmt.Sprintf("checking connectivity Pod to curl http://%s:%d", nodeIP, nodePort))
-		assertConsistentConnectivity(ctx, f, testPod.ObjectMeta.Name, windowsOS, windowsCheck(fmt.Sprintf("http://%s", net.JoinHostPort(nodeIP, strconv.Itoa(nodePort)))))
+		assertConsistentConnectivity(ctx, f, testPod.ObjectMeta.Name, windowsOS, windowsCheck(fmt.Sprintf("http://%s", net.JoinHostPort(nodeIP, strconv.Itoa(nodePort)))), internalMaxTries)
 
 	})
 }))


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

/sig testing
/sig windows

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This pull request addresses a `TODO` item from the `test/e2e/windows/hybrid_network.go` file.

The max retries count was chosen to be similar with the value from:
https://github.com/kubernetes/kubernetes/blob/1144c85a929bb7a7d30e3343c660286511afb1e3/test/e2e/network/netpol/test_helper.go#L68-L71

In my experience by monitoring the [sig-windows-networking](https://testgrid.k8s.io/sig-windows-networking) Prowjobs, the following pieces of code will rarely fail, if we don't address the `TODO` item:
* https://github.com/kubernetes/kubernetes/blob/370c85f5ab0b0bfc3b30f235ddb040c246b0e1ff/test/e2e/windows/hybrid_network.go#L87
* https://github.com/kubernetes/kubernetes/blob/370c85f5ab0b0bfc3b30f235ddb040c246b0e1ff/test/e2e/windows/hybrid_network.go#L98

This is happening because in the `assertConsistentConnectivity` function, we have:
https://github.com/kubernetes/kubernetes/blob/370c85f5ab0b0bfc3b30f235ddb040c246b0e1ff/test/e2e/windows/hybrid_network.go#L122

The `gomega.Consistently` expects the `connChecker` to successfully query destination for the `duration` (10 secs).

However, if the destination is `8.8.8.8` or `www.google.com`, we can expect failures, so the retries logic is necessary in the `connChecker`.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A
#### Special notes for your reviewer:

I have this patch already running since a while on [sig-windows-networking](https://testgrid.k8s.io/sig-windows-networking) Prowjobs, and I didn't see the described flakiness scenario reproduced at all.

Unfortunately, I don't have any testgrid links with the rare occasions when failures occurred without this patch.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
