### PR TITLE
Fix calculation of pod termination grace period

### DIFF
--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -640,13 +640,13 @@ func TestUpdatePod(t *testing.T) {
 				startedAt:          time.Unix(3, 0),
 				terminatingAt:      time.Unix(3, 0),
 				terminatedAt:       time.Unix(6, 0),
-				gracePeriod:        30,
+				gracePeriod:        1,
 				startedTerminating: true,
 				restartRequested:   true, // because we received a create during termination
 				finished:           true,
 				activeUpdate: &UpdatePodOptions{
 					Pod:            newNamedPod("1", "ns", "running-pod", false),
-					KillPodOptions: &KillPodOptions{PodTerminationGracePeriodSecondsOverride: intp(30)},
+					KillPodOptions: &KillPodOptions{PodTerminationGracePeriodSecondsOverride: intp(1)},
 				},
 			}),
 			expectKnownTerminated: true,
@@ -717,14 +717,14 @@ func TestUpdatePod(t *testing.T) {
 				startedAt:          time.Unix(3, 0),
 				terminatingAt:      time.Unix(3, 0),
 				terminatedAt:       time.Unix(5, 0),
-				gracePeriod:        30,
+				gracePeriod:        1,
 				startedTerminating: true,
 				finished:           true,
 				evicted:            true,
 				activeUpdate: &UpdatePodOptions{
 					Pod: newNamedPod("1", "ns", "running-pod", false),
 					KillPodOptions: &KillPodOptions{
-						PodTerminationGracePeriodSecondsOverride: intp(30),
+						PodTerminationGracePeriodSecondsOverride: intp(1),
 						Evict:                                    true,
 					},
 				},
@@ -745,9 +745,9 @@ func TestUpdatePod(t *testing.T) {
 				terminatedAt:  time.Unix(3, 0),
 				activeUpdate: &UpdatePodOptions{
 					Pod:            newPodWithPhase("1", "done-pod", v1.PodSucceeded),
-					KillPodOptions: &KillPodOptions{PodTerminationGracePeriodSecondsOverride: intp(30)},
+					KillPodOptions: &KillPodOptions{PodTerminationGracePeriodSecondsOverride: intp(1)},
 				},
-				gracePeriod:        30,
+				gracePeriod:        1,
 				startedTerminating: true,
 				finished:           true,
 			}),
@@ -966,7 +966,7 @@ func TestUpdatePodDoesNotForgetSyncPodKill(t *testing.T) {
 		// we buffer pending updates and the pod worker may compress the create and kill
 		syncPodRecords := processed[uid]
 		var match bool
-		grace := int64(30)
+		grace := int64(1)
 		for _, possible := range [][]syncPodRecord{
 			{{name: string(uid), updateType: kubetypes.SyncPodKill, gracePeriod: &grace}, {name: string(uid), terminated: true}},
 			{{name: string(uid), updateType: kubetypes.SyncPodCreate}, {name: string(uid), updateType: kubetypes.SyncPodKill, gracePeriod: &grace}, {name: string(uid), terminated: true}},

--- a/test/e2e_node/mirror_pod_grace_period_test.go
+++ b/test/e2e_node/mirror_pod_grace_period_test.go
@@ -73,6 +73,12 @@ var _ = SIGDescribe("MirrorPodWithGracePeriod", func() {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("wait for the mirror pod to be running for grace period")
+
+			// Just for debugging
+			gomega.Consistently(ctx, func(ctx context.Context) error {
+				return checkMirrorPodRunningWithUID(ctx, f.ClientSet, mirrorPodName, ns, uid)
+			}, 1*time.Second, 200*time.Millisecond).Should(gomega.BeNil())
+
 			gomega.Consistently(ctx, func(ctx context.Context) error {
 				return checkMirrorPodRunningWithUID(ctx, f.ClientSet, mirrorPodName, ns, uid)
 			}, 19*time.Second, 200*time.Millisecond).Should(gomega.BeNil())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes caliculation of pod termination grace period.
Now, when execute `kubectl delete pod --force --grace-period=0`, "pod "nginx" force deleted" message is shown and the result of `kubectl get pod nginx` is `Error from server (NotFound): pods "nginx" not found`. So pod seems deleted.
But actually, pod process is still living because `terminationGracePeriodSeconds` is priored than `--force --grace-period=0`.
This behavior has been changed sometime. In ver1.18, `--force --grace-period=0` behavior was correct.
please see #120449 .
This PR fixes caliculation of pod termination grace period.
By this change, when execute `kubectl delete pod --force --grace-period=0`, pod process also killed immediately.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #120449

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
