### PR TITLE
Bump CloudDualStackNodeIPs to beta for 1.29

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -72,6 +72,7 @@ const (
 
 	// owner: @danwinship
 	// alpha: v1.27
+	// beta: v1.29
 	//
 	// Enables dual-stack --node-ip in kubelet with external cloud providers
 	CloudDualStackNodeIPs featuregate.Feature = "CloudDualStackNodeIPs"
@@ -970,7 +971,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	AppArmor: {Default: true, PreRelease: featuregate.Beta},
 
-	CloudDualStackNodeIPs: {Default: false, PreRelease: featuregate.Alpha},
+	CloudDualStackNodeIPs: {Default: true, PreRelease: featuregate.Beta},
 
 	ClusterTrustBundle: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -40,6 +40,7 @@ const (
 
 	// owner: @danwinship
 	// alpha: v1.27
+	// beta: v1.29
 	//
 	// Enables dual-stack values in the
 	// `alpha.kubernetes.io/provided-node-ip` annotation
@@ -62,6 +63,6 @@ func SetupCurrentKubernetesSpecificFeatureGates(featuregates featuregate.Mutable
 // To add a new feature, define a key for it at k8s.io/api/pkg/features and add it here.
 var cloudPublicFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	CloudControllerManagerWebhook: {Default: false, PreRelease: featuregate.Alpha},
-	CloudDualStackNodeIPs:         {Default: false, PreRelease: featuregate.Alpha},
+	CloudDualStackNodeIPs:         {Default: true, PreRelease: featuregate.Beta},
 	StableLoadBalancerNodeSet:     {Default: true, PreRelease: featuregate.Beta},
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig network
/priority important-soon

#### What this PR does / why we need it:
Updates KEP 3705 "Cloud Dual-Stack --node-ip Handling" to beta for 1.29.

#### Does this PR introduce a user-facing change?
```release-note
The CloudDualStackNodeIPs feature is now beta, meaning that when using
an external cloud provider that has been updated to support the feature,
you can pass comma-separated dual-stack `--node-ips` to kubelet and have
the cloud provider take both IPs into account.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3705
```
