### PR TITLE
kms: remove livez check

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -332,16 +332,21 @@ func (s *EtcdOptions) maybeApplyResourceTransformers(c *server.Config) (err erro
 
 		c.ResourceTransformers = dynamicTransformers
 		if !s.SkipHealthEndpoints {
-			c.AddHealthChecks(dynamicTransformers)
+			addHealthChecksWithoutLivez(c, dynamicTransformers)
 		}
 	} else {
 		c.ResourceTransformers = encryptionconfig.StaticTransformers(encryptionConfiguration.Transformers)
 		if !s.SkipHealthEndpoints {
-			c.AddHealthChecks(encryptionConfiguration.HealthChecks...)
+			addHealthChecksWithoutLivez(c, encryptionConfiguration.HealthChecks...)
 		}
 	}
 
 	return nil
+}
+
+func addHealthChecksWithoutLivez(c *server.Config, healthChecks ...healthz.HealthChecker) {
+	c.HealthzChecks = append(c.HealthzChecks, healthChecks...)
+	c.ReadyzChecks = append(c.ReadyzChecks, healthChecks...)
 }
 
 func (s *EtcdOptions) addEtcdHealthEndpoint(c *server.Config) error {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
@@ -234,63 +234,85 @@ func TestKMSHealthzEndpoint(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		encryptionConfigPath string
-		wantChecks           []string
+		wantHealthzChecks    []string
+		wantReadyzChecks     []string
+		wantLivezChecks      []string
 		skipHealth           bool
 		reload               bool
 	}{
 		{
-			name:                 "no kms-provider, expect no kms healthz check",
+			name:                 "no kms-provider, expect no kms healthz check, no kms livez check",
 			encryptionConfigPath: "testdata/encryption-configs/no-kms-provider.yaml",
-			wantChecks:           []string{"etcd"},
+			wantHealthzChecks:    []string{"etcd"},
+			wantReadyzChecks:     []string{"etcd", "etcd-readiness"},
+			wantLivezChecks:      []string{"etcd"},
 		},
 		{
-			name:                 "no kms-provider+reload, expect single kms healthz check",
+			name:                 "no kms-provider+reload, expect single kms healthz check, no kms livez check",
 			encryptionConfigPath: "testdata/encryption-configs/no-kms-provider.yaml",
 			reload:               true,
-			wantChecks:           []string{"etcd", "kms-providers"},
+			wantHealthzChecks:    []string{"etcd", "kms-providers"},
+			wantReadyzChecks:     []string{"etcd", "kms-providers", "etcd-readiness"},
+			wantLivezChecks:      []string{"etcd"},
 		},
 		{
-			name:                 "single kms-provider, expect single kms healthz check",
+			name:                 "single kms-provider, expect single kms healthz check, no kms livez check",
 			encryptionConfigPath: "testdata/encryption-configs/single-kms-provider.yaml",
-			wantChecks:           []string{"etcd", "kms-provider-0"},
+			wantHealthzChecks:    []string{"etcd", "kms-provider-0"},
+			wantReadyzChecks:     []string{"etcd", "kms-provider-0", "etcd-readiness"},
+			wantLivezChecks:      []string{"etcd"},
 		},
 		{
-			name:                 "two kms-providers, expect two kms healthz checks",
+			name:                 "two kms-providers, expect two kms healthz checks, no kms livez check",
 			encryptionConfigPath: "testdata/encryption-configs/multiple-kms-providers.yaml",
-			wantChecks:           []string{"etcd", "kms-provider-0", "kms-provider-1"},
+			wantHealthzChecks:    []string{"etcd", "kms-provider-0", "kms-provider-1"},
+			wantReadyzChecks:     []string{"etcd", "kms-provider-0", "kms-provider-1", "etcd-readiness"},
+			wantLivezChecks:      []string{"etcd"},
 		},
 		{
-			name:                 "two kms-providers+reload, expect single kms healthz check",
+			name:                 "two kms-providers+reload, expect single kms healthz check, no kms livez check",
 			encryptionConfigPath: "testdata/encryption-configs/multiple-kms-providers.yaml",
 			reload:               true,
-			wantChecks:           []string{"etcd", "kms-providers"},
+			wantHealthzChecks:    []string{"etcd", "kms-providers"},
+			wantReadyzChecks:     []string{"etcd", "kms-providers", "etcd-readiness"},
+			wantLivezChecks:      []string{"etcd"},
 		},
 		{
-			name:                 "kms v1+v2, expect three kms healthz checks",
+			name:                 "kms v1+v2, expect three kms healthz checks, no kms livez check",
 			encryptionConfigPath: "testdata/encryption-configs/multiple-kms-providers-with-v2.yaml",
-			wantChecks:           []string{"etcd", "kms-provider-0", "kms-provider-1", "kms-provider-2"},
+			wantHealthzChecks:    []string{"etcd", "kms-provider-0", "kms-provider-1", "kms-provider-2"},
+			wantReadyzChecks:     []string{"etcd", "kms-provider-0", "kms-provider-1", "kms-provider-2", "etcd-readiness"},
+			wantLivezChecks:      []string{"etcd"},
 		},
 		{
-			name:                 "kms v1+v2+reload, expect single kms healthz check",
+			name:                 "kms v1+v2+reload, expect single kms healthz check, no kms livez check",
 			encryptionConfigPath: "testdata/encryption-configs/multiple-kms-providers-with-v2.yaml",
 			reload:               true,
-			wantChecks:           []string{"etcd", "kms-providers"},
+			wantHealthzChecks:    []string{"etcd", "kms-providers"},
+			wantReadyzChecks:     []string{"etcd", "kms-providers", "etcd-readiness"},
+			wantLivezChecks:      []string{"etcd"},
 		},
 		{
-			name:                 "multiple kms v2, expect single kms healthz check",
+			name:                 "multiple kms v2, expect single kms healthz check, no kms livez check",
 			encryptionConfigPath: "testdata/encryption-configs/multiple-kms-v2-providers.yaml",
-			wantChecks:           []string{"etcd", "kms-providers"},
+			wantHealthzChecks:    []string{"etcd", "kms-providers"},
+			wantReadyzChecks:     []string{"etcd", "kms-providers", "etcd-readiness"},
+			wantLivezChecks:      []string{"etcd"},
 		},
 		{
-			name:                 "multiple kms v2+reload, expect single kms healthz check",
+			name:                 "multiple kms v2+reload, expect single kms healthz check, no kms livez check",
 			encryptionConfigPath: "testdata/encryption-configs/multiple-kms-v2-providers.yaml",
 			reload:               true,
-			wantChecks:           []string{"etcd", "kms-providers"},
+			wantHealthzChecks:    []string{"etcd", "kms-providers"},
+			wantReadyzChecks:     []string{"etcd", "kms-providers", "etcd-readiness"},
+			wantLivezChecks:      []string{"etcd"},
 		},
 		{
-			name:                 "two kms-providers with skip, expect zero kms healthz checks",
+			name:                 "two kms-providers with skip, expect zero kms healthz checks, no kms livez check",
 			encryptionConfigPath: "testdata/encryption-configs/multiple-kms-providers.yaml",
-			wantChecks:           nil,
+			wantHealthzChecks:    nil,
+			wantReadyzChecks:     nil,
+			wantLivezChecks:      nil,
 			skipHealth:           true,
 		},
 	}
@@ -310,7 +332,9 @@ func TestKMSHealthzEndpoint(t *testing.T) {
 				t.Fatalf("Failed to add healthz error: %v", err)
 			}
 
-			healthChecksAreEqual(t, tc.wantChecks, serverConfig.HealthzChecks)
+			healthChecksAreEqual(t, tc.wantHealthzChecks, serverConfig.HealthzChecks, "healthz")
+			healthChecksAreEqual(t, tc.wantReadyzChecks, serverConfig.ReadyzChecks, "readyz")
+			healthChecksAreEqual(t, tc.wantLivezChecks, serverConfig.LivezChecks, "livez")
 		})
 	}
 }
