### PR TITLE
KEP-3895: Promote interactive delete to beta

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
@@ -160,10 +160,8 @@ func (f *DeleteFlags) AddFlags(cmd *cobra.Command) {
 	if f.Raw != nil {
 		cmd.Flags().StringVar(f.Raw, "raw", *f.Raw, "Raw URI to DELETE to the server.  Uses the transport specified by the kubeconfig file.")
 	}
-	if cmdutil.InteractiveDelete.IsEnabled() {
-		if f.Interactive != nil {
-			cmd.Flags().BoolVarP(f.Interactive, "interactive", "i", *f.Interactive, "If true, delete resource only when user confirms. This flag is in Alpha.")
-		}
+	if f.Interactive != nil {
+		cmd.Flags().BoolVarP(f.Interactive, "interactive", "i", *f.Interactive, "If true, delete resource only when user confirms. This flag is in Alpha.")
 	}
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -54,41 +54,37 @@ func TestDeleteFlagValidation(t *testing.T) {
 	defer f.Cleanup()
 
 	tests := []struct {
-		flags        DeleteFlags
-		enableAlphas []cmdutil.FeatureGate
-		args         [][]string
-		expectedErr  string
+		flags       DeleteFlags
+		args        [][]string
+		expectedErr string
 	}{
 		{
 			flags: DeleteFlags{
 				Raw:         pointer.String("test"),
 				Interactive: pointer.Bool(true),
 			},
-			enableAlphas: []cmdutil.FeatureGate{cmdutil.InteractiveDelete},
-			expectedErr:  "--interactive can not be used with --raw",
+			expectedErr: "--interactive can not be used with --raw",
 		},
 	}
 
 	for _, test := range tests {
 		cmd := fakecmd()
-		cmdtesting.WithAlphaEnvs(test.enableAlphas, t, func(t *testing.T) {
-			deleteOptions, err := test.flags.ToOptions(nil, genericiooptions.NewTestIOStreamsDiscard())
-			if err != nil {
-				t.Fatalf("unexpected error creating delete options: %s", err)
-			}
-			deleteOptions.Filenames = []string{"../../../testdata/redis-master-controller.yaml"}
-			err = deleteOptions.Complete(f, nil, cmd)
-			if err != nil {
-				t.Fatalf("unexpected error creating delete options: %s", err)
-			}
-			err = deleteOptions.Validate()
-			if err == nil {
-				t.Fatalf("missing expected error")
-			}
-			if test.expectedErr != err.Error() {
-				t.Errorf("expected error %s, got %s", test.expectedErr, err)
-			}
-		})
+		deleteOptions, err := test.flags.ToOptions(nil, genericiooptions.NewTestIOStreamsDiscard())
+		if err != nil {
+			t.Fatalf("unexpected error creating delete options: %s", err)
+		}
+		deleteOptions.Filenames = []string{"../../../testdata/redis-master-controller.yaml"}
+		err = deleteOptions.Complete(f, nil, cmd)
+		if err != nil {
+			t.Fatalf("unexpected error creating delete options: %s", err)
+		}
+		err = deleteOptions.Validate()
+		if err == nil {
+			t.Fatalf("missing expected error")
+		}
+		if test.expectedErr != err.Error() {
+			t.Errorf("expected error %s, got %s", test.expectedErr, err)
+		}
 	}
 }
 
@@ -362,34 +358,50 @@ func TestDeleteObjectWithInteractive(t *testing.T) {
 		}),
 	}
 
-	cmdtesting.WithAlphaEnvs([]cmdutil.FeatureGate{cmdutil.InteractiveDelete}, t, func(t *testing.T) {
-		streams, in, buf, _ := genericiooptions.NewTestIOStreams()
-		fmt.Fprint(in, "y")
-		cmd := NewCmdDelete(tf, streams)
-		cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
-		cmd.Flags().Set("output", "name")
-		cmd.Flags().Set("interactive", "true")
-		cmd.Run(cmd, []string{})
+	streams, in, buf, _ := genericiooptions.NewTestIOStreams()
+	fmt.Fprint(in, "y")
+	cmd := NewCmdDelete(tf, streams)
+	err := cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	err = cmd.Flags().Set("output", "name")
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	err = cmd.Flags().Set("interactive", "true")
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	cmd.Run(cmd, []string{})
 
-		if buf.String() != "You are about to delete the following 1 resource(s):\nreplicationcontroller/redis-master\nDo you want to continue? (y/n): replicationcontroller/redis-master\n" {
-			t.Errorf("unexpected output: %s", buf.String())
-		}
+	if buf.String() != "You are about to delete the following 1 resource(s):\nreplicationcontroller/redis-master\nDo you want to continue? (y/n): replicationcontroller/redis-master\n" {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
 
-		streams, in, buf, _ = genericiooptions.NewTestIOStreams()
-		fmt.Fprint(in, "n")
-		cmd = NewCmdDelete(tf, streams)
-		cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
-		cmd.Flags().Set("output", "name")
-		cmd.Flags().Set("interactive", "true")
-		cmd.Run(cmd, []string{})
+	streams, in, buf, _ = genericiooptions.NewTestIOStreams()
+	fmt.Fprint(in, "n")
+	cmd = NewCmdDelete(tf, streams)
+	err = cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	err = cmd.Flags().Set("output", "name")
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	err = cmd.Flags().Set("interactive", "true")
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	cmd.Run(cmd, []string{})
 
-		if buf.String() != "You are about to delete the following 1 resource(s):\nreplicationcontroller/redis-master\nDo you want to continue? (y/n): deletion is cancelled\n" {
-			t.Errorf("unexpected output: %s", buf.String())
-		}
-		if buf.String() == ": replicationcontroller/redis-master\n" {
-			t.Errorf("unexpected output: %s", buf.String())
-		}
-	})
+	if buf.String() != "You are about to delete the following 1 resource(s):\nreplicationcontroller/redis-master\nDo you want to continue? (y/n): deletion is cancelled\n" {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+	if buf.String() == ": replicationcontroller/redis-master\n" {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
 }
 
 func TestGracePeriodScenarios(t *testing.T) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -427,7 +427,6 @@ type FeatureGate string
 const (
 	ApplySet              FeatureGate = "KUBECTL_APPLYSET"
 	CmdPluginAsSubcommand FeatureGate = "KUBECTL_ENABLE_CMD_SHADOW"
-	InteractiveDelete     FeatureGate = "KUBECTL_INTERACTIVE_DELETE"
 )
 
 func (f FeatureGate) IsEnabled() bool {

--- a/test/cmd/delete.sh
+++ b/test/cmd/delete.sh
@@ -58,9 +58,6 @@ run_kubectl_delete_interactive_tests() {
   set -o nounset
   set -o errexit
 
-  # enable interactivity flag feature environment variable
-  export KUBECTL_INTERACTIVE_DELETE=true
-
   ns_one="namespace-$(date +%s)-${RANDOM}"
   ns_two="namespace-$(date +%s)-${RANDOM}"
   kubectl create namespace "${ns_one}"
@@ -118,8 +115,6 @@ run_kubectl_delete_interactive_tests() {
   # no configmaps should be in either of those namespaces with label deletetest3
   kubectl config set-context "${CONTEXT}" --namespace="${ns_one}"
   kube::test::get_object_assert 'configmap -l deletetest3' "{{range.items}}{{${id_field:?}}}:{{end}}" ''
-
-  unset KUBECTL_INTERACTIVE_DELETE
 
   set +o nounset
   set +o errexit


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR promotes interactive flag in kubectl delete command to beta.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
--interactive flag in kubectl delete will be visible to all users by default.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3895
```
