### PR TITLE
Increase range of job_sync_duration_seconds

### DIFF
--- a/pkg/controller/job/metrics/metrics.go
+++ b/pkg/controller/job/metrics/metrics.go
@@ -38,7 +38,7 @@ var (
 			Name:           "job_sync_duration_seconds",
 			Help:           "The time it took to sync a job",
 			StabilityLevel: metrics.STABLE,
-			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
+			Buckets:        metrics.ExponentialBuckets(0.004, 2, 15),
 		},
 		[]string{"completion_mode", "result", "action"},
 	)

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -384,8 +384,6 @@
   - completion_mode
   - result
   buckets:
-  - 0.001
-  - 0.002
   - 0.004
   - 0.008
   - 0.016
@@ -399,6 +397,8 @@
   - 4.096
   - 8.192
   - 16.384
+  - 32.768
+  - 65.536
 - name: job_syncs_total
   subsystem: job_controller
   help: The number of job syncs


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Set the lower end to 4ms, which makes the higher bucket reach 1min.

The job controller makes up to 2 operations per pod in a sync, and it can process up to 500 pods. Having visibility up to 1 min can give a better sense of the performance of the controller when using a low API QPS, such as 20, the default.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Set the resolution for the job_controller_job_sync_duration_seconds metric from 4ms to 1min
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
