### PR TITLE
Fix querystring lost on connection upgrade

### DIFF
--- a/pkg/registry/core/pod/rest/subresources.go
+++ b/pkg/registry/core/pod/rest/subresources.go
@@ -77,7 +77,12 @@ func (r *ProxyREST) Connect(ctx context.Context, id string, opts runtime.Object,
 	}
 	location.Path = net.JoinPreservingTrailingSlash(location.Path, proxyOpts.Path)
 	// Return a proxy handler that uses the desired transport, wrapped with additional proxy handling (to get URL rewriting, X-Forwarded-* headers, etc)
-	return newThrottledUpgradeAwareProxyHandler(location, transport, true, false, responder), nil
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// Fix querystring missing on connection upgrade
+		location.RawQuery = req.URL.RawQuery
+		handler := newThrottledUpgradeAwareProxyHandler(location, transport, true, false, responder)
+		handler.ServeHTTP(w, req)
+	}), nil
 }
 
 // Support both GET and POST methods. We must support GET for browsers that want to use WebSockets.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
Use restful api(/api/v1/namespaces/{namespace}/services/{name}/proxy?foo=bar) of kube-apiserver for accessing incluster websocket services, the querystring is lost during connection upgrading.
Currently our temporary solution is to put RawQuery in the header and extract it on the server side, this is somewhat strange.
We felt this issue needed to be fixed and it really affected us.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/89360

#### Special notes for your reviewer:
The querystring is lost in `pod proxy(pkg/registry/core/pod/rest/subresource.go)` and `service proxy(pkg/registry/core/service/proxy.go)` because of
the `ServiceProxyOptions` and `PodProxyOptions` does not get RawQuery passthrought.

The code reference link is shown as below:
- pod proxy(https://github.com/kubernetes/kubernetes/blob/a0873d37c58757ac6c2a339af1e4f8d601cdef20/pkg/registry/core/pod/rest/subresources.go#L69)
- service proxy(https://github.com/kubernetes/kubernetes/blob/a0873d37c58757ac6c2a339af1e4f8d601cdef20/pkg/registry/core/service/proxy.go#L66)

Opt-in has the advantage of limiting the scope of the change, but it will cause quite a few changes, so we prefer to make a safer change in a proxy wrapper of http.HandlerFunc in pod/service proxy Connect function.

@brianpursley Thanks for providing scenarios and examples to confirm the root cause.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
