### PR TITLE
e2e pods: fix WaitForPodsResponding retry

### DIFF
--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -581,10 +581,11 @@ func WaitForPodsResponding(ctx context.Context, c clientset.Interface, ns string
 
 			if err != nil {
 				// We may encounter errors here because of a race between the pod readiness and apiserver
-				// proxy. So, we log the error and retry if this occurs.
-				return nil, fmt.Errorf("Controller %s: failed to Get from replica pod %s:\n%s\nPod status:\n%s",
+				// proxy or because of temporary failures. The error gets wrapped for framework.HandleRetry.
+				// Gomega+Ginkgo will handle logging.
+				return nil, fmt.Errorf("controller %s: failed to Get from replica pod %s:\n%w\nPod status:\n%s",
 					controllerName, pod.Name,
-					format.Object(err, 1), format.Object(pod.Status, 1))
+					err, format.Object(pod.Status, 1))
 			}
 			responses = append(responses, response{podName: pod.Name, response: string(body)})
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

The status error was embedded inside the new error constructed by WaitForPodsResponding's get function, but not wrapped. Therefore `apierrors.IsServiceUnavailable(err)` didn't find it and returned false -> no retries.

Wrapping fixes this and Gomega formatting of the error remains useful:

	err := &errors.StatusError{}
	err.ErrStatus.Code = 503
	err.ErrStatus.Message = "temporary failure"

	err2 := fmt.Errorf("Controller %s: failed to Get from replica pod %s:\n%w\nPod status:\n%s",
		"foo", "bar",
		err, "some status")
	fmt.Println(format.Object(err2, 1))
        fmt.Println(errors.IsServiceUnavailable(err2))

=>

    <*fmt.wrapError | 0xc000139340>:
    Controller foo: failed to Get from replica pod bar:
    temporary failure
    Pod status:
    some status
    {
        msg: "Controller foo: failed to Get from replica pod bar:\ntemporary failure\nPod status:\nsome status",
        err: <*errors.StatusError | 0xc0001a01e0>{
            ErrStatus: {
                TypeMeta: {Kind: "", APIVersion: ""},
                ListMeta: {
                    SelfLink: "",
                    ResourceVersion: "",
                    Continue: "",
                    RemainingItemCount: nil,
                },
                Status: "",
                Message: "temporary failure",
                Reason: "",
                Details: nil,
                Code: 503,
            },
        },
    }

    true



#### Which issue(s) this PR fixes:
Fixes #120539

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?
```release-note
e2e framework: retrying after intermittent apiserver failures was fixed in WaitForPodsResponding
```

/cc @alculquicondor 