### PR TITLE
kube-proxy config/CLI doc fixups

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -142,13 +142,25 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&o.ConfigFile, "config", o.ConfigFile, "The path to the configuration file.")
 	fs.StringVar(&o.WriteConfigTo, "write-config-to", o.WriteConfigTo, "If set, write the default configuration values to this file and exit.")
-	fs.StringVar(&o.config.ClientConnection.Kubeconfig, "kubeconfig", o.config.ClientConnection.Kubeconfig, "Path to kubeconfig file with authorization information (the master location can be overridden by the master flag).")
-	fs.StringVar(&o.config.ClusterCIDR, "cluster-cidr", o.config.ClusterCIDR, "The CIDR range of the pods in the cluster. (For dual-stack clusters, this can be a comma-separated dual-stack pair of CIDR ranges.). When --detect-local-mode is set to ClusterCIDR, kube-proxy will consider traffic to be local if its source IP is in this range. (Otherwise it is not used.) "+
+
+	fs.BoolVar(&o.CleanupAndExit, "cleanup", o.CleanupAndExit, "If true cleanup iptables and ipvs rules and exit.")
+
+	fs.Var(cliflag.NewMapStringBool(&o.config.FeatureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
+		"Options are:\n"+strings.Join(utilfeature.DefaultFeatureGate.KnownFeatures(), "\n")+"\n"+
 		"This parameter is ignored if a config file is specified by --config.")
-	fs.StringVar(&o.config.ClientConnection.ContentType, "kube-api-content-type", o.config.ClientConnection.ContentType, "Content type of requests sent to apiserver.")
+
+	fs.StringVar(&o.config.ClientConnection.Kubeconfig, "kubeconfig", o.config.ClientConnection.Kubeconfig, "Path to kubeconfig file with authorization information (the master location can be overridden by the master flag).")
 	fs.StringVar(&o.master, "master", o.master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
+	fs.StringVar(&o.config.ClientConnection.ContentType, "kube-api-content-type", o.config.ClientConnection.ContentType, "Content type of requests sent to apiserver.")
+	fs.Int32Var(&o.config.ClientConnection.Burst, "kube-api-burst", o.config.ClientConnection.Burst, "Burst to use while talking with kubernetes apiserver")
+	fs.Float32Var(&o.config.ClientConnection.QPS, "kube-api-qps", o.config.ClientConnection.QPS, "QPS to use while talking with kubernetes apiserver")
+
 	fs.StringVar(&o.hostnameOverride, "hostname-override", o.hostnameOverride, "If non-empty, will be used as the name of the Node that kube-proxy is running on. If unset, the node name is assumed to be the same as the node's hostname.")
-	fs.StringVar(&o.config.IPVS.Scheduler, "ipvs-scheduler", o.config.IPVS.Scheduler, "The ipvs scheduler type when proxy mode is ipvs")
+	fs.Var(&utilflag.IPVar{Val: &o.config.BindAddress}, "bind-address", "Overrides kube-proxy's idea of what its node's primary IP is. Note that the name is a historical artifact, and kube-proxy does not actually bind any sockets to this IP. This parameter is ignored if a config file is specified by --config.")
+	fs.Var(&utilflag.IPPortVar{Val: &o.config.HealthzBindAddress}, "healthz-bind-address", "The IP address and port for the health check server to serve on, defaulting to \"0.0.0.0:10256\" (if --bind-address is unset or IPv4), or \"[::]:10256\" (if --bind-address is IPv6). Set empty to disable. This parameter is ignored if a config file is specified by --config.")
+	fs.Var(&utilflag.IPPortVar{Val: &o.config.MetricsBindAddress}, "metrics-bind-address", "The IP address and port for the metrics server to serve on, defaulting to \"127.0.0.1:10249\" (if --bind-address is unset or IPv4), or \"[::1]:10249\" (if --bind-address is IPv6). (Set to \"0.0.0.0:10249\" / \"[::]:10249\" to bind on all interfaces.) Set empty to disable. This parameter is ignored if a config file is specified by --config.")
+	fs.BoolVar(&o.config.BindAddressHardFail, "bind-address-hard-fail", o.config.BindAddressHardFail, "If true kube-proxy will treat failure to bind to a port as fatal and exit")
+	fs.BoolVar(&o.config.EnableProfiling, "profiling", o.config.EnableProfiling, "If true enables profiling via web interface on /debug/pprof handler. This parameter is ignored if a config file is specified by --config.")
 	fs.StringVar(&o.config.ShowHiddenMetricsForVersion, "show-hidden-metrics-for-version", o.config.ShowHiddenMetricsForVersion,
 		"The previous version for which you want to show hidden metrics. "+
 			"Only the previous minor version is meaningful, other values will not be allowed. "+
@@ -157,42 +169,39 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 			"rather than being surprised when they are permanently removed in the release after that. "+
 			"This parameter is ignored if a config file is specified by --config.")
 
+	fs.Var(&o.config.Mode, "proxy-mode", "Which proxy mode to use: on Linux this can be 'iptables' (default) or 'ipvs'. On Windows the only supported value is 'kernelspace'."+
+		"This parameter is ignored if a config file is specified by --config.")
+
+	fs.Int32Var(o.config.IPTables.MasqueradeBit, "iptables-masquerade-bit", ptr.Deref(o.config.IPTables.MasqueradeBit, 14), "If using the iptables or ipvs proxy mode, the bit of the fwmark space to mark packets requiring SNAT with.  Must be within the range [0, 31].")
+	fs.BoolVar(&o.config.IPTables.MasqueradeAll, "masquerade-all", o.config.IPTables.MasqueradeAll, "If using the iptables or ipvs proxy mode, SNAT all traffic sent via Service cluster IPs. This may be required with some CNI plugins.")
+	fs.BoolVar(o.config.IPTables.LocalhostNodePorts, "iptables-localhost-nodeports", ptr.Deref(o.config.IPTables.LocalhostNodePorts, true), "If false, kube-proxy will disable the legacy behavior of allowing NodePort services to be accessed via localhost. (Applies only to iptables mode and IPv4; localhost NodePorts are never allowed with other proxy modes or with IPv6.)")
+	fs.DurationVar(&o.config.IPTables.SyncPeriod.Duration, "iptables-sync-period", o.config.IPTables.SyncPeriod.Duration, "An interval (e.g. '5s', '1m', '2h22m') indicating how frequently various re-synchronizing and cleanup operations are performed. Must be greater than 0.")
+	fs.DurationVar(&o.config.IPTables.MinSyncPeriod.Duration, "iptables-min-sync-period", o.config.IPTables.MinSyncPeriod.Duration, "The minimum period between iptables rule resyncs (e.g. '5s', '1m', '2h22m'). A value of 0 means every Service or EndpointSlice change will result in an immediate iptables resync.")
+
+	fs.DurationVar(&o.config.IPVS.SyncPeriod.Duration, "ipvs-sync-period", o.config.IPVS.SyncPeriod.Duration, "An interval (e.g. '5s', '1m', '2h22m') indicating how frequently various re-synchronizing and cleanup operations are performed. Must be greater than 0.")
+	fs.DurationVar(&o.config.IPVS.MinSyncPeriod.Duration, "ipvs-min-sync-period", o.config.IPVS.MinSyncPeriod.Duration, "The minimum period between IPVS rule resyncs (e.g. '5s', '1m', '2h22m'). A value of 0 means every Service or EndpointSlice change will result in an immediate IPVS resync.")
+	fs.StringVar(&o.config.IPVS.Scheduler, "ipvs-scheduler", o.config.IPVS.Scheduler, "The ipvs scheduler type when proxy mode is ipvs")
 	fs.StringSliceVar(&o.config.IPVS.ExcludeCIDRs, "ipvs-exclude-cidrs", o.config.IPVS.ExcludeCIDRs, "A comma-separated list of CIDRs which the ipvs proxier should not touch when cleaning up IPVS rules.")
+	fs.BoolVar(&o.config.IPVS.StrictARP, "ipvs-strict-arp", o.config.IPVS.StrictARP, "Enable strict ARP by setting arp_ignore to 1 and arp_announce to 2")
+	fs.DurationVar(&o.config.IPVS.TCPTimeout.Duration, "ipvs-tcp-timeout", o.config.IPVS.TCPTimeout.Duration, "The timeout for idle IPVS TCP connections, 0 to leave as-is. (e.g. '5s', '1m', '2h22m').")
+	fs.DurationVar(&o.config.IPVS.TCPFinTimeout.Duration, "ipvs-tcpfin-timeout", o.config.IPVS.TCPFinTimeout.Duration, "The timeout for IPVS TCP connections after receiving a FIN packet, 0 to leave as-is. (e.g. '5s', '1m', '2h22m').")
+	fs.DurationVar(&o.config.IPVS.UDPTimeout.Duration, "ipvs-udp-timeout", o.config.IPVS.UDPTimeout.Duration, "The timeout for IPVS UDP packets, 0 to leave as-is. (e.g. '5s', '1m', '2h22m').")
+
+	fs.Var(&o.config.DetectLocalMode, "detect-local-mode", "Mode to use to detect local traffic. This parameter is ignored if a config file is specified by --config.")
+	fs.StringVar(&o.config.DetectLocal.BridgeInterface, "pod-bridge-interface", o.config.DetectLocal.BridgeInterface, "A bridge interface name. When --detect-local-mode is set to BridgeInterface, kube-proxy will consider traffic to be local if it originates from this bridge.")
+	fs.StringVar(&o.config.DetectLocal.InterfaceNamePrefix, "pod-interface-name-prefix", o.config.DetectLocal.InterfaceNamePrefix, "An interface name prefix. When --detect-local-mode is set to InterfaceNamePrefix, kube-proxy will consider traffic to be local if it originates from any interface whose name begins with this prefix.")
+	fs.StringVar(&o.config.ClusterCIDR, "cluster-cidr", o.config.ClusterCIDR, "The CIDR range of the pods in the cluster. (For dual-stack clusters, this can be a comma-separated dual-stack pair of CIDR ranges.). When --detect-local-mode is set to ClusterCIDR, kube-proxy will consider traffic to be local if its source IP is in this range. (Otherwise it is not used.) "+
+		"This parameter is ignored if a config file is specified by --config.")
+
 	fs.StringSliceVar(&o.config.NodePortAddresses, "nodeport-addresses", o.config.NodePortAddresses,
 		"A list of CIDR ranges that contain valid node IPs. If set, connections to NodePort services will only be accepted on node IPs in one of the indicated ranges. If unset, NodePort connections will be accepted on all local IPs. This parameter is ignored if a config file is specified by --config.")
 
-	fs.BoolVar(&o.CleanupAndExit, "cleanup", o.CleanupAndExit, "If true cleanup iptables and ipvs rules and exit.")
-
-	fs.Var(&utilflag.IPVar{Val: &o.config.BindAddress}, "bind-address", "Overrides kube-proxy's idea of what its node's primary IP is. Note that the name is a historical artifact, and kube-proxy does not actually bind any sockets to this IP. This parameter is ignored if a config file is specified by --config.")
-	fs.Var(&utilflag.IPPortVar{Val: &o.config.HealthzBindAddress}, "healthz-bind-address", "The IP address and port for the health check server to serve on, defaulting to \"0.0.0.0:10256\" (if --bind-address is unset or IPv4), or \"[::]:10256\" (if --bind-address is IPv6). Set empty to disable. This parameter is ignored if a config file is specified by --config.")
-	fs.Var(&utilflag.IPPortVar{Val: &o.config.MetricsBindAddress}, "metrics-bind-address", "The IP address and port for the metrics server to serve on, defaulting to \"127.0.0.1:10249\" (if --bind-address is unset or IPv4), or \"[::1]:10249\" (if --bind-address is IPv6). (Set to \"0.0.0.0:10249\" / \"[::]:10249\" to bind on all interfaces.) Set empty to disable. This parameter is ignored if a config file is specified by --config.")
-	fs.BoolVar(&o.config.BindAddressHardFail, "bind-address-hard-fail", o.config.BindAddressHardFail, "If true kube-proxy will treat failure to bind to a port as fatal and exit")
-	fs.Var(utilflag.PortRangeVar{Val: &o.config.PortRange}, "proxy-port-range", "This was previously used to configure the userspace proxy, but is now unused.")
-	fs.Var(&o.config.Mode, "proxy-mode", "Which proxy mode to use: on Linux this can be 'iptables' (default) or 'ipvs'. On Windows the only supported value is 'kernelspace'."+
-		"This parameter is ignored if a config file is specified by --config.")
-	fs.Var(cliflag.NewMapStringBool(&o.config.FeatureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
-		"Options are:\n"+strings.Join(utilfeature.DefaultFeatureGate.KnownFeatures(), "\n")+"\n"+
-		"This parameter is ignored if a config file is specified by --config.")
-
-	fs.Int32Var(&o.healthzPort, "healthz-port", o.healthzPort, "The port to bind the health check server. Use 0 to disable.")
-	fs.MarkDeprecated("healthz-port", "This flag is deprecated and will be removed in a future release. Please use --healthz-bind-address instead.")
-	fs.Int32Var(&o.metricsPort, "metrics-port", o.metricsPort, "The port to bind the metrics server. Use 0 to disable.")
-	fs.MarkDeprecated("metrics-port", "This flag is deprecated and will be removed in a future release. Please use --metrics-bind-address instead.")
 	fs.Int32Var(o.config.OOMScoreAdj, "oom-score-adj", ptr.Deref(o.config.OOMScoreAdj, int32(qos.KubeProxyOOMScoreAdj)), "The oom-score-adj value for kube-proxy process. Values must be within the range [-1000, 1000]. This parameter is ignored if a config file is specified by --config.")
-	fs.Int32Var(o.config.IPTables.MasqueradeBit, "iptables-masquerade-bit", ptr.Deref(o.config.IPTables.MasqueradeBit, 14), "If using the iptables or ipvs proxy mode, the bit of the fwmark space to mark packets requiring SNAT with.  Must be within the range [0, 31].")
 	fs.Int32Var(o.config.Conntrack.MaxPerCore, "conntrack-max-per-core", *o.config.Conntrack.MaxPerCore,
 		"Maximum number of NAT connections to track per CPU core (0 to leave the limit as-is and ignore conntrack-min).")
 	fs.Int32Var(o.config.Conntrack.Min, "conntrack-min", *o.config.Conntrack.Min,
 		"Minimum number of conntrack entries to allocate, regardless of conntrack-max-per-core (set conntrack-max-per-core=0 to leave the limit as-is).")
-	fs.Int32Var(&o.config.ClientConnection.Burst, "kube-api-burst", o.config.ClientConnection.Burst, "Burst to use while talking with kubernetes apiserver")
 
-	fs.DurationVar(&o.config.IPTables.SyncPeriod.Duration, "iptables-sync-period", o.config.IPTables.SyncPeriod.Duration, "An interval (e.g. '5s', '1m', '2h22m') indicating how frequently various re-synchronizing and cleanup operations are performed. Must be greater than 0.")
-	fs.DurationVar(&o.config.IPTables.MinSyncPeriod.Duration, "iptables-min-sync-period", o.config.IPTables.MinSyncPeriod.Duration, "The minimum period between iptables rule resyncs (e.g. '5s', '1m', '2h22m'). A value of 0 means every Service or EndpointSlice change will result in an immediate iptables resync.")
-	fs.DurationVar(&o.config.IPVS.SyncPeriod.Duration, "ipvs-sync-period", o.config.IPVS.SyncPeriod.Duration, "An interval (e.g. '5s', '1m', '2h22m') indicating how frequently various re-synchronizing and cleanup operations are performed. Must be greater than 0.")
-	fs.DurationVar(&o.config.IPVS.MinSyncPeriod.Duration, "ipvs-min-sync-period", o.config.IPVS.MinSyncPeriod.Duration, "The minimum period between IPVS rule resyncs (e.g. '5s', '1m', '2h22m'). A value of 0 means every Service or EndpointSlice change will result in an immediate IPVS resync.")
-	fs.DurationVar(&o.config.IPVS.TCPTimeout.Duration, "ipvs-tcp-timeout", o.config.IPVS.TCPTimeout.Duration, "The timeout for idle IPVS TCP connections, 0 to leave as-is. (e.g. '5s', '1m', '2h22m').")
-	fs.DurationVar(&o.config.IPVS.TCPFinTimeout.Duration, "ipvs-tcpfin-timeout", o.config.IPVS.TCPFinTimeout.Duration, "The timeout for IPVS TCP connections after receiving a FIN packet, 0 to leave as-is. (e.g. '5s', '1m', '2h22m').")
-	fs.DurationVar(&o.config.IPVS.UDPTimeout.Duration, "ipvs-udp-timeout", o.config.IPVS.UDPTimeout.Duration, "The timeout for IPVS UDP packets, 0 to leave as-is. (e.g. '5s', '1m', '2h22m').")
 	fs.DurationVar(&o.config.Conntrack.TCPEstablishedTimeout.Duration, "conntrack-tcp-timeout-established", o.config.Conntrack.TCPEstablishedTimeout.Duration, "Idle timeout for established TCP connections (0 to leave as-is)")
 	fs.DurationVar(
 		&o.config.Conntrack.TCPCloseWaitTimeout.Duration, "conntrack-tcp-timeout-close-wait",
@@ -200,15 +209,13 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 		"NAT timeout for TCP connections in the CLOSE_WAIT state")
 	fs.DurationVar(&o.config.ConfigSyncPeriod.Duration, "config-sync-period", o.config.ConfigSyncPeriod.Duration, "How often configuration from the apiserver is refreshed.  Must be greater than 0.")
 
-	fs.BoolVar(&o.config.IPVS.StrictARP, "ipvs-strict-arp", o.config.IPVS.StrictARP, "Enable strict ARP by setting arp_ignore to 1 and arp_announce to 2")
-	fs.BoolVar(&o.config.IPTables.MasqueradeAll, "masquerade-all", o.config.IPTables.MasqueradeAll, "If using the iptables or ipvs proxy mode, SNAT all traffic sent via Service cluster IPs. This may be required with some CNI plugins.")
-	fs.BoolVar(o.config.IPTables.LocalhostNodePorts, "iptables-localhost-nodeports", ptr.Deref(o.config.IPTables.LocalhostNodePorts, true), "If false, kube-proxy will disable the legacy behavior of allowing NodePort services to be accessed via localhost. (Applies only to iptables mode and IPv4; localhost NodePorts are never allowed with other proxy modes or with IPv6.)")
-	fs.BoolVar(&o.config.EnableProfiling, "profiling", o.config.EnableProfiling, "If true enables profiling via web interface on /debug/pprof handler. This parameter is ignored if a config file is specified by --config.")
+	fs.Int32Var(&o.healthzPort, "healthz-port", o.healthzPort, "The port to bind the health check server. Use 0 to disable.")
+	_ = fs.MarkDeprecated("healthz-port", "This flag is deprecated and will be removed in a future release. Please use --healthz-bind-address instead.")
+	fs.Int32Var(&o.metricsPort, "metrics-port", o.metricsPort, "The port to bind the metrics server. Use 0 to disable.")
+	_ = fs.MarkDeprecated("metrics-port", "This flag is deprecated and will be removed in a future release. Please use --metrics-bind-address instead.")
+	fs.Var(utilflag.PortRangeVar{Val: &o.config.PortRange}, "proxy-port-range", "This was previously used to configure the userspace proxy, but is now unused.")
+	_ = fs.MarkDeprecated("proxy-port-range", "This flag has no effect and will be removed in a future release.")
 
-	fs.Float32Var(&o.config.ClientConnection.QPS, "kube-api-qps", o.config.ClientConnection.QPS, "QPS to use while talking with kubernetes apiserver")
-	fs.Var(&o.config.DetectLocalMode, "detect-local-mode", "Mode to use to detect local traffic. This parameter is ignored if a config file is specified by --config.")
-	fs.StringVar(&o.config.DetectLocal.BridgeInterface, "pod-bridge-interface", o.config.DetectLocal.BridgeInterface, "A bridge interface name. When --detect-local-mode is set to BridgeInterface, kube-proxy will consider traffic to be local if it originates from this bridge.")
-	fs.StringVar(&o.config.DetectLocal.InterfaceNamePrefix, "pod-interface-name-prefix", o.config.DetectLocal.InterfaceNamePrefix, "An interface name prefix. When --detect-local-mode is set to InterfaceNamePrefix, kube-proxy will consider traffic to be local if it originates from any interface whose name begins with this prefix.")
 	logsapi.AddFlags(&o.config.Logging, fs)
 }
 

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -143,12 +143,11 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ConfigFile, "config", o.ConfigFile, "The path to the configuration file.")
 	fs.StringVar(&o.WriteConfigTo, "write-config-to", o.WriteConfigTo, "If set, write the default configuration values to this file and exit.")
 	fs.StringVar(&o.config.ClientConnection.Kubeconfig, "kubeconfig", o.config.ClientConnection.Kubeconfig, "Path to kubeconfig file with authorization information (the master location can be overridden by the master flag).")
-	fs.StringVar(&o.config.ClusterCIDR, "cluster-cidr", o.config.ClusterCIDR, "The CIDR range of pods in the cluster. When configured, traffic sent to a Service cluster IP from outside this range will be masqueraded and traffic sent from pods to an external LoadBalancer IP will be directed to the respective cluster IP instead. "+
-		"For dual-stack clusters, a comma-separated list is accepted with at least one CIDR per IP family (IPv4 and IPv6). "+
+	fs.StringVar(&o.config.ClusterCIDR, "cluster-cidr", o.config.ClusterCIDR, "The CIDR range of the pods in the cluster. (For dual-stack clusters, this can be a comma-separated dual-stack pair of CIDR ranges.). When --detect-local-mode is set to ClusterCIDR, kube-proxy will consider traffic to be local if its source IP is in this range. (Otherwise it is not used.) "+
 		"This parameter is ignored if a config file is specified by --config.")
 	fs.StringVar(&o.config.ClientConnection.ContentType, "kube-api-content-type", o.config.ClientConnection.ContentType, "Content type of requests sent to apiserver.")
 	fs.StringVar(&o.master, "master", o.master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
-	fs.StringVar(&o.hostnameOverride, "hostname-override", o.hostnameOverride, "If non-empty, will use this string as identification instead of the actual hostname.")
+	fs.StringVar(&o.hostnameOverride, "hostname-override", o.hostnameOverride, "If non-empty, will be used as the name of the Node that kube-proxy is running on. If unset, the node name is assumed to be the same as the node's hostname.")
 	fs.StringVar(&o.config.IPVS.Scheduler, "ipvs-scheduler", o.config.IPVS.Scheduler, "The ipvs scheduler type when proxy mode is ipvs")
 	fs.StringVar(&o.config.ShowHiddenMetricsForVersion, "show-hidden-metrics-for-version", o.config.ShowHiddenMetricsForVersion,
 		"The previous version for which you want to show hidden metrics. "+
@@ -158,17 +157,17 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 			"rather than being surprised when they are permanently removed in the release after that. "+
 			"This parameter is ignored if a config file is specified by --config.")
 
-	fs.StringSliceVar(&o.config.IPVS.ExcludeCIDRs, "ipvs-exclude-cidrs", o.config.IPVS.ExcludeCIDRs, "A comma-separated list of CIDR's which the ipvs proxier should not touch when cleaning up IPVS rules.")
+	fs.StringSliceVar(&o.config.IPVS.ExcludeCIDRs, "ipvs-exclude-cidrs", o.config.IPVS.ExcludeCIDRs, "A comma-separated list of CIDRs which the ipvs proxier should not touch when cleaning up IPVS rules.")
 	fs.StringSliceVar(&o.config.NodePortAddresses, "nodeport-addresses", o.config.NodePortAddresses,
-		"A string slice of values which specify the addresses to use for NodePorts. Values may be valid IP blocks (e.g. 1.2.3.0/24, 1.2.3.4/32). The default empty string slice ([]) means to use all local addresses. This parameter is ignored if a config file is specified by --config.")
+		"A list of CIDR ranges that contain valid node IPs. If set, connections to NodePort services will only be accepted on node IPs in one of the indicated ranges. If unset, NodePort connections will be accepted on all local IPs. This parameter is ignored if a config file is specified by --config.")
 
 	fs.BoolVar(&o.CleanupAndExit, "cleanup", o.CleanupAndExit, "If true cleanup iptables and ipvs rules and exit.")
 
-	fs.Var(&utilflag.IPVar{Val: &o.config.BindAddress}, "bind-address", "The IP address for the proxy server to serve on (set to '0.0.0.0' for all IPv4 interfaces and '::' for all IPv6 interfaces). This parameter is ignored if a config file is specified by --config.")
-	fs.Var(&utilflag.IPPortVar{Val: &o.config.HealthzBindAddress}, "healthz-bind-address", "The IP address with port for the health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable. This parameter is ignored if a config file is specified by --config.")
-	fs.Var(&utilflag.IPPortVar{Val: &o.config.MetricsBindAddress}, "metrics-bind-address", "The IP address with port for the metrics server to serve on (set to '0.0.0.0:10249' for all IPv4 interfaces and '[::]:10249' for all IPv6 interfaces). Set empty to disable. This parameter is ignored if a config file is specified by --config.")
+	fs.Var(&utilflag.IPVar{Val: &o.config.BindAddress}, "bind-address", "Overrides kube-proxy's idea of what its node's primary IP is. Note that the name is a historical artifact, and kube-proxy does not actually bind any sockets to this IP. This parameter is ignored if a config file is specified by --config.")
+	fs.Var(&utilflag.IPPortVar{Val: &o.config.HealthzBindAddress}, "healthz-bind-address", "The IP address and port for the health check server to serve on, defaulting to \"0.0.0.0:10256\" (if --bind-address is unset or IPv4), or \"[::]:10256\" (if --bind-address is IPv6). Set empty to disable. This parameter is ignored if a config file is specified by --config.")
+	fs.Var(&utilflag.IPPortVar{Val: &o.config.MetricsBindAddress}, "metrics-bind-address", "The IP address and port for the metrics server to serve on, defaulting to \"127.0.0.1:10249\" (if --bind-address is unset or IPv4), or \"[::1]:10249\" (if --bind-address is IPv6). (Set to \"0.0.0.0:10249\" / \"[::]:10249\" to bind on all interfaces.) Set empty to disable. This parameter is ignored if a config file is specified by --config.")
 	fs.BoolVar(&o.config.BindAddressHardFail, "bind-address-hard-fail", o.config.BindAddressHardFail, "If true kube-proxy will treat failure to bind to a port as fatal and exit")
-	fs.Var(utilflag.PortRangeVar{Val: &o.config.PortRange}, "proxy-port-range", "Range of host ports (beginPort-endPort, single port or beginPort+offset, inclusive) that may be consumed in order to proxy service traffic. If (unspecified, 0, or 0-0) then ports will be randomly chosen.")
+	fs.Var(utilflag.PortRangeVar{Val: &o.config.PortRange}, "proxy-port-range", "This was previously used to configure the userspace proxy, but is now unused.")
 	fs.Var(&o.config.Mode, "proxy-mode", "Which proxy mode to use: on Linux this can be 'iptables' (default) or 'ipvs'. On Windows the only supported value is 'kernelspace'."+
 		"This parameter is ignored if a config file is specified by --config.")
 	fs.Var(cliflag.NewMapStringBool(&o.config.FeatureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
@@ -180,17 +179,17 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.Int32Var(&o.metricsPort, "metrics-port", o.metricsPort, "The port to bind the metrics server. Use 0 to disable.")
 	fs.MarkDeprecated("metrics-port", "This flag is deprecated and will be removed in a future release. Please use --metrics-bind-address instead.")
 	fs.Int32Var(o.config.OOMScoreAdj, "oom-score-adj", ptr.Deref(o.config.OOMScoreAdj, int32(qos.KubeProxyOOMScoreAdj)), "The oom-score-adj value for kube-proxy process. Values must be within the range [-1000, 1000]. This parameter is ignored if a config file is specified by --config.")
-	fs.Int32Var(o.config.IPTables.MasqueradeBit, "iptables-masquerade-bit", ptr.Deref(o.config.IPTables.MasqueradeBit, 14), "If using the pure iptables proxy, the bit of the fwmark space to mark packets requiring SNAT with.  Must be within the range [0, 31].")
+	fs.Int32Var(o.config.IPTables.MasqueradeBit, "iptables-masquerade-bit", ptr.Deref(o.config.IPTables.MasqueradeBit, 14), "If using the iptables or ipvs proxy mode, the bit of the fwmark space to mark packets requiring SNAT with.  Must be within the range [0, 31].")
 	fs.Int32Var(o.config.Conntrack.MaxPerCore, "conntrack-max-per-core", *o.config.Conntrack.MaxPerCore,
 		"Maximum number of NAT connections to track per CPU core (0 to leave the limit as-is and ignore conntrack-min).")
 	fs.Int32Var(o.config.Conntrack.Min, "conntrack-min", *o.config.Conntrack.Min,
 		"Minimum number of conntrack entries to allocate, regardless of conntrack-max-per-core (set conntrack-max-per-core=0 to leave the limit as-is).")
 	fs.Int32Var(&o.config.ClientConnection.Burst, "kube-api-burst", o.config.ClientConnection.Burst, "Burst to use while talking with kubernetes apiserver")
 
-	fs.DurationVar(&o.config.IPTables.SyncPeriod.Duration, "iptables-sync-period", o.config.IPTables.SyncPeriod.Duration, "The maximum interval of how often iptables rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.")
-	fs.DurationVar(&o.config.IPTables.MinSyncPeriod.Duration, "iptables-min-sync-period", o.config.IPTables.MinSyncPeriod.Duration, "The minimum interval of how often the iptables rules can be refreshed as endpoints and services change (e.g. '5s', '1m', '2h22m').")
-	fs.DurationVar(&o.config.IPVS.SyncPeriod.Duration, "ipvs-sync-period", o.config.IPVS.SyncPeriod.Duration, "The maximum interval of how often ipvs rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.")
-	fs.DurationVar(&o.config.IPVS.MinSyncPeriod.Duration, "ipvs-min-sync-period", o.config.IPVS.MinSyncPeriod.Duration, "The minimum interval of how often the ipvs rules can be refreshed as endpoints and services change (e.g. '5s', '1m', '2h22m').")
+	fs.DurationVar(&o.config.IPTables.SyncPeriod.Duration, "iptables-sync-period", o.config.IPTables.SyncPeriod.Duration, "An interval (e.g. '5s', '1m', '2h22m') indicating how frequently various re-synchronizing and cleanup operations are performed. Must be greater than 0.")
+	fs.DurationVar(&o.config.IPTables.MinSyncPeriod.Duration, "iptables-min-sync-period", o.config.IPTables.MinSyncPeriod.Duration, "The minimum period between iptables rule resyncs (e.g. '5s', '1m', '2h22m'). A value of 0 means every Service or EndpointSlice change will result in an immediate iptables resync.")
+	fs.DurationVar(&o.config.IPVS.SyncPeriod.Duration, "ipvs-sync-period", o.config.IPVS.SyncPeriod.Duration, "An interval (e.g. '5s', '1m', '2h22m') indicating how frequently various re-synchronizing and cleanup operations are performed. Must be greater than 0.")
+	fs.DurationVar(&o.config.IPVS.MinSyncPeriod.Duration, "ipvs-min-sync-period", o.config.IPVS.MinSyncPeriod.Duration, "The minimum period between IPVS rule resyncs (e.g. '5s', '1m', '2h22m'). A value of 0 means every Service or EndpointSlice change will result in an immediate IPVS resync.")
 	fs.DurationVar(&o.config.IPVS.TCPTimeout.Duration, "ipvs-tcp-timeout", o.config.IPVS.TCPTimeout.Duration, "The timeout for idle IPVS TCP connections, 0 to leave as-is. (e.g. '5s', '1m', '2h22m').")
 	fs.DurationVar(&o.config.IPVS.TCPFinTimeout.Duration, "ipvs-tcpfin-timeout", o.config.IPVS.TCPFinTimeout.Duration, "The timeout for IPVS TCP connections after receiving a FIN packet, 0 to leave as-is. (e.g. '5s', '1m', '2h22m').")
 	fs.DurationVar(&o.config.IPVS.UDPTimeout.Duration, "ipvs-udp-timeout", o.config.IPVS.UDPTimeout.Duration, "The timeout for IPVS UDP packets, 0 to leave as-is. (e.g. '5s', '1m', '2h22m').")
@@ -202,14 +201,14 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.config.ConfigSyncPeriod.Duration, "config-sync-period", o.config.ConfigSyncPeriod.Duration, "How often configuration from the apiserver is refreshed.  Must be greater than 0.")
 
 	fs.BoolVar(&o.config.IPVS.StrictARP, "ipvs-strict-arp", o.config.IPVS.StrictARP, "Enable strict ARP by setting arp_ignore to 1 and arp_announce to 2")
-	fs.BoolVar(&o.config.IPTables.MasqueradeAll, "masquerade-all", o.config.IPTables.MasqueradeAll, "If using the pure iptables proxy, SNAT all traffic sent via Service cluster IPs (this not commonly needed)")
-	fs.BoolVar(o.config.IPTables.LocalhostNodePorts, "iptables-localhost-nodeports", ptr.Deref(o.config.IPTables.LocalhostNodePorts, true), "If false Kube-proxy will disable the legacy behavior of allowing NodePort services to be accessed via localhost, This only applies to iptables mode and ipv4.")
+	fs.BoolVar(&o.config.IPTables.MasqueradeAll, "masquerade-all", o.config.IPTables.MasqueradeAll, "If using the iptables or ipvs proxy mode, SNAT all traffic sent via Service cluster IPs. This may be required with some CNI plugins.")
+	fs.BoolVar(o.config.IPTables.LocalhostNodePorts, "iptables-localhost-nodeports", ptr.Deref(o.config.IPTables.LocalhostNodePorts, true), "If false, kube-proxy will disable the legacy behavior of allowing NodePort services to be accessed via localhost. (Applies only to iptables mode and IPv4; localhost NodePorts are never allowed with other proxy modes or with IPv6.)")
 	fs.BoolVar(&o.config.EnableProfiling, "profiling", o.config.EnableProfiling, "If true enables profiling via web interface on /debug/pprof handler. This parameter is ignored if a config file is specified by --config.")
 
 	fs.Float32Var(&o.config.ClientConnection.QPS, "kube-api-qps", o.config.ClientConnection.QPS, "QPS to use while talking with kubernetes apiserver")
 	fs.Var(&o.config.DetectLocalMode, "detect-local-mode", "Mode to use to detect local traffic. This parameter is ignored if a config file is specified by --config.")
-	fs.StringVar(&o.config.DetectLocal.BridgeInterface, "pod-bridge-interface", o.config.DetectLocal.BridgeInterface, "A bridge interface name in the cluster. Kube-proxy considers traffic as local if originating from an interface which matches the value. This argument should be set if DetectLocalMode is set to BridgeInterface.")
-	fs.StringVar(&o.config.DetectLocal.InterfaceNamePrefix, "pod-interface-name-prefix", o.config.DetectLocal.InterfaceNamePrefix, "An interface prefix in the cluster. Kube-proxy considers traffic as local if originating from interfaces that match the given prefix. This argument should be set if DetectLocalMode is set to InterfaceNamePrefix.")
+	fs.StringVar(&o.config.DetectLocal.BridgeInterface, "pod-bridge-interface", o.config.DetectLocal.BridgeInterface, "A bridge interface name. When --detect-local-mode is set to BridgeInterface, kube-proxy will consider traffic to be local if it originates from this bridge.")
+	fs.StringVar(&o.config.DetectLocal.InterfaceNamePrefix, "pod-interface-name-prefix", o.config.DetectLocal.InterfaceNamePrefix, "An interface name prefix. When --detect-local-mode is set to InterfaceNamePrefix, kube-proxy will consider traffic to be local if it originates from any interface whose name begins with this prefix.")
 	logsapi.AddFlags(&o.config.Logging, fs)
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -53273,7 +53273,7 @@ func schema_k8sio_kube_proxy_config_v1alpha1_DetectLocalConfiguration(ref common
 				Properties: map[string]spec.Schema{
 					"bridgeInterface": {
 						SchemaProps: spec.SchemaProps{
-							Description: "BridgeInterface is a string argument which represents a single bridge interface name. Kube-proxy considers traffic as local if originating from this given bridge. This argument should be set if DetectLocalMode is set to LocalModeBridgeInterface.",
+							Description: "bridgeInterface is a bridge interface name. When DetectLocalMode is set to LocalModeBridgeInterface, kube-proxy will consider traffic to be local if it originates from this bridge.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -53281,7 +53281,7 @@ func schema_k8sio_kube_proxy_config_v1alpha1_DetectLocalConfiguration(ref common
 					},
 					"interfaceNamePrefix": {
 						SchemaProps: spec.SchemaProps{
-							Description: "InterfaceNamePrefix is a string argument which represents a single interface prefix name. Kube-proxy considers traffic as local if originating from one or more interfaces which match the given prefix. This argument should be set if DetectLocalMode is set to LocalModeInterfaceNamePrefix.",
+							Description: "interfaceNamePrefix is an interface name prefix. When DetectLocalMode is set to LocalModeInterfaceNamePrefix, kube-proxy will consider traffic to be local if it originates from any interface whose name begins with this prefix.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -53331,9 +53331,31 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyConfiguration(ref common.R
 							},
 						},
 					},
+					"clientConnection": {
+						SchemaProps: spec.SchemaProps{
+							Description: "clientConnection specifies the kubeconfig file and client connection settings for the proxy server to use when communicating with the apiserver.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/component-base/config/v1alpha1.ClientConnectionConfiguration"),
+						},
+					},
+					"logging": {
+						SchemaProps: spec.SchemaProps{
+							Description: "logging specifies the options of logging. Refer to [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/component-base/logs/api/v1.LoggingConfiguration"),
+						},
+					},
+					"hostnameOverride": {
+						SchemaProps: spec.SchemaProps{
+							Description: "hostnameOverride, if non-empty, will be used as the name of the Node that kube-proxy is running on. If unset, the node name is assumed to be the same as the node's hostname.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"bindAddress": {
 						SchemaProps: spec.SchemaProps{
-							Description: "bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0 for all interfaces)",
+							Description: "bindAddress can be used to override kube-proxy's idea of what its node's primary IP is. Note that the name is a historical artifact, and kube-proxy does not actually bind any sockets to this IP.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -53341,7 +53363,7 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyConfiguration(ref common.R
 					},
 					"healthzBindAddress": {
 						SchemaProps: spec.SchemaProps{
-							Description: "healthzBindAddress is the IP address and port for the health check server to serve on, defaulting to 0.0.0.0:10256",
+							Description: "healthzBindAddress is the IP address and port for the health check server to serve on, defaulting to \"0.0.0.0:10256\" (if bindAddress is unset or IPv4), or \"[::]:10256\" (if bindAddress is IPv6).",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -53349,7 +53371,7 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyConfiguration(ref common.R
 					},
 					"metricsBindAddress": {
 						SchemaProps: spec.SchemaProps{
-							Description: "metricsBindAddress is the IP address and port for the metrics server to serve on, defaulting to 127.0.0.1:10249 (set to 0.0.0.0 for all interfaces)",
+							Description: "metricsBindAddress is the IP address and port for the metrics server to serve on, defaulting to \"127.0.0.1:10249\" (if bindAddress is unset or IPv4), or \"[::1]:10249\" (if bindAddress is IPv6). (Set to \"0.0.0.0:10249\" / \"[::]:10249\" to bind on all interfaces.)",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -53357,7 +53379,7 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyConfiguration(ref common.R
 					},
 					"bindAddressHardFail": {
 						SchemaProps: spec.SchemaProps{
-							Description: "bindAddressHardFail, if true, kube-proxy will treat failure to bind to a port as fatal and exit",
+							Description: "bindAddressHardFail, if true, tells kube-proxy to treat failure to bind to a port as fatal and exit",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
@@ -53371,27 +53393,20 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyConfiguration(ref common.R
 							Format:      "",
 						},
 					},
-					"clusterCIDR": {
+					"showHiddenMetricsForVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "clusterCIDR is the CIDR range of the pods in the cluster. It is used to bridge traffic coming from outside of the cluster. If not provided, no off-cluster bridging will be performed.",
+							Description: "showHiddenMetricsForVersion is the version for which you want to show hidden metrics.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
-					"hostnameOverride": {
+					"mode": {
 						SchemaProps: spec.SchemaProps{
-							Description: "hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.",
+							Description: "mode specifies which proxy mode to use.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
-						},
-					},
-					"clientConnection": {
-						SchemaProps: spec.SchemaProps{
-							Description: "clientConnection specifies the kubeconfig file and client connection settings for the proxy server to use when communicating with the apiserver.",
-							Default:     map[string]interface{}{},
-							Ref:         ref("k8s.io/component-base/config/v1alpha1.ClientConnectionConfiguration"),
 						},
 					},
 					"iptables": {
@@ -53408,27 +53423,56 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyConfiguration(ref common.R
 							Ref:         ref("k8s.io/kube-proxy/config/v1alpha1.KubeProxyIPVSConfiguration"),
 						},
 					},
+					"winkernel": {
+						SchemaProps: spec.SchemaProps{
+							Description: "winkernel contains winkernel-related configuration options.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/kube-proxy/config/v1alpha1.KubeProxyWinkernelConfiguration"),
+						},
+					},
+					"detectLocalMode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "detectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"detectLocal": {
+						SchemaProps: spec.SchemaProps{
+							Description: "detectLocal contains optional configuration settings related to DetectLocalMode.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/kube-proxy/config/v1alpha1.DetectLocalConfiguration"),
+						},
+					},
+					"clusterCIDR": {
+						SchemaProps: spec.SchemaProps{
+							Description: "clusterCIDR is the CIDR range of the pods in the cluster. (For dual-stack clusters, this can be a comma-separated dual-stack pair of CIDR ranges.). When DetectLocalMode is set to LocalModeClusterCIDR, kube-proxy will consider traffic to be local if its source IP is in this range. (Otherwise it is not used.)",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"nodePortAddresses": {
+						SchemaProps: spec.SchemaProps{
+							Description: "nodePortAddresses is a list of CIDR ranges that contain valid node IPs. If set, connections to NodePort services will only be accepted on node IPs in one of the indicated ranges. If unset, NodePort connections will be accepted on all local IPs.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 					"oomScoreAdj": {
 						SchemaProps: spec.SchemaProps{
 							Description: "oomScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within the range [-1000, 1000]",
 							Type:        []string{"integer"},
 							Format:      "int32",
-						},
-					},
-					"mode": {
-						SchemaProps: spec.SchemaProps{
-							Description: "mode specifies which proxy mode to use.",
-							Default:     "",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"portRange": {
-						SchemaProps: spec.SchemaProps{
-							Description: "portRange is the range of host ports (beginPort-endPort, inclusive) that may be consumed in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.",
-							Default:     "",
-							Type:        []string{"string"},
-							Format:      "",
 						},
 					},
 					"conntrack": {
@@ -53445,60 +53489,16 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyConfiguration(ref common.R
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
-					"nodePortAddresses": {
+					"portRange": {
 						SchemaProps: spec.SchemaProps{
-							Description: "nodePortAddresses is the --nodeport-addresses value for kube-proxy process. Values must be valid IP blocks. These values are as a parameter to select the interfaces where nodeport works. In case someone would like to expose a service on localhost for local visit and some other interfaces for particular purpose, a list of IP blocks would do that. If set it to \"127.0.0.0/8\", kube-proxy will only select the loopback interface for NodePort. If set it to a non-zero IP block, kube-proxy will filter that down to just the IPs that applied to the node. An empty string slice is meant to select all network interfaces.",
-							Type:        []string{"array"},
-							Items: &spec.SchemaOrArray{
-								Schema: &spec.Schema{
-									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
-									},
-								},
-							},
-						},
-					},
-					"winkernel": {
-						SchemaProps: spec.SchemaProps{
-							Description: "winkernel contains winkernel-related configuration options.",
-							Default:     map[string]interface{}{},
-							Ref:         ref("k8s.io/kube-proxy/config/v1alpha1.KubeProxyWinkernelConfiguration"),
-						},
-					},
-					"showHiddenMetricsForVersion": {
-						SchemaProps: spec.SchemaProps{
-							Description: "ShowHiddenMetricsForVersion is the version for which you want to show hidden metrics.",
+							Description: "portRange was previously used to configure the userspace proxy, but is now unused.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
-						},
-					},
-					"detectLocalMode": {
-						SchemaProps: spec.SchemaProps{
-							Description: "DetectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR",
-							Default:     "",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"detectLocal": {
-						SchemaProps: spec.SchemaProps{
-							Description: "DetectLocal contains optional configuration settings related to DetectLocalMode.",
-							Default:     map[string]interface{}{},
-							Ref:         ref("k8s.io/kube-proxy/config/v1alpha1.DetectLocalConfiguration"),
-						},
-					},
-					"logging": {
-						SchemaProps: spec.SchemaProps{
-							Description: "logging specifies the options of logging. Refer to [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.",
-							Default:     map[string]interface{}{},
-							Ref:         ref("k8s.io/component-base/logs/api/v1.LoggingConfiguration"),
 						},
 					},
 				},
-				Required: []string{"bindAddress", "healthzBindAddress", "metricsBindAddress", "bindAddressHardFail", "enableProfiling", "clusterCIDR", "hostnameOverride", "clientConnection", "iptables", "ipvs", "oomScoreAdj", "mode", "portRange", "conntrack", "configSyncPeriod", "nodePortAddresses", "winkernel", "showHiddenMetricsForVersion", "detectLocalMode", "detectLocal"},
+				Required: []string{"clientConnection", "hostnameOverride", "bindAddress", "healthzBindAddress", "metricsBindAddress", "bindAddressHardFail", "enableProfiling", "showHiddenMetricsForVersion", "mode", "iptables", "ipvs", "winkernel", "detectLocalMode", "detectLocal", "clusterCIDR", "nodePortAddresses", "oomScoreAdj", "conntrack", "configSyncPeriod", "portRange"},
 			},
 		},
 		Dependencies: []string{
@@ -53522,7 +53522,7 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyConntrackConfiguration(ref
 					},
 					"min": {
 						SchemaProps: spec.SchemaProps{
-							Description: "min is the minimum value of connect-tracking records to allocate, regardless of conntrackMaxPerCore (set maxPerCore=0 to leave the limit as-is).",
+							Description: "min is the minimum value of connect-tracking records to allocate, regardless of maxPerCore (set maxPerCore=0 to leave the limit as-is).",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -53557,14 +53557,14 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyIPTablesConfiguration(ref 
 				Properties: map[string]spec.Schema{
 					"masqueradeBit": {
 						SchemaProps: spec.SchemaProps{
-							Description: "masqueradeBit is the bit of the iptables fwmark space to use for SNAT if using the pure iptables proxy mode. Values must be within the range [0, 31].",
+							Description: "masqueradeBit is the bit of the iptables fwmark space to use for SNAT if using the iptables or ipvs proxy mode. Values must be within the range [0, 31].",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
 					},
 					"masqueradeAll": {
 						SchemaProps: spec.SchemaProps{
-							Description: "masqueradeAll tells kube-proxy to SNAT everything if using the pure iptables proxy mode.",
+							Description: "masqueradeAll tells kube-proxy to SNAT all traffic sent to Service cluster IPs, when using the iptables or ipvs proxy mode. This may be required with some CNI plugins.",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
@@ -53572,21 +53572,21 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyIPTablesConfiguration(ref 
 					},
 					"localhostNodePorts": {
 						SchemaProps: spec.SchemaProps{
-							Description: "LocalhostNodePorts tells kube-proxy to allow service NodePorts to be accessed via localhost (iptables mode only)",
+							Description: "localhostNodePorts, if false, tells kube-proxy to disable the legacy behavior of allowing NodePort services to be accessed via localhost. (Applies only to iptables mode and IPv4; localhost NodePorts are never allowed with other proxy modes or with IPv6.)",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 					"syncPeriod": {
 						SchemaProps: spec.SchemaProps{
-							Description: "syncPeriod is the period that iptables rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.",
+							Description: "syncPeriod is an interval (e.g. '5s', '1m', '2h22m') indicating how frequently various re-synchronizing and cleanup operations are performed. Must be greater than 0.",
 							Default:     0,
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
 					"minSyncPeriod": {
 						SchemaProps: spec.SchemaProps{
-							Description: "minSyncPeriod is the minimum period that iptables rules are refreshed (e.g. '5s', '1m', '2h22m').",
+							Description: "minSyncPeriod is the minimum period between iptables rule resyncs (e.g. '5s', '1m', '2h22m'). A value of 0 means every Service or EndpointSlice change will result in an immediate iptables resync.",
 							Default:     0,
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
@@ -53609,21 +53609,21 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyIPVSConfiguration(ref comm
 				Properties: map[string]spec.Schema{
 					"syncPeriod": {
 						SchemaProps: spec.SchemaProps{
-							Description: "syncPeriod is the period that ipvs rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.",
+							Description: "syncPeriod is an interval (e.g. '5s', '1m', '2h22m') indicating how frequently various re-synchronizing and cleanup operations are performed. Must be greater than 0.",
 							Default:     0,
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
 					"minSyncPeriod": {
 						SchemaProps: spec.SchemaProps{
-							Description: "minSyncPeriod is the minimum period that ipvs rules are refreshed (e.g. '5s', '1m', '2h22m').",
+							Description: "minSyncPeriod is the minimum period between IPVS rule resyncs (e.g. '5s', '1m', '2h22m'). A value of 0 means every Service or EndpointSlice change will result in an immediate IPVS resync.",
 							Default:     0,
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
 					"scheduler": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ipvs scheduler",
+							Description: "scheduler is the IPVS scheduler to use",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -53631,7 +53631,7 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyIPVSConfiguration(ref comm
 					},
 					"excludeCIDRs": {
 						SchemaProps: spec.SchemaProps{
-							Description: "excludeCIDRs is a list of CIDR's which the ipvs proxier should not touch when cleaning up ipvs services.",
+							Description: "excludeCIDRs is a list of CIDRs which the ipvs proxier should not touch when cleaning up ipvs services.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -53646,7 +53646,7 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyIPVSConfiguration(ref comm
 					},
 					"strictARP": {
 						SchemaProps: spec.SchemaProps{
-							Description: "strict ARP configure arp_ignore and arp_announce to avoid answering ARP queries from kube-ipvs0 interface",
+							Description: "strictARP configures arp_ignore and arp_announce to avoid answering ARP queries from kube-ipvs0 interface",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
@@ -53699,7 +53699,7 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyWinkernelConfiguration(ref
 					},
 					"sourceVip": {
 						SchemaProps: spec.SchemaProps{
-							Description: "sourceVip is the IP address of the source VIP endoint used for NAT when loadbalancing",
+							Description: "sourceVip is the IP address of the source VIP endpoint used for NAT when loadbalancing",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -53715,7 +53715,7 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyWinkernelConfiguration(ref
 					},
 					"rootHnsEndpointName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RootHnsEndpointName is the name of hnsendpoint that is attached to l2bridge for root network namespace",
+							Description: "rootHnsEndpointName is the name of hnsendpoint that is attached to l2bridge for root network namespace",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -53723,7 +53723,7 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyWinkernelConfiguration(ref
 					},
 					"forwardHealthCheckVip": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ForwardHealthCheckVip forwards service VIP for health check port on Windows",
+							Description: "forwardHealthCheckVip forwards service VIP for health check port on Windows",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -30,36 +30,44 @@ import (
 // details for the Kubernetes proxy server.
 type KubeProxyIPTablesConfiguration struct {
 	// masqueradeBit is the bit of the iptables fwmark space to use for SNAT if using
-	// the pure iptables proxy mode. Values must be within the range [0, 31].
+	// the iptables or ipvs proxy mode. Values must be within the range [0, 31].
 	MasqueradeBit *int32
-	// masqueradeAll tells kube-proxy to SNAT everything if using the pure iptables proxy mode.
+	// masqueradeAll tells kube-proxy to SNAT all traffic sent to Service cluster IPs,
+	// when using the iptables or ipvs proxy mode. This may be required with some CNI
+	// plugins.
 	MasqueradeAll bool
-	// LocalhostNodePorts tells kube-proxy to allow service NodePorts to be accessed via
-	// localhost (iptables mode only)
+	// localhostNodePorts, if false, tells kube-proxy to disable the legacy behavior
+	// of allowing NodePort services to be accessed via localhost. (Applies only to
+	// iptables mode and IPv4; localhost NodePorts are never allowed with other proxy
+	// modes or with IPv6.)
 	LocalhostNodePorts *bool
-	// syncPeriod is the period that iptables rules are refreshed (e.g. '5s', '1m',
-	// '2h22m').  Must be greater than 0.
+	// syncPeriod is an interval (e.g. '5s', '1m', '2h22m') indicating how frequently
+	// various re-synchronizing and cleanup operations are performed. Must be greater
+	// than 0.
 	SyncPeriod metav1.Duration
-	// minSyncPeriod is the minimum period that iptables rules are refreshed (e.g. '5s', '1m',
-	// '2h22m').
+	// minSyncPeriod is the minimum period between iptables rule resyncs (e.g. '5s',
+	// '1m', '2h22m'). A value of 0 means every Service or EndpointSlice change will
+	// result in an immediate iptables resync.
 	MinSyncPeriod metav1.Duration
 }
 
 // KubeProxyIPVSConfiguration contains ipvs-related configuration
 // details for the Kubernetes proxy server.
 type KubeProxyIPVSConfiguration struct {
-	// syncPeriod is the period that ipvs rules are refreshed (e.g. '5s', '1m',
-	// '2h22m').  Must be greater than 0.
+	// syncPeriod is an interval (e.g. '5s', '1m', '2h22m') indicating how frequently
+	// various re-synchronizing and cleanup operations are performed. Must be greater
+	// than 0.
 	SyncPeriod metav1.Duration
-	// minSyncPeriod is the minimum period that ipvs rules are refreshed (e.g. '5s', '1m',
-	// '2h22m').
+	// minSyncPeriod is the minimum period between IPVS rule resyncs (e.g. '5s', '1m',
+	// '2h22m'). A value of 0 means every Service or EndpointSlice change will result
+	// in an immediate IPVS resync.
 	MinSyncPeriod metav1.Duration
-	// ipvs scheduler
+	// scheduler is the IPVS scheduler to use
 	Scheduler string
-	// excludeCIDRs is a list of CIDR's which the ipvs proxier should not touch
+	// excludeCIDRs is a list of CIDRs which the ipvs proxier should not touch
 	// when cleaning up ipvs services.
 	ExcludeCIDRs []string
-	// strict ARP configure arp_ignore and arp_announce to avoid answering ARP queries
+	// strictARP configures arp_ignore and arp_announce to avoid answering ARP queries
 	// from kube-ipvs0 interface
 	StrictARP bool
 	// tcpTimeout is the timeout value used for idle IPVS TCP sessions.
@@ -103,23 +111,23 @@ type KubeProxyWinkernelConfiguration struct {
 	// enableDSR tells kube-proxy whether HNS policies should be created
 	// with DSR
 	EnableDSR bool
-	// RootHnsEndpointName is the name of hnsendpoint that is attached to
+	// rootHnsEndpointName is the name of hnsendpoint that is attached to
 	// l2bridge for root network namespace
 	RootHnsEndpointName string
-	// ForwardHealthCheckVip forwards service VIP for health check port on
+	// forwardHealthCheckVip forwards service VIP for health check port on
 	// Windows
 	ForwardHealthCheckVip bool
 }
 
 // DetectLocalConfiguration contains optional settings related to DetectLocalMode option
 type DetectLocalConfiguration struct {
-	// BridgeInterface is a string argument which represents a single bridge interface name.
-	// Kube-proxy considers traffic as local if originating from this given bridge.
-	// This argument should be set if DetectLocalMode is set to BridgeInterface.
+	// bridgeInterface is a bridge interface name. When DetectLocalMode is set to
+	// LocalModeBridgeInterface, kube-proxy will consider traffic to be local if
+	// it originates from this bridge.
 	BridgeInterface string
-	// InterfaceNamePrefix is a string argument which represents a single interface prefix name.
-	// Kube-proxy considers traffic as local if originating from one or more interfaces which match
-	// the given prefix. This argument should be set if DetectLocalMode is set to InterfaceNamePrefix.
+	// interfaceNamePrefix is an interface name prefix. When DetectLocalMode is set to
+	// LocalModeInterfaceNamePrefix, kube-proxy will consider traffic to be local if
+	// it originates from any interface whose name begins with this prefix.
 	InterfaceNamePrefix string
 }
 
@@ -133,25 +141,34 @@ type KubeProxyConfiguration struct {
 	// featureGates is a map of feature names to bools that enable or disable alpha/experimental features.
 	FeatureGates map[string]bool
 
-	// bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0
-	// for all interfaces)
+	// bindAddress can be used to override kube-proxy's idea of what its node's
+	// primary IP is. Note that the name is a historical artifact, and kube-proxy does
+	// not actually bind any sockets to this IP.
 	BindAddress string
-	// healthzBindAddress is the IP address and port for the health check server to serve on,
-	// defaulting to 0.0.0.0:10256
+	// healthzBindAddress is the IP address and port for the health check server to
+	// serve on, defaulting to "0.0.0.0:10256" (if bindAddress is unset or IPv4), or
+	// "[::]:10256" (if bindAddress is IPv6).
 	HealthzBindAddress string
-	// metricsBindAddress is the IP address and port for the metrics server to serve on,
-	// defaulting to 127.0.0.1:10249 (set to 0.0.0.0 for all interfaces)
+	// metricsBindAddress is the IP address and port for the metrics server to serve
+	// on, defaulting to "127.0.0.1:10249" (if bindAddress is unset or IPv4), or
+	// "[::1]:10249" (if bindAddress is IPv6). (Set to "0.0.0.0:10249" / "[::]:10249"
+	// to bind on all interfaces.)
 	MetricsBindAddress string
-	// BindAddressHardFail, if true, kube-proxy will treat failure to bind to a port as fatal and exit
+	// bindAddressHardFail, if true, tells kube-proxy to treat failure to bind to a
+	// port as fatal and exit
 	BindAddressHardFail bool
 	// enableProfiling enables profiling via web interface on /debug/pprof handler.
 	// Profiling handlers will be handled by metrics server.
 	EnableProfiling bool
-	// clusterCIDR is the CIDR range of the pods in the cluster. It is used to
-	// bridge traffic coming from outside of the cluster. If not provided,
-	// no off-cluster bridging will be performed.
+	// clusterCIDR is the CIDR range of the pods in the cluster. (For dual-stack
+	// clusters, this can be a comma-separated dual-stack pair of CIDR ranges.). When
+	// DetectLocalMode is set to LocalModeClusterCIDR, kube-proxy will consider
+	// traffic to be local if its source IP is in this range. (Otherwise it is not
+	// used.)
 	ClusterCIDR string
-	// hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
+	// hostnameOverride, if non-empty, will be used as the name of the Node that
+	// kube-proxy is running on. If unset, the node name is assumed to be the same as
+	// the node's hostname.
 	HostnameOverride string
 	// clientConnection specifies the kubeconfig file and client connection settings for the proxy
 	// server to use when communicating with the apiserver.
@@ -165,32 +182,30 @@ type KubeProxyConfiguration struct {
 	OOMScoreAdj *int32
 	// mode specifies which proxy mode to use.
 	Mode ProxyMode
-	// portRange is the range of host ports (beginPort-endPort, inclusive) that may be consumed
-	// in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.
+	// portRange was previously used to configure the userspace proxy, but is now unused.
 	PortRange string
 	// conntrack contains conntrack-related configuration options.
 	Conntrack KubeProxyConntrackConfiguration
 	// configSyncPeriod is how often configuration from the apiserver is refreshed. Must be greater
 	// than 0.
 	ConfigSyncPeriod metav1.Duration
-	// nodePortAddresses is the --nodeport-addresses value for kube-proxy process. Values must be valid
-	// IP blocks. These values are as a parameter to select the interfaces where nodeport works.
-	// In case someone would like to expose a service on localhost for local visit and some other interfaces for
-	// particular purpose, a list of IP blocks would do that.
-	// If set it to "127.0.0.0/8", kube-proxy will only select the loopback interface for NodePort.
-	// If set it to a non-zero IP block, kube-proxy will filter that down to just the IPs that applied to the node.
-	// An empty string slice is meant to select all network interfaces.
+	// nodePortAddresses is a list of CIDR ranges that contain valid node IPs. If set,
+	// connections to NodePort services will only be accepted on node IPs in one of
+	// the indicated ranges. If unset, NodePort connections will be accepted on all
+	// local IPs.
 	NodePortAddresses []string
 	// winkernel contains winkernel-related configuration options.
 	Winkernel KubeProxyWinkernelConfiguration
-	// ShowHiddenMetricsForVersion is the version for which you want to show hidden metrics.
+	// showHiddenMetricsForVersion is the version for which you want to show hidden metrics.
 	ShowHiddenMetricsForVersion string
-	// DetectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR
+
+	// detectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR
 	DetectLocalMode LocalMode
-	// DetectLocal contains optional configuration settings related to DetectLocalMode.
+	// detectLocal contains optional configuration settings related to DetectLocalMode.
 	DetectLocal DetectLocalConfiguration
-	// Logging specifies the options of logging.
-	// Refer to [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go) for more information.
+	// logging specifies the options of logging.
+	// Refer to [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go)
+	// for more information.
 	Logging logsapi.LoggingConfiguration
 }
 

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -141,6 +141,18 @@ type KubeProxyConfiguration struct {
 	// featureGates is a map of feature names to bools that enable or disable alpha/experimental features.
 	FeatureGates map[string]bool
 
+	// clientConnection specifies the kubeconfig file and client connection settings for the proxy
+	// server to use when communicating with the apiserver.
+	ClientConnection componentbaseconfig.ClientConnectionConfiguration
+	// logging specifies the options of logging.
+	// Refer to [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go)
+	// for more information.
+	Logging logsapi.LoggingConfiguration
+
+	// hostnameOverride, if non-empty, will be used as the name of the Node that
+	// kube-proxy is running on. If unset, the node name is assumed to be the same as
+	// the node's hostname.
+	HostnameOverride string
 	// bindAddress can be used to override kube-proxy's idea of what its node's
 	// primary IP is. Note that the name is a historical artifact, and kube-proxy does
 	// not actually bind any sockets to this IP.
@@ -160,53 +172,46 @@ type KubeProxyConfiguration struct {
 	// enableProfiling enables profiling via web interface on /debug/pprof handler.
 	// Profiling handlers will be handled by metrics server.
 	EnableProfiling bool
+	// showHiddenMetricsForVersion is the version for which you want to show hidden metrics.
+	ShowHiddenMetricsForVersion string
+
+	// mode specifies which proxy mode to use.
+	Mode ProxyMode
+	// iptables contains iptables-related configuration options.
+	IPTables KubeProxyIPTablesConfiguration
+	// ipvs contains ipvs-related configuration options.
+	IPVS KubeProxyIPVSConfiguration
+	// winkernel contains winkernel-related configuration options.
+	Winkernel KubeProxyWinkernelConfiguration
+
+	// detectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR
+	DetectLocalMode LocalMode
+	// detectLocal contains optional configuration settings related to DetectLocalMode.
+	DetectLocal DetectLocalConfiguration
 	// clusterCIDR is the CIDR range of the pods in the cluster. (For dual-stack
 	// clusters, this can be a comma-separated dual-stack pair of CIDR ranges.). When
 	// DetectLocalMode is set to LocalModeClusterCIDR, kube-proxy will consider
 	// traffic to be local if its source IP is in this range. (Otherwise it is not
 	// used.)
 	ClusterCIDR string
-	// hostnameOverride, if non-empty, will be used as the name of the Node that
-	// kube-proxy is running on. If unset, the node name is assumed to be the same as
-	// the node's hostname.
-	HostnameOverride string
-	// clientConnection specifies the kubeconfig file and client connection settings for the proxy
-	// server to use when communicating with the apiserver.
-	ClientConnection componentbaseconfig.ClientConnectionConfiguration
-	// iptables contains iptables-related configuration options.
-	IPTables KubeProxyIPTablesConfiguration
-	// ipvs contains ipvs-related configuration options.
-	IPVS KubeProxyIPVSConfiguration
-	// oomScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within
-	// the range [-1000, 1000]
-	OOMScoreAdj *int32
-	// mode specifies which proxy mode to use.
-	Mode ProxyMode
-	// portRange was previously used to configure the userspace proxy, but is now unused.
-	PortRange string
-	// conntrack contains conntrack-related configuration options.
-	Conntrack KubeProxyConntrackConfiguration
-	// configSyncPeriod is how often configuration from the apiserver is refreshed. Must be greater
-	// than 0.
-	ConfigSyncPeriod metav1.Duration
+
 	// nodePortAddresses is a list of CIDR ranges that contain valid node IPs. If set,
 	// connections to NodePort services will only be accepted on node IPs in one of
 	// the indicated ranges. If unset, NodePort connections will be accepted on all
 	// local IPs.
 	NodePortAddresses []string
-	// winkernel contains winkernel-related configuration options.
-	Winkernel KubeProxyWinkernelConfiguration
-	// showHiddenMetricsForVersion is the version for which you want to show hidden metrics.
-	ShowHiddenMetricsForVersion string
 
-	// detectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR
-	DetectLocalMode LocalMode
-	// detectLocal contains optional configuration settings related to DetectLocalMode.
-	DetectLocal DetectLocalConfiguration
-	// logging specifies the options of logging.
-	// Refer to [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go)
-	// for more information.
-	Logging logsapi.LoggingConfiguration
+	// oomScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within
+	// the range [-1000, 1000]
+	OOMScoreAdj *int32
+	// conntrack contains conntrack-related configuration options.
+	Conntrack KubeProxyConntrackConfiguration
+	// configSyncPeriod is how often configuration from the apiserver is refreshed. Must be greater
+	// than 0.
+	ConfigSyncPeriod metav1.Duration
+
+	// portRange was previously used to configure the userspace proxy, but is now unused.
+	PortRange string
 }
 
 // ProxyMode represents modes used by the Kubernetes proxy server.

--- a/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
@@ -126,39 +126,39 @@ func Convert_config_DetectLocalConfiguration_To_v1alpha1_DetectLocalConfiguratio
 
 func autoConvert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguration(in *v1alpha1.KubeProxyConfiguration, out *config.KubeProxyConfiguration, s conversion.Scope) error {
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
+	if err := configv1alpha1.Convert_v1alpha1_ClientConnectionConfiguration_To_config_ClientConnectionConfiguration(&in.ClientConnection, &out.ClientConnection, s); err != nil {
+		return err
+	}
+	out.Logging = in.Logging
+	out.HostnameOverride = in.HostnameOverride
 	out.BindAddress = in.BindAddress
 	out.HealthzBindAddress = in.HealthzBindAddress
 	out.MetricsBindAddress = in.MetricsBindAddress
 	out.BindAddressHardFail = in.BindAddressHardFail
 	out.EnableProfiling = in.EnableProfiling
-	out.ClusterCIDR = in.ClusterCIDR
-	out.HostnameOverride = in.HostnameOverride
-	if err := configv1alpha1.Convert_v1alpha1_ClientConnectionConfiguration_To_config_ClientConnectionConfiguration(&in.ClientConnection, &out.ClientConnection, s); err != nil {
-		return err
-	}
+	out.ShowHiddenMetricsForVersion = in.ShowHiddenMetricsForVersion
+	out.Mode = config.ProxyMode(in.Mode)
 	if err := Convert_v1alpha1_KubeProxyIPTablesConfiguration_To_config_KubeProxyIPTablesConfiguration(&in.IPTables, &out.IPTables, s); err != nil {
 		return err
 	}
 	if err := Convert_v1alpha1_KubeProxyIPVSConfiguration_To_config_KubeProxyIPVSConfiguration(&in.IPVS, &out.IPVS, s); err != nil {
 		return err
 	}
-	out.OOMScoreAdj = (*int32)(unsafe.Pointer(in.OOMScoreAdj))
-	out.Mode = config.ProxyMode(in.Mode)
-	out.PortRange = in.PortRange
-	if err := Convert_v1alpha1_KubeProxyConntrackConfiguration_To_config_KubeProxyConntrackConfiguration(&in.Conntrack, &out.Conntrack, s); err != nil {
-		return err
-	}
-	out.ConfigSyncPeriod = in.ConfigSyncPeriod
-	out.NodePortAddresses = *(*[]string)(unsafe.Pointer(&in.NodePortAddresses))
 	if err := Convert_v1alpha1_KubeProxyWinkernelConfiguration_To_config_KubeProxyWinkernelConfiguration(&in.Winkernel, &out.Winkernel, s); err != nil {
 		return err
 	}
-	out.ShowHiddenMetricsForVersion = in.ShowHiddenMetricsForVersion
 	out.DetectLocalMode = config.LocalMode(in.DetectLocalMode)
 	if err := Convert_v1alpha1_DetectLocalConfiguration_To_config_DetectLocalConfiguration(&in.DetectLocal, &out.DetectLocal, s); err != nil {
 		return err
 	}
-	out.Logging = in.Logging
+	out.ClusterCIDR = in.ClusterCIDR
+	out.NodePortAddresses = *(*[]string)(unsafe.Pointer(&in.NodePortAddresses))
+	out.OOMScoreAdj = (*int32)(unsafe.Pointer(in.OOMScoreAdj))
+	if err := Convert_v1alpha1_KubeProxyConntrackConfiguration_To_config_KubeProxyConntrackConfiguration(&in.Conntrack, &out.Conntrack, s); err != nil {
+		return err
+	}
+	out.ConfigSyncPeriod = in.ConfigSyncPeriod
+	out.PortRange = in.PortRange
 	return nil
 }
 
@@ -169,39 +169,39 @@ func Convert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguration(in
 
 func autoConvert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration(in *config.KubeProxyConfiguration, out *v1alpha1.KubeProxyConfiguration, s conversion.Scope) error {
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
+	if err := configv1alpha1.Convert_config_ClientConnectionConfiguration_To_v1alpha1_ClientConnectionConfiguration(&in.ClientConnection, &out.ClientConnection, s); err != nil {
+		return err
+	}
+	out.Logging = in.Logging
+	out.HostnameOverride = in.HostnameOverride
 	out.BindAddress = in.BindAddress
 	out.HealthzBindAddress = in.HealthzBindAddress
 	out.MetricsBindAddress = in.MetricsBindAddress
 	out.BindAddressHardFail = in.BindAddressHardFail
 	out.EnableProfiling = in.EnableProfiling
-	out.ClusterCIDR = in.ClusterCIDR
-	out.HostnameOverride = in.HostnameOverride
-	if err := configv1alpha1.Convert_config_ClientConnectionConfiguration_To_v1alpha1_ClientConnectionConfiguration(&in.ClientConnection, &out.ClientConnection, s); err != nil {
-		return err
-	}
+	out.ShowHiddenMetricsForVersion = in.ShowHiddenMetricsForVersion
+	out.Mode = v1alpha1.ProxyMode(in.Mode)
 	if err := Convert_config_KubeProxyIPTablesConfiguration_To_v1alpha1_KubeProxyIPTablesConfiguration(&in.IPTables, &out.IPTables, s); err != nil {
 		return err
 	}
 	if err := Convert_config_KubeProxyIPVSConfiguration_To_v1alpha1_KubeProxyIPVSConfiguration(&in.IPVS, &out.IPVS, s); err != nil {
 		return err
 	}
-	out.OOMScoreAdj = (*int32)(unsafe.Pointer(in.OOMScoreAdj))
-	out.Mode = v1alpha1.ProxyMode(in.Mode)
-	out.PortRange = in.PortRange
-	if err := Convert_config_KubeProxyConntrackConfiguration_To_v1alpha1_KubeProxyConntrackConfiguration(&in.Conntrack, &out.Conntrack, s); err != nil {
-		return err
-	}
-	out.ConfigSyncPeriod = in.ConfigSyncPeriod
-	out.NodePortAddresses = *(*[]string)(unsafe.Pointer(&in.NodePortAddresses))
 	if err := Convert_config_KubeProxyWinkernelConfiguration_To_v1alpha1_KubeProxyWinkernelConfiguration(&in.Winkernel, &out.Winkernel, s); err != nil {
 		return err
 	}
-	out.ShowHiddenMetricsForVersion = in.ShowHiddenMetricsForVersion
 	out.DetectLocalMode = v1alpha1.LocalMode(in.DetectLocalMode)
 	if err := Convert_config_DetectLocalConfiguration_To_v1alpha1_DetectLocalConfiguration(&in.DetectLocal, &out.DetectLocal, s); err != nil {
 		return err
 	}
-	out.Logging = in.Logging
+	out.ClusterCIDR = in.ClusterCIDR
+	out.NodePortAddresses = *(*[]string)(unsafe.Pointer(&in.NodePortAddresses))
+	out.OOMScoreAdj = (*int32)(unsafe.Pointer(in.OOMScoreAdj))
+	if err := Convert_config_KubeProxyConntrackConfiguration_To_v1alpha1_KubeProxyConntrackConfiguration(&in.Conntrack, &out.Conntrack, s); err != nil {
+		return err
+	}
+	out.ConfigSyncPeriod = in.ConfigSyncPeriod
+	out.PortRange = in.PortRange
 	return nil
 }
 

--- a/pkg/proxy/apis/config/zz_generated.deepcopy.go
+++ b/pkg/proxy/apis/config/zz_generated.deepcopy.go
@@ -76,8 +76,16 @@ func (in *KubeProxyConfiguration) DeepCopyInto(out *KubeProxyConfiguration) {
 		}
 	}
 	out.ClientConnection = in.ClientConnection
+	in.Logging.DeepCopyInto(&out.Logging)
 	in.IPTables.DeepCopyInto(&out.IPTables)
 	in.IPVS.DeepCopyInto(&out.IPVS)
+	out.Winkernel = in.Winkernel
+	out.DetectLocal = in.DetectLocal
+	if in.NodePortAddresses != nil {
+		in, out := &in.NodePortAddresses, &out.NodePortAddresses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.OOMScoreAdj != nil {
 		in, out := &in.OOMScoreAdj, &out.OOMScoreAdj
 		*out = new(int32)
@@ -85,14 +93,6 @@ func (in *KubeProxyConfiguration) DeepCopyInto(out *KubeProxyConfiguration) {
 	}
 	in.Conntrack.DeepCopyInto(&out.Conntrack)
 	out.ConfigSyncPeriod = in.ConfigSyncPeriod
-	if in.NodePortAddresses != nil {
-		in, out := &in.NodePortAddresses, &out.NodePortAddresses
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
-	out.Winkernel = in.Winkernel
-	out.DetectLocal = in.DetectLocal
-	in.Logging.DeepCopyInto(&out.Logging)
 	return
 }
 

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
@@ -137,6 +137,18 @@ type KubeProxyConfiguration struct {
 	// featureGates is a map of feature names to bools that enable or disable alpha/experimental features.
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 
+	// clientConnection specifies the kubeconfig file and client connection settings for the proxy
+	// server to use when communicating with the apiserver.
+	ClientConnection componentbaseconfigv1alpha1.ClientConnectionConfiguration `json:"clientConnection"`
+	// logging specifies the options of logging.
+	// Refer to [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go)
+	// for more information.
+	Logging logsapi.LoggingConfiguration `json:"logging,omitempty"`
+
+	// hostnameOverride, if non-empty, will be used as the name of the Node that
+	// kube-proxy is running on. If unset, the node name is assumed to be the same as
+	// the node's hostname.
+	HostnameOverride string `json:"hostnameOverride"`
 	// bindAddress can be used to override kube-proxy's idea of what its node's
 	// primary IP is. Note that the name is a historical artifact, and kube-proxy does
 	// not actually bind any sockets to this IP.
@@ -156,53 +168,46 @@ type KubeProxyConfiguration struct {
 	// enableProfiling enables profiling via web interface on /debug/pprof handler.
 	// Profiling handlers will be handled by metrics server.
 	EnableProfiling bool `json:"enableProfiling"`
+	// showHiddenMetricsForVersion is the version for which you want to show hidden metrics.
+	ShowHiddenMetricsForVersion string `json:"showHiddenMetricsForVersion"`
+
+	// mode specifies which proxy mode to use.
+	Mode ProxyMode `json:"mode"`
+	// iptables contains iptables-related configuration options.
+	IPTables KubeProxyIPTablesConfiguration `json:"iptables"`
+	// ipvs contains ipvs-related configuration options.
+	IPVS KubeProxyIPVSConfiguration `json:"ipvs"`
+	// winkernel contains winkernel-related configuration options.
+	Winkernel KubeProxyWinkernelConfiguration `json:"winkernel"`
+
+	// detectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR
+	DetectLocalMode LocalMode `json:"detectLocalMode"`
+	// detectLocal contains optional configuration settings related to DetectLocalMode.
+	DetectLocal DetectLocalConfiguration `json:"detectLocal"`
 	// clusterCIDR is the CIDR range of the pods in the cluster. (For dual-stack
 	// clusters, this can be a comma-separated dual-stack pair of CIDR ranges.). When
 	// DetectLocalMode is set to LocalModeClusterCIDR, kube-proxy will consider
 	// traffic to be local if its source IP is in this range. (Otherwise it is not
 	// used.)
 	ClusterCIDR string `json:"clusterCIDR"`
-	// hostnameOverride, if non-empty, will be used as the name of the Node that
-	// kube-proxy is running on. If unset, the node name is assumed to be the same as
-	// the node's hostname.
-	HostnameOverride string `json:"hostnameOverride"`
-	// clientConnection specifies the kubeconfig file and client connection settings for the proxy
-	// server to use when communicating with the apiserver.
-	ClientConnection componentbaseconfigv1alpha1.ClientConnectionConfiguration `json:"clientConnection"`
-	// iptables contains iptables-related configuration options.
-	IPTables KubeProxyIPTablesConfiguration `json:"iptables"`
-	// ipvs contains ipvs-related configuration options.
-	IPVS KubeProxyIPVSConfiguration `json:"ipvs"`
-	// oomScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within
-	// the range [-1000, 1000]
-	OOMScoreAdj *int32 `json:"oomScoreAdj"`
-	// mode specifies which proxy mode to use.
-	Mode ProxyMode `json:"mode"`
-	// portRange was previously used to configure the userspace proxy, but is now unused.
-	PortRange string `json:"portRange"`
-	// conntrack contains conntrack-related configuration options.
-	Conntrack KubeProxyConntrackConfiguration `json:"conntrack"`
-	// configSyncPeriod is how often configuration from the apiserver is refreshed. Must be greater
-	// than 0.
-	ConfigSyncPeriod metav1.Duration `json:"configSyncPeriod"`
+
 	// nodePortAddresses is a list of CIDR ranges that contain valid node IPs. If set,
 	// connections to NodePort services will only be accepted on node IPs in one of
 	// the indicated ranges. If unset, NodePort connections will be accepted on all
 	// local IPs.
 	NodePortAddresses []string `json:"nodePortAddresses"`
-	// winkernel contains winkernel-related configuration options.
-	Winkernel KubeProxyWinkernelConfiguration `json:"winkernel"`
-	// showHiddenMetricsForVersion is the version for which you want to show hidden metrics.
-	ShowHiddenMetricsForVersion string `json:"showHiddenMetricsForVersion"`
 
-	// detectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR
-	DetectLocalMode LocalMode `json:"detectLocalMode"`
-	// detectLocal contains optional configuration settings related to DetectLocalMode.
-	DetectLocal DetectLocalConfiguration `json:"detectLocal"`
-	// logging specifies the options of logging.
-	// Refer to [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go)
-	// for more information.
-	Logging logsapi.LoggingConfiguration `json:"logging,omitempty"`
+	// oomScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within
+	// the range [-1000, 1000]
+	OOMScoreAdj *int32 `json:"oomScoreAdj"`
+	// conntrack contains conntrack-related configuration options.
+	Conntrack KubeProxyConntrackConfiguration `json:"conntrack"`
+	// configSyncPeriod is how often configuration from the apiserver is refreshed. Must be greater
+	// than 0.
+	ConfigSyncPeriod metav1.Duration `json:"configSyncPeriod"`
+
+	// portRange was previously used to configure the userspace proxy, but is now unused.
+	PortRange string `json:"portRange"`
 }
 
 // ProxyMode represents modes used by the Kubernetes proxy server.

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
@@ -26,36 +26,44 @@ import (
 // details for the Kubernetes proxy server.
 type KubeProxyIPTablesConfiguration struct {
 	// masqueradeBit is the bit of the iptables fwmark space to use for SNAT if using
-	// the pure iptables proxy mode. Values must be within the range [0, 31].
+	// the iptables or ipvs proxy mode. Values must be within the range [0, 31].
 	MasqueradeBit *int32 `json:"masqueradeBit"`
-	// masqueradeAll tells kube-proxy to SNAT everything if using the pure iptables proxy mode.
+	// masqueradeAll tells kube-proxy to SNAT all traffic sent to Service cluster IPs,
+	// when using the iptables or ipvs proxy mode. This may be required with some CNI
+	// plugins.
 	MasqueradeAll bool `json:"masqueradeAll"`
-	// LocalhostNodePorts tells kube-proxy to allow service NodePorts to be accessed via
-	// localhost (iptables mode only)
+	// localhostNodePorts, if false, tells kube-proxy to disable the legacy behavior
+	// of allowing NodePort services to be accessed via localhost. (Applies only to
+	// iptables mode and IPv4; localhost NodePorts are never allowed with other proxy
+	// modes or with IPv6.)
 	LocalhostNodePorts *bool `json:"localhostNodePorts"`
-	// syncPeriod is the period that iptables rules are refreshed (e.g. '5s', '1m',
-	// '2h22m').  Must be greater than 0.
+	// syncPeriod is an interval (e.g. '5s', '1m', '2h22m') indicating how frequently
+	// various re-synchronizing and cleanup operations are performed. Must be greater
+	// than 0.
 	SyncPeriod metav1.Duration `json:"syncPeriod"`
-	// minSyncPeriod is the minimum period that iptables rules are refreshed (e.g. '5s', '1m',
-	// '2h22m').
+	// minSyncPeriod is the minimum period between iptables rule resyncs (e.g. '5s',
+	// '1m', '2h22m'). A value of 0 means every Service or EndpointSlice change will
+	// result in an immediate iptables resync.
 	MinSyncPeriod metav1.Duration `json:"minSyncPeriod"`
 }
 
 // KubeProxyIPVSConfiguration contains ipvs-related configuration
 // details for the Kubernetes proxy server.
 type KubeProxyIPVSConfiguration struct {
-	// syncPeriod is the period that ipvs rules are refreshed (e.g. '5s', '1m',
-	// '2h22m').  Must be greater than 0.
+	// syncPeriod is an interval (e.g. '5s', '1m', '2h22m') indicating how frequently
+	// various re-synchronizing and cleanup operations are performed. Must be greater
+	// than 0.
 	SyncPeriod metav1.Duration `json:"syncPeriod"`
-	// minSyncPeriod is the minimum period that ipvs rules are refreshed (e.g. '5s', '1m',
-	// '2h22m').
+	// minSyncPeriod is the minimum period between IPVS rule resyncs (e.g. '5s', '1m',
+	// '2h22m'). A value of 0 means every Service or EndpointSlice change will result
+	// in an immediate IPVS resync.
 	MinSyncPeriod metav1.Duration `json:"minSyncPeriod"`
-	// ipvs scheduler
+	// scheduler is the IPVS scheduler to use
 	Scheduler string `json:"scheduler"`
-	// excludeCIDRs is a list of CIDR's which the ipvs proxier should not touch
+	// excludeCIDRs is a list of CIDRs which the ipvs proxier should not touch
 	// when cleaning up ipvs services.
 	ExcludeCIDRs []string `json:"excludeCIDRs"`
-	// strict ARP configure arp_ignore and arp_announce to avoid answering ARP queries
+	// strictARP configures arp_ignore and arp_announce to avoid answering ARP queries
 	// from kube-ipvs0 interface
 	StrictARP bool `json:"strictARP"`
 	// tcpTimeout is the timeout value used for idle IPVS TCP sessions.
@@ -76,7 +84,7 @@ type KubeProxyConntrackConfiguration struct {
 	// per CPU core (0 to leave the limit as-is and ignore min).
 	MaxPerCore *int32 `json:"maxPerCore"`
 	// min is the minimum value of connect-tracking records to allocate,
-	// regardless of conntrackMaxPerCore (set maxPerCore=0 to leave the limit as-is).
+	// regardless of maxPerCore (set maxPerCore=0 to leave the limit as-is).
 	Min *int32 `json:"min"`
 	// tcpEstablishedTimeout is how long an idle TCP connection will be kept open
 	// (e.g. '2s').  Must be greater than 0 to set.
@@ -93,29 +101,29 @@ type KubeProxyWinkernelConfiguration struct {
 	// networkName is the name of the network kube-proxy will use
 	// to create endpoints and policies
 	NetworkName string `json:"networkName"`
-	// sourceVip is the IP address of the source VIP endoint used for
+	// sourceVip is the IP address of the source VIP endpoint used for
 	// NAT when loadbalancing
 	SourceVip string `json:"sourceVip"`
 	// enableDSR tells kube-proxy whether HNS policies should be created
 	// with DSR
 	EnableDSR bool `json:"enableDSR"`
-	// RootHnsEndpointName is the name of hnsendpoint that is attached to
+	// rootHnsEndpointName is the name of hnsendpoint that is attached to
 	// l2bridge for root network namespace
 	RootHnsEndpointName string `json:"rootHnsEndpointName"`
-	// ForwardHealthCheckVip forwards service VIP for health check port on
+	// forwardHealthCheckVip forwards service VIP for health check port on
 	// Windows
 	ForwardHealthCheckVip bool `json:"forwardHealthCheckVip"`
 }
 
 // DetectLocalConfiguration contains optional settings related to DetectLocalMode option
 type DetectLocalConfiguration struct {
-	// BridgeInterface is a string argument which represents a single bridge interface name.
-	// Kube-proxy considers traffic as local if originating from this given bridge.
-	// This argument should be set if DetectLocalMode is set to LocalModeBridgeInterface.
+	// bridgeInterface is a bridge interface name. When DetectLocalMode is set to
+	// LocalModeBridgeInterface, kube-proxy will consider traffic to be local if
+	// it originates from this bridge.
 	BridgeInterface string `json:"bridgeInterface"`
-	// InterfaceNamePrefix is a string argument which represents a single interface prefix name.
-	// Kube-proxy considers traffic as local if originating from one or more interfaces which match
-	// the given prefix. This argument should be set if DetectLocalMode is set to LocalModeInterfaceNamePrefix.
+	// interfaceNamePrefix is an interface name prefix. When DetectLocalMode is set to
+	// LocalModeInterfaceNamePrefix, kube-proxy will consider traffic to be local if
+	// it originates from any interface whose name begins with this prefix.
 	InterfaceNamePrefix string `json:"interfaceNamePrefix"`
 }
 
@@ -129,25 +137,34 @@ type KubeProxyConfiguration struct {
 	// featureGates is a map of feature names to bools that enable or disable alpha/experimental features.
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 
-	// bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0
-	// for all interfaces)
+	// bindAddress can be used to override kube-proxy's idea of what its node's
+	// primary IP is. Note that the name is a historical artifact, and kube-proxy does
+	// not actually bind any sockets to this IP.
 	BindAddress string `json:"bindAddress"`
-	// healthzBindAddress is the IP address and port for the health check server to serve on,
-	// defaulting to 0.0.0.0:10256
+	// healthzBindAddress is the IP address and port for the health check server to
+	// serve on, defaulting to "0.0.0.0:10256" (if bindAddress is unset or IPv4), or
+	// "[::]:10256" (if bindAddress is IPv6).
 	HealthzBindAddress string `json:"healthzBindAddress"`
-	// metricsBindAddress is the IP address and port for the metrics server to serve on,
-	// defaulting to 127.0.0.1:10249 (set to 0.0.0.0 for all interfaces)
+	// metricsBindAddress is the IP address and port for the metrics server to serve
+	// on, defaulting to "127.0.0.1:10249" (if bindAddress is unset or IPv4), or
+	// "[::1]:10249" (if bindAddress is IPv6). (Set to "0.0.0.0:10249" / "[::]:10249"
+	// to bind on all interfaces.)
 	MetricsBindAddress string `json:"metricsBindAddress"`
-	// bindAddressHardFail, if true, kube-proxy will treat failure to bind to a port as fatal and exit
+	// bindAddressHardFail, if true, tells kube-proxy to treat failure to bind to a
+	// port as fatal and exit
 	BindAddressHardFail bool `json:"bindAddressHardFail"`
 	// enableProfiling enables profiling via web interface on /debug/pprof handler.
 	// Profiling handlers will be handled by metrics server.
 	EnableProfiling bool `json:"enableProfiling"`
-	// clusterCIDR is the CIDR range of the pods in the cluster. It is used to
-	// bridge traffic coming from outside of the cluster. If not provided,
-	// no off-cluster bridging will be performed.
+	// clusterCIDR is the CIDR range of the pods in the cluster. (For dual-stack
+	// clusters, this can be a comma-separated dual-stack pair of CIDR ranges.). When
+	// DetectLocalMode is set to LocalModeClusterCIDR, kube-proxy will consider
+	// traffic to be local if its source IP is in this range. (Otherwise it is not
+	// used.)
 	ClusterCIDR string `json:"clusterCIDR"`
-	// hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
+	// hostnameOverride, if non-empty, will be used as the name of the Node that
+	// kube-proxy is running on. If unset, the node name is assumed to be the same as
+	// the node's hostname.
 	HostnameOverride string `json:"hostnameOverride"`
 	// clientConnection specifies the kubeconfig file and client connection settings for the proxy
 	// server to use when communicating with the apiserver.
@@ -161,29 +178,26 @@ type KubeProxyConfiguration struct {
 	OOMScoreAdj *int32 `json:"oomScoreAdj"`
 	// mode specifies which proxy mode to use.
 	Mode ProxyMode `json:"mode"`
-	// portRange is the range of host ports (beginPort-endPort, inclusive) that may be consumed
-	// in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.
+	// portRange was previously used to configure the userspace proxy, but is now unused.
 	PortRange string `json:"portRange"`
 	// conntrack contains conntrack-related configuration options.
 	Conntrack KubeProxyConntrackConfiguration `json:"conntrack"`
 	// configSyncPeriod is how often configuration from the apiserver is refreshed. Must be greater
 	// than 0.
 	ConfigSyncPeriod metav1.Duration `json:"configSyncPeriod"`
-	// nodePortAddresses is the --nodeport-addresses value for kube-proxy process. Values must be valid
-	// IP blocks. These values are as a parameter to select the interfaces where nodeport works.
-	// In case someone would like to expose a service on localhost for local visit and some other interfaces for
-	// particular purpose, a list of IP blocks would do that.
-	// If set it to "127.0.0.0/8", kube-proxy will only select the loopback interface for NodePort.
-	// If set it to a non-zero IP block, kube-proxy will filter that down to just the IPs that applied to the node.
-	// An empty string slice is meant to select all network interfaces.
+	// nodePortAddresses is a list of CIDR ranges that contain valid node IPs. If set,
+	// connections to NodePort services will only be accepted on node IPs in one of
+	// the indicated ranges. If unset, NodePort connections will be accepted on all
+	// local IPs.
 	NodePortAddresses []string `json:"nodePortAddresses"`
 	// winkernel contains winkernel-related configuration options.
 	Winkernel KubeProxyWinkernelConfiguration `json:"winkernel"`
-	// ShowHiddenMetricsForVersion is the version for which you want to show hidden metrics.
+	// showHiddenMetricsForVersion is the version for which you want to show hidden metrics.
 	ShowHiddenMetricsForVersion string `json:"showHiddenMetricsForVersion"`
-	// DetectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR
+
+	// detectLocalMode determines mode to use for detecting local traffic, defaults to LocalModeClusterCIDR
 	DetectLocalMode LocalMode `json:"detectLocalMode"`
-	// DetectLocal contains optional configuration settings related to DetectLocalMode.
+	// detectLocal contains optional configuration settings related to DetectLocalMode.
 	DetectLocal DetectLocalConfiguration `json:"detectLocal"`
 	// logging specifies the options of logging.
 	// Refer to [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/options.go)

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/zz_generated.deepcopy.go
@@ -54,8 +54,16 @@ func (in *KubeProxyConfiguration) DeepCopyInto(out *KubeProxyConfiguration) {
 		}
 	}
 	out.ClientConnection = in.ClientConnection
+	in.Logging.DeepCopyInto(&out.Logging)
 	in.IPTables.DeepCopyInto(&out.IPTables)
 	in.IPVS.DeepCopyInto(&out.IPVS)
+	out.Winkernel = in.Winkernel
+	out.DetectLocal = in.DetectLocal
+	if in.NodePortAddresses != nil {
+		in, out := &in.NodePortAddresses, &out.NodePortAddresses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.OOMScoreAdj != nil {
 		in, out := &in.OOMScoreAdj, &out.OOMScoreAdj
 		*out = new(int32)
@@ -63,14 +71,6 @@ func (in *KubeProxyConfiguration) DeepCopyInto(out *KubeProxyConfiguration) {
 	}
 	in.Conntrack.DeepCopyInto(&out.Conntrack)
 	out.ConfigSyncPeriod = in.ConfigSyncPeriod
-	if in.NodePortAddresses != nil {
-		in, out := &in.NodePortAddresses, &out.NodePortAddresses
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
-	out.Winkernel = in.Winkernel
-	out.DetectLocal = in.DetectLocal
-	in.Logging.DeepCopyInto(&out.Logging)
 	return
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind documentation

/sig network
/priority important-longterm

#### What this PR does / why we need it:
Fixes some problems with the kube-proxy config file / command-line option docs:
- Lots of things were out-of-date (eg, describing how `--bind-address` worked in the userspace proxy, how `--cluster-cidr` worked before we introduced `--detect-local-mode`, and how `--sync-period` worked like 5 optimizations ago)
- _Most_ of the API docs obeyed the convention of starting each struct field comment with the lowercasified field name, but some didn't.
- The v1alpha and internal docs were out of sync in various minor ways (eg, typos fixed in one, but not the other).
- The config file docs and CLI docs were out of sync in slightly larger ways. (Especially, the CLI docs had been updated for IPv6/dual-stack, but the config docs had not.)
- Some things were just confusing...

Note there are two commits; the first just rewords documentation without changing code and the second just rearranges things without changing the words. (Oh, and adds one `fs.MarkDeprecated`.)

There was discussion in #119525 about deprecating `--bind-address` in favor of something like `--node-ip-override`, but this doesn't do that. (It probably needs more discussion. In particular, the only thing `--bind-address` currently controls, on Linux, is what node IP we expect cloud load balancers to target, but it seems like that ought to be the same as "what node IPs we accept NodePort connections on", and thus ought to just be deprecated in favor of `--nodeport-addresses`...)

#### Which issue(s) this PR fixes:
Possibly #111840; it's not clear exactly what we want there.
The `--bind-address` doc fixes were inspired by #119525.

#### Does this PR introduce a user-facing change?
```release-note
The kube-proxy command-line documentation was updated to clarify that
`--bind-address` does not actually have anything to do with binding to an
address, and you probably don't actually want to be using it.
```
