### PR TITLE
remove SkipFilterSchemaForKubectlOpenAPIV2Validation

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/builder_test.go
@@ -44,42 +44,30 @@ func TestNewBuilder(t *testing.T) {
 		wantedSchema      string
 		wantedItemsSchema string
 
-		v2                                            bool // produce OpenAPIv2
-		skipFilterSchemaForKubectlOpenAPIV2Validation bool // produce OpenAPIv2 without going through the ToStructuralOpenAPIV2 path
+		v2 bool // produce OpenAPIv2
 	}{
 		{
 			"nil",
 			"",
 			`{"type":"object","x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`, `{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
 			true,
-			false,
 		},
 		{"with properties",
 			`{"type":"object","properties":{"spec":{"type":"object"},"status":{"type":"object"}}}`,
 			`{"type":"object","properties":{"apiVersion":{"type":"string"},"kind":{"type":"string"},"metadata":{"$ref":"#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},"spec":{"type":"object"},"status":{"type":"object"}},"x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`,
 			`{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
 			true,
-			false,
 		},
 		{"type only",
 			`{"type":"object"}`,
 			`{"type":"object","properties":{"apiVersion":{"type":"string"},"kind":{"type":"string"},"metadata":{"$ref":"#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"}},"x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`,
 			`{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
 			true,
-			false,
 		},
 		{"preserve unknown at root v2",
 			`{"type":"object","x-kubernetes-preserve-unknown-fields":true}`,
 			`{"type":"object","x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`,
 			`{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
-			true,
-			false,
-		},
-		{"preserve unknown at root v3",
-			`{"type":"object","x-kubernetes-preserve-unknown-fields":true}`,
-			`{"type":"object","x-kubernetes-preserve-unknown-fields":true,"properties":{"apiVersion":{"type":"string"},"kind":{"type":"string"},"metadata":{"$ref":"#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"}},"x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`,
-			`{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
-			true,
 			true,
 		},
 		{"with extensions",
@@ -184,174 +172,6 @@ func TestNewBuilder(t *testing.T) {
 }`,
 			`{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
 			true,
-			false,
-		},
-		{"with extensions as v3 schema",
-			`
-{
-  "type":"object",
-  "properties": {
-    "int-or-string-1": {
-      "x-kubernetes-int-or-string": true,
-      "anyOf": [
-        {"type":"integer"},
-        {"type":"string"}
-      ]
-    },
-    "int-or-string-2": {
-      "x-kubernetes-int-or-string": true,
-      "allOf": [{
-        "anyOf": [
-          {"type":"integer"},
-          {"type":"string"}
-        ]
-      }, {
-        "anyOf": [
-          {"minimum": 42.0}
-        ]
-      }]
-    },
-    "int-or-string-3": {
-      "x-kubernetes-int-or-string": true,
-      "anyOf": [
-        {"type":"integer"},
-        {"type":"string"}
-      ],
-      "allOf": [{
-        "anyOf": [
-          {"minimum": 42.0}
-        ]
-      }]
-    },
-    "int-or-string-4": {
-      "x-kubernetes-int-or-string": true,
-      "anyOf": [
-        {"minimum": 42.0}
-      ]
-    },
-    "int-or-string-5": {
-      "x-kubernetes-int-or-string": true,
-      "anyOf": [
-        {"minimum": 42.0}
-      ],
-      "allOf": [
-        {"minimum": 42.0}
-      ]
-    },
-    "int-or-string-6": {
-      "x-kubernetes-int-or-string": true
-    },
-    "preserve-unknown-fields": {
-      "x-kubernetes-preserve-unknown-fields": true
-    },
-    "embedded-object": {
-      "x-kubernetes-embedded-resource": true,
-      "x-kubernetes-preserve-unknown-fields": true,
-      "type": "object"
-    }
-  }
-}`,
-			`
-{
-  "type":"object",
-  "properties": {
-    "apiVersion": {"type":"string"},
-    "kind": {"type":"string"},
-    "metadata": {"$ref":"#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},
-    "int-or-string-1": {
-      "x-kubernetes-int-or-string": true,
-      "anyOf": [
-        {"type":"integer"},
-        {"type":"string"}
-      ]
-    },
-    "int-or-string-2": {
-      "x-kubernetes-int-or-string": true,
-      "allOf": [{
-        "anyOf": [
-          {"type":"integer"},
-          {"type":"string"}
-        ]
-      }, {
-        "anyOf": [
-          {"minimum": 42.0}
-        ]
-      }]
-    },
-    "int-or-string-3": {
-      "x-kubernetes-int-or-string": true,
-      "anyOf": [
-        {"type":"integer"},
-        {"type":"string"}
-      ],
-      "allOf": [{
-        "anyOf": [
-          {"minimum": 42.0}
-        ]
-      }]
-    },
-    "int-or-string-4": {
-      "x-kubernetes-int-or-string": true,
-      "allOf": [{
-        "anyOf": [
-          {"type":"integer"},
-          {"type":"string"}
-        ]
-      }],
-      "anyOf": [
-        {"minimum": 42.0}
-      ]
-    },
-    "int-or-string-5": {
-      "x-kubernetes-int-or-string": true,
-      "anyOf": [
-        {"minimum": 42.0}
-      ],
-      "allOf": [{
-        "anyOf": [
-          {"type":"integer"},
-          {"type":"string"}
-        ]
-      }, {
-        "minimum": 42.0
-      }]
-    },
-    "int-or-string-6": {
-      "x-kubernetes-int-or-string": true,
-      "anyOf": [
-        {"type":"integer"},
-        {"type":"string"}
-      ]
-    },
-    "preserve-unknown-fields": {
-      "x-kubernetes-preserve-unknown-fields": true
-    },
-    "embedded-object": {
-      "x-kubernetes-embedded-resource": true,
-      "x-kubernetes-preserve-unknown-fields": true,
-      "type": "object",
-      "required":["kind","apiVersion"],
-      "properties":{
-        "apiVersion":{
-          "description":"apiVersion defines the versioned schema of this representation of an object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-          "type":"string"
-        },
-        "kind":{
-          "description":"kind is a string value representing the type of this object. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "type":"string"
-        },
-        "metadata":{
-          "description":"Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-          "$ref":"#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        }
-      }
-    }
-  },
-  "x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]
-}`,
-			`{"$ref":"#/definitions/io.k8s.bar.v1.Foo"}`,
-			true,
-			true,
 		},
 	}
 	for _, tt := range tests {
@@ -391,7 +211,7 @@ func TestNewBuilder(t *testing.T) {
 					},
 					Scope: apiextensionsv1.NamespaceScoped,
 				},
-			}, "v1", schema, Options{V2: tt.v2, SkipFilterSchemaForKubectlOpenAPIV2Validation: tt.skipFilterSchemaForKubectlOpenAPIV2Validation})
+			}, "v1", schema, Options{V2: tt.v2})
 
 			var wantedSchema, wantedItemsSchema spec.Schema
 			if err := json.Unmarshal([]byte(tt.wantedSchema), &wantedSchema); err != nil {
@@ -613,13 +433,6 @@ func TestBuildOpenAPIV2(t *testing.T) {
 			nil,
 			`{"type":"object","properties":{"apiVersion":{"type":"string"},"kind":{"type":"string"},"metadata":{"$ref":"#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},"foo":{"type":"string"}},"x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`,
 			Options{V2: true},
-		},
-		{
-			"v3",
-			`{"type":"object","properties":{"foo":{"type":"string","oneOf":[{"pattern":"a"},{"pattern":"b"}]}}}`,
-			nil,
-			`{"type":"object","properties":{"apiVersion":{"type":"string"},"kind":{"type":"string"},"metadata":{"$ref":"#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},"foo":{"type":"string","oneOf":[{"pattern":"a"},{"pattern":"b"}]}},"x-kubernetes-group-version-kind":[{"group":"bar.k8s.io","kind":"Foo","version":"v1"}]}`,
-			Options{V2: true, SkipFilterSchemaForKubectlOpenAPIV2Validation: true},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Variable was only used by SSA to generate a best effort non lossy OpenAPI V2 schema to convert to SMD. Since the conversion is done directly from OpenAPI V3 now (https://github.com/kubernetes/kubernetes/pull/115324), remove this flag. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/triage accepted