@@ -320,17 +344,20 @@ func TestReadinessCheck(t *testing.T) {
 		name              string
 		wantReadyzChecks  []string
 		wantHealthzChecks []string
+		wantLivezChecks   []string
 		skipHealth        bool
 	}{
 		{
 			name:              "Readyz should have etcd-readiness check",
 			wantReadyzChecks:  []string{"etcd", "etcd-readiness"},
 			wantHealthzChecks: []string{"etcd"},
+			wantLivezChecks:   []string{"etcd"},
 		},
 		{
 			name:              "skip health, Readyz should not have etcd-readiness check",
 			wantReadyzChecks:  nil,
 			wantHealthzChecks: nil,
+			wantLivezChecks:   nil,
 			skipHealth:        true,
 		},
 	}
@@ -346,13 +373,14 @@ func TestReadinessCheck(t *testing.T) {
 				t.Fatalf("Failed to add healthz error: %v", err)
 			}
 
-			healthChecksAreEqual(t, tc.wantReadyzChecks, serverConfig.ReadyzChecks)
-			healthChecksAreEqual(t, tc.wantHealthzChecks, serverConfig.HealthzChecks)
+			healthChecksAreEqual(t, tc.wantReadyzChecks, serverConfig.ReadyzChecks, "readyz")
+			healthChecksAreEqual(t, tc.wantHealthzChecks, serverConfig.HealthzChecks, "healthz")
+			healthChecksAreEqual(t, tc.wantLivezChecks, serverConfig.LivezChecks, "livez")
 		})
 	}
 }
 
