### PR TITLE
Don't run the nodeipam controller on KCM if cloud provider external

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -553,6 +553,11 @@ export TLS_CIPHER_SUITES=""
 # and kubelet
 export CLOUD_PROVIDER_FLAG="${CLOUD_PROVIDER_FLAG:-external}"
 
+# Don't run the node-ipam-controller on the KCM if cloud-provider external
+if [[ "${CLOUD_PROVIDER_FLAG}" ==  "external" ]]; then
+  RUN_CONTROLLERS="${RUN_CONTROLLERS:-*,-node-ipam-controller}"
+fi
+
 # When ENABLE_AUTH_PROVIDER_GCP is set, following flags for out-of-tree credential provider for GCP
 # are presented to kubelet:
 # --image-credential-provider-config=${path-to-config}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -602,6 +602,11 @@ export TLS_CIPHER_SUITES=""
 # and kubelet
 export CLOUD_PROVIDER_FLAG="${CLOUD_PROVIDER_FLAG:-external}"
 
+# Don't run the node-ipam-controller on the KCM if cloud-provider external
+if [[ "${CLOUD_PROVIDER_FLAG}" ==  "external" ]]; then
+  RUN_CONTROLLERS="${RUN_CONTROLLERS:-*,-node-ipam-controller}"
+fi
+
 # When ENABLE_AUTH_PROVIDER_GCP is set, following flags for out-of-tree credential provider for GCP
 # are presented to kubelet:
 # --image-credential-provider-config=${path-to-config}


### PR DESCRIPTION
```release-note
NONE
```

Fixes: #120387 

```
E0903 15:52:57.448708       9 controllermanager.go:586] "Error starting controller" err="--cidr-allocator-type is set to 'CloudAllocator' but cloud provider is not configured" controller="node-ipam-controller"
E0903 15:52:57.448717       9 controllermanager.go:240] "Error starting controllers" err="--cidr-allocator-type is set to 'CloudAllocator' but cloud provider is not configured"
Flag --volume-host-allow-local-loopback has been deprecated, This flag is currently no-op and will be deleted.
```

```
aojea
  [3 minutes ago](https://kubernetes.slack.com/archives/C718BPBQ8/p1693768087237869?thread_ts=1693739705.140789&cid=C718BPBQ8)
it tries to run the CloudAllocator ipam controller from KCM





aojea
  [3 minutes ago](https://kubernetes.slack.com/archives/C718BPBQ8/p1693768089641969?thread_ts=1693739705.140789&cid=C718BPBQ8)
and it fails


aojea
  [2 minutes ago](https://kubernetes.slack.com/archives/C718BPBQ8/p1693768103030669?thread_ts=1693739705.140789&cid=C718BPBQ8)
and the KCM runs all the other controllers to create the serviceaccount IIRC


aojea
  [2 minutes ago](https://kubernetes.slack.com/archives/C718BPBQ8/p1693768108326019?thread_ts=1693739705.140789&cid=C718BPBQ8)
so the addon manager can not progress


aojea
  [2 minutes ago](https://kubernetes.slack.com/archives/C718BPBQ8/p1693768117770889?thread_ts=1693739705.140789&cid=C718BPBQ8)
and install the corresponding roles for the other components
New
```