### PR TITLE
Including JTI & node reference in issued service account tokens (kep 4193)

### DIFF
--- a/pkg/controller/serviceaccount/tokengetter.go
+++ b/pkg/controller/serviceaccount/tokengetter.go
@@ -19,6 +19,7 @@ package serviceaccount
 import (
 	"context"
 	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	v1listers "k8s.io/client-go/listers/core/v1"
@@ -31,14 +32,15 @@ type clientGetter struct {
 	secretLister         v1listers.SecretLister
 	serviceAccountLister v1listers.ServiceAccountLister
 	podLister            v1listers.PodLister
+	nodeLister           v1listers.NodeLister
 }
 
 // NewGetterFromClient returns a ServiceAccountTokenGetter that
-// uses the specified client to retrieve service accounts and secrets.
+// uses the specified client to retrieve service accounts, pods, secrets and nodes.
 // The client should NOT authenticate using a service account token
 // the returned getter will be used to retrieve, or recursion will result.
-func NewGetterFromClient(c clientset.Interface, secretLister v1listers.SecretLister, serviceAccountLister v1listers.ServiceAccountLister, podLister v1listers.PodLister) serviceaccount.ServiceAccountTokenGetter {
-	return clientGetter{c, secretLister, serviceAccountLister, podLister}
+func NewGetterFromClient(c clientset.Interface, secretLister v1listers.SecretLister, serviceAccountLister v1listers.ServiceAccountLister, podLister v1listers.PodLister, nodeLister v1listers.NodeLister) serviceaccount.ServiceAccountTokenGetter {
+	return clientGetter{c, secretLister, serviceAccountLister, podLister, nodeLister}
 }
 
 func (c clientGetter) GetServiceAccount(namespace, name string) (*v1.ServiceAccount, error) {
@@ -60,4 +62,15 @@ func (c clientGetter) GetSecret(namespace, name string) (*v1.Secret, error) {
 		return secret, nil
 	}
 	return c.client.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c clientGetter) GetNode(name string) (*v1.Node, error) {
+	// handle the case where the node lister isn't set due to feature being disabled
+	if c.nodeLister == nil {
+		return nil, apierrors.NewNotFound(v1.Resource("nodes"), name)
+	}
+	if node, err := c.nodeLister.Get(name); err == nil {
+		return node, nil
+	}
+	return c.client.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -736,6 +736,36 @@ const (
 	// Decouples Taint Eviction Controller, performing taint-based Pod eviction, from Node Lifecycle Controller.
 	SeparateTaintEvictionController featuregate.Feature = "SeparateTaintEvictionController"
 
+	// owner: @munnerz
+	// kep: http://kep.k8s.io/4193
+	// alpha: v1.29
+	//
+	// Controls whether JTIs (UUIDs) are embedded into generated service account tokens, and whether these JTIs are
+	// recorded into the audit log for future requests made by these tokens.
+	ServiceAccountTokenJTI featuregate.Feature = "ServiceAccountTokenJTI"
+
+	// owner: @munnerz
+	// kep: http://kep.k8s.io/4193
+	// alpha: v1.29
+	//
+	// Controls whether the apiserver supports binding service account tokens to Node objects.
+	ServiceAccountTokenNodeBinding featuregate.Feature = "ServiceAccountTokenNodeBinding"
+
+	// owner: @munnerz
+	// kep: http://kep.k8s.io/4193
+	// alpha: v1.29
+	//
+	// Controls whether the apiserver will validate Node claims in service account tokens.
+	ServiceAccountTokenNodeBindingValidation featuregate.Feature = "ServiceAccountTokenNodeBindingValidation"
+
+	// owner: @munnerz
+	// kep: http://kep.k8s.io/4193
+	// alpha: v1.29
+	//
+	// Controls whether the apiserver embeds the node name and uid for the associated node when issuing
+	// service account tokens bound to Pod objects.
+	ServiceAccountTokenPodNodeInfo featuregate.Feature = "ServiceAccountTokenPodNodeInfo"
+
 	// owner: @xuzhenglun
 	// kep: http://kep.k8s.io/3682
 	// alpha: v1.27
@@ -1101,6 +1131,14 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	SecurityContextDeny: {Default: false, PreRelease: featuregate.Alpha},
 
 	SeparateTaintEvictionController: {Default: true, PreRelease: featuregate.Beta},
+
+	ServiceAccountTokenJTI: {Default: false, PreRelease: featuregate.Alpha},
+
+	ServiceAccountTokenPodNodeInfo: {Default: false, PreRelease: featuregate.Alpha},
+
+	ServiceAccountTokenNodeBinding: {Default: false, PreRelease: featuregate.Alpha},
+
+	ServiceAccountTokenNodeBindingValidation: {Default: false, PreRelease: featuregate.Alpha},
 
 	ServiceNodePortStaticSubrange: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.29; remove in 1.31
 

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -217,7 +217,12 @@ func (p *legacyProvider) NewRESTStorage(apiResourceConfigSource serverstorage.AP
 	// potentially override the generic serviceaccount storage with one that supports pods
 	var serviceAccountStorage *serviceaccountstore.REST
 	if p.ServiceAccountIssuer != nil {
-		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, p.ServiceAccountIssuer, p.APIAudiences, p.ServiceAccountMaxExpiration, podStorage.Pod.Store, storage["secrets"].(rest.Getter), p.ExtendExpiration)
+		var nodeGetter rest.Getter
+		if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountTokenNodeBinding) ||
+			utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountTokenPodNodeInfo) {
+			nodeGetter = nodeStorage.Node.Store
+		}
+		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, p.ServiceAccountIssuer, p.APIAudiences, p.ServiceAccountMaxExpiration, podStorage.Pod.Store, storage["secrets"].(rest.Getter), nodeGetter, p.ExtendExpiration)
 		if err != nil {
 			return genericapiserver.APIGroupInfo{}, err
 		}

--- a/pkg/registry/core/rest/storage_core_generic.go
+++ b/pkg/registry/core/rest/storage_core_generic.go
@@ -95,9 +95,9 @@ func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.API
 
 	var serviceAccountStorage *serviceaccountstore.REST
 	if c.ServiceAccountIssuer != nil {
-		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, c.ServiceAccountIssuer, c.APIAudiences, c.ServiceAccountMaxExpiration, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), secretStorage.Store, c.ExtendExpiration)
+		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, c.ServiceAccountIssuer, c.APIAudiences, c.ServiceAccountMaxExpiration, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), secretStorage.Store, newNotFoundGetter(schema.GroupResource{Resource: "nodes"}), c.ExtendExpiration)
 	} else {
-		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, nil, nil, 0, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), newNotFoundGetter(schema.GroupResource{Resource: "secrets"}), false)
+		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, nil, nil, 0, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), newNotFoundGetter(schema.GroupResource{Resource: "secrets"}), newNotFoundGetter(schema.GroupResource{Resource: "nodes"}), false)
 	}
 	if err != nil {
 		return genericapiserver.APIGroupInfo{}, err

--- a/pkg/registry/core/serviceaccount/storage/storage.go
+++ b/pkg/registry/core/serviceaccount/storage/storage.go
@@ -39,7 +39,7 @@ type REST struct {
 }
 
 // NewREST returns a RESTStorage object that will work against service accounts.
-func NewREST(optsGetter generic.RESTOptionsGetter, issuer token.TokenGenerator, auds authenticator.Audiences, max time.Duration, podStorage, secretStorage rest.Getter, extendExpiration bool) (*REST, error) {
+func NewREST(optsGetter generic.RESTOptionsGetter, issuer token.TokenGenerator, auds authenticator.Audiences, max time.Duration, podStorage, secretStorage, nodeStorage rest.Getter, extendExpiration bool) (*REST, error) {
 	store := &genericregistry.Store{
 		NewFunc:                   func() runtime.Object { return &api.ServiceAccount{} },
 		NewListFunc:               func() runtime.Object { return &api.ServiceAccountList{} },
@@ -64,6 +64,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter, issuer token.TokenGenerator, 
 			svcaccts:             store,
 			pods:                 podStorage,
 			secrets:              secretStorage,
+			nodes:                nodeStorage,
 			issuer:               issuer,
 			auds:                 auds,
 			audsSet:              sets.NewString(auds...),

--- a/pkg/registry/core/serviceaccount/storage/storage_test.go
+++ b/pkg/registry/core/serviceaccount/storage/storage_test.go
@@ -38,7 +38,7 @@ func newStorage(t *testing.T) (*REST, *etcd3testing.EtcdTestServer) {
 		DeleteCollectionWorkers: 1,
 		ResourcePrefix:          "serviceaccounts",
 	}
-	rest, err := NewREST(restOptions, nil, nil, 0, nil, nil, false)
+	rest, err := NewREST(restOptions, nil, nil, 0, nil, nil, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error from REST storage: %v", err)
 	}

--- a/pkg/registry/core/serviceaccount/storage/token.go
+++ b/pkg/registry/core/serviceaccount/storage/token.go
@@ -29,13 +29,18 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/warning"
+	"k8s.io/klog/v2"
 	authenticationapi "k8s.io/kubernetes/pkg/apis/authentication"
 	authenticationvalidation "k8s.io/kubernetes/pkg/apis/authentication/validation"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
 	token "k8s.io/kubernetes/pkg/serviceaccount"
 )
 
@@ -53,6 +58,7 @@ type TokenREST struct {
 	svcaccts             rest.Getter
 	pods                 rest.Getter
 	secrets              rest.Getter
+	nodes                rest.Getter
 	issuer               token.TokenGenerator
 	auds                 authenticator.Audiences
 	audsSet              sets.String
@@ -127,6 +133,7 @@ func (r *TokenREST) Create(ctx context.Context, name string, obj runtime.Object,
 
 	var (
 		pod    *api.Pod
+		node   *api.Node
 		secret *api.Secret
 	)
 
@@ -136,7 +143,7 @@ func (r *TokenREST) Create(ctx context.Context, name string, obj runtime.Object,
 		gvk := schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind)
 		switch {
 		case gvk.Group == "" && gvk.Kind == "Pod":
-			newCtx := newContext(ctx, "pods", ref.Name, gvk)
+			newCtx := newContext(ctx, "pods", ref.Name, namespace, gvk)
 			podObj, err := r.pods.Get(newCtx, ref.Name, &metav1.GetOptions{})
 			if err != nil {
 				return nil, err
@@ -146,8 +153,41 @@ func (r *TokenREST) Create(ctx context.Context, name string, obj runtime.Object,
 				return nil, errors.NewBadRequest(fmt.Sprintf("cannot bind token for serviceaccount %q to pod running with different serviceaccount name.", name))
 			}
 			uid = pod.UID
+			if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountTokenPodNodeInfo) {
+				if nodeName := pod.Spec.NodeName; nodeName != "" {
+					newCtx := newContext(ctx, "nodes", nodeName, "", api.SchemeGroupVersion.WithKind("Node"))
+					// set ResourceVersion=0 to allow this to be read/served from the apiservers watch cache
+					nodeObj, err := r.nodes.Get(newCtx, nodeName, &metav1.GetOptions{ResourceVersion: "0"})
+					if err != nil {
+						nodeObj, err = r.nodes.Get(newCtx, nodeName, &metav1.GetOptions{}) // fallback to a live lookup on any error
+					}
+					switch {
+					case errors.IsNotFound(err):
+						// if the referenced Node object does not exist, we still embed just the pod name into the
+						// claims so that clients still have some indication of what node a pod is assigned to when
+						// inspecting a token (even if the UID is not present).
+						klog.V(4).ErrorS(err, "failed fetching node for pod", "pod", klog.KObj(pod), "podUID", pod.UID, "nodeName", nodeName)
+						node = &api.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+					case err != nil:
+						return nil, errors.NewInternalError(err)
+					default:
+						node = nodeObj.(*api.Node)
+					}
+				}
+			}
+		case gvk.Group == "" && gvk.Kind == "Node":
+			if !utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountTokenNodeBinding) {
+				return nil, errors.NewBadRequest(fmt.Sprintf("cannot bind token to a Node object as the %q feature-gate is disabled", features.ServiceAccountTokenNodeBinding))
+			}
+			newCtx := newContext(ctx, "nodes", ref.Name, "", gvk)
+			nodeObj, err := r.nodes.Get(newCtx, ref.Name, &metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			node = nodeObj.(*api.Node)
+			uid = node.UID
 		case gvk.Group == "" && gvk.Kind == "Secret":
-			newCtx := newContext(ctx, "secrets", ref.Name, gvk)
+			newCtx := newContext(ctx, "secrets", ref.Name, namespace, gvk)
 			secretObj, err := r.secrets.Get(newCtx, ref.Name, &metav1.GetOptions{})
 			if err != nil {
 				return nil, err
@@ -179,7 +219,10 @@ func (r *TokenREST) Create(ctx context.Context, name string, obj runtime.Object,
 		exp = token.ExpirationExtensionSeconds
 	}
 
-	sc, pc := token.Claims(*svcacct, pod, secret, exp, warnAfter, req.Spec.Audiences)
+	sc, pc, err := token.Claims(*svcacct, pod, secret, node, exp, warnAfter, req.Spec.Audiences)
+	if err != nil {
+		return nil, err
+	}
 	tokdata, err := r.issuer.GenerateToken(sc, pc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate token: %v", err)
@@ -191,6 +234,9 @@ func (r *TokenREST) Create(ctx context.Context, name string, obj runtime.Object,
 		Token:               tokdata,
 		ExpirationTimestamp: metav1.Time{Time: nowTime.Add(time.Duration(out.Spec.ExpirationSeconds) * time.Second)},
 	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountTokenJTI) && len(sc.ID) > 0 {
+		audit.AddAuditAnnotation(ctx, serviceaccount.CredentialIDKey, serviceaccount.CredentialIDForJTI(sc.ID))
+	}
 	return out, nil
 }
 
@@ -199,15 +245,11 @@ func (r *TokenREST) GroupVersionKind(schema.GroupVersion) schema.GroupVersionKin
 }
 
 // newContext return a copy of ctx in which new RequestInfo is set
-func newContext(ctx context.Context, resource, name string, gvk schema.GroupVersionKind) context.Context {
-	oldInfo, found := genericapirequest.RequestInfoFrom(ctx)
-	if !found {
-		return ctx
-	}
+func newContext(ctx context.Context, resource, name, namespace string, gvk schema.GroupVersionKind) context.Context {
 	newInfo := genericapirequest.RequestInfo{
 		IsResourceRequest: true,
 		Verb:              "get",
-		Namespace:         oldInfo.Namespace,
+		Namespace:         namespace,
 		Resource:          resource,
 		Name:              name,
 		Parts:             []string{resource, name},

--- a/pkg/serviceaccount/claims.go
+++ b/pkg/serviceaccount/claims.go
@@ -22,12 +22,15 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"gopkg.in/square/go-jose.v2/jwt"
-	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/klog/v2"
 
+	"k8s.io/apiserver/pkg/audit"
 	apiserverserviceaccount "k8s.io/apiserver/pkg/authentication/serviceaccount"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 const (
@@ -38,8 +41,12 @@ const (
 	ExpirationExtensionSeconds = 24 * 365 * 60 * 60
 )
 
-// time.Now stubbed out to allow testing
-var now = time.Now
+var (
+	// time.Now stubbed out to allow testing
+	now = time.Now
+	// uuid.New stubbed out to allow testing
+	newUUID = uuid.NewString
+)
 
 type privateClaims struct {
 	Kubernetes kubernetes `json:"kubernetes.io,omitempty"`
@@ -50,6 +57,7 @@ type kubernetes struct {
 	Svcacct   ref              `json:"serviceaccount,omitempty"`
 	Pod       *ref             `json:"pod,omitempty"`
 	Secret    *ref             `json:"secret,omitempty"`
+	Node      *ref             `json:"node,omitempty"`
 	WarnAfter *jwt.NumericDate `json:"warnafter,omitempty"`
 }
 
@@ -58,7 +66,7 @@ type ref struct {
 	UID  string `json:"uid,omitempty"`
 }
 
-func Claims(sa core.ServiceAccount, pod *core.Pod, secret *core.Secret, expirationSeconds, warnafter int64, audience []string) (*jwt.Claims, interface{}) {
+func Claims(sa core.ServiceAccount, pod *core.Pod, secret *core.Secret, node *core.Node, expirationSeconds, warnafter int64, audience []string) (*jwt.Claims, interface{}, error) {
 	now := now()
 	sc := &jwt.Claims{
 		Subject:   apiserverserviceaccount.MakeUsername(sa.Namespace, sa.Name),
@@ -66,6 +74,9 @@ func Claims(sa core.ServiceAccount, pod *core.Pod, secret *core.Secret, expirati
 		IssuedAt:  jwt.NewNumericDate(now),
 		NotBefore: jwt.NewNumericDate(now),
 		Expiry:    jwt.NewNumericDate(now.Add(time.Duration(expirationSeconds) * time.Second)),
+	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountTokenJTI) {
+		sc.ID = newUUID()
 	}
 	pc := &privateClaims{
 		Kubernetes: kubernetes{
@@ -76,16 +87,37 @@ func Claims(sa core.ServiceAccount, pod *core.Pod, secret *core.Secret, expirati
 			},
 		},
 	}
+
+	if secret != nil && (node != nil || pod != nil) {
+		return nil, nil, fmt.Errorf("internal error, token can only be bound to one object type")
+	}
 	switch {
 	case pod != nil:
 		pc.Kubernetes.Pod = &ref{
 			Name: pod.Name,
 			UID:  string(pod.UID),
 		}
+		if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountTokenPodNodeInfo) {
+			// if this is bound to a pod and the node information is available, persist that too
+			if node != nil {
+				pc.Kubernetes.Node = &ref{
+					Name: node.Name,
+					UID:  string(node.UID),
+				}
+			}
+		}
 	case secret != nil:
 		pc.Kubernetes.Secret = &ref{
 			Name: secret.Name,
 			UID:  string(secret.UID),
+		}
+	case node != nil:
+		if !utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountTokenNodeBinding) {
+			return nil, nil, fmt.Errorf("token bound to Node object requested, but %q feature gate is disabled", features.ServiceAccountTokenNodeBinding)
+		}
+		pc.Kubernetes.Node = &ref{
+			Name: node.Name,
+			UID:  string(node.UID),
 		}
 	}
 
@@ -93,7 +125,7 @@ func Claims(sa core.ServiceAccount, pod *core.Pod, secret *core.Secret, expirati
 		pc.Kubernetes.WarnAfter = jwt.NewNumericDate(now.Add(time.Duration(warnafter) * time.Second))
 	}
 
-	return sc, pc
+	return sc, pc, nil
 }
 
 func NewValidator(getter ServiceAccountTokenGetter) Validator {
@@ -146,6 +178,7 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims, 
 	namespace := private.Kubernetes.Namespace
 	saref := private.Kubernetes.Svcacct
 	podref := private.Kubernetes.Pod
+	noderef := private.Kubernetes.Node
 	secref := private.Kubernetes.Secret
 	// Make sure service account still exists (name and UID)
 	serviceAccount, err := v.getter.GetServiceAccount(namespace, saref.Name)
@@ -153,13 +186,14 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims, 
 		klog.V(4).Infof("Could not retrieve service account %s/%s: %v", namespace, saref.Name, err)
 		return nil, err
 	}
-	if serviceAccount.DeletionTimestamp != nil && serviceAccount.DeletionTimestamp.Time.Before(invalidIfDeletedBefore) {
-		klog.V(4).Infof("Service account has been deleted %s/%s", namespace, saref.Name)
-		return nil, fmt.Errorf("service account %s/%s has been deleted", namespace, saref.Name)
-	}
+
 	if string(serviceAccount.UID) != saref.UID {
 		klog.V(4).Infof("Service account UID no longer matches %s/%s: %q != %q", namespace, saref.Name, string(serviceAccount.UID), saref.UID)
 		return nil, fmt.Errorf("service account UID (%s) does not match claim (%s)", serviceAccount.UID, saref.UID)
+	}
+	if serviceAccount.DeletionTimestamp != nil && serviceAccount.DeletionTimestamp.Time.Before(invalidIfDeletedBefore) {
+		klog.V(4).Infof("Service account has been deleted %s/%s", namespace, saref.Name)
+		return nil, fmt.Errorf("service account %s/%s has been deleted", namespace, saref.Name)
 	}
 
 	if secref != nil {
@@ -169,13 +203,13 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims, 
 			klog.V(4).Infof("Could not retrieve bound secret %s/%s for service account %s/%s: %v", namespace, secref.Name, namespace, saref.Name, err)
 			return nil, errors.New("service account token has been invalidated")
 		}
-		if secret.DeletionTimestamp != nil && secret.DeletionTimestamp.Time.Before(invalidIfDeletedBefore) {
-			klog.V(4).Infof("Bound secret is deleted and awaiting removal: %s/%s for service account %s/%s", namespace, secref.Name, namespace, saref.Name)
-			return nil, errors.New("service account token has been invalidated")
-		}
 		if secref.UID != string(secret.UID) {
 			klog.V(4).Infof("Secret UID no longer matches %s/%s: %q != %q", namespace, secref.Name, string(secret.UID), secref.UID)
 			return nil, fmt.Errorf("secret UID (%s) does not match service account secret ref claim (%s)", secret.UID, secref.UID)
+		}
+		if secret.DeletionTimestamp != nil && secret.DeletionTimestamp.Time.Before(invalidIfDeletedBefore) {
+			klog.V(4).Infof("Bound secret is deleted and awaiting removal: %s/%s for service account %s/%s", namespace, secref.Name, namespace, saref.Name)
+			return nil, errors.New("service account token has been invalidated")
 		}
 	}
 
@@ -187,16 +221,49 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims, 
 			klog.V(4).Infof("Could not retrieve bound pod %s/%s for service account %s/%s: %v", namespace, podref.Name, namespace, saref.Name, err)
 			return nil, errors.New("service account token has been invalidated")
 		}
-		if pod.DeletionTimestamp != nil && pod.DeletionTimestamp.Time.Before(invalidIfDeletedBefore) {
-			klog.V(4).Infof("Bound pod is deleted and awaiting removal: %s/%s for service account %s/%s", namespace, podref.Name, namespace, saref.Name)
-			return nil, errors.New("service account token has been invalidated")
-		}
 		if podref.UID != string(pod.UID) {
 			klog.V(4).Infof("Pod UID no longer matches %s/%s: %q != %q", namespace, podref.Name, string(pod.UID), podref.UID)
 			return nil, fmt.Errorf("pod UID (%s) does not match service account pod ref claim (%s)", pod.UID, podref.UID)
 		}
+		if pod.DeletionTimestamp != nil && pod.DeletionTimestamp.Time.Before(invalidIfDeletedBefore) {
+			klog.V(4).Infof("Bound pod is deleted and awaiting removal: %s/%s for service account %s/%s", namespace, podref.Name, namespace, saref.Name)
+			return nil, errors.New("service account token has been invalidated")
+		}
 		podName = podref.Name
 		podUID = podref.UID
+	}
+
+	var nodeName, nodeUID string
+	if noderef != nil {
+		switch {
+		case podref != nil:
+			if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountTokenPodNodeInfo) {
+				// for pod-bound tokens, just extract the node claims
+				nodeName = noderef.Name
+				nodeUID = noderef.UID
+			}
+		case podref == nil:
+			if !utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountTokenNodeBindingValidation) {
+				klog.V(4).Infof("ServiceAccount token is bound to a Node object, but the node bound token validation feature is disabled")
+				return nil, fmt.Errorf("token is bound to a Node object but the %s feature gate is disabled", features.ServiceAccountTokenNodeBindingValidation)
+			}
+
+			node, err := v.getter.GetNode(noderef.Name)
+			if err != nil {
+				klog.V(4).Infof("Could not retrieve node object %q for service account %s/%s: %v", noderef.Name, namespace, saref.Name, err)
+				return nil, errors.New("service account token has been invalidated")
+			}
+			if noderef.UID != string(node.UID) {
+				klog.V(4).Infof("Node UID no longer matches %s: %q != %q", noderef.Name, string(node.UID), noderef.UID)
+				return nil, fmt.Errorf("node UID (%s) does not match service account node ref claim (%s)", node.UID, noderef.UID)
+			}
+			if node.DeletionTimestamp != nil && node.DeletionTimestamp.Time.Before(invalidIfDeletedBefore) {
+				klog.V(4).Infof("Node %q is deleted and awaiting removal for service account %s/%s", node.Name, namespace, saref.Name)
+				return nil, errors.New("service account token has been invalidated")
+			}
+			nodeName = noderef.Name
+			nodeUID = noderef.UID
+		}
 	}
 
 	// Check special 'warnafter' field for projected service account token transition.
@@ -212,12 +279,19 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims, 
 		}
 	}
 
+	var jti string
+	if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountTokenJTI) {
+		jti = public.ID
+	}
 	return &apiserverserviceaccount.ServiceAccountInfo{
-		Namespace: private.Kubernetes.Namespace,
-		Name:      private.Kubernetes.Svcacct.Name,
-		UID:       private.Kubernetes.Svcacct.UID,
-		PodName:   podName,
-		PodUID:    podUID,
+		Namespace:    private.Kubernetes.Namespace,
+		Name:         private.Kubernetes.Svcacct.Name,
+		UID:          private.Kubernetes.Svcacct.UID,
+		PodName:      podName,
+		PodUID:       podUID,
+		NodeName:     nodeName,
+		NodeUID:      nodeUID,
+		CredentialID: apiserverserviceaccount.CredentialIDForJTI(jti),
 	}, nil
 }
 

--- a/pkg/serviceaccount/claims_test.go
+++ b/pkg/serviceaccount/claims_test.go
@@ -29,13 +29,21 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 func init() {
 	now = func() time.Time {
 		// epoch time: 1514764800
 		return time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC)
+	}
+
+	newUUID = func() string {
+		// always return a fixed/static UUID for testing
+		return "fixed"
 	}
 }
 
@@ -61,17 +69,27 @@ func TestClaims(t *testing.T) {
 			UID:       "mysecret-uid",
 		},
 	}