-func healthChecksAreEqual(t *testing.T, want []string, healthChecks []healthz.HealthChecker) {
+func healthChecksAreEqual(t *testing.T, want []string, healthChecks []healthz.HealthChecker, checkerType string) {
 	t.Helper()
 
 	wantSet := sets.NewString(want...)
@@ -365,6 +393,6 @@ func healthChecksAreEqual(t *testing.T, want []string, healthChecks []healthz.He
 	gotSet.Delete("log", "ping") // not relevant for our tests
 
 	if !wantSet.Equal(gotSet) {
-		t.Errorf("healthz checks are not equal, missing=%q, extra=%q", wantSet.Difference(gotSet).List(), gotSet.Difference(wantSet).List())
+		t.Errorf("%s checks are not equal, missing=%q, extra=%q", checkerType, wantSet.Difference(gotSet).List(), gotSet.Difference(wantSet).List())
 	}
 }

--- a/test/integration/controlplane/transformation/kms_transformation_test.go
+++ b/test/integration/controlplane/transformation/kms_transformation_test.go
@@ -1028,6 +1028,8 @@ resources:
 	// healthz/kms-provider-0 and /healthz/kms-provider-1 should be OK.
 	mustBeHealthy(t, "/kms-provider-0", "ok", test.kubeAPIServer.ClientConfig)
 	mustBeHealthy(t, "/kms-provider-1", "ok", test.kubeAPIServer.ClientConfig)
+	mustNotHaveLivez(t, "/kms-provider-0", "404 page not found", test.kubeAPIServer.ClientConfig)
+	mustNotHaveLivez(t, "/kms-provider-1", "404 page not found", test.kubeAPIServer.ClientConfig)
 
 	// Stage 2 - kms-plugin for provider-1 is down. Therefore, expect the healthz check
 	// to fail and report that provider-1 is down
@@ -1035,7 +1037,10 @@ resources:
 	mustBeUnHealthy(t, "/kms-provider-0",
 		"internal server error: rpc error: code = FailedPrecondition desc = failed precondition - key disabled",
 		test.kubeAPIServer.ClientConfig)
+
+	mustNotHaveLivez(t, "/kms-provider-0", "404 page not found", test.kubeAPIServer.ClientConfig)
 	mustBeHealthy(t, "/kms-provider-1", "ok", test.kubeAPIServer.ClientConfig)
+	mustNotHaveLivez(t, "/kms-provider-1", "404 page not found", test.kubeAPIServer.ClientConfig)
 	pluginMock1.ExitFailedState()
 
 	// Stage 3 - kms-plugin for provider-1 is now up. Therefore, expect the health check for provider-1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Remove /livez livezchecks for KMS v1 and v2 to ensure KMS health does not cause kube-apiserver restart. KMS health checks are still in place as a healthz and readiness checks.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #93968

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Remove /livez livezchecks for KMS v1 and v2 to ensure KMS health does not cause kube-apiserver restart. KMS health checks are still in place as a healthz and readiness checks.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
