### PR TITLE
Improve logging on kube-proxy exit

### DIFF
--- a/pkg/proxy/node.go
+++ b/pkg/proxy/node.go
@@ -57,7 +57,7 @@ func (n *NodePodCIDRHandler) OnNodeAdd(node *v1.Node) {
 	if !reflect.DeepEqual(n.podCIDRs, podCIDRs) {
 		klog.ErrorS(nil, "Using NodeCIDR LocalDetector mode, current PodCIDRs are different than previous PodCIDRs, restarting",
 			"node", klog.KObj(node), "newPodCIDRs", podCIDRs, "oldPodCIDRs", n.podCIDRs)
-		panic("Current Node PodCIDRs are different than previous PodCIDRs, restarting")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 }
 
@@ -75,7 +75,7 @@ func (n *NodePodCIDRHandler) OnNodeUpdate(_, node *v1.Node) {
 	if !reflect.DeepEqual(n.podCIDRs, podCIDRs) {
 		klog.ErrorS(nil, "Using NodeCIDR LocalDetector mode, current PodCIDRs are different than previous PodCIDRs, restarting",
 			"node", klog.KObj(node), "newPodCIDRs", podCIDRs, "oldPODCIDRs", n.podCIDRs)
-		panic("Current Node PodCIDRs are different than previous PodCIDRs, restarting")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 }
 

--- a/pkg/proxy/node_test.go
+++ b/pkg/proxy/node_test.go
@@ -17,13 +17,21 @@ limitations under the License.
 package proxy
 
 import (
+	"strconv"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 func TestNodePodCIDRHandlerAdd(t *testing.T) {
+	oldKlogOsExit := klog.OsExit
+	defer func() {
+		klog.OsExit = oldKlogOsExit
+	}()
+	klog.OsExit = customExit
+
 	tests := []struct {
 		name            string
 		oldNodePodCIDRs []string
@@ -71,12 +79,19 @@ func TestNodePodCIDRHandlerAdd(t *testing.T) {
 					t.Errorf("The code did panic")
 				}
 			}()
+
 			n.OnNodeAdd(node)
 		})
 	}
 }
 
 func TestNodePodCIDRHandlerUpdate(t *testing.T) {
+	oldKlogOsExit := klog.OsExit
+	defer func() {
+		klog.OsExit = oldKlogOsExit
+	}()
+	klog.OsExit = customExit
+
 	tests := []struct {
 		name            string
 		oldNodePodCIDRs []string
@@ -125,7 +140,12 @@ func TestNodePodCIDRHandlerUpdate(t *testing.T) {
 					t.Errorf("The code did panic")
 				}
 			}()
+
 			n.OnNodeUpdate(oldNode, node)
 		})
 	}
+}
+
+func customExit(exitCode int) {
+	panic(strconv.Itoa(exitCode))
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/120355

#### Special notes for your reviewer:

```release-note
kube-proxy don't panic on exit when the Node object changes its PodCIDR
```

#### Does this PR introduce a user-facing change?

```
No
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
https://github.com/kubernetes/kubernetes/commit/a38b9363ec3f0c10bb6e6ebc47d731d6c88ae03f#r126178773
```