### PR TITLE
Encapsulate KCM controllers with their metadata

### DIFF
--- a/cmd/kube-controller-manager/app/apps.go
+++ b/cmd/kube-controller-manager/app/apps.go
@@ -37,6 +37,7 @@ import (
 func newDaemonSetControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.DaemonSetController,
+		aliases:  []string{"daemonset"},
 		initFunc: startDaemonSetController,
 	}
 }
@@ -60,6 +61,7 @@ func startDaemonSetController(ctx context.Context, controllerContext ControllerC
 func newStatefulSetControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.StatefulSetController,
+		aliases:  []string{"statefulset"},
 		initFunc: startStatefulSetController,
 	}
 }
@@ -78,6 +80,7 @@ func startStatefulSetController(ctx context.Context, controllerContext Controlle
 func newReplicaSetControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.ReplicaSetController,
+		aliases:  []string{"replicaset"},
 		initFunc: startReplicaSetController,
 	}
 }
@@ -96,6 +99,7 @@ func startReplicaSetController(ctx context.Context, controllerContext Controller
 func newDeploymentControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.DeploymentController,
+		aliases:  []string{"deployment"},
 		initFunc: startDeploymentController,
 	}
 }

--- a/cmd/kube-controller-manager/app/apps.go
+++ b/cmd/kube-controller-manager/app/apps.go
@@ -27,13 +27,20 @@ import (
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/controller-manager/controller"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/daemon"
 	"k8s.io/kubernetes/pkg/controller/deployment"
 	"k8s.io/kubernetes/pkg/controller/replicaset"
 	"k8s.io/kubernetes/pkg/controller/statefulset"
 )
 
-func startDaemonSetController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newDaemonSetControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.DaemonSetController,
+		initFunc: startDaemonSetController,
+	}
+}
+func startDaemonSetController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	dsc, err := daemon.NewDaemonSetsController(
 		ctx,
 		controllerContext.InformerFactory.Apps().V1().DaemonSets(),
@@ -50,7 +57,13 @@ func startDaemonSetController(ctx context.Context, controllerContext ControllerC
 	return nil, true, nil
 }
 
-func startStatefulSetController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newStatefulSetControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.StatefulSetController,
+		initFunc: startStatefulSetController,
+	}
+}
+func startStatefulSetController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go statefulset.NewStatefulSetController(
 		ctx,
 		controllerContext.InformerFactory.Core().V1().Pods(),
@@ -62,7 +75,14 @@ func startStatefulSetController(ctx context.Context, controllerContext Controlle
 	return nil, true, nil
 }
 
-func startReplicaSetController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newReplicaSetControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.ReplicaSetController,
+		initFunc: startReplicaSetController,
+	}
+}
+
+func startReplicaSetController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go replicaset.NewReplicaSetController(
 		klog.FromContext(ctx),
 		controllerContext.InformerFactory.Apps().V1().ReplicaSets(),
@@ -73,7 +93,14 @@ func startReplicaSetController(ctx context.Context, controllerContext Controller
 	return nil, true, nil
 }
 
-func startDeploymentController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newDeploymentControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.DeploymentController,
+		initFunc: startDeploymentController,
+	}
+}
+
+func startDeploymentController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	dc, err := deployment.NewDeploymentController(
 		ctx,
 		controllerContext.InformerFactory.Apps().V1().Deployments(),

--- a/cmd/kube-controller-manager/app/autoscaling.go
+++ b/cmd/kube-controller-manager/app/autoscaling.go
@@ -39,6 +39,7 @@ import (
 func newHorizontalPodAutoscalerControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.HorizontalPodAutoscalerController,
+		aliases:  []string{"horizontalpodautoscaling"},
 		initFunc: startHorizontalPodAutoscalerControllerWithRESTClient,
 	}
 }

--- a/cmd/kube-controller-manager/app/autoscaling.go
+++ b/cmd/kube-controller-manager/app/autoscaling.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/scale"
 	"k8s.io/controller-manager/controller"
+	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/podautoscaler"
 	"k8s.io/kubernetes/pkg/controller/podautoscaler/metrics"
 	"k8s.io/kubernetes/pkg/features"
@@ -35,11 +36,14 @@ import (
 	"k8s.io/metrics/pkg/client/external_metrics"
 )
 
-func startHPAController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
-	return startHPAControllerWithRESTClient(ctx, controllerContext)
+func newHorizontalPodAutoscalerControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.HorizontalPodAutoscalerController,
+		initFunc: startHorizontalPodAutoscalerControllerWithRESTClient,
+	}
 }
 
-func startHPAControllerWithRESTClient(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func startHorizontalPodAutoscalerControllerWithRESTClient(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 
 	clientConfig := controllerContext.ClientBuilder.ConfigOrDie("horizontal-pod-autoscaler")
 	hpaClient := controllerContext.ClientBuilder.ClientOrDie("horizontal-pod-autoscaler")

--- a/cmd/kube-controller-manager/app/batch.go
+++ b/cmd/kube-controller-manager/app/batch.go
@@ -32,6 +32,7 @@ import (
 func newJobControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.JobController,
+		aliases:  []string{"job"},
 		initFunc: startJobController,
 	}
 }
@@ -53,6 +54,7 @@ func startJobController(ctx context.Context, controllerContext ControllerContext
 func newCronJobControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.CronJobController,
+		aliases:  []string{"cronjob"},
 		initFunc: startCronJobController,
 	}
 }

--- a/cmd/kube-controller-manager/app/batch.go
+++ b/cmd/kube-controller-manager/app/batch.go
@@ -24,11 +24,19 @@ import (
 	"fmt"
 
 	"k8s.io/controller-manager/controller"
+	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/cronjob"
 	"k8s.io/kubernetes/pkg/controller/job"
 )
 
