### PR TITLE
Allow storage migration of CTB without attest authorization

### DIFF
--- a/plugin/pkg/admission/certificates/ctbattest/admission_test.go
+++ b/plugin/pkg/admission/certificates/ctbattest/admission_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
@@ -205,6 +206,51 @@ func TestPluginValidate(t *testing.T) {
 				operation: admission.Update,
 			},
 			allowed: false,
+		},
+		{
+			description:                      "should always allow no-op update",
+			clusterTrustBundleFeatureEnabled: true,
+			authzErr:                         errors.New("broken"),
+			attributes: &testAttributes{
+				resource: certificatesapi.Resource("clustertrustbundles"),
+				oldObj: &certificatesapi.ClusterTrustBundle{
+					Spec: certificatesapi.ClusterTrustBundleSpec{
+						SignerName: "panda.com/foo",
+					},
+				},
+				obj: &certificatesapi.ClusterTrustBundle{
+					Spec: certificatesapi.ClusterTrustBundleSpec{
+						SignerName: "panda.com/foo",
+					},
+				},
+				operation: admission.Update,
+			},
+			allowed: true,
+		},
+		{
+			description:                      "should always allow finalizer update",
+			clusterTrustBundleFeatureEnabled: true,
+			authzErr:                         errors.New("broken"),
+			attributes: &testAttributes{
+				resource: certificatesapi.Resource("clustertrustbundles"),
+				oldObj: &certificatesapi.ClusterTrustBundle{
+					Spec: certificatesapi.ClusterTrustBundleSpec{
+						SignerName: "panda.com/foo",
+					},
+				},
+				obj: &certificatesapi.ClusterTrustBundle{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							{APIVersion: "something"},
+						},
+					},
+					Spec: certificatesapi.ClusterTrustBundleSpec{
+						SignerName: "panda.com/foo",
+					},
+				},
+				operation: admission.Update,
+			},
+			allowed: true,
 		},
 	}
 


### PR DESCRIPTION
/kind bug

```release-note
No-op and GC related updates to cluster trust bundles no longer require attest authorization when the ClusterTrustBundleAttest plugin is enabled.
```

/assign liggitt ahmedtd