### PR TITLE
[WIP] Add option to disable 6-minute force detach timer

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -303,6 +303,7 @@ func startAttachDetachController(ctx context.Context, controllerContext Controll
 			GetDynamicPluginProber(controllerContext.ComponentConfig.PersistentVolumeBinderController.VolumeConfiguration),
 			controllerContext.ComponentConfig.AttachDetachController.DisableAttachDetachReconcilerSync,
 			controllerContext.ComponentConfig.AttachDetachController.ReconcilerSyncLoopPeriod.Duration,
+			controllerContext.ComponentConfig.AttachDetachController.DisableForceDetachTimer,
 			attachdetach.DefaultTimerConfig,
 		)
 	if attachDetachControllerErr != nil {

--- a/cmd/kube-controller-manager/app/options/attachdetachcontroller.go
+++ b/cmd/kube-controller-manager/app/options/attachdetachcontroller.go
@@ -18,8 +18,9 @@ package options
 
 import (
 	"fmt"
-	"github.com/spf13/pflag"
 	"time"
+
+	"github.com/spf13/pflag"
 
 	attachdetachconfig "k8s.io/kubernetes/pkg/controller/volume/attachdetach/config"
 )
@@ -36,6 +37,7 @@ func (o *AttachDetachControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	}
 
 	fs.BoolVar(&o.DisableAttachDetachReconcilerSync, "disable-attach-detach-reconcile-sync", false, "Disable volume attach detach reconciler sync. Disabling this may cause volumes to be mismatched with pods. Use wisely.")
+	fs.BoolVar(&o.DisableForceDetachTimer, "disable-force-detach-timer", false, "Disable force detach when the detach timeout is reached (6 min). If true, the volume won't be forcefully detached when the detach timeout is reached util the non-graceful feature is manually triggered on the target node.")
 	fs.DurationVar(&o.ReconcilerSyncLoopPeriod.Duration, "attach-detach-reconcile-sync-period", o.ReconcilerSyncLoopPeriod.Duration, "The reconciler sync wait time between volume attach detach. This duration must be larger than one second, and increasing this value from the default may allow for volumes to be mismatched with pods.")
 }
 
@@ -46,6 +48,7 @@ func (o *AttachDetachControllerOptions) ApplyTo(cfg *attachdetachconfig.AttachDe
 	}
 
 	cfg.DisableAttachDetachReconcilerSync = o.DisableAttachDetachReconcilerSync
