### PR TITLE
validate hpa target values

### DIFF
--- a/pkg/apis/autoscaling/validation/validation.go
+++ b/pkg/apis/autoscaling/validation/validation.go
@@ -442,6 +442,14 @@ func validateMetricTarget(mt autoscaling.MetricTarget, fldPath *field.Path) fiel
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("type"), mt.Type, "must be either Utilization, Value, or AverageValue"))
 	}
 
+	if mt.Type == autoscaling.ValueMetricType && mt.Value == nil && mt.AverageValue != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("value"), mt.Value, "must be set for metric target type Value"))
+	}
+
+	if mt.Type == autoscaling.AverageValueMetricType && mt.AverageValue == nil && mt.Value != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("averageValue"), mt.AverageValue, "must be set for metric target type AverageValue"))
+	}
+
 	if mt.Value != nil && mt.Value.Sign() != 1 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("value"), mt.Value, "must be positive"))
 	}

--- a/pkg/apis/autoscaling/validation/validation.go
+++ b/pkg/apis/autoscaling/validation/validation.go
@@ -18,7 +18,6 @@ package validation
 
 import (
 	"fmt"
-
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	pathvalidation "k8s.io/apimachinery/pkg/api/validation/path"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -397,7 +396,7 @@ func validateObjectSource(src *autoscaling.ObjectMetricSource, fldPath *field.Pa
 		}
 	}
 	if src.Target.Value == nil && src.Target.AverageValue == nil {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("target").Child("averageValue"), "must set either a target value or averageValue"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("target").Child("averageValue"), "must set either a target value or averageValue"))
 	}
 
 	return allErrs

--- a/pkg/apis/autoscaling/validation/validation.go
+++ b/pkg/apis/autoscaling/validation/validation.go
@@ -344,10 +344,6 @@ func validateObjectSource(src *autoscaling.ObjectMetricSource, fldPath *field.Pa
 	allErrs = append(allErrs, validateMetricIdentifier(src.Metric, fldPath.Child("metric"))...)
 	allErrs = append(allErrs, validateMetricTarget(src.Target, fldPath.Child("target"))...)
 
-	if src.Target.Value == nil && src.Target.AverageValue == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("target").Child("averageValue"), "must set either a target value or averageValue"))
-	}
-
 	return allErrs
 }
 
@@ -356,10 +352,6 @@ func validateExternalSource(src *autoscaling.ExternalMetricSource, fldPath *fiel
 
 	allErrs = append(allErrs, validateMetricIdentifier(src.Metric, fldPath.Child("metric"))...)
 	allErrs = append(allErrs, validateMetricTarget(src.Target, fldPath.Child("target"))...)
-
-	if src.Target.Value == nil && src.Target.AverageValue == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("target").Child("averageValue"), "must set either a target value for metric or a per-pod target"))
-	}
 
 	if src.Target.Value != nil && src.Target.AverageValue != nil {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("target").Child("value"), "may not set both a target value for metric and a per-pod target"))
@@ -373,10 +365,6 @@ func validatePodsSource(src *autoscaling.PodsMetricSource, fldPath *field.Path) 
 
 	allErrs = append(allErrs, validateMetricIdentifier(src.Metric, fldPath.Child("metric"))...)
 	allErrs = append(allErrs, validateMetricTarget(src.Target, fldPath.Child("target"))...)
-
-	if src.Target.AverageValue == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("target").Child("averageValue"), "must specify a positive target averageValue"))
-	}
 
 	return allErrs
 }
@@ -442,11 +430,11 @@ func validateMetricTarget(mt autoscaling.MetricTarget, fldPath *field.Path) fiel
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("type"), mt.Type, "must be either Utilization, Value, or AverageValue"))
 	}
 
-	if mt.Type == autoscaling.ValueMetricType && mt.Value == nil && mt.AverageValue != nil {
+	if mt.Type == autoscaling.ValueMetricType && mt.Value == nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("value"), mt.Value, "must be set for metric target type Value"))
 	}
 
-	if mt.Type == autoscaling.AverageValueMetricType && mt.AverageValue == nil && mt.Value != nil {
+	if mt.Type == autoscaling.AverageValueMetricType && mt.AverageValue == nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("averageValue"), mt.AverageValue, "must be set for metric target type AverageValue"))
 	}
 

