### PR TITLE
Register metrics for apiserver handlers

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/metrics/metrics.go
@@ -18,8 +18,10 @@ package metrics
 
 import (
 	"context"
+	"sync"
 
 	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 )
 
 type RequestBodyVerb string
@@ -46,6 +48,15 @@ var (
 		[]string{"resource", "verb"},
 	)
 )
+
+var registerMetrics sync.Once
+
+// Register all metrics.
+func Register() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(RequestBodySizes)
+	})
+}
 
 func RecordRequestBodySize(ctx context.Context, resource string, verb RequestBodyVerb, size int) {
 	RequestBodySizes.WithContext(ctx).WithLabelValues(resource, string(verb)).Observe(float64(size))

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package routes
 
 import (
+	handlersmetrics "k8s.io/apiserver/pkg/endpoints/handlers/metrics"
 	apimetrics "k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/server/mux"
 	cachermetrics "k8s.io/apiserver/pkg/storage/cacher/metrics"
@@ -52,4 +53,5 @@ func register() {
 	etcd3metrics.Register()
 	flowcontrolmetrics.Register()
 	peerproxymetrics.Register()
+	handlersmetrics.Register()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
I'm interested in using metric `apiserver_request_body_size_bytes` but it doesn't seem to be registered. This PR is to register metrics for `endpoints/handlers`.

#### Does this PR introduce a user-facing change?

```
Registered metric `apiserver_request_body_size_bytes` to track the size distribution of requests by `resource` and `verb`.
```

/sig instrumentation
