### PR TITLE
kubeadm: drop deprecated pointer package

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/kubelet.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet.go
@@ -23,7 +23,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	kubeletconfig "k8s.io/kubelet/config/v1beta1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
@@ -151,7 +151,7 @@ func (kc *kubeletConfig) Default(cfg *kubeadmapi.ClusterConfiguration, _ *kubead
 	}
 
 	if kc.config.Authentication.Anonymous.Enabled == nil {
-		kc.config.Authentication.Anonymous.Enabled = pointer.Bool(kubeletAuthenticationAnonymousEnabled)
+		kc.config.Authentication.Anonymous.Enabled = ptr.To(kubeletAuthenticationAnonymousEnabled)
 	} else if *kc.config.Authentication.Anonymous.Enabled {
 		warnDefaultComponentConfigValue(kind, "authentication.anonymous.enabled", kubeletAuthenticationAnonymousEnabled, *kc.config.Authentication.Anonymous.Enabled)
 	}
@@ -166,7 +166,7 @@ func (kc *kubeletConfig) Default(cfg *kubeadmapi.ClusterConfiguration, _ *kubead
 
 	// Let clients using other authentication methods like ServiceAccount tokens also access the kubelet API
 	if kc.config.Authentication.Webhook.Enabled == nil {
-		kc.config.Authentication.Webhook.Enabled = pointer.Bool(kubeletAuthenticationWebhookEnabled)
+		kc.config.Authentication.Webhook.Enabled = ptr.To(kubeletAuthenticationWebhookEnabled)
 	} else if !*kc.config.Authentication.Webhook.Enabled {
 		warnDefaultComponentConfigValue(kind, "authentication.webhook.enabled", kubeletAuthenticationWebhookEnabled, *kc.config.Authentication.Webhook.Enabled)
 	}
@@ -179,7 +179,7 @@ func (kc *kubeletConfig) Default(cfg *kubeadmapi.ClusterConfiguration, _ *kubead
 	}
 
 	if kc.config.HealthzPort == nil {
-		kc.config.HealthzPort = pointer.Int32(constants.KubeletHealthzPort)
+		kc.config.HealthzPort = ptr.To[int32](constants.KubeletHealthzPort)
 	} else if *kc.config.HealthzPort != constants.KubeletHealthzPort {
 		warnDefaultComponentConfigValue(kind, "healthzPort", constants.KubeletHealthzPort, *kc.config.HealthzPort)
 	}
@@ -203,7 +203,7 @@ func (kc *kubeletConfig) Default(cfg *kubeadmapi.ClusterConfiguration, _ *kubead
 	}
 	if ok {
 		if kc.config.ResolverConfig == nil {
-			kc.config.ResolverConfig = pointer.String(kubeletSystemdResolverConfig)
+			kc.config.ResolverConfig = ptr.To(kubeletSystemdResolverConfig)
 		} else {
 			if *kc.config.ResolverConfig != kubeletSystemdResolverConfig {
 				warnDefaultComponentConfigValue(kind, "resolvConf", kubeletSystemdResolverConfig, *kc.config.ResolverConfig)

--- a/cmd/kubeadm/app/componentconfigs/kubelet_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	kubeletconfig "k8s.io/kubelet/config/v1beta1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
@@ -52,7 +52,7 @@ func TestKubeletDefault(t *testing.T) {
 	var resolverConfig *string
 	if isSystemdResolvedActive, _ := isServiceActive("systemd-resolved"); isSystemdResolvedActive {
 		// If systemd-resolved is active, we need to set the default resolver config
-		resolverConfig = pointer.String(kubeletSystemdResolverConfig)
+		resolverConfig = ptr.To(kubeletSystemdResolverConfig)
 	}
 
 	tests := []struct {
@@ -73,17 +73,17 @@ func TestKubeletDefault(t *testing.T) {
 							ClientCAFile: constants.CACertName,
 						},
 						Anonymous: kubeletconfig.KubeletAnonymousAuthentication{
-							Enabled: pointer.Bool(kubeletAuthenticationAnonymousEnabled),
+							Enabled: ptr.To(kubeletAuthenticationAnonymousEnabled),
 						},
 						Webhook: kubeletconfig.KubeletWebhookAuthentication{
-							Enabled: pointer.Bool(kubeletAuthenticationWebhookEnabled),
+							Enabled: ptr.To(kubeletAuthenticationWebhookEnabled),
 						},
 					},
 					Authorization: kubeletconfig.KubeletAuthorization{
 						Mode: kubeletconfig.KubeletAuthorizationModeWebhook,
 					},
 					HealthzBindAddress: kubeletHealthzBindAddress,
-					HealthzPort:        pointer.Int32(constants.KubeletHealthzPort),
+					HealthzPort:        ptr.To[int32](constants.KubeletHealthzPort),
 					RotateCertificates: kubeletRotateCertificates,
 					ResolverConfig:     resolverConfig,
 					CgroupDriver:       constants.CgroupDriverSystemd,
@@ -107,17 +107,17 @@ func TestKubeletDefault(t *testing.T) {
 							ClientCAFile: constants.CACertName,
 						},
 						Anonymous: kubeletconfig.KubeletAnonymousAuthentication{
-							Enabled: pointer.Bool(kubeletAuthenticationAnonymousEnabled),
+							Enabled: ptr.To(kubeletAuthenticationAnonymousEnabled),
 						},
 						Webhook: kubeletconfig.KubeletWebhookAuthentication{
-							Enabled: pointer.Bool(kubeletAuthenticationWebhookEnabled),
+							Enabled: ptr.To(kubeletAuthenticationWebhookEnabled),
 						},
 					},
 					Authorization: kubeletconfig.KubeletAuthorization{
 						Mode: kubeletconfig.KubeletAuthorizationModeWebhook,
 					},
 					HealthzBindAddress: kubeletHealthzBindAddress,
-					HealthzPort:        pointer.Int32(constants.KubeletHealthzPort),
+					HealthzPort:        ptr.To[int32](constants.KubeletHealthzPort),
 					RotateCertificates: kubeletRotateCertificates,
 					ResolverConfig:     resolverConfig,
 					CgroupDriver:       constants.CgroupDriverSystemd,
@@ -141,17 +141,17 @@ func TestKubeletDefault(t *testing.T) {
 							ClientCAFile: constants.CACertName,
 						},
 						Anonymous: kubeletconfig.KubeletAnonymousAuthentication{
-							Enabled: pointer.Bool(kubeletAuthenticationAnonymousEnabled),
+							Enabled: ptr.To(kubeletAuthenticationAnonymousEnabled),
 						},
 						Webhook: kubeletconfig.KubeletWebhookAuthentication{
-							Enabled: pointer.Bool(kubeletAuthenticationWebhookEnabled),
+							Enabled: ptr.To(kubeletAuthenticationWebhookEnabled),
 						},
 					},
 					Authorization: kubeletconfig.KubeletAuthorization{
 						Mode: kubeletconfig.KubeletAuthorizationModeWebhook,
 					},
 					HealthzBindAddress: kubeletHealthzBindAddress,
-					HealthzPort:        pointer.Int32(constants.KubeletHealthzPort),
+					HealthzPort:        ptr.To[int32](constants.KubeletHealthzPort),
 					RotateCertificates: kubeletRotateCertificates,
 					ResolverConfig:     resolverConfig,
 					CgroupDriver:       constants.CgroupDriverSystemd,
@@ -176,17 +176,17 @@ func TestKubeletDefault(t *testing.T) {
 							ClientCAFile: constants.CACertName,
 						},
 						Anonymous: kubeletconfig.KubeletAnonymousAuthentication{
-							Enabled: pointer.Bool(kubeletAuthenticationAnonymousEnabled),
+							Enabled: ptr.To(kubeletAuthenticationAnonymousEnabled),
 						},
 						Webhook: kubeletconfig.KubeletWebhookAuthentication{
-							Enabled: pointer.Bool(kubeletAuthenticationWebhookEnabled),
+							Enabled: ptr.To(kubeletAuthenticationWebhookEnabled),
 						},
 					},
 					Authorization: kubeletconfig.KubeletAuthorization{
 						Mode: kubeletconfig.KubeletAuthorizationModeWebhook,
 					},
 					HealthzBindAddress: kubeletHealthzBindAddress,
-					HealthzPort:        pointer.Int32(constants.KubeletHealthzPort),
+					HealthzPort:        ptr.To[int32](constants.KubeletHealthzPort),
 					RotateCertificates: kubeletRotateCertificates,
 					ResolverConfig:     resolverConfig,
 					CgroupDriver:       constants.CgroupDriverSystemd,
@@ -208,17 +208,17 @@ func TestKubeletDefault(t *testing.T) {
 							ClientCAFile: filepath.Join("/path/to/certs", constants.CACertName),
 						},
 						Anonymous: kubeletconfig.KubeletAnonymousAuthentication{
-							Enabled: pointer.Bool(kubeletAuthenticationAnonymousEnabled),
+							Enabled: ptr.To(kubeletAuthenticationAnonymousEnabled),
 						},
 						Webhook: kubeletconfig.KubeletWebhookAuthentication{
-							Enabled: pointer.Bool(kubeletAuthenticationWebhookEnabled),
+							Enabled: ptr.To(kubeletAuthenticationWebhookEnabled),
 						},
 					},
 					Authorization: kubeletconfig.KubeletAuthorization{
 						Mode: kubeletconfig.KubeletAuthorizationModeWebhook,
 					},
 					HealthzBindAddress: kubeletHealthzBindAddress,
-					HealthzPort:        pointer.Int32(constants.KubeletHealthzPort),
+					HealthzPort:        ptr.To[int32](constants.KubeletHealthzPort),
 					RotateCertificates: kubeletRotateCertificates,
 					ResolverConfig:     resolverConfig,
 					CgroupDriver:       constants.CgroupDriverSystemd,

--- a/cmd/kubeadm/app/componentconfigs/kubelet_windows.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_windows.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 	kubeletconfig "k8s.io/kubelet/config/v1beta1"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // Mutate modifies absolute path fields in the KubeletConfiguration to be Windows compatible absolute paths.
@@ -70,7 +70,7 @@ func mutatePaths(cfg *kubeletconfig.KubeletConfiguration, drive string) {
 
 	// Mutate the fields we care about.
 	klog.V(2).Infof("[componentconfig] kubelet/Windows: changing field \"resolverConfig\" to empty")
-	cfg.ResolverConfig = utilpointer.String("")
+	cfg.ResolverConfig = ptr.To("")
 	mutateStringField("staticPodPath", &cfg.StaticPodPath)
 	mutateStringField("authentication.x509.clientCAFile", &cfg.Authentication.X509.ClientCAFile)
 }

--- a/cmd/kubeadm/app/componentconfigs/kubelet_windows_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_windows_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	kubeletconfig "k8s.io/kubelet/config/v1beta1"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestMutatePaths(t *testing.T) {
@@ -46,7 +46,7 @@ func TestMutatePaths(t *testing.T) {
 				},
 			},
 			expected: &kubeletconfig.KubeletConfiguration{
-				ResolverConfig: utilpointer.String(""),
+				ResolverConfig: ptr.To(""),
 				StaticPodPath:  filepath.Join(drive, "/foo/staticpods"),
 				Authentication: kubeletconfig.KubeletAuthentication{
 					X509: kubeletconfig.KubeletX509Authentication{
@@ -67,7 +67,7 @@ func TestMutatePaths(t *testing.T) {
 				},
 			},
 			expected: &kubeletconfig.KubeletConfiguration{
-				ResolverConfig: utilpointer.String(""),
+				ResolverConfig: ptr.To(""),
 				StaticPodPath:  "./foo/staticpods",
 				Authentication: kubeletconfig.KubeletAuthentication{
 					X509: kubeletconfig.KubeletX509Authentication{

--- a/cmd/kubeadm/app/phases/upgrade/health.go
+++ b/cmd/kubeadm/app/phases/upgrade/health.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -112,14 +112,14 @@ func createJob(client clientset.Interface, cfg *kubeadmapi.ClusterConfiguration)
 			Namespace: ns,
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit: pointer.Int32(0),
+			BackoffLimit: ptr.To[int32](0),
 			Template: v1.PodTemplateSpec{
 				Spec: v1.PodSpec{
 					RestartPolicy: v1.RestartPolicyNever,
 					SecurityContext: &v1.PodSecurityContext{
-						RunAsUser:    pointer.Int64(999),
-						RunAsGroup:   pointer.Int64(999),
-						RunAsNonRoot: pointer.Bool(true),
+						RunAsUser:    ptr.To[int64](999),
+						RunAsGroup:   ptr.To[int64](999),
+						RunAsNonRoot: ptr.To(true),
 					},
 					Tolerations: []v1.Toleration{
 						{

--- a/cmd/kubeadm/app/util/staticpod/utils_linux.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_linux.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pkg/errors"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -140,7 +140,7 @@ func runKubeControllerManagerAsNonRoot(pod *v1.Pod, runAsUser, runAsGroup, suppl
 		}
 	}
 	pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
-		AllowPrivilegeEscalation: pointer.Bool(false),
+		AllowPrivilegeEscalation: ptr.To(false),
 		Capabilities: &v1.Capabilities{
 			// We drop all capabilities that are added by default.
 			Drop: []v1.Capability{"ALL"},
@@ -159,7 +159,7 @@ func runKubeSchedulerAsNonRoot(pod *v1.Pod, runAsUser, runAsGroup *int64, update
 		return err
 	}
 	pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
-		AllowPrivilegeEscalation: pointer.Bool(false),
+		AllowPrivilegeEscalation: ptr.To(false),
 		// We drop all capabilities that are added by default.
 		Capabilities: &v1.Capabilities{
 			Drop: []v1.Capability{"ALL"},
@@ -184,7 +184,7 @@ func runEtcdAsNonRoot(pod *v1.Pod, runAsUser, runAsGroup *int64, updatePathOwner
 		return err
 	}
 	pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
-		AllowPrivilegeEscalation: pointer.Bool(false),
+		AllowPrivilegeEscalation: ptr.To(false),
 		// We drop all capabilities that are added by default.
 		Capabilities: &v1.Capabilities{
 			Drop: []v1.Capability{"ALL"},

--- a/cmd/kubeadm/app/util/staticpod/utils_linux_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_linux_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -40,8 +40,8 @@ type ownerAndPermissions struct {
 func verifyPodSecurityContext(t *testing.T, pod *v1.Pod, wantRunAsUser, wantRunAsGroup int64, wantSupGroup []int64) {
 	t.Helper()
 	wantPodSecurityContext := &v1.PodSecurityContext{
-		RunAsUser:          pointer.Int64(wantRunAsUser),
-		RunAsGroup:         pointer.Int64(wantRunAsGroup),
+		RunAsUser:          ptr.To(wantRunAsUser),
+		RunAsGroup:         ptr.To(wantRunAsGroup),
 		SupplementalGroups: wantSupGroup,
 		SeccompProfile: &v1.SeccompProfile{
 			Type: v1.SeccompProfileTypeRuntimeDefault,
@@ -109,7 +109,7 @@ func TestRunKubeControllerManagerAsNonRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 	verifyPodSecurityContext(t, &pod, runAsUser, runAsGroup, []int64{supGroup})
-	verifyContainerSecurityContext(t, pod.Spec.Containers[0], nil, []v1.Capability{"ALL"}, pointer.Bool(false))
+	verifyContainerSecurityContext(t, pod.Spec.Containers[0], nil, []v1.Capability{"ALL"}, ptr.To(false))
 	wantUpdateFiles := map[string]ownerAndPermissions{
 		filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.ControllerManagerKubeConfigFileName): {uid: runAsUser, gid: runAsGroup, permissions: 0600},
 		filepath.Join(cfg.CertificatesDir, kubeadmconstants.ServiceAccountPrivateKeyName):                   {uid: 0, gid: supGroup, permissions: 0640},
@@ -129,7 +129,7 @@ func TestRunKubeSchedulerAsNonRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 	verifyPodSecurityContext(t, &pod, runAsUser, runAsGroup, nil)
-	verifyContainerSecurityContext(t, pod.Spec.Containers[0], nil, []v1.Capability{"ALL"}, pointer.Bool(false))
+	verifyContainerSecurityContext(t, pod.Spec.Containers[0], nil, []v1.Capability{"ALL"}, ptr.To(false))
 	wantUpdateFiles := map[string]ownerAndPermissions{
 		filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.SchedulerKubeConfigFileName): {uid: runAsUser, gid: runAsGroup, permissions: 0600},
 	}
@@ -158,7 +158,7 @@ func TestRunEtcdAsNonRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 	verifyPodSecurityContext(t, &pod, runAsUser, runAsGroup, nil)
-	verifyContainerSecurityContext(t, pod.Spec.Containers[0], nil, []v1.Capability{"ALL"}, pointer.Bool(false))
+	verifyContainerSecurityContext(t, pod.Spec.Containers[0], nil, []v1.Capability{"ALL"}, ptr.To(false))
 	wantUpdateFiles := map[string]ownerAndPermissions{
 		cfg.Etcd.Local.DataDir: {uid: runAsUser, gid: runAsGroup, permissions: 0700},
 		filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdServerKeyName): {uid: runAsUser, gid: runAsGroup, permissions: 0600},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind deprecation

#### What this PR does / why we need it:

This replaces deprecated k8s.io/utils/pointer functions with their ptr equivalent. See https://github.com/kubernetes/utils/pull/283 for details.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
