### PR TITLE
Added ignore-not-found flag for kubectl patch

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -65,6 +65,7 @@ type PatchOptions struct {
 	Patch       string
 	PatchFile   string
 	Subresource string
+	IgnoreNotFound bool
 
 	namespace                    string
 	enforceNamespace             bool
@@ -140,6 +141,7 @@ func NewCmdPatch(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra
 	cmd.Flags().StringVarP(&o.Patch, "patch", "p", "", "The patch to be applied to the resource JSON file.")
 	cmd.Flags().StringVar(&o.PatchFile, "patch-file", "", "A file containing a patch to be applied to the resource.")
 	cmd.Flags().StringVar(&o.PatchType, "type", "strategic", fmt.Sprintf("The type of patch being provided; one of %v", sets.StringKeySet(patchTypes).List()))
+	cmd.Flags().BoolVar(&o.IgnoreNotFound, "ignore-not-found", o.IgnoreNotFound, "If the requested object does not exist the command will return exit code 0.")
 	cmdutil.AddDryRunFlag(cmd)
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to update")
 	cmd.Flags().BoolVar(&o.Local, "local", o.Local, "If true, patch will operate on the content of the file, not the server-side resource.")
@@ -313,6 +315,9 @@ func (o *PatchOptions) RunPatch() error {
 		return printer.PrintObj(targetObj, o.Out)
 	})
 	if err != nil {
+		if o.IgnoreNotFound && apierrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 	if count == 0 {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -60,11 +60,11 @@ type PatchOptions struct {
 	ToPrinter   func(string) (printers.ResourcePrinter, error)
 	Recorder    genericclioptions.Recorder
 
-	Local       bool
-	PatchType   string
-	Patch       string
-	PatchFile   string
-	Subresource string
+	Local          bool
+	PatchType      string
+	Patch          string
+	PatchFile      string
+	Subresource    string
 	IgnoreNotFound bool
 
 	namespace                    string

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/kubectl/pkg/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestPatchObject(t *testing.T) {
@@ -238,5 +239,51 @@ func TestPatchSubresource(t *testing.T) {
 	// check the status.phase value is updated in the response
 	if actualStatus != expectedStatus {
 		t.Errorf("unexpected pod status to be set to %s got: %s", expectedStatus, actualStatus)
+	}
+}
+
+func TestPatchIgnoreNotFound(t *testing.T) {
+	ns := &corev1.NamespaceList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "1",
+		},
+		Items: []corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "testns", Namespace: "test", ResourceVersion: "11"},
+				Spec:       corev1.NamespaceSpec{},
+			},
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/namespaces/test/services/nonexistentservice" && (m == "PATCH" || m == "GET"):
+				return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, nil
+			case p == "/api/v1/namespaces/test" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &ns.Items[0])}, nil
+			default:
+				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+				return nil, nil
+			}
+		}),
+	}
+	stream, _, buf, _ := genericiooptions.NewTestIOStreams()
+
+	cmd := NewCmdPatch(tf, stream)
+	cmd.Flags().Set("namespace", "test")
+	cmd.Flags().Set("ignore-not-found", "true")
+	cmd.Flags().Set("patch", `{"spec":{"type":"NodePort"}}`)
+	cmd.Flags().Set("output", "name")
+	cmd.Run(cmd, []string{"services/nonexistentservice"})
+
+	if buf.String() != "" {
+		t.Errorf("unexpected output: %s", buf.String())
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
@@ -259,7 +259,6 @@ func TestPatchIgnoreNotFoundWithNonexistentResource(t *testing.T) {
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
-
 	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
 
 	tf.UnstructuredClient = &fake.RESTClient{
@@ -276,8 +275,8 @@ func TestPatchIgnoreNotFoundWithNonexistentResource(t *testing.T) {
 			}
 		}),
 	}
-	stream, _, buf, _ := genericiooptions.NewTestIOStreams()
 
