### PR TITLE
Changed the generator codes for the kubernetes metrics reference table

### DIFF
--- a/test/instrumentation/documentation/main.go
+++ b/test/instrumentation/documentation/main.go
@@ -60,85 +60,58 @@ components using an HTTP scrape, and fetch the current metrics data in Prometheu
 
 Stable metrics observe strict API contracts and no labels can be added or removed from stable metrics during their lifetime.
 
-<table class="table metrics" caption="This is the list of STABLE metrics emitted from core Kubernetes components">
-<thead>
-	<tr>
-		<th class="metric_name">Name</th>
-		<th class="metric_stability_level">Stability Level</th>
-		<th class="metric_type">Type</th>
-		<th class="metric_help">Help</th>
-		<th class="metric_labels">Labels</th>
-		<th class="metric_const_labels">Const Labels</th>
-		<th class="metric_deprecated_version">Deprecated Version</th>
-	</tr>
-</thead>
-<tbody>
-{{range $index, $metric := .StableMetrics}}
-<tr class="metric"><td class="metric_name">{{with $metric}}{{.BuildFQName}}{{end}}</td>
-<td class="metric_stability_level" data-stability="{{$metric.StabilityLevel | ToLower}}">{{$metric.StabilityLevel}}</td>
-<td class="metric_type" data-type="{{$metric.Type | ToLower}}">{{$metric.Type}}</td>
-<td class="metric_description">{{$metric.Help}}</td>
-{{if not $metric.Labels }}<td class="metric_labels_varying"></td>{{else }}<td class="metric_labels_varying">{{range $label := $metric.Labels}}<div class="metric_label">{{$label}}</div>{{end}}</td>{{end}}
-{{if not $metric.ConstLabels }}<td class="metric_labels_constant"></td>{{else }}<td class="metric_labels_constant">{{range $key, $value := $metric.ConstLabels}}<div class="metric_label">{{$key}}:{{$value}}</div>{{end}}</td>{{end}}
-{{if not $metric.DeprecatedVersion }}<td class="metric_deprecated_version"></td>{{else }}<td class="metric_deprecated_version">{{$metric.DeprecatedVersion}}</td>{{end}}</tr>{{end}}
-</tbody>
-</table>
+<div class="metrics">
+{{- range $index, $metric := .StableMetrics -}}
+	<div class="metric" data-stability="{{$metric.StabilityLevel | ToLower}}">
+	<div class="metric_name">{{with $metric}}{{.BuildFQName}}{{- end -}}</div>
+	<div class="metric_help">{{- $metric.Help -}}</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">{{- $metric.StabilityLevel -}}</span></li>
+	<li data-type="{{$metric.Type | ToLower}}"><label class="metric_detail">Type:</label> <span class="metric_type">{{- $metric.Type -}}</span></li>
+	{{if $metric.Labels }}<li class="metric_labels_varying"><label class="metric_detail">Labels:</label>{{range $label := $metric.Labels}}<span class="metric_label">{{- $label -}}</span>{{- end -}}</li>{{- end -}}
+	{{if $metric.ConstLabels }}<li class="metric_labels_constant"><label class="metric_detail">Const Labels:</label>{{range $key, $value := $metric.ConstLabels}}<span class="metric_label">{{$key}}:{{$value}}</span>{{- end -}}</li>{{- end -}}
+	{{if $metric.DeprecatedVersion }}<li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>{{- $metric.DeprecatedVersion -}}</span></li>{{- end -}}
+	</ul>
+	</div>{{end}}
+</div>
 
 ### List of Beta Kubernetes Metrics
 
 Beta metrics observe a looser API contract than its stable counterparts. No labels can be removed from beta metrics during their lifetime, however, labels can be added while the metric is in the beta stage. This offers the assurance that beta metrics will honor existing dashboards and alerts, while allowing for amendments in the future. 
 
-<table class="table metrics" caption="This is the list of BETA metrics emitted from core Kubernetes components">
-<thead>
-	<tr>
-		<th class="metric_name">Name</th>
-		<th class="metric_stability_level">Stability Level</th>
-		<th class="metric_type">Type</th>
-		<th class="metric_help">Help</th>
-		<th class="metric_labels">Labels</th>
-		<th class="metric_const_labels">Const Labels</th>
-		<th class="metric_deprecated_version">Deprecated Version</th>
-	</tr>
-</thead>
-<tbody>
-{{range $index, $metric := .BetaMetrics}}
-<tr class="metric"><td class="metric_name">{{with $metric}}{{.BuildFQName}}{{end}}</td>
-<td class="metric_stability_level" data-stability="{{$metric.StabilityLevel | ToLower}}">{{$metric.StabilityLevel}}</td>
-<td class="metric_type" data-type="{{$metric.Type | ToLower}}">{{$metric.Type}}</td>
-<td class="metric_description">{{$metric.Help}}</td>
-{{if not $metric.Labels }}<td class="metric_labels_varying"></td>{{else }}<td class="metric_labels_varying">{{range $label := $metric.Labels}}<div class="metric_label">{{$label}}</div>{{end}}</td>{{end}}
-{{if not $metric.ConstLabels }}<td class="metric_labels_constant"></td>{{else }}<td class="metric_labels_constant">{{range $key, $value := $metric.ConstLabels}}<div class="metric_label">{{$key}}:{{$value}}</div>{{end}}</td>{{end}}
-{{if not $metric.DeprecatedVersion }}<td class="metric_deprecated_version"></td>{{else }}<td class="metric_deprecated_version">{{$metric.DeprecatedVersion}}</td>{{end}}</tr>{{end}}
-</tbody>
-</table>
+<div class="metrics">
+{{- range $index, $metric := .BetaMetrics -}}
+	<div class="metric" data-stability="{{$metric.StabilityLevel | ToLower}}">
+	<div class="metric_name">{{with $metric}}{{.BuildFQName}}{{- end -}}</div>
+	<div class="metric_help">{{- $metric.Help -}}</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">{{- $metric.StabilityLevel -}}</span></li>
+	<li data-type="{{$metric.Type | ToLower}}"><label class="metric_detail">Type:</label> <span class="metric_type">{{- $metric.Type -}}</span></li>
+	{{if $metric.Labels }}<li class="metric_labels_varying"><label class="metric_detail">Labels:</label>{{range $label := $metric.Labels}}<span class="metric_label">{{- $label -}}</span>{{- end -}}</li>{{- end -}}
+	{{if $metric.ConstLabels }}<li class="metric_labels_constant"><label class="metric_detail">Const Labels:</label>{{range $key, $value := $metric.ConstLabels}}<span class="metric_label">{{$key}}:{{$value}}</span>{{- end -}}</li>{{- end -}}
+	{{if $metric.DeprecatedVersion }}<li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>{{- $metric.DeprecatedVersion -}}</span></li>{{- end -}}
+	</ul>
+	</div>{{end}}
+</div>
 
 ### List of Alpha Kubernetes Metrics
 
 Alpha metrics do not have any API guarantees. These metrics must be used at your own risk, subsequent versions of Kubernetes may remove these metrics altogether, or mutate the API in such a way that breaks existing dashboards and alerts. 
 
