### PR TITLE
Automated cherry pick of #119824: fix race on etcd client constructor for healthchecks

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -157,10 +157,10 @@ func newETCD3Check(c storagebackend.Config, timeout time.Duration, stopCh <-chan
 	var prober *etcd3ProberMonitor
 	clientErr := fmt.Errorf("etcd client connection not yet established")
 
-	go wait.PollUntil(time.Second, func() (bool, error) {
-		newProber, err := newETCD3ProberMonitor(c)
+	go wait.PollImmediateUntil(time.Second, func() (bool, error) {
 		lock.Lock()
 		defer lock.Unlock()
+		newProber, err := newETCD3ProberMonitor(c)
 		// Ensure that server is already not shutting down.
 		select {
 		case <-stopCh:


### PR DESCRIPTION
Cherry pick of #119824 on release-1.28.

#119824: fix race on etcd client constructor for healthchecks

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```

Fix flakes  in https://testgrid.k8s.io/sig-release-1.28-blocking#ci-kubernetes-unit-1-28.


