### PR TITLE
Rename request body size metric to conform with Prometheus best practices

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/metrics/metrics.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+
 	"k8s.io/component-base/metrics"
 )
 
@@ -35,8 +36,8 @@ var (
 	RequestBodySizes = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem: "apiserver",
-			Name:      "request_body_sizes",
-			Help:      "Apiserver request body sizes broken out by size.",
+			Name:      "request_body_size_bytes",
+			Help:      "Apiserver request body size in bytes broken out by resource and verb.",
 			// we use 0.05 KB as the smallest bucket with 0.1 KB increments up to the
 			// apiserver limit.
 			Buckets:        metrics.LinearBuckets(50000, 100000, 31),

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -134,42 +134,42 @@ func TestLimitedReadBody(t *testing.T) {
 			requestBody: strings.NewReader("aaaa"),
 			limit:       5,
 			expectedMetrics: `
-        # HELP apiserver_request_body_sizes [ALPHA] Apiserver request body sizes broken out by size.
-        # TYPE apiserver_request_body_sizes histogram
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="50000"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="150000"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="250000"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="350000"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="450000"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="550000"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="650000"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="750000"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="850000"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="950000"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="1.05e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="1.15e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="1.25e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="1.35e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="1.45e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="1.55e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="1.65e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="1.75e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="1.85e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="1.95e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="2.05e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="2.15e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="2.25e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="2.35e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="2.45e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="2.55e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="2.65e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="2.75e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="2.85e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="2.95e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="3.05e+06"} 1
-        apiserver_request_body_sizes_bucket{resource="resource.group",verb="create",le="+Inf"} 1
-        apiserver_request_body_sizes_sum{resource="resource.group",verb="create"} 4
-        apiserver_request_body_sizes_count{resource="resource.group",verb="create"} 1
+        # HELP apiserver_request_body_size_bytes [ALPHA] Apiserver request body size in bytes broken out by resource and verb.
+        # TYPE apiserver_request_body_size_bytes histogram
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="50000"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="150000"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="250000"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="350000"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="450000"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="550000"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="650000"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="750000"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="850000"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="950000"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="1.05e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="1.15e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="1.25e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="1.35e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="1.45e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="1.55e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="1.65e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="1.75e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="1.85e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="1.95e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="2.05e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="2.15e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="2.25e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="2.35e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="2.45e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="2.55e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="2.65e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="2.75e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="2.85e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="2.95e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="3.05e+06"} 1
+        apiserver_request_body_size_bytes_bucket{resource="resource.group",verb="create",le="+Inf"} 1
+        apiserver_request_body_size_bytes_sum{resource="resource.group",verb="create"} 4
+        apiserver_request_body_size_bytes_count{resource="resource.group",verb="create"} 1
 `,
 			expectedErr: false,
 		},
@@ -192,7 +192,7 @@ func TestLimitedReadBody(t *testing.T) {
 				}
 				return
 			}
-			if err = testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tc.expectedMetrics), "apiserver_request_body_sizes"); err != nil {
+			if err = testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tc.expectedMetrics), "apiserver_request_body_size_bytes"); err != nil {
 				t.Errorf("unexpected err: %v", err)
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Rename the apiserver_request_body_sizes metric to
apiserver_request_body_size_bytes to conform with Prometheus best practices.

This can be done safely without deprecation because that metric wasn't registered before. cf https://github.com/kubernetes/kubernetes/pull/120474/

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Rename apiserver_request_body_sizes metric to apiserver_request_body_size_bytes
```