+	stream, _, buf, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdPatch(tf, stream)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
@@ -294,7 +293,6 @@ func TestPatchIgnoreNotFoundWithNonexistentResource(t *testing.T) {
 
 func TestPatchIgnoreNotFoundWithExistingResource(t *testing.T) {
 	cmdtesting.InitTestErrorHandler(t)
-	
 	_, svc, _ := cmdtesting.TestData()
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
@@ -280,10 +280,10 @@ func TestPatchIgnoreNotFoundWithNonexistentResource(t *testing.T) {
 	cmd := NewCmdPatch(tf, stream)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
-	cmd.Flags().Set("namespace", "test")
-	cmd.Flags().Set("ignore-not-found", "true")
-	cmd.Flags().Set("patch", `{"spec":{"type":"NodePort"}}`)
-	cmd.Flags().Set("output", "name")
+	_ := cmd.Flags().Set("namespace", "test")
+	_ := cmd.Flags().Set("ignore-not-found", "true")
+	_ := cmd.Flags().Set("patch", `{"spec":{"type":"NodePort"}}`)
+	_ := cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"services/nonexistentservice"})
 
 	if buf.String() != "" {
@@ -320,10 +320,10 @@ func TestPatchIgnoreNotFoundWithExistingResource(t *testing.T) {
 	stream, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdPatch(tf, stream)
-	cmd.Flags().Set("namespace", "test")
-	cmd.Flags().Set("ignore-not-found", "true")
-	cmd.Flags().Set("patch", `{"spec":{"type":"NodePort"}}`)
-	cmd.Flags().Set("output", "name")
+	_ := cmd.Flags().Set("namespace", "test")
+	_ := cmd.Flags().Set("ignore-not-found", "true")
+	_ := cmd.Flags().Set("patch", `{"spec":{"type":"NodePort"}}`)
+	_ := cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"services/frontend"})
 
 	// uses the name from the response

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
@@ -23,12 +23,12 @@ import (
 
 	jsonpath "github.com/exponent-io/jsonpath"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/kubectl/pkg/scheme"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestPatchObject(t *testing.T) {
@@ -243,6 +243,8 @@ func TestPatchSubresource(t *testing.T) {
 }
 
 func TestPatchIgnoreNotFoundWithNonexistentResource(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+
 	ns := &corev1.NamespaceList{
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: "1",
@@ -291,6 +293,8 @@ func TestPatchIgnoreNotFoundWithNonexistentResource(t *testing.T) {
 }
 
 func TestPatchIgnoreNotFoundWithExistingResource(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+	
 	_, svc, _ := cmdtesting.TestData()
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
@@ -280,10 +280,10 @@ func TestPatchIgnoreNotFoundWithNonexistentResource(t *testing.T) {
 	cmd := NewCmdPatch(tf, stream)
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
-	_ := cmd.Flags().Set("namespace", "test")
-	_ := cmd.Flags().Set("ignore-not-found", "true")
-	_ := cmd.Flags().Set("patch", `{"spec":{"type":"NodePort"}}`)
-	_ := cmd.Flags().Set("output", "name")
+	_ = cmd.Flags().Set("namespace", "test")
+	_ = cmd.Flags().Set("ignore-not-found", "true")
+	_ = cmd.Flags().Set("patch", `{"spec":{"type":"NodePort"}}`)
+	_ = cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"services/nonexistentservice"})
 
 	if buf.String() != "" {
@@ -320,10 +320,10 @@ func TestPatchIgnoreNotFoundWithExistingResource(t *testing.T) {
 	stream, _, buf, _ := genericiooptions.NewTestIOStreams()
 
 	cmd := NewCmdPatch(tf, stream)
-	_ := cmd.Flags().Set("namespace", "test")
-	_ := cmd.Flags().Set("ignore-not-found", "true")
-	_ := cmd.Flags().Set("patch", `{"spec":{"type":"NodePort"}}`)
-	_ := cmd.Flags().Set("output", "name")
+	_ = cmd.Flags().Set("namespace", "test")
+	_ = cmd.Flags().Set("ignore-not-found", "true")
+	_ = cmd.Flags().Set("patch", `{"spec":{"type":"NodePort"}}`)
+	_ = cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"services/frontend"})
 
 	// uses the name from the response


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature 

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds the optional `--ignore-not-found` flag to `kubectl patch` command. This makes the `patch` command consistent with other commands like `get`, and `delete`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #108798 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The `kubectl patch` command now supports the optional `--ignore-not-found` flag
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
