### PR TITLE
Automated cherry pick of #118189: TopologyAwareHints: Take lock in HasPopulatedHints

### DIFF
--- a/staging/src/k8s.io/endpointslice/topologycache/topologycache.go
+++ b/staging/src/k8s.io/endpointslice/topologycache/topologycache.go
@@ -153,8 +153,10 @@ func (t *TopologyCache) AddHints(logger klog.Logger, si *SliceInfo) ([]*discover
 		return slicesToCreate, slicesToUpdate, events
 	}
 
-	hintsEnabled := t.hintsPopulatedByService.Has(si.ServiceKey)
-	t.SetHints(si.ServiceKey, si.AddressType, allocatedHintsByZone)
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	hintsEnabled := t.hasPopulatedHintsLocked(si.ServiceKey)
+	t.setHintsLocked(si.ServiceKey, si.AddressType, allocatedHintsByZone)
 
 	// if hints were not enabled before, we publish an event to indicate we enabled them.
 	if !hintsEnabled {
@@ -174,6 +176,10 @@ func (t *TopologyCache) SetHints(serviceKey string, addrType discovery.AddressTy
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
+	t.setHintsLocked(serviceKey, addrType, allocatedHintsByZone)
+}
+
+func (t *TopologyCache) setHintsLocked(serviceKey string, addrType discovery.AddressType, allocatedHintsByZone EndpointZoneInfo) {
 	_, ok := t.endpointsByService[serviceKey]
 	if !ok {
 		t.endpointsByService[serviceKey] = map[discovery.AddressType]EndpointZoneInfo{}
@@ -262,6 +268,13 @@ func (t *TopologyCache) SetNodes(logger klog.Logger, nodes []*v1.Node) {
 
 // HasPopulatedHints checks whether there are populated hints for a given service in the cache.
 func (t *TopologyCache) HasPopulatedHints(serviceKey string) bool {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.hasPopulatedHintsLocked(serviceKey)
+}
+
+func (t *TopologyCache) hasPopulatedHintsLocked(serviceKey string) bool {
 	return t.hintsPopulatedByService.Has(serviceKey)
 }
 

--- a/staging/src/k8s.io/endpointslice/topologycache/topologycache_test.go
+++ b/staging/src/k8s.io/endpointslice/topologycache/topologycache_test.go
@@ -690,6 +690,9 @@ func TestTopologyCacheRace(t *testing.T) {
 	go func() {
 		cache.AddHints(logger, sliceInfo)
 	}()
+	go func() {
+		cache.HasPopulatedHints(sliceInfo.ServiceKey)
+	}()
 }
 
 // Test Helpers


### PR DESCRIPTION
Cherry pick of #118189 on release-1.28.

#118189: TopologyAwareHints: Take lock in HasPopulatedHints

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a concurrent map access in TopologyCache's `HasPopulatedHints` method.
```