### PR TITLE
test-e2e: Retrigger the RBD image post merge job

### DIFF
--- a/test/images/volume/rbd/README.md
+++ b/test/images/volume/rbd/README.md
@@ -2,7 +2,7 @@
 
 * The container needs to run with `docker --privileged` mode
 
-block.tar.gz is a small ext2 filesystem created by `create_block.sh` (run as root!)
+`block.tar.gz` is a small ext2 filesystem created by `create_block.sh` (run as root!)
 
 # Credentials
 


### PR DESCRIPTION
The post merge job was failed #117103
and this causes the e2e tests to fail. Considering we have increased the timeout recently,  retriggering the job.


/kind cleanup

```release-note
NONE
```

