### PR TITLE
resource claim controller: separate generated suffix from base

### DIFF
--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -616,7 +616,7 @@ func (ec *Controller) handleClaim(ctx context.Context, pod *v1.Pod, podClaim v1.
 			annotations = make(map[string]string)
 		}
 		annotations[podResourceClaimAnnotation] = podClaim.Name
-		generateName := pod.Name + "-" + podClaim.Name
+		generateName := pod.Name + "-" + podClaim.Name + "-"
 		maxBaseLen := 57 // Leave space for hyphen and 5 random characters in a name with 63 characters.
 		if len(generateName) > maxBaseLen {
 			// We could leave truncation to the apiserver, but as

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -62,7 +62,7 @@ var (
 	testClaimReserved      = reserveClaim(testClaimAllocated, testPodWithResource)
 	testClaimReservedTwice = reserveClaim(testClaimReserved, otherTestPod)
 
-	generatedTestClaim          = makeGeneratedClaim(podResourceClaimName, testPodName+"-"+podResourceClaimName, testNamespace, className, 1, makeOwnerReference(testPodWithResource, true))
+	generatedTestClaim          = makeGeneratedClaim(podResourceClaimName, testPodName+"-"+podResourceClaimName+"-", testNamespace, className, 1, makeOwnerReference(testPodWithResource, true))
 	generatedTestClaimAllocated = allocateClaim(generatedTestClaim)
 	generatedTestClaimReserved  = reserveClaim(generatedTestClaimAllocated, testPodWithResource)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When the resource claim name inside the pod had some suffix like "1a" in "resource-1a", the generated name suffix got added directly after that, leading to "my-pod-resource-1ax6zgt".

Adding another hyphen makes the result more readable: "my-pod-resource-1a-x6zgt".

#### Special notes for your reviewer:

This is not an API break although it is use-visible: the API is that the final name gets recorded in the pod status. How that name gets generated is an implementation detail which is allowed to change.

#### Does this PR introduce a user-facing change?
```release-note
Generated ResourceClaim names are now more readable because of an additional hyphen before the random suffix (`<pod name>-<claim name>-<random suffix>` ).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3063
```