-func startJobController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newJobControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.JobController,
+		initFunc: startJobController,
+	}
+}
+
+func startJobController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	jobController, err := job.NewController(
 		ctx,
 		controllerContext.InformerFactory.Core().V1().Pods(),
@@ -42,7 +50,14 @@ func startJobController(ctx context.Context, controllerContext ControllerContext
 	return nil, true, nil
 }
 
-func startCronJobController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newCronJobControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.CronJobController,
+		initFunc: startCronJobController,
+	}
+}
+
+func startCronJobController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	cj2c, err := cronjob.NewControllerV2(ctx, controllerContext.InformerFactory.Batch().V1().Jobs(),
 		controllerContext.InformerFactory.Batch().V1().CronJobs(),
 		controllerContext.ClientBuilder.ClientOrDie("cronjob-controller"),

--- a/cmd/kube-controller-manager/app/bootstrap.go
+++ b/cmd/kube-controller-manager/app/bootstrap.go
@@ -21,10 +21,18 @@ import (
 	"fmt"
 
 	"k8s.io/controller-manager/controller"
+	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/bootstrap"
 )
 
-func startBootstrapSignerController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newBootstrapSignerControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:                names.BootstrapSignerController,
+		initFunc:            startBootstrapSignerController,
+		isDisabledByDefault: true,
+	}
+}
+func startBootstrapSignerController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	bsc, err := bootstrap.NewSigner(
 		controllerContext.ClientBuilder.ClientOrDie("bootstrap-signer"),
 		controllerContext.InformerFactory.Core().V1().Secrets(),
@@ -38,7 +46,14 @@ func startBootstrapSignerController(ctx context.Context, controllerContext Contr
 	return nil, true, nil
 }
 
-func startTokenCleanerController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newTokenCleanerControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:                names.TokenCleanerController,
+		initFunc:            startTokenCleanerController,
+		isDisabledByDefault: true,
+	}
+}
+func startTokenCleanerController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	tcc, err := bootstrap.NewTokenCleaner(
 		controllerContext.ClientBuilder.ClientOrDie("token-cleaner"),
 		controllerContext.InformerFactory.Core().V1().Secrets(),

--- a/cmd/kube-controller-manager/app/bootstrap.go
+++ b/cmd/kube-controller-manager/app/bootstrap.go
@@ -28,6 +28,7 @@ import (
 func newBootstrapSignerControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:                names.BootstrapSignerController,
+		aliases:             []string{"bootstrapsigner"},
 		initFunc:            startBootstrapSignerController,
 		isDisabledByDefault: true,
 	}
@@ -49,6 +50,7 @@ func startBootstrapSignerController(ctx context.Context, controllerContext Contr
 func newTokenCleanerControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:                names.TokenCleanerController,
+		aliases:             []string{"tokencleaner"},
 		initFunc:            startTokenCleanerController,
 		isDisabledByDefault: true,
 	}

--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/controller-manager/controller"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/certificates/approver"
 	"k8s.io/kubernetes/pkg/controller/certificates/cleaner"
 	"k8s.io/kubernetes/pkg/controller/certificates/rootcacertpublisher"
@@ -32,7 +33,14 @@ import (
 	csrsigningconfig "k8s.io/kubernetes/pkg/controller/certificates/signer/config"
 )
 
-func startCSRSigningController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newCertificateSigningRequestSigningControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.CertificateSigningRequestSigningController,
+		initFunc: startCertificateSigningRequestSigningController,
+	}
+}
+
+func startCertificateSigningRequestSigningController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	logger := klog.FromContext(ctx)
 	missingSingleSigningFile := controllerContext.ComponentConfig.CSRSigningController.ClusterSigningCertFile == "" || controllerContext.ComponentConfig.CSRSigningController.ClusterSigningKeyFile == ""
 	if missingSingleSigningFile && !anySpecificFilesSet(controllerContext.ComponentConfig.CSRSigningController) {
@@ -148,7 +156,13 @@ func getLegacyUnknownSignerFiles(config csrsigningconfig.CSRSigningControllerCon
 	return config.ClusterSigningCertFile, config.ClusterSigningKeyFile
 }
 
-func startCSRApprovingController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newCertificateSigningRequestApprovingControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.CertificateSigningRequestApprovingController,
+		initFunc: startCertificateSigningRequestApprovingController,
+	}
+}
+func startCertificateSigningRequestApprovingController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	approver := approver.NewCSRApprovingController(
 		ctx,
 		controllerContext.ClientBuilder.ClientOrDie("certificate-controller"),
@@ -159,7 +173,13 @@ func startCSRApprovingController(ctx context.Context, controllerContext Controll
 	return nil, true, nil
 }
 
-func startCSRCleanerController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newCertificateSigningRequestCleanerControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.CertificateSigningRequestCleanerController,
+		initFunc: startCertificateSigningRequestCleanerController,
+	}
+}
+func startCertificateSigningRequestCleanerController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	cleaner := cleaner.NewCSRCleanerController(
 		controllerContext.ClientBuilder.ClientOrDie("certificate-controller").CertificatesV1().CertificateSigningRequests(),
 		controllerContext.InformerFactory.Certificates().V1().CertificateSigningRequests(),
@@ -168,7 +188,14 @@ func startCSRCleanerController(ctx context.Context, controllerContext Controller
 	return nil, true, nil
 }
 
-func startRootCACertPublisher(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newRootCACertificatePublisherControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.RootCACertificatePublisherController,
+		initFunc: startRootCACertificatePublisherController,
+	}
+}
+
+func startRootCACertificatePublisherController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	var (
 		rootCA []byte
 		err    error

--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -36,6 +36,7 @@ import (
 func newCertificateSigningRequestSigningControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.CertificateSigningRequestSigningController,
+		aliases:  []string{"csrsigning"},
 		initFunc: startCertificateSigningRequestSigningController,
 	}
 }
@@ -159,6 +160,7 @@ func getLegacyUnknownSignerFiles(config csrsigningconfig.CSRSigningControllerCon
 func newCertificateSigningRequestApprovingControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.CertificateSigningRequestApprovingController,
+		aliases:  []string{"csrapproving"},
 		initFunc: startCertificateSigningRequestApprovingController,
 	}
 }
@@ -176,6 +178,7 @@ func startCertificateSigningRequestApprovingController(ctx context.Context, cont
 func newCertificateSigningRequestCleanerControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.CertificateSigningRequestCleanerController,
+		aliases:  []string{"csrcleaner"},
 		initFunc: startCertificateSigningRequestCleanerController,
 	}
 }
@@ -191,6 +194,7 @@ func startCertificateSigningRequestCleanerController(ctx context.Context, contro
 func newRootCACertificatePublisherControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.RootCACertificatePublisherController,
+		aliases:  []string{"root-ca-cert-publisher"},
 		initFunc: startRootCACertificatePublisherController,
 	}
 }

--- a/cmd/kube-controller-manager/app/controllermanager_test.go
+++ b/cmd/kube-controller-manager/app/controllermanager_test.go
@@ -21,8 +21,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	cpnames "k8s.io/cloud-provider/names"
+	"k8s.io/component-base/featuregate"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 )
@@ -95,4 +100,59 @@ func TestControllerNamesDeclaration(t *testing.T) {
 
 func TestNewControllerDescriptorsShouldNotPanic(t *testing.T) {
 	NewControllerDescriptors()
+}
+
+func TestNewControllerDescriptorsAlwaysReturnsDescriptorsForAllControllers(t *testing.T) {
+	controllersWithoutFeatureGates := KnownControllers()
+
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, "AllAlpha", true)()
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, "AllBeta", true)()
+
+	controllersWithFeatureGates := KnownControllers()
+
+	if diff := cmp.Diff(controllersWithoutFeatureGates, controllersWithFeatureGates); diff != "" {
+		t.Errorf("unexpected controllers after enabling feature gates, NewControllerDescriptors should always return all controller descriptors. Controllers should define required feature gates in ControllerDescriptor.requiredFeatureGates. Diff of returned controllers:\n%s", diff)
+	}
+}
+
+func TestFeatureGatedControllersShouldNotDefineAliases(t *testing.T) {
+	featureGateRegex := regexp.MustCompile("^([a-zA-Z0-9]+)")
+
+	alphaFeatures := sets.NewString()
+	for _, featureText := range utilfeature.DefaultFeatureGate.KnownFeatures() {
+		// we have to parse this from KnownFeatures, because usage of mutable FeatureGate is not allowed in unit tests
+		feature := featureGateRegex.FindString(featureText)
+		if strings.Contains(featureText, string(featuregate.Alpha)) && feature != "AllAlpha" {
+			alphaFeatures.Insert(feature)
+		}
+
+	}
+
+	for name, controller := range NewControllerDescriptors() {
+		if len(controller.GetAliases()) == 0 {
+			continue
+		}
+
+		requiredFeatureGates := controller.GetRequiredFeatureGates()
+		if len(requiredFeatureGates) == 0 {
+			continue
+		}
+
+		// DO NOT ADD any new controllers here. These two controllers are an exception, because they were added before this test was introduced
+		if name == names.LegacyServiceAccountTokenCleanerController || name == names.ResourceClaimController {
+			continue
+		}
+
+		areAllRequiredFeaturesAlpha := true
+		for _, feature := range requiredFeatureGates {
+			if !alphaFeatures.Has(string(feature)) {
+				areAllRequiredFeaturesAlpha = false
+				break
+			}
+		}
+
+		if areAllRequiredFeaturesAlpha {
+			t.Errorf("alias check failed: controller name %q should not be aliased as it is still guarded by alpha feature gates (%v) and thus should have only a canonical name", name, requiredFeatureGates)
+		}
+	}
 }

