### PR TITLE
node ready condition should conform to the validation of node IPs.

### DIFF
--- a/pkg/kubelet/host.go
+++ b/pkg/kubelet/host.go
@@ -1,0 +1,63 @@
+package kubelet
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/kubelet/nodestatus"
+)
+
+type hostState struct {
+	validators []validator
+}
+
+func newHostState() *hostState {
+	return &hostState{}
+}
+
+func (s *hostState) addValidator(validator validator) {
+	s.validators = append(s.validators, validator)
+}
+
+func (s *hostState) hostErrors() error {
+	var errs []error
+	for _, v := range s.validators {
+		if err := v.validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.NewAggregate(errs)
+}
+
+type validator interface {
+	validate() error
+}
+
+type nodeIPsValidator struct {
+	nodeIPs *nodestatus.NodeIPsState
+}
+
+func (n *nodeIPsValidator) validate() error {
+	nodeIP, secondaryNodeIP := n.nodeIPs.NodeIP, n.nodeIPs.SecondaryNodeIP
+	if n.nodeIPs.NodeIPSpecified {
+		if err := validateNodeIP(nodeIP); err != nil {
+			return fmt.Errorf("failed to validate nodeIP: %v", err)
+		}
+		klog.V(4).InfoS("Using node IP", "IP", nodeIP.String())
+	}
+	if n.nodeIPs.SecondaryNodeIPSpecified {
+		if err := validateNodeIP(secondaryNodeIP); err != nil {
+			return fmt.Errorf("failed to validate secondaryNodeIP: %v", err)
+		}
+		klog.V(4).InfoS("Using secondary node IP", "IP", secondaryNodeIP.String())
+	}
+	return nil
+}
+
+func newNodeIPsValidator(nodeIPsState *nodestatus.NodeIPsState) *nodeIPsValidator {
+	return &nodeIPsValidator{
+		nodeIPs: nodeIPsState,
+	}
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -736,6 +736,9 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
 		klet.runtimeState.addHealthCheck("EventedPLEG", klet.eventedPleg.Healthy)
 	}
+
+	klet.hostState = newHostState()
+
 	if _, err := klet.updatePodCIDR(ctx, kubeCfg.PodCIDR); err != nil {
 		klog.ErrorS(err, "Pod CIDR update failed")
 	}
@@ -1062,6 +1065,9 @@ type Kubelet struct {
 	// Last timestamp when runtime responded on ping.
 	// Mutex is used to protect this value.
 	runtimeState *runtimeState
+
+	// The kubelet validates against the host when posting node status.
+	hostState *hostState
 
 	// Volume plugins.
 	volumePluginMgr *volume.VolumePluginMgr

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -736,9 +736,12 @@ func (kl *Kubelet) defaultNodeStatusFuncs() []func(context.Context, *v1.Node) er
 	if kl.appArmorValidator != nil {
 		validateHostFunc = kl.appArmorValidator.ValidateHost
 	}
+
+	nodeIPsState := nodestatus.NewNodeIPsState(kl.nodeIPs)
+
 	var setters []func(ctx context.Context, n *v1.Node) error
 	setters = append(setters,
-		nodestatus.NodeAddress(kl.nodeIPs, kl.nodeIPValidator, kl.hostname, kl.hostnameOverridden, kl.externalCloudProvider, kl.cloud, nodeAddressesFunc),
+		nodestatus.NodeAddress(nodeIPsState, kl.nodeIPValidator, kl.hostname, kl.hostnameOverridden, kl.externalCloudProvider, kl.cloud, nodeAddressesFunc),
 		nodestatus.MachineInfo(string(kl.nodeName), kl.maxPods, kl.podsPerCore, kl.GetCachedMachineInfo, kl.containerManager.GetCapacity,
 			kl.containerManager.GetDevicePluginResourceCapacity, kl.containerManager.GetNodeAllocatableReservation, kl.recordEvent, kl.supportLocalStorageCapacityIsolation()),
 		nodestatus.VersionInfo(kl.cadvisor.VersionInfo, kl.containerRuntime.Type, kl.containerRuntime.Version),
@@ -748,13 +751,16 @@ func (kl *Kubelet) defaultNodeStatusFuncs() []func(context.Context, *v1.Node) er
 	)
 	// Volume limits
 	setters = append(setters, nodestatus.VolumeLimits(kl.volumePluginMgr.ListVolumePluginWithLimits))
+	// NodeIPs validator
+	kl.hostState.addValidator(newNodeIPsValidator(nodeIPsState))
 
 	setters = append(setters,
 		nodestatus.MemoryPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderMemoryPressure, kl.recordNodeStatusEvent),
 		nodestatus.DiskPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderDiskPressure, kl.recordNodeStatusEvent),
 		nodestatus.PIDPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderPIDPressure, kl.recordNodeStatusEvent),
 		nodestatus.ReadyCondition(kl.clock.Now, kl.runtimeState.runtimeErrors, kl.runtimeState.networkErrors, kl.runtimeState.storageErrors,
-			validateHostFunc, kl.containerManager.Status, kl.shutdownManager.ShutdownStatus, kl.recordNodeStatusEvent, kl.supportLocalStorageCapacityIsolation()),
+			validateHostFunc, kl.containerManager.Status, kl.shutdownManager.ShutdownStatus, kl.hostState.hostErrors,
+			kl.recordNodeStatusEvent, kl.supportLocalStorageCapacityIsolation()),
 		nodestatus.VolumesInUse(kl.volumeManager.ReconcilerStatesHasBeenSynced, kl.volumeManager.GetVolumesInUse),
 		// TODO(mtaufen): I decided not to move this setter for now, since all it does is send an event
 		// and record state back to the Kubelet runtime object. In the future, I'd like to isolate


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The status of the node is modified by a combination of functions that encompass updates for the node’s conditions. However, when updating the conditions, it must take into account the execution of other functions. In case any errors occur, we need to set the condition to “not ready” (false).

#### Which issue(s) this PR fixes:

Fixes #120727 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

It increases the precision of node readiness.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
