### PR TITLE
Specify imagePullSecret in kubectl run subcommand

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -192,6 +192,7 @@ func addRunFlags(cmd *cobra.Command, opt *RunOptions) {
 	cmd.Flags().StringVar(&opt.Image, "image", opt.Image, i18n.T("The image for the container to run."))
 	cmd.MarkFlagRequired("image")
 	cmd.Flags().String("image-pull-policy", "", i18n.T("The image pull policy for the container.  If left empty, this value will not be specified by the client and defaulted by the server."))
+	cmd.Flags().String("image-pull-secret", "", i18n.T("The image pull secret for the container. It is needed when running an image from a private registry."))
 	cmd.Flags().Bool("rm", false, "If true, delete the pod after it exits.  Only valid when attaching to the container, e.g. with '--attach' or with '-i/--stdin'.")
 	cmd.Flags().StringArray("env", []string{}, "Environment variables to set in the container.")
 	cmd.Flags().StringVar(&opt.Port, "port", opt.Port, i18n.T("The port that this container exposes."))

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/run.go
@@ -240,6 +240,7 @@ func (BasicPod) ParamNames() []generate.GeneratorParam {
 		{Name: "name", Required: true},
 		{Name: "image", Required: true},
 		{Name: "image-pull-policy", Required: false},
+		{Name: "image-pull-secret", Required: false},
 		{Name: "port", Required: false},
 		{Name: "hostport", Required: false},
 		{Name: "stdin", Required: false},
@@ -311,6 +312,13 @@ func (BasicPod) Generate(genericParams map[string]interface{}) (runtime.Object, 
 		restartPolicy = v1.RestartPolicyAlways
 	}
 
+	var imagePullSecrets []v1.LocalObjectReference = nil
+	if secretName, ok := params["image-pull-secret"]; ok && len(secretName) > 0 {
+		imagePullSecrets = []v1.LocalObjectReference{
+			{Name: secretName},
+		}
+	}
+
 	privileged, err := generate.GetBool(params, "privileged", false)
 	if err != nil {
 		return nil, err
@@ -341,8 +349,9 @@ func (BasicPod) Generate(genericParams map[string]interface{}) (runtime.Object, 
 					SecurityContext: securityContext,
 				},
 			},
-			DNSPolicy:     v1.DNSClusterFirst,
-			RestartPolicy: restartPolicy,
+			DNSPolicy:        v1.DNSClusterFirst,
+			RestartPolicy:    restartPolicy,
+			ImagePullSecrets: imagePullSecrets,
 		},
 	}
 	imagePullPolicy := v1.PullPolicy(params["image-pull-policy"])


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
It adds a `--image-pull-secret` flag to `kubectl` run subcommand. So, the users will be able to run images from private registries.

#### Which issue(s) this PR fixes:
I couldn't find an issue related to this PR.

#### Special notes for your reviewer:
Although imagePullSecret is a list of secrets in pod's manifest, this flag's value is a single string. That's because `kubectl run` runs only a single container and a single pull secret would be enough for this purpose.

#### Does this PR introduce a user-facing change?
```release-note
To pull images from private registries using kubectl run command, enter the name of the registry's credentials secret via `--image-pull-secret=` flag.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [Pull an Image from a Private Registry]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
```