--- a/cmd/kube-controller-manager/app/controllermanager_test.go
+++ b/cmd/kube-controller-manager/app/controllermanager_test.go
@@ -41,7 +41,7 @@ func TestControllerNamesConsistency(t *testing.T) {
 }
 
 func TestControllerNamesDeclaration(t *testing.T) {
-	declaredControllers := sets.New(
+	declaredControllers := sets.NewString(
 		names.ServiceAccountTokenController,
 		names.EndpointsController,
 		names.EndpointSliceController,
@@ -91,4 +91,8 @@ func TestControllerNamesDeclaration(t *testing.T) {
 			t.Errorf("name declaration check failed: controller name %q should be declared in  \"controller_names.go\" and added to this test", name)
 		}
 	}
+}
+
+func TestNewControllerDescriptorsShouldNotPanic(t *testing.T) {
+	NewControllerDescriptors()
 }

--- a/cmd/kube-controller-manager/app/controllermanager_test.go
+++ b/cmd/kube-controller-manager/app/controllermanager_test.go
@@ -83,6 +83,7 @@ func TestControllerNamesDeclaration(t *testing.T) {
 		names.StorageVersionGarbageCollectorController,
 		names.ResourceClaimController,
 		names.LegacyServiceAccountTokenCleanerController,
+		names.ValidatingAdmissionPolicyStatusController,
 	)
 
 	for _, name := range KnownControllers() {

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/quota/v1/generic"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
@@ -39,8 +40,11 @@ import (
 	cloudnodelifecyclecontroller "k8s.io/cloud-provider/controllers/nodelifecycle"
 	routecontroller "k8s.io/cloud-provider/controllers/route"
 	servicecontroller "k8s.io/cloud-provider/controllers/service"
+	cpnames "k8s.io/cloud-provider/names"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/controller-manager/controller"
 	csitrans "k8s.io/csi-translation-lib"
+	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	pkgcontroller "k8s.io/kubernetes/pkg/controller"
 	endpointcontroller "k8s.io/kubernetes/pkg/controller/endpoint"
 	"k8s.io/kubernetes/pkg/controller/garbagecollector"
@@ -63,6 +67,7 @@ import (
 	persistentvolumecontroller "k8s.io/kubernetes/pkg/controller/volume/persistentvolume"
 	"k8s.io/kubernetes/pkg/controller/volume/pvcprotection"
 	"k8s.io/kubernetes/pkg/controller/volume/pvprotection"
+	"k8s.io/kubernetes/pkg/features"
 	quotainstall "k8s.io/kubernetes/pkg/quota/v1/install"
 	"k8s.io/kubernetes/pkg/volume/csimigration"
 	"k8s.io/utils/clock"
@@ -76,7 +81,15 @@ const (
 	defaultNodeMaskCIDRIPv6 = 64
 )
 
-func startServiceController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newServiceLBControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:                      cpnames.ServiceLBController,
+		initFunc:                  startServiceLBController,
+		isCloudProviderController: true,
+	}
+}
+
+func startServiceLBController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	serviceController, err := servicecontroller.New(
 		controllerContext.Cloud,
 		controllerContext.ClientBuilder.ClientOrDie("service-controller"),
@@ -93,8 +106,14 @@ func startServiceController(ctx context.Context, controllerContext ControllerCon
 	go serviceController.Run(ctx, int(controllerContext.ComponentConfig.ServiceController.ConcurrentServiceSyncs), controllerContext.ControllerManagerMetrics)
 	return nil, true, nil
 }
+func newNodeIpamControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.NodeIpamController,
+		initFunc: startNodeIpamController,
+	}
+}
 
-func startNodeIpamController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func startNodeIpamController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	var serviceCIDR *net.IPNet
 	var secondaryServiceCIDR *net.IPNet
 	logger := klog.FromContext(ctx)
@@ -166,7 +185,14 @@ func startNodeIpamController(ctx context.Context, controllerContext ControllerCo
 	return nil, true, nil
 }
 
-func startNodeLifecycleController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newNodeLifecycleControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.NodeLifecycleController,
+		initFunc: startNodeLifecycleController,
+	}
+}
+
+func startNodeLifecycleController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	lifecycleController, err := lifecyclecontroller.NewNodeLifecycleController(
 		ctx,
 		controllerContext.InformerFactory.Coordination().V1().Leases(),
@@ -190,7 +216,15 @@ func startNodeLifecycleController(ctx context.Context, controllerContext Control
 	return nil, true, nil
 }
 
-func startCloudNodeLifecycleController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newCloudNodeLifecycleControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:                      cpnames.CloudNodeLifecycleController,
+		initFunc:                  startCloudNodeLifecycleController,
+		isCloudProviderController: true,
+	}
+}
+
+func startCloudNodeLifecycleController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	logger := klog.FromContext(ctx)
 	cloudNodeLifecycleController, err := cloudnodelifecyclecontroller.NewCloudNodeLifecycleController(
 		controllerContext.InformerFactory.Core().V1().Nodes(),
@@ -210,7 +244,15 @@ func startCloudNodeLifecycleController(ctx context.Context, controllerContext Co
 	return nil, true, nil
 }
 
-func startRouteController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newNodeRouteControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:                      cpnames.NodeRouteController,
+		initFunc:                  startNodeRouteController,
+		isCloudProviderController: true,
+	}
+}
+
+func startNodeRouteController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	logger := klog.FromContext(ctx)
 	if !controllerContext.ComponentConfig.KubeCloudShared.AllocateNodeCIDRs || !controllerContext.ComponentConfig.KubeCloudShared.ConfigureCloudRoutes {
 		logger.Info("Will not configure cloud provider routes for allocate-node-cidrs", "CIDRs", controllerContext.ComponentConfig.KubeCloudShared.AllocateNodeCIDRs, "routes", controllerContext.ComponentConfig.KubeCloudShared.ConfigureCloudRoutes)
@@ -240,7 +282,14 @@ func startRouteController(ctx context.Context, controllerContext ControllerConte
 	return nil, true, nil
 }
 
-func startPersistentVolumeBinderController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newPersistentVolumeBinderControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.PersistentVolumeBinderController,
+		initFunc: startPersistentVolumeBinderController,
+	}
+}
+
+func startPersistentVolumeBinderController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	logger := klog.FromContext(ctx)
 	plugins, err := ProbeControllerVolumePlugins(logger, controllerContext.Cloud, controllerContext.ComponentConfig.PersistentVolumeBinderController.VolumeConfiguration)
 	if err != nil {
@@ -268,7 +317,14 @@ func startPersistentVolumeBinderController(ctx context.Context, controllerContex
 	return nil, true, nil
 }
 
-func startAttachDetachController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newPersistentVolumeAttachDetachControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.PersistentVolumeAttachDetachController,
+		initFunc: startPersistentVolumeAttachDetachController,
+	}
+}
+
+func startPersistentVolumeAttachDetachController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	logger := klog.FromContext(ctx)
 	csiNodeInformer := controllerContext.InformerFactory.Storage().V1().CSINodes()
 	csiDriverInformer := controllerContext.InformerFactory.Storage().V1().CSIDrivers()
