### PR TITLE
Promote e2e test for PersistentVolume & PersistentVolumeClaim Endpoints + 13 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2967,6 +2967,19 @@
     able to start with Secret and ConfigMap volumes mounted into the container.
   release: v1.13
   file: test/e2e/storage/empty_dir_wrapper.go
+- testname: PersistentVolumes(Claims), lifecycle
+  codename: '[sig-storage] PersistentVolumes CSI Conformance should run through the
+    lifecycle of a PV and a PVC [Conformance]'
+  description: Creating PV and PVC MUST succeed. Listing PVs with a labelSelector
+    MUST succeed. Listing PVCs in a namespace MUST succeed. Patching a PV MUST succeed
+    with its new label found. Patching a PVC MUST succeed with its new label found.
+    Reading a PV and PVC MUST succeed with required UID retrieved. Deleting a PVC
+    and PV MUST succeed and it MUST be confirmed. Replacement PV and PVC MUST be created.
+    Updating a PV MUST succeed with its new label found. Updating a PVC MUST succeed
+    with its new label found. Deleting the PVC and PV via deleteCollection MUST succeed
+    and it MUST be confirmed.
+  release: v1.29
+  file: test/e2e/storage/persistent_volumes.go
 - testname: Projected Volume, multiple projections
   codename: '[sig-storage] Projected combined should project all components that make
     up the projection API [Projection][NodeConformance] [Conformance]'

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -393,7 +393,19 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 			}
 		})
 
-		ginkgo.It("should run through the lifecycle of a PV and a PVC", func(ctx context.Context) {
+		/*
+			Release: v1.29
+			Testname: PersistentVolumes(Claims), lifecycle
+			Description: Creating PV and PVC MUST succeed. Listing PVs with a labelSelector
+			MUST succeed. Listing PVCs in a namespace MUST succeed. Patching a PV MUST succeed
+			with its new label found. Patching a PVC MUST succeed with its new label found.
+			Reading a PV and PVC MUST succeed with required UID retrieved. Deleting a PVC
+			and PV MUST succeed and it MUST be confirmed. Replacement PV and PVC MUST be created.
+			Updating a PV MUST succeed with its new label found. Updating a PVC MUST succeed
+			with its new label found. Deleting the PVC and PV via deleteCollection MUST succeed
+			and it MUST be confirmed.
+		*/
+		framework.ConformanceIt("should run through the lifecycle of a PV and a PVC", func(ctx context.Context) {
 
 			pvClient := c.CoreV1().PersistentVolumes()
 			pvcClient := c.CoreV1().PersistentVolumeClaims(ns)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- deleteStorageV1CollectionCSIDriver
- patchStorageV1CSIDriver
- replaceStorageV1CSIDriver    

**Which issue(s) this PR fixes:**
Fixes #118098

**Testgrid Link:**
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.run.through.the.lifecycle.of.a.CSIDriver)


**Special notes for your reviewer:**
This test cover all 7 StorageV1CSIDriver Endpoints. Once the test have been promoted to conformance and proven stable the [current test for create, read, list & delete](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/csi_inline.go#L46) could be removed to reduce the test load.
Adds +3 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance