### PR TITLE
add trace support for kubelet csi-plugin

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
 	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
@@ -914,4 +915,8 @@ func (adc *attachDetachController) GetSubpather() subpath.Interface {
 
 func (adc *attachDetachController) GetCSIDriverLister() storagelistersv1.CSIDriverLister {
 	return adc.csiDriverLister
+}
+
+func (adc *attachDetachController) GetTracerProvider() trace.TracerProvider {
+	return trace.NewNoopTracerProvider()
 }

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
 	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
@@ -474,4 +475,8 @@ func (expc *expandController) GetEventRecorder() record.EventRecorder {
 func (expc *expandController) GetSubpather() subpath.Interface {
 	// not needed for expand controller
 	return nil
+}
+
+func (expc *expandController) GetTracerProvider() trace.TracerProvider {
+	return trace.NewNoopTracerProvider()
 }

--- a/pkg/controller/volume/persistentvolume/volume_host.go
+++ b/pkg/controller/volume/persistentvolume/volume_host.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
 
+	"go.opentelemetry.io/otel/trace"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,6 +38,10 @@ import (
 // VolumeHost interface implementation for PersistentVolumeController.
 
 var _ vol.VolumeHost = &PersistentVolumeController{}
+
+func (ctrl *PersistentVolumeController) GetTracerProvider() trace.TracerProvider {
+	return trace.NewNoopTracerProvider()
+}
 
 func (ctrl *PersistentVolumeController) GetPluginDir(pluginName string) string {
 	return ""

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -810,7 +810,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	// which affects node ready status. This function must be called before Kubelet is initialized so that the Node
 	// ReadyState is accurate with the storage state.
 	klet.volumePluginMgr, err =
-		NewInitializedVolumePluginMgr(klet, secretManager, configMapManager, tokenManager, clusterTrustBundleManager, kubeDeps.VolumePlugins, kubeDeps.DynamicPluginProber)
+		NewInitializedVolumePluginMgr(klet, secretManager, configMapManager, tokenManager, clusterTrustBundleManager, kubeDeps.VolumePlugins, kubeDeps.DynamicPluginProber, kubeDeps.TracerProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -383,7 +383,7 @@ func newTestKubeletWithImageList(
 
 	var prober volume.DynamicPluginProber // TODO (#51147) inject mock
 	kubelet.volumePluginMgr, err =
-		NewInitializedVolumePluginMgr(kubelet, kubelet.secretManager, kubelet.configMapManager, token.NewManager(kubelet.kubeClient), &clustertrustbundle.NoopManager{}, allPlugins, prober)
+		NewInitializedVolumePluginMgr(kubelet, kubelet.secretManager, kubelet.configMapManager, token.NewManager(kubelet.kubeClient), &clustertrustbundle.NoopManager{}, allPlugins, prober, oteltrace.NewNoopTracerProvider())
 	require.NoError(t, err, "Failed to initialize VolumePluginMgr")
 
 	kubelet.volumeManager = kubeletvolume.NewVolumeManager(

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/mock/gomock"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"k8s.io/mount-utils"
 
 	v1 "k8s.io/api/core/v1"
@@ -105,7 +106,7 @@ func TestRunOnce(t *testing.T) {
 
 	plug := &volumetest.FakeVolumePlugin{PluginName: "fake", Host: nil}
 	kb.volumePluginMgr, err =
-		NewInitializedVolumePluginMgr(kb, fakeSecretManager, fakeConfigMapManager, nil, clusterTrustBundleManager, []volume.VolumePlugin{plug}, nil /* prober */)
+		NewInitializedVolumePluginMgr(kb, fakeSecretManager, fakeConfigMapManager, nil, clusterTrustBundleManager, []volume.VolumePlugin{plug}, nil /* prober */, oteltrace.NewNoopTracerProvider())
 	if err != nil {
 		t.Fatalf("failed to initialize VolumePluginMgr: %v", err)
 	}

--- a/pkg/volume/csi/csi_client_test.go
+++ b/pkg/volume/csi/csi_client_test.go
@@ -28,6 +28,7 @@ import (
 
 	csipbv1 "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/trace"
 
 	api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -431,7 +432,7 @@ func TestClientNodeGetInfo(t *testing.T) {
 		fakeCloser := fake.NewCloser(t)
 		client := &csiDriverClient{
 			driverName: "Fake Driver Name",
-			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager, tp trace.TracerProvider) (csipbv1.NodeClient, io.Closer, error) {
 				nodeClient := fake.NewNodeClient(false /* stagingCapable */)
 				nodeClient.SetNextError(tc.err)
 				nodeClient.SetNodeGetInfoResp(&csipbv1.NodeGetInfoResponse{
@@ -502,7 +503,7 @@ func TestClientNodePublishVolume(t *testing.T) {
 		fakeCloser := fake.NewCloser(t)
 		client := &csiDriverClient{
 			driverName: "Fake Driver Name",
-			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager, tp trace.TracerProvider) (csipbv1.NodeClient, io.Closer, error) {
 				return nodeClient, fakeCloser, nil
 			},
 		}
@@ -560,7 +561,7 @@ func TestClientNodeUnpublishVolume(t *testing.T) {
 		fakeCloser := fake.NewCloser(t)
 		client := &csiDriverClient{
 			driverName: "Fake Driver Name",
-			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager, tp trace.TracerProvider) (csipbv1.NodeClient, io.Closer, error) {
 				nodeClient := fake.NewNodeClient(false /* stagingCapable */)
 				nodeClient.SetNextError(tc.err)
 				return nodeClient, fakeCloser, nil
@@ -614,7 +615,7 @@ func TestClientNodeStageVolume(t *testing.T) {
 		fakeCloser := fake.NewCloser(t)
 		client := &csiDriverClient{
 			driverName: "Fake Driver Name",
-			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager, tp trace.TracerProvider) (csipbv1.NodeClient, io.Closer, error) {
 				return nodeClient, fakeCloser, nil
 			},
 		}
@@ -670,7 +671,7 @@ func TestClientNodeUnstageVolume(t *testing.T) {
 		fakeCloser := fake.NewCloser(t)
 		client := &csiDriverClient{
 			driverName: "Fake Driver Name",
-			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager, tp trace.TracerProvider) (csipbv1.NodeClient, io.Closer, error) {
 				nodeClient := fake.NewNodeClient(false /* stagingCapable */)
 				nodeClient.SetNextError(tc.err)
 				return nodeClient, fakeCloser, nil
@@ -748,7 +749,7 @@ func testClientNodeSupportsCapabilities(
 		fakeCloser := fake.NewCloser(t)
 		client := &csiDriverClient{
 			driverName: "Fake Driver Name",
-			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager, tp trace.TracerProvider) (csipbv1.NodeClient, io.Closer, error) {
 				nodeClient := nodeClientGenerator(tc.capable)
 				return nodeClient, fakeCloser, nil
 			},
@@ -806,7 +807,7 @@ func TestNodeExpandVolume(t *testing.T) {
 		fakeCloser := fake.NewCloser(t)
 		client := &csiDriverClient{
 			driverName: "Fake Driver Name",
-			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager, tp trace.TracerProvider) (csipbv1.NodeClient, io.Closer, error) {
 				nodeClient := fake.NewNodeClient(false /* stagingCapable */)
 				nodeClient.SetNextError(tc.err)
 				return nodeClient, fakeCloser, nil
@@ -1075,7 +1076,7 @@ func TestAccessModeMapping(t *testing.T) {
 			fakeCloser := fake.NewCloser(t)
 			client := &csiDriverClient{
 				driverName: "Fake Driver Name",
-				nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
+				nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager, tp trace.TracerProvider) (csipbv1.NodeClient, io.Closer, error) {
 					nodeClient := fake.NewNodeClientWithSingleNodeMultiWriter(tc.singleNodeMultiWriterSet)
 					return nodeClient, fakeCloser, nil
 				},

--- a/pkg/volume/csi/csi_metrics_test.go
+++ b/pkg/volume/csi/csi_metrics_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	csipbv1 "github.com/container-storage-interface/spec/lib/go/csi"
+	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/csi/fake"
@@ -47,7 +48,7 @@ func TestGetMetrics(t *testing.T) {
 		metricsGetter := &metricsCsi{volumeID: tc.volumeID, targetPath: tc.targetPath}
 		metricsGetter.csiClient = &csiDriverClient{
 			driverName: "com.google.gcepd",
-			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager, tp trace.TracerProvider) (csipbv1.NodeClient, io.Closer, error) {
 				nodeClient := fake.NewNodeClientWithVolumeStats(true /* VolumeStatsCapable */)
 				fakeCloser := fake.NewCloser(t)
 				nodeClient.SetNodeVolumeStatsResp(getRawVolumeInfo())
@@ -116,7 +117,7 @@ func TestGetMetricsDriverNotSupportStats(t *testing.T) {
 		metricsGetter := &metricsCsi{volumeID: tc.volumeID, targetPath: tc.targetPath}
 		metricsGetter.csiClient = &csiDriverClient{
 			driverName: "com.simple.SimpleDriver",
-			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager) (csipbv1.NodeClient, io.Closer, error) {
+			nodeV1ClientCreator: func(addr csiAddr, m *MetricsManager, tp trace.TracerProvider) (csipbv1.NodeClient, io.Closer, error) {
 				nodeClient := fake.NewNodeClientWithVolumeStats(false /* VolumeStatsCapable */)
 				fakeCloser := fake.NewCloser(t)
 				nodeClient.SetNodeVolumeStatsResp(getRawVolumeInfo())

--- a/pkg/volume/csi/expander.go
+++ b/pkg/volume/csi/expander.go
@@ -42,7 +42,7 @@ func (c *csiPlugin) NodeExpand(resizeOptions volume.NodeResizeOptions) (bool, er
 		return false, errors.New(log("Expander.NodeExpand failed to get CSI persistent source: %v", err))
 	}
 
-	csClient, err := newCsiDriverClient(csiDriverName(csiSource.Driver))
+	csClient, err := newCsiDriverClient(csiDriverName(csiSource.Driver), c.host.GetTracerProvider())
 	if err != nil {
 		// Treat the absence of the CSI driver as a transient error
 		// See https://github.com/kubernetes/kubernetes/issues/120268

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 
+	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
@@ -449,6 +450,8 @@ type VolumeHost interface {
 
 	// Returns an interface that should be used to execute subpath operations
 	GetSubpather() subpath.Interface
+
+	GetTracerProvider() trace.TracerProvider
 }
 
 // VolumePluginMgr tracks registered plugins.

--- a/pkg/volume/testing/volume_host.go
+++ b/pkg/volume/testing/volume_host.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -249,6 +250,10 @@ func (f *fakeVolumeHost) WaitForKubeletErrNil() error {
 		defer f.mux.Unlock()
 		return f.kubeletErr == nil, nil
 	})
+}
+
+func (f *fakeVolumeHost) GetTracerProvider() trace.TracerProvider {
+	return trace.NewNoopTracerProvider()
 }
 
 type fakeAttachDetachVolumeHost struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Add trace support for kubelet csi plugin

Fixes part of #113414

I used kind as local environment and use https://github.com/kubernetes-csi/csi-driver-host-path as demo csi driver. following is the span in demo

![image](https://github.com/kubernetes/kubernetes/assets/11855957/7b2c9394-a3eb-40b2-b768-f1e769c51cdd)

![image](https://github.com/kubernetes/kubernetes/assets/11855957/bd1402c9-56d9-48d5-8e0e-3e5eee6eafbc)

![image](https://github.com/kubernetes/kubernetes/assets/11855957/0cf60551-3672-43d9-9f3d-c833af6b4570)


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: [<link>](https://github.com/kubernetes/enhancements/issues/2831)
- [Usage]: <link>
- [Other doc]: <link>
```
