### PR TITLE
kubeadm: use difflib with ManifestFilesAreEqual update unit tests

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -766,18 +766,18 @@ func TestManifestFilesAreEqual(t *testing.T) {
 			podYamls:       []string{validPod, validPod2},
 			expectedResult: false,
 			expectErr:      false,
-			expectedDiff: string(`
-- 					"2",
-+ 					"1",`),
+			expectedDiff: string(`@@ -12 +12 @@
+-  - image: gcr.io/google_containers/etcd-amd64:3.1.11
++  - image: gcr.io/google_containers/etcd-amd64:3.1.12
+`),
 		},
 		{
-			description:    "manifests are not equal for adding new defaults",
+			description:    "manifests are not equal after adding new defaults",
 			podYamls:       []string{validPod, invalidWithDefaultFields},
 			expectedResult: false,
 			expectErr:      false,
-			expectedDiff: string(`
-- 		RestartPolicy:                 "Always",
-+ 		RestartPolicy:                 "",`),
+			expectedDiff: string(`@@ -14,0 +15 @@
++  restartPolicy: Always`),
 		},
 		{
 			description:    "first manifest doesn't exist",
@@ -830,7 +830,7 @@ func TestManifestFilesAreEqual(t *testing.T) {
 			}
 			if !strings.Contains(diff, rt.expectedDiff) {
 				t.Errorf(
-					"ManifestFilesAreEqual diff doesn't expected\n%s\n\texpected diff: %s\nactual diff: %s",
+					"ManifestFilesAreEqual diff doesn't expected\n%s\n\texpected diff:\n%s\nactual diff:\n%s",
 					rt.description,
 					rt.expectedDiff,
 					diff,


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

cmp.Diff() gives sporadic results.

In ManifestFilesAreEqual, load files from disk, construct pods, convert to YAML and then produce a diff using difflib.

This _should_ produce deterministic results and no flakes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/2932

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
