### PR TITLE
Track vendored status of unwanted deps, add more cloud dependencies

### DIFF
--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -6,6 +6,7 @@
       "cloud.google.com/go/compute": "cloud dependency",
       "cloud.google.com/go/firestore": "db/datastore clients should not be required",
       "cloud.google.com/go/storage": "cloud dependency",
+      "github.com/GoogleCloudPlatform/k8s-cloud-provider": "cloud dependency",
       "github.com/PuerkitoBio/urlesc": "unmaintained, archive mode",
       "github.com/armon/consul-api": "MPL license not in CNCF allowlist",
       "github.com/bketelsen/crypt": "unused, crypto",
@@ -92,6 +93,10 @@
       ],
       "cloud.google.com/go/storage": [
         "cloud.google.com/go"
+      ],
+      "github.com/GoogleCloudPlatform/k8s-cloud-provider": [
+        "k8s.io/kubernetes",
+        "k8s.io/legacy-cloud-providers"
       ],
       "github.com/go-kit/kit": [
         "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -239,6 +244,7 @@
     },
     "unwantedVendored": [
       "cloud.google.com/go/compute",
+      "github.com/GoogleCloudPlatform/k8s-cloud-provider",
       "github.com/gogo/protobuf",
       "github.com/golang/mock",
       "github.com/google/shlex",

--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -236,6 +236,25 @@
         "google.golang.org/grpc",
         "sigs.k8s.io/apiserver-network-proxy/konnectivity-client"
       ]
-    }
+    },
+    "unwantedVendored": [
+      "cloud.google.com/go/compute",
+      "github.com/gogo/protobuf",
+      "github.com/golang/mock",
+      "github.com/google/shlex",
+      "github.com/googleapis/enterprise-certificate-proxy",
+      "github.com/googleapis/gax-go/v2",
+      "github.com/gregjones/httpcache",
+      "github.com/grpc-ecosystem/go-grpc-prometheus",
+      "github.com/grpc-ecosystem/grpc-gateway",
+      "github.com/json-iterator/go",
+      "github.com/pkg/errors",
+      "github.com/rubiojr/go-vhd",
+      "go.opencensus.io",
+      "golang.org/x/exp",
+      "google.golang.org/api",
+      "google.golang.org/appengine",
+      "google.golang.org/genproto"
+    ]
   }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @dims
/sig architecture
/area code-organization

this gives us visibility if an unwanted dependency transitions from being referenced but not vendored to actually being vendored