### PR TITLE
Implement semantic equality for metav1.LabelSelectorRequirement.

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -22,11 +22,9 @@ import (
 	"strconv"
 	"strings"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/kubernetes/pkg/apis/core"
@@ -91,27 +89,7 @@ func NonConvertibleFields(annotations map[string]string) map[string]string {
 
 // Semantic can do semantic deep equality checks for core objects.
 // Example: apiequality.Semantic.DeepEqual(aPod, aPodWithNonNilButEmptyMaps) == true
-var Semantic = conversion.EqualitiesOrDie(
-	func(a, b resource.Quantity) bool {
-		// Ignore formatting, only care that numeric value stayed the same.
-		// TODO: if we decide it's important, it should be safe to start comparing the format.
-		//
-		// Uninitialized quantities are equivalent to 0 quantities.
-		return a.Cmp(b) == 0
-	},
-	func(a, b metav1.MicroTime) bool {
-		return a.UTC() == b.UTC()
-	},
-	func(a, b metav1.Time) bool {
-		return a.UTC() == b.UTC()
-	},
-	func(a, b labels.Selector) bool {
-		return a.String() == b.String()
-	},
-	func(a, b fields.Selector) bool {
-		return a.String() == b.String()
-	},
-)
+var Semantic = apiequality.Semantic.Copy()
 
 var standardResourceQuotaScopes = sets.NewString(
 	string(core.ResourceQuotaScopeTerminating),

--- a/staging/src/k8s.io/apimachinery/pkg/api/equality/semantic_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/equality/semantic_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package equality_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSemanticDeepEqual(t *testing.T) {
+	for _, tc := range []struct {
+		a, b     interface{}
+		expected bool
+	}{
+		{
+			a: metav1.LabelSelectorRequirement{
+				Key:      "j",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"a"},
+			},
+			b: metav1.LabelSelectorRequirement{
+				Key:      "k",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"a"},
+			},
+			expected: false,
+		},
+		{
+			a: metav1.LabelSelectorRequirement{
+				Key:      "k",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"a", "b"},
+			},
+			b: metav1.LabelSelectorRequirement{
+				Key:      "k",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"b", "a"},
+			},
+			expected: true,
+		},
+		{
+			a: metav1.LabelSelectorRequirement{
+				Key:      "k",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"a"},
+			},
+			b: metav1.LabelSelectorRequirement{
+				Key:      "k",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"a", "a"},
+			},
+			expected: true,
+		},
+		{
+			a: metav1.LabelSelectorRequirement{
+				Key:      "k",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{"a"},
+			},
+			b: metav1.LabelSelectorRequirement{
+				Key:      "k",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{"a", "a"},
+			},
+			expected: true,
+		},
+		{
+			a: metav1.LabelSelectorRequirement{
+				Key:      "k",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"a"},
+			},
+			b: metav1.LabelSelectorRequirement{
+				Key:      "k",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{"a", "a"},
+			},
+			expected: false,
+		},
+		{
+			a: metav1.LabelSelectorRequirement{
+				Key:      "k",
+				Operator: metav1.LabelSelectorOpExists,
+				Values:   []string{"a"},
+			},
+			b: metav1.LabelSelectorRequirement{
+				Key:      "k",
+				Operator: metav1.LabelSelectorOpExists,
+				Values:   []string{"a", "a"},
+			},
+			expected: false,
+		},
+		{
+			a: metav1.LabelSelectorRequirement{
+				Key:      "k",
+				Operator: metav1.LabelSelectorOpDoesNotExist,
+				Values:   []string{"a"},
+			},
+			b: metav1.LabelSelectorRequirement{
+				Key:      "k",
+				Operator: metav1.LabelSelectorOpDoesNotExist,
+				Values:   []string{"a", "a"},
+			},
+			expected: false,
+		},
+	} {
+		if actual := equality.Semantic.DeepEqual(tc.a, tc.b); actual != tc.expected {
+			t.Errorf("Semantic.DeepEqual(%#v, %#v) did not return %t", tc.a, tc.b, tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
Set-based requirements with repeated or differently-ordered values should now be considered semantically equal.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Fixes a roundtrip test failure reported in https://github.com/kubernetes/kubernetes/issues/119716 that apparently occurs when fuzzing produces a set-based label selector requirement containing duplicate values. As far as I can tell, this sort of requirement is valid and has semantics identical to a requirement that has had its values deduplicated.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
