### PR TITLE
Automated cherry pick of #120577: Increase range of job_sync_duration_seconds

### DIFF
--- a/pkg/controller/job/metrics/metrics.go
+++ b/pkg/controller/job/metrics/metrics.go
@@ -38,7 +38,7 @@ var (
 			Name:           "job_sync_duration_seconds",
 			Help:           "The time it took to sync a job",
 			StabilityLevel: metrics.ALPHA,
-			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
+			Buckets:        metrics.ExponentialBuckets(0.004, 2, 15),
 		},
 		[]string{"completion_mode", "result", "action"},
 	)


### PR DESCRIPTION
Cherry pick of #120577 on release-1.25.

#120577: Increase range of job_sync_duration_seconds

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Set the resolution for the job_controller_job_sync_duration_seconds metric from 4ms to 1min
```