### PR TITLE
Fix for Kubeproxy Mock framework where hcn object is holding always new object and not the pointer reference

### DIFF
--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -237,16 +237,16 @@ func TestCreateRemoteEndpointOverlay(t *testing.T) {
 		t.Errorf("Failed to cast endpointsInfo %q", svcPortName.String())
 
 	} else {
-		if epInfo.hnsID != endpointGuid1 {
+		if epInfo.hnsID != "EPID-3" {
 			t.Errorf("%v does not match %v", epInfo.hnsID, endpointGuid1)
 		}
 	}
 
-	if *proxier.endPointsRefCount[endpointGuid1] <= 0 {
+	if *proxier.endPointsRefCount["EPID-3"] <= 0 {
 		t.Errorf("RefCount not incremented. Current value: %v", *proxier.endPointsRefCount[endpointGuid1])
 	}
 
-	if *proxier.endPointsRefCount[endpointGuid1] != *epInfo.refCount {
+	if *proxier.endPointsRefCount["EPID-3"] != *epInfo.refCount {
 		t.Errorf("Global refCount: %v does not match endpoint refCount: %v", *proxier.endPointsRefCount[endpointGuid1], *epInfo.refCount)
 	}
 }
@@ -530,6 +530,7 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 			}}
 		}),
 	)
+
 	proxier.setInitialized(true)
 	proxier.syncProxyRules()
 	ep := proxier.endpointsMap[svcPortName1][0]
@@ -759,7 +760,7 @@ func TestCreateDsrLoadBalancer(t *testing.T) {
 		}
 		if len(svcInfo.loadBalancerIngressIPs) == 0 {
 			t.Errorf("svcInfo does not have any loadBalancerIngressIPs, %+v", svcInfo)
-		} else if svcInfo.loadBalancerIngressIPs[0].healthCheckHnsID != loadbalancerGuid1 {
+		} else if svcInfo.loadBalancerIngressIPs[0].healthCheckHnsID != "LBID-4" {
 			t.Errorf("The Hns Loadbalancer HealthCheck Id %v does not match %v. ServicePortName %q", svcInfo.loadBalancerIngressIPs[0].healthCheckHnsID, loadbalancerGuid1, svcPortName.String())
 		}
 	}
@@ -917,7 +918,7 @@ func TestEndpointSlice(t *testing.T) {
 		t.Errorf("Failed to cast endpointsInfo %q", svcPortName.String())
 
 	} else {
-		if epInfo.hnsID != endpointGuid1 {
+		if epInfo.hnsID != "EPID-3" {
 			t.Errorf("Hns EndpointId %v does not match %v. ServicePortName %q", epInfo.hnsID, endpointGuid1, svcPortName.String())
 		}
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind cleanup
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Moved endpointMap, loadbalancerMap from the hcnMock's struct context to global context. Earlier every hcnMock object was holding a new object and not the pointer reference. Hence the loadbalancer id generation and endpoint id generation was not happening incrementally. With this change, the id context is kept global and incremental id generation will work.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #120744

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixing issue with incremental id generation for loadbalancer and endpoint in Kubeproxy mock test framework.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
