### PR TITLE
use imageFsInfo for ImageStats rather than list image

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_image.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image.go
@@ -130,18 +130,15 @@ func (m *kubeGenericRuntimeManager) RemoveImage(ctx context.Context, image kubec
 }
 
 // ImageStats returns the statistics of the image.
-// Notice that current logic doesn't really work for images which share layers (e.g. docker image),
-// this is a known issue, and we'll address this by getting imagefs stats directly from CRI.
-// TODO: Get imagefs stats directly from CRI.
 func (m *kubeGenericRuntimeManager) ImageStats(ctx context.Context) (*kubecontainer.ImageStats, error) {
-	allImages, err := m.imageService.ListImages(ctx, nil)
+	imagefs, err := m.imageService.ImageFsInfo(ctx)
 	if err != nil {
-		klog.ErrorS(err, "Failed to list images")
+		klog.ErrorS(err, "Failed to get ImageFsInfo")
 		return nil, err
 	}
 	stats := &kubecontainer.ImageStats{}
-	for _, img := range allImages {
-		stats.TotalStorageBytes += img.Size_
+	for _, img := range imagefs {
+		stats.TotalStorageBytes += img.UsedBytes.Value
 	}
 	return stats, nil
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
@@ -225,7 +225,12 @@ func TestImageStats(t *testing.T) {
 	fakeImageService.SetFakeImageSize(imageSize)
 	images := []string{"1111", "2222", "3333"}
 	fakeImageService.SetFakeImages(images)
-
+	usage := runtimeapi.FilesystemUsage{
+		UsedBytes: &runtimeapi.UInt64Value{
+			Value: imageSize * uint64(len(images)),
+		},
+	}
+	fakeImageService.SetFakeFilesystemUsage([]*runtimeapi.FilesystemUsage{&usage})
 	actualStats, err := fakeManager.ImageStats(ctx)
 	assert.NoError(t, err)
 	expectedStats := &kubecontainer.ImageStats{TotalStorageBytes: imageSize * uint64(len(images))}
@@ -237,7 +242,7 @@ func TestImageStatsWithError(t *testing.T) {
 	_, fakeImageService, fakeManager, err := createTestRuntimeManager()
 	assert.NoError(t, err)
 
-	fakeImageService.InjectError("ListImages", fmt.Errorf("test-failure"))
+	fakeImageService.InjectError("ImageFsInfo", fmt.Errorf("test-failure"))
 
 	actualImageStats, err := fakeManager.ImageStats(ctx)
 	assert.Error(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Comment says we should use ImageFsInfo rather than ImageStats.  
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
