### PR TITLE
add aojea as client-go approver

### DIFF
--- a/staging/src/k8s.io/client-go/OWNERS
+++ b/staging/src/k8s.io/client-go/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+  - aojea
   - caesarxuchao
   - deads2k
   - liggitt


### PR DESCRIPTION
After 12 months as reviewer

https://github.com/kubernetes/kubernetes/pull/112068

continuously reviewing and contributing to client-go, I think is fair to move to the next ladder.
```
git log  --author=aojea --oneline staging/src/k8s.io/client-go/
cc77b97c5e9 (HEAD -> aojea_owner, origin/aojea_owner) add aojea as client-go approver
3f3e1d507d0 (origin/transport_cache_metrics, transport_cache_metrics) add new metrics for the internal client-go transport generator
60d25c3ed77 (origin/spdy_passthrugh) improve remotecommand testing fuzzing the data stream
ba42ed9a493 (origin/ipaddress, ipaddress) make update
bf9ce7fd760 (origin/hlee/issue-103721/staticcheck) remove unused fakeUpgradeConnection
0019f986130 no lint unused variables
01a0fba3620 fix unassigned error on client-go test
d126b148384 migrate nolint coments to golangci-lint
b9d865a8185 CloseIdleConnections for wrapped Transport
938cc5445dc (origin/RoundTripperWrapper) assert RoundTripperWrapper interface
ef190f860a9 client-go token source transport implement RoundTripperWrapper interface
032d0d6ea94 (origin/restclient-shared-transport) updated generated
909a1738fdf expose NewForConfigAndClient for the metadata client
b584195e5cc expose NewForConfigAndClient for the dynamic client
f519ab25ab0 NewDiscoveryClientForConfigAndClient constructor
80fbc817263 RESTClient contructors for config and http client
72c35be086f (origin/clientgo_trace) client-go httpstats
0cd75e8fec6 run hack/update-netparse-cve.sh

```


/kind documentation
```release-note
NONE
```

/assign @liggitt @deads2k 
