### PR TITLE
Delete EndpointSlices when service selector is removed

### DIFF
--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -347,12 +347,6 @@ func (c *Controller) syncService(logger klog.Logger, key string) error {
 		return nil
 	}
 
-	if service.Spec.Selector == nil {
-		// services without a selector receive no endpoint slices from this controller;
-		// these services will receive endpoint slices that are created out-of-band via the REST API.
-		return nil
-	}
-
 	logger.V(5).Info("About to update endpoint slices for service", "key", key)
 
 	podLabelSelector := labels.Set(service.Spec.Selector).AsSelectorPreValidated()


### PR DESCRIPTION
When service has endpoints and its selector is removed, then endpoint slice mirroring controller would create its own EndpointSlices by mirroring the Endpoints. At the same time it also retaining existing EndpointSlices containing service as the owner reference. These EndpointSlices are no more needed and hence removing EndpointSlices when service selector is made to be empty.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

By deleting EndpointSlices owned by endpoint slice controller, the mapping between EndpointSlices and Endpoints should be always correct.

#### Which issue(s) this PR fixes:

Fixes #118376

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