--- a/pkg/apis/autoscaling/validation/validation.go
+++ b/pkg/apis/autoscaling/validation/validation.go
@@ -344,6 +344,10 @@ func validateObjectSource(src *autoscaling.ObjectMetricSource, fldPath *field.Pa
 	allErrs = append(allErrs, validateMetricIdentifier(src.Metric, fldPath.Child("metric"))...)
 	allErrs = append(allErrs, validateMetricTarget(src.Target, fldPath.Child("target"))...)
 
+	if src.Target.Value == nil && src.Target.AverageValue == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("target").Child("averageValue"), "must set either a target value or averageValue"))
+	}
+
 	return allErrs
 }
 
@@ -352,6 +356,10 @@ func validateExternalSource(src *autoscaling.ExternalMetricSource, fldPath *fiel
 
 	allErrs = append(allErrs, validateMetricIdentifier(src.Metric, fldPath.Child("metric"))...)
 	allErrs = append(allErrs, validateMetricTarget(src.Target, fldPath.Child("target"))...)
+
+	if src.Target.Value == nil && src.Target.AverageValue == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("target").Child("averageValue"), "must set either a target value for metric or a per-pod target"))
+	}
 
 	if src.Target.Value != nil && src.Target.AverageValue != nil {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("target").Child("value"), "may not set both a target value for metric and a per-pod target"))
@@ -365,6 +373,10 @@ func validatePodsSource(src *autoscaling.PodsMetricSource, fldPath *field.Path) 
 
 	allErrs = append(allErrs, validateMetricIdentifier(src.Metric, fldPath.Child("metric"))...)
 	allErrs = append(allErrs, validateMetricTarget(src.Target, fldPath.Child("target"))...)
+
+	if src.Target.AverageValue == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("target").Child("averageValue"), "must specify a positive target averageValue"))
+	}
 
 	return allErrs
 }

--- a/pkg/apis/autoscaling/validation/validation.go
+++ b/pkg/apis/autoscaling/validation/validation.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"fmt"
+
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	pathvalidation "k8s.io/apimachinery/pkg/api/validation/path"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -51,9 +52,11 @@ func ValidationOptionsForHPA(newAutoscaler, oldAutoscaler *autoscaling.Horizonta
 		return opts
 	}
 	// Check for existing bad mismatched target type/value fields for ObjectMetricSource
+	// If UtilizationMetricType was set previously then either one of the values could have been used to pass validation before
 	for _, ms := range oldAutoscaler.Spec.Metrics {
 		if ms.Object != nil && ((ms.Object.Target.Type == autoscaling.ValueMetricType && ms.Object.Target.Value == nil) ||
-			(ms.Object.Target.Type == autoscaling.AverageValueMetricType && ms.Object.Target.AverageValue == nil)) {
+			(ms.Object.Target.Type == autoscaling.AverageValueMetricType && ms.Object.Target.AverageValue == nil) ||
+			(ms.Object.Target.Type == autoscaling.UtilizationMetricType)) {
 			opts.AllowMismatchedTargetTypeAndValue = true
 			return opts
 		}

--- a/pkg/apis/autoscaling/validation/validation_test.go
+++ b/pkg/apis/autoscaling/validation/validation_test.go
@@ -1352,7 +1352,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32Ptr(1),
+					MinReplicas:    utilpointer.Int32(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{

--- a/pkg/apis/autoscaling/validation/validation_test.go
+++ b/pkg/apis/autoscaling/validation/validation_test.go
@@ -1075,7 +1075,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 							Name: "somemetric",
 						},
 						Target: autoscaling.MetricTarget{
-							Type: autoscaling.ValueMetricType,
+							Type:  autoscaling.ValueMetricType,
 							Value: resource.NewMilliQuantity(100, resource.DecimalSI),
 						},
 					},

--- a/pkg/apis/autoscaling/validation/validation_test.go
+++ b/pkg/apis/autoscaling/validation/validation_test.go
@@ -1262,7 +1262,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 								Selector: metricLabelSelector,
 							},
 							Target: autoscaling.MetricTarget{
-								Type:         autoscaling.ValueMetricType,
+								Type:         autoscaling.AverageValueMetricType,
 								AverageValue: resource.NewMilliQuantity(-300, resource.DecimalSI),
 							},
 						},
@@ -1317,6 +1317,64 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				},
 			},
 			msg: "must be either Utilization, Value, or AverageValue",
