### PR TITLE
e2e_node: Assign enough time to finish the postStart hook

### DIFF
--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -236,7 +236,12 @@ var _ = SIGDescribe("[NodeConformance] Containers Lifecycle ", func() {
 						Name:  regular1,
 						Image: busyboxImage,
 						Command: ExecCommand(regular1, execCommand{
-							Delay:    2,
+							// Allocate sufficient time for its postStart hook
+							// to complete.
+							// Note that we've observed approximately a 2s
+							// delay before the postStart hook is called.
+							// 10s > 1s + 2s(estimated maximum delay) + other possible delays
+							Delay:    10,
 							ExitCode: 0,
 						}),
 						Lifecycle: &v1.Lifecycle{
@@ -334,7 +339,12 @@ var _ = SIGDescribe("[NodeConformance] Containers Lifecycle ", func() {
 						Name:  regular1,
 						Image: busyboxImage,
 						Command: ExecCommand(regular1, execCommand{
-							Delay:    2,
+							// Allocate sufficient time for its postStart hook
+							// to complete.
+							// Note that we've observed approximately a 2s
+							// delay before the postStart hook is called.
+							// 10s > 1s + 2s(estimated maximum delay) + other possible delays
+							Delay:    10,
 							ExitCode: 0,
 						}),
 						Lifecycle: &v1.Lifecycle{


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

```
[FAILED] couldn't find that PostStart-regular-1 ever exited, got 2023-08-29 00:39:12 +0000 UTC 49.060000 regular-1 Starting
2023-08-29 00:39:12 +0000 UTC 49.070000 regular-1 Started
2023-08-29 00:39:12 +0000 UTC 49.070000 regular-1 Delaying
2023-08-29 00:39:14 +0000 UTC 50.970000 PostStart-regular-1 Starting
2023-08-29 00:39:14 +0000 UTC 50.980000 PostStart-regular-1 Started
2023-08-29 00:39:14 +0000 UTC 50.980000 PostStart-regular-1 Delaying
2023-08-29 00:39:14 +0000 UTC 51.070000 regular-1 Exiting
2023-08-29 00:39:14 +0000 UTC 51.430000 regular-2 Starting
2023-08-29 00:39:14 +0000 UTC 51.430000 regular-2 Started
2023-08-29 00:39:14 +0000 UTC 51.430000 regular-2 Delaying
2023-08-29 00:39:15 +0000 UTC 52.440000 regular-2 Exiting
In [It] at: test/e2e_node/container_lifecycle_test.go:377 @ 08/29/23 00:39:18.148
```

Looking at the error message, the problem seems that the regular-1 container exits before its postStart hook is finished.

This deflakes the `Containers Lifecycle should not launch second container before PostStart of the first container completed` test by assigning enough time to finish the postStart hook.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #120458 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
