### PR TITLE
Improvements added in kubectl create deployment help 

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
@@ -53,7 +53,10 @@ var (
 	kubectl create deployment my-dep --image=nginx --replicas=3
 
 	# Create a deployment named my-dep that runs the busybox image and expose port 5701
-	kubectl create deployment my-dep --image=busybox --port=5701`))
+	kubectl create deployment my-dep --image=busybox --port=5701
+
+	# Create a deployment named my-dep that runs multiple containers
+	kubectl create deployment dep --image=busybox:latest --port=5701 --image=ubuntu:latest --image=nginx`))
 )
 
 // CreateDeploymentOptions is returned by NewCmdCreateDeployment
@@ -112,9 +115,9 @@ func NewCmdCreateDeployment(f cmdutil.Factory, ioStreams genericiooptions.IOStre
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddDryRunFlag(cmd)
-	cmd.Flags().StringSliceVar(&o.Images, "image", o.Images, "Image names to run.")
+	cmd.Flags().StringSliceVar(&o.Images, "image", o.Images, "Image names to run. A deployment can have multiple images set for multi-container pod. It is to be noted that command can't be mentioned along with list of images. ")
 	cmd.MarkFlagRequired("image")
-	cmd.Flags().Int32Var(&o.Port, "port", o.Port, "The port that this container exposes.")
+	cmd.Flags().Int32Var(&o.Port, "port", o.Port, "The containerPort that this deployment exposes.")
 	cmd.Flags().Int32VarP(&o.Replicas, "replicas", "r", o.Replicas, "Number of replicas to create. Default is 1.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
@@ -56,7 +56,7 @@ var (
 	kubectl create deployment my-dep --image=busybox --port=5701
 
 	# Create a deployment named my-dep that runs multiple containers
-	kubectl create deployment dep --image=busybox:latest --port=5701 --image=ubuntu:latest --image=nginx`))
+	kubectl create deployment my-dep --image=busybox:latest --image=ubuntu:latest --image=nginx`))
 )
 
 // CreateDeploymentOptions is returned by NewCmdCreateDeployment
@@ -115,7 +115,7 @@ func NewCmdCreateDeployment(f cmdutil.Factory, ioStreams genericiooptions.IOStre
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddDryRunFlag(cmd)
-	cmd.Flags().StringSliceVar(&o.Images, "image", o.Images, "Image names to run. A deployment can have multiple images set for multi-container pod. It is to be noted that command can't be mentioned along with list of images. ")
+	cmd.Flags().StringSliceVar(&o.Images, "image", o.Images, "Image names to run. A deployment can have multiple images set for multi-container pod.")
 	cmd.MarkFlagRequired("image")
 	cmd.Flags().Int32Var(&o.Port, "port", o.Port, "The containerPort that this deployment exposes.")
 	cmd.Flags().Int32VarP(&o.Replicas, "replicas", "r", o.Replicas, "Number of replicas to create. Default is 1.")


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
- Added improvement details in port, image section of `kubectl create deployment --help`
- Added example of multiple images in imperative command
#### Which issue(s) this PR fixes:
Fixes: #https://github.com/kubernetes/kubectl/issues/1457