### PR TITLE
Revert "Skip kube-dns tests if coredns is installed"

### DIFF
--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -65,7 +65,6 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/name: "KubeDNS"
 spec:
   # replicas: not specified here:
   # 1. In order to make Addon Manager do not reconcile this replicas parameter.

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -30,7 +30,7 @@ metadata:
 spec:
   selector:
     k8s-app: kube-dns
-  clusterIP: {{ pillar['dns_server'] }}
+  clusterIP: dns_server
   ports:
   - name: dns
     port: 53
@@ -65,7 +65,6 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/name: "KubeDNS"
 spec:
   # replicas: not specified here:
   # 1. In order to make Addon Manager do not reconcile this replicas parameter.
@@ -122,7 +121,7 @@ spec:
           # guaranteed class. Currently, this container falls into the
           # "burstable" category so the kubelet doesn't backoff from restarting it.
           limits:
-            memory: {{ pillar['dns_memory_limit'] }}
+            memory: 'dns_memory_limit'
           requests:
             cpu: 100m
             memory: 70Mi
@@ -145,7 +144,7 @@ spec:
           initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
-        - --domain={{ pillar['dns_domain'] }}.
+        - --domain=dns_domain.
         - --dns-port=10053
         - --config-dir=/kube-dns-config
         - --v=2
@@ -192,7 +191,7 @@ spec:
         - --no-negcache
         - --dns-loop-detect
         - --log-facility=-
-        - --server=/{{ pillar['dns_domain'] }}/127.0.0.1#10053
+        - --server=/dns_domain/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053
         - --server=/ip6.arpa/127.0.0.1#10053
         ports:
@@ -231,8 +230,8 @@ spec:
         args:
         - --v=2
         - --logtostderr
-        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.{{ pillar['dns_domain'] }},5,SRV
-        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.{{ pillar['dns_domain'] }},5,SRV
+        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.dns_domain,5,SRV
+        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.dns_domain,5,SRV
         ports:
         - containerPort: 10054
           name: metrics

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -65,7 +65,6 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/name: "KubeDNS"
 spec:
   # replicas: not specified here:
   # 1. In order to make Addon Manager do not reconcile this replicas parameter.


### PR DESCRIPTION
Reverts kubernetes/kubernetes#120749

see https://github.com/kubernetes/kubernetes/pull/120771
/cc @upodroid @aojea 

```release-note
None
```
