### PR TITLE
Skip kube-up related GCE tests when running e2e tests on kops

### DIFF
--- a/test/e2e/framework/skipper/skipper.go
+++ b/test/e2e/framework/skipper/skipper.go
@@ -141,6 +141,13 @@ func SkipUnlessProviderIs(supportedProviders ...string) {
 	}
 }
 
+// SkipUnlessToolingIs skips if the tooling is not included in the supportedTooling.
+func SkipUnlessToolingIs(supportedTooling ...string) {
+	if !framework.ToolingIs(supportedTooling...) {
+		skipInternalf(1, "Only supported for clusters created by %v (not %s)", supportedTooling, framework.TestContext.Tooling)
+	}
+}
+
 // SkipUnlessMultizone skips if the cluster does not have multizone.
 func SkipUnlessMultizone(ctx context.Context, c clientset.Interface) {
 	zones, err := e2enode.GetClusterZones(ctx, c)

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -100,7 +100,7 @@ type TestContextType struct {
 	// Provider identifies the infrastructure provider (gce, gke, aws)
 	Provider string
 
-	// Tooling is the tooling in use (e.g. kops, gke).  Provider is the cloud provider and might not uniquely identify the tooling.
+	// Tooling identifies the tool used to create the cluster (e.g. kind, kops, gke, kube-up, capg). Multiple tools can create a K8s cluster on the same cloud provider .
 	Tooling string
 
 	// timeouts contains user-configurable timeouts for various operations.
@@ -398,7 +398,7 @@ func RegisterClusterFlags(flags *flag.FlagSet) {
 	// If this becomes true as well, they should be refactored into RegisterCommonFlags.
 	flags.BoolVar(&TestContext.PrepullImages, "prepull-images", false, "If true, prepull images so image pull failures do not cause test failures.")
 	flags.StringVar(&TestContext.Provider, "provider", "", "The name of the Kubernetes provider (gce, gke, local, skeleton (the fallback if not set), etc.)")
-	flags.StringVar(&TestContext.Tooling, "tooling", "", "The tooling in use (kops, gke, etc.)")
+	flags.StringVar(&TestContext.Tooling, "tooling", "kube-up", "The tooling used to create the cluster (kops, gke, kube-up).")
 	flags.StringVar(&TestContext.OutputDir, "e2e-output-dir", "/tmp", "Output directory for interesting/useful test data, like performance data, benchmarks, and other metrics.")
 	flags.StringVar(&TestContext.Prefix, "prefix", "e2e", "A prefix to be added to cloud resources created during testing.")
 	flags.StringVar(&TestContext.MasterOSDistro, "master-os-distro", "debian", "The OS distribution of cluster master (debian, ubuntu, gci, coreos, or custom).")

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -166,6 +166,16 @@ func ProviderIs(providers ...string) bool {
 	return false
 }
 
+// ToolingIs returns true if the tool is included is the tooling. Otherwise false.
+func ToolingIs(tooling ...string) bool {
+	for _, tool := range tooling {
+		if strings.EqualFold(tool, TestContext.Tooling) {
+			return true
+		}
+	}
+	return false
+}
+
 // MasterOSDistroIs returns true if the master OS distro is included in the supportedMasterOsDistros. Otherwise false.
 func MasterOSDistroIs(supportedMasterOsDistros ...string) bool {
 	for _, distro := range supportedMasterOsDistros {

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -62,6 +62,7 @@ var _ = common.SIGDescribe("Firewall rule", func() {
 
 	ginkgo.BeforeEach(func() {
 		e2eskipper.SkipUnlessProviderIs("gce")
+		e2eskipper.SkipUnlessToolingIs("kube-up")
 
 		var err error
 		cs = f.ClientSet


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
I'm migrating away from kube-up clusters to kops clusters for k/k e2e testing. Some of our e2e tests are written to test functionality that is only present in kube-up so those tests now only run on kube-up clusters. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/test-infra/pull/30686

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