@@ -304,7 +360,14 @@ func startAttachDetachController(ctx context.Context, controllerContext Controll
 	return nil, true, nil
 }
 
-func startVolumeExpandController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newPersistentVolumeExpanderControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.PersistentVolumeExpanderController,
+		initFunc: startPersistentVolumeExpanderController,
+	}
+}
+
+func startPersistentVolumeExpanderController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	logger := klog.FromContext(ctx)
 	plugins, err := ProbeExpandableVolumePlugins(logger, controllerContext.ComponentConfig.PersistentVolumeBinderController.VolumeConfiguration)
 	if err != nil {
@@ -326,10 +389,16 @@ func startVolumeExpandController(ctx context.Context, controllerContext Controll
 	}
 	go expandController.Run(ctx)
 	return nil, true, nil
-
 }
 
-func startEphemeralVolumeController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newEphemeralVolumeControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.EphemeralVolumeController,
+		initFunc: startEphemeralVolumeController,
+	}
+}
+
+func startEphemeralVolumeController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	ephemeralController, err := ephemeral.NewController(
 		controllerContext.ClientBuilder.ClientOrDie("ephemeral-volume-controller"),
 		controllerContext.InformerFactory.Core().V1().Pods(),
@@ -343,7 +412,17 @@ func startEphemeralVolumeController(ctx context.Context, controllerContext Contr
 
 const defaultResourceClaimControllerWorkers = 10
 
-func startResourceClaimController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newResourceClaimControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.ResourceClaimController,
+		initFunc: startResourceClaimController,
+		requiredFeatureGates: []featuregate.Feature{
+			features.DynamicResourceAllocation,
+		},
+	}
+}
+
+func startResourceClaimController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	ephemeralController, err := resourceclaim.NewController(
 		klog.FromContext(ctx),
 		controllerContext.ClientBuilder.ClientOrDie("resource-claim-controller"),
@@ -358,18 +437,32 @@ func startResourceClaimController(ctx context.Context, controllerContext Control
 	return nil, true, nil
 }
 
-func startEndpointController(ctx context.Context, controllerCtx ControllerContext) (controller.Interface, bool, error) {
+func newEndpointsControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.EndpointsController,
+		initFunc: startEndpointsController,
+	}
+}
+
+func startEndpointsController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go endpointcontroller.NewEndpointController(
-		controllerCtx.InformerFactory.Core().V1().Pods(),
-		controllerCtx.InformerFactory.Core().V1().Services(),
-		controllerCtx.InformerFactory.Core().V1().Endpoints(),
-		controllerCtx.ClientBuilder.ClientOrDie("endpoint-controller"),
-		controllerCtx.ComponentConfig.EndpointController.EndpointUpdatesBatchPeriod.Duration,
-	).Run(ctx, int(controllerCtx.ComponentConfig.EndpointController.ConcurrentEndpointSyncs))
+		controllerContext.InformerFactory.Core().V1().Pods(),
+		controllerContext.InformerFactory.Core().V1().Services(),
+		controllerContext.InformerFactory.Core().V1().Endpoints(),
+		controllerContext.ClientBuilder.ClientOrDie("endpoint-controller"),
+		controllerContext.ComponentConfig.EndpointController.EndpointUpdatesBatchPeriod.Duration,
+	).Run(ctx, int(controllerContext.ComponentConfig.EndpointController.ConcurrentEndpointSyncs))
 	return nil, true, nil
 }
 
-func startReplicationController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newReplicationControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.ReplicationControllerController,
+		initFunc: startReplicationController,
+	}
+}
+
+func startReplicationController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go replicationcontroller.NewReplicationManager(
 		klog.FromContext(ctx),
 		controllerContext.InformerFactory.Core().V1().Pods(),
@@ -380,7 +473,14 @@ func startReplicationController(ctx context.Context, controllerContext Controlle
 	return nil, true, nil
 }
 
-func startPodGCController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newPodGarbageCollectorControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.PodGarbageCollectorController,
+		initFunc: startPodGarbageCollectorController,
+	}
+}
+
+func startPodGarbageCollectorController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go podgc.NewPodGC(
 		ctx,
 		controllerContext.ClientBuilder.ClientOrDie("pod-garbage-collector"),
@@ -391,7 +491,14 @@ func startPodGCController(ctx context.Context, controllerContext ControllerConte
 	return nil, true, nil
 }
 
-func startResourceQuotaController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newResourceQuotaControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.ResourceQuotaController,
+		initFunc: startResourceQuotaController,
+	}
+}
+
+func startResourceQuotaController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	resourceQuotaControllerClient := controllerContext.ClientBuilder.ClientOrDie("resourcequota-controller")
 	resourceQuotaControllerDiscoveryClient := controllerContext.ClientBuilder.DiscoveryClientOrDie("resourcequota-controller")
 	discoveryFunc := resourceQuotaControllerDiscoveryClient.ServerPreferredNamespacedResources
@@ -422,7 +529,14 @@ func startResourceQuotaController(ctx context.Context, controllerContext Control
 	return nil, true, nil
 }
 
-func startNamespaceController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newNamespaceControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.NamespaceController,
+		initFunc: startNamespaceController,
+	}
+}
+
+func startNamespaceController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	// the namespace cleanup controller is very chatty.  It makes lots of discovery calls and then it makes lots of delete calls
 	// the ratelimiter negatively affects its speed.  Deleting 100 total items in a namespace (that's only a few of each resource
 	// including events), takes ~10 seconds by default.
@@ -456,7 +570,14 @@ func startModifiedNamespaceController(ctx context.Context, controllerContext Con
 	return nil, true, nil
 }
 