+	node := &core.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mynode",
+			UID:  "mynode-uid",
+		},
+	}
 	cs := []struct {
 		// input
 		sa        core.ServiceAccount
 		pod       *core.Pod
 		sec       *core.Secret
+		node      *core.Node
 		exp       int64
 		warnafter int64
 		aud       []string
+		err       string
 		// desired
 		sc *jwt.Claims
 		pc *privateClaims
+
+		featureJTI, featurePodNodeInfo, featureNodeBinding bool
 	}{
 		{
 			// pod and secret
@@ -82,20 +100,7 @@ func TestClaims(t *testing.T) {
 			exp: 0,
 			// nil audience
 			aud: nil,
-
-			sc: &jwt.Claims{
-				Subject:   "system:serviceaccount:myns:mysvcacct",
-				IssuedAt:  jwt.NewNumericDate(time.Unix(1514764800, 0)),
-				NotBefore: jwt.NewNumericDate(time.Unix(1514764800, 0)),
-				Expiry:    jwt.NewNumericDate(time.Unix(1514764800, 0)),
-			},
-			pc: &privateClaims{
-				Kubernetes: kubernetes{
-					Namespace: "myns",
-					Svcacct:   ref{Name: "mysvcacct", UID: "mysvcacct-uid"},
-					Pod:       &ref{Name: "mypod", UID: "mypod-uid"},
-				},
-			},
+			err: "internal error, token can only be bound to one object type",
 		},
 		{
 			// pod
@@ -167,7 +172,6 @@ func TestClaims(t *testing.T) {
 			// warn after provided
 			sa:        sa,
 			pod:       pod,
-			sec:       sec,
 			exp:       60 * 60 * 24,
 			warnafter: 60 * 60,
 			// nil audience
@@ -188,6 +192,141 @@ func TestClaims(t *testing.T) {
 				},
 			},
 		},
+		{
+			// node with feature gate disabled
+			sa:   sa,
+			node: node,
+			// really fast
+			exp: 0,
+			// nil audience
+			aud: nil,
+			err: "token bound to Node object requested, but \"ServiceAccountTokenNodeBinding\" feature gate is disabled",
+		},
+		{
+			// node & pod with feature gate disabled
+			sa:   sa,
+			node: node,
+			pod:  pod,
+			// really fast
+			exp: 0,
+			// nil audience
+			aud: nil,
+
+			sc: &jwt.Claims{
+				Subject:   "system:serviceaccount:myns:mysvcacct",
+				IssuedAt:  jwt.NewNumericDate(time.Unix(1514764800, 0)),
+				NotBefore: jwt.NewNumericDate(time.Unix(1514764800, 0)),
+				Expiry:    jwt.NewNumericDate(time.Unix(1514764800, 0)),
+			},
+			pc: &privateClaims{
+				Kubernetes: kubernetes{
+					Namespace: "myns",
+					Pod:       &ref{Name: "mypod", UID: "mypod-uid"},
+					Svcacct:   ref{Name: "mysvcacct", UID: "mysvcacct-uid"},
+				},
+			},
+		},
+		{
+			// node alone
+			sa:   sa,
+			node: node,
+			// enable node binding feature
+			featureNodeBinding: true,
+			// really fast
+			exp: 0,
+			// nil audience
+			aud: nil,
+
+			sc: &jwt.Claims{
+				Subject:   "system:serviceaccount:myns:mysvcacct",
+				IssuedAt:  jwt.NewNumericDate(time.Unix(1514764800, 0)),
+				NotBefore: jwt.NewNumericDate(time.Unix(1514764800, 0)),
+				Expiry:    jwt.NewNumericDate(time.Unix(1514764800, 0)),
+			},
+			pc: &privateClaims{
+				Kubernetes: kubernetes{
+					Namespace: "myns",
+					Svcacct:   ref{Name: "mysvcacct", UID: "mysvcacct-uid"},
+					Node:      &ref{Name: "mynode", UID: "mynode-uid"},
+				},
+			},
+		},
+		{
+			// node and pod
+			sa:   sa,
+			pod:  pod,
+			node: node,
+			// enable embedding pod node info feature
+			featurePodNodeInfo: true,
+			// really fast
+			exp: 0,
+			// nil audience
+			aud: nil,
+
+			sc: &jwt.Claims{
+				Subject:   "system:serviceaccount:myns:mysvcacct",
+				IssuedAt:  jwt.NewNumericDate(time.Unix(1514764800, 0)),
+				NotBefore: jwt.NewNumericDate(time.Unix(1514764800, 0)),
+				Expiry:    jwt.NewNumericDate(time.Unix(1514764800, 0)),
+			},
+			pc: &privateClaims{
+				Kubernetes: kubernetes{
+					Namespace: "myns",
+					Svcacct:   ref{Name: "mysvcacct", UID: "mysvcacct-uid"},
+					Pod:       &ref{Name: "mypod", UID: "mypod-uid"},
+					Node:      &ref{Name: "mynode", UID: "mynode-uid"},
+				},
+			},
+		},
+		{
+			// node and secret should error
+			sa:   sa,
+			sec:  sec,
+			node: node,
+			// enable embedding node info feature
+			featureNodeBinding: true,
+			// really fast
+			exp: 0,
+			// nil audience
+			aud: nil,
+			err: "internal error, token can only be bound to one object type",
+		},
+		{
+			// ensure JTI is set
+			sa: sa,
+			// enable setting JTI feature
+			featureJTI: true,
+			// really fast
+			exp: 0,
+			// nil audience
+			aud: nil,
+
+			sc: &jwt.Claims{
+				Subject:   "system:serviceaccount:myns:mysvcacct",
+				IssuedAt:  jwt.NewNumericDate(time.Unix(1514764800, 0)),
+				NotBefore: jwt.NewNumericDate(time.Unix(1514764800, 0)),
+				Expiry:    jwt.NewNumericDate(time.Unix(1514764800, 0)),
+				ID:        "fixed",
+			},
+			pc: &privateClaims{
+				Kubernetes: kubernetes{
+					Namespace: "myns",
+					Svcacct:   ref{Name: "mysvcacct", UID: "mysvcacct-uid"},
+				},
+			},
+		},
+		{
+			// ensure it fails if node binding gate is disabled
+			sa:                 sa,
+			node:               node,
+			featureNodeBinding: false,
+			// really fast
+			exp: 0,
+			// nil audience
+			aud: nil,
+
+			err: "token bound to Node object requested, but \"ServiceAccountTokenNodeBinding\" feature gate is disabled",
+		},
 	}
 	for i, c := range cs {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
@@ -202,7 +341,18 @@ func TestClaims(t *testing.T) {
 				return string(b)
 			}
 
-			sc, pc := Claims(c.sa, c.pod, c.sec, c.exp, c.warnafter, c.aud)
+			// set feature flags for the duration of the test case
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceAccountTokenJTI, c.featureJTI)()
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceAccountTokenNodeBinding, c.featureNodeBinding)()
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceAccountTokenPodNodeInfo, c.featurePodNodeInfo)()
+
+			sc, pc, err := Claims(c.sa, c.pod, c.sec, c.node, c.exp, c.warnafter, c.aud)
+			if err != nil && err.Error() != c.err {
+				t.Errorf("expected error %q but got: %v", c.err, err)
+			}
+			if err == nil && c.err != "" {
+				t.Errorf("expected an error but got none")
+			}
 			if spew(sc) != spew(c.sc) {
 				t.Errorf("standard claims differed\n\tsaw:\t%s\n\twant:\t%s", spew(sc), spew(c.sc))
 			}
