### PR TITLE
service controller: update node  UID has changed

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -707,6 +708,9 @@ func shouldSyncUpdatedNode(oldNode, newNode *v1.Node) bool {
 	if oldNode.Spec.ProviderID != newNode.Spec.ProviderID {
 		return true
 	}
+	if oldNode.UID != newNode.UID {
+		return true
+	}
 	if !utilfeature.DefaultFeatureGate.Enabled(features.StableLoadBalancerNodeSet) {
 		return respectsPredicates(oldNode, allNodePredicates...) != respectsPredicates(newNode, allNodePredicates...)
 	}
@@ -768,10 +772,12 @@ func nodesSufficientlyEqual(oldNodes, newNodes []*v1.Node) bool {
 	// This holds the Node fields which trigger a sync when changed.
 	type protoNode struct {
 		providerID string
+		uid        types.UID
 	}
 	distill := func(n *v1.Node) protoNode {
 		return protoNode{
 			providerID: n.Spec.ProviderID,
+			uid:        n.UID,
 		}
 	}
 


### PR DESCRIPTION

Add one of the following kinds:
/kind bug




#### What this PR does / why we need it:

Node UID may change without changing name, this should trigger load balancer hosts update


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Please see discussion in https://github.com/kubernetes/kubernetes/pull/120492 and https://github.com/kubernetes/kubernetes/pull/120311


