### PR TITLE
node not ready if there are no addresses

### DIFF
--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -502,6 +502,9 @@ func ReadyCondition(
 		if len(missingCapacities) > 0 {
 			errs = append(errs, fmt.Errorf("missing node capacity for resources: %s", strings.Join(missingCapacities, ", ")))
 		}
+		if len(node.Status.Addresses) == 0 {
+			errs = append(errs, fmt.Errorf("missing node addresses"))
+		}
 		if aggregatedErr := errors.NewAggregate(errs); aggregatedErr != nil {
 			newNodeReadyCondition = v1.NodeCondition{
 				Type:              v1.NodeReady,

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -1411,6 +1411,11 @@ func TestReadyCondition(t *testing.T) {
 				v1.ResourcePods:             *resource.NewQuantity(100, resource.DecimalSI),
 				v1.ResourceEphemeralStorage: *resource.NewQuantity(5000, resource.BinarySI),
 			},
+			Addresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeInternalIP, Address: "fd01::1234"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
 		},
 	}
 
@@ -1420,6 +1425,11 @@ func TestReadyCondition(t *testing.T) {
 				v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
 				v1.ResourceMemory: *resource.NewQuantity(10e9, resource.BinarySI),
 				v1.ResourcePods:   *resource.NewQuantity(100, resource.DecimalSI),
+			},
+			Addresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeInternalIP, Address: "fd01::1234"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
 			},
 		},
 	}
@@ -1486,9 +1496,31 @@ func TestReadyCondition(t *testing.T) {
 			expectConditions: []v1.NodeCondition{*makeReadyCondition(false, "[runtime, network]", now, now)},
 		},
 		{
-			desc:             "new, not ready: missing capacities",
-			node:             &v1.Node{},
+			desc: "new, not ready: missing capacities",
+			node: &v1.Node{
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+						{Type: v1.NodeInternalIP, Address: "fd01::1234"},
+						{Type: v1.NodeHostName, Address: testKubeletHostname},
+					},
+				},
+			},
 			expectConditions: []v1.NodeCondition{*makeReadyCondition(false, "missing node capacity for resources: cpu, memory, pods, ephemeral-storage", now, now)},
+		},
+		{
+			desc: "new, not ready: missing addresses",
+			node: &v1.Node{
+				Status: v1.NodeStatus{
+					Capacity: v1.ResourceList{
+						v1.ResourceCPU:              *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:           *resource.NewQuantity(10e9, resource.BinarySI),
+						v1.ResourcePods:             *resource.NewQuantity(100, resource.DecimalSI),
+						v1.ResourceEphemeralStorage: *resource.NewQuantity(5000, resource.BinarySI),
+					},
+				},
+			},
+			expectConditions: []v1.NodeCondition{*makeReadyCondition(false, "missing node addresses", now, now)},
 		},
 		{
 			desc:                                 "new, ready: localStorageCapacityIsolation is not supported",


### PR DESCRIPTION

/kind bug

Fixes #120727

There can be different situations that the Node is set as ready but the node.status.Addresses are not set
- cloud-provider external takes some time to set the addresses, however, the ccm uses a taint to workaround this problem
- kubelet without cloud-provider and invalid ips specified in the --node-ip flag (not present in the host)

The consequences of the Node being ready without Addresses is that hostNetwork pods will not have a PodIPs, and pods using hostnetwork that get scheduled on that node that depend on those IPs, per example using the downward API will fail.

```release-note
kubelet: wait for Node.Status.Addresses to be assigned to be ready
```

/sig network
/sig node
/sig cloud-provider