### PR TITLE
add aojea as controplane reviewer

### DIFF
--- a/pkg/controlplane/OWNERS
+++ b/pkg/controlplane/OWNERS
@@ -8,6 +8,7 @@ approvers:
   - wojtek-t
   - jpbetz
 reviewers:
+  - aojea
   - thockin
   - smarterclayton
   - wojtek-t


### PR DESCRIPTION

/kind cleanup
/kind documentation

```release-note
NONE
```

Despite I literally implemented some of the controllers in the folder, I do not think it make sense to have much granularity and create independent OWNER files, because all code here is related.
I prefer to start as a reviewer on the folder and move up later to approver if I keep maintaining code in the folder

```
git log  --author=ojea --oneline pkg/controlplane/
c5147c91b88 (origin/servicedefault_informer, servicedefault_informer) controlplane: kubernetes.default controller stop polling
756f1bfe993 add repair loop
e6f197a9916 plumb new ipallocators in the apiserver
6e78e3279a2 (origin/watch_instead_poll_system_namespaces, watch_instead_poll_system_namespaces) consider default a system namespace to be managed by the namespace controller
eecfaf658ee decouple system namespaces from bootstrap controller
abf74613acf (origin/refactor_allocators) remove dead code
586a3d4ac55 (origin/controller-client-go) refactor controlplane to use just one client-go
5a20c425f2e (origin/lease_reconciler) apiserver: use endpoint lease reconciler as default
cd9b22aabca (origin/apiserver_dual_service) apiserver endpoint reconciler ip families
da8ce6aa3ef (origin/master_leases) improve error message on control-plane endpoint reconciler
7c12daed0f5 (origin/service_finalizer_delete) move repair loop interval to a constant

```

/assign @sttts @wojtek-t @deads2k 