### PR TITLE
dra helper: skip allocated claims during UnsuitableNodes calculation

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/controller/controller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/controller/controller.go
@@ -661,6 +661,11 @@ func (ctrl *controller) checkPodClaim(ctx context.Context, pod *v1.Pod, podClaim
 		// Nothing to do for it as part of pod scheduling.
 		return nil, nil
 	}
+	if claim.Status.Allocation != nil {
+		// Already allocated, class and parameter are not needed and nothing
+		// need to be done for the claim either.
+		return nil, nil
+	}
 	class, err := ctrl.rcLister.Get(claim.Spec.ResourceClassName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The UnsuitableNodes interface method was defined as getting passed only unallocated claims, but was implemented so that it also included allocated claims with delayed allocation.

This had two negative consequences:
- When the test driver checked whether all claims fit onto a node, it incorrectly rejected a node where, for example, one out of two claims was already allocated and the pending one would have fit. This caused random flakes in the scheduler_perf benchmark because those tests fill up the entire cluster and, depending on timing, sometimes not all claims got allocated at once.
- If the class or parameters for an allocated claim got deleted, UnsuitableNodes failed although those are not needed anymore after allocation.

#### Special notes for your reviewer:

This does not affect Kubernetes itself except that it might explain a test flake because the test driver uses this code - not investigated yet, the problem showed up in a new scheduler_perf testcase which is not yet run in Prow.

But DRA drivers which use the package from 1.28.x are affected and thus this fix should get backported.

#### Does this PR introduce a user-facing change?
```release-note
k8s.io/dynamic-resource-allocation/controller: UnsuitableNodes did not handle a mix of allocated and unallocated claims correctly.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3063
```