+		}, {
+			horizontalPodAutoscaler: autoscaling.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
+				Spec: autoscaling.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
+					MinReplicas:    utilpointer.Int32Ptr(1),
+					MaxReplicas:    5,
+					Metrics: []autoscaling.MetricSpec{
+						{
+							Type: autoscaling.ObjectMetricSourceType,
+							Object: &autoscaling.ObjectMetricSource{
+								DescribedObject: autoscaling.CrossVersionObjectReference{
+									Kind: "ReplicationController",
+									Name: "myrc",
+								},
+								Metric: autoscaling.MetricIdentifier{
+									Name:     "somemetric",
+									Selector: metricLabelSelector,
+								},
+								Target: autoscaling.MetricTarget{
+									Type:  autoscaling.AverageValueMetricType,
+									Value: resource.NewMilliQuantity(300, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+			},
+			msg: "must be set for metric target type AverageValue",
+		}, {
+			horizontalPodAutoscaler: autoscaling.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
+				Spec: autoscaling.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
+					MinReplicas:    utilpointer.Int32Ptr(1),
+					MaxReplicas:    5,
+					Metrics: []autoscaling.MetricSpec{
+						{
+							Type: autoscaling.ObjectMetricSourceType,
+							Object: &autoscaling.ObjectMetricSource{
+								DescribedObject: autoscaling.CrossVersionObjectReference{
+									Kind: "ReplicationController",
+									Name: "myrc",
+								},
+								Metric: autoscaling.MetricIdentifier{
+									Name:     "somemetric",
+									Selector: metricLabelSelector,
+								},
+								Target: autoscaling.MetricTarget{
+									Type:         autoscaling.ValueMetricType,
+									AverageValue: resource.NewMilliQuantity(300, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+			},
+			msg: "must be set for metric target type Value",
 		}, {
 			horizontalPodAutoscaler: autoscaling.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},

--- a/pkg/apis/autoscaling/validation/validation_test.go
+++ b/pkg/apis/autoscaling/validation/validation_test.go
@@ -1845,7 +1845,7 @@ func prepareMismatchedTargetTypeAndValueCasesBadUpdate() []autoscaling.Horizonta
 						Name: "somemetric",
 					},
 					Target: autoscaling.MetricTarget{
-						Type:         autoscaling.ValueMetricType,
+						Type: autoscaling.ValueMetricType,
 					},
 				},
 			}},

--- a/pkg/apis/autoscaling/validation/validation_test.go
+++ b/pkg/apis/autoscaling/validation/validation_test.go
@@ -1323,7 +1323,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32Ptr(1),
+					MinReplicas:    utilpointer.Int32(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{

--- a/pkg/apis/autoscaling/validation/validation_test.go
+++ b/pkg/apis/autoscaling/validation/validation_test.go
@@ -1015,6 +1015,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Name: api.ResourceCPU,
 						Target: autoscaling.MetricTarget{
 							Type: autoscaling.ValueMetricType,
+							Value: resource.NewMilliQuantity(100, resource.DecimalSI),
 						},
 					},
 				}},
@@ -1035,6 +1036,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 						Container: "test-application",
 						Target: autoscaling.MetricTarget{
 							Type: autoscaling.ValueMetricType,
+							Value: resource.NewMilliQuantity(100, resource.DecimalSI),
 						},
 					},
 				}},
@@ -1061,52 +1063,6 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			},
 		},
 		msg: "must specify a metric name",
-	}, {
-		horizontalPodAutoscaler: autoscaling.HorizontalPodAutoscaler{
-			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
-			Spec: autoscaling.HorizontalPodAutoscalerSpec{
-				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
-				MaxReplicas:    5,
-				Metrics: []autoscaling.MetricSpec{{
-					Type: autoscaling.PodsMetricSourceType,
-					Pods: &autoscaling.PodsMetricSource{
-						Metric: autoscaling.MetricIdentifier{
-							Name: "somemetric",
-						},
-						Target: autoscaling.MetricTarget{
-							Type: autoscaling.ValueMetricType,
-						},
-					},
-				}},
-			},
-		},
-		msg: "must specify a positive target averageValue",
-	}, {
-		horizontalPodAutoscaler: autoscaling.HorizontalPodAutoscaler{
-			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
-			Spec: autoscaling.HorizontalPodAutoscalerSpec{
-				ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-				MinReplicas:    utilpointer.Int32(1),
-				MaxReplicas:    5,
-				Metrics: []autoscaling.MetricSpec{{
-					Type: autoscaling.ObjectMetricSourceType,
-					Object: &autoscaling.ObjectMetricSource{
-						DescribedObject: autoscaling.CrossVersionObjectReference{
-							Kind: "ReplicationController",
-							Name: "myrc",
-						},
-						Metric: autoscaling.MetricIdentifier{
-							Name: "somemetric",
-						},
-						Target: autoscaling.MetricTarget{
-							Type: autoscaling.ValueMetricType,
-						},
-					},
-				}},
-			},
-		},
-		msg: "must set either a target value or averageValue",
 	}, {
 		horizontalPodAutoscaler: autoscaling.HorizontalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
@@ -1200,31 +1156,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			},
 		},
 		msg: "'/'",
