### PR TITLE
[WIP] Correct Time and MicroTime OpenAPI schema

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16535,9 +16535,20 @@
       "type": "object"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
-      "description": "MicroTime is version of Time with microsecond level precision.",
-      "format": "date-time",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "maxLength": 0,
+          "type": "string"
+        }
+      ],
+      "description": "MicroTime is version of Time with microsecond level precision."
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
       "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
@@ -16802,9 +16813,20 @@
       "type": "object"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
-      "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-      "format": "date-time",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "maxLength": 0,
+          "type": "string"
+        }
+      ],
+      "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers."
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
       "description": "Event represents a single event to a watched resource.",

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -8751,8 +8751,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "MicroTime is version of Time with microsecond level precision.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
@@ -9040,8 +9048,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1_openapi.json
@@ -1350,8 +1350,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1alpha1_openapi.json
@@ -1507,8 +1507,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1beta1_openapi.json
@@ -1509,8 +1509,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__apiextensions.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apiextensions.k8s.io__v1_openapi.json
@@ -1636,8 +1636,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__apiregistration.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apiregistration.k8s.io__v1_openapi.json
@@ -801,8 +801,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -5955,8 +5955,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__authentication.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__authentication.k8s.io__v1_openapi.json
@@ -495,8 +495,16 @@
         "x-kubernetes-map-type": "atomic"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       }
     },

--- a/api/openapi-spec/v3/apis__authentication.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__authentication.k8s.io__v1alpha1_openapi.json
@@ -395,8 +395,16 @@
         "x-kubernetes-map-type": "atomic"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       }
     },

--- a/api/openapi-spec/v3/apis__authentication.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__authentication.k8s.io__v1beta1_openapi.json
@@ -395,8 +395,16 @@
         "x-kubernetes-map-type": "atomic"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       }
     },

--- a/api/openapi-spec/v3/apis__authorization.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__authorization.k8s.io__v1_openapi.json
@@ -777,8 +777,16 @@
         "x-kubernetes-map-type": "atomic"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       }
     },

