### PR TITLE
Fix missing conformance metadata forAPI Chunking tests

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -637,6 +637,38 @@
     of 'Terminating' scoped ResourceQuota.
   release: v1.16
   file: test/e2e/apimachinery/resource_quota.go
+- testname: API Chunking, server should return chunks of results for list calls
+  codename: '[sig-api-machinery] Servers with support for API chunking should return
+    chunks of results for list calls [Conformance]'
+  description: Create a large number of PodTemplates. Attempt to retrieve the first
+    chunk with limit set; the server MUST return the chunk of the size not exceeding
+    the limit with RemainingItems set in the response. Attempt to retrieve the remaining
+    items by providing the received continuation token and limit; the server MUST
+    return the remaining items in chunks of the size not exceeding the limit, with
+    appropriately set RemainingItems field in the response and with the ResourceVersion
+    returned in the first response. Attempt to list all objects at once without setting
+    the limit; the server MUST return all items in a single response.
+  release: v1.29
+  file: test/e2e/apimachinery/chunking.go
+- testname: API Chunking, server should support continue listing from the last key
+    even if the original version has been compacted away
+  codename: '[sig-api-machinery] Servers with support for API chunking should support
+    continue listing from the last key if the original version has been compacted
+    away, though the list is inconsistent [Slow] [Conformance]'
+  description: Create a large number of PodTemplates. Attempt to retrieve the first
+    chunk with limit set; the server MUST return the chunk of the size not exceeding
+    the limit with RemainingItems set in the response. Attempt to retrieve the second
+    page until the continuation token expires; the server MUST return a continuation
+    token for inconsistent list continuation. Attempt to retrieve the second page
+    with the received inconsistent list continuation token; the server MUST return
+    the number of items not exceeding the limit, a new continuation token and appropriately
+    set RemainingItems field in the response. Attempt to retrieve the remaining pages
+    by passing the received continuation token; the server MUST return the remaining
+    items in chunks of the size not exceeding the limit, with appropriately set RemainingItems
+    field in the response and with the ResourceVersion returned as part of the inconsistent
+    list.
+  release: v1.29
+  file: test/e2e/apimachinery/chunking.go
 - testname: API metadata HTTP return
   codename: '[sig-api-machinery] Servers with support for Table transformation should
     return a 406 for a backend which does not implement metadata [Conformance]'

--- a/test/e2e/apimachinery/chunking.go
+++ b/test/e2e/apimachinery/chunking.go
@@ -69,6 +69,17 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 		})
 	})
 
+	/*
+		Release: v1.29
+		Testname: API Chunking, server should return chunks of results for list calls
+		Description: Create a large number of PodTemplates. Attempt to retrieve the first chunk with limit set;
+		the server MUST return the chunk of the size not exceeding the limit with RemainingItems set in the response.
+		Attempt to retrieve the remaining items by providing the received continuation token and limit;
+		the server MUST return the remaining items in chunks of the size not exceeding the limit, with appropriately
+		set RemainingItems field in the response and with the ResourceVersion returned in the first response.
+		Attempt to list all objects at once without setting the limit; the server MUST return all items in a single
+		response.
+	*/
 	framework.ConformanceIt("should return chunks of results for list calls", func(ctx context.Context) {
 		ns := f.Namespace.Name
 		c := f.ClientSet
@@ -116,6 +127,20 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 		gomega.Expect(list.Items).To(gomega.HaveLen(numberOfTotalResources))
 	})
 
+	/*
+		Release: v1.29
+		Testname: API Chunking, server should support continue listing from the last key even if the original version has been compacted away
+		Description: Create a large number of PodTemplates. Attempt to retrieve the first chunk with limit set;
+		the server MUST return the chunk of the size not exceeding the limit with RemainingItems set in the response.
+		Attempt to retrieve the second page until the continuation token expires; the server MUST return a
+		continuation token for inconsistent list continuation.
+		Attempt to retrieve the second page with the received inconsistent list continuation token; the server
+		MUST return the number of items not exceeding the limit, a new continuation token and appropriately set
+		RemainingItems field in the response.
+		Attempt to retrieve the remaining pages by passing the received continuation token; the server
+		MUST return the remaining items in chunks of the size not exceeding the limit, with appropriately
+		set RemainingItems field in the response and with the ResourceVersion returned as part of the inconsistent list.
+	*/
 	framework.ConformanceIt("should support continue listing from the last key if the original version has been compacted away, though the list is inconsistent [Slow]", func(ctx context.Context) {
 		ns := f.Namespace.Name
 		c := f.ClientSet


### PR DESCRIPTION
```release-note
NONE
```

/sig api-machinery
/kind feature
/priority important-soon