-	},
-
-		{
-			horizontalPodAutoscaler: autoscaling.HorizontalPodAutoscaler{
-				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
-				Spec: autoscaling.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    utilpointer.Int32(1),
-					MaxReplicas:    5,
-					Metrics: []autoscaling.MetricSpec{{
-						Type: autoscaling.ExternalMetricSourceType,
-						External: &autoscaling.ExternalMetricSource{
-							Metric: autoscaling.MetricIdentifier{
-								Name:     "somemetric",
-								Selector: metricLabelSelector,
-							},
-							Target: autoscaling.MetricTarget{
-								Type: autoscaling.ValueMetricType,
-							},
-						},
-					}},
-				},
-			},
-			msg: "must set either a target value for metric or a per-pod target",
-		}, {
+	}, {
 			horizontalPodAutoscaler: autoscaling.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -534,7 +534,7 @@ func (a *HorizontalController) reconcileKey(ctx context.Context, key string) (de
 
 // computeStatusForObjectMetric computes the desired number of replicas for the specified metric of type ObjectMetricSourceType.
 func (a *HorizontalController) computeStatusForObjectMetric(specReplicas, statusReplicas int32, metricSpec autoscalingv2.MetricSpec, hpa *autoscalingv2.HorizontalPodAutoscaler, selector labels.Selector, status *autoscalingv2.MetricStatus, metricSelector labels.Selector) (replicas int32, timestamp time.Time, metricName string, condition autoscalingv2.HorizontalPodAutoscalerCondition, err error) {
-	if metricSpec.Object.Target.Type == autoscalingv2.ValueMetricType {
+	if metricSpec.Object.Target.Type == autoscalingv2.ValueMetricType && metricSpec.Object.Target.Value != nil {
 		replicaCountProposal, usageProposal, timestampProposal, err := a.replicaCalc.GetObjectMetricReplicas(specReplicas, metricSpec.Object.Target.Value.MilliValue(), metricSpec.Object.Metric.Name, hpa.Namespace, &metricSpec.Object.DescribedObject, selector, metricSelector)
 		if err != nil {
 			condition := a.getUnableComputeReplicaCountCondition(hpa, "FailedGetObjectMetric", err)
@@ -554,7 +554,7 @@ func (a *HorizontalController) computeStatusForObjectMetric(specReplicas, status
 			},
 		}
 		return replicaCountProposal, timestampProposal, fmt.Sprintf("%s metric %s", metricSpec.Object.DescribedObject.Kind, metricSpec.Object.Metric.Name), autoscalingv2.HorizontalPodAutoscalerCondition{}, nil
-	} else if metricSpec.Object.Target.Type == autoscalingv2.AverageValueMetricType {
+	} else if metricSpec.Object.Target.Type == autoscalingv2.AverageValueMetricType && metricSpec.Object.Target.AverageValue != nil {
 		replicaCountProposal, usageProposal, timestampProposal, err := a.replicaCalc.GetObjectPerPodMetricReplicas(statusReplicas, metricSpec.Object.Target.AverageValue.MilliValue(), metricSpec.Object.Metric.Name, hpa.Namespace, &metricSpec.Object.DescribedObject, metricSelector)
 		if err != nil {
 			condition := a.getUnableComputeReplicaCountCondition(hpa, "FailedGetObjectMetric", err)

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -534,7 +534,7 @@ func (a *HorizontalController) reconcileKey(ctx context.Context, key string) (de
 
 // computeStatusForObjectMetric computes the desired number of replicas for the specified metric of type ObjectMetricSourceType.
 func (a *HorizontalController) computeStatusForObjectMetric(specReplicas, statusReplicas int32, metricSpec autoscalingv2.MetricSpec, hpa *autoscalingv2.HorizontalPodAutoscaler, selector labels.Selector, status *autoscalingv2.MetricStatus, metricSelector labels.Selector) (replicas int32, timestamp time.Time, metricName string, condition autoscalingv2.HorizontalPodAutoscalerCondition, err error) {
-	if metricSpec.Object.Target.Type == autoscalingv2.ValueMetricType && metricSpec.Object.Target.Value != nil {
+	if metricSpec.Object.Target.Type == autoscalingv2.ValueMetricType {
 		replicaCountProposal, usageProposal, timestampProposal, err := a.replicaCalc.GetObjectMetricReplicas(specReplicas, metricSpec.Object.Target.Value.MilliValue(), metricSpec.Object.Metric.Name, hpa.Namespace, &metricSpec.Object.DescribedObject, selector, metricSelector)
 		if err != nil {
 			condition := a.getUnableComputeReplicaCountCondition(hpa, "FailedGetObjectMetric", err)
@@ -554,7 +554,7 @@ func (a *HorizontalController) computeStatusForObjectMetric(specReplicas, status
 			},
 		}
 		return replicaCountProposal, timestampProposal, fmt.Sprintf("%s metric %s", metricSpec.Object.DescribedObject.Kind, metricSpec.Object.Metric.Name), autoscalingv2.HorizontalPodAutoscalerCondition{}, nil
-	} else if metricSpec.Object.Target.Type == autoscalingv2.AverageValueMetricType && metricSpec.Object.Target.AverageValue != nil {
+	} else if metricSpec.Object.Target.Type == autoscalingv2.AverageValueMetricType {
 		replicaCountProposal, usageProposal, timestampProposal, err := a.replicaCalc.GetObjectPerPodMetricReplicas(statusReplicas, metricSpec.Object.Target.AverageValue.MilliValue(), metricSpec.Object.Metric.Name, hpa.Namespace, &metricSpec.Object.DescribedObject, metricSelector)
 		if err != nil {
 			condition := a.getUnableComputeReplicaCountCondition(hpa, "FailedGetObjectMetric", err)

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
@@ -81,7 +81,8 @@ func (autoscalerStrategy) PrepareForCreate(ctx context.Context, obj runtime.Obje
 // Validate validates a new autoscaler.
 func (autoscalerStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	autoscaler := obj.(*autoscaling.HorizontalPodAutoscaler)
-	return validation.ValidateHorizontalPodAutoscaler(autoscaler)
+	opts := validation.ValidationOptionsForHPA(autoscaler, nil)
+	return validation.ValidateHorizontalPodAutoscaler(autoscaler, opts)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -128,7 +129,10 @@ func hasContainerMetricSources(hpa *autoscaling.HorizontalPodAutoscaler) bool {
 
 // ValidateUpdate is the default update validation for an end user.
 func (autoscalerStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateHorizontalPodAutoscalerUpdate(obj.(*autoscaling.HorizontalPodAutoscaler), old.(*autoscaling.HorizontalPodAutoscaler))
+	autoscaler := obj.(*autoscaling.HorizontalPodAutoscaler)
+	oldAutoscaler := old.(*autoscaling.HorizontalPodAutoscaler)
+	opts := validation.ValidationOptionsForHPA(autoscaler, oldAutoscaler)
+	return validation.ValidateHorizontalPodAutoscalerUpdate(autoscaler, oldAutoscaler, opts)
 }
 
 // WarningsOnUpdate returns warnings for the given update.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes a bug where if the corresponding value (value, averageValue) of the the type of target (Value, AverageValue) is not set but the opposite type is, HPA object would pass validation but then cause kube-controller-manager to crash loop due to nil pointer dereference looking for that corresponding value. This PR adds an additional check to make sure the corresponding value gets set.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:
Observed in 1.27 and 1.28, possibly might be an issue in earlier versions as well. 
Can be replicated by deploying an hpa with a valid scaleTargetRef and adding this object to the metrics 
```
...
- apiVersion: autoscaling/v2
  kind: HorizontalPodAutoscaler
  spec:
    maxReplicas: 10
    metrics:
    - type: Object
      object:
        metric:
          name: requests-per-second
        describedObject:
          apiVersion: networking.k8s.io/v1beta1
          kind: Ingress
          name: main-route
        target:
          type: AverageValue
          value: 1
...
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