--- a/api/openapi-spec/v3/apis__autoscaling__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__autoscaling__v1_openapi.json
@@ -994,8 +994,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__autoscaling__v2_openapi.json
+++ b/api/openapi-spec/v3/apis__autoscaling__v2_openapi.json
@@ -1702,8 +1702,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -5146,8 +5146,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__certificates.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__certificates.k8s.io__v1_openapi.json
@@ -1032,8 +1032,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__certificates.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__certificates.k8s.io__v1alpha1_openapi.json
@@ -906,8 +906,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__coordination.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__coordination.k8s.io__v1_openapi.json
@@ -637,8 +637,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "MicroTime is version of Time with microsecond level precision.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
@@ -926,8 +934,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__discovery.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__discovery.k8s.io__v1_openapi.json
@@ -1084,8 +1084,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__events.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__events.k8s.io__v1_openapi.json
@@ -759,8 +759,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "MicroTime is version of Time with microsecond level precision.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
@@ -1048,8 +1056,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__flowcontrol.apiserver.k8s.io__v1beta2_openapi.json
+++ b/api/openapi-spec/v3/apis__flowcontrol.apiserver.k8s.io__v1beta2_openapi.json
@@ -1529,8 +1529,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__flowcontrol.apiserver.k8s.io__v1beta3_openapi.json
+++ b/api/openapi-spec/v3/apis__flowcontrol.apiserver.k8s.io__v1beta3_openapi.json
@@ -1533,8 +1533,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__internal.apiserver.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__internal.apiserver.k8s.io__v1alpha1_openapi.json
@@ -1020,8 +1020,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
@@ -1647,8 +1647,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__networking.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__networking.k8s.io__v1alpha1_openapi.json
@@ -1123,8 +1123,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__node.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__node.k8s.io__v1_openapi.json
@@ -984,8 +984,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__policy__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__policy__v1_openapi.json
@@ -1102,8 +1102,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__rbac.authorization.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__rbac.authorization.k8s.io__v1_openapi.json
@@ -1359,8 +1359,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha2_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha2_openapi.json
@@ -1538,8 +1538,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__scheduling.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__scheduling.k8s.io__v1_openapi.json
@@ -897,8 +897,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/api/openapi-spec/v3/apis__storage.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__storage.k8s.io__v1_openapi.json
@@ -2791,8 +2791,16 @@
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "anyOf": [
+          {
+            "format": "date-time"
+          },
+          {
+            "maxLength": 0
+          }
+        ],
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-        "format": "date-time",
+        "nullable": true,
         "type": "string"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -24,10 +24,10 @@ limitations under the License.
 package openapi
 
 import (
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 	common "k8s.io/kube-openapi/pkg/common"
 	spec "k8s.io/kube-openapi/pkg/validation/spec"
@@ -993,7 +993,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta":                                                         schema_pkg_apis_meta_v1_ListMeta(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.ListOptions":                                                      schema_pkg_apis_meta_v1_ListOptions(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.ManagedFieldsEntry":                                               schema_pkg_apis_meta_v1_ManagedFieldsEntry(ref),
-		"k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime":                                                        schema_pkg_apis_meta_v1_MicroTime(ref),
+		"k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime":                                                        v1.MicroTime{}.OpenAPIDefinition(),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta":                                                       schema_pkg_apis_meta_v1_ObjectMeta(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.OwnerReference":                                                   schema_pkg_apis_meta_v1_OwnerReference(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.PartialObjectMetadata":                                            schema_pkg_apis_meta_v1_PartialObjectMetadata(ref),
@@ -1011,7 +1011,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/apimachinery/pkg/apis/meta/v1.TableOptions":                                                     schema_pkg_apis_meta_v1_TableOptions(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.TableRow":                                                         schema_pkg_apis_meta_v1_TableRow(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.TableRowCondition":                                                schema_pkg_apis_meta_v1_TableRowCondition(ref),
-		"k8s.io/apimachinery/pkg/apis/meta/v1.Time":                                                             schema_pkg_apis_meta_v1_Time(ref),
+		"k8s.io/apimachinery/pkg/apis/meta/v1.Time":                                                             v1.Time{}.OpenAPIDefinition(),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.Timestamp":                                                        schema_pkg_apis_meta_v1_Timestamp(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta":                                                         schema_pkg_apis_meta_v1_TypeMeta(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.UpdateOptions":                                                    schema_pkg_apis_meta_v1_UpdateOptions(ref),
@@ -46468,8 +46468,8 @@ func schema_pkg_apis_apiextensions_v1_JSON(ref common.ReferenceCallback) common.
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
-				Type:        v1.JSON{}.OpenAPISchemaType(),
-				Format:      v1.JSON{}.OpenAPISchemaFormat(),
+				Type:        apiextensionsv1.JSON{}.OpenAPISchemaType(),
+				Format:      apiextensionsv1.JSON{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -46854,8 +46854,8 @@ func schema_pkg_apis_apiextensions_v1_JSONSchemaPropsOrArray(ref common.Referenc
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "JSONSchemaPropsOrArray represents a value that can either be a JSONSchemaProps or an array of JSONSchemaProps. Mainly here for serialization purposes.",
-				Type:        v1.JSONSchemaPropsOrArray{}.OpenAPISchemaType(),
-				Format:      v1.JSONSchemaPropsOrArray{}.OpenAPISchemaFormat(),
+				Type:        apiextensionsv1.JSONSchemaPropsOrArray{}.OpenAPISchemaType(),
+				Format:      apiextensionsv1.JSONSchemaPropsOrArray{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -46866,8 +46866,8 @@ func schema_pkg_apis_apiextensions_v1_JSONSchemaPropsOrBool(ref common.Reference
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "JSONSchemaPropsOrBool represents JSONSchemaProps or a boolean value. Defaults to true for the boolean property.",
-				Type:        v1.JSONSchemaPropsOrBool{}.OpenAPISchemaType(),
-				Format:      v1.JSONSchemaPropsOrBool{}.OpenAPISchemaFormat(),
+				Type:        apiextensionsv1.JSONSchemaPropsOrBool{}.OpenAPISchemaType(),
+				Format:      apiextensionsv1.JSONSchemaPropsOrBool{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -46878,8 +46878,8 @@ func schema_pkg_apis_apiextensions_v1_JSONSchemaPropsOrStringArray(ref common.Re
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "JSONSchemaPropsOrStringArray represents a JSONSchemaProps or a string array.",
-				Type:        v1.JSONSchemaPropsOrStringArray{}.OpenAPISchemaType(),
-				Format:      v1.JSONSchemaPropsOrStringArray{}.OpenAPISchemaFormat(),
+				Type:        apiextensionsv1.JSONSchemaPropsOrStringArray{}.OpenAPISchemaType(),
+				Format:      apiextensionsv1.JSONSchemaPropsOrStringArray{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -49069,8 +49069,8 @@ func schema_pkg_apis_meta_v1_Duration(ref common.ReferenceCallback) common.OpenA
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Duration is a wrapper around time.Duration which supports correct marshaling to YAML and JSON. In particular, it marshals into strings, which can be used as map keys in json.",
-				Type:        metav1.Duration{}.OpenAPISchemaType(),
-				Format:      metav1.Duration{}.OpenAPISchemaFormat(),
+				Type:        v1.Duration{}.OpenAPISchemaType(),
+				Format:      v1.Duration{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -49677,18 +49677,6 @@ func schema_pkg_apis_meta_v1_ManagedFieldsEntry(ref common.ReferenceCallback) co
 		},
 		Dependencies: []string{
 			"k8s.io/apimachinery/pkg/apis/meta/v1.FieldsV1", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
-	}
-}
-
-func schema_pkg_apis_meta_v1_MicroTime(ref common.ReferenceCallback) common.OpenAPIDefinition {
-	return common.OpenAPIDefinition{
-		Schema: spec.Schema{
-			SchemaProps: spec.SchemaProps{
-				Description: "MicroTime is version of Time with microsecond level precision.",
-				Type:        metav1.MicroTime{}.OpenAPISchemaType(),
-				Format:      metav1.MicroTime{}.OpenAPISchemaFormat(),
-			},
-		},
 	}
 }
 
@@ -50585,18 +50573,6 @@ func schema_pkg_apis_meta_v1_TableRowCondition(ref common.ReferenceCallback) com
 					},
 				},
 				Required: []string{"type", "status"},
-			},
-		},
-	}
-}
-
-func schema_pkg_apis_meta_v1_Time(ref common.ReferenceCallback) common.OpenAPIDefinition {
-	return common.OpenAPIDefinition{
-		Schema: spec.Schema{
-			SchemaProps: spec.SchemaProps{
-				Description: "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-				Type:        metav1.Time{}.OpenAPISchemaType(),
-				Format:      metav1.Time{}.OpenAPISchemaFormat(),
 			},
 		},
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -24,9 +24,9 @@ limitations under the License.
 package openapi
 
 import (
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	common "k8s.io/kube-openapi/pkg/common"
 	spec "k8s.io/kube-openapi/pkg/validation/spec"
 )
@@ -130,7 +130,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta":                                                   schema_pkg_apis_meta_v1_ListMeta(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.ListOptions":                                                schema_pkg_apis_meta_v1_ListOptions(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.ManagedFieldsEntry":                                         schema_pkg_apis_meta_v1_ManagedFieldsEntry(ref),
-		"k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime":                                                  schema_pkg_apis_meta_v1_MicroTime(ref),
+		"k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime":                                                  v1.MicroTime{}.OpenAPIDefinition(),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta":                                                 schema_pkg_apis_meta_v1_ObjectMeta(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.OwnerReference":                                             schema_pkg_apis_meta_v1_OwnerReference(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.PartialObjectMetadata":                                      schema_pkg_apis_meta_v1_PartialObjectMetadata(ref),
@@ -148,7 +148,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/apimachinery/pkg/apis/meta/v1.TableOptions":                                               schema_pkg_apis_meta_v1_TableOptions(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.TableRow":                                                   schema_pkg_apis_meta_v1_TableRow(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.TableRowCondition":                                          schema_pkg_apis_meta_v1_TableRowCondition(ref),
-		"k8s.io/apimachinery/pkg/apis/meta/v1.Time":                                                       schema_pkg_apis_meta_v1_Time(ref),
+		"k8s.io/apimachinery/pkg/apis/meta/v1.Time":                                                       v1.Time{}.OpenAPIDefinition(),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.Timestamp":                                                  schema_pkg_apis_meta_v1_Timestamp(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta":                                                   schema_pkg_apis_meta_v1_TypeMeta(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.UpdateOptions":                                              schema_pkg_apis_meta_v1_UpdateOptions(ref),
@@ -1868,8 +1868,8 @@ func schema_pkg_apis_apiextensions_v1_JSON(ref common.ReferenceCallback) common.
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
-				Type:        v1.JSON{}.OpenAPISchemaType(),
-				Format:      v1.JSON{}.OpenAPISchemaFormat(),
+				Type:        apiextensionsv1.JSON{}.OpenAPISchemaType(),
+				Format:      apiextensionsv1.JSON{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -2254,8 +2254,8 @@ func schema_pkg_apis_apiextensions_v1_JSONSchemaPropsOrArray(ref common.Referenc
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "JSONSchemaPropsOrArray represents a value that can either be a JSONSchemaProps or an array of JSONSchemaProps. Mainly here for serialization purposes.",
-				Type:        v1.JSONSchemaPropsOrArray{}.OpenAPISchemaType(),
-				Format:      v1.JSONSchemaPropsOrArray{}.OpenAPISchemaFormat(),
+				Type:        apiextensionsv1.JSONSchemaPropsOrArray{}.OpenAPISchemaType(),
+				Format:      apiextensionsv1.JSONSchemaPropsOrArray{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -2266,8 +2266,8 @@ func schema_pkg_apis_apiextensions_v1_JSONSchemaPropsOrBool(ref common.Reference
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "JSONSchemaPropsOrBool represents JSONSchemaProps or a boolean value. Defaults to true for the boolean property.",
-				Type:        v1.JSONSchemaPropsOrBool{}.OpenAPISchemaType(),
-				Format:      v1.JSONSchemaPropsOrBool{}.OpenAPISchemaFormat(),
+				Type:        apiextensionsv1.JSONSchemaPropsOrBool{}.OpenAPISchemaType(),
+				Format:      apiextensionsv1.JSONSchemaPropsOrBool{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -2278,8 +2278,8 @@ func schema_pkg_apis_apiextensions_v1_JSONSchemaPropsOrStringArray(ref common.Re
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "JSONSchemaPropsOrStringArray represents a JSONSchemaProps or a string array.",
-				Type:        v1.JSONSchemaPropsOrStringArray{}.OpenAPISchemaType(),
-				Format:      v1.JSONSchemaPropsOrStringArray{}.OpenAPISchemaFormat(),
+				Type:        apiextensionsv1.JSONSchemaPropsOrStringArray{}.OpenAPISchemaType(),
+				Format:      apiextensionsv1.JSONSchemaPropsOrStringArray{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -4421,8 +4421,8 @@ func schema_pkg_apis_meta_v1_Duration(ref common.ReferenceCallback) common.OpenA
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Duration is a wrapper around time.Duration which supports correct marshaling to YAML and JSON. In particular, it marshals into strings, which can be used as map keys in json.",
-				Type:        metav1.Duration{}.OpenAPISchemaType(),
-				Format:      metav1.Duration{}.OpenAPISchemaFormat(),
+				Type:        v1.Duration{}.OpenAPISchemaType(),
+				Format:      v1.Duration{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -5029,18 +5029,6 @@ func schema_pkg_apis_meta_v1_ManagedFieldsEntry(ref common.ReferenceCallback) co
 		},
 		Dependencies: []string{
 			"k8s.io/apimachinery/pkg/apis/meta/v1.FieldsV1", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
-	}
-}
-
-func schema_pkg_apis_meta_v1_MicroTime(ref common.ReferenceCallback) common.OpenAPIDefinition {
-	return common.OpenAPIDefinition{
-		Schema: spec.Schema{
-			SchemaProps: spec.SchemaProps{
-				Description: "MicroTime is version of Time with microsecond level precision.",
-				Type:        metav1.MicroTime{}.OpenAPISchemaType(),
-				Format:      metav1.MicroTime{}.OpenAPISchemaFormat(),
-			},
-		},
 	}
 }
 
@@ -5937,18 +5925,6 @@ func schema_pkg_apis_meta_v1_TableRowCondition(ref common.ReferenceCallback) com
 					},
 				},
 				Required: []string{"type", "status"},
-			},
-		},
-	}
-}
-
-func schema_pkg_apis_meta_v1_Time(ref common.ReferenceCallback) common.OpenAPIDefinition {
-	return common.OpenAPIDefinition{
-		Schema: spec.Schema{
-			SchemaProps: spec.SchemaProps{
-				Description: "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-				Type:        metav1.Time{}.OpenAPISchemaType(),
-				Format:      metav1.Time{}.OpenAPISchemaFormat(),
 			},
 		},
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go
@@ -19,6 +19,9 @@ package v1
 import (
 	"encoding/json"
 	"time"
+
+	"k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 const RFC3339Micro = "2006-01-02T15:04:05.000000Z07:00"
@@ -160,15 +163,58 @@ func (t MicroTime) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.UTC().Format(RFC3339Micro))
 }
 
-// OpenAPISchemaType is used by the kube-openapi generator when constructing
-// the OpenAPI spec of this type.
-//
-// See: https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators
-func (_ MicroTime) OpenAPISchemaType() []string { return []string{"string"} }
-
-// OpenAPISchemaFormat is used by the kube-openapi generator when constructing
-// the OpenAPI spec of this type.
-func (_ MicroTime) OpenAPISchemaFormat() string { return "date-time" }
+func (_ MicroTime) OpenAPIDefinition() common.OpenAPIDefinition {
+	desc := "MicroTime is version of Time with microsecond level precision."
+	zero := int64(0)
+	return common.EmbedOpenAPIDefinitionIntoV2Extension(common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type:        spec.StringOrArray{"string"},
+				Description: desc,
+				Nullable:    true,
+				AnyOf: []spec.Schema{
+					{
+						SchemaProps: spec.SchemaProps{
+							Format: `date-time`,
+						},
+					},
+					{
+						SchemaProps: spec.SchemaProps{
+							MaxLength: &zero,
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{},
+	}, common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: desc,
+				AnyOf: []spec.Schema{
+					{
+						SchemaProps: spec.SchemaProps{
+							Type: spec.StringOrArray{"null"},
+						},
+					},
+					{
+						SchemaProps: spec.SchemaProps{
+							Type:   spec.StringOrArray{"string"},
+							Format: `date-time`,
+						},
+					},
+					{
+						SchemaProps: spec.SchemaProps{
+							Type:      spec.StringOrArray{"string"},
+							MaxLength: &zero,
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{},
+	})
+}
 
 // MarshalQueryParameter converts to a URL query parameter value
 func (t MicroTime) MarshalQueryParameter() (string, error) {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
@@ -19,6 +19,9 @@ package v1
 import (
 	"encoding/json"
 	"time"
+
+	"k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // Time is a wrapper around time.Time which supports correct
@@ -161,15 +164,58 @@ func (t Time) ToUnstructured() interface{} {
 	return string(buf)
 }
 
-// OpenAPISchemaType is used by the kube-openapi generator when constructing
-// the OpenAPI spec of this type.
-//
-// See: https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators
-func (_ Time) OpenAPISchemaType() []string { return []string{"string"} }
-
-// OpenAPISchemaFormat is used by the kube-openapi generator when constructing
-// the OpenAPI spec of this type.
-func (_ Time) OpenAPISchemaFormat() string { return "date-time" }
+func (_ Time) OpenAPIDefinition() common.OpenAPIDefinition {
+	zero := int64(0)
+	desc := "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers."
+	return common.EmbedOpenAPIDefinitionIntoV2Extension(common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type:        spec.StringOrArray{"string"},
+				Description: desc,
+				Nullable:    true,
+				AnyOf: []spec.Schema{
+					{
+						SchemaProps: spec.SchemaProps{
+							Format: `date-time`,
+						},
+					},
+					{
+						SchemaProps: spec.SchemaProps{
+							MaxLength: &zero,
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{},
+	}, common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: desc,
+				AnyOf: []spec.Schema{
+					{
+						SchemaProps: spec.SchemaProps{
+							Type: spec.StringOrArray{"null"},
+						},
+					},
+					{
+						SchemaProps: spec.SchemaProps{
+							Type:   spec.StringOrArray{"string"},
+							Format: `date-time`,
+						},
+					},
+					{
+						SchemaProps: spec.SchemaProps{
+							Type:      spec.StringOrArray{"string"},
+							MaxLength: &zero,
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{},
+	})
+}
 
 // MarshalQueryParameter converts to a URL query parameter value
 func (t Time) MarshalQueryParameter() (string, error) {

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -56,7 +56,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta":                  schema_pkg_apis_meta_v1_ListMeta(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.ListOptions":               schema_pkg_apis_meta_v1_ListOptions(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.ManagedFieldsEntry":        schema_pkg_apis_meta_v1_ManagedFieldsEntry(ref),
-		"k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime":                 schema_pkg_apis_meta_v1_MicroTime(ref),
+		"k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime":                 v1.MicroTime{}.OpenAPIDefinition(),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta":                schema_pkg_apis_meta_v1_ObjectMeta(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.OwnerReference":            schema_pkg_apis_meta_v1_OwnerReference(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.PartialObjectMetadata":     schema_pkg_apis_meta_v1_PartialObjectMetadata(ref),
@@ -74,7 +74,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/apimachinery/pkg/apis/meta/v1.TableOptions":              schema_pkg_apis_meta_v1_TableOptions(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.TableRow":                  schema_pkg_apis_meta_v1_TableRow(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.TableRowCondition":         schema_pkg_apis_meta_v1_TableRowCondition(ref),
-		"k8s.io/apimachinery/pkg/apis/meta/v1.Time":                      schema_pkg_apis_meta_v1_Time(ref),
+		"k8s.io/apimachinery/pkg/apis/meta/v1.Time":                      v1.Time{}.OpenAPIDefinition(),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.Timestamp":                 schema_pkg_apis_meta_v1_Timestamp(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta":                  schema_pkg_apis_meta_v1_TypeMeta(ref),
 		"k8s.io/apimachinery/pkg/apis/meta/v1.UpdateOptions":             schema_pkg_apis_meta_v1_UpdateOptions(ref),
@@ -1300,18 +1300,6 @@ func schema_pkg_apis_meta_v1_ManagedFieldsEntry(ref common.ReferenceCallback) co
 	}
 }
 
-func schema_pkg_apis_meta_v1_MicroTime(ref common.ReferenceCallback) common.OpenAPIDefinition {
-	return common.OpenAPIDefinition{
-		Schema: spec.Schema{
-			SchemaProps: spec.SchemaProps{
-				Description: "MicroTime is version of Time with microsecond level precision.",
-				Type:        v1.MicroTime{}.OpenAPISchemaType(),
-				Format:      v1.MicroTime{}.OpenAPISchemaFormat(),
-			},
-		},
-	}
-}
-
 func schema_pkg_apis_meta_v1_ObjectMeta(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
@@ -2205,18 +2193,6 @@ func schema_pkg_apis_meta_v1_TableRowCondition(ref common.ReferenceCallback) com
 					},
 				},
 				Required: []string{"type", "status"},
-			},
-		},
-	}
-}
-
-func schema_pkg_apis_meta_v1_Time(ref common.ReferenceCallback) common.OpenAPIDefinition {
-	return common.OpenAPIDefinition{
-		Schema: spec.Schema{
-			SchemaProps: spec.SchemaProps{
-				Description: "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-				Type:        v1.Time{}.OpenAPISchemaType(),
-				Format:      v1.Time{}.OpenAPISchemaFormat(),
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

OpenAPI spec does not reflect unmarhsalling behavior:

1. Time and MicroTime both marshal/unmarshal [into `null` when the value is zero](https://github.com/kubernetes/kubernetes/issues/118771). `null` is a valid value for `v1.Time` and `v1.MicroTime`. The current spec doesn't allow this.
2. Default in spec is set to `{}` when it should be `null`/empty due to their being a `struct`
3. `date-time` allows overly broad set of date-times for both `Time` and `MicroTime`, but this is not too bad

This PR attempts to use a more representative OpenAPI definition for Time and MicroTime by fixing 1 and 2. The third issue needs to be fixed in kube-openapi code-generator.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #118771 for Time/MicroTime

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
