### PR TITLE
Re-use switch type assignments

### DIFF
--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -868,12 +868,11 @@ func runMultisyncTests(t *testing.T, ctx context.Context, tests []controllerTest
 			time.Sleep(600 * time.Millisecond)
 
 			// There were some changes, process them
-			switch obj.(type) {
+			switch obj := obj.(type) {
 			case *v1.PersistentVolumeClaim:
-				claim := obj.(*v1.PersistentVolumeClaim)
 				// Simulate "claim updated" event
-				ctrl.claims.Update(claim)
-				err = ctrl.syncClaim(context.TODO(), claim)
+				ctrl.claims.Update(obj)
+				err = ctrl.syncClaim(context.TODO(), obj)
 				if err != nil {
 					if err == pvtesting.ErrVersionConflict {
 						// Ignore version errors
@@ -887,10 +886,9 @@ func runMultisyncTests(t *testing.T, ctx context.Context, tests []controllerTest
 				// Process generated changes
 				continue
 			case *v1.PersistentVolume:
-				volume := obj.(*v1.PersistentVolume)
 				// Simulate "volume updated" event
-				ctrl.volumes.store.Update(volume)
-				err = ctrl.syncVolume(context.TODO(), volume)
+				ctrl.volumes.store.Update(obj)
+				err = ctrl.syncVolume(context.TODO(), obj)
 				if err != nil {
 					if err == pvtesting.ErrVersionConflict {
 						// Ignore version errors

--- a/pkg/controller/volume/persistentvolume/testing/testing.go
+++ b/pkg/controller/volume/persistentvolume/testing/testing.go
@@ -397,13 +397,11 @@ func (r *VolumeReactor) PopChange(ctx context.Context) interface{} {
 	// For debugging purposes, print the queue
 	logger := klog.FromContext(ctx)
 	for _, obj := range r.changedObjects {
-		switch obj.(type) {
+		switch obj := obj.(type) {
 		case *v1.PersistentVolume:
-			vol, _ := obj.(*v1.PersistentVolume)
-			logger.V(4).Info("Reactor queue", "volumeName", vol.Name)
+			logger.V(4).Info("Reactor queue", "volumeName", obj.Name)
 		case *v1.PersistentVolumeClaim:
-			claim, _ := obj.(*v1.PersistentVolumeClaim)
-			logger.V(4).Info("Reactor queue", "PVC", klog.KObj(claim))
+			logger.V(4).Info("Reactor queue", "PVC", klog.KObj(obj))
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As done throughout the k/k codebase, re-use the switch type assignment ("switch foo := foo.(type)") instead of a forced type assignment in each case statement.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
