### PR TITLE
kubectl debug: add auto profile

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles_test.go
@@ -1293,3 +1293,379 @@ func TestSysAdminProfile(t *testing.T) {
 		})
 	}
 }
+
+func TestAutoProfile(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+		Spec: corev1.PodSpec{EphemeralContainers: []corev1.EphemeralContainer{
+			{
+				EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+					Name: "dbg", Image: "dbgimage",
+				},
+			},
+		}},
+	}
+
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		containerName string
+		target        runtime.Object
+		enforce       string
+		expectPod     *corev1.Pod
+		expectErr     error
+	}{
+		{
+			name:          "nil target",
+			pod:           pod,
+			containerName: "dbg",
+			target:        nil,
+			expectErr:     fmt.Errorf("auto profile: objects of type <nil> are not supported"),
+		},
+		{
+			name:          "debug by ephemeral container",
+			pod:           pod,
+			containerName: "dbg",
+			target:        pod,
+			expectPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{EphemeralContainers: []corev1.EphemeralContainer{
+					{
+						EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+							Name: "dbg", Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{"SYS_PTRACE"},
+								},
+							},
+						},
+					},
+				}},
+			},
+		},
+		{
+			name:          "debug by ephemeral container with baseline policy enforcement",
+			pod:           pod,
+			containerName: "dbg",
+			target:        pod,
+			enforce:       "baseline",
+			expectPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{EphemeralContainers: []corev1.EphemeralContainer{
+					{
+						EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+							Name: "dbg", Image: "dbgimage",
+						},
+					},
+				}},
+			},
+		},
+		{
+			name:          "debug by ephemeral container with restricted policy enforcement",
+			pod:           pod,
+			containerName: "dbg",
+			target:        pod,
+			enforce:       "restricted",
+			expectPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{EphemeralContainers: []corev1.EphemeralContainer{
+					{
+						EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+							Name: "dbg", Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot: ptr.To(true),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+								AllowPrivilegeEscalation: ptr.To(false),
+								SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
+							},
+						},
+					},
+				}},
+			},
+		},
+		{
+			name: "debug by pod copy",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{Name: "dbg", Image: "dbgimage"},
+					},
+				},
+			},
+			containerName: "dbg",
+			target: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+					},
+				},
+			},
+			expectPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{
+							Name:  "dbg",
+							Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{"SYS_PTRACE"},
+								},
+							},
+						},
+					},
+					ShareProcessNamespace: ptr.To(true),
+				},
+			},
+		},
+		{
+			name: "debug by pod copy preserve existing capability",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{
+							Name:  "dbg",
+							Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{"NET_ADMIN"},
+								},
+							},
+						},
+					},
+				},
+			},
+			containerName: "dbg",
+			target: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+					},
+				},
+			},
+			expectPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{
+							Name:  "dbg",
+							Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{"NET_ADMIN", "SYS_PTRACE"},
+								},
+							},
+						},
+					},
+					ShareProcessNamespace: ptr.To(true),
+				},
+			},
+		},
+		{
+			name: "debug by pod copy with baseline policy enforcement",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{Name: "dbg", Image: "dbgimage"},
+					},
+				},
+			},
+			containerName: "dbg",
+			target: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+					},
+				},
+			},
+			enforce: "baseline",
+			expectPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
+				Spec: corev1.PodSpec{
+					ShareProcessNamespace: ptr.To(true),
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{Name: "dbg", Image: "dbgimage"},
+					},
+				},
+			},
+		},
+		{
+			name: "debug by pod copy with restricted policy enforcement",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{Name: "dbg", Image: "dbgimage"},
+					},
+				},
+			},
+			containerName: "dbg",
+			target: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+					},
+				},
+			},
+			enforce: "restricted",
+			expectPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "podcopy"},
+				Spec: corev1.PodSpec{
+					ShareProcessNamespace: ptr.To(true),
+					Containers: []corev1.Container{
+						{Name: "app", Image: "appimage"},
+						{
+							Name:  "dbg",
+							Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot: ptr.To(true),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+								AllowPrivilegeEscalation: ptr.To(false),
+								SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "debug by node",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "dbg", Image: "dbgimage"},
+					},
+				},
+			},
+			containerName: "dbg",
+			target:        testNode,
+			expectPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{
+					HostNetwork: true,
+					HostPID:     true,
+					HostIPC:     true,
+					Containers: []corev1.Container{
+						{
+							Name:  "dbg",
+							Image: "dbgimage",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									MountPath: "/host",
+									Name:      "host-root",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "host-root",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{Path: "/"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "debug by node with baseline policy enforcement",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "dbg", Image: "dbgimage"},
+					},
+				},
+			},
+			containerName: "dbg",
+			target:        testNode,
+			enforce:       "baseline",
+			expectPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "dbg", Image: "dbgimage"},
+					},
+				},
+			},
+		},
+		{
+			name: "debug by node with restricted policy enforcement",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "dbg",
+							Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{"ALL"},
+								},
+								AllowPrivilegeEscalation: ptr.To(false),
+								SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
+							},
+						},
+					},
+				},
+			},
+			containerName: "dbg",
+			target:        testNode,
+			enforce:       "restricted",
+			expectPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "dbg",
+							Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot: ptr.To(true),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+								AllowPrivilegeEscalation: ptr.To(false),
+								SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			applier := &autoProfile{KeepFlags{InitContainers: true}, test.enforce}
+			err := applier.Apply(test.pod, test.containerName, test.target)
+			if (err == nil) != (test.expectErr == nil) || (err != nil && test.expectErr != nil && err.Error() != test.expectErr.Error()) {
+				t.Fatalf("expect error: %v, got error: %v", test.expectErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(test.expectPod, test.pod); diff != "" {
+				t.Error("unexpected diff in generated object: (-want +got):\n", diff)
+			}
+		})
+	}
+}

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -1047,6 +1047,7 @@ runTests() {
     record_command run_kubectl_debug_restricted_tests
     record_command run_kubectl_debug_netadmin_tests
     record_command run_kubectl_debug_custom_profile_tests
+    record_command run_kubectl_debug_auto_tests
   fi
   if kube::test::if_supports_resource "${nodes}" ; then
     record_command run_kubectl_debug_node_tests
@@ -1054,6 +1055,7 @@ runTests() {
     record_command run_kubectl_debug_baseline_node_tests
     record_command run_kubectl_debug_restricted_node_tests
     record_command run_kubectl_debug_netadmin_node_tests
+    record_command run_kubectl_debug_auto_node_tests
   fi
 
   cleanup_tests


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

`auto` profile of `kubectl debug` is defined in [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug#debugging-profiles), but it has not been implemented yet.
So this PR implements it.
`general`, `baseline`, or `restricted` profile is automatically selected by `--profile auto` depending on the `pod-security.kubernetes.io/enforce` annotation on the namespace.

#### Which issue(s) this PR fixes:

https://github.com/kubernetes/kubectl/issues/1108

#### Special notes for your reviewer:

[Default Profile and Automation Selection of KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug#default-profile-and-automation-selection) says that:

> This will become the default behavior, but in order to maintain backwards compatibility the "legacy" profile will be the default profile until the 1.25 release. When --profile is not specified kubectl debug will print a warning about the upcoming change in behavior.

But now(at v1.30), `legacy` profile is stil the default.
Should we plan to change the default profile to `auto` from `legacy` at this point?(rf: https://github.com/kubernetes/kubernetes/pull/123149#discussion_r1598690150)

#### Does this PR introduce a user-facing change?

```release-note
`general`, `baseline`, or `restricted` profile of `kubectl debug` is automatically selected by `--profile auto` depending on the `pod-security.kubernetes.io/enforce` annotation on the namespace.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1441-kubectl-debug#default-profile-and-automation-selection
```
