### PR TITLE
reintroduce resourcequota.NewMonitor

### DIFF
--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -151,16 +151,15 @@ func NewController(ctx context.Context, options *ControllerOptions) (*Controller
 	)
 
 	if options.DiscoveryFunc != nil {
-		qm := &QuotaMonitor{
-			informersStarted:  options.InformersStarted,
-			informerFactory:   options.InformerFactory,
-			ignoredResources:  options.IgnoredResourcesFunc(),
-			resourceChanges:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "resource_quota_controller_resource_changes"),
-			resyncPeriod:      options.ReplenishmentResyncPeriod,
-			replenishmentFunc: rq.replenishQuota,
-			registry:          rq.registry,
-			updateFilter:      options.UpdateFilter,
-		}
+		qm := NewMonitor(
+			options.InformersStarted,
+			options.InformerFactory,
+			options.IgnoredResourcesFunc(),
+			options.ReplenishmentResyncPeriod,
+			rq.replenishQuota,
+			rq.registry,
+			options.UpdateFilter,
+		)
 
 		rq.quotaMonitor = qm
 

--- a/pkg/controller/resourcequota/resource_quota_monitor.go
+++ b/pkg/controller/resourcequota/resource_quota_monitor.go
@@ -103,6 +103,20 @@ type QuotaMonitor struct {
 	updateFilter UpdateFilter
 }
 
+// NewMonitor creates a new instance of a QuotaMonitor
+func NewMonitor(informersStarted <-chan struct{}, informerFactory informerfactory.InformerFactory, ignoredResources map[schema.GroupResource]struct{}, resyncPeriod controller.ResyncPeriodFunc, replenishmentFunc ReplenishmentFunc, registry quota.Registry, updateFilter UpdateFilter) *QuotaMonitor {
+	return &QuotaMonitor{
+		informersStarted:  informersStarted,
+		informerFactory:   informerFactory,
+		ignoredResources:  ignoredResources,
+		resourceChanges:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "resource_quota_controller_resource_changes"),
+		resyncPeriod:      resyncPeriod,
+		replenishmentFunc: replenishmentFunc,
+		registry:          registry,
+		updateFilter:      updateFilter,
+	}
+}
+
 // monitor runs a Controller with a local stop channel.
 type monitor struct {
 	controller cache.Controller


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- this function is used by other packages and  was mistakenly removed in https://github.com/kubernetes/kubernetes/pull/115100
- let resource quota controller use this constructor instead of an object instantiation

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

After bumping kubernetes dependencies, other projects depending on this public constructor will fail to compile. E.g. https://github.com/openshift/cluster-policy-controller/pull/132. Since the QuotaMonitor members are private, there is no workaround.

#### Special notes for your reviewer:

This PR should be backported to 1.28 for compatibility reasons.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
