### PR TITLE
SidecarContainers: update the description of InitContainerStatuses type

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -3733,6 +3733,8 @@ type PodStatus struct {
 	// init container will have ready = true, the most recently started container will have
 	// startTime set.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-and-container-status
+	// A Pod can have one or more init containers, which are run before the app containers are started.
+	// More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#understanding-init-containers
 	InitContainerStatuses []ContainerStatus
 	// The list has one entry per app container in the manifest.
 	// +optional


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

> We need to update the field description for InitContainerStatuses to indicate the presence of Sidecar Containers there now.
> 
> https://github.com/kubernetes/kubernetes/blob/fc786dcd1d2efcc241e0e2392086934f2806555d/pkg/apis/core/types.go#L3736C41-L3736C41
> 
> KEP: [kubernetes/enhancements#753](https://github.com/kubernetes/enhancements/issues/753)
> 
> 

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/120676

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
KEP: [kubernetes/enhancements#753](https://github.com/kubernetes/enhancements/issues/753)
```
