### PR TITLE
Revert "Do not attempt to overwrite higher system (sysctl) values"

### DIFF
--- a/cmd/kube-proxy/app/conntrack.go
+++ b/cmd/kube-proxy/app/conntrack.go
@@ -96,7 +96,7 @@ func (realConntracker) setIntSysCtl(name string, value int) error {
 	entry := "net/netfilter/" + name
 
 	sys := sysctl.New()
-	if val, _ := sys.GetSysctl(entry); val != value && val < value {
+	if val, _ := sys.GetSysctl(entry); val != value {
 		klog.InfoS("Set sysctl", "entry", entry, "value", value)
 		if err := sys.SetSysctl(entry, value); err != nil {
 			return err


### PR DESCRIPTION
Reverts kubernetes/kubernetes#103174

kube-proxy sets up some conntrack-related syctls during boot which fails if the underlying host/file-system is read-only (nodes running in a containerized environment). 

#103174 adds a workaround by skipping setting up sysctl if the existing value is already greater than what kube-proxy is trying to configure. 

It is based on the following assumption:
```
However a sysctl overwrite only makes sense if the current value is lower than the previously known
and expected value.  If the value was increased on the host, that shouldn't really bother kube-proxy 
and just go on with it.
```
which doesn't look right. 

/cc @aojea @danwinship @khenidak @thockin 
/area kube-proxy
/sig network
/kind cleanup

```release-note
Changes behavior of kube-proxy by allowing to set sysctl values lower than the existing one.
```