### PR TITLE
Fetch qos class of pod from status fields

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -4785,17 +4785,12 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 		return allErrs
 	}
 
-	//TODO(vinaykul,InPlacePodVerticalScaling): With KEP 2527, we can rely on persistence of PodStatus.QOSClass
-	// We can use PodStatus.QOSClass instead of GetPodQOS here, in kubelet, and elsewhere, as PodStatus.QOSClass
-	// does not change once it is bootstrapped in podCreate. This needs to be addressed before beta as a
-	// separate PR covering all uses of GetPodQOS. With that change, we can drop the below block.
-	// Ref: https://github.com/kubernetes/kubernetes/pull/102884#discussion_r1093790446
-	// Ref: https://github.com/kubernetes/kubernetes/pull/102884/#discussion_r663280487
+	// With KEP 2527, we can rely on persistence of PodStatus.QOSClass, as PodStatus.QOSClass
+	// does not change once it is bootstrapped in podCreate.
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		// reject attempts to change pod qos
-		oldQoS := qos.GetPodQOS(oldPod)
 		newQoS := qos.GetPodQOS(newPod)
-		if newQoS != oldQoS {
+		if newQoS != oldPod.Status.QOSClass {
 			allErrs = append(allErrs, field.Invalid(fldPath, newQoS, "Pod QoS is immutable"))
 		}
 	}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -11061,12 +11061,17 @@ func TestValidatePodUpdate(t *testing.T) {
 		err  string
 		test string
 	}{
-		{new: core.Pod{}, old: core.Pod{}, err: "", test: "nothing"}, {
+		{
+			new: core.Pod{},
+			old: core.Pod{},
+			err: "", test: "nothing",
+		}, {
 			new: core.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 			},
 			old: core.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
+				Status:     core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			err:  "metadata.name",
 			test: "ids",
@@ -11232,6 +11237,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						ImagePullPolicy:          "Always",
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			err:  "",
 			test: "image change",
@@ -11257,6 +11263,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						ImagePullPolicy:          "Always",
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			err:  "",
 			test: "init container image change",
@@ -11331,11 +11338,14 @@ func TestValidatePodUpdate(t *testing.T) {
 				Spec: core.PodSpec{},
 			},
 			old: core.Pod{
-				Spec: core.PodSpec{},
+				Spec:   core.PodSpec{},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			err:  "",
 			test: "activeDeadlineSeconds no change, nil",
-		}, {
+		},
+
+		{
 			new: core.Pod{
 				Spec: core.PodSpec{
 					ActiveDeadlineSeconds: &activeDeadlineSecondsPositive,
@@ -11354,7 +11364,9 @@ func TestValidatePodUpdate(t *testing.T) {
 					ActiveDeadlineSeconds: &activeDeadlineSecondsPositive,
 				},
 			},
-			old:  core.Pod{},
+			old: core.Pod{
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
+			},
 			err:  "",
 			test: "activeDeadlineSeconds change to positive from nil",
 		}, {
@@ -11367,10 +11379,12 @@ func TestValidatePodUpdate(t *testing.T) {
 				Spec: core.PodSpec{
 					ActiveDeadlineSeconds: &activeDeadlineSecondsLarger,
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			err:  "",
 			test: "activeDeadlineSeconds change to smaller positive",
-		}, {
+		},
+		{
 			new: core.Pod{
 				Spec: core.PodSpec{
 					ActiveDeadlineSeconds: &activeDeadlineSecondsLarger,
@@ -11466,6 +11480,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						},
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBurstable},
 			},
 			err:  "",
 			test: "cpu limit change",
@@ -11497,6 +11512,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						},
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBurstable},
 			},
 			err:  "",
 			test: "memory limit change",
@@ -11559,6 +11575,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						},
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBurstable},
 			},
 			err:  "",
 			test: "cpu request change",
@@ -11590,6 +11607,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						},
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBurstable},
 			},
 			err:  "",
 			test: "memory request change",
@@ -11654,6 +11672,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						},
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSGuaranteed},
 			},
 			err:  "",
 			test: "Pod QoS unchanged, guaranteed -> guaranteed",
@@ -11687,6 +11706,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						},
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBurstable},
 			},
 			err:  "",
 			test: "Pod QoS unchanged, burstable -> burstable",
@@ -11719,6 +11739,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						},
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBurstable},
 			},
 			err:  "",
 			test: "Pod QoS unchanged, burstable -> burstable, add limits",
@@ -11751,6 +11772,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						},
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBurstable},
 			},
 			err:  "",
 			test: "Pod QoS unchanged, burstable -> burstable, remove limits",
@@ -11783,6 +11805,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						},
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBurstable},
 			},
 			err:  "",
 			test: "Pod QoS unchanged, burstable -> burstable, add requests",
@@ -11815,6 +11838,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						},
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBurstable},
 			},
 			err:  "",
 			test: "Pod QoS unchanged, burstable -> burstable, remove requests",
