### PR TITLE
Support skip for PreEnqueue

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -94,6 +94,7 @@ const (
 	Wait
 	// Skip is used in the following scenarios:
 	// - when a Bind plugin chooses to skip binding.
+	// - when a PreEnqueue plugin returns Skip so that the pod will be skipped in the current scheduling cycle.
 	// - when a PreFilter plugin returns Skip so that coupled Filter plugin/PreFilterExtensions() will be skipped.
 	// - when a PreScore plugin returns Skip so that coupled Score plugin will be skipped.
 	Skip

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -181,6 +181,8 @@ type QueuedPodInfo struct {
 	UnschedulablePlugins sets.Set[string]
 	// Whether the Pod is scheduling gated (by PreEnqueuePlugins) or not.
 	Gated bool
+	// Whether the Pod is skipped by the scheduler or not.
+	Skip bool
 }
 
 // DeepCopy returns a deep copy of the QueuedPodInfo object.
@@ -192,6 +194,7 @@ func (pqi *QueuedPodInfo) DeepCopy() *QueuedPodInfo {
 		InitialAttemptTimestamp: pqi.InitialAttemptTimestamp,
 		UnschedulablePlugins:    pqi.UnschedulablePlugins.Clone(),
 		Gated:                   pqi.Gated,
+		Skip:                    pqi.Skip,
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/sig scheduling
/kind feature

Open issue:
https://github.com/kubernetes/kubernetes/issues/120237

#### What this PR does / why we need it:
We have skip status for PreFilter to return, and when we skip prefilter, the following filter will not run, but we don't have skip choice for PreEnqueue, we'd better add this.

After we support this:
When we skip for the preEnqueue, we can skip add the pod to activeQueue, it's more reasonable and saving time for plugin customer scheduler to optimize.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
