### PR TITLE
graduate PersistentVolumeLastPhaseTransitionTime to beta in v1.29

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1044,7 +1044,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	PDBUnhealthyPodEvictionPolicy: {Default: true, PreRelease: featuregate.Beta},
 
-	PersistentVolumeLastPhaseTransitionTime: {Default: false, PreRelease: featuregate.Alpha},
+	PersistentVolumeLastPhaseTransitionTime: {Default: true, PreRelease: featuregate.Beta},
 
 	PodAndContainerStatsFromCRI: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/registry/core/persistentvolume/storage/storage_test.go
+++ b/pkg/registry/core/persistentvolume/storage/storage_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package storage
 
 import (
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -166,6 +169,7 @@ func TestWatch(t *testing.T) {
 }
 
 func TestUpdateStatus(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PersistentVolumeLastPhaseTransitionTime, true)()
 	storage, statusStorage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()

--- a/pkg/registry/core/persistentvolume/strategy.go
+++ b/pkg/registry/core/persistentvolume/strategy.go
@@ -71,7 +71,7 @@ func (persistentvolumeStrategy) PrepareForCreate(ctx context.Context, obj runtim
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.PersistentVolumeLastPhaseTransitionTime) {
 		pv.Status.Phase = api.VolumePending
-		now := nowFunc()
+		now := NowFunc()
 		pv.Status.LastPhaseTransitionTime = &now
 	}
 
@@ -143,7 +143,7 @@ func (persistentvolumeStatusStrategy) GetResetFields() map[fieldpath.APIVersion]
 	return fields
 }
 
-var nowFunc = metav1.Now
+var NowFunc = metav1.Now
 
 // PrepareForUpdate sets the Spec field which is not allowed to be changed when updating a PV's Status
 func (persistentvolumeStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
@@ -159,7 +159,7 @@ func (persistentvolumeStatusStrategy) PrepareForUpdate(ctx context.Context, obj,
 
 		case oldPv.Status.Phase != newPv.Status.Phase && (newPv.Status.LastPhaseTransitionTime == nil || newPv.Status.LastPhaseTransitionTime.Equal(oldPv.Status.LastPhaseTransitionTime)):
 			// phase changed and client didn't set or didn't change the transition time
-			now := nowFunc()
+			now := NowFunc()
 			newPv.Status.LastPhaseTransitionTime = &now
 		}
 	}

--- a/pkg/registry/core/persistentvolume/strategy_test.go
+++ b/pkg/registry/core/persistentvolume/strategy_test.go
@@ -46,9 +46,9 @@ func TestStatusUpdate(t *testing.T) {
 	now := metav1.Now()
 	origin := metav1.NewTime(now.Add(time.Hour))
 	later := metav1.NewTime(now.Add(time.Hour * 2))
-	nowFunc = func() metav1.Time { return now }
+	NowFunc = func() metav1.Time { return now }
 	defer func() {
-		nowFunc = metav1.Now
+		NowFunc = metav1.Now
 	}()
 	tests := []struct {
 		name        string
@@ -376,9 +376,9 @@ func TestStatusUpdate(t *testing.T) {
 
 func TestStatusCreate(t *testing.T) {
 	now := metav1.Now()
-	nowFunc = func() metav1.Time { return now }
+	NowFunc = func() metav1.Time { return now }
 	defer func() {
-		nowFunc = metav1.Now
+		NowFunc = metav1.Now
 	}()
 	tests := []struct {
 		name        string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind api-change
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

PersistentVolumeLastPhaseTransitionTime is planned to graduate to beta in 1.29.

PR for updating KEP: https://github.com/kubernetes/enhancements/pull/4125

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Here are the criteria for beta graduation according to this KEP:

- Manually test upgrade->downgrade->upgrade path:  https://github.com/kubernetes/enhancements/pull/4125#issuecomment-1717312211

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
PersistentVolumeLastPhaseTransitionTime is now beta, enabled by default.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->


```docs
- [KEP]: https://kep.k8s.io/3762
```
