### PR TITLE
Promote  kubelet resource metric e2e test to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -3346,4 +3346,10 @@
     was configured with a subpath.
   release: v1.12
   file: test/e2e/storage/subpath.go
-
+- testname: Kubelet resource metrics
+  codename: '[sig-instrumentation] Metrics should grab all metrics from kubelet''s
+    /metrics/resource endpoint [Conformance]'
+  description: Should attempt to grab all resource metrics from kubelet metrics/resource
+    endpoint.
+  release: v1.28
+  file: test/e2e/instrumentation/metrics.go 

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1366,6 +1366,13 @@
     The event is deleted and MUST NOT show up when listing all events.
   release: v1.25
   file: test/e2e/instrumentation/core_events.go
+- testname: Kubelet resource metrics
+  codename: '[sig-instrumentation] Metrics should grab all metrics from kubelet /metrics/resource
+    endpoint [Conformance]'
+  description: Should attempt to grab all resource metrics from kubelet metrics/resource
+    endpoint.
+  release: v1.29
+  file: test/e2e/instrumentation/metrics.go
 - testname: DNS, cluster
   codename: '[sig-network] DNS should provide /etc/hosts entries for the cluster [Conformance]'
   description: When a Pod is created, the pod MUST be able to resolve cluster dns
@@ -3346,10 +3353,4 @@
     was configured with a subpath.
   release: v1.12
   file: test/e2e/storage/subpath.go
-- testname: Kubelet resource metrics
-  codename: '[sig-instrumentation] Metrics should grab all metrics from kubelet''s
-    /metrics/resource endpoint [Conformance]'
-  description: Should attempt to grab all resource metrics from kubelet metrics/resource
-    endpoint.
-  release: v1.28
-  file: test/e2e/instrumentation/metrics.go 
+

--- a/test/e2e/instrumentation/metrics.go
+++ b/test/e2e/instrumentation/metrics.go
@@ -56,7 +56,7 @@ var _ = common.SIGDescribe("Metrics", func() {
 	   Testname: Kubelet resource metrics
 	   Description: Should attempt to grab all resource metrics from kubelet metrics/resource endpoint.
 	*/
-	ginkgo.It("should grab all metrics from kubelet /metrics/resource endpoint", func(ctx context.Context) {
+	framework.ConformanceIt("should grab all metrics from kubelet /metrics/resource endpoint", func(ctx context.Context) {
 		ginkgo.By("Connecting to kubelet's /metrics/resource endpoint")
 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
 		if errors.Is(err, e2emetrics.MetricsGrabbingDisabledError) {


### PR DESCRIPTION
#### What type of PR is this?
/area conformance

#### What this PR does / why we need it:
Follow up on https://github.com/kubernetes/kubernetes/pull/116897#discussion_r1267434370 

#### Which issue(s) this PR fixes:
Fixes [#727 ](https://github.com/kubernetes/enhancements/issues/727)

Testgrid Link:
[Testgrid](https://testgrid.k8s.io/sig-instrumentation-tests#gci-gce&include-filter-by-regex=Metrics.should.grab.all.metrics.from.kubelet)

@kubernetes/sig-architecture-pr-reviews @kubernetes/sig-instrumentation-pr-reviews @kubernetes/cncf-conformance-wg

