### PR TITLE
Improve service unit test failure report

### DIFF
--- a/pkg/api/service/util_test.go
+++ b/pkg/api/service/util_test.go
@@ -26,6 +26,7 @@ import (
 
 func TestGetLoadBalancerSourceRanges(t *testing.T) {
 	checkError := func(v string) {
+		t.Helper()
 		annotations := make(map[string]string)
 		annotations[api.AnnotationLoadBalancerSourceRangesKey] = v
 		svc := api.Service{}
@@ -49,6 +50,7 @@ func TestGetLoadBalancerSourceRanges(t *testing.T) {
 	checkError("10.0.0.1")
 
 	checkOK := func(v string) utilnet.IPNetSet {
+		t.Helper()
 		annotations := make(map[string]string)
 		annotations[api.AnnotationLoadBalancerSourceRangesKey] = v
 		svc := api.Service{}
@@ -112,6 +114,7 @@ func TestGetLoadBalancerSourceRanges(t *testing.T) {
 
 func TestAllowAll(t *testing.T) {
 	checkAllowAll := func(allowAll bool, cidrs ...string) {
+		t.Helper()
 		ipnets, err := utilnet.ParseIPNets(cidrs...)
 		if err != nil {
 			t.Errorf("Unexpected error parsing cidrs: %v", cidrs)
@@ -131,6 +134,7 @@ func TestAllowAll(t *testing.T) {
 
 func TestExternallyAccessible(t *testing.T) {
 	checkExternallyAccessible := func(expect bool, service *api.Service) {
+		t.Helper()
 		res := ExternallyAccessible(service)
 		if res != expect {
 			t.Errorf("Expected ExternallyAccessible = %v, got %v", expect, res)
@@ -174,6 +178,7 @@ func TestExternallyAccessible(t *testing.T) {
 
 func TestRequestsOnlyLocalTraffic(t *testing.T) {
 	checkRequestsOnlyLocalTraffic := func(requestsOnlyLocalTraffic bool, service *api.Service) {
+		t.Helper()
 		res := RequestsOnlyLocalTraffic(service)
 		if res != requestsOnlyLocalTraffic {
 			t.Errorf("Expected requests OnlyLocal traffic = %v, got %v",
@@ -220,6 +225,7 @@ func TestRequestsOnlyLocalTraffic(t *testing.T) {
 
 func TestNeedsHealthCheck(t *testing.T) {
 	checkNeedsHealthCheck := func(needsHealthCheck bool, service *api.Service) {
+		t.Helper()
 		res := NeedsHealthCheck(service)
 		if res != needsHealthCheck {
 			t.Errorf("Expected needs health check = %v, got %v",

--- a/pkg/api/v1/service/util_test.go
+++ b/pkg/api/v1/service/util_test.go
@@ -26,6 +26,7 @@ import (
 
 func TestGetLoadBalancerSourceRanges(t *testing.T) {
 	checkError := func(v string) {
+		t.Helper()
 		annotations := make(map[string]string)
 		annotations[v1.AnnotationLoadBalancerSourceRangesKey] = v
 		svc := v1.Service{}
@@ -49,6 +50,7 @@ func TestGetLoadBalancerSourceRanges(t *testing.T) {
 	checkError("10.0.0.1")
 
 	checkOK := func(v string) utilnet.IPNetSet {
+		t.Helper()
 		annotations := make(map[string]string)
 		annotations[v1.AnnotationLoadBalancerSourceRangesKey] = v
 		svc := v1.Service{}
@@ -112,6 +114,7 @@ func TestGetLoadBalancerSourceRanges(t *testing.T) {
 
 func TestAllowAll(t *testing.T) {
 	checkAllowAll := func(allowAll bool, cidrs ...string) {
+		t.Helper()
 		ipnets, err := utilnet.ParseIPNets(cidrs...)
 		if err != nil {
 			t.Errorf("Unexpected error parsing cidrs: %v", cidrs)
@@ -131,6 +134,7 @@ func TestAllowAll(t *testing.T) {
 
 func TestExternallyAccessible(t *testing.T) {
 	checkExternallyAccessible := func(expect bool, service *v1.Service) {
+		t.Helper()
 		res := ExternallyAccessible(service)
 		if res != expect {
 			t.Errorf("Expected ExternallyAccessible = %v, got %v", expect, res)
@@ -174,6 +178,7 @@ func TestExternallyAccessible(t *testing.T) {
 
 func TestExternalPolicyLocal(t *testing.T) {
 	checkExternalPolicyLocal := func(requestsOnlyLocalTraffic bool, service *v1.Service) {
+		t.Helper()
 		res := ExternalPolicyLocal(service)
 		if res != requestsOnlyLocalTraffic {
 			t.Errorf("Expected requests OnlyLocal traffic = %v, got %v",
@@ -240,6 +245,7 @@ func TestExternalPolicyLocal(t *testing.T) {
 
 func TestNeedsHealthCheck(t *testing.T) {
 	checkNeedsHealthCheck := func(needsHealthCheck bool, service *v1.Service) {
+		t.Helper()
 		res := NeedsHealthCheck(service)
 		if res != needsHealthCheck {
 			t.Errorf("Expected needs health check = %v, got %v",
@@ -280,6 +286,7 @@ func TestNeedsHealthCheck(t *testing.T) {
 
 func TestInternalPolicyLocal(t *testing.T) {
 	checkInternalPolicyLocal := func(expected bool, service *v1.Service) {
+		t.Helper()
 		res := InternalPolicyLocal(service)
 		if res != expected {
 			t.Errorf("Expected internal local traffic = %v, got %v",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

To follow up https://github.com/kubernetes/kubernetes/pull/119150#discussion_r1310293456, mark the helper functions with t.Helper() so that if t.Errorf() in these functions gets called, it will report that the failure occurred on the line number of the caller of the helper, rather than the line number of the helper itself, which makes it hard to identify which case causes the failure.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

cc @danwinship 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