@@ -226,6 +376,8 @@ type claimTestCase struct {
 	expiry    jwt.NumericDate
 	notBefore jwt.NumericDate
 	expectErr string
+
+	featureNodeBindingValidation bool
 }
 
 func TestValidatePrivateClaims(t *testing.T) {
@@ -235,6 +387,7 @@ func TestValidatePrivateClaims(t *testing.T) {
 		serviceAccount = &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "saname", Namespace: "ns", UID: "sauid"}}
 		secret         = &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secretname", Namespace: "ns", UID: "secretuid"}}
 		pod            = &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "podname", Namespace: "ns", UID: "poduid"}}
+		node           = &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "nodename", UID: "nodeuid"}}
 	)
 
 	deletionTestCases := []deletionTestCase{
@@ -268,57 +421,64 @@ func TestValidatePrivateClaims(t *testing.T) {
 	testcases := []claimTestCase{
 		{
 			name:      "good",
-			getter:    fakeGetter{serviceAccount, nil, nil},
+			getter:    fakeGetter{serviceAccount, nil, nil, nil},
 			private:   &privateClaims{Kubernetes: kubernetes{Svcacct: ref{Name: "saname", UID: "sauid"}, Namespace: "ns"}},
 			expectErr: "",
 		},
 		{
 			name:      "expired",
-			getter:    fakeGetter{serviceAccount, nil, nil},
+			getter:    fakeGetter{serviceAccount, nil, nil, nil},
 			private:   &privateClaims{Kubernetes: kubernetes{Svcacct: ref{Name: "saname", UID: "sauid"}, Namespace: "ns"}},
 			expiry:    *jwt.NewNumericDate(now().Add(-1_000 * time.Hour)),
 			expectErr: "service account token has expired",
 		},
 		{
 			name:      "not yet valid",
-			getter:    fakeGetter{serviceAccount, nil, nil},
+			getter:    fakeGetter{serviceAccount, nil, nil, nil},
 			private:   &privateClaims{Kubernetes: kubernetes{Svcacct: ref{Name: "saname", UID: "sauid"}, Namespace: "ns"}},
 			notBefore: *jwt.NewNumericDate(now().Add(1_000 * time.Hour)),
 			expectErr: "service account token is not valid yet",
 		},
 		{
 			name:      "missing serviceaccount",
-			getter:    fakeGetter{nil, nil, nil},
+			getter:    fakeGetter{nil, nil, nil, nil},
 			private:   &privateClaims{Kubernetes: kubernetes{Svcacct: ref{Name: "saname", UID: "sauid"}, Namespace: "ns"}},
 			expectErr: `serviceaccounts "saname" not found`,
 		},
 		{
 			name:      "missing secret",
-			getter:    fakeGetter{serviceAccount, nil, nil},
+			getter:    fakeGetter{serviceAccount, nil, nil, nil},
 			private:   &privateClaims{Kubernetes: kubernetes{Svcacct: ref{Name: "saname", UID: "sauid"}, Secret: &ref{Name: "secretname", UID: "secretuid"}, Namespace: "ns"}},
 			expectErr: "service account token has been invalidated",
 		},
 		{
 			name:      "missing pod",
-			getter:    fakeGetter{serviceAccount, nil, nil},
+			getter:    fakeGetter{serviceAccount, nil, nil, nil},
 			private:   &privateClaims{Kubernetes: kubernetes{Svcacct: ref{Name: "saname", UID: "sauid"}, Pod: &ref{Name: "podname", UID: "poduid"}, Namespace: "ns"}},
 			expectErr: "service account token has been invalidated",
 		},
 		{
+			name:                         "missing node",
+			getter:                       fakeGetter{serviceAccount, nil, nil, nil},
+			private:                      &privateClaims{Kubernetes: kubernetes{Svcacct: ref{Name: "saname", UID: "sauid"}, Node: &ref{Name: "nodename", UID: "nodeuid"}, Namespace: "ns"}},
+			expectErr:                    "service account token has been invalidated",
+			featureNodeBindingValidation: true,
+		},
+		{
 			name:      "different uid serviceaccount",
-			getter:    fakeGetter{serviceAccount, nil, nil},
+			getter:    fakeGetter{serviceAccount, nil, nil, nil},
 			private:   &privateClaims{Kubernetes: kubernetes{Svcacct: ref{Name: "saname", UID: "sauidold"}, Namespace: "ns"}},
 			expectErr: "service account UID (sauid) does not match claim (sauidold)",
 		},
 		{
 			name:      "different uid secret",
-			getter:    fakeGetter{serviceAccount, secret, nil},
+			getter:    fakeGetter{serviceAccount, secret, nil, nil},
 			private:   &privateClaims{Kubernetes: kubernetes{Svcacct: ref{Name: "saname", UID: "sauid"}, Secret: &ref{Name: "secretname", UID: "secretuidold"}, Namespace: "ns"}},
 			expectErr: "secret UID (secretuid) does not match service account secret ref claim (secretuidold)",
 		},
 		{
 			name:      "different uid pod",
-			getter:    fakeGetter{serviceAccount, nil, pod},
+			getter:    fakeGetter{serviceAccount, nil, pod, nil},
 			private:   &privateClaims{Kubernetes: kubernetes{Svcacct: ref{Name: "saname", UID: "sauid"}, Pod: &ref{Name: "podname", UID: "poduidold"}, Namespace: "ns"}},
 			expectErr: "pod UID (poduid) does not match service account pod ref claim (poduidold)",
 		},
@@ -329,10 +489,12 @@ func TestValidatePrivateClaims(t *testing.T) {
 			deletedServiceAccount = serviceAccount.DeepCopy()
 			deletedPod            = pod.DeepCopy()
 			deletedSecret         = secret.DeepCopy()
+			deletedNode           = node.DeepCopy()
 		)
 		deletedServiceAccount.DeletionTimestamp = deletionTestCase.time
 		deletedPod.DeletionTimestamp = deletionTestCase.time
 		deletedSecret.DeletionTimestamp = deletionTestCase.time
+		deletedNode.DeletionTimestamp = deletionTestCase.time
 
 		var saDeletedErr, deletedErr string
 		if deletionTestCase.expectErr {
@@ -343,32 +505,42 @@ func TestValidatePrivateClaims(t *testing.T) {
 		testcases = append(testcases,
 			claimTestCase{
 				name:      deletionTestCase.name + " serviceaccount",
-				getter:    fakeGetter{deletedServiceAccount, nil, nil},
+				getter:    fakeGetter{deletedServiceAccount, nil, nil, nil},
 				private:   &privateClaims{Kubernetes: kubernetes{Svcacct: ref{Name: "saname", UID: "sauid"}, Namespace: "ns"}},
 				expectErr: saDeletedErr,
 			},
 			claimTestCase{
 				name:      deletionTestCase.name + " secret",
-				getter:    fakeGetter{serviceAccount, deletedSecret, nil},
+				getter:    fakeGetter{serviceAccount, deletedSecret, nil, nil},
 				private:   &privateClaims{Kubernetes: kubernetes{Svcacct: ref{Name: "saname", UID: "sauid"}, Secret: &ref{Name: "secretname", UID: "secretuid"}, Namespace: "ns"}},
 				expectErr: deletedErr,
 			},
 			claimTestCase{
 				name:      deletionTestCase.name + " pod",
-				getter:    fakeGetter{serviceAccount, nil, deletedPod},
+				getter:    fakeGetter{serviceAccount, nil, deletedPod, nil},
 				private:   &privateClaims{Kubernetes: kubernetes{Svcacct: ref{Name: "saname", UID: "sauid"}, Pod: &ref{Name: "podname", UID: "poduid"}, Namespace: "ns"}},
 				expectErr: deletedErr,
+			},
+			claimTestCase{
+				name:                         deletionTestCase.name + " node",
+				getter:                       fakeGetter{serviceAccount, nil, nil, deletedNode},
+				private:                      &privateClaims{Kubernetes: kubernetes{Svcacct: ref{Name: "saname", UID: "sauid"}, Node: &ref{Name: "nodename", UID: "nodeuid"}, Namespace: "ns"}},
+				expectErr:                    deletedErr,
+				featureNodeBindingValidation: true,
 			},
 		)
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			v := &validator{tc.getter}
+			v := &validator{getter: tc.getter}
 			expiry := jwt.NumericDate(nowUnix)
 			if tc.expiry != 0 {
 				expiry = tc.expiry
 			}
+
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceAccountTokenNodeBindingValidation, tc.featureNodeBindingValidation)()
+
 			_, err := v.Validate(context.Background(), "", &jwt.Claims{Expiry: &expiry, NotBefore: &tc.notBefore}, tc.private)
 			if len(tc.expectErr) > 0 {
 				if errStr := errString(err); tc.expectErr != errStr {
@@ -393,6 +565,7 @@ type fakeGetter struct {
 	serviceAccount *v1.ServiceAccount
 	secret         *v1.Secret
 	pod            *v1.Pod
+	node           *v1.Node
 }
 
 func (f fakeGetter) GetServiceAccount(namespace, name string) (*v1.ServiceAccount, error) {
@@ -412,4 +585,10 @@ func (f fakeGetter) GetSecret(namespace, name string) (*v1.Secret, error) {
 		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "secrets"}, name)
 	}
 	return f.secret, nil
+}
+func (f fakeGetter) GetNode(name string) (*v1.Node, error) {
+	if f.node == nil {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "nodes"}, name)
+	}
+	return f.node, nil
 }

--- a/pkg/serviceaccount/jwt.go
+++ b/pkg/serviceaccount/jwt.go
@@ -43,6 +43,7 @@ type ServiceAccountTokenGetter interface {
 	GetServiceAccount(namespace, name string) (*v1.ServiceAccount, error)
 	GetPod(namespace, name string) (*v1.Pod, error)
 	GetSecret(namespace, name string) (*v1.Secret, error)
+	GetNode(name string) (*v1.Node, error)
 }
 
 type TokenGenerator interface {

--- a/pkg/serviceaccount/jwt_test.go
+++ b/pkg/serviceaccount/jwt_test.go
@@ -371,6 +371,9 @@ func TestTokenGenerateAndValidate(t *testing.T) {
 			v1listers.NewPodLister(newIndexer(func(namespace, name string) (interface{}, error) {
 				return tc.Client.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 			})),
+			v1listers.NewNodeLister(newIndexer(func(_, name string) (interface{}, error) {
+				return tc.Client.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+			})),
 		)
 		var secretsWriter typedv1core.SecretsGetter
 		if tc.Client != nil {
@@ -443,6 +446,11 @@ func (f *fakeIndexer) GetByKey(key string) (interface{}, bool, error) {
 	parts := strings.SplitN(key, "/", 2)
 	namespace := parts[0]
 	name := ""
+	// implies the key does not contain a / (this is a cluster-scoped object)
+	if len(parts) == 1 {
+		name = parts[0]
+		namespace = ""
+	}
 	if len(parts) == 2 {
 		name = parts[1]
 	}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount/util.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount/util.go
@@ -36,12 +36,21 @@ const (
 	ServiceAccountUsernameSeparator = ":"
 	ServiceAccountGroupPrefix       = "system:serviceaccounts:"
 	AllServiceAccountsGroup         = "system:serviceaccounts"
+	// CredentialIDKey is the key used in a user's "extra" to specify the unique
+	// identifier for this identity document).
+	CredentialIDKey = "authentication.kubernetes.io/credential-id"
 	// PodNameKey is the key used in a user's "extra" to specify the pod name of
 	// the authenticating request.
 	PodNameKey = "authentication.kubernetes.io/pod-name"
 	// PodUIDKey is the key used in a user's "extra" to specify the pod UID of
 	// the authenticating request.
 	PodUIDKey = "authentication.kubernetes.io/pod-uid"
+	// NodeNameKey is the key used in a user's "extra" to specify the node name of
+	// the authenticating request.
+	NodeNameKey = "authentication.kubernetes.io/node-name"
+	// NodeUIDKey is the key used in a user's "extra" to specify the node UID of
+	// the authenticating request.
+	NodeUIDKey = "authentication.kubernetes.io/node-uid"
 )
 
 // MakeUsername generates a username from the given namespace and ServiceAccount name.
@@ -119,6 +128,8 @@ func UserInfo(namespace, name, uid string) user.Info {
 type ServiceAccountInfo struct {
 	Name, Namespace, UID string
 	PodName, PodUID      string
+	CredentialID         string
+	NodeName, NodeUID    string
 }
 
 func (sa *ServiceAccountInfo) UserInfo() user.Info {
@@ -127,13 +138,41 @@ func (sa *ServiceAccountInfo) UserInfo() user.Info {
 		UID:    sa.UID,
 		Groups: MakeGroupNames(sa.Namespace),
 	}
+
 	if sa.PodName != "" && sa.PodUID != "" {
-		info.Extra = map[string][]string{
-			PodNameKey: {sa.PodName},
-			PodUIDKey:  {sa.PodUID},
+		if info.Extra == nil {
+			info.Extra = make(map[string][]string)
+		}
+		info.Extra[PodNameKey] = []string{sa.PodName}
+		info.Extra[PodUIDKey] = []string{sa.PodUID}
+	}
+	if sa.CredentialID != "" {
+		if info.Extra == nil {
+			info.Extra = make(map[string][]string)
+		}
+		info.Extra[CredentialIDKey] = []string{sa.CredentialID}
+	}
+	if sa.NodeName != "" {
+		if info.Extra == nil {
+			info.Extra = make(map[string][]string)
+		}
+		info.Extra[NodeNameKey] = []string{sa.NodeName}
+		// node UID is optional and will only be set if the node name is set
+		if sa.NodeUID != "" {
+			info.Extra[NodeUIDKey] = []string{sa.NodeUID}
 		}
 	}
+
 	return info
+}
+
+// CredentialIDForJTI converts a given JTI string into a credential identifier for use in a
+// users 'extra' info.
+func CredentialIDForJTI(jti string) string {
+	if len(jti) == 0 {
+		return ""
+	}
+	return "JTI=" + jti
 }
 
 // IsServiceAccountToken returns true if the secret is a valid api token for the service account

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_token.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_token.go
@@ -19,6 +19,7 @@ package create
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -96,12 +97,18 @@ var (
 		# Request a token bound to an instance of a Secret object with a specific UID
 		kubectl create token myapp --bound-object-kind Secret --bound-object-name mysecret --bound-object-uid 0d4691ed-659b-4935-a832-355f77ee47cc
 `)
+)
 
-	boundObjectKindToAPIVersion = map[string]string{
+func boundObjectKindToAPIVersions() map[string]string {
+	kinds := map[string]string{
 		"Pod":    "v1",
 		"Secret": "v1",
 	}
-)
+	if os.Getenv("KUBECTL_NODE_BOUND_TOKENS") == "true" {
+		kinds["Node"] = "v1"
+	}
+	return kinds
+}
 
 func NewTokenOpts(ioStreams genericiooptions.IOStreams) *TokenOptions {
 	return &TokenOptions{
@@ -144,7 +151,7 @@ func NewCmdCreateToken(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) 
 	cmd.Flags().DurationVar(&o.Duration, "duration", o.Duration, "Requested lifetime of the issued token. If not set, the lifetime will be determined by the server automatically. The server may return a token with a longer or shorter lifetime.")
 
 	cmd.Flags().StringVar(&o.BoundObjectKind, "bound-object-kind", o.BoundObjectKind, "Kind of an object to bind the token to. "+
-		"Supported kinds are "+strings.Join(sets.StringKeySet(boundObjectKindToAPIVersion).List(), ", ")+". "+
+		"Supported kinds are "+strings.Join(sets.StringKeySet(boundObjectKindToAPIVersions()).List(), ", ")+". "+
 		"If set, --bound-object-name must be provided.")
 	cmd.Flags().StringVar(&o.BoundObjectName, "bound-object-name", o.BoundObjectName, "Name of an object to bind the token to. "+
 		"The token will expire when the object is deleted. "+
@@ -221,8 +228,8 @@ func (o *TokenOptions) Validate() error {
 			return fmt.Errorf("--bound-object-uid can only be set if --bound-object-kind is provided")
 		}
 	} else {
-		if _, ok := boundObjectKindToAPIVersion[o.BoundObjectKind]; !ok {
-			return fmt.Errorf("supported --bound-object-kind values are %s", strings.Join(sets.StringKeySet(boundObjectKindToAPIVersion).List(), ", "))
+		if _, ok := boundObjectKindToAPIVersions()[o.BoundObjectKind]; !ok {
+			return fmt.Errorf("supported --bound-object-kind values are %s", strings.Join(sets.StringKeySet(boundObjectKindToAPIVersions()).List(), ", "))
 		}
 		if len(o.BoundObjectName) == 0 {
 			return fmt.Errorf("--bound-object-name is required if --bound-object-kind is provided")
@@ -245,7 +252,7 @@ func (o *TokenOptions) Run() error {
 	if len(o.BoundObjectKind) > 0 {
 		request.Spec.BoundObjectRef = &authenticationv1.BoundObjectReference{
 			Kind:       o.BoundObjectKind,
-			APIVersion: boundObjectKindToAPIVersion[o.BoundObjectKind],
+			APIVersion: boundObjectKindToAPIVersions()[o.BoundObjectKind],
 			Name:       o.BoundObjectName,
 			UID:        types.UID(o.BoundObjectUID),
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Replaces https://github.com/kubernetes/kubernetes/pull/119739

#### Which issue(s) this PR fixes:

Implements https://github.com/kubernetes/enhancements/issues/4193

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
* kube-apiserver adds alpha support (guarded by the ServiceAccountTokenJTI feature gate) for adding a `jti` (JWT ID) claim to service account tokens it issues, adding an `authentication.kubernetes.io/credential-id` audit annotation in audit logs when the tokens are issued, and `authentication.kubernetes.io/credential-id` entry in the extra user info when the token is used to authenticate.
* kube-apiserver adds alpha support (guarded by the ServiceAccountTokenPodNodeInfo feature gate) for including the node name (and uid, if the node exists) as additional claims in service account tokens it issues which are bound to pods, and `authentication.kubernetes.io/node-name` and `authentication.kubernetes.io/node-uid` extra user info when the token is used to authenticate.
* kube-apiserver adds alpha support (guarded by the ServiceAccountTokenNodeBinding feature gate) for allowing TokenRequests that bind tokens directly to nodes, and (guarded by the ServiceAccountTokenNodeBindingValidation feature gate) for validating the node name and uid still exist when the token is used.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/4193-bound-service-account-token-improvements
- [Usage]: https://github.com/kubernetes/website/pull/43590
```

---

Create a test/example pod:

```
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
spec:
  serviceAccountName: default
  containers:
  - image: debian
    name: main
    command: ["sleep", "infinity"]
```

Fetch a bound service account token for the pod:

```
kubectl create token --bound-object-kind=Pod --bound-object-name=test-pod default
```

Inspect the issued JWT:

```
{
  "aud": [
    "https://kubernetes.default.svc.cluster.local"
  ],
  "exp": 1695235074,
  "iat": 1695231474,
  "iss": "https://kubernetes.default.svc.cluster.local",
  "jti": "f49d0e9c-b48a-4bb0-88eb-518e1f983b40",
  "kubernetes.io": {
    "namespace": "default",
    "node": {
      "name": "kind-control-plane",
      "uid": "ce69eb6e-28c3-427d-94af-b42787a40255"
    },
    "pod": {
      "name": "test-pod",
      "uid": "356ec107-7eb3-4eea-bf46-17561f1605c5"
    },
    "serviceaccount": {
      "name": "default",
      "uid": "73ca6024-51c2-419c-a193-db4b639b3293"
    }
  },
  "nbf": 1695231474,
  "sub": "system:serviceaccount:default:default"
}
```