### PR TITLE
Promote e2e test for StorageClass Endpoints + 7 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -3365,6 +3365,16 @@
     to delete the secret, the deletion must succeed.
   release: v1.21
   file: test/e2e/common/storage/secrets_volume.go
+- testname: StorageClass, lifecycle
+  codename: '[sig-storage] StorageClasses CSI Conformance should run through the lifecycle
+    of a StorageClass [Conformance]'
+  description: Creating a StorageClass MUST succeed. Reading the StorageClass MUST
+    succeed. Patching the StorageClass MUST succeed with its new label found. Deleting
+    the StorageClass MUST succeed and it MUST be confirmed. Replacement StorageClass
+    MUST be created. Updating the StorageClass MUST succeed with its new label found.
+    Deleting the StorageClass via deleteCollection MUST succeed and it MUST be confirmed.
+  release: v1.29
+  file: test/e2e/storage/storageclass.go
 - testname: 'SubPath: Reading content from a configmap volume.'
   codename: '[sig-storage] Subpath Atomic writer volumes should support subpaths with
     configmap pod [Conformance]'

--- a/test/e2e/storage/storageclass.go
+++ b/test/e2e/storage/storageclass.go
@@ -40,7 +40,17 @@ var _ = utils.SIGDescribe("StorageClasses", func() {
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 
 	ginkgo.Describe("CSI Conformance", func() {
-		ginkgo.It("should run through the lifecycle of a StorageClass", func(ctx context.Context) {
+
+		/*
+			Release: v1.29
+			Testname: StorageClass, lifecycle
+			Description: Creating a StorageClass MUST succeed. Reading the StorageClass MUST
+			succeed. Patching the StorageClass MUST succeed with its new label found. Deleting
+			the StorageClass MUST succeed and it MUST be confirmed. Replacement StorageClass
+			MUST be created. Updating the StorageClass MUST succeed with its new label found.
+			Deleting the StorageClass via deleteCollection MUST succeed and it MUST be confirmed.
+		*/
+		framework.ConformanceIt("should run through the lifecycle of a StorageClass", func(ctx context.Context) {
 
 			scClient := f.ClientSet.StorageV1().StorageClasses()
 			var initialSC, replacementSC *storagev1.StorageClass


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- createStorageV1StorageClass
- deleteStorageV1CollectionStorageClass
- deleteStorageV1StorageClass
- listStorageV1StorageClass
- patchStorageV1StorageClass
- readStorageV1StorageClass
- replaceStorageV1StorageClass

**Which issue(s) this PR fixes:**
Fixes #120470

**Testgrid Link:**
[Testgrid](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.run.through.the.lifecycle.of.a.StorageClass)


**Special notes for your reviewer:**
Adds +7 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance