### PR TITLE
illumos does not have SO_REUSEPORT.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_noportreuse.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_noportreuse.go
@@ -1,5 +1,5 @@
-//go:build !windows && !illumos
-// +build !windows && !illumos
+//go:build illumos
+// +build illumos
 
 /*
 Copyright 2020 The Kubernetes Authors.
@@ -20,6 +20,7 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -28,11 +29,7 @@ import (
 )
 
 func permitPortReuse(network, addr string, conn syscall.RawConn) error {
-	return conn.Control(func(fd uintptr) {
-		if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
-			klog.Warningf("failed to set SO_REUSEPORT on socket: %v", err)
-		}
-	})
+	return fmt.Errorf("port reuse is not supported")
 }
 
 func permitAddressReuse(network, addr string, conn syscall.RawConn) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Grafana 10.1.0 fails to build on illumos platforms, where previously it built fine.  This is due to:

```
# k8s.io/apiserver/pkg/server/options
../.gopath/pkg/mod/k8s.io/apiserver@v0.27.1/pkg/server/options/serving_unix.go:32:69: undefined: unix.SO_REUSEPORT
exit status 1
```

The illumos platform does not have `SO_REUSEPORT` for userland applications.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

I've tested this patch successfully fixes the build on illumos, using a forked version of apiserver here: https://github.com/jperkin/apiserver

I can successfully launch `grafana server` after installing the fixed build.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
