### PR TITLE
[WIP] DO-NOT-MERGE [failing-test]use changed label for kube dns in e2e network test cases

### DIFF
--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -71,7 +71,7 @@ func newDNSTestCommon() dnsTestCommon {
 
 func (t *dnsTestCommon) init(ctx context.Context) {
 	ginkgo.By("Finding a DNS pod")
-	label := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": "kube-dns"}))
+	label := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": "KubeDNS"}))
 	options := metav1.ListOptions{LabelSelector: label.String()}
 
 	namespace := "kube-system"
@@ -244,7 +244,7 @@ func (t *dnsTestCommon) deleteUtilPod(ctx context.Context) {
 // deleteCoreDNSPods manually deletes the CoreDNS pods to apply the changes to the ConfigMap.
 func (t *dnsTestCommon) deleteCoreDNSPods(ctx context.Context) {
 
-	label := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": "kube-dns"}))
+	label := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": "KubeDNS"}))
 	options := metav1.ListOptions{LabelSelector: label.String()}
 
 	pods, err := t.f.ClientSet.CoreV1().Pods("kube-system").List(ctx, options)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
https://github.com/kubernetes/kubernetes/pull/120749/ changed the label for DNS.

#### Which issue(s) this PR fixes:
Fixes None
https://prow.k8s.io/?job=ci-kubernetes-e2e-gci-gce-serial-kube-dns

#### Special notes for your reviewer:
```
{ failed [FAILED] Expected
    <[]v1.Pod | len:0, cap:0>: nil
not to be empty
In [It] at: test/e2e/network/dns_common.go:80 @ 09/20/23 05:28:44.245
}
```
/cc @upodroid @aojea 
/assign @dims 

#### Does this PR introduce a user-facing change?

```release-note
None
```
