### PR TITLE
Improvements made  in kubectl create secret generic help command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
@@ -69,6 +69,8 @@ var (
 
 	secretForGenericLong = templates.LongDesc(i18n.T(`
 		Create a secret based on a file, directory, or specified literal value.
+	
+		Using generic subcommand indicate an Opaque secret. When used with empty --type flag, the command creates an empty secret of type Opaque.
 
 		A single secret may package one or more key/value pairs.
 
@@ -81,6 +83,9 @@ var (
 		symlinks, devices, pipes, etc).`))
 
 	secretForGenericExample = templates.Examples(i18n.T(`
+	  # Create an empty secret my-secret of type Opaque
+	  kubectl create secret generic empty-secret
+
 	  # Create a new secret named my-secret with keys for each file in folder bar
 	  kubectl create secret generic my-secret --from-file=path/to/bar
 
@@ -143,7 +148,7 @@ func NewCmdCreateSecretGeneric(f cmdutil.Factory, ioStreams genericiooptions.IOS
 	cmd := &cobra.Command{
 		Use:                   "generic NAME [--type=string] [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Create a secret from a local file, directory, or literal value"),
+		Short:                 i18n.T("Create a secret from a local file, directory, or literal value. Using generic subcommand indicate an Opaque secret. When used with empty --type flag, the command creates an empty secret of type Opaque."),
 		Long:                  secretForGenericLong,
 		Example:               secretForGenericExample,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -161,7 +166,7 @@ func NewCmdCreateSecretGeneric(f cmdutil.Factory, ioStreams genericiooptions.IOS
 	cmd.Flags().StringSliceVar(&o.FileSources, "from-file", o.FileSources, "Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid secret key.")
 	cmd.Flags().StringArrayVar(&o.LiteralSources, "from-literal", o.LiteralSources, "Specify a key and literal value to insert in secret (i.e. mykey=somevalue)")
 	cmd.Flags().StringSliceVar(&o.EnvFileSources, "from-env-file", o.EnvFileSources, "Specify the path to a file to read lines of key=val pairs to create a secret.")
-	cmd.Flags().StringVar(&o.Type, "type", o.Type, i18n.T("The type of secret to create"))
+	cmd.Flags().StringVar(&o.Type, "type", o.Type, i18n.T("The string value indicate type of secret which is used to facilitate programmatic handling of secret data. Type can be built-in or user defined and vary in terms of validations performed and constraints kubernetes imposed on them. Empty type value indicate Opaque secret. Learn more about built-in types and usage here : https://kubernetes.io/docs/concepts/configuration/secret/#secret-types "))
 	cmd.Flags().BoolVar(&o.AppendHash, "append-hash", o.AppendHash, "Append a hash of the secret to its name.")
 
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
@@ -148,7 +148,7 @@ func NewCmdCreateSecretGeneric(f cmdutil.Factory, ioStreams genericiooptions.IOS
 	cmd := &cobra.Command{
 		Use:                   "generic NAME [--type=string] [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Create a secret from a local file, directory, or literal value. Using generic subcommand indicate an Opaque secret. When used with empty --type flag, the command creates an empty secret of type Opaque."),
+		Short:                 i18n.T("Create a secret from a local file, directory, or literal value. The default type for a secret is Opaque unless otherwise specified by the --type flag."),
 		Long:                  secretForGenericLong,
 		Example:               secretForGenericExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
@@ -70,7 +70,7 @@ var (
 	secretForGenericLong = templates.LongDesc(i18n.T(`
 		Create a secret based on a file, directory, or specified literal value.
 	
-		Using generic subcommand indicate an Opaque secret. When used with empty --type flag, the command creates an empty secret of type Opaque.
+		The default type for a secret is Opaque unless otherwise specified by the --type flag.
 
 		A single secret may package one or more key/value pairs.
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
Adds Details in --type flag description, Example for empty secret and added details in description

#### Which issue(s) this PR fixes:

Fixes #https://github.com/kubernetes/kubectl/issues/1452

## Does this PR introduce a user-facing change?
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->



#### Special notes for your reviewer:
None 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added improvements in the --type flag description and more details in the output of `kubectl create secret generip help`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
``` 