+	cfg.DisableForceDetachTimer = o.DisableForceDetachTimer
 	cfg.ReconcilerSyncLoopPeriod = o.ReconcilerSyncLoopPeriod
 
 	return nil

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -119,6 +119,7 @@ func NewAttachDetachController(
 	prober volume.DynamicPluginProber,
 	disableReconciliationSync bool,
 	reconcilerSyncDuration time.Duration,
+	disableForceDetachTimer bool,
 	timerConfig TimerConfig) (AttachDetachController, error) {
 
 	adc := &attachDetachController{
@@ -167,6 +168,7 @@ func NewAttachDetachController(
 	// Default these to values in options
 	adc.reconciler = reconciler.NewReconciler(
 		timerConfig.ReconcilerLoopPeriod,
+		disableForceDetachTimer,
 		timerConfig.ReconcilerMaxWaitForUnmountDuration,
 		reconcilerSyncDuration,
 		disableReconciliationSync,

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -64,6 +64,7 @@ func Test_NewAttachDetachController_Positive(t *testing.T) {
 		nil, /* prober */
 		false,
 		5*time.Second,
+		false,
 		DefaultTimerConfig,
 	)
 
@@ -193,6 +194,7 @@ func attachDetachRecoveryTestCase(t *testing.T, extraPods1 []*v1.Pod, extraPods2
 		prober,
 		false,
 		1*time.Second,
+		false,
 		DefaultTimerConfig,
 	)
 
@@ -458,6 +460,7 @@ func volumeAttachmentRecoveryTestCase(t *testing.T, tc vaTest) {
 		nil, /* prober */
 		false,
 		1*time.Second,
+		false,
 		DefaultTimerConfig,
 	)
 	if err != nil {

--- a/pkg/controller/volume/attachdetach/config/types.go
+++ b/pkg/controller/volume/attachdetach/config/types.go
@@ -26,6 +26,9 @@ type AttachDetachControllerConfiguration struct {
 	// the actual state of the world by triggering attach detach operations.
 	// This flag enables or disables reconcile.  Is false by default, and thus enabled.
 	DisableAttachDetachReconcilerSync bool
+	// DisableForceDetachTimer allows to disable the force detach when the detach timeout
+	// is reached (6 min). Is false by default that maches the current behavior.
+	DisableForceDetachTimer bool
 	// ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop
 	// wait between successive executions. Is set to 5 sec by default.
 	ReconcilerSyncLoopPeriod metav1.Duration

--- a/pkg/controller/volume/attachdetach/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/volume/attachdetach/config/v1alpha1/zz_generated.conversion.go
@@ -61,12 +61,14 @@ func RegisterConversions(s *runtime.Scheme) error {
 
 func autoConvert_v1alpha1_AttachDetachControllerConfiguration_To_config_AttachDetachControllerConfiguration(in *v1alpha1.AttachDetachControllerConfiguration, out *config.AttachDetachControllerConfiguration, s conversion.Scope) error {
 	out.DisableAttachDetachReconcilerSync = in.DisableAttachDetachReconcilerSync
+	out.DisableForceDetachTimer = in.DisableForceDetachTimer
 	out.ReconcilerSyncLoopPeriod = in.ReconcilerSyncLoopPeriod
 	return nil
 }
 
 func autoConvert_config_AttachDetachControllerConfiguration_To_v1alpha1_AttachDetachControllerConfiguration(in *config.AttachDetachControllerConfiguration, out *v1alpha1.AttachDetachControllerConfiguration, s conversion.Scope) error {
 	out.DisableAttachDetachReconcilerSync = in.DisableAttachDetachReconcilerSync
+	out.DisableForceDetachTimer = in.DisableForceDetachTimer
 	out.ReconcilerSyncLoopPeriod = in.ReconcilerSyncLoopPeriod
 	return nil
 }

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -66,6 +66,7 @@ type Reconciler interface {
 // cleared.
 func NewReconciler(
 	loopPeriod time.Duration,
+	disableForceDetachTimer bool,
 	maxWaitForUnmountDuration time.Duration,
 	syncDuration time.Duration,
 	disableReconciliationSync bool,
@@ -77,6 +78,7 @@ func NewReconciler(
 	recorder record.EventRecorder) Reconciler {
 	return &reconciler{
 		loopPeriod:                loopPeriod,
+		disableForceDetachTimer:   disableForceDetachTimer,
 		maxWaitForUnmountDuration: maxWaitForUnmountDuration,
 		syncDuration:              syncDuration,
 		disableReconciliationSync: disableReconciliationSync,
@@ -92,6 +94,7 @@ func NewReconciler(
 
 type reconciler struct {
 	loopPeriod                time.Duration
+	disableForceDetachTimer   bool
 	maxWaitForUnmountDuration time.Duration
 	syncDuration              time.Duration
 	desiredStateOfWorld       cache.DesiredStateOfWorld
@@ -208,7 +211,7 @@ func (rc *reconciler) reconcile(ctx context.Context) {
 				continue
 			}
 			// Check whether timeout has reached the maximum waiting time
-			timeout := elapsedTime > rc.maxWaitForUnmountDuration
+			timeout := !rc.disableForceDetachTimer && elapsedTime > rc.maxWaitForUnmountDuration
 
 			isHealthy, err := rc.nodeIsHealthy(attachedVolume.NodeName)
 			if err != nil {

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
@@ -75,7 +75,7 @@ func Test_Run_Positive_DoNothing(t *testing.T) {
 		fakeKubeClient, informerFactory.Core().V1().Nodes().Lister(), asw)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, false, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 
 	// Act
 	_, ctx := ktesting.NewTestContext(t)
@@ -111,7 +111,7 @@ func Test_Run_Positive_OneDesiredVolumeAttach(t *testing.T) {
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, false, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	podName := "pod-uid"
 	volumeName := v1.UniqueVolumeName("volume-name")
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
@@ -165,7 +165,7 @@ func Test_Run_Positive_OneDesiredVolumeAttachThenDetachWithUnmountedVolume(t *te
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, false, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	podName := "pod-uid"
 	volumeName := v1.UniqueVolumeName("volume-name")
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
@@ -243,7 +243,7 @@ func Test_Run_Positive_OneDesiredVolumeAttachThenDetachWithMountedVolume(t *test
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, false, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	podName := "pod-uid"
 	volumeName := v1.UniqueVolumeName("volume-name")
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
@@ -322,7 +322,7 @@ func Test_Run_Negative_OneDesiredVolumeAttachThenDetachWithUnmountedVolumeUpdate
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	nsu := statusupdater.NewFakeNodeStatusUpdater(true /* returnError */)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, false, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	podName := "pod-uid"
 	volumeName := v1.UniqueVolumeName("volume-name")
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
@@ -400,7 +400,7 @@ func Test_Run_OneVolumeAttachAndDetachMultipleNodesWithReadWriteMany(t *testing.
 	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, false, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	podName2 := "pod-uid2"
 	volumeName := v1.UniqueVolumeName("volume-name")
@@ -495,7 +495,7 @@ func Test_Run_OneVolumeAttachAndDetachMultipleNodesWithReadWriteOnce(t *testing.
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, false, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	podName2 := "pod-uid2"
 	volumeName := v1.UniqueVolumeName("volume-name")
@@ -588,7 +588,7 @@ func Test_Run_OneVolumeAttachAndDetachUncertainNodesWithReadWriteOnce(t *testing
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, false, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	podName2 := "pod-uid2"
 	volumeName := v1.UniqueVolumeName("volume-name")
@@ -655,7 +655,7 @@ func Test_Run_UpdateNodeStatusFailBeforeOneVolumeDetachNodeWithReadWriteOnce(t *
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	rc := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, false, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	reconciliationLoopFunc := rc.(*reconciler).reconciliationLoopFunc(ctx)
 	podName1 := "pod-uid1"
 	volumeName := v1.UniqueVolumeName("volume-name")
@@ -715,7 +715,7 @@ func Test_Run_OneVolumeDetachFailNodeWithReadWriteOnce(t *testing.T) {
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, false, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	podName2 := "pod-uid2"
 	podName3 := "pod-uid3"
@@ -803,7 +803,7 @@ func Test_Run_OneVolumeAttachAndDetachTimeoutNodesWithReadWriteOnce(t *testing.T
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+		reconcilerLoopPeriod, false, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	podName2 := "pod-uid2"
 	volumeName := v1.UniqueVolumeName("volume-name")
@@ -879,7 +879,7 @@ func Test_Run_OneVolumeDetachOnOutOfServiceTaintedNode(t *testing.T) {
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxLongWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad,
+		reconcilerLoopPeriod, false, maxLongWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad,
 		nsu, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	volumeName1 := v1.UniqueVolumeName("volume-name1")
@@ -963,7 +963,7 @@ func Test_Run_OneVolumeDetachOnNoOutOfServiceTaintedNode(t *testing.T) {
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxLongWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad,
+		reconcilerLoopPeriod, false, maxLongWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad,
 		nsu, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	volumeName1 := v1.UniqueVolumeName("volume-name1")
@@ -1040,7 +1040,7 @@ func Test_Run_OneVolumeDetachOnUnhealthyNode(t *testing.T) {
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 	reconciler := NewReconciler(
-		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad,
+		reconcilerLoopPeriod, false, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad,
 		nsu, nodeLister, fakeRecorder)
 	podName1 := "pod-uid1"
 	volumeName1 := v1.UniqueVolumeName("volume-name1")
@@ -1173,7 +1173,7 @@ func Test_ReportMultiAttachError(t *testing.T) {
 		nodeLister := informerFactory.Core().V1().Nodes().Lister()
 		nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 		rc := NewReconciler(
-			reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
+			reconcilerLoopPeriod, false, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
 
 		nodes := []k8stypes.NodeName{}
 		for _, n := range test.nodes {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -51994,6 +51994,14 @@ func schema_k8sio_kube_controller_manager_config_v1alpha1_AttachDetachController
 							Format:      "",
 						},
 					},
+					"DisableForceDetachTimer": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DisableForceDetachTimer allows to disable the force detach when the detach timeout is reached (6 min). Is false by default that maches the current behavior.",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"ReconcilerSyncLoopPeriod": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop wait between successive executions. Is set to 5 sec by default.",
@@ -52002,7 +52010,7 @@ func schema_k8sio_kube_controller_manager_config_v1alpha1_AttachDetachController
 						},
 					},
 				},
-				Required: []string{"DisableAttachDetachReconcilerSync", "ReconcilerSyncLoopPeriod"},
+				Required: []string{"DisableAttachDetachReconcilerSync", "DisableForceDetachTimer", "ReconcilerSyncLoopPeriod"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -176,6 +176,9 @@ type AttachDetachControllerConfiguration struct {
 	// the actual state of the world by triggering attach detach operations.
 	// This flag enables or disables reconcile.  Is false by default, and thus enabled.
 	DisableAttachDetachReconcilerSync bool
+	// DisableForceDetachTimer allows to disable the force detach when the detach timeout
+	// is reached (6 min). Is false by default that maches the current behavior.
+	DisableForceDetachTimer bool
 	// ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop
 	// wait between successive executions. Is set to 5 sec by default.
 	ReconcilerSyncLoopPeriod metav1.Duration

--- a/test/integration/volume/attach_detach_test.go
+++ b/test/integration/volume/attach_detach_test.go
@@ -441,6 +441,7 @@ func createAdClients(t *testing.T, server *kubeapiservertesting.TestServer, sync
 		nil, /* prober */
 		false,
 		5*time.Second,
+		false,
 		timers,
 	)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

From sig-storage [meeting](https://docs.google.com/document/d/1-8KEG8AjAgKznS9NFm3qWqkGyCHmvU6HVl0sk5hwoAE/edit): 

now that we have non-graceful node shutdown, we want to allow disabling of the 6-minute force detach timer, which violates the CSI spec. The mechanism will be a new command line option to KCM that defaults to current behavior.
- 1.29: add flag, default to not disable 6 min
- In 1.30, have discussion on deprecation

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-controller-manager: Add `--disable-force-detach-timer` flag to support disable 6-minute force detach timer. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
