### PR TITLE
Automated cherry pick of #118189: TopologyAwareHints: Take lock in HasPopulatedHints

### DIFF
--- a/pkg/controller/endpointslice/topologycache/topologycache_test.go
+++ b/pkg/controller/endpointslice/topologycache/topologycache_test.go
@@ -686,6 +686,9 @@ func TestTopologyCacheRace(t *testing.T) {
 	go func() {
 		cache.AddHints(sliceInfo)
 	}()
+	go func() {
+		cache.HasPopulatedHints(sliceInfo.ServiceKey)
+	}()
 }
 
 // Test Helpers


### PR DESCRIPTION
Cherry pick of #118189 on release-1.26.

#118189: TopologyAwareHints: Take lock in HasPopulatedHints

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a concurrent map access in TopologyCache's `HasPopulatedHints` method.
```