### PR TITLE
golangci-lint: warn about deprecated APIs only as hints

### DIFF
--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -83,6 +83,14 @@ issues:
         - gosimple
       text: "S1033: unnecessary guard around call to delete"
 
+    # Didn't make it into https://github.com/kubernetes/kubernetes/issues/117288.
+    # Discussion on Slack concluded that "it's hard to have a universal policy for all
+    # functions marked deprecated" and thus this can only be a hint which must
+    # be considered on a case-by-case basis.
+    - linters:
+        - staticcheck
+      text: "SA1019: .*is deprecated"
+
     # https://github.com/kubernetes/kubernetes/issues/117288#issuecomment-1507030071
     - linters:
         - stylecheck

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -89,6 +89,14 @@ issues:
         - gosimple
       text: "S1033: unnecessary guard around call to delete"
 
+    # Didn't make it into https://github.com/kubernetes/kubernetes/issues/117288.
+    # Discussion on Slack concluded that "it's hard to have a universal policy for all
+    # functions marked deprecated" and thus this can only be a hint which must
+    # be considered on a case-by-case basis.
+    - linters:
+        - staticcheck
+      text: "SA1019: .*is deprecated"
+
     # https://github.com/kubernetes/kubernetes/issues/117288#issuecomment-1507030071
     - linters:
         - stylecheck

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -94,6 +94,14 @@ issues:
         - gosimple
       text: "S1033: unnecessary guard around call to delete"
 
+    # Didn't make it into https://github.com/kubernetes/kubernetes/issues/117288.
+    # Discussion on Slack concluded that "it's hard to have a universal policy for all
+    # functions marked deprecated" and thus this can only be a hint which must
+    # be considered on a case-by-case basis.
+    - linters:
+        - staticcheck
+      text: "SA1019: .*is deprecated"
+
     # https://github.com/kubernetes/kubernetes/issues/117288#issuecomment-1507030071
     - linters:
         - stylecheck


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This particualar warning didn't make it into
https://github.com/kubernetes/kubernetes/issues/117288.  Discussion on Slack concluded that "it's hard to have a universal policy for all functions marked deprecated" and thus this can only be a hint which must be considered on a case-by-case basis.

For example, APIs like sets.String are very unlikely to ever go away, therefore it is entirely up to developers whether they switch to sets.Set even though sets.String is marked as deprecated.

Ideally, the deprecation message should explain this. It doesn't for sets ("use generic Set instead"), so a better message in that case would have been "consider using generic Set instead".

#### Which issue(s) this PR fixes:
Related-to:  https://github.com/kubernetes/kubernetes/issues/117288

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @liggitt 