### PR TITLE
scheduler_perf: use different log names for different DRA drivers

### DIFF
--- a/test/integration/scheduler_perf/dra_test.go
+++ b/test/integration/scheduler_perf/dra_test.go
@@ -216,7 +216,7 @@ func (op *createResourceDriverOp) run(ctx context.Context, tb testing.TB, client
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		ctx := klog.NewContext(ctx, klog.LoggerWithName(klog.FromContext(ctx), "DRA test driver"))
+		ctx := klog.NewContext(ctx, klog.LoggerWithName(klog.FromContext(ctx), op.DriverName))
 		controller.Run(ctx, 5 /* workers */)
 	}()
 	tb.Cleanup(func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This helps when using -feature-gate=ContextualLogging=true and running the SchedulingWithMultipleResourceClaims test case because then output from the two driver instances is easy to distinguish.

#### Which issue(s) this PR fixes:
Was used when investigating https://github.com/kubernetes/kubernetes/pull/120334

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
