### PR TITLE
Automated cherry pick of #120334: scheduler: start scheduling attempt with clean

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -571,6 +571,10 @@ func (p *PriorityQueue) Pop() (*framework.QueuedPodInfo, error) {
 	pInfo := obj.(*framework.QueuedPodInfo)
 	pInfo.Attempts++
 	p.schedulingCycle++
+
+	// Reset the set of unschedulable plugins for the next attempt.
+	pInfo.UnschedulablePlugins = sets.NewString()
+
 	return pInfo, nil
 }
 


### PR DESCRIPTION
Cherry pick of #120334 on release-1.26.

#120334: scheduler: start scheduling attempt with clean

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```