-func startServiceAccountController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newServiceAccountControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.ServiceAccountController,
+		initFunc: startServiceAccountController,
+	}
+}
+
+func startServiceAccountController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	sac, err := serviceaccountcontroller.NewServiceAccountsController(
 		controllerContext.InformerFactory.Core().V1().ServiceAccounts(),
 		controllerContext.InformerFactory.Core().V1().Namespaces(),
@@ -470,7 +591,14 @@ func startServiceAccountController(ctx context.Context, controllerContext Contro
 	return nil, true, nil
 }
 
-func startTTLController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newTTLControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.TTLController,
+		initFunc: startTTLController,
+	}
+}
+
+func startTTLController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go ttlcontroller.NewTTLController(
 		ctx,
 		controllerContext.InformerFactory.Core().V1().Nodes(),
@@ -479,7 +607,14 @@ func startTTLController(ctx context.Context, controllerContext ControllerContext
 	return nil, true, nil
 }
 
-func startGarbageCollectorController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newGarbageCollectorControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.GarbageCollectorController,
+		initFunc: startGarbageCollectorController,
+	}
+}
+
+func startGarbageCollectorController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	if !controllerContext.ComponentConfig.GarbageCollectorController.EnableGarbageCollector {
 		return nil, false, nil
 	}
@@ -523,7 +658,14 @@ func startGarbageCollectorController(ctx context.Context, controllerContext Cont
 	return garbageCollector, true, nil
 }
 
-func startPVCProtectionController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newPersistentVolumeClaimProtectionControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.PersistentVolumeClaimProtectionController,
+		initFunc: startPersistentVolumeClaimProtectionController,
+	}
+}
+
+func startPersistentVolumeClaimProtectionController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	pvcProtectionController, err := pvcprotection.NewPVCProtectionController(
 		klog.FromContext(ctx),
 		controllerContext.InformerFactory.Core().V1().PersistentVolumeClaims(),
@@ -537,7 +679,14 @@ func startPVCProtectionController(ctx context.Context, controllerContext Control
 	return nil, true, nil
 }
 
-func startPVProtectionController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newPersistentVolumeProtectionControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.PersistentVolumeProtectionController,
+		initFunc: startPersistentVolumeProtectionController,
+	}
+}
+
+func startPersistentVolumeProtectionController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go pvprotection.NewPVProtectionController(
 		klog.FromContext(ctx),
 		controllerContext.InformerFactory.Core().V1().PersistentVolumes(),
@@ -546,7 +695,14 @@ func startPVProtectionController(ctx context.Context, controllerContext Controll
 	return nil, true, nil
 }
 
-func startTTLAfterFinishedController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newTTLAfterFinishedControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.TTLAfterFinishedController,
+		initFunc: startTTLAfterFinishedController,
+	}
+}
+
+func startTTLAfterFinishedController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go ttlafterfinished.New(
 		ctx,
 		controllerContext.InformerFactory.Batch().V1().Jobs(),
@@ -555,7 +711,17 @@ func startTTLAfterFinishedController(ctx context.Context, controllerContext Cont
 	return nil, true, nil
 }
 
-func startLegacySATokenCleaner(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newLegacyServiceAccountTokenCleanerControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.LegacyServiceAccountTokenCleanerController,
+		initFunc: startLegacyServiceAccountTokenCleanerController,
+		requiredFeatureGates: []featuregate.Feature{
+			features.LegacyServiceAccountTokenCleanUp,
+		},
+	}
+}
+
+func startLegacyServiceAccountTokenCleanerController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	cleanUpPeriod := controllerContext.ComponentConfig.LegacySATokenCleaner.CleanUpPeriod.Duration
 	legacySATokenCleaner, err := serviceaccountcontroller.NewLegacySATokenCleaner(
 		controllerContext.InformerFactory.Core().V1().ServiceAccounts(),
@@ -690,7 +856,18 @@ func setNodeCIDRMaskSizes(cfg nodeipamconfig.NodeIPAMControllerConfiguration, cl
 	return sortedSizes(ipv4Mask, ipv6Mask), nil
 }
 
-func startStorageVersionGCController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newStorageVersionGarbageCollectorControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.StorageVersionGarbageCollectorController,
+		initFunc: startStorageVersionGarbageCollectorController,
+		requiredFeatureGates: []featuregate.Feature{
+			genericfeatures.APIServerIdentity,
+			genericfeatures.StorageVersionAPI,
+		},
+	}
+}
+
+func startStorageVersionGarbageCollectorController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go storageversiongc.NewStorageVersionGC(
 		ctx,
 		controllerContext.ClientBuilder.ClientOrDie("storage-version-garbage-collector"),

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -84,6 +84,7 @@ const (
 func newServiceLBControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:                      cpnames.ServiceLBController,
+		aliases:                   []string{"service"},
 		initFunc:                  startServiceLBController,
 		isCloudProviderController: true,
 	}
@@ -109,6 +110,7 @@ func startServiceLBController(ctx context.Context, controllerContext ControllerC
 func newNodeIpamControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.NodeIpamController,
+		aliases:  []string{"nodeipam"},
 		initFunc: startNodeIpamController,
 	}
 }
@@ -188,6 +190,7 @@ func startNodeIpamController(ctx context.Context, controllerContext ControllerCo
 func newNodeLifecycleControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.NodeLifecycleController,
+		aliases:  []string{"nodelifecycle"},
 		initFunc: startNodeLifecycleController,
 	}
 }
@@ -219,6 +222,7 @@ func startNodeLifecycleController(ctx context.Context, controllerContext Control
 func newCloudNodeLifecycleControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:                      cpnames.CloudNodeLifecycleController,
+		aliases:                   []string{"cloud-node-lifecycle"},
 		initFunc:                  startCloudNodeLifecycleController,
 		isCloudProviderController: true,
 	}
@@ -247,6 +251,7 @@ func startCloudNodeLifecycleController(ctx context.Context, controllerContext Co
 func newNodeRouteControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:                      cpnames.NodeRouteController,
+		aliases:                   []string{"route"},
 		initFunc:                  startNodeRouteController,
 		isCloudProviderController: true,
 	}
@@ -285,6 +290,7 @@ func startNodeRouteController(ctx context.Context, controllerContext ControllerC
 func newPersistentVolumeBinderControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.PersistentVolumeBinderController,
+		aliases:  []string{"persistentvolume-binder"},
 		initFunc: startPersistentVolumeBinderController,
 	}
 }
@@ -320,6 +326,7 @@ func startPersistentVolumeBinderController(ctx context.Context, controllerContex
 func newPersistentVolumeAttachDetachControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.PersistentVolumeAttachDetachController,
+		aliases:  []string{"attachdetach"},
 		initFunc: startPersistentVolumeAttachDetachController,
 	}
 }
@@ -363,6 +370,7 @@ func startPersistentVolumeAttachDetachController(ctx context.Context, controller
 func newPersistentVolumeExpanderControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.PersistentVolumeExpanderController,
+		aliases:  []string{"persistentvolume-expander"},
 		initFunc: startPersistentVolumeExpanderController,
 	}
 }
@@ -394,6 +402,7 @@ func startPersistentVolumeExpanderController(ctx context.Context, controllerCont
 func newEphemeralVolumeControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.EphemeralVolumeController,
+		aliases:  []string{"ephemeral-volume"},
 		initFunc: startEphemeralVolumeController,
 	}
 }
@@ -415,6 +424,7 @@ const defaultResourceClaimControllerWorkers = 10
 func newResourceClaimControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.ResourceClaimController,
+		aliases:  []string{"resource-claim-controller"},
 		initFunc: startResourceClaimController,
 		requiredFeatureGates: []featuregate.Feature{
 			features.DynamicResourceAllocation,
@@ -440,6 +450,7 @@ func startResourceClaimController(ctx context.Context, controllerContext Control
 func newEndpointsControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.EndpointsController,
+		aliases:  []string{"endpoint"},
 		initFunc: startEndpointsController,
 	}
 }
