### PR TITLE
kubelet: use a default terminationGracePeriod of 30s for graceful shutdown pods

### DIFF
--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
@@ -118,7 +118,7 @@ func TestManager(t *testing.T) {
 	longGracePeriod := int64(1000)
 	normalPodLongGracePeriod := makePod("normal-pod-long-grace-period", scheduling.DefaultPriorityWhenNoDefaultClassExists, &longGracePeriod /* terminationGracePeriod */)
 
-	var tests = []struct {
+	tests := []struct {
 		desc                             string
 		activePods                       []*v1.Pod
 		shutdownGracePeriodRequested     time.Duration
@@ -179,8 +179,8 @@ func TestManager(t *testing.T) {
 				},
 				"failed-pod": {
 					Phase:   v1.PodFailed,
-					Message: "Pod was terminated in response to imminent node shutdown.",
 					Reason:  "Terminated",
+					Message: "Pod was terminated in response to imminent node shutdown.",
 					Conditions: []v1.PodCondition{
 						{
 							Type:    v1.DisruptionTarget,
@@ -206,7 +206,7 @@ func TestManager(t *testing.T) {
 			},
 		},
 		{
-			desc:                             "no override (total=30s, critical=10s)",
+			desc:                             "no override (total=30s, critical=30s)",
 			activePods:                       []*v1.Pod{normalPodNoGracePeriod, criticalPodNoGracePeriod},
 			shutdownGracePeriodRequested:     time.Duration(30 * time.Second),
 			shutdownGracePeriodCriticalPods:  time.Duration(10 * time.Second),
@@ -239,7 +239,7 @@ func TestManager(t *testing.T) {
 			expectedPodToGracePeriodOverride: map[string]int64{"normal-pod-nil-grace-period": 20, "critical-pod-nil-grace-period": 10, "normal-pod-grace-period": 2, "critical-pod-grace-period": 2},
 		},
 		{
-			desc:                             "no override (total=30s, critical=10s) pod with long terminationGracePeriod is overridden",
+			desc:                             "no override (total=30s, critical=30s) pod with long terminationGracePeriod is overridden",
 			activePods:                       []*v1.Pod{normalPodNoGracePeriod, criticalPodNoGracePeriod, normalPodGracePeriod, criticalPodGracePeriod, normalPodLongGracePeriod},
 			shutdownGracePeriodRequested:     time.Duration(30 * time.Second),
 			shutdownGracePeriodCriticalPods:  time.Duration(10 * time.Second),
@@ -249,7 +249,7 @@ func TestManager(t *testing.T) {
 			expectedPodToGracePeriodOverride: map[string]int64{"normal-pod-nil-grace-period": 20, "critical-pod-nil-grace-period": 10, "normal-pod-grace-period": 2, "critical-pod-grace-period": 2, "normal-pod-long-grace-period": 20},
 		},
 		{
-			desc:                             "no override (total=30, critical=0)",
+			desc:                             "no override (total=30, critical=10)",
 			activePods:                       []*v1.Pod{normalPodNoGracePeriod, criticalPodNoGracePeriod},
 			shutdownGracePeriodRequested:     time.Duration(30 * time.Second),
 			shutdownGracePeriodCriticalPods:  time.Duration(0 * time.Second),
@@ -259,7 +259,7 @@ func TestManager(t *testing.T) {
 			expectedPodToGracePeriodOverride: map[string]int64{"normal-pod-nil-grace-period": 30, "critical-pod-nil-grace-period": 0},
 		},
 		{
-			desc:                             "override successful (total=30, critical=10)",
+			desc:                             "override successful (total=20, critical=10)",
 			activePods:                       []*v1.Pod{normalPodNoGracePeriod, criticalPodNoGracePeriod},
 			shutdownGracePeriodRequested:     time.Duration(30 * time.Second),
 			shutdownGracePeriodCriticalPods:  time.Duration(10 * time.Second),
@@ -402,7 +402,7 @@ func TestManager(t *testing.T) {
 }
 
 func TestFeatureEnabled(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		desc                         string
 		shutdownGracePeriodRequested time.Duration
 		featureGateEnabled           bool
@@ -480,7 +480,7 @@ func TestRestart(t *testing.T) {
 
 	var shutdownChan chan bool
 	var shutdownChanMut sync.Mutex
-	var connChan = make(chan struct{}, 1)
+	connChan := make(chan struct{}, 1)
 
 	lock.Lock()
 	systemDbus = func() (dbusInhibiter, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This fixes a bug when Node Graceful Shutdown is enabled where all pods get a terminationGracePeriod of the maximum time set for graceful shutdown.

Kubernetes CI testing does not set Node Graceful Shutdowns on by default. Test pods and many other pods do not set a termination grace period and so would be set to potentially very high timeouts (65 minutes is what I am configuring). This differs from the default termination timeout of 30 seconds for a terminating pod. The flow for Node Graceful Shutdown is:

* Set a 30s default grace period
* If the pod sets a termination period:
  * If the pod termination period is greater than the configured group's period, then set the maximum period to be the group's
  * Otherwise use the terminationGracePeriodSeconds from the pod's configuration

The PR sets the default termination period to 30 seconds, and if the pod sets a custom terminationGracePeriod then the custom grace period is used.

#### Which issue(s) this PR fixes:
Fixes #120271

#### Special notes for your reviewer:
[Documentation References](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/) for 30s default termination.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubelet: Node Graceful Shutdown has a fix to use a default of 30s grace period for pods that do not use terminationGracePeriodSeconds.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
