### PR TITLE
Update CHANGELOG OWNERS to reflect 1.29 Release Notes team

### DIFF
--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -12,14 +12,14 @@ approvers:
   - harshanarayana # 1.27 Release Notes Lead
   - ramrodo # 1.26 Release Notes Lead
   - sanchita-07 # 1.28 Release Notes Lead
+  - fsmunoz # 1.29 Release Notes Lead
 reviewers:
   - release-managers
-  - AnaMMedina21 # 1.28 Release Notes Shadow
-  - fsmunoz # 1.28 Release Notes Shadow
-  - michaelfromyeg # 1.28 Release Notes Shadow
-  - muddapu # 1.28 Release Notes Shadow
-  - rashansmith # 1.28 Release Notes Shadow
-  - sanchita-07 # 1.28 Release Notes Lead
+  - fsmunoz # 1.29 Release Notes Lead
+  - fykaa # 1.29 Release Notes Shadow
+  - mengjiao-liu # 1.29 Release Notes Shadow
+  - muddapu # 1.29 Release Notes Shadow
+  - rashansmith # 1.29 Release Notes Shadow
 labels:
   - sig/release
   - area/release-eng


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR updates the OWNERS file and adds the 1.29 release-notes team as approver and reviewers.

/assign @Priyankasaggu11929 @salaxander 