### PR TITLE
kubelet: do not initialize node address if cloud provider external

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -334,6 +334,16 @@ const (
 	// deletion ordering.
 	HonorPVReclaimPolicy featuregate.Feature = "HonorPVReclaimPolicy"
 
+	// owner: @aojea
+	// Deprecated: v1.29
+	//
+	// Changes when the Node addresses are assigned to the Node when using
+	// external cloud provider. The default is for only the external cloud provider
+	// to set the Node addresses. Enabling this means that the kubelet, if not address
+	// has been configured, will assign addresses to the Node based on the --node-ip
+	// flag parameters.
+	InitializeNodeAddressesCloudProviderExternal featuregate.Feature = "InitializeNodeAddressesCloudProviderExternal"
+
 	// owner: @leakingtapan
 	// alpha: v1.21
 	//
@@ -1041,6 +1051,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	HPAContainerMetrics: {Default: true, PreRelease: featuregate.Beta},
 
 	HonorPVReclaimPolicy: {Default: false, PreRelease: featuregate.Alpha},
+
+	InitializeNodeAddressesCloudProviderExternal: {Default: false, PreRelease: featuregate.Deprecated},
 
 	InTreePluginAWSUnregister: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -32,11 +32,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	cloudprovider "k8s.io/cloud-provider"
 	cloudproviderapi "k8s.io/cloud-provider/api"
 	cloudprovidernodeutil "k8s.io/cloud-provider/node/helpers"
 	"k8s.io/component-base/version"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -121,6 +123,10 @@ func NodeAddress(nodeIPs []net.IP, // typically Kubelet.nodeIPs
 		}
 
 		if externalCloudProvider {
+			// If --cloud-provider=external delegate the node address configuration to the cloud provider.
+			if !utilfeature.DefaultFeatureGate.Enabled(features.InitializeNodeAddressesCloudProviderExternal) {
+				return nil
+			}
 			// If --cloud-provider=external and node address is already set,
 			// then we return early because provider set addresses should take precedence.
 			// Otherwise, we try to look up the node IP and let the cloud provider override it later


### PR DESCRIPTION
/kind bug
/kind api-change
/kind deprecation
Fixes #120720

kubelet: do not initialize node address if cloud provider external

Kubelet, if using cloud provider external, initializes temporary
the node addresses using the non-cloud provider logic, until the
cloud provider overrides it.

This behavior has undesired consequences if the cloud-provider addresses
are different than the original ones, specially for hostNetwork pods,
that inherit these addresses from the Node.

Add a feature gate to preserve the old behavior InitializeNodeAddressesCloudProviderExternal
so users can opt-in for the old behavior, but don´t allow kubelet to
override the Node addresses by default.

```release-note
kubelet, when using cloud-provider=external, no longers initializes the Node.Status.Addresses and expects the external cloud-providers to set them. Users can opt-in to the previous behavior by setting the feature gate InitializeNodeAddressesCloudProviderExternal 
```
