### PR TITLE
Automated cherry pick of #120749: skip kube-dns tests if kube-dns is missing

### DIFF
--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -65,6 +65,7 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "KubeDNS"
 spec:
   # replicas: not specified here:
   # 1. In order to make Addon Manager do not reconcile this replicas parameter.

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -30,7 +30,7 @@ metadata:
 spec:
   selector:
     k8s-app: kube-dns
-  clusterIP: dns_server
+  clusterIP: {{ pillar['dns_server'] }}
   ports:
   - name: dns
     port: 53
@@ -65,6 +65,7 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "KubeDNS"
 spec:
   # replicas: not specified here:
   # 1. In order to make Addon Manager do not reconcile this replicas parameter.
@@ -121,7 +122,7 @@ spec:
           # guaranteed class. Currently, this container falls into the
           # "burstable" category so the kubelet doesn't backoff from restarting it.
           limits:
-            memory: 'dns_memory_limit'
+            memory: {{ pillar['dns_memory_limit'] }}
           requests:
             cpu: 100m
             memory: 70Mi
@@ -144,7 +145,7 @@ spec:
           initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
-        - --domain=dns_domain.
+        - --domain={{ pillar['dns_domain'] }}.
         - --dns-port=10053
         - --config-dir=/kube-dns-config
         - --v=2
@@ -191,7 +192,7 @@ spec:
         - --no-negcache
         - --dns-loop-detect
         - --log-facility=-
-        - --server=/dns_domain/127.0.0.1#10053
+        - --server=/{{ pillar['dns_domain'] }}/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053
         - --server=/ip6.arpa/127.0.0.1#10053
         ports:
@@ -230,8 +231,8 @@ spec:
         args:
         - --v=2
         - --logtostderr
-        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.dns_domain,5,SRV
-        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.dns_domain,5,SRV
+        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.{{ pillar['dns_domain'] }},5,SRV
+        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.{{ pillar['dns_domain'] }},5,SRV
         ports:
         - containerPort: 10054
           name: metrics

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -65,6 +65,7 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "KubeDNS"
 spec:
   # replicas: not specified here:
   # 1. In order to make Addon Manager do not reconcile this replicas parameter.

--- a/test/e2e/autoscaling/dns_autoscaling.go
+++ b/test/e2e/autoscaling/dns_autoscaling.go
@@ -41,8 +41,8 @@ import (
 // Constants used in dns-autoscaling test.
 const (
 	DNSdefaultTimeout      = 5 * time.Minute
-	ClusterAddonLabelKey   = "k8s-app"
-	DNSLabelName           = "kube-dns"
+	ClusterAddonLabelKey   = "kubernetes.io/name"
+	DNSLabelName           = "KubeDNS"
 	DNSAutoscalerLabelName = "kube-dns-autoscaler"
 )
 
@@ -57,16 +57,19 @@ var _ = SIGDescribe("DNS horizontal autoscaling", func() {
 	var DNSParams3 DNSParamsLinear
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
-		e2eskipper.SkipUnlessProviderIs("gce", "gke")
 		c = f.ClientSet
-
 		nodes, err := e2enode.GetReadySchedulableNodes(ctx, c)
 		framework.ExpectNoError(err)
 		nodeCount := len(nodes.Items)
 
 		ginkgo.By("Collecting original replicas count and DNS scaling params")
 		originDNSReplicasCount, err = getDNSReplicas(ctx, c)
-		framework.ExpectNoError(err)
+		if err != nil {
+			if strings.Contains(err.Error(), "expected 1 DNS deployment") && originDNSReplicasCount == 0 {
+				e2eskipper.Skipf(err.Error())
+			}
+			framework.Failf("unexpected error: %v", err)
+		}
 
 		pcm, err := fetchDNSScalingConfigMap(ctx, c)
 		framework.ExpectNoError(err)
@@ -311,7 +314,7 @@ func getDNSReplicas(ctx context.Context, c clientset.Interface) (int, error) {
 		return 0, err
 	}
 	if len(deployments.Items) != 1 {
-		return 0, fmt.Errorf("expected 1 DNS deployment, got %v", len(deployments.Items))
+		return len(deployments.Items), fmt.Errorf("expected 1 DNS deployment, got %v", len(deployments.Items))
 	}
 
 	deployment := deployments.Items[0]


### PR DESCRIPTION
Cherry pick of #120749 on release-1.28.

#120749: skip kube-dns tests if kube-dns is missing

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```