### PR TITLE
Automated cherry pick of #120101: fix: concurrent map writes in e2e test

### DIFF
--- a/test/e2e/storage/vsphere/bootstrap.go
+++ b/test/e2e/storage/vsphere/bootstrap.go
@@ -51,7 +51,7 @@ func bootstrapOnce(f *framework.Framework) {
 	if err != nil {
 		framework.Failf("Failed to get nodes: %v", err)
 	}
-	TestContext = Context{NodeMapper: &NodeMapper{}, VSphereInstances: vsphereInstances}
+	TestContext = Context{NodeMapper: NewNodeMapper(), VSphereInstances: vsphereInstances}
 	// 3. Get Node to VSphere mapping
 	err = TestContext.NodeMapper.GenerateNodeMap(vsphereInstances, *nodeList)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #120101 on release-1.28.

#120101: fix: concurrent map writes in e2e test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```