### PR TITLE
Remove usages of sets.Strings

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -214,7 +214,7 @@ func NewCustomResourceDefinitionHandler(
 // watches are expected to handle storage disruption gracefully,
 // both on the server-side (by terminating the watch connection)
 // and on the client side (by restarting the watch)
-var longRunningFilter = genericfilters.BasicLongRunningRequestCheck(sets.NewString("watch"), sets.NewString())
+var longRunningFilter = genericfilters.BasicLongRunningRequestCheck(sets.New[string]("watch"), sets.New[string]())
 
 // possiblyAcrossAllNamespacesVerbs contains those verbs which can be per-namespace and across all
 // namespaces for namespaces resources. I.e. for these an empty namespace in the requestInfo is fine.

--- a/staging/src/k8s.io/apiserver/pkg/admission/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/config.go
@@ -108,7 +108,7 @@ func ReadAdmissionConfiguration(pluginNames []string, configFilePath string, con
 	// in order to preserve backwards compatibility, we set plugins that
 	// previously read input from a non-versioned file configuration to the
 	// current input file.
-	legacyPluginsWithUnversionedConfig := sets.NewString("ImagePolicyWebhook", "PodNodeSelector")
+	legacyPluginsWithUnversionedConfig := sets.New[string]("ImagePolicyWebhook", "PodNodeSelector")
 	externalConfig := &apiserverv1.AdmissionConfiguration{}
 	for _, pluginName := range pluginNames {
 		if legacyPluginsWithUnversionedConfig.Has(pluginName) {

--- a/staging/src/k8s.io/apiserver/pkg/admission/handler.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/handler.go
@@ -34,7 +34,7 @@ type ReadyFunc func() bool
 // Handler is a base for admission control handlers that
 // support a predefined set of operations
 type Handler struct {
-	operations sets.String
+	operations sets.Set[string]
 	readyFunc  ReadyFunc
 }
 
@@ -46,7 +46,7 @@ func (h *Handler) Handles(operation Operation) bool {
 // NewHandler creates a new base handler that handles the passed
 // in operations
 func NewHandler(ops ...Operation) *Handler {
-	operations := sets.NewString()
+	operations := sets.Set[string]{}
 	for _, op := range ops {
 		operations.Insert(string(op))
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
@@ -49,7 +49,7 @@ func newHandlerForTest(c clientset.Interface) (*Lifecycle, informers.SharedInfor
 // newHandlerForTestWithClock returns a configured handler for testing.
 func newHandlerForTestWithClock(c clientset.Interface, cacheClock clock.Clock) (*Lifecycle, informers.SharedInformerFactory, error) {
 	f := informers.NewSharedInformerFactory(c, 5*time.Minute)
-	handler, err := newLifecycleWithClock(sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem), cacheClock)
+	handler, err := newLifecycleWithClock(sets.New[string](metav1.NamespaceDefault, metav1.NamespaceSystem), cacheClock)
 	if err != nil {
 		return nil, f, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/reinvocationcontext.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/reinvocationcontext.go
@@ -27,9 +27,9 @@ type webhookReinvokeContext struct {
 	lastWebhookOutput runtime.Object
 	// previouslyInvokedReinvocableWebhooks holds the set of webhooks that have been invoked and
 	// should be reinvoked if a later mutation occurs
-	previouslyInvokedReinvocableWebhooks sets.String
+	previouslyInvokedReinvocableWebhooks sets.Set[string]
 	// reinvokeWebhooks holds the set of webhooks that should be reinvoked
-	reinvokeWebhooks sets.String
+	reinvokeWebhooks sets.Set[string]
 }
 
 func (rc *webhookReinvokeContext) ShouldReinvokeWebhook(webhook string) bool {
@@ -50,7 +50,7 @@ func (rc *webhookReinvokeContext) SetLastWebhookInvocationOutput(object runtime.
 
 func (rc *webhookReinvokeContext) AddReinvocableWebhookToPreviouslyInvoked(webhook string) {
 	if rc.previouslyInvokedReinvocableWebhooks == nil {
-		rc.previouslyInvokedReinvocableWebhooks = sets.NewString()
+		rc.previouslyInvokedReinvocableWebhooks = sets.New[string]()
 	}
 	rc.previouslyInvokedReinvocableWebhooks.Insert(webhook)
 }
@@ -58,11 +58,11 @@ func (rc *webhookReinvokeContext) AddReinvocableWebhookToPreviouslyInvoked(webho
 func (rc *webhookReinvokeContext) RequireReinvokingPreviouslyInvokedPlugins() {
 	if len(rc.previouslyInvokedReinvocableWebhooks) > 0 {
 		if rc.reinvokeWebhooks == nil {
-			rc.reinvokeWebhooks = sets.NewString()
+			rc.reinvokeWebhooks = sets.New[string]()
 		}
 		for s := range rc.previouslyInvokedReinvocableWebhooks {
 			rc.reinvokeWebhooks.Insert(s)
 		}
-		rc.previouslyInvokedReinvocableWebhooks = sets.NewString()
+		rc.previouslyInvokedReinvocableWebhooks = sets.New[string]()
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/predicates/rules/rules_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/predicates/rules/rules_test.go
@@ -396,11 +396,11 @@ func TestScope(t *testing.T) {
 			noMatch: attrList(),
 		},
 	}
-	keys := sets.NewString()
+	keys := sets.New[string]()
 	for name := range table {
 		keys.Insert(name)
 	}
-	for _, name := range keys.List() {
+	for _, name := range keys.UnsortedList() {
 		tt := table[name]
 		for i, m := range tt.match {
 			t.Run(fmt.Sprintf("%s_match_%d", name, i), func(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
@@ -164,7 +164,7 @@ func validateCertificateAuthority(certificateAuthority string, fldPath *field.Pa
 func validateClaimValidationRules(rules []api.ClaimValidationRule, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	seenClaims := sets.NewString()
+	seenClaims := sets.New[string]()
 	for i, rule := range rules {
 		fldPath := fldPath.Index(i)
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation.go
@@ -78,7 +78,7 @@ func ValidateEncryptionConfiguration(c *config.EncryptionConfiguration, reload b
 	}
 
 	// kmsProviderNames is used to track config names to ensure they are unique.
-	kmsProviderNames := sets.NewString()
+	kmsProviderNames := sets.New[string]()
 	for i, conf := range c.Resources {
 		r := root.Index(i).Child("resources")
 		p := root.Index(i).Child("providers")
@@ -363,7 +363,7 @@ func validateKey(key config.Key, fieldPath *field.Path, expectedLen []int) field
 	return allErrs
 }
 
-func validateKMSConfiguration(c *config.KMSConfiguration, fieldPath *field.Path, kmsProviderNames sets.String, reload bool) field.ErrorList {
+func validateKMSConfiguration(c *config.KMSConfiguration, fieldPath *field.Path, kmsProviderNames sets.Set[string], reload bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateKMSConfigName(c, fieldPath.Child("name"), kmsProviderNames, reload)...)
@@ -425,7 +425,7 @@ func validateKMSAPIVersion(c *config.KMSConfiguration, fieldPath *field.Path) fi
 	return allErrs
 }
 
-func validateKMSConfigName(c *config.KMSConfiguration, fieldPath *field.Path, kmsProviderNames sets.String, reload bool) field.ErrorList {
+func validateKMSConfigName(c *config.KMSConfiguration, fieldPath *field.Path, kmsProviderNames sets.Set[string], reload bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if c.Name == "" {
 		allErrs = append(allErrs, field.Required(fieldPath, fmt.Sprintf(mandatoryFieldErrFmt, "name", "provider")))

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation_test.go
@@ -1134,7 +1134,7 @@ func TestKMSProviderName(t *testing.T) {
 		desc             string
 		in               *config.KMSConfiguration
 		reload           bool
-		kmsProviderNames sets.String
+		kmsProviderNames sets.Set[string]
 		want             field.ErrorList
 	}{{
 		desc: "valid name",
@@ -1159,7 +1159,7 @@ func TestKMSProviderName(t *testing.T) {
 	}, {
 		desc:             "duplicate name, kms v2, reload=false",
 		in:               &config.KMSConfiguration{APIVersion: "v2", Name: "foo"},
-		kmsProviderNames: sets.NewString("foo"),
+		kmsProviderNames: sets.New[string]("foo"),
 		want: field.ErrorList{
 			field.Invalid(nameField, "foo", fmt.Sprintf(duplicateKMSConfigNameErrFmt, "foo")),
 		},
@@ -1167,20 +1167,20 @@ func TestKMSProviderName(t *testing.T) {
 		desc:             "duplicate name, kms v2, reload=true",
 		in:               &config.KMSConfiguration{APIVersion: "v2", Name: "foo"},
 		reload:           true,
-		kmsProviderNames: sets.NewString("foo"),
+		kmsProviderNames: sets.New[string]("foo"),
 		want: field.ErrorList{
 			field.Invalid(nameField, "foo", fmt.Sprintf(duplicateKMSConfigNameErrFmt, "foo")),
 		},
 	}, {
 		desc:             "duplicate name, kms v1, reload=false",
 		in:               &config.KMSConfiguration{APIVersion: "v1", Name: "foo"},
-		kmsProviderNames: sets.NewString("foo"),
+		kmsProviderNames: sets.New[string]("foo"),
 		want:             field.ErrorList{},
 	}, {
 		desc:             "duplicate name, kms v1, reload=true",
 		in:               &config.KMSConfiguration{APIVersion: "v1", Name: "foo"},
 		reload:           true,
-		kmsProviderNames: sets.NewString("foo"),
+		kmsProviderNames: sets.New[string]("foo"),
 		want: field.ErrorList{
 			field.Invalid(nameField, "foo", fmt.Sprintf(duplicateKMSConfigNameErrFmt, "foo")),
 		},

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/util.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/util.go
@@ -22,8 +22,8 @@ import (
 )
 
 // AllStages returns all possible stages
-func AllStages() sets.String {
-	return sets.NewString(
+func AllStages() sets.Set[string] {
+	return sets.New[string](
 		string(audit.StageRequestReceived),
 		string(audit.StageResponseStarted),
 		string(audit.StageResponseComplete),
@@ -32,8 +32,8 @@ func AllStages() sets.String {
 }
 
 // AllLevels returns all possible levels
-func AllLevels() sets.String {
-	return sets.NewString(
+func AllLevels() sets.Set[string] {
+	return sets.New[string](
 		string(audit.LevelNone),
 		string(audit.LevelMetadata),
 		string(audit.LevelRequest),
@@ -59,9 +59,9 @@ func ConvertStagesToStrings(stages []audit.Stage) []string {
 }
 
 // ConvertStringSetToStages converts a string set to an array of stages
-func ConvertStringSetToStages(set sets.String) []audit.Stage {
+func ConvertStringSetToStages(set sets.Set[string]) []audit.Stage {
 	stages := make([]audit.Stage, len(set))
-	for i, stage := range set.List() {
+	for i, stage := range set.UnsortedList() {
 		stages[i] = audit.Stage(stage)
 	}
 	return stages

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous_test.go
@@ -37,7 +37,7 @@ func TestAnonymous(t *testing.T) {
 	if r.User.GetName() != user.Anonymous {
 		t.Fatalf("Expected username %s, got %s", user.Anonymous, r.User.GetName())
 	}
-	if !sets.NewString(r.User.GetGroups()...).Equal(sets.NewString(user.AllUnauthenticated)) {
+	if !sets.New[string](r.User.GetGroups()...).Equal(sets.New[string](user.AllUnauthenticated)) {
 		t.Fatalf("Expected group %s, got %v", user.AllUnauthenticated, r.User.GetGroups())
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
@@ -212,8 +212,8 @@ type Verifier struct {
 }
 
 // NewVerifier create a request.Authenticator by verifying a client cert on the request, then delegating to the wrapped auth
-func NewVerifier(opts x509.VerifyOptions, auth authenticator.Request, allowedCommonNames sets.String) authenticator.Request {
-	return NewDynamicCAVerifier(StaticVerifierFn(opts), auth, StaticStringSlice(allowedCommonNames.List()))
+func NewVerifier(opts x509.VerifyOptions, auth authenticator.Request, allowedCommonNames sets.Set[string]) authenticator.Request {
+	return NewDynamicCAVerifier(StaticVerifierFn(opts), auth, StaticStringSlice(allowedCommonNames.UnsortedList()))
 }
 
 // NewDynamicCAVerifier create a request.Authenticator by verifying a client cert on the request, then delegating to the wrapped auth

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
@@ -554,7 +554,7 @@ func TestX509Verifier(t *testing.T) {
 
 		Opts x509.VerifyOptions
 
-		AllowedCNs sets.String
+		AllowedCNs sets.Set[string]
 
 		ExpectOK  bool
 		ExpectErr bool
@@ -601,7 +601,7 @@ func TestX509Verifier(t *testing.T) {
 		},
 		"valid client cert with wrong CN": {
 			Opts:       getDefaultVerifyOptions(t),
-			AllowedCNs: sets.NewString("foo", "bar"),
+			AllowedCNs: sets.New[string]("foo", "bar"),
 			Certs:      getCerts(t, clientCNCert),
 
 			ExpectOK:  false,
@@ -609,7 +609,7 @@ func TestX509Verifier(t *testing.T) {
 		},
 		"valid client cert with right CN": {
 			Opts:       getDefaultVerifyOptions(t),
-			AllowedCNs: sets.NewString("client_cn"),
+			AllowedCNs: sets.New[string]("client_cn"),
 			Certs:      getCerts(t, clientCNCert),
 
 			ExpectOK:  true,

--- a/staging/src/k8s.io/apiserver/pkg/authorization/path/path.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/path/path.go
@@ -29,7 +29,7 @@ import (
 // Each path is either a fully matching path or it ends in * in case a prefix match is done. A leading / is optional.
 func NewAuthorizer(alwaysAllowPaths []string) (authorizer.Authorizer, error) {
 	var prefixes []string
-	paths := sets.NewString()
+	paths := sets.New[string]()
 	for _, p := range alwaysAllowPaths {
 		p = strings.TrimPrefix(p, "/")
 		if len(p) == 0 {

--- a/staging/src/k8s.io/apiserver/pkg/cel/escaping.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/escaping.go
@@ -25,7 +25,7 @@ import (
 // celReservedSymbols is a list of RESERVED symbols defined in the CEL lexer.
 // No identifiers are allowed to collide with these symbols.
 // https://github.com/google/cel-spec/blob/master/doc/langdef.md#syntax
-var celReservedSymbols = sets.NewString(
+var celReservedSymbols = sets.New[string](
 	"true", "false", "null", "in",
 	"as", "break", "const", "continue", "else",
 	"for", "function", "if", "import", "let",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -237,7 +237,7 @@ func handleInternal(storage map[string]rest.Storage, admissionControl admission.
 		Defaulter:       scheme,
 		Typer:           scheme,
 		Namer:           namer,
-		RootScopedKinds: sets.NewString("SimpleRoot"),
+		RootScopedKinds: sets.New[string]("SimpleRoot"),
 
 		EquivalentResourceRegistry: runtime.NewEquivalentResourceRegistry(),
 
@@ -296,8 +296,8 @@ func handleInternal(storage map[string]rest.Storage, admissionControl admission.
 
 func testRequestInfoResolver() *request.RequestInfoFactory {
 	return &request.RequestInfoFactory{
-		APIPrefixes:          sets.NewString("api", "apis"),
-		GrouplessAPIPrefixes: sets.NewString("api"),
+		APIPrefixes:          sets.New[string]("api", "apis"),
+		GrouplessAPIPrefixes: sets.New[string]("api"),
 	}
 }
 
@@ -3311,7 +3311,7 @@ func TestParentResourceIsRequired(t *testing.T) {
 		Defaulter:       scheme,
 		Typer:           scheme,
 		Namer:           namer,
-		RootScopedKinds: sets.NewString("SimpleRoot"),
+		RootScopedKinds: sets.New[string]("SimpleRoot"),
 
 		EquivalentResourceRegistry: runtime.NewEquivalentResourceRegistry(),
 
@@ -4454,8 +4454,8 @@ func newTestServer(handler http.Handler) *httptest.Server {
 
 func newTestRequestInfoResolver() *request.RequestInfoFactory {
 	return &request.RequestInfoFactory{
-		APIPrefixes:          sets.NewString("api", "apis"),
-		GrouplessAPIPrefixes: sets.NewString("api"),
+		APIPrefixes:          sets.New[string]("api", "apis"),
+		GrouplessAPIPrefixes: sets.New[string]("api"),
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/root_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/root_test.go
@@ -84,8 +84,8 @@ func contextHandler(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		resolver := &request.RequestInfoFactory{
-			APIPrefixes:          sets.NewString("api", "apis"),
-			GrouplessAPIPrefixes: sets.NewString("api"),
+			APIPrefixes:          sets.New[string]("api", "apis"),
+			GrouplessAPIPrefixes: sets.New[string]("api"),
 		}
 		info, err := resolver.NewRequestInfo(req)
 		if err == nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/requestinfo_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/requestinfo_test.go
@@ -23,7 +23,7 @@ import (
 
 func newTestRequestInfoResolver() *request.RequestInfoFactory {
 	return &request.RequestInfoFactory{
-		APIPrefixes:          sets.NewString("api", "apis"),
-		GrouplessAPIPrefixes: sets.NewString("api"),
+		APIPrefixes:          sets.New[string]("api", "apis"),
+		GrouplessAPIPrefixes: sets.New[string]("api"),
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	watchVerbs = sets.NewString("watch")
+	watchVerbs = sets.New[string]("watch")
 )
 
 // WithLatencyTrackers adds a LatencyTrackers instance to the

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
@@ -72,7 +72,7 @@ type APIGroupVersion struct {
 	MetaGroupVersion *schema.GroupVersion
 
 	// RootScopedKinds are the root scoped kinds for the primary GroupVersion
-	RootScopedKinds sets.String
+	RootScopedKinds sets.Set[string]
 
 	// Serializer is used to determine how to convert responses from API methods into bytes to send over
 	// the wire.

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -78,7 +78,7 @@ func PatchResource(r rest.Patcher, scope *RequestScope, admit admission.Interfac
 		patchType := types.PatchType(contentType)
 
 		// Ensure the patchType is one we support
-		if !sets.NewString(patchTypes...).Has(contentType) {
+		if !sets.New[string](patchTypes...).Has(contentType) {
 			scope.err(negotiation.NewUnsupportedMediaTypeError(patchTypes), w, req)
 			return
 		}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -1133,7 +1133,7 @@ func AddObjectParams(ws *restful.WebService, route *restful.RouteBuilder, obj in
 		return err
 	}
 	st := sv.Type()
-	excludedNameSet := sets.NewString(excludedNames...)
+	excludedNameSet := sets.New[string](excludedNames...)
 	switch st.Kind() {
 	case reflect.Struct:
 		for i := 0; i < st.NumField(); i++ {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -304,7 +304,7 @@ var (
 
 	// these are the valid request methods which we report in our metrics. Any other request methods
 	// will be aggregated under 'unknown'
-	validRequestMethods = utilsets.NewString(
+	validRequestMethods = utilsets.New[string](
 		"APPLY",
 		"CONNECT",
 		"CREATE",
@@ -321,7 +321,7 @@ var (
 		"WATCHLIST")
 
 	// These are the valid connect requests which we report in our metrics.
-	validConnectRequests = utilsets.NewString(
+	validConnectRequests = utilsets.New[string](
 		"log",
 		"exec",
 		"portforward",
@@ -697,7 +697,7 @@ func cleanDryRun(u *url.URL) string {
 	// we have to dedup and sort the elements before joining them together
 	// TODO: this is a fairly large allocation for what it does, consider
 	//   a sort and dedup in a single pass
-	return strings.Join(utilsets.NewString(dryRun...).List(), ",")
+	return strings.Join(utilsets.New[string](dryRun...).UnsortedList(), ",")
 }
 
 func cleanFieldValidation(u *url.URL) string {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
@@ -68,21 +68,21 @@ type RequestInfo struct {
 // CRUDdy GET/POST/PUT/DELETE actions on REST objects.
 // TODO: find a way to keep this up to date automatically.  Maybe dynamically populate list as handlers added to
 // master's Mux.
-var specialVerbs = sets.NewString("proxy", "watch")
+var specialVerbs = sets.New[string]("proxy", "watch")
 
 // specialVerbsNoSubresources contains root verbs which do not allow subresources
-var specialVerbsNoSubresources = sets.NewString("proxy")
+var specialVerbsNoSubresources = sets.New[string]("proxy")
 
 // namespaceSubresources contains subresources of namespace
 // this list allows the parser to distinguish between a namespace subresource, and a namespaced resource
-var namespaceSubresources = sets.NewString("status", "finalize")
+var namespaceSubresources = sets.New[string]("status", "finalize")
 
 // NamespaceSubResourcesForTest exports namespaceSubresources for testing in pkg/controlplane/master_test.go, so we never drift
-var NamespaceSubResourcesForTest = sets.NewString(namespaceSubresources.List()...)
+var NamespaceSubResourcesForTest = sets.New[string](namespaceSubresources.UnsortedList()...)
 
 type RequestInfoFactory struct {
-	APIPrefixes          sets.String // without leading and trailing slashes
-	GrouplessAPIPrefixes sets.String // without leading and trailing slashes
+	APIPrefixes          sets.Set[string] // without leading and trailing slashes
+	GrouplessAPIPrefixes sets.Set[string] // without leading and trailing slashes
 }
 
 // TODO write an integration test against the swagger doc to test the RequestInfo and match up behavior to responses

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
@@ -185,8 +185,8 @@ func TestGetNonAPIRequestInfo(t *testing.T) {
 
 func newTestRequestInfoResolver() *RequestInfoFactory {
 	return &RequestInfoFactory{
-		APIPrefixes:          sets.NewString("api", "apis"),
-		GrouplessAPIPrefixes: sets.NewString("api"),
+		APIPrefixes:          sets.New[string]("api", "apis"),
+		GrouplessAPIPrefixes: sets.New[string]("api"),
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/quota/v1/resources.go
+++ b/staging/src/k8s.io/apiserver/pkg/quota/v1/resources.go
@@ -250,8 +250,8 @@ func IsNegative(a corev1.ResourceList) []corev1.ResourceName {
 }
 
 // ToSet takes a list of resource names and converts to a string set
-func ToSet(resourceNames []corev1.ResourceName) sets.String {
-	result := sets.NewString()
+func ToSet(resourceNames []corev1.ResourceName) sets.Set[string] {
+	result := sets.New[string]()
 	for _, resourceName := range resourceNames {
 		result.Insert(string(resourceName))
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -915,8 +915,8 @@ func deletionFinalizersForGarbageCollection(ctx context.Context, e *Store, acces
 		newFinalizers = append(newFinalizers, metav1.FinalizerDeleteDependents)
 	}
 
-	oldFinalizerSet := sets.NewString(accessor.GetFinalizers()...)
-	newFinalizersSet := sets.NewString(newFinalizers...)
+	oldFinalizerSet := sets.New[string](accessor.GetFinalizers()...)
+	newFinalizersSet := sets.New[string](newFinalizers...)
 	if oldFinalizerSet.Equal(newFinalizersSet) {
 		return false, accessor.GetFinalizers()
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -81,7 +81,7 @@ func TestNewWithDelegate(t *testing.T) {
 	delegateConfig := NewConfig(codecs)
 	delegateConfig.ExternalAddress = "192.168.10.4:443"
 	delegateConfig.PublicAddress = netutils.ParseIPSloppy("192.168.10.4")
-	delegateConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
+	delegateConfig.LegacyAPIGroupPrefixes = sets.New[string]("/api")
 	delegateConfig.LoopbackClientConfig = &rest.Config{}
 	clientset := fake.NewSimpleClientset()
 	if clientset == nil {
@@ -113,7 +113,7 @@ func TestNewWithDelegate(t *testing.T) {
 	wrappingConfig := NewConfig(codecs)
 	wrappingConfig.ExternalAddress = "192.168.10.4:443"
 	wrappingConfig.PublicAddress = netutils.ParseIPSloppy("192.168.10.4")
-	wrappingConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
+	wrappingConfig.LegacyAPIGroupPrefixes = sets.New[string]("/api")
 	wrappingConfig.LoopbackClientConfig = &rest.Config{}
 
 	wrappingConfig.HealthzChecks = append(wrappingConfig.HealthzChecks, healthz.NamedCheck("wrapping-health", func(r *http.Request) error {
@@ -266,11 +266,11 @@ func checkExpectedPathsAtRoot(url string, expectedPaths []string, t *testing.T) 
 		if !ok {
 			t.Errorf("paths not found")
 		}
-		pathset := sets.NewString()
+		pathset := sets.New[string]()
 		for _, p := range paths {
 			pathset.Insert(p.(string))
 		}
-		expectedset := sets.NewString(expectedPaths...)
+		expectedset := sets.New[string](expectedPaths...)
 		for p := range pathset.Difference(expectedset) {
 			t.Errorf("Got %v path, which we did not expect", p)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds_test.go
@@ -339,25 +339,25 @@ func Test_removeDeletedKinds(t *testing.T) {
 func Test_shouldRemoveResource(t *testing.T) {
 	tests := []struct {
 		name              string
-		resourcesToRemove sets.String
+		resourcesToRemove sets.Set[string]
 		resourceName      string
 		want              bool
 	}{
 		{
 			name:              "prefix-matches",
-			resourcesToRemove: sets.NewString("foo"),
+			resourcesToRemove: sets.New[string]("foo"),
 			resourceName:      "foo/scale",
 			want:              true,
 		},
 		{
 			name:              "exact-matches",
-			resourcesToRemove: sets.NewString("foo"),
+			resourcesToRemove: sets.New[string]("foo"),
 			resourceName:      "foo",
 			want:              true,
 		},
 		{
 			name:              "no-match",
-			resourcesToRemove: sets.NewString("foo"),
+			resourcesToRemove: sets.New[string]("foo"),
 			resourceName:      "bar",
 			want:              false,
 		},

--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/config.go
@@ -34,7 +34,7 @@ import (
 var cfgScheme = runtime.NewScheme()
 
 // validEgressSelectorNames contains the set of valid egress selctor names.
-var validEgressSelectorNames = sets.NewString("controlplane", "cluster", "etcd")
+var validEgressSelectorNames = sets.New[string]("controlplane", "cluster", "etcd")
 
 func init() {
 	install.Install(cfgScheme)
@@ -102,7 +102,7 @@ func ValidateEgressSelectorConfiguration(config *apiserver.EgressSelectorConfigu
 		}
 	}
 
-	seen := sets.String{}
+	seen := sets.New[string]()
 	for i, service := range config.EgressSelections {
 		canonicalName := strings.ToLower(service.Name)
 		fldPath := field.NewPath("service", "connection")
@@ -114,7 +114,7 @@ func ValidateEgressSelectorConfiguration(config *apiserver.EgressSelectorConfigu
 		seen.Insert(canonicalName)
 
 		if !validEgressSelectorNames.Has(canonicalName) {
-			allErrs = append(allErrs, field.NotSupported(fldPath, canonicalName, validEgressSelectorNames.List()))
+			allErrs = append(allErrs, field.NotSupported(fldPath, canonicalName, validEgressSelectorNames.UnsortedList()))
 			continue
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/longrunning.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/longrunning.go
@@ -25,7 +25,7 @@ import (
 )
 
 // BasicLongRunningRequestCheck returns true if the given request has one of the specified verbs or one of the specified subresources, or is a profiler request.
-func BasicLongRunningRequestCheck(longRunningVerbs, longRunningSubresources sets.String) apirequest.LongRunningRequestCheck {
+func BasicLongRunningRequestCheck(longRunningVerbs, longRunningSubresources sets.Set[string]) apirequest.LongRunningRequestCheck {
 	return func(r *http.Request, requestInfo *apirequest.RequestInfo) bool {
 		if longRunningVerbs.Has(requestInfo.Verb) {
 			return true

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
@@ -43,8 +43,8 @@ const (
 )
 
 var (
-	nonMutatingRequestVerbs = sets.NewString("get", "list", "watch")
-	watchVerbs              = sets.NewString("watch")
+	nonMutatingRequestVerbs = sets.New[string]("get", "list", "watch")
+	watchVerbs              = sets.New[string]("watch")
 )
 
 func handleError(w http.ResponseWriter, r *http.Request, err error) {

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight_test.go
@@ -34,9 +34,9 @@ import (
 
 func createMaxInflightServer(t *testing.T, callsWg, blockWg *sync.WaitGroup, disableCallsWg *bool, disableCallsWgMutex *sync.Mutex, nonMutating, mutating int) *httptest.Server {
 	fcmetrics.Register()
-	longRunningRequestCheck := BasicLongRunningRequestCheck(sets.NewString("watch"), sets.NewString("proxy"))
+	longRunningRequestCheck := BasicLongRunningRequestCheck(sets.New[string]("watch"), sets.New[string]("proxy"))
 
-	requestInfoFactory := &apirequest.RequestInfoFactory{APIPrefixes: sets.NewString("apis", "api"), GrouplessAPIPrefixes: sets.NewString("api")}
+	requestInfoFactory := &apirequest.RequestInfoFactory{APIPrefixes: sets.New[string]("apis", "api"), GrouplessAPIPrefixes: sets.New[string]("api")}
 	handler := WithMaxInFlightLimit(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// A short, accounted request that does not wait for block WaitGroup.

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -164,8 +164,8 @@ func newApfServerWithFilter(t *testing.T, flowControlFilter utilflowcontrol.Inte
 }
 
 func newApfHandlerWithFilter(t *testing.T, flowControlFilter utilflowcontrol.Interface, onExecute, postExecute func()) http.Handler {
-	requestInfoFactory := &apirequest.RequestInfoFactory{APIPrefixes: sets.NewString("apis", "api"), GrouplessAPIPrefixes: sets.NewString("api")}
-	longRunningRequestCheck := BasicLongRunningRequestCheck(sets.NewString("watch"), sets.NewString("proxy"))
+	requestInfoFactory := &apirequest.RequestInfoFactory{APIPrefixes: sets.New[string]("apis", "api"), GrouplessAPIPrefixes: sets.New[string]("api")}
+	longRunningRequestCheck := BasicLongRunningRequestCheck(sets.New[string]("watch"), sets.New[string]("proxy"))
 
 	apfHandler := WithPriorityAndFairness(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		onExecute()
@@ -1228,8 +1228,8 @@ func newClientset(t *testing.T, objects ...runtime.Object) clientset.Interface {
 // a real apiserver.
 // the specified user is added as the authenticated user to the request context.
 func newHandlerChain(t *testing.T, handler http.Handler, filter utilflowcontrol.Interface, userName string, requestTimeout time.Duration) http.Handler {
-	requestInfoFactory := &apirequest.RequestInfoFactory{APIPrefixes: sets.NewString("apis", "api"), GrouplessAPIPrefixes: sets.NewString("api")}
-	longRunningRequestCheck := BasicLongRunningRequestCheck(sets.NewString("watch"), sets.NewString("proxy"))
+	requestInfoFactory := &apirequest.RequestInfoFactory{APIPrefixes: sets.New[string]("apis", "api"), GrouplessAPIPrefixes: sets.New[string]("api")}
+	longRunningRequestCheck := BasicLongRunningRequestCheck(sets.New[string]("watch"), sets.New[string]("proxy"))
 
 	apfHandler := WithPriorityAndFairness(handler, longRunningRequestCheck, filter, defaultRequestWorkEstimator)
 

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
@@ -388,8 +388,8 @@ func TestErrConnKilled(t *testing.T) {
 		panic(http.ErrAbortHandler)
 	})
 	resolver := &request.RequestInfoFactory{
-		APIPrefixes:          sets.NewString("api", "apis"),
-		GrouplessAPIPrefixes: sets.NewString("api"),
+		APIPrefixes:          sets.New[string]("api", "apis"),
+		GrouplessAPIPrefixes: sets.New[string]("api"),
 	}
 
 	ts := httptest.NewServer(WithPanicRecovery(handler, resolver))
@@ -448,8 +448,8 @@ func TestErrConnKilledHTTP2(t *testing.T) {
 		panic(http.ErrAbortHandler)
 	})
 	resolver := &request.RequestInfoFactory{
-		APIPrefixes:          sets.NewString("api", "apis"),
-		GrouplessAPIPrefixes: sets.NewString("api"),
+		APIPrefixes:          sets.New[string]("api", "apis"),
+		GrouplessAPIPrefixes: sets.New[string]("api"),
 	}
 
 	// test server

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -118,7 +118,7 @@ type GenericAPIServer struct {
 
 	// legacyAPIGroupPrefixes is used to set up URL parsing for authorization and for validating requests
 	// to InstallLegacyAPIGroup
-	legacyAPIGroupPrefixes sets.String
+	legacyAPIGroupPrefixes sets.Set[string]
 
 	// admissionControl is used to build the RESTStorage that backs an API Group.
 	admissionControl admission.Interface
@@ -184,7 +184,7 @@ type GenericAPIServer struct {
 	postStartHookLock      sync.Mutex
 	postStartHooks         map[string]postStartHookEntry
 	postStartHooksCalled   bool
-	disabledPostStartHooks sets.String
+	disabledPostStartHooks sets.Set[string]
 
 	preShutdownHookLock    sync.Mutex
 	preShutdownHooks       map[string]preShutdownHookEntry
@@ -806,7 +806,7 @@ func (s *GenericAPIServer) installAPIResources(apiPrefix string, apiGroupInfo *A
 // underlying storage will be destroyed on this servers shutdown.
 func (s *GenericAPIServer) InstallLegacyAPIGroup(apiPrefix string, apiGroupInfo *APIGroupInfo) error {
 	if !s.legacyAPIGroupPrefixes.Has(apiPrefix) {
-		return fmt.Errorf("%q is not in the allowed legacy API prefixes: %v", apiPrefix, s.legacyAPIGroupPrefixes.List())
+		return fmt.Errorf("%q is not in the allowed legacy API prefixes: %v", apiPrefix, s.legacyAPIGroupPrefixes.UnsortedList())
 	}
 
 	openAPIModels, err := s.getOpenAPIModels(apiPrefix, apiGroupInfo)

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -128,7 +128,7 @@ func setUp(t *testing.T) (Config, *assert.Assertions) {
 	config := NewConfig(codecs)
 	config.ExternalAddress = "192.168.10.4:443"
 	config.PublicAddress = netutils.ParseIPSloppy("192.168.10.4")
-	config.LegacyAPIGroupPrefixes = sets.NewString("/api")
+	config.LegacyAPIGroupPrefixes = sets.New[string]("/api")
 	config.LoopbackClientConfig = &restclient.Config{}
 
 	clientset := fake.NewSimpleClientset()
@@ -170,7 +170,7 @@ func TestNew(t *testing.T) {
 func TestInstallAPIGroups(t *testing.T) {
 	config, assert := setUp(t)
 
-	config.LegacyAPIGroupPrefixes = sets.NewString("/apiPrefix")
+	config.LegacyAPIGroupPrefixes = sets.New[string]("/apiPrefix")
 	config.DiscoveryAddresses = discovery.DefaultAddresses{DefaultAddress: "ExternalAddress"}
 
 	s, err := config.Complete(nil).New("test", NewEmptyDelegate())
@@ -211,7 +211,7 @@ func TestInstallAPIGroups(t *testing.T) {
 	err = s.InstallLegacyAPIGroup("/apiPrefix", &apis[0])
 	assert.NoError(err)
 	groupPaths := []string{
-		config.LegacyAPIGroupPrefixes.List()[0], // /apiPrefix
+		config.LegacyAPIGroupPrefixes.UnsortedList()[0], // /apiPrefix
 	}
 	for _, api := range apis[1:] {
 		err = s.InstallAPIGroup(&api)
@@ -300,14 +300,14 @@ func TestInstallAPIGroups(t *testing.T) {
 		for _, r := range resources.APIResources {
 			switch r.Name {
 			case "getter":
-				if got, expected := sets.NewString([]string(r.Verbs)...), sets.NewString("get"); !got.Equal(expected) {
+				if got, expected := sets.New[string]([]string(r.Verbs)...), sets.New[string]("get"); !got.Equal(expected) {
 					t.Errorf("[%d] unexpected verbs for resource %s/%s: got=%v expected=%v", i, resources.GroupVersion, r.Name, got, expected)
 				}
 			case "noverbs":
 				if r.Verbs == nil {
 					t.Errorf("[%d] unexpected nil verbs slice. Expected: []string{}", i)
 				}
-				if got, expected := sets.NewString([]string(r.Verbs)...), sets.NewString(); !got.Equal(expected) {
+				if got, expected := sets.New[string]([]string(r.Verbs)...), sets.New[string](); !got.Equal(expected) {
 					t.Errorf("[%d] unexpected verbs for resource %s/%s: got=%v expected=%v", i, resources.GroupVersion, r.Name, got, expected)
 				}
 			}
@@ -450,7 +450,7 @@ func TestNotRestRoutesHaveAuth(t *testing.T) {
 
 	authz := mockAuthorizer{}
 
-	config.LegacyAPIGroupPrefixes = sets.NewString("/apiPrefix")
+	config.LegacyAPIGroupPrefixes = sets.New[string]("/apiPrefix")
 	config.Authorization.Authorizer = &authz
 
 	config.EnableIndex = true

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
@@ -214,12 +214,12 @@ func (c *healthzCheck) Check(r *http.Request) error {
 }
 
 // getExcludedChecks extracts the health check names to be excluded from the query param
-func getExcludedChecks(r *http.Request) sets.String {
+func getExcludedChecks(r *http.Request) sets.Set[string] {
 	checks, found := r.URL.Query()["exclude"]
 	if found {
-		return sets.NewString(checks...)
+		return sets.New[string](checks...)
 	}
-	return sets.NewString()
+	return sets.New[string]()
 }
 
 // handleRootHealth returns an http.HandlerFunc that serves the provided checks.
@@ -252,9 +252,9 @@ func handleRootHealth(name string, firstTimeHealthy func(), checks ...HealthChec
 			}
 		}
 		if excluded.Len() > 0 {
-			fmt.Fprintf(&individualCheckOutput, "warn: some health checks cannot be excluded: no matches for %s\n", formatQuoted(excluded.List()...))
+			fmt.Fprintf(&individualCheckOutput, "warn: some health checks cannot be excluded: no matches for %s\n", formatQuoted(excluded.UnsortedList()...))
 			klog.V(6).Infof("cannot exclude some health checks, no health checks are installed matching %s",
-				formatQuoted(excluded.List()...))
+				formatQuoted(excluded.UnsortedList()...))
 		}
 		// always be verbose on failure
 		if len(failedChecks) > 0 {

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
@@ -211,19 +211,19 @@ func TestGetExcludedChecks(t *testing.T) {
 	tests := []struct {
 		name string
 		r    *http.Request
-		want sets.String
+		want sets.Set[string]
 	}{
 		{"Should have no excluded health checks",
 			createGetRequestWithUrl("/healthz?verbose=true"),
-			sets.NewString(),
+			sets.New[string](),
 		},
 		{"Should extract out the ping health check",
 			createGetRequestWithUrl("/healthz?exclude=ping"),
-			sets.NewString("ping"),
+			sets.New[string]("ping"),
 		},
 		{"Should extract out ping and log health check",
 			createGetRequestWithUrl("/healthz?exclude=ping&exclude=log"),
-			sets.NewString("ping", "log"),
+			sets.New[string]("ping", "log"),
 		},
 	}
 	for _, tt := range tests {

--- a/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
@@ -126,7 +126,7 @@ func (m *PathRecorderMux) refreshMuxLocked() {
 		newMux.pathToHandler[path] = handler
 	}
 
-	keys := sets.StringKeySet(m.prefixToHandler).List()
+	keys := sets.KeySet(m.prefixToHandler).UnsortedList()
 	sort.Sort(sort.Reverse(byPrefixPriority(keys)))
 	for _, prefix := range keys {
 		newMux.prefixHandlers = append(newMux.prefixHandlers, prefixHandler{

--- a/staging/src/k8s.io/apiserver/pkg/server/options/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/admission_test.go
@@ -28,7 +28,7 @@ import (
 func TestEnabledPluginNames(t *testing.T) {
 	scenarios := []struct {
 		expectedPluginNames       []string
-		setDefaultOffPlugins      sets.String
+		setDefaultOffPlugins      sets.Set[string]
 		setRecommendedPluginOrder []string
 		setEnablePlugins          []string
 		setDisablePlugins         []string
@@ -43,21 +43,21 @@ func TestEnabledPluginNames(t *testing.T) {
 		{
 			expectedPluginNames:       []string{"pluginB"},
 			setRecommendedPluginOrder: []string{"pluginA", "pluginB", "pluginC", "pluginD"},
-			setDefaultOffPlugins:      sets.NewString("pluginA", "pluginC", "pluginD"),
+			setDefaultOffPlugins:      sets.New[string]("pluginA", "pluginC", "pluginD"),
 		},
 
 		// scenario 2: use default off plugins and with RecommendedPluginOrder
 		{
 			expectedPluginNames:       []string{"pluginA", "pluginB", "pluginC", "pluginD"},
 			setRecommendedPluginOrder: []string{"pluginA", "pluginB", "pluginC", "pluginD"},
-			setDefaultOffPlugins:      sets.NewString(),
+			setDefaultOffPlugins:      sets.New[string](),
 		},
 
 		// scenario 3: use default off plugins and specified by enable-admission-plugins with RecommendedPluginOrder
 		{
 			expectedPluginNames:       []string{"pluginA", "pluginB", "pluginC", "pluginD"},
 			setRecommendedPluginOrder: []string{"pluginA", "pluginB", "pluginC", "pluginD"},
-			setDefaultOffPlugins:      sets.NewString("pluginC", "pluginD"),
+			setDefaultOffPlugins:      sets.New[string]("pluginC", "pluginD"),
 			setEnablePlugins:          []string{"pluginD", "pluginC"},
 		},
 
@@ -65,7 +65,7 @@ func TestEnabledPluginNames(t *testing.T) {
 		{
 			expectedPluginNames:       []string{"pluginB"},
 			setRecommendedPluginOrder: []string{"pluginA", "pluginB", "pluginC", "pluginD"},
-			setDefaultOffPlugins:      sets.NewString("pluginC", "pluginD"),
+			setDefaultOffPlugins:      sets.New[string]("pluginC", "pluginD"),
 			setDisablePlugins:         []string{"pluginA"},
 		},
 
@@ -73,7 +73,7 @@ func TestEnabledPluginNames(t *testing.T) {
 		{
 			expectedPluginNames:       []string{"pluginA", "pluginC"},
 			setRecommendedPluginOrder: []string{"pluginA", "pluginB", "pluginC", "pluginD"},
-			setDefaultOffPlugins:      sets.NewString("pluginC", "pluginD"),
+			setDefaultOffPlugins:      sets.New[string]("pluginC", "pluginD"),
 			setEnablePlugins:          []string{"pluginC"},
 			setDisablePlugins:         []string{"pluginB"},
 		},
@@ -82,7 +82,7 @@ func TestEnabledPluginNames(t *testing.T) {
 		{
 			expectedPluginNames:       []string{"pluginA", "pluginB", "pluginC"},
 			setRecommendedPluginOrder: []string{"pluginA", "pluginB", "pluginC", "pluginD"},
-			setDefaultOffPlugins:      sets.NewString("pluginD"),
+			setDefaultOffPlugins:      sets.New[string]("pluginD"),
 			setAdmissionControl:       []string{"pluginA", "pluginB"},
 		},
 
@@ -90,7 +90,7 @@ func TestEnabledPluginNames(t *testing.T) {
 		{
 			expectedPluginNames:       []string{"pluginA", "pluginB", "pluginC"},
 			setRecommendedPluginOrder: []string{"pluginA", "pluginB", "pluginC", "pluginD"},
-			setDefaultOffPlugins:      sets.NewString("pluginC", "pluginD"),
+			setDefaultOffPlugins:      sets.New[string]("pluginC", "pluginD"),
 			setAdmissionControl:       []string{"pluginA", "pluginB", "pluginC"},
 		},
 	}
@@ -208,7 +208,7 @@ func TestValidate(t *testing.T) {
 	for index, scenario := range scenarios {
 		t.Run(fmt.Sprintf("scenario %d", index), func(t *testing.T) {
 			options := NewAdmissionOptions()
-			options.DefaultOffPlugins = sets.NewString("pluginC", "pluginD")
+			options.DefaultOffPlugins = sets.New[string]("pluginC", "pluginD")
 			options.RecommendedPluginOrder = []string{"pluginA", "pluginB", "pluginC", "pluginD"}
 			options.Plugins = &admission.Plugins{}
 			for _, plugin := range options.RecommendedPluginOrder {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
@@ -470,7 +470,7 @@ func (o *AuditLogOptions) Validate() []error {
 	}
 
 	// Check log format
-	if !sets.NewString(pluginlog.AllowedFormats...).Has(o.Format) {
+	if !sets.New[string](pluginlog.AllowedFormats...).Has(o.Format) {
 		allErrors = append(allErrors, fmt.Errorf("invalid audit log format %s, allowed formats are %q", o.Format, strings.Join(pluginlog.AllowedFormats, ",")))
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
@@ -2087,7 +2087,7 @@ func Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange(t *testing.T) {
 				t.Errorf("log mismatch (-want +got):\n%s", diff)
 			}
 
-			ignoredFields := sets.NewString("Transformer", "EncryptedObject.EncryptedDEKSource", "UID", "CacheKey")
+			ignoredFields := sets.New[string]("Transformer", "EncryptedObject.EncryptedDEKSource", "UID", "CacheKey")
 
 			gotState := *h.state.Load()
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -70,7 +70,7 @@ type EtcdOptions struct {
 	SkipHealthEndpoints bool
 }
 
-var storageTypes = sets.NewString(
+var storageTypes = sets.New[string](
 	storagebackend.StorageTypeETCD3,
 )
 
@@ -98,7 +98,7 @@ func (s *EtcdOptions) Validate() []error {
 	}
 
 	if s.StorageConfig.Type != storagebackend.StorageTypeUnset && !storageTypes.Has(s.StorageConfig.Type) {
-		allErrors = append(allErrors, fmt.Errorf("--storage-backend invalid, allowed values: %s. If not specified, it will default to 'etcd3'", strings.Join(storageTypes.List(), ", ")))
+		allErrors = append(allErrors, fmt.Errorf("--storage-backend invalid, allowed values: %s. If not specified, it will default to 'etcd3'", strings.Join(storageTypes.UnsortedList(), ", ")))
 	}
 
 	for _, override := range s.EtcdServersOverrides {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
@@ -383,8 +383,8 @@ func TestReadinessCheck(t *testing.T) {
 func healthChecksAreEqual(t *testing.T, want []string, healthChecks []healthz.HealthChecker, checkerType string) {
 	t.Helper()
 
-	wantSet := sets.NewString(want...)
-	gotSet := sets.NewString()
+	wantSet := sets.New[string](want...)
+	gotSet := sets.New[string]()
 
 	for _, h := range healthChecks {
 		gotSet.Insert(h.Name())
@@ -393,6 +393,6 @@ func healthChecksAreEqual(t *testing.T, want []string, healthChecks []healthz.He
 	gotSet.Delete("log", "ping") // not relevant for our tests
 
 	if !wantSet.Equal(gotSet) {
-		t.Errorf("%s checks are not equal, missing=%q, extra=%q", checkerType, wantSet.Difference(gotSet).List(), gotSet.Difference(wantSet).List())
+		t.Errorf("%s checks are not equal, missing=%q, extra=%q", checkerType, wantSet.Difference(gotSet).UnsortedList(), gotSet.Difference(wantSet).UnsortedList())
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/index.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/index.go
@@ -36,14 +36,14 @@ type ListedPathProviders []ListedPathProvider
 
 // ListedPaths unions and sorts the included paths.
 func (p ListedPathProviders) ListedPaths() []string {
-	ret := sets.String{}
+	ret := sets.New[string]()
 	for _, provider := range p {
 		for _, path := range provider.ListedPaths() {
 			ret.Insert(path)
 		}
 	}
 
-	return ret.List()
+	return ret.UnsortedList()
 }
 
 // Index provides a webservice for the http root / listing all known paths.

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
@@ -309,7 +309,7 @@ func Backends(storageConfig storagebackend.Config) []Backend {
 }
 
 func backends(storageConfig storagebackend.Config, grOverrides map[schema.GroupResource]groupResourceOverrides) []Backend {
-	servers := sets.NewString(storageConfig.Transport.ServerList...)
+	servers := sets.New[string](storageConfig.Transport.ServerList...)
 
 	for _, overrides := range grOverrides {
 		servers.Insert(overrides.etcdLocation...)

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
@@ -198,7 +198,7 @@ type configController struct {
 
 type updateAttempt struct {
 	timeUpdated  time.Time
-	updatedItems sets.String // FlowSchema names
+	updatedItems sets.Set[string] // FlowSchema names
 }
 
 // priorityLevelState holds the state specific to a priority level.
@@ -558,7 +558,7 @@ func (cfgCtlr *configController) digestConfigObjects(newPLs []*flowcontrol.Prior
 	var errs []error
 	currResult := updateAttempt{
 		timeUpdated:  cfgCtlr.clock.Now(),
-		updatedItems: sets.String{},
+		updatedItems: sets.New[string](),
 	}
 	var suggestedDelay time.Duration
 	for _, fsu := range fsStatusUpdates {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/gen_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/gen_test.go
@@ -88,7 +88,7 @@ func (ftr *fsTestingRecord) addDigests(digests []RequestDigest, matches bool) {
 	}
 }
 
-var flowDistinguisherMethodTypes = sets.NewString(
+var flowDistinguisherMethodTypes = sets.New[string](
 	string(flowcontrol.FlowDistinguisherMethodByUserType),
 	string(flowcontrol.FlowDistinguisherMethodByNamespaceType),
 )
@@ -192,7 +192,7 @@ var mandFTRCatchAll = &fsTestingRecord{
 // relatively likely to be well formed but might not be.  An ill
 // formed spec references a priority level drawn from badPLNames.
 // goodPLNames may be empty, but badPLNames may not.
-func genFS(t *testing.T, rng *rand.Rand, name string, mayMatchClusterScope bool, goodPLNames, badPLNames sets.String) *fsTestingRecord {
+func genFS(t *testing.T, rng *rand.Rand, name string, mayMatchClusterScope bool, goodPLNames, badPLNames sets.Set[string]) *fsTestingRecord {
 	fs := &flowcontrol.FlowSchema{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec:       flowcontrol.FlowSchemaSpec{}}
@@ -654,7 +654,7 @@ func genNonResourceRule(rng *rand.Rand, pfx string, matchAllNonResources, someMa
 	return nrr, matchingRIs, skippingRIs
 }
 
-func pickSetString(rng *rand.Rand, set sets.String) string {
+func pickSetString(rng *rand.Rand, set sets.Set[string]) string {
 	i, n := 0, rng.Intn(len(set))
 	for s := range set {
 		if i == n {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/match_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/match_test.go
@@ -33,8 +33,8 @@ func TestMatching(t *testing.T) {
 	checkFTR(t, mandFTRExempt)
 	checkFTR(t, mandFTRCatchAll)
 	rngOuter := rand.New(rand.NewSource(42))
-	goodPLNames := sets.NewString("pl1", "pl2", "pl3", "pl4", "pl5")
-	badPLNames := sets.NewString("ql1", "ql2", "ql3", "ql4", "ql5")
+	goodPLNames := sets.New[string]("pl1", "pl2", "pl3", "pl4", "pl5")
+	badPLNames := sets.New[string]("ql1", "ql2", "ql3", "ql4", "ql5")
 	for i := 0; i < 300; i++ {
 		rng := rand.New(rand.NewSource(int64(rngOuter.Uint64())))
 		t.Run(fmt.Sprintf("trial%d:", i), func(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/watch_tracker.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/watch_tracker.go
@@ -30,7 +30,7 @@ import (
 )
 
 // readOnlyVerbs contains verbs for read-only requests.
-var readOnlyVerbs = sets.NewString("get", "list", "watch", "proxy")
+var readOnlyVerbs = sets.New[string]("get", "list", "watch", "proxy")
 
 // watchIdentifier identifies group of watches that are similar.
 // As described in the "Priority and Fairness" KEP, we consider

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/watch_tracker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/watch_tracker_test.go
@@ -99,8 +99,8 @@ func TestRegisterWatch(t *testing.T) {
 	}
 
 	requestInfoFactory := &request.RequestInfoFactory{
-		APIPrefixes:          sets.NewString("api", "apis"),
-		GrouplessAPIPrefixes: sets.NewString("api"),
+		APIPrefixes:          sets.New[string]("api", "apis"),
+		GrouplessAPIPrefixes: sets.New[string]("api"),
 	}
 
 	for _, testCase := range testCases {
@@ -152,8 +152,8 @@ func TestGetInterestedWatchCount(t *testing.T) {
 		httpRequest("GET", "apis/group/v1/namespaces/bar/pods", "watch=true&fieldSelector=metadata.name=mypod"),
 	}
 	requestInfoFactory := &request.RequestInfoFactory{
-		APIPrefixes:          sets.NewString("api", "apis"),
-		GrouplessAPIPrefixes: sets.NewString("api"),
+		APIPrefixes:          sets.New[string]("api", "apis"),
+		GrouplessAPIPrefixes: sets.New[string]("api"),
 	}
 	for _, req := range registeredWatches {
 		requestInfo, err := requestInfoFactory.NewRequestInfo(req)
@@ -277,8 +277,8 @@ func TestGetInterestedWatchCountWithIndex(t *testing.T) {
 		httpRequest("GET", "api/v1/namespaces/foo/pods", "watch=true&fieldSelector=spec.nodeName=node2"),
 	}
 	requestInfoFactory := &request.RequestInfoFactory{
-		APIPrefixes:          sets.NewString("api", "apis"),
-		GrouplessAPIPrefixes: sets.NewString("api"),
+		APIPrefixes:          sets.New[string]("api", "apis"),
+		GrouplessAPIPrefixes: sets.New[string]("api"),
 	}
 	for _, req := range registeredWatches {
 		requestInfo, err := requestInfoFactory.NewRequestInfo(req)

--- a/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peerproxy_handler_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/peerproxy/peerproxy_handler_test.go
@@ -272,7 +272,7 @@ func newHandlerChain(t *testing.T, handler http.Handler, reconciler reconcilers.
 	handler = withFakeUser(handler)
 
 	// Add requestInfo handler
-	requestInfoFactory := &apirequest.RequestInfoFactory{APIPrefixes: sets.NewString("apis", "api"), GrouplessAPIPrefixes: sets.NewString("api")}
+	requestInfoFactory := &apirequest.RequestInfoFactory{APIPrefixes: sets.New[string]("apis", "api"), GrouplessAPIPrefixes: sets.New[string]("api")}
 	handler = apifilters.WithRequestInfo(handler, requestInfoFactory)
 	return handler
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
@@ -85,8 +85,8 @@ func contextHandler(handler http.Handler, user user.Info) http.Handler {
 			ctx = genericapirequest.WithUser(ctx, user)
 		}
 		resolver := &genericapirequest.RequestInfoFactory{
-			APIPrefixes:          sets.NewString("api", "apis"),
-			GrouplessAPIPrefixes: sets.NewString("api"),
+			APIPrefixes:          sets.New[string]("api", "apis"),
+			GrouplessAPIPrefixes: sets.New[string]("api"),
 		}
 		info, err := resolver.NewRequestInfo(req)
 		if err == nil {

--- a/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
@@ -137,8 +137,8 @@ func (o AggregatorOptions) RunAggregator(stopCh <-chan struct{}) error {
 		return err
 	}
 	serverConfig.LongRunningFunc = filters.BasicLongRunningRequestCheck(
-		sets.NewString("watch", "proxy"),
-		sets.NewString("attach", "exec", "proxy", "log", "portforward"),
+		sets.New[string]("watch", "proxy"),
+		sets.New[string]("attach", "exec", "proxy", "log", "portforward"),
 	)
 	serverConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(openapi.GetOpenAPIDefinitions, openapinamer.NewDefinitionNamer(aggregatorscheme.Scheme))
 	serverConfig.OpenAPIConfig.Info.Title = "kube-aggregator"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
In this PR, usages of deprecated parts of utils/sets package are removed. More specifically, `sets.Set[string]` is used instead of `sets.String`

#### Which issue(s) this PR fixes:
Not any

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

