### PR TITLE
Don't reuse the device of a restartable init container

### DIFF
--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -591,6 +591,103 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 				framework.Fail(fmt.Sprintf("stale device assignment after pod deletion while kubelet was down allocated=%v error=%v", allocated, err))
 			}
 		})
+
+		ginkgo.It("Can schedule a pod with a restartable init container [NodeAlphaFeature:SidecarContainers]", func(ctx context.Context) {
+			podRECMD := "devs=$(ls /tmp/ | egrep '^Dev-[0-9]+$') && echo stub devices: $devs && sleep %s"
+			sleepOneSecond := "1s"
+			rl := v1.ResourceList{v1.ResourceName(SampleDeviceResourceName): *resource.NewQuantity(1, resource.DecimalSI)}
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "device-plugin-test-" + string(uuid.NewUUID())},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyAlways,
+					InitContainers: []v1.Container{
+						{
+							Image:   busyboxImage,
+							Name:    "init-1",
+							Command: []string{"sh", "-c", fmt.Sprintf(podRECMD, sleepOneSecond)},
+							Resources: v1.ResourceRequirements{
+								Limits:   rl,
+								Requests: rl,
+							},
+						},
+						{
+							Image:   busyboxImage,
+							Name:    "restartable-init-2",
+							Command: []string{"sh", "-c", fmt.Sprintf(podRECMD, sleepIntervalForever)},
+							Resources: v1.ResourceRequirements{
+								Limits:   rl,
+								Requests: rl,
+							},
+							RestartPolicy: &containerRestartPolicyAlways,
+						},
+					},
+					Containers: []v1.Container{{
+						Image:   busyboxImage,
+						Name:    "regular-1",
+						Command: []string{"sh", "-c", fmt.Sprintf(podRECMD, sleepIntervalForever)},
+						Resources: v1.ResourceRequirements{
+							Limits:   rl,
+							Requests: rl,
+						},
+					}},
+				},
+			}
+
+			pod1 := e2epod.NewPodClient(f).CreateSync(ctx, pod)
+			deviceIDRE := "stub devices: (Dev-[0-9]+)"
+
+			devID1, err := parseLog(ctx, f, pod1.Name, pod1.Spec.InitContainers[0].Name, deviceIDRE)
+			framework.ExpectNoError(err, "getting logs for pod %q/%q", pod1.Name, pod1.Spec.InitContainers[0].Name)
+			gomega.Expect(devID1).To(gomega.Not(gomega.Equal("")), "pod1's init container requested a device but started successfully without")
+
+			devID2, err := parseLog(ctx, f, pod1.Name, pod1.Spec.InitContainers[1].Name, deviceIDRE)
+			framework.ExpectNoError(err, "getting logs for pod %q/%q", pod1.Name, pod1.Spec.InitContainers[1].Name)
+			gomega.Expect(devID2).To(gomega.Not(gomega.Equal("")), "pod1's restartable init container requested a device but started successfully without")
+
+			gomega.Expect(devID2).To(gomega.Equal(devID1), "pod1's init container and restartable init container should share the same device")
+
+			devID3, err := parseLog(ctx, f, pod1.Name, pod1.Spec.Containers[0].Name, deviceIDRE)
+			framework.ExpectNoError(err, "getting logs for pod %q/%q", pod1.Name, pod1.Spec.Containers[0].Name)
+			gomega.Expect(devID3).To(gomega.Not(gomega.Equal("")), "pod1's regular container requested a device but started successfully without")
+
+			gomega.Expect(devID3).NotTo(gomega.Equal(devID2), "pod1's restartable init container and regular container should not share the same device")
+
+			podResources, err := getV1NodeDevices(ctx)
+			framework.ExpectNoError(err)
+
+			framework.Logf("PodResources.PodResources:%+v\n", podResources.PodResources)
+			framework.Logf("len(PodResources.PodResources):%+v", len(podResources.PodResources))
+
+			gomega.Expect(podResources.PodResources).To(gomega.HaveLen(2))
+
+			var resourcesForOurPod *kubeletpodresourcesv1.PodResources
+			for _, res := range podResources.GetPodResources() {
+				if res.Name == pod1.Name {
+					resourcesForOurPod = res
+				}
+			}
+
+			gomega.Expect(resourcesForOurPod).NotTo(gomega.BeNil())
+
+			gomega.Expect(resourcesForOurPod.Name).To(gomega.Equal(pod1.Name))
+			gomega.Expect(resourcesForOurPod.Namespace).To(gomega.Equal(pod1.Namespace))
+
+			// Note that the kubelet does not report resources for restartable
+			// init containers for now.
+			// See https://github.com/kubernetes/kubernetes/issues/120501.
+			// TODO: Fix this test to check the resources allocated to the
+			// restartable init container once the kubelet reports resources
+			// for restartable init containers.
+			gomega.Expect(resourcesForOurPod.Containers).To(gomega.HaveLen(1))
+
+			gomega.Expect(resourcesForOurPod.Containers[0].Name).To(gomega.Equal(pod1.Spec.Containers[0].Name))
+
+			gomega.Expect(resourcesForOurPod.Containers[0].Devices).To(gomega.HaveLen(1))
+
+			gomega.Expect(resourcesForOurPod.Containers[0].Devices[0].ResourceName).To(gomega.Equal(SampleDeviceResourceName))
+
+			gomega.Expect(resourcesForOurPod.Containers[0].Devices[0].DeviceIds).To(gomega.HaveLen(1))
+		})
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This makes sure that the device resources allocated to a restartable init container are not reused by regular containers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
xref: https://github.com/kubernetes/kubernetes/issues/119442

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where the device resources allocated to an init container, with containerRestartPolicy of `Always`, were erroneously reused by a regular container.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers
```

/cc @ffromani 