### PR TITLE
fix(queue_test): make sure the first bind failure via counter

### DIFF
--- a/test/integration/scheduler/queue_test.go
+++ b/test/integration/scheduler/queue_test.go
@@ -445,9 +445,19 @@ func TestCustomResourceEnqueue(t *testing.T) {
 // TestRequeueByBindFailure verify Pods failed by bind plugin are
 // put back to the queue regardless of whether event happens or not.
 func TestRequeueByBindFailure(t *testing.T) {
+	fakeBind := &firstFailBindPlugin{}
 	registry := frameworkruntime.Registry{
-		"firstFailBindPlugin": newFirstFailBindPlugin,
+		"firstFailBindPlugin": func(o runtime.Object, fh framework.Handle) (framework.Plugin, error) {
+			binder, err := defaultbinder.New(nil, fh)
+			if err != nil {
+				return nil, err
+			}
+
+			fakeBind.defaultBinderPlugin = binder.(framework.BindPlugin)
+			return fakeBind, nil
+		},
 	}
+
 	cfg := configtesting.V1ToInternalWithDefaults(t, configv1.KubeSchedulerConfiguration{
 		Profiles: []configv1.KubeSchedulerProfile{{
 			SchedulerName: pointer.String(v1.DefaultSchedulerName),
@@ -488,16 +498,17 @@ func TestRequeueByBindFailure(t *testing.T) {
 		t.Fatalf("Failed to create Pod %q: %v", pod.Name, err)
 	}
 
-	// first binding try should fail.
-	err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, testutils.PodSchedulingError(cs, ns, pod.Name))
+	// 1. first binding try should fail.
+	// 2. The pod should be enqueued to activeQ/backoffQ without any event.
+	// 3. The pod should be scheduled in the second binding try.
+	// Here, waiting until (3).
+	err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, testutils.PodScheduled(cs, ns, pod.Name))
 	if err != nil {
-		t.Fatalf("Expect pod-1 to be rejected by the bind plugin: %v", err)
+		t.Fatalf("Expect pod-1 to be scheduled by the bind plugin: %v", err)
 	}
 
-	// The pod should be enqueued to activeQ/backoffQ without any event.
-	// The pod should be scheduled in the second binding try.
-	err = wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, testutils.PodScheduled(cs, ns, pod.Name))
-	if err != nil {
+	// Make sure the first binding trial was failed, and this pod is scheduled at the second trial.
+	if fakeBind.counter != 1 {
 		t.Fatalf("Expect pod-1 to be scheduled by the bind plugin in the second binding try: %v", err)
 	}
 }
@@ -506,17 +517,6 @@ func TestRequeueByBindFailure(t *testing.T) {
 type firstFailBindPlugin struct {
 	counter             int
 	defaultBinderPlugin framework.BindPlugin
-}
-
-func newFirstFailBindPlugin(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
-	binder, err := defaultbinder.New(nil, handle)
-	if err != nil {
-		return nil, err
-	}
-
-	return &firstFailBindPlugin{
-		defaultBinderPlugin: binder.(framework.BindPlugin),
-	}, nil
 }
 
 func (*firstFailBindPlugin) Name() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake
/priority important-soon
/triage accepted

#### What this PR does / why we need it:

In the past impl, if the scheduler works very quickly and the Pod scheduling has been done twice by executing L492, 
[L492 `PollUntilContextTimeout`](https://github.com/kubernetes/kubernetes/blob/ef7d4047025d0ce1e6428949b4c77afceedefbf8/test/integration/scheduler/queue_test.go#L492) cannot catch the moment of unschedulable state in pod-1 and this test fails.
This leads the flaky reported in #120363. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #120363

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
