### PR TITLE
[releng] Update publishing-bot rules for active release branches that uses go1.20 to Go 1.20.8

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -6,22 +6,22 @@ rules:
       branch: master
       dir: staging/src/k8s.io/code-generator
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/code-generator
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/code-generator
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.27
       dir: staging/src/k8s.io/code-generator
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.28
       dir: staging/src/k8s.io/code-generator
@@ -32,22 +32,22 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.27
       dir: staging/src/k8s.io/apimachinery
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.28
       dir: staging/src/k8s.io/apimachinery
@@ -62,7 +62,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/api
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -70,7 +70,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/api
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -78,7 +78,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/api
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -86,7 +86,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/api
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -110,7 +110,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -124,7 +124,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -138,7 +138,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -152,7 +152,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -180,7 +180,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/component-base
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -192,7 +192,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-base
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -204,7 +204,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/component-base
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -216,7 +216,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/component-base
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -242,7 +242,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -254,7 +254,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -266,7 +266,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -278,7 +278,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/component-helpers
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -304,12 +304,12 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kms
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/kms
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -321,7 +321,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/kms
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -351,7 +351,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/apiserver
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -365,7 +365,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/apiserver
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -381,7 +381,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/apiserver
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -397,7 +397,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/apiserver
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -435,7 +435,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -453,7 +453,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -473,7 +473,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -493,7 +493,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/kube-aggregator
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -539,7 +539,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -562,7 +562,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -587,7 +587,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -612,7 +612,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -657,7 +657,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -676,7 +676,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -695,7 +695,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -714,7 +714,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -756,7 +756,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -776,7 +776,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -798,7 +798,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -820,7 +820,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -857,7 +857,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/metrics
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -871,7 +871,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/metrics
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -885,7 +885,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/metrics
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -899,7 +899,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/metrics
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -927,7 +927,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -939,7 +939,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -951,7 +951,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -963,7 +963,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/cli-runtime
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -991,7 +991,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1005,7 +1005,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1019,7 +1019,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1033,7 +1033,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/sample-cli-plugin
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1062,7 +1062,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1076,7 +1076,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1090,7 +1090,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1104,7 +1104,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/kube-proxy
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1125,22 +1125,22 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cri-api
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/cri-api
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/cri-api
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.27
       dir: staging/src/k8s.io/cri-api
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.28
       dir: staging/src/k8s.io/cri-api
@@ -1167,7 +1167,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kubelet
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1181,7 +1181,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubelet
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1195,7 +1195,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kubelet
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1209,7 +1209,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/kubelet
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1245,7 +1245,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1259,7 +1259,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1273,7 +1273,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1287,7 +1287,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/kube-scheduler
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1321,7 +1321,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1337,7 +1337,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1355,7 +1355,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1373,7 +1373,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/controller-manager
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1415,7 +1415,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1435,7 +1435,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1457,7 +1457,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1479,7 +1479,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/cloud-provider
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1527,7 +1527,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1549,7 +1549,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1573,7 +1573,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1597,7 +1597,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/kube-controller-manager
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1633,7 +1633,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1643,7 +1643,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1653,7 +1653,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1663,7 +1663,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/cluster-bootstrap
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1685,7 +1685,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1695,7 +1695,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1705,7 +1705,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1715,7 +1715,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/csi-translation-lib
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1732,22 +1732,22 @@ rules:
       branch: master
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.25
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.26
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.27
       dir: staging/src/k8s.io/mount-utils
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     source:
       branch: release-1.28
       dir: staging/src/k8s.io/mount-utils
@@ -1778,7 +1778,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1804,7 +1804,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1832,7 +1832,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1856,7 +1856,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1904,7 +1904,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/kubectl
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1926,7 +1926,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/kubectl
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1948,7 +1948,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/kubectl
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1970,7 +1970,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/kubectl
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2012,7 +2012,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.25
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.25
@@ -2028,7 +2028,7 @@ rules:
       branch: release-1.25
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2046,7 +2046,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2064,7 +2064,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/pod-security-admission
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2104,7 +2104,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2120,7 +2120,7 @@ rules:
       branch: release-1.26
       dir: staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.27
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2136,7 +2136,7 @@ rules:
       branch: release-1.27
       dir: staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2171,7 +2171,7 @@ rules:
       branch: master
       dir: staging/src/k8s.io/endpointslice
   - name: release-1.28
-    go: 1.20.7
+    go: 1.20.8
     dependencies:
     - repository: api
       branch: release-1.28


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Update publishing-bot rules for active release branches that uses go1.20 to Go 1.20.8

#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes/release/issues/3242

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

/assign @saschagrunert @jeremyrickard  @liggitt @nikhita 
cc @kubernetes/release-engineering 