@@ -11848,6 +11872,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						},
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSGuaranteed},
 			},
 			err:  "Pod QoS is immutable",
 			test: "Pod QoS change, guaranteed -> burstable",
@@ -11880,6 +11905,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						},
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBurstable},
 			},
 			err:  "Pod QoS is immutable",
 			test: "Pod QoS change, burstable -> guaranteed",
@@ -11909,6 +11935,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Image:                    "foo:V2",
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			err:  "Pod QoS is immutable",
 			test: "Pod QoS change, besteffort -> burstable",
@@ -11938,6 +11965,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						},
 					}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBurstable},
 			},
 			err:  "Pod QoS is immutable",
 			test: "Pod QoS change, burstable -> besteffort",
@@ -12069,7 +12097,9 @@ func TestValidatePodUpdate(t *testing.T) {
 				Spec: core.PodSpec{
 					NodeName:    "node1",
 					Tolerations: []core.Toleration{{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: &[]int64{20}[0]}},
-				}},
+				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
+			},
 			err:  "",
 			test: "modified tolerationSeconds in existing toleration value in pod spec updates",
 		}, {
@@ -12133,6 +12163,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					NodeName:    "node1",
 					Tolerations: []core.Toleration{{Key: "key1", Value: "value1", Operator: "Equal", Effect: "NoExecute", TolerationSeconds: &[]int64{10}[0]}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			err:  "",
 			test: "added valid new toleration to existing tolerations in pod spec updates",
@@ -12232,6 +12263,7 @@ func TestValidatePodUpdate(t *testing.T) {
 				Spec: core.PodSpec{
 					TerminationGracePeriodSeconds: utilpointer.Int64(-1),
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			err:  "",
 			test: "update termination grace period seconds",
@@ -12338,7 +12370,9 @@ func TestValidatePodUpdate(t *testing.T) {
 					SchedulingGates: []core.PodSchedulingGate{{Name: "foo"}},
 				},
 			},
-			old:  core.Pod{},
+			old: core.Pod{
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
+			},
 			err:  "Forbidden: only deletion is allowed, but found new scheduling gate 'foo'",
 			test: "update pod spec schedulingGates: add new scheduling gate",
 		}, {
@@ -12373,6 +12407,7 @@ func TestValidatePodUpdate(t *testing.T) {
 				Spec: core.PodSpec{
 					SchedulingGates: []core.PodSchedulingGate{{Name: "foo"}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			err:  "",
 			test: "update pod spec schedulingGates: legal deletion",
@@ -12397,6 +12432,7 @@ func TestValidatePodUpdate(t *testing.T) {
 				Spec: core.PodSpec{
 					SchedulingGates: []core.PodSchedulingGate{{Name: "baz"}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			new: core.Pod{
 				Spec: core.PodSpec{
@@ -12472,6 +12508,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					},
 					SchedulingGates: []core.PodSchedulingGate{{Name: "baz"}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			new: core.Pod{
 				Spec: core.PodSpec{
@@ -12525,6 +12562,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					},
 					SchedulingGates: []core.PodSchedulingGate{{Name: "baz"}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			new: core.Pod{
 				Spec: core.PodSpec{
@@ -12658,6 +12696,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					},
 					SchedulingGates: []core.PodSchedulingGate{{Name: "baz"}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			new: core.Pod{
 				Spec: core.PodSpec{
@@ -12967,6 +13006,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					},
 					SchedulingGates: []core.PodSchedulingGate{{Name: "baz"}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			new: core.Pod{
 				Spec: core.PodSpec{
@@ -13010,6 +13050,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					},
 					SchedulingGates: []core.PodSchedulingGate{{Name: "baz"}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			new: core.Pod{
 				Spec: core.PodSpec{
@@ -13062,6 +13103,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					},
 					SchedulingGates: []core.PodSchedulingGate{{Name: "baz"}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			new: core.Pod{
 				Spec: core.PodSpec{
@@ -13090,6 +13132,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					},
 					SchedulingGates: []core.PodSchedulingGate{{Name: "baz"}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			new: core.Pod{
 				Spec: core.PodSpec{
@@ -13121,6 +13164,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					},
 					SchedulingGates: []core.PodSchedulingGate{{Name: "baz"}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			new: core.Pod{
 				Spec: core.PodSpec{
@@ -13175,6 +13219,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					Affinity:        nil,
 					SchedulingGates: []core.PodSchedulingGate{{Name: "baz"}},
 				},
+				Status: core.PodStatus{QOSClass: core.PodQOSBestEffort},
 			},
 			new: core.Pod{
 				Spec: core.PodSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR is about refactoring code to fetch Pod QOS policy from its status rather than computing each time.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

Alpha Feature Code Issues in KEP: https://github.com/kubernetes/enhancements/issues/1287

Reference to TODO in code: https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/validation/validation.go#L4788-L4793
