### PR TITLE
WIP: fix apiserver crashes on concurrent map iteration and write

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/context.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/context.go
@@ -18,10 +18,18 @@ package audit
 
 import (
 	"context"
+	"net"
 	"sync"
+	"time"
 
+	authnv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
 )
@@ -40,7 +48,7 @@ type AuditContext struct {
 
 	// Event is the audit Event object that is being captured to be written in
 	// the API audit log.
-	Event auditinternal.Event
+	Event *auditinternal.Event
 
 	// annotationMutex guards event.Annotations
 	annotationMutex sync.Mutex
@@ -51,6 +59,169 @@ func (ac *AuditContext) Enabled() bool {
 	// Note: An unset Level should be considered Enabled, so that request data (e.g. annotations)
 	// can still be captured before the audit policy is evaluated.
 	return ac != nil && ac.RequestAuditConfig.Level != auditinternal.LevelNone
+}
+
+// Level Get the level of the event.
+// Null value level can also be compared.
+func (ac *AuditContext) Level() auditinternal.Level {
+	var ret auditinternal.Level
+	ac.visitEventIfNotNil(func(event *auditinternal.Event) {
+		ret = event.Level
+	})
+	return ret
+}
+
+func (ac *AuditContext) AuditID() types.UID {
+	var ret types.UID
+	ac.visitEventIfNotNil(func(event *auditinternal.Event) {
+		ret = event.AuditID
+	})
+	return ret
+}
+
+func (ac *AuditContext) EventIsNil() bool {
+	var result bool
+	ac.visitEventIfNotNil(func(event *auditinternal.Event) {
+		result = event == nil
+	})
+	return result
+}
+
+func (ac *AuditContext) visitEventIfNotNil(f func(event *auditinternal.Event)) {
+	ac.annotationMutex.Lock()
+	defer ac.annotationMutex.Unlock()
+	if ac.Event == nil {
+		return
+	}
+	f(ac.Event)
+}
+
+func (ac *AuditContext) visiteEventIfNotNilLocked(f func(event *auditinternal.Event)) {
+	if ac.Event == nil {
+		return
+	}
+	f(ac.Event)
+}
+
+func (ac *AuditContext) LogRequestObject(objMeta metav1.Object, gvr schema.GroupVersionResource, subresource string, obj *runtime.Unknown) {
+	ac.visitEventIfNotNil(func(ae *auditinternal.Event) {
+		if ae.ObjectRef == nil {
+			ae.ObjectRef = &auditinternal.ObjectReference{}
+		}
+
+		if objMeta != nil {
+			if len(ae.ObjectRef.Namespace) == 0 {
+				ae.ObjectRef.Namespace = objMeta.GetNamespace()
+			}
+			if len(ae.ObjectRef.Name) == 0 {
+				ae.ObjectRef.Name = objMeta.GetName()
+			}
+			if len(ae.ObjectRef.UID) == 0 {
+				ae.ObjectRef.UID = objMeta.GetUID()
+			}
+			if len(ae.ObjectRef.ResourceVersion) == 0 {
+				ae.ObjectRef.ResourceVersion = objMeta.GetResourceVersion()
+			}
+		}
+		if len(ae.ObjectRef.APIVersion) == 0 {
+			ae.ObjectRef.APIGroup = gvr.Group
+			ae.ObjectRef.APIVersion = gvr.Version
+		}
+		if len(ae.ObjectRef.Resource) == 0 {
+			ae.ObjectRef.Resource = gvr.Resource
+		}
+		if len(ae.ObjectRef.Subresource) == 0 {
+			ae.ObjectRef.Subresource = subresource
+		}
+
+		if ae.Level.Less(auditinternal.LevelRequest) {
+			return
+		}
+		ae.RequestObject = obj
+	})
+}
+
+func (ac *AuditContext) LogImpersonatedUser(user user.Info) {
+	ac.visitEventIfNotNil(func(ev *auditinternal.Event) {
+		if ev == nil || ev.Level.Less(auditinternal.LevelMetadata) {
+			return
+		}
+		ev.ImpersonatedUser = &authnv1.UserInfo{
+			Username: user.GetName(),
+		}
+		ev.ImpersonatedUser.Groups = user.GetGroups()
+		ev.ImpersonatedUser.UID = user.GetUID()
+		ev.ImpersonatedUser.Extra = map[string]authnv1.ExtraValue{}
+		for k, v := range user.GetExtra() {
+			ev.ImpersonatedUser.Extra[k] = authnv1.ExtraValue(v)
+		}
+	})
+}
+
+func (ac *AuditContext) LogRequestMetadata(uri string, agent string, sourceIps []net.IP, requestReceivedTimestamp time.Time, level auditinternal.Level, attribs authorizer.Attributes) {
+	ac.visitEventIfNotNil(func(ev *auditinternal.Event) {
+		ev.RequestReceivedTimestamp = metav1.NewMicroTime(requestReceivedTimestamp)
+		ev.Verb = attribs.GetVerb()
+		ev.RequestURI = uri
+		ev.UserAgent = agent
+		ev.Level = level
+
+		ips := sourceIps
+		ev.SourceIPs = make([]string, len(ips))
+		for i := range ips {
+			ev.SourceIPs[i] = ips[i].String()
+		}
+
+		if user := attribs.GetUser(); user != nil {
+			ev.User.Username = user.GetName()
+			ev.User.Extra = map[string]authnv1.ExtraValue{}
+			for k, v := range user.GetExtra() {
+				ev.User.Extra[k] = authnv1.ExtraValue(v)
+			}
+			ev.User.Groups = user.GetGroups()
+			ev.User.UID = user.GetUID()
+		}
+
+		if attribs.IsResourceRequest() {
+			ev.ObjectRef = &auditinternal.ObjectReference{
+				Namespace:   attribs.GetNamespace(),
+				Name:        attribs.GetName(),
+				Resource:    attribs.GetResource(),
+				Subresource: attribs.GetSubresource(),
+				APIGroup:    attribs.GetAPIGroup(),
+				APIVersion:  attribs.GetAPIVersion(),
+			}
+		}
+	})
+}
+
+func (ac *AuditContext) LogResponseObject(status *metav1.Status, obj *runtime.Unknown) {
+	ac.visitEventIfNotNil(func(ae *auditinternal.Event) {
+		if status != nil {
+			// selectively copy the bounded fields.
+			ae.ResponseStatus = &metav1.Status{
+				Status:  status.Status,
+				Message: status.Message,
+				Reason:  status.Reason,
+				Details: status.Details,
+				Code:    status.Code,
+			}
+		}
+		if ae.Level.Less(auditinternal.LevelRequestResponse) {
+			return
+		}
+		ae.ResponseObject = obj
+	})
+}
+
+// LogRequestPatch fills in the given patch as the request object into an audit event.
+func (ac *AuditContext) LogRequestPatch(patch []byte) {
+	ac.visitEventIfNotNil(func(ae *auditinternal.Event) {
+		ae.RequestObject = &runtime.Unknown{
+			Raw:         patch,
+			ContentType: runtime.ContentTypeJSON,
+		}
+	})
 }
 
 // AddAuditAnnotation sets the audit annotation for the given key, value pair.
@@ -110,16 +281,16 @@ func AddAuditAnnotationsMap(ctx context.Context, annotations map[string]string) 
 
 // addAuditAnnotationLocked records the audit annotation on the event.
 func addAuditAnnotationLocked(ac *AuditContext, key, value string) {
-	ae := &ac.Event
-
-	if ae.Annotations == nil {
-		ae.Annotations = make(map[string]string)
-	}
-	if v, ok := ae.Annotations[key]; ok && v != value {
-		klog.Warningf("Failed to set annotations[%q] to %q for audit:%q, it has already been set to %q", key, value, ae.AuditID, ae.Annotations[key])
-		return
-	}
-	ae.Annotations[key] = value
+	ac.visiteEventIfNotNilLocked(func(ae *auditinternal.Event) {
+		if ae.Annotations == nil {
+			ae.Annotations = make(map[string]string)
+		}
+		if v, ok := ae.Annotations[key]; ok && v != value {
+			klog.Warningf("Failed to set annotations[%q] to %q for audit:%q, it has already been set to %q", key, value, ae.AuditID, ae.Annotations[key])
+			return
+		}
+		ae.Annotations[key] = value
+	})
 }
 
 // WithAuditContext returns a new context that stores the AuditContext.

--- a/staging/src/k8s.io/apiserver/pkg/audit/context.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/context.go
@@ -131,14 +131,6 @@ func WithAuditContext(parent context.Context) context.Context {
 	return genericapirequest.WithValue(parent, auditKey, &AuditContext{})
 }
 
-// AuditEventFrom returns the audit event struct on the ctx
-func AuditEventFrom(ctx context.Context) *auditinternal.Event {
-	if ac := AuditContextFrom(ctx); ac.Enabled() {
-		return &ac.Event
-	}
-	return nil
-}
-
 // AuditContextFrom returns the pair of the audit configuration object
 // that applies to the given request and the audit event that is going to
 // be written to the API audit log.

--- a/staging/src/k8s.io/apiserver/pkg/audit/context_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/context_test.go
@@ -89,28 +89,28 @@ func TestAddAuditAnnotation(t *testing.T) {
 		// Annotations should be retained.
 		ctx: WithAuditContext(context.Background()),
 		validator: func(t *testing.T, ctx context.Context) {
-			ev := AuditContextFrom(ctx).Event
+			ev := AuditContextFrom(ctx).event
 			expectAnnotations(t, ev.Annotations)
 		},
 	}, {
 		description: "with metadata level",
 		ctx:         withAuditContextAndLevel(context.Background(), auditinternal.LevelMetadata),
 		validator: func(t *testing.T, ctx context.Context) {
-			ev := AuditContextFrom(ctx).Event
+			ev := AuditContextFrom(ctx).event
 			expectAnnotations(t, ev.Annotations)
 		},
 	}, {
 		description: "with none level",
 		ctx:         withAuditContextAndLevel(context.Background(), auditinternal.LevelNone),
 		validator: func(t *testing.T, ctx context.Context) {
-			ev := AuditContextFrom(ctx).Event
+			ev := AuditContextFrom(ctx).event
 			assert.Empty(t, ev.Annotations)
 		},
 	}, {
 		description: "with overlapping annotations",
 		ctx:         ctxWithAnnotation,
 		validator: func(t *testing.T, ctx context.Context) {
-			ev := AuditContextFrom(ctx).Event
+			ev := AuditContextFrom(ctx).event
 			expectAnnotations(t, ev.Annotations)
 			// Verify that the pre-existing annotation is not overwritten.
 			assert.Equal(t, annotationExtraValue, ev.Annotations[fmt.Sprintf(annotationKeyTemplate, 0)])
@@ -153,7 +153,7 @@ func TestAuditAnnotationsWithAuditLoggingSetup(t *testing.T) {
 		"before-evaluation": "1",
 		"after-evaluation":  "2",
 	}
-	actual := AuditContextFrom(ctx).Event.Annotations
+	actual := AuditContextFrom(ctx).event.Annotations
 	assert.Equal(t, expected, actual)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/audit/request.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"time"
 
-	authnv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,105 +44,38 @@ func LogRequestMetadata(ctx context.Context, req *http.Request, requestReceivedT
 	if !ac.Enabled() {
 		return
 	}
-	ev := &ac.Event
-
-	ev.RequestReceivedTimestamp = metav1.NewMicroTime(requestReceivedTimestamp)
-	ev.Verb = attribs.GetVerb()
-	ev.RequestURI = req.URL.RequestURI()
-	ev.UserAgent = maybeTruncateUserAgent(req)
-	ev.Level = level
-
-	ips := utilnet.SourceIPs(req)
-	ev.SourceIPs = make([]string, len(ips))
-	for i := range ips {
-		ev.SourceIPs[i] = ips[i].String()
-	}
-
-	if user := attribs.GetUser(); user != nil {
-		ev.User.Username = user.GetName()
-		ev.User.Extra = map[string]authnv1.ExtraValue{}
-		for k, v := range user.GetExtra() {
-			ev.User.Extra[k] = authnv1.ExtraValue(v)
-		}
-		ev.User.Groups = user.GetGroups()
-		ev.User.UID = user.GetUID()
-	}
-
-	if attribs.IsResourceRequest() {
-		ev.ObjectRef = &auditinternal.ObjectReference{
-			Namespace:   attribs.GetNamespace(),
-			Name:        attribs.GetName(),
-			Resource:    attribs.GetResource(),
-			Subresource: attribs.GetSubresource(),
-			APIGroup:    attribs.GetAPIGroup(),
-			APIVersion:  attribs.GetAPIVersion(),
-		}
-	}
+	ac.LogRequestMetadata(req.URL.RequestURI(), maybeTruncateUserAgent(req), utilnet.SourceIPs(req), requestReceivedTimestamp, level, attribs)
 }
 
 // LogImpersonatedUser fills in the impersonated user attributes into an audit event.
-func LogImpersonatedUser(ae *auditinternal.Event, user user.Info) {
-	if ae == nil || ae.Level.Less(auditinternal.LevelMetadata) {
+func LogImpersonatedUser(ctx context.Context, user user.Info) {
+	ac := AuditContextFrom(ctx)
+	if !ac.Enabled() {
 		return
 	}
-	ae.ImpersonatedUser = &authnv1.UserInfo{
-		Username: user.GetName(),
+	if ac.EventIsNil() || ac.Level().Less(auditinternal.LevelMetadata) {
+		return
 	}
-	ae.ImpersonatedUser.Groups = user.GetGroups()
-	ae.ImpersonatedUser.UID = user.GetUID()
-	ae.ImpersonatedUser.Extra = map[string]authnv1.ExtraValue{}
-	for k, v := range user.GetExtra() {
-		ae.ImpersonatedUser.Extra[k] = authnv1.ExtraValue(v)
-	}
+	ac.LogImpersonatedUser(user)
 }
 
 // LogRequestObject fills in the request object into an audit event. The passed runtime.Object
 // will be converted to the given gv.
 func LogRequestObject(ctx context.Context, obj runtime.Object, objGV schema.GroupVersion, gvr schema.GroupVersionResource, subresource string, s runtime.NegotiatedSerializer) {
-	ae := AuditEventFrom(ctx)
-	if ae == nil || ae.Level.Less(auditinternal.LevelMetadata) {
+	ac := AuditContextFrom(ctx)
+	if !ac.Enabled() {
 		return
 	}
-
-	// complete ObjectRef
-	if ae.ObjectRef == nil {
-		ae.ObjectRef = &auditinternal.ObjectReference{}
+	if ac.EventIsNil() || ac.Level().Less(auditinternal.LevelMetadata) {
+		return
 	}
 
 	// meta.Accessor is more general than ObjectMetaAccessor, but if it fails, we can just skip setting these bits
-	if meta, err := meta.Accessor(obj); err == nil {
-		if len(ae.ObjectRef.Namespace) == 0 {
-			ae.ObjectRef.Namespace = meta.GetNamespace()
-		}
-		if len(ae.ObjectRef.Name) == 0 {
-			ae.ObjectRef.Name = meta.GetName()
-		}
-		if len(ae.ObjectRef.UID) == 0 {
-			ae.ObjectRef.UID = meta.GetUID()
-		}
-		if len(ae.ObjectRef.ResourceVersion) == 0 {
-			ae.ObjectRef.ResourceVersion = meta.GetResourceVersion()
-		}
-	}
-	if len(ae.ObjectRef.APIVersion) == 0 {
-		ae.ObjectRef.APIGroup = gvr.Group
-		ae.ObjectRef.APIVersion = gvr.Version
-	}
-	if len(ae.ObjectRef.Resource) == 0 {
-		ae.ObjectRef.Resource = gvr.Resource
-	}
-	if len(ae.ObjectRef.Subresource) == 0 {
-		ae.ObjectRef.Subresource = subresource
-	}
-
-	if ae.Level.Less(auditinternal.LevelRequest) {
-		return
-	}
-
+	objMeta, _ := meta.Accessor(obj)
 	if shouldOmitManagedFields(ctx) {
 		copy, ok, err := copyWithoutManagedFields(obj)
 		if err != nil {
-			klog.ErrorS(err, "Error while dropping managed fields from the request", "auditID", ae.AuditID)
+			klog.ErrorS(err, "Error while dropping managed fields from the request", "auditID", ac.AuditID())
 		}
 		if ok {
 			obj = copy
@@ -151,54 +83,38 @@ func LogRequestObject(ctx context.Context, obj runtime.Object, objGV schema.Grou
 	}
 
 	// TODO(audit): hook into the serializer to avoid double conversion
-	var err error
-	ae.RequestObject, err = encodeObject(obj, objGV, s)
+	requestObject, err := encodeObject(obj, objGV, s)
 	if err != nil {
 		// TODO(audit): add error slice to audit event struct
-		klog.ErrorS(err, "Encoding failed of request object", "auditID", ae.AuditID, "gvr", gvr.String(), "obj", obj)
+		klog.ErrorS(err, "Encoding failed of request object", "auditID", ac.AuditID(), "gvr", gvr.String(), "obj", obj)
 		return
 	}
+	ac.LogRequestObject(objMeta, gvr, subresource, requestObject)
 }
 
 // LogRequestPatch fills in the given patch as the request object into an audit event.
 func LogRequestPatch(ctx context.Context, patch []byte) {
-	ae := AuditEventFrom(ctx)
-	if ae == nil || ae.Level.Less(auditinternal.LevelRequest) {
+	ac := AuditContextFrom(ctx)
+	if ac.EventIsNil() || ac.Level().Less(auditinternal.LevelRequest) {
 		return
 	}
-
-	ae.RequestObject = &runtime.Unknown{
-		Raw:         patch,
-		ContentType: runtime.ContentTypeJSON,
-	}
+	ac.LogRequestPatch(patch)
 }
 
 // LogResponseObject fills in the response object into an audit event. The passed runtime.Object
 // will be converted to the given gv.
 func LogResponseObject(ctx context.Context, obj runtime.Object, gv schema.GroupVersion, s runtime.NegotiatedSerializer) {
-	ae := AuditEventFrom(ctx)
-	if ae == nil || ae.Level.Less(auditinternal.LevelMetadata) {
+	ac := AuditContextFrom(ctx)
+	if ac.EventIsNil() || ac.Level().Less(auditinternal.LevelMetadata) {
 		return
-	}
-	if status, ok := obj.(*metav1.Status); ok {
-		// selectively copy the bounded fields.
-		ae.ResponseStatus = &metav1.Status{
-			Status:  status.Status,
-			Message: status.Message,
-			Reason:  status.Reason,
-			Details: status.Details,
-			Code:    status.Code,
-		}
 	}
 
-	if ae.Level.Less(auditinternal.LevelRequestResponse) {
-		return
-	}
+	status, _ := obj.(*metav1.Status)
 
 	if shouldOmitManagedFields(ctx) {
 		copy, ok, err := copyWithoutManagedFields(obj)
 		if err != nil {
-			klog.ErrorS(err, "Error while dropping managed fields from the response", "auditID", ae.AuditID)
+			klog.ErrorS(err, "Error while dropping managed fields from the response", "auditID", ac.AuditID())
 		}
 		if ok {
 			obj = copy
@@ -207,10 +123,11 @@ func LogResponseObject(ctx context.Context, obj runtime.Object, gv schema.GroupV
 
 	// TODO(audit): hook into the serializer to avoid double conversion
 	var err error
-	ae.ResponseObject, err = encodeObject(obj, gv, s)
+	responseObject, err := encodeObject(obj, gv, s)
 	if err != nil {
-		klog.ErrorS(err, "Encoding failed of response object", "auditID", ae.AuditID, "obj", obj)
+		klog.ErrorS(err, "Encoding failed of response object", "auditID", ac.AuditID(), "obj", obj)
 	}
+	ac.LogResponseObject(status, responseObject)
 }
 
 func encodeObject(obj runtime.Object, gv schema.GroupVersion, serializer runtime.NegotiatedSerializer) (*runtime.Unknown, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #120507

#### Special notes for your reviewer:

We can easily use the following command to reproduce #120507

```bash
$ export CGO_ENABLED=1 # go test race needs to rely on him
$ cd ./staging/src/k8s.io/apiserver/pkg/endpoints/filters
$ go test ./ -race --run=TestAuditBackendRaceCondition -v
```

- `AuditContext#VisitEventLocked` added. We use it to ensure the safety of r/w to AuditContext#Event concurrently.
- `Sink#ProcessEvents` api fixed 


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
bugfix: kube-apiserver will not fatally exit due to concurrent r/w of Audit.Event#Annotations.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
