### PR TITLE
Refactor streaming watch encoder to enable caching

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response_test.go
@@ -212,3 +212,13 @@ func TestAsPartialObjectMetadataList(t *testing.T) {
 		})
 	}
 }
+
+func TestWatchEncoderIdentifier(t *testing.T) {
+	eventFields := reflect.VisibleFields(reflect.TypeOf(metav1.WatchEvent{}))
+	if len(eventFields) != 2 {
+		t.Error("New field was added to metav1.WatchEvent.")
+		t.Error("  Ensure that the following places are updated accordingly:")
+		t.Error("  - watchEncoder::doEncode method when creating outEvent")
+		t.Error("  - watchEncoder::typeIdentifier to capture all relevant fields in identifier")
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -222,7 +222,7 @@ func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
-	watchEncoder := newWatchEncoder(req.Context(), kind, s.EmbeddedEncoder, s.Encoder)
+	watchEncoder := newWatchEncoder(req.Context(), kind, s.EmbeddedEncoder, s.Encoder, framer)
 	ch := s.Watching.ResultChan()
 	done := req.Context().Done()
 
@@ -249,7 +249,7 @@ func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			metrics.WatchEvents.WithContext(req.Context()).WithLabelValues(kind.Group, kind.Version, kind.Kind).Inc()
 			isWatchListLatencyRecordingRequired := shouldRecordWatchListLatency(event)
 
-			if err := watchEncoder.Encode(event, framer); err != nil {
+			if err := watchEncoder.Encode(event); err != nil {
 				utilruntime.HandleError(err)
 				// client disconnect.
 				return

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/util/httpstream/wsstream"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -213,9 +212,6 @@ func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var e streaming.Encoder
-	e = streaming.NewEncoder(framer, s.Encoder)
-
 	// ensure the connection times out
 	timeoutCh, cleanup := s.TimeoutFactory.TimeoutCh()
 	defer cleanup()
@@ -226,10 +222,7 @@ func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
-	var unknown runtime.Unknown
-	internalEvent := &metav1.InternalEvent{}
-	outEvent := &metav1.WatchEvent{}
-	buf := runtime.NewSpliceBuffer()
+	watchEncoder := newWatchEncoder(req.Context(), kind, s.EmbeddedEncoder, s.Encoder)
 	ch := s.Watching.ResultChan()
 	done := req.Context().Done()
 
@@ -256,43 +249,18 @@ func (s *WatchServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			metrics.WatchEvents.WithContext(req.Context()).WithLabelValues(kind.Group, kind.Version, kind.Kind).Inc()
 			isWatchListLatencyRecordingRequired := shouldRecordWatchListLatency(event)
 
-			if err := s.EmbeddedEncoder.Encode(event.Object, buf); err != nil {
-				// unexpected error
-				utilruntime.HandleError(fmt.Errorf("unable to encode watch object %T: %v", event.Object, err))
-				return
-			}
-
-			// ContentType is not required here because we are defaulting to the serializer
-			// type
-			unknown.Raw = buf.Bytes()
-			event.Object = &unknown
-			metrics.WatchEventsSizes.WithContext(req.Context()).WithLabelValues(kind.Group, kind.Version, kind.Kind).Observe(float64(len(unknown.Raw)))
-
-			*outEvent = metav1.WatchEvent{}
-
-			// create the external type directly and encode it.  Clients will only recognize the serialization we provide.
-			// The internal event is being reused, not reallocated so its just a few extra assignments to do it this way
-			// and we get the benefit of using conversion functions which already have to stay in sync
-			*internalEvent = metav1.InternalEvent(event)
-			err := metav1.Convert_v1_InternalEvent_To_v1_WatchEvent(internalEvent, outEvent, nil)
-			if err != nil {
-				utilruntime.HandleError(fmt.Errorf("unable to convert watch object: %v", err))
+			if err := watchEncoder.Encode(event, framer); err != nil {
+				utilruntime.HandleError(err)
 				// client disconnect.
 				return
 			}
-			if err := e.Encode(outEvent); err != nil {
-				utilruntime.HandleError(fmt.Errorf("unable to encode watch object %T: %v (%#v)", outEvent, err, e))
-				// client disconnect.
-				return
-			}
+
 			if len(ch) == 0 {
 				flusher.Flush()
 			}
 			if isWatchListLatencyRecordingRequired {
 				metrics.RecordWatchListLatency(req.Context(), s.Scope.Resource, s.metricsScope)
 			}
-
-			buf.Reset()
 		}
 	}
 }

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -2361,6 +2361,19 @@ func TestWatchTransformCaching(t *testing.T) {
 	}
 	defer wTableIncludeObject.Close()
 
+	wTableIncludeObjectFiltered, err := clientSet.CoreV1().RESTClient().Get().
+		AbsPath("/api/v1/namespaces/watch-transform/configmaps").
+		SetHeader("Accept", "application/json;as=Table;g=meta.k8s.io;v=v1beta1").
+		VersionedParams(listOptions, metav1.ParameterCodec).
+		Param("includeObject", string(metav1.IncludeObject)).
+		Param("labelSelector", "foo=bar").
+		Timeout(timeout).
+		Stream(ctx)
+	if err != nil {
+		t.Fatalf("Failed to start table object watch: %v", err)
+	}
+	defer wTableIncludeObjectFiltered.Close()
+
 	configMap, err := clientSet.CoreV1().ConfigMaps("watch-transform").Create(ctx, &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "test1"},
 		Data: map[string]string{
@@ -2397,6 +2410,30 @@ func TestWatchTransformCaching(t *testing.T) {
 		t.Fatalf("Failed to create a second configMap: %v", err)
 	}
 
+	// Now update both configmaps so that filtering watch can observe them.
+	// This is needed to validate whether events caching done by apiserver
+	// distinguished objects by type.
+
+	configMapUpdated, err := clientSet.CoreV1().ConfigMaps("watch-transform").Update(ctx, &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "test1", Labels: map[string]string{"foo": "bar"}},
+		Data: map[string]string{
+			"foo": "baz",
+		},
+	}, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to update a configMap: %v", err)
+	}
+
+	configMap2Updated, err := clientSet.CoreV1().ConfigMaps("watch-transform").Update(ctx, &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "test2", Labels: map[string]string{"foo": "bar"}},
+		Data: map[string]string{
+			"foo": "baz",
+		},
+	}, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to update a second configMap: %v", err)
+	}
+
 	metaChecks := []partialObjectMetadataCheck{
 		func(res *metav1beta1.PartialObjectMetadata) {
 			if !apiequality.Semantic.DeepEqual(configMap.ObjectMeta, res.ObjectMeta) {
@@ -2406,6 +2443,16 @@ func TestWatchTransformCaching(t *testing.T) {
 		func(res *metav1beta1.PartialObjectMetadata) {
 			if !apiequality.Semantic.DeepEqual(configMap2.ObjectMeta, res.ObjectMeta) {
 				t.Errorf("expected object: %#v, got: %#v", configMap2.ObjectMeta, res.ObjectMeta)
+			}
+		},
+		func(res *metav1beta1.PartialObjectMetadata) {
+			if !apiequality.Semantic.DeepEqual(configMapUpdated.ObjectMeta, res.ObjectMeta) {
+				t.Errorf("expected object: %#v, got: %#v", configMapUpdated.ObjectMeta, res.ObjectMeta)
+			}
+		},
+		func(res *metav1beta1.PartialObjectMetadata) {
+			if !apiequality.Semantic.DeepEqual(configMap2Updated.ObjectMeta, res.ObjectMeta) {
+				t.Errorf("expected object: %#v, got: %#v", configMap2Updated.ObjectMeta, res.ObjectMeta)
 			}
 		},
 	}
@@ -2421,39 +2468,67 @@ func TestWatchTransformCaching(t *testing.T) {
 		}
 	}
 
-	objectMetas := expectTableWatchEvents(t, 2, 3, metav1.IncludeMetadata, json.NewDecoder(wTableIncludeMeta))
+	objectMetas := expectTableWatchEvents(t, 4, 3, metav1.IncludeMetadata, json.NewDecoder(wTableIncludeMeta))
 	tableMetaCheck(configMap, objectMetas[0])
 	tableMetaCheck(configMap2, objectMetas[1])
+	tableMetaCheck(configMapUpdated, objectMetas[2])
+	tableMetaCheck(configMap2Updated, objectMetas[3])
 
-	tableObjectCheck := func(expected *v1.ConfigMap, got []byte) {
+	tableObjectCheck := func(expectedType watch.EventType, expectedObj *v1.ConfigMap, got streamedEvent) {
 		var obj *v1.ConfigMap
-		if err := json.Unmarshal(got, &obj); err != nil {
+		if err := json.Unmarshal(got.rawObject, &obj); err != nil {
 			t.Fatal(err)
 		}
+		if expectedType != watch.EventType(got.eventType) {
+			t.Errorf("expected type: %#v, got: %#v", expectedType, got.eventType)
+		}
 		obj.TypeMeta = metav1.TypeMeta{}
-		if !apiequality.Semantic.DeepEqual(expected, obj) {
-			t.Errorf("expected object: %#v, got: %#v", expected, obj)
+		if !apiequality.Semantic.DeepEqual(expectedObj, obj) {
+			t.Errorf("expected object: %#v, got: %#v", expectedObj, obj)
 		}
 	}
 
-	objects := expectTableWatchEvents(t, 2, 3, metav1.IncludeObject, json.NewDecoder(wTableIncludeObject))
-	tableObjectCheck(configMap, objects[0])
-	tableObjectCheck(configMap2, objects[1])
+	objects := expectTableWatchEventsWithTypes(t, 4, 3, metav1.IncludeObject, json.NewDecoder(wTableIncludeObject))
+	tableObjectCheck(watch.Added, configMap, objects[0])
+	tableObjectCheck(watch.Added, configMap2, objects[1])
+	tableObjectCheck(watch.Modified, configMapUpdated, objects[2])
+	tableObjectCheck(watch.Modified, configMap2Updated, objects[3])
 
-	delayedObjects := expectTableWatchEvents(t, 1, 3, metav1.IncludeObject, json.NewDecoder(wTableIncludeObjectDelayed))
-	tableObjectCheck(configMap2, delayedObjects[0])
+	filteredObjects := expectTableWatchEventsWithTypes(t, 2, 3, metav1.IncludeObject, json.NewDecoder(wTableIncludeObjectFiltered))
+	tableObjectCheck(watch.Added, configMapUpdated, filteredObjects[0])
+	tableObjectCheck(watch.Added, configMap2Updated, filteredObjects[1])
+
+	delayedObjects := expectTableWatchEventsWithTypes(t, 3, 3, metav1.IncludeObject, json.NewDecoder(wTableIncludeObjectDelayed))
+	tableObjectCheck(watch.Added, configMap2, delayedObjects[0])
+	tableObjectCheck(watch.Modified, configMapUpdated, delayedObjects[1])
+	tableObjectCheck(watch.Modified, configMap2Updated, delayedObjects[2])
 }
 
 func expectTableWatchEvents(t *testing.T, count, columns int, policy metav1.IncludeObjectPolicy, d *json.Decoder) [][]byte {
+	events := expectTableWatchEventsWithTypes(t, count, columns, policy, d)
+	var objects [][]byte
+	for _, event := range events {
+		objects = append(objects, event.rawObject)
+	}
+	return objects
+}
+
+type streamedEvent struct {
+	eventType string
+	rawObject []byte
+}
+
+func expectTableWatchEventsWithTypes(t *testing.T, count, columns int, policy metav1.IncludeObjectPolicy, d *json.Decoder) []streamedEvent {
 	t.Helper()
 
-	var objects [][]byte
+	var events []streamedEvent
 
 	for i := 0; i < count; i++ {
 		var evt metav1.WatchEvent
 		if err := d.Decode(&evt); err != nil {
 			t.Fatal(err)
 		}
+
 		var table metav1beta1.Table
 		if err := json.Unmarshal(evt.Object.Raw, &table); err != nil {
 			t.Fatal(err)
@@ -2484,7 +2559,7 @@ func expectTableWatchEvents(t *testing.T, count, columns int, policy metav1.Incl
 			if meta.TypeMeta != partialObj {
 				t.Fatalf("expected partial object: %#v", meta)
 			}
-			objects = append(objects, row.Object.Raw)
+			events = append(events, streamedEvent{eventType: evt.Type, rawObject: row.Object.Raw})
 		case metav1.IncludeNone:
 			if len(row.Object.Raw) != 0 {
 				t.Fatalf("Expected no object: %s", string(row.Object.Raw))
@@ -2493,10 +2568,10 @@ func expectTableWatchEvents(t *testing.T, count, columns int, policy metav1.Incl
 			if len(row.Object.Raw) == 0 {
 				t.Fatalf("Expected object: %s", string(row.Object.Raw))
 			}
-			objects = append(objects, row.Object.Raw)
+			events = append(events, streamedEvent{eventType: evt.Type, rawObject: row.Object.Raw})
 		}
 	}
-	return objects
+	return events
 }
 
 func expectPartialObjectMetaEvents(t *testing.T, d *json.Decoder, values ...string) {


### PR DESCRIPTION
Fix: https://github.com/kubernetes/kubernetes/issues/110146

```release-note
NONE
```

I used the benchmark that was originally added in https://github.com/kubernetes/kubernetes/pull/113326 to benchmark this change.  It seems it's achieving what we wanted:
```
wojtekt@wojtekt-l:~/go/src/k8s.io/kubernetes$ benchcmp old.txt new.txt 
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                                 old ns/op     new ns/op     delta
BenchmarkWatchHTTP-8                      36086         34110         -5.48%
BenchmarkWatchHTTP_UTF8-8                 34019         33528         -1.44%
BenchmarkWatchWebsocket-8                 37032         37368         +0.91%
BenchmarkWatchProtobuf-8                  14550         15401         +5.85%
BenchmarkWatchCachingObjectJSON-8         23124         10613         -54.10%
BenchmarkWatchCachingObjectProtobuf-8     12834         10562         -17.70%
```

For completeness also memory [cpu should be ignored here]
```
before:
BenchmarkWatchHTTP-8                    	   33645	     32539 ns/op	     835 B/op	      12 allocs/op
BenchmarkWatchHTTP_UTF8-8               	   32142	     34380 ns/op	     835 B/op	      12 allocs/op
BenchmarkWatchWebsocket-8               	   33790	     35212 ns/op	    3186 B/op	      20 allocs/op
BenchmarkWatchProtobuf-8                	   73652	     15181 ns/op	     736 B/op	       7 allocs/op
BenchmarkWatchCachingObjectJSON-8       	   51310	     25799 ns/op	     152 B/op	       6 allocs/op
BenchmarkWatchCachingObjectProtobuf-8   	   89762	     12142 ns/op	     120 B/op	       4 allocs/op
PASS

after:
BenchmarkWatchHTTP-8                    	   36710	     34183 ns/op	     835 B/op	      12 allocs/op
BenchmarkWatchHTTP_UTF8-8               	   35911	     29547 ns/op	     835 B/op	      12 allocs/op
BenchmarkWatchWebsocket-8               	   32452	     37185 ns/op	    3187 B/op	      20 allocs/op
BenchmarkWatchProtobuf-8                	   81285	     15854 ns/op	     736 B/op	       7 allocs/op
BenchmarkWatchCachingObjectJSON-8       	   46171	     26953 ns/op	     152 B/op	       6 allocs/op
BenchmarkWatchCachingObjectProtobuf-8   	   94173	     13723 ns/op	     120 B/op	       4 allocs/op
PASS
```


The first 3 tests are fluctuating across runs, but the CachingObject ones are consistently better.

/kind cleanup
/priority important-longterm
/sig api-machinery