@@ -458,6 +469,7 @@ func startEndpointsController(ctx context.Context, controllerContext ControllerC
 func newReplicationControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.ReplicationControllerController,
+		aliases:  []string{"replicationcontroller"},
 		initFunc: startReplicationController,
 	}
 }
@@ -476,6 +488,7 @@ func startReplicationController(ctx context.Context, controllerContext Controlle
 func newPodGarbageCollectorControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.PodGarbageCollectorController,
+		aliases:  []string{"podgc"},
 		initFunc: startPodGarbageCollectorController,
 	}
 }
@@ -494,6 +507,7 @@ func startPodGarbageCollectorController(ctx context.Context, controllerContext C
 func newResourceQuotaControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.ResourceQuotaController,
+		aliases:  []string{"resourcequota"},
 		initFunc: startResourceQuotaController,
 	}
 }
@@ -532,6 +546,7 @@ func startResourceQuotaController(ctx context.Context, controllerContext Control
 func newNamespaceControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.NamespaceController,
+		aliases:  []string{"namespace"},
 		initFunc: startNamespaceController,
 	}
 }
@@ -573,6 +588,7 @@ func startModifiedNamespaceController(ctx context.Context, controllerContext Con
 func newServiceAccountControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.ServiceAccountController,
+		aliases:  []string{"serviceaccount"},
 		initFunc: startServiceAccountController,
 	}
 }
@@ -594,6 +610,7 @@ func startServiceAccountController(ctx context.Context, controllerContext Contro
 func newTTLControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.TTLController,
+		aliases:  []string{"ttl"},
 		initFunc: startTTLController,
 	}
 }
@@ -610,6 +627,7 @@ func startTTLController(ctx context.Context, controllerContext ControllerContext
 func newGarbageCollectorControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.GarbageCollectorController,
+		aliases:  []string{"garbagecollector"},
 		initFunc: startGarbageCollectorController,
 	}
 }
@@ -661,6 +679,7 @@ func startGarbageCollectorController(ctx context.Context, controllerContext Cont
 func newPersistentVolumeClaimProtectionControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.PersistentVolumeClaimProtectionController,
+		aliases:  []string{"pvc-protection"},
 		initFunc: startPersistentVolumeClaimProtectionController,
 	}
 }
@@ -682,6 +701,7 @@ func startPersistentVolumeClaimProtectionController(ctx context.Context, control
 func newPersistentVolumeProtectionControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.PersistentVolumeProtectionController,
+		aliases:  []string{"pv-protection"},
 		initFunc: startPersistentVolumeProtectionController,
 	}
 }
@@ -698,6 +718,7 @@ func startPersistentVolumeProtectionController(ctx context.Context, controllerCo
 func newTTLAfterFinishedControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.TTLAfterFinishedController,
+		aliases:  []string{"ttl-after-finished"},
 		initFunc: startTTLAfterFinishedController,
 	}
 }
@@ -714,6 +735,7 @@ func startTTLAfterFinishedController(ctx context.Context, controllerContext Cont
 func newLegacyServiceAccountTokenCleanerControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.LegacyServiceAccountTokenCleanerController,
+		aliases:  []string{"legacy-service-account-token-cleaner"},
 		initFunc: startLegacyServiceAccountTokenCleanerController,
 		requiredFeatureGates: []featuregate.Feature{
 			features.LegacyServiceAccountTokenCleanUp,
@@ -859,6 +881,7 @@ func setNodeCIDRMaskSizes(cfg nodeipamconfig.NodeIPAMControllerConfiguration, cl
 func newStorageVersionGarbageCollectorControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.StorageVersionGarbageCollectorController,
+		aliases:  []string{"storage-version-gc"},
 		initFunc: startStorageVersionGarbageCollectorController,
 		requiredFeatureGates: []featuregate.Feature{
 			genericfeatures.APIServerIdentity,

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -427,7 +427,7 @@ func newResourceClaimControllerDescriptor() *ControllerDescriptor {
 		aliases:  []string{"resource-claim-controller"},
 		initFunc: startResourceClaimController,
 		requiredFeatureGates: []featuregate.Feature{
-			features.DynamicResourceAllocation,
+			features.DynamicResourceAllocation, // TODO update app.TestFeatureGatedControllersShouldNotDefineAliases when removing this feature
 		},
 	}
 }
@@ -738,7 +738,7 @@ func newLegacyServiceAccountTokenCleanerControllerDescriptor() *ControllerDescri
 		aliases:  []string{"legacy-service-account-token-cleaner"},
 		initFunc: startLegacyServiceAccountTokenCleanerController,
 		requiredFeatureGates: []featuregate.Feature{
-			features.LegacyServiceAccountTokenCleanUp,
+			features.LegacyServiceAccountTokenCleanUp, // TODO update app.TestFeatureGatedControllersShouldNotDefineAliases when removing this feature
 		},
 	}
 }

--- a/cmd/kube-controller-manager/app/discovery.go
+++ b/cmd/kube-controller-manager/app/discovery.go
@@ -31,6 +31,7 @@ import (
 func newEndpointSliceControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.EndpointSliceController,
+		aliases:  []string{"endpointslice"},
 		initFunc: startEndpointSliceController,
 	}
 }
@@ -52,6 +53,7 @@ func startEndpointSliceController(ctx context.Context, controllerContext Control
 func newEndpointSliceMirroringControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.EndpointSliceMirroringController,
+		aliases:  []string{"endpointslicemirroring"},
 		initFunc: startEndpointSliceMirroringController,
 	}
 }

--- a/cmd/kube-controller-manager/app/discovery.go
+++ b/cmd/kube-controller-manager/app/discovery.go
@@ -23,11 +23,19 @@ import (
 	"context"
 
 	"k8s.io/controller-manager/controller"
+	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	endpointslicecontroller "k8s.io/kubernetes/pkg/controller/endpointslice"
 	endpointslicemirroringcontroller "k8s.io/kubernetes/pkg/controller/endpointslicemirroring"
 )
 
-func startEndpointSliceController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newEndpointSliceControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.EndpointSliceController,
+		initFunc: startEndpointSliceController,
+	}
+}
+
+func startEndpointSliceController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go endpointslicecontroller.NewController(
 		ctx,
 		controllerContext.InformerFactory.Core().V1().Pods(),
@@ -41,7 +49,14 @@ func startEndpointSliceController(ctx context.Context, controllerContext Control
 	return nil, true, nil
 }
 
-func startEndpointSliceMirroringController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newEndpointSliceMirroringControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.EndpointSliceMirroringController,
+		initFunc: startEndpointSliceMirroringController,
+	}
+}
+
+func startEndpointSliceMirroringController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go endpointslicemirroringcontroller.NewController(
 		ctx,
 		controllerContext.InformerFactory.Core().V1().Endpoints(),

--- a/cmd/kube-controller-manager/app/policy.go
+++ b/cmd/kube-controller-manager/app/policy.go
@@ -32,6 +32,7 @@ import (
 func newDisruptionControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.DisruptionController,
+		aliases:  []string{"disruption"},
 		initFunc: startDisruptionController,
 	}
 }

