### PR TITLE
docs: update `kubectl` to use proper testgrid url

### DIFF
--- a/staging/src/k8s.io/kubectl/docs/maintainers/MAINTAINERS.md
+++ b/staging/src/k8s.io/kubectl/docs/maintainers/MAINTAINERS.md
@@ -37,7 +37,7 @@ Look for:
 
 ### Test triage
 
-Monitor [test grid](https://k8s-testgrid.appspot.com/sig-cli-master)
+Monitor [test grid](https://testgrid.k8s.io/sig-cli-master)
 and make sure the tests are passing.
 
 If any tests are failing, debug them and send a fix.  Ask for help if you get stuck.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
This PR corrects the testgrid url that was changed by sig-k8s-infra and sig-testing earlier this year. 

#### Which issue(s) this PR fixes:
ref: https://github.com/kubernetes/test-infra/issues/30370

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @ardaguclu @brianpursley @eddiezane @KnVerey @mpuckett159 @seans3 @soltysh