### PR TITLE
kmsv2: enable KMSv2KDF feature gate by default

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -260,7 +260,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	KMSv2: {Default: true, PreRelease: featuregate.Beta},
 
-	KMSv2KDF: {Default: false, PreRelease: featuregate.Beta}, // default and lock to true in 1.29, remove in 1.31
+	KMSv2KDF: {Default: true, PreRelease: featuregate.Beta}, // lock to true in 1.29 once KMSv2 is GA, remove in 1.31
 
 	OpenAPIEnums: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION
/kind feature
/assign aramase
/triage accepted
/milestone v1.29 

Fixes #119911

```release-note
Changed the `KMSv2KDF` feature gate to be enabled by default.
```

```docs
TODO link to docs PR
```