--- a/cmd/kube-controller-manager/app/policy.go
+++ b/cmd/kube-controller-manager/app/policy.go
@@ -25,10 +25,18 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/scale"
 	"k8s.io/controller-manager/controller"
+	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/disruption"
 )
 
-func startDisruptionController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newDisruptionControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.DisruptionController,
+		initFunc: startDisruptionController,
+	}
+}
+
+func startDisruptionController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	client := controllerContext.ClientBuilder.ClientOrDie("disruption-controller")
 	config := controllerContext.ClientBuilder.ConfigOrDie("disruption-controller")
 	scaleKindResolver := scale.NewDiscoveryScaleKindResolver(client.Discovery())

--- a/cmd/kube-controller-manager/app/rbac.go
+++ b/cmd/kube-controller-manager/app/rbac.go
@@ -20,10 +20,18 @@ import (
 	"context"
 
 	"k8s.io/controller-manager/controller"
+	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/clusterroleaggregation"
 )
 
-func startClusterRoleAggregrationController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newClusterRoleAggregrationControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.ClusterRoleAggregationController,
+		initFunc: startClusterRoleAggregationController,
+	}
+}
+
+func startClusterRoleAggregationController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	go clusterroleaggregation.NewClusterRoleAggregation(
 		controllerContext.InformerFactory.Rbac().V1().ClusterRoles(),
 		controllerContext.ClientBuilder.ClientOrDie("clusterrole-aggregation-controller").RbacV1(),

--- a/cmd/kube-controller-manager/app/rbac.go
+++ b/cmd/kube-controller-manager/app/rbac.go
@@ -27,6 +27,7 @@ import (
 func newClusterRoleAggregrationControllerDescriptor() *ControllerDescriptor {
 	return &ControllerDescriptor{
 		name:     names.ClusterRoleAggregationController,
+		aliases:  []string{"clusterrole-aggregation"},
 		initFunc: startClusterRoleAggregationController,
 	}
 }

--- a/cmd/kube-controller-manager/app/testing/testserver.go
+++ b/cmd/kube-controller-manager/app/testing/testserver.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app"
 	kubecontrollerconfig "k8s.io/kubernetes/cmd/kube-controller-manager/app/config"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
-	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 )
 
 func init() {
@@ -97,7 +96,7 @@ func StartTestServer(ctx context.Context, customFlags []string) (result TestServ
 	if err != nil {
 		return TestServer{}, err
 	}
-	all, disabled, aliases := app.KnownControllers(), app.ControllersDisabledByDefault(), names.KCMControllerAliases()
+	all, disabled, aliases := app.KnownControllers(), app.ControllersDisabledByDefault(), app.ControllerAliases()
 	namedFlagSets := s.Flags(all, disabled, aliases)
 	for _, f := range namedFlagSets.FlagSets {
 		fs.AddFlagSet(f)

--- a/cmd/kube-controller-manager/app/testing/testserver.go
+++ b/cmd/kube-controller-manager/app/testing/testserver.go
@@ -97,7 +97,7 @@ func StartTestServer(ctx context.Context, customFlags []string) (result TestServ
 	if err != nil {
 		return TestServer{}, err
 	}
-	all, disabled, aliases := app.KnownControllers(), app.ControllersDisabledByDefault.List(), names.KCMControllerAliases()
+	all, disabled, aliases := app.KnownControllers(), app.ControllersDisabledByDefault(), names.KCMControllerAliases()
 	namedFlagSets := s.Flags(all, disabled, aliases)
 	for _, f := range namedFlagSets.FlagSets {
 		fs.AddFlagSet(f)

--- a/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
+++ b/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
@@ -21,14 +21,26 @@ import (
 
 	pluginvalidatingadmissionpolicy "k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy"
 	"k8s.io/apiserver/pkg/cel/openapi/resolver"
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/controller-manager/controller"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/validatingadmissionpolicystatus"
 	"k8s.io/kubernetes/pkg/generated/openapi"
 )
 
-func startValidatingAdmissionPolicyStatusController(ctx context.Context, controllerContext ControllerContext) (controller.Interface, bool, error) {
+func newValidatingAdmissionPolicyStatusControllerDescriptor() *ControllerDescriptor {
+	return &ControllerDescriptor{
+		name:     names.ValidatingAdmissionPolicyStatusController,
+		initFunc: startValidatingAdmissionPolicyStatusController,
+		requiredFeatureGates: []featuregate.Feature{
+			genericfeatures.ValidatingAdmissionPolicy,
+		},
+	}
+}
+
+func startValidatingAdmissionPolicyStatusController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	// KCM won't start the controller without the feature gate set.
 	typeChecker := &pluginvalidatingadmissionpolicy.TypeChecker{
 		SchemaResolver: resolver.NewDefinitionsSchemaResolver(scheme.Scheme, openapi.GetOpenAPIDefinitions),

--- a/cmd/kube-controller-manager/names/controller_names.go
+++ b/cmd/kube-controller-manager/names/controller_names.go
@@ -33,20 +33,17 @@ import cpnames "k8s.io/cloud-provider/names"
 //
 // USE CASES
 // The following places should use the controller name constants, when:
-//  1. registering a controller in app.NewControllerInitializers or app.KnownControllers:
-//     1.1. disabling a controller by default in app.ControllersDisabledByDefault
-//     1.2. checking if IsControllerEnabled
-//     1.3. defining an alias in KCMControllerAliases (for backwards compatibility only)
-//  2. used anywhere inside the controller itself:
-//     2.1. [TODO] logger component should be configured with the controller name by calling LoggerWithName
-//     2.2. [TODO] logging should use a canonical controller name when referencing a controller (Eg. Starting X, Shutting down X)
-//     2.3. [TODO] emitted events should have an EventSource.Component set to the controller name (usually when initializing an EventRecorder)
-//     2.4. [TODO] registering ControllerManagerMetrics with ControllerStarted and ControllerStopped
-//     2.5. [TODO] calling WaitForNamedCacheSync
-//  3. defining controller options for "--help" command or generated documentation
-//     3.1. controller name should be used to create a pflag.FlagSet when registering controller options (the name is rendered in a controller flag group header)
-//     3.2. when defined flag's help mentions a controller name
-//  4. defining a new service account for a new controller (old controllers may have inconsistent service accounts to stay backwards compatible)
+//  1. defining a new app.ControllerDescriptor so it can be used in app.NewControllerDescriptors or app.KnownControllers:
+//  2. defining an alias in KCMControllerAliases (for backwards compatibility only)
+//  3. used anywhere inside the controller itself:
+//     3.1. [TODO] logging should use a canonical controller name when referencing a controller (Eg. Starting X, Shutting down X)
+//     3.2. [TODO] emitted events should have an EventSource.Component set to the controller name (usually when initializing an EventRecorder)
+//     3.3. [TODO] registering ControllerManagerMetrics with ControllerStarted and ControllerStopped
+//     3.4. [TODO] calling WaitForNamedCacheSync
+//  4. defining controller options for "--help" command or generated documentation
+//     1.1. controller name should be used to create a pflag.FlagSet when registering controller options (the name is rendered in a controller flag group header) in options.KubeControllerManagerOptions
+//     1.2. when defined flag's help mentions a controller name
+//  5. defining a new service account for a new controller (old controllers may have inconsistent service accounts to stay backwards compatible)
 const (
 	ServiceAccountTokenController                = "serviceaccount-token-controller"
 	EndpointsController                          = "endpoints-controller"

--- a/cmd/kube-controller-manager/names/controller_names.go
+++ b/cmd/kube-controller-manager/names/controller_names.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package names
 
-import cpnames "k8s.io/cloud-provider/names"
-
 // Canonical controller names
 //
 // NAMING CONVENTIONS
@@ -28,22 +26,21 @@ import cpnames "k8s.io/cloud-provider/names"
 // CHANGE POLICY
 // The controller names should be treated as IDs.
 // They can only be changed if absolutely necessary. For example if an inappropriate name was chosen in the past, or if the scope of the controller changes.
-// When a name is changed, the old name should be aliased in KCMControllerAliases, while preserving all old aliases.
+// When a name is changed, the old name should be aliased in app.ControllerDescriptor#GetAliases, while preserving all old aliases.
 // This is done to achieve backwards compatibility
 //
 // USE CASES
 // The following places should use the controller name constants, when:
 //  1. defining a new app.ControllerDescriptor so it can be used in app.NewControllerDescriptors or app.KnownControllers:
-//  2. defining an alias in KCMControllerAliases (for backwards compatibility only)
-//  3. used anywhere inside the controller itself:
-//     3.1. [TODO] logging should use a canonical controller name when referencing a controller (Eg. Starting X, Shutting down X)
-//     3.2. [TODO] emitted events should have an EventSource.Component set to the controller name (usually when initializing an EventRecorder)
-//     3.3. [TODO] registering ControllerManagerMetrics with ControllerStarted and ControllerStopped
-//     3.4. [TODO] calling WaitForNamedCacheSync
-//  4. defining controller options for "--help" command or generated documentation
-//     1.1. controller name should be used to create a pflag.FlagSet when registering controller options (the name is rendered in a controller flag group header) in options.KubeControllerManagerOptions
-//     1.2. when defined flag's help mentions a controller name
-//  5. defining a new service account for a new controller (old controllers may have inconsistent service accounts to stay backwards compatible)
+//  2. used anywhere inside the controller itself:
+//     2.1. [TODO] logging should use a canonical controller name when referencing a controller (Eg. Starting X, Shutting down X)
+//     2.2. [TODO] emitted events should have an EventSource.Component set to the controller name (usually when initializing an EventRecorder)
+//     2.3. [TODO] registering ControllerManagerMetrics with ControllerStarted and ControllerStopped
+//     2.4. [TODO] calling WaitForNamedCacheSync
+//  3. defining controller options for "--help" command or generated documentation
+//     3.1. controller name should be used to create a pflag.FlagSet when registering controller options (the name is rendered in a controller flag group header) in options.KubeControllerManagerOptions
+//     3.2. when defined flag's help mentions a controller name
+//  4. defining a new service account for a new controller (old controllers may have inconsistent service accounts to stay backwards compatible)
 const (
 	ServiceAccountTokenController                = "serviceaccount-token-controller"
 	EndpointsController                          = "endpoints-controller"
@@ -85,54 +82,3 @@ const (
 	LegacyServiceAccountTokenCleanerController   = "legacy-serviceaccount-token-cleaner-controller"
 	ValidatingAdmissionPolicyStatusController    = "validatingadmissionpolicy-status-controller"
 )
-
-// KCMControllerAliases returns a mapping of aliases to canonical controller names
-//
-// These aliases ensure backwards compatibility and should never be removed!
-// Only addition of new aliases is allowed, and only when a canonical name is changed (please see CHANGE POLICY of controller names)
-func KCMControllerAliases() map[string]string {
-	// return a new reference to achieve immutability of the mapping
-	return map[string]string{
-		"serviceaccount-token":                 ServiceAccountTokenController,
-		"endpoint":                             EndpointsController,
-		"endpointslice":                        EndpointSliceController,
-		"endpointslicemirroring":               EndpointSliceMirroringController,
-		"replicationcontroller":                ReplicationControllerController,
-		"podgc":                                PodGarbageCollectorController,
-		"resourcequota":                        ResourceQuotaController,
-		"namespace":                            NamespaceController,
-		"serviceaccount":                       ServiceAccountController,
-		"garbagecollector":                     GarbageCollectorController,
-		"daemonset":                            DaemonSetController,
-		"job":                                  JobController,
-		"deployment":                           DeploymentController,
-		"replicaset":                           ReplicaSetController,
-		"horizontalpodautoscaling":             HorizontalPodAutoscalerController,
-		"disruption":                           DisruptionController,
-		"statefulset":                          StatefulSetController,
-		"cronjob":                              CronJobController,
-		"csrsigning":                           CertificateSigningRequestSigningController,
-		"csrapproving":                         CertificateSigningRequestApprovingController,
-		"csrcleaner":                           CertificateSigningRequestCleanerController,
-		"ttl":                                  TTLController,
-		"bootstrapsigner":                      BootstrapSignerController,
-		"tokencleaner":                         TokenCleanerController,
-		"nodeipam":                             NodeIpamController,
-		"nodelifecycle":                        NodeLifecycleController,
-		"service":                              cpnames.ServiceLBController,
-		"route":                                cpnames.NodeRouteController,
-		"cloud-node-lifecycle":                 cpnames.CloudNodeLifecycleController,
-		"persistentvolume-binder":              PersistentVolumeBinderController,
-		"attachdetach":                         PersistentVolumeAttachDetachController,
-		"persistentvolume-expander":            PersistentVolumeExpanderController,
-		"clusterrole-aggregation":              ClusterRoleAggregationController,
-		"pvc-protection":                       PersistentVolumeClaimProtectionController,
-		"pv-protection":                        PersistentVolumeProtectionController,
-		"ttl-after-finished":                   TTLAfterFinishedController,
-		"root-ca-cert-publisher":               RootCACertificatePublisherController,
-		"ephemeral-volume":                     EphemeralVolumeController,
-		"storage-version-gc":                   StorageVersionGarbageCollectorController,
-		"resource-claim-controller":            ResourceClaimController,
-		"legacy-service-account-token-cleaner": LegacyServiceAccountTokenCleanerController,
-	}
-}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

this is a followup to following PR and a discussion: https://github.com/kubernetes/kubernetes/pull/115813#discussion_r1214768774


- These metadata can be used to handle controllers in a generic way.
- This enables showing feature gated controllers in kube-controller-manager's help.
- It is possible to obtain a controllerName in the InitFunc so it can be passed down to and used by the controller.
- include ServiceAccountTokenController in the NewRegistrableControllers to make it more generic
- move start controller pre- and post- checks/actions out of StartControllers into StartController function


```
metadata about a controller:
- name
- requiredFeatureGates
- aliases
- isDisabledByDefault
- isCloudProviderController
- requiresSpecialHandling
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

similar thing can be done for cloud-controller-manager, but it is better to open a new separate PR for that

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-controller-manager's help will include controllers behind a feature gate in `--controllers` flag
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
