### PR TITLE
[wip] cadvisor bump to 0.48.1 in build dependencies.

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -261,7 +261,7 @@ dependencies:
 
   # cadvisor
   - name: "gcr.io/cadvisor/cadvisor: dependents"
-    version: "v0.47.2"
+    version: "v0.48.1"
     refPaths:
     - path: test/e2e_node/resource_collector.go
       match: gcr.io\/cadvisor\/cadvisor:v\d+\.\d+\.\d+

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -52,7 +52,8 @@ const (
 // before test running so that the image pulling won't fail in actual test.
 var NodePrePullImageList = sets.NewString(
 	imageutils.GetE2EImage(imageutils.Agnhost),
-	"gcr.io/cadvisor/cadvisor:v0.47.2",
+	"gcr.io/cadvisor/cadvisor:v0.48.1",
+	"registry.k8s.io/stress:v1",
 	busyboxImage,
 	"registry.k8s.io/e2e-test-images/busybox@sha256:a9155b13325b2abef48e71de77bb8ac015412a566829f621d06bfae5c699b1b9",
 	imageutils.GetE2EImage(imageutils.Nginx),

--- a/test/e2e_node/resource_collector.go
+++ b/test/e2e_node/resource_collector.go
@@ -50,7 +50,7 @@ import (
 
 const (
 	// resource monitoring
-	cadvisorImageName = "gcr.io/cadvisor/cadvisor:v0.47.2"
+	cadvisorImageName = "gcr.io/cadvisor/cadvisor:v0.48.1"
 	cadvisorPodName   = "cadvisor"
 	cadvisorPort      = 8090
 	// housekeeping interval of Cadvisor (second)


### PR DESCRIPTION
make use of cadvisor 0.48.1 as dependencies are on 0.48.1

This update the same in build and test images.


/kind cleanup

```release-note
NONE
```

