### PR TITLE
Fix systemd unit string matches

### DIFF
--- a/pkg/kubelet/kubelet_server_journal.go
+++ b/pkg/kubelet/kubelet_server_journal.go
@@ -53,7 +53,7 @@ var (
 	// The set of known safe characters to pass to journalctl / GetWinEvent flags - only add to this list if the
 	// character cannot be used to create invalid sequences. This is intended as a broad defense against malformed
 	// input that could cause an escape.
-	reServiceNameUnsafeCharacters = regexp.MustCompile(`[^a-zA-Z\-_0-9@]+`)
+	reServiceNameUnsafeCharacters = regexp.MustCompile(`[^a-zA-Z\-_.:0-9@]+`)
 )
 
 // journalServer returns text output from the OS specific service logger to view

--- a/pkg/kubelet/kubelet_server_journal_test.go
+++ b/pkg/kubelet/kubelet_server_journal_test.go
@@ -130,6 +130,10 @@ func Test_validateServices(t *testing.T) {
 	var (
 		service1 = "svc1"
 		service2 = "svc2"
+		service3 = "svc.foo"
+		service4 = "svc_foo"
+		service5 = "svc@foo"
+		service6 = "svc:foo"
 		invalid1 = "svc\n"
 		invalid2 = "svc.foo\n"
 	)
@@ -140,10 +144,14 @@ func Test_validateServices(t *testing.T) {
 	}{
 		{name: "one service", services: []string{service1}},
 		{name: "two services", services: []string{service1, service2}},
+		{name: "dot service", services: []string{service3}},
+		{name: "underscore service", services: []string{service4}},
+		{name: "at service", services: []string{service5}},
+		{name: "colon service", services: []string{service6}},
 		{name: "invalid service new line", services: []string{invalid1}, wantErr: true},
 		{name: "invalid service with dot", services: []string{invalid2}, wantErr: true},
 		{name: "long service", services: []string{strings.Repeat(service1, 100)}, wantErr: true},
-		{name: "max number of services", services: []string{service1, service2, service1, service2, service1}, wantErr: true},
+		{name: "max number of services", services: []string{service1, service2, service3, service4, service5}, wantErr: true},
 	}
 	for _, tt := range tests {
 		errs := validateServices(tt.services)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
It fixes the systemd unit matching for log queries. Valid service characters can be found in the systemd docs https://www.freedesktop.org/software/systemd/man/systemd.unit.html

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #120618

#### Special notes for your reviewer:
You can find troubleshooting and replication in the original issue

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix systemLogQuery service name matching
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>

- [Other doc]: <link>
-->
```docs
- [Usage]: [https://kubernetes.io/docs/concepts/cluster-administration/system-logs/#log-query]
```
