### PR TITLE
cmd/kube-apiserver: remove import of cmd/kubeadm, add import-boss rules

### DIFF
--- a/cmd/kube-apiserver/.import-restrictions
+++ b/cmd/kube-apiserver/.import-restrictions
@@ -1,0 +1,8 @@
+rules:
+  - selectorRegexp: k8s[.]io/kubernetes
+    allowedPrefixes:
+      - k8s.io/kubernetes/cmd/kube-apiserver
+      - k8s.io/kubernetes/pkg
+      - k8s.io/kubernetes/plugin
+      - k8s.io/kubernetes/test/utils
+      - k8s.io/kubernetes/third_party


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

```
The package "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
is used for a couple of function calls:
- pkiutil.NewCertAndKey() to generate a cert/key pair
- pkiutil.WriteCertAndKey() to write the pair to disk

Unroll and simplify the functions to obtain the same functionality
while removing the cmd/kubeadm dependency.
```

```
Allow only /pkg, /plugin, /third_party, /cmd/kube-apiserver, /test/utils.
This disallows imports of other cmd packages like cmd/kubeadm.
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/120419

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
