### PR TITLE
Automated cherry pick of #119870: Fallback to legacy discovery on a wider range of conditions

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -2763,54 +2763,76 @@ func TestAggregatedServerPreferredResources(t *testing.T) {
 }
 
 func TestDiscoveryContentTypeVersion(t *testing.T) {
+	v2beta1 := schema.GroupVersionKind{Group: "apidiscovery.k8s.io", Version: "v2beta1", Kind: "APIGroupDiscoveryList"}
 	tests := []struct {
 		contentType string
-		isV2Beta1   bool
+		gvk         schema.GroupVersionKind
+		match       bool
+		expectErr   bool
 	}{
 		{
 			contentType: "application/json; g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList",
-			isV2Beta1:   true,
+			gvk:         v2beta1,
+			match:       true,
+			expectErr:   false,
 		},
 		{
 			// content-type parameters are not in correct order, but comparison ignores order.
 			contentType: "application/json; v=v2beta1;as=APIGroupDiscoveryList;g=apidiscovery.k8s.io",
-			isV2Beta1:   true,
+			gvk:         v2beta1,
+			match:       true,
+			expectErr:   false,
 		},
 		{
 			// content-type parameters are not in correct order, but comparison ignores order.
 			contentType: "application/json; as=APIGroupDiscoveryList;g=apidiscovery.k8s.io;v=v2beta1",
-			isV2Beta1:   true,
+			gvk:         v2beta1,
+			match:       true,
+			expectErr:   false,
 		},
 		{
 			// Ignores extra parameter "charset=utf-8"
 			contentType: "application/json; g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList;charset=utf-8",
-			isV2Beta1:   true,
+			gvk:         v2beta1,
+			match:       true,
+			expectErr:   false,
 		},
 		{
 			contentType: "application/json",
-			isV2Beta1:   false,
+			gvk:         v2beta1,
+			match:       false,
+			expectErr:   false,
 		},
 		{
 			contentType: "application/json; charset=UTF-8",
-			isV2Beta1:   false,
+			gvk:         v2beta1,
+			match:       false,
+			expectErr:   false,
 		},
 		{
 			contentType: "text/json",
-			isV2Beta1:   false,
+			gvk:         v2beta1,
+			match:       false,
+			expectErr:   false,
 		},
 		{
 			contentType: "text/html",
-			isV2Beta1:   false,
+			gvk:         v2beta1,
+			match:       false,
+			expectErr:   false,
 		},
 		{
 			contentType: "",
-			isV2Beta1:   false,
+			gvk:         v2beta1,
+			match:       false,
+			expectErr:   true,
 		},
 	}
 
 	for _, test := range tests {
-		isV2Beta1 := isV2Beta1ContentType(test.contentType)
-		assert.Equal(t, test.isV2Beta1, isV2Beta1)
+		match, err := ContentTypeIsGVK(test.contentType, test.gvk)
+		assert.Equal(t, test.expectErr, err != nil)
+		assert.Equal(t, test.match, match)
 	}
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
@@ -26,12 +26,14 @@ import (
 	apidiscoveryv2beta1 "k8s.io/api/apidiscovery/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints"
 	discoveryendpoint "k8s.io/apiserver/pkg/endpoints/discovery/aggregated"
 	"k8s.io/apiserver/pkg/endpoints/request"
-	scheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -43,6 +45,13 @@ var APIRegistrationGroupVersion metav1.GroupVersion = metav1.GroupVersion{Group:
 // Maximum is 20000. Set to higher than that so apiregistration always is listed
 // first (mirrors v1 discovery behavior)
 var APIRegistrationGroupPriority int = 20001
+
+// Aggregated discovery content-type GVK.
+var v2Beta1GVK = schema.GroupVersionKind{
+	Group:   "apidiscovery.k8s.io",
+	Version: "v2beta1",
+	Kind:    "APIGroupDiscoveryList",
+}
 
 // Given a list of APIServices and proxyHandlers for contacting them,
 // DiscoveryManager caches a list of discovery documents for each server
@@ -204,7 +213,7 @@ func (dm *discoveryManager) fetchFreshDiscoveryForService(gv metav1.GroupVersion
 		Path:              req.URL.Path,
 		IsResourceRequest: false,
 	}))
-	req.Header.Add("Accept", runtime.ContentTypeJSON+";g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList")
+	req.Header.Add("Accept", discovery.AcceptV2Beta1)
 
 	if exists && len(cached.etag) > 0 {
 		req.Header.Add("If-None-Match", cached.etag)
@@ -217,8 +226,9 @@ func (dm *discoveryManager) fetchFreshDiscoveryForService(gv metav1.GroupVersion
 	writer := newInMemoryResponseWriter()
 	handler.ServeHTTP(writer, req)
 
-	switch writer.respCode {
-	case http.StatusNotModified:
+	isV2Beta1GVK, _ := discovery.ContentTypeIsGVK(writer.Header().Get("Content-Type"), v2Beta1GVK)
+	switch {
+	case writer.respCode == http.StatusNotModified:
 		// Keep old entry, update timestamp
 		cached = cachedResult{
 			discovery:   cached.discovery,
@@ -228,8 +238,47 @@ func (dm *discoveryManager) fetchFreshDiscoveryForService(gv metav1.GroupVersion
 
 		dm.setCacheEntryForService(info.service, cached)
 		return &cached, nil
-	case http.StatusNotAcceptable:
-		// Discovery Document is not being served at all.
+	case writer.respCode == http.StatusServiceUnavailable:
+		return nil, fmt.Errorf("service %s returned non-success response code: %v",
+			info.service.String(), writer.respCode)
+	case writer.respCode == http.StatusOK && isV2Beta1GVK:
+		parsed := &apidiscoveryv2beta1.APIGroupDiscoveryList{}
+		if err := runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), writer.data, parsed); err != nil {
+			return nil, err
+		}
+
+		klog.V(3).Infof("DiscoveryManager: Successfully downloaded discovery for %s", info.service.String())
+
+		// Convert discovery info into a map for convenient lookup later
+		discoMap := map[metav1.GroupVersion]apidiscoveryv2beta1.APIVersionDiscovery{}
+		for _, g := range parsed.Items {
+			for _, v := range g.Versions {
+				discoMap[metav1.GroupVersion{Group: g.Name, Version: v.Version}] = v
+				for i := range v.Resources {
+					// avoid nil panics in v0.26.0-v0.26.3 client-go clients
+					// see https://github.com/kubernetes/kubernetes/issues/118361
+					if v.Resources[i].ResponseKind == nil {
+						v.Resources[i].ResponseKind = &metav1.GroupVersionKind{}
+					}
+					for j := range v.Resources[i].Subresources {
+						if v.Resources[i].Subresources[j].ResponseKind == nil {
+							v.Resources[i].Subresources[j].ResponseKind = &metav1.GroupVersionKind{}
+						}
+					}
+				}
+			}
+		}
+
+		// Save cached result
+		cached = cachedResult{
+			discovery:   discoMap,
+			etag:        writer.Header().Get("Etag"),
+			lastUpdated: now,
+		}
+		dm.setCacheEntryForService(info.service, cached)
+		return &cached, nil
+	default:
+		// Could not get acceptable response for Aggregated Discovery.
 		// Fall back to legacy discovery information
 		if len(gv.Version) == 0 {
 			return nil, errors.New("not found")
@@ -265,7 +314,7 @@ func (dm *discoveryManager) fetchFreshDiscoveryForService(gv metav1.GroupVersion
 		handler.ServeHTTP(writer, req)
 
 		if writer.respCode != http.StatusOK {
-			return nil, fmt.Errorf("failed to download discovery for %s: %v", path, writer.String())
+			return nil, fmt.Errorf("failed to download legacy discovery for %s: %v", path, writer.String())
 		}
 
 		parsed := &metav1.APIResourceList{}
@@ -278,6 +327,7 @@ func (dm *discoveryManager) fetchFreshDiscoveryForService(gv metav1.GroupVersion
 		if err != nil {
 			return nil, err
 		}
+		klog.V(3).Infof("DiscoveryManager: Successfully downloaded legacy discovery for %s", info.service.String())
 
 		discoMap := map[metav1.GroupVersion]apidiscoveryv2beta1.APIVersionDiscovery{
 			// Convert old-style APIGroupList to new information
@@ -296,48 +346,6 @@ func (dm *discoveryManager) fetchFreshDiscoveryForService(gv metav1.GroupVersion
 		// one group version and an API Service may serve multiple
 		// group versions.
 		return &cached, nil
-
-	case http.StatusOK:
-		parsed := &apidiscoveryv2beta1.APIGroupDiscoveryList{}
-		if err := runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), writer.data, parsed); err != nil {
-			return nil, err
-		}
-		klog.V(3).Infof("DiscoveryManager: Successfully downloaded discovery for %s", info.service.String())
-
-		// Convert discovery info into a map for convenient lookup later
-		discoMap := map[metav1.GroupVersion]apidiscoveryv2beta1.APIVersionDiscovery{}
-		for _, g := range parsed.Items {
-			for _, v := range g.Versions {
-				discoMap[metav1.GroupVersion{Group: g.Name, Version: v.Version}] = v
-				for i := range v.Resources {
-					// avoid nil panics in v0.26.0-v0.26.3 client-go clients
-					// see https://github.com/kubernetes/kubernetes/issues/118361
-					if v.Resources[i].ResponseKind == nil {
-						v.Resources[i].ResponseKind = &metav1.GroupVersionKind{}
-					}
-					for j := range v.Resources[i].Subresources {
-						if v.Resources[i].Subresources[j].ResponseKind == nil {
-							v.Resources[i].Subresources[j].ResponseKind = &metav1.GroupVersionKind{}
-						}
-					}
-				}
-			}
-		}
-
-		// Save cached result
-		cached = cachedResult{
-			discovery:   discoMap,
-			etag:        writer.Header().Get("Etag"),
-			lastUpdated: now,
-		}
-		dm.setCacheEntryForService(info.service, cached)
-		return &cached, nil
-
-	default:
-		klog.Infof("DiscoveryManager: Failed to download discovery for %v: %v %s",
-			info.service.String(), writer.respCode, writer.data)
-		return nil, fmt.Errorf("service %s returned non-success response code: %v",
-			info.service.String(), writer.respCode)
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #119870 on release-1.27.

#119870: Fallback to legacy discovery on a wider range of conditions

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a regression in default 1.27 configurations in kube-apiserver: fixed the AggregatedDiscoveryEndpoint feature (beta in 1.27+) to successfully fetch discovery information from aggregated API servers that do not check `Accept` headers when serving the `/apis` endpoint
```