-<table class="table metrics" caption="This is the list of ALPHA metrics emitted from core Kubernetes components">
-<thead>
-	<tr>
-		<th class="metric_name">Name</th>
-		<th class="metric_stability_level">Stability Level</th>
-		<th class="metric_type">Type</th>
-		<th class="metric_help">Help</th>
-		<th class="metric_labels">Labels</th>
-		<th class="metric_const_labels">Const Labels</th>
-		<th class="metric_deprecated_version">Deprecated Version</th>
-	</tr>
-</thead>
-<tbody>
-{{range $index, $metric := .AlphaMetrics}}
-<tr class="metric"><td class="metric_name">{{with $metric}}{{.BuildFQName}}{{end}}</td>
-<td class="metric_stability_level" data-stability="{{$metric.StabilityLevel | ToLower}}">{{$metric.StabilityLevel}}</td>
-<td class="metric_type" data-type="{{$metric.Type | ToLower}}">{{$metric.Type}}</td>
-<td class="metric_description">{{$metric.Help}}</td>
-{{if not $metric.Labels }}<td class="metric_labels_varying"></td>{{else }}<td class="metric_labels_varying">{{range $label := $metric.Labels}}<div class="metric_label">{{$label}}</div>{{end}}</td>{{end}}
-{{if not $metric.ConstLabels }}<td class="metric_labels_constant"></td>{{else }}<td class="metric_labels_constant">{{range $key, $value := $metric.ConstLabels}}<div class="metric_label">{{$key}}:{{$value}}</div>{{end}}</td>{{end}}
-{{if not $metric.DeprecatedVersion }}<td class="metric_deprecated_version"></td>{{else }}<td class="metric_deprecated_version">{{$metric.DeprecatedVersion}}</td>{{end}}</tr>{{end}}
-</tbody>
-</table>
+<div class="metrics">
+{{- range $index, $metric := .AlphaMetrics -}}
+	<div class="metric" data-stability="{{$metric.StabilityLevel | ToLower}}">
+	<div class="metric_name">{{with $metric}}{{.BuildFQName}}{{- end -}}</div>
+	<div class="metric_help">{{- $metric.Help -}}</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">{{- $metric.StabilityLevel -}}</span></li>
+	<li data-type="{{$metric.Type | ToLower}}"><label class="metric_detail">Type:</label> <span class="metric_type">{{- $metric.Type -}}</span></li>
+	{{if $metric.Labels }}<li class="metric_labels_varying"><label class="metric_detail">Labels:</label>{{range $label := $metric.Labels}}<span class="metric_label">{{- $label -}}</span>{{- end -}}</li>{{- end -}}
+	{{if $metric.ConstLabels }}<li class="metric_labels_constant"><label class="metric_detail">Const Labels:</label>{{range $key, $value := $metric.ConstLabels}}<span class="metric_label">{{$key}}:{{$value}}</span>{{- end -}}</li>{{- end -}}
+	{{if $metric.DeprecatedVersion }}<li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>{{- $metric.DeprecatedVersion -}}</span></li>{{- end -}}
+	</ul>
+	</div>{{end}}
+</div>
 `
 )
 


### PR DESCRIPTION
This PR aims to implement a single column list for the metrics table by making amendments to the current generator code
As discussed over at the k8s/website issue [#38438](https://github.com/kubernetes/website/issues/38438) and [#42342](https://github.com/kubernetes/website/issues/42342)

The PR at k8s/website: https://github.com/kubernetes/website/pull/42823

#### Does this PR introduce a user-facing change?
None

#### Special notes for your reviewer:
  Please have a look at [The deployment preview](https://deploy-preview-42823--kubernetes-io-main-staging.netlify.app/docs/reference/instrumentation/metrics/) for a better perspective of the PR

Also, PR https://github.com/kubernetes/kubernetes/pull/120369 mentions the changes in documentation.md produced by this generator code

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:



