### PR TITLE
dra scheduler: fall back to SSA for PodSchedulingContext updates

### DIFF
--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -21,24 +21,33 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
+	resourcev1alpha2 "k8s.io/api/resource/v1alpha2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	configv1 "k8s.io/kube-scheduler/config/v1"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
 	configtesting "k8s.io/kubernetes/pkg/scheduler/apis/config/testing"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	testutils "k8s.io/kubernetes/test/integration/util"
+	"k8s.io/kubernetes/test/utils/format"
 	"k8s.io/utils/pointer"
 )
 
@@ -610,4 +619,132 @@ func TestNodeEvents(t *testing.T) {
 		t.Errorf("Pod %s didn't schedule: %v", pod2.Name, err)
 	}
 
+}
+
+// TestPodSchedulingContextSSA checks that the dynamicresources plugin falls
+// back to SSA successfully when the normal Update call encountered
+// a conflict.
+//
+// This is an integration test because:
+//   - Unit testing does not cover RBAC rules.
+//   - Triggering this particular race is harder in E2E testing
+//     and harder to verify (needs apiserver metrics and there's
+//     no standard API for those).
+func TestPodSchedulingContextSSA(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DynamicResourceAllocation, true)()
+
+	testCtx := testutils.InitTestAPIServer(t, "podschedulingcontext-ssa", nil)
+	testCtx.DisableEventSink = true
+	testCtx = testutils.InitTestSchedulerWithOptions(t, testCtx, 0)
+	testutils.SyncSchedulerInformerFactory(testCtx)
+	go testCtx.Scheduler.Run(testCtx.SchedulerCtx)
+
+	// Set up enough objects that the scheduler will start trying to
+	// schedule the pod and create the PodSchedulingContext.
+	nodeRes := map[v1.ResourceName]string{
+		v1.ResourcePods:   "32",
+		v1.ResourceCPU:    "30m",
+		v1.ResourceMemory: "30",
+	}
+	for _, name := range []string{"node-a", "node-b"} {
+		if _, err := testutils.CreateNode(testCtx.ClientSet, st.MakeNode().Name(name).Capacity(nodeRes).Obj()); err != nil {
+			t.Fatalf("Failed to create node: %v", err)
+		}
+	}
+
+	defer func() {
+		if err := testCtx.ClientSet.ResourceV1alpha2().ResourceClasses().DeleteCollection(testCtx.Ctx, metav1.DeleteOptions{}, metav1.ListOptions{}); err != nil {
+			t.Errorf("Unexpected error deleting ResourceClasses: %v", err)
+		}
+	}()
+	class := &resourcev1alpha2.ResourceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-class",
+		},
+		DriverName: "does-not-matter",
+	}
+	if _, err := testCtx.ClientSet.ResourceV1alpha2().ResourceClasses().Create(testCtx.Ctx, class, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create class: %v", err)
+	}
+
+	claim := &resourcev1alpha2.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-claim",
+			Namespace: testCtx.NS.Name,
+		},
+		Spec: resourcev1alpha2.ResourceClaimSpec{
+			ResourceClassName: class.Name,
+		},
+	}
+	if _, err := testCtx.ClientSet.ResourceV1alpha2().ResourceClaims(claim.Namespace).Create(testCtx.Ctx, claim, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create claim: %v", err)
+	}
+
+	podConf := testutils.PausePodConfig{
+		Name:      "testpod",
+		Namespace: testCtx.NS.Name,
+	}
+	pod := testutils.InitPausePod(&podConf)
+	podClaimName := "myclaim"
+	pod.Spec.Containers[0].Resources.Claims = []v1.ResourceClaim{{Name: podClaimName}}
+	pod.Spec.ResourceClaims = []v1.PodResourceClaim{{Name: podClaimName, Source: v1.ClaimSource{ResourceClaimName: &claim.Name}}}
+	if _, err := testCtx.ClientSet.CoreV1().Pods(pod.Namespace).Create(testCtx.Ctx, pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create pod: %v", err)
+	}
+
+	// Check that the PodSchedulingContext exists and has a selected node.
+	var schedulingCtx *resourcev1alpha2.PodSchedulingContext
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 10*time.Microsecond, 30*time.Second, true,
+		func(context.Context) (bool, error) {
+			var err error
+			schedulingCtx, err = testCtx.ClientSet.ResourceV1alpha2().PodSchedulingContexts(pod.Namespace).Get(testCtx.Ctx, pod.Name, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			if err == nil && schedulingCtx.Spec.SelectedNode != "" {
+				return true, nil
+			}
+			return false, err
+		}); err != nil {
+		t.Fatalf("Failed while waiting for PodSchedulingContext with selected node: %v\nLast PodSchedulingContext:\n%s", err, format.Object(schedulingCtx, 1))
+	}
+
+	// Force the plugin to use SSA.
+	var podSchedulingContextPatchCounter atomic.Int64
+	roundTrip := testutils.RoundTripWrapper(func(transport http.RoundTripper, req *http.Request) (*http.Response, error) {
+		if strings.HasPrefix(req.URL.Path, "/apis/resource.k8s.io/") &&
+			strings.HasSuffix(req.URL.Path, "/podschedulingcontexts/"+pod.Name) {
+			switch req.Method {
+			case http.MethodPut, http.MethodPost:
+				return &http.Response{
+					Status:     fmt.Sprintf("%d %s", http.StatusConflict, metav1.StatusReasonConflict),
+					StatusCode: http.StatusConflict,
+				}, nil
+			case http.MethodPatch:
+				podSchedulingContextPatchCounter.Add(1)
+			}
+		}
+		return transport.RoundTrip(req)
+	})
+	testCtx.RoundTrip.Store(&roundTrip)
+
+	// Now force the scheduler to update the PodSchedulingContext by setting UnsuitableNodes so that
+	// the selected node is not suitable.
+	schedulingCtx.Status.ResourceClaims = []resourcev1alpha2.ResourceClaimSchedulingStatus{{
+		Name:            podClaimName,
+		UnsuitableNodes: []string{schedulingCtx.Spec.SelectedNode},
+	}}
+
+	if _, err := testCtx.ClientSet.ResourceV1alpha2().PodSchedulingContexts(pod.Namespace).UpdateStatus(testCtx.Ctx, schedulingCtx, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Unexpected PodSchedulingContext status update error: %v", err)
+	}
+
+	// We know that the scheduler has to use SSA because above we inject a conflict
+	// error whenever it tries to use a plain update. We just need to wait for it...
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 10*time.Microsecond, time.Minute, true,
+		func(context.Context) (bool, error) {
+			return podSchedulingContextPatchCounter.Load() > 0, nil
+		}); err != nil {
+		t.Fatalf("Failed while waiting for PodSchedulingContext Patch: %v", err)
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

During scheduler_perf testing, roughly 10% of the PodSchedulingContext update operations failed with a conflict error. Using SSA would avoid that, but performance measurements showed that this causes a considerable slowdown (primarily because of the slower encoding with JSON instead of protobuf, but also because server-side processing is more expensive).

Therefore a normal update is tried first and SSA only gets used when there has been a conflict. Using SSA in that case instead of giving up outright is better because it avoids another scheduling attempt.

#### Which issue(s) this PR fixes:

Related-to: https://github.com/kubernetes/kubernetes/issues/120502

#### Special notes for your reviewer:

On my machine, "stress" shows that the new test is stable:
```
45s: 236 runs so far, 1 failures (0.42%)
```

That one failure seems unrelated:
```
        found unexpected goroutines:
        [Goroutine 5614 in state sleep, with time.Sleep on top of the stack:
        goroutine 5614 [sleep]:
        time.Sleep(0x2aa6db101)
                /nvme/gopath/go-1.21.0/src/runtime/time.go:195 +0x125
        k8s.io/client-go/tools/events.(*eventBroadcasterImpl).attemptRecording(0xc00636a630, 0xc002f5a780)
                /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/events/event_broadcaster.go:221 +0x77
        k8s.io/client-go/tools/events.(*eventBroadcasterImpl).recordToSink.func1()
                /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/events/event_broadcaster.go:200 +0x3a
        created by k8s.io/client-go/tools/events.(*eventBroadcasterImpl).recordToSink in goroutine 5021
                /nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/events/event_broadcaster.go:173 +0xdb
        ]
 >
FAIL    k8s.io/kubernetes/test/integration/scheduler    10.704s
```

This is a known issue (https://github.com/kubernetes/kubernetes/pull/115514) and it should be fixed. I double-checked that `Shutdown() ` is called. ~~Needs to be investigated if it occurs in practice.~~ I got rid of this goroutine leak by not starting the event recorder in the first place - it's not needed.

#### Does this PR introduce a user-facing change?
```release-note
dra: the scheduler plugin avoids additional scheduling attempts in some cases by falling back to SSA after a conflict
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3063
```
