### PR TITLE
e2e framework: adapt unit test to Go 1.22

### DIFF
--- a/test/e2e/framework/internal/output/output.go
+++ b/test/e2e/framework/internal/output/output.go
@@ -110,6 +110,7 @@ func simplify(in string, expected TestResult) string {
 	out := normalizeLocation(in)
 	out = stripTimes(out)
 	out = stripAddresses(out)
+	out = normalizeInitFunctions(out)
 	if expected.NormalizeOutput != nil {
 		out = expected.NormalizeOutput(out)
 	}
@@ -176,5 +177,14 @@ func normalizeLocation(in string) string {
 	out = functionArgs.ReplaceAllString(out, "$1()")
 	out = testFailureOutput.ReplaceAllString(out, "")
 	out = klogPrefix.ReplaceAllString(out, "<klog> ")
+	return out
+}
+
+var initFunc = regexp.MustCompile(`(init\.+func|glob\.+func)`)
+
+// normalizeInitFunctions maps both init.func (used by Go >= 1.22) and
+// glob..func (used by Go < 1.22) to <init.func>.
+func normalizeInitFunctions(in string) string {
+	out := initFunc.ReplaceAllString(in, "<init.func>")
 	return out
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Go 1.22 changed the name of init functions from "glob..func" to "init.func". That difference is acceptable and has to be ignored when comparing output.

#### Which issue(s) this PR fixes:
Fixes #120652

#### Special notes for your reviewer:

May have to get backported - TBD.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @Rajalakshmi-Girish 