### PR TITLE
only configure swap if swap is enabled

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -320,7 +320,7 @@ func swapControllerAvailable() bool {
 	swapControllerAvailabilityOnce.Do(func() {
 		const warn = "Failed to detect the availability of the swap controller, assuming not available"
 		p := "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes"
-		if libcontainercgroups.IsCgroup2UnifiedMode() {
+		if isCgroup2UnifiedMode() {
 			// memory.swap.max does not exist in the cgroup root, so we check /sys/fs/cgroup/<SELF>/memory.swap.max
 			_, unified, err := cgroups.ParseCgroupFileUnified("/proc/self/cgroup")
 			if err != nil {

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -107,18 +107,8 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(pod *v1.Pod,
 
 	lcr.HugepageLimits = GetHugepageLimitsFromResources(container.Resources)
 
-	if swapConfigurationHelper := newSwapConfigurationHelper(*m.machineInfo); utilfeature.DefaultFeatureGate.Enabled(kubefeatures.NodeSwap) {
-		// NOTE(ehashman): Behaviour is defined in the opencontainers runtime spec:
-		// https://github.com/opencontainers/runtime-spec/blob/1c3f411f041711bbeecf35ff7e93461ea6789220/config-linux.md#memory
-		switch m.memorySwapBehavior {
-		case kubelettypes.LimitedSwap:
-			swapConfigurationHelper.ConfigureLimitedSwap(lcr, pod, container)
-		default:
-			swapConfigurationHelper.ConfigureUnlimitedSwap(lcr)
-		}
-	} else {
-		swapConfigurationHelper.ConfigureNoSwap(lcr)
-	}
+	// Configure swap for the container
+	m.configureContainerSwapResources(lcr, pod, container)
 
 	// Set memory.min and memory.high to enforce MemoryQoS
 	if enforceMemoryQoS {
@@ -168,6 +158,30 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(pod *v1.Pod,
 	}
 
 	return lcr
+}
+
+// configureContainerSwapResources configures the swap resources for a specified (linux) container.
+// Swap is only configured if a swap cgroup controller is available and the NodeSwap feature gate is enabled.
+func (m *kubeGenericRuntimeManager) configureContainerSwapResources(lcr *runtimeapi.LinuxContainerResources, pod *v1.Pod, container *v1.Container) {
+	if !swapControllerAvailable() {
+		klog.InfoS("No swap cgroup controller present", "swapBehavior", m.memorySwapBehavior, "pod", klog.KObj(pod), "containerName", container.Name)
+		return
+	}
+	swapConfigurationHelper := newSwapConfigurationHelper(*m.machineInfo)
+
+	if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.NodeSwap) {
+		swapConfigurationHelper.ConfigureNoSwap(lcr)
+		return
+	}
+
+	// NOTE(ehashman): Behavior is defined in the opencontainers runtime spec:
+	// https://github.com/opencontainers/runtime-spec/blob/1c3f411f041711bbeecf35ff7e93461ea6789220/config-linux.md#memory
+	switch m.memorySwapBehavior {
+	case kubelettypes.LimitedSwap:
+		swapConfigurationHelper.ConfigureLimitedSwap(lcr, pod, container)
+	default:
+		swapConfigurationHelper.ConfigureUnlimitedSwap(lcr)
+	}
 }
 
 // generateContainerResources generates platform specific (linux) container resources config for runtime
@@ -315,7 +329,10 @@ var (
 	swapControllerAvailabilityOnce sync.Once
 )
 
-func swapControllerAvailable() bool {
+// Note: this function variable is being added here so it would be possible to mock
+// the swap controller availability for unit tests by assigning a new function to it. Without it,
+// the swap controller availability would solely depend on the environment running the test.
+var swapControllerAvailable = func() bool {
 	// See https://github.com/containerd/containerd/pull/7838/
 	swapControllerAvailabilityOnce.Do(func() {
 		const warn = "Failed to detect the availability of the swap controller, assuming not available"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

This PR fixes the startup of kubernetes on systems using cgroupv2 where swap is not enabled. This can be demonstrated on such as system using kind and any kubernetes version of 1.28.0, 1.28.1, or 1.28.2.

Since the `memory.swap.max` value is set, this causes containerd and runc to try to write a value for the cgroup causing containers to fail when starting with messages such as:
```
Sep 20 09:48:54 k8s-dra-driver-cluster-control-plane kubelet[318]: E0920 09:48:54.918262     318 pod_workers.go:1300] "Error syncing pod, skipping" err="failed to \"StartContainer\" for \"kube-apiserver\" with RunContainerError: \"failed to create co
ntainerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error setting cgroup config for procHooks process: unable to set unified resource \\\"memory.swa
p.max\\\": open /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-poddfde4e625667960b6c2b494dd6946943.slice/cri-containerd-4085d63ae91fe66c6fd8ea3e7d2d20d3f7492ef51f11621e2dcbb7f47d345d0f.
scope/memory.swap.max: no such file or directory: unknown\"" pod="kube-system/kube-apiserver-k8s-dra-driver-cluster-control-plane" podUID="dfde4e625667960b6c2b494dd6946943"
```

This is independent of whether `NodeSwap` is enabled or not.

Note that the issue seemed to have been introduced in #118764 with the fix extending the logic added in #119486 to also be applicable to cgroupv2 systems with swap disabled.

<!--
#### Which issue(s) this PR fixes:

Fixes #
-->

#### Special notes for your reviewer:

Assuming:
* cgroupv2 is being used (`/sys/fs/cgroup/cgroup.controllers` is present)
* swap is disabled (`swapon -s` shows nothing)

This should be reproducible in kind with the following:
```
kind create cluster --retain --image kindest/node:v1.28.0 --name test-cluster
```
which will create a single-node kind cluster using k8s `v1.28.0`. This will cause an error when starting the control-plane node.

Running:
```
kind export logs --name test-cluster
```
Will ensure that the kubelet logs are available.  These can be inspected using
```
~$ grep memory.swap.max /tmp/769685610/test-cluster-control-plane/kubelet.log | tail -1
Sep 20 19:59:32 foo-control-plane kubelet[263]: E0920 19:59:32.930675     263 pod_workers.go:1300] "Error syncing pod, skipping" err="failed to \"StartContainer\" for \"etcd\" with RunContainerError: \"failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error setting cgroup config for procHooks process: unable to set unified resource \\\"memory.swap.max\\\": open /sys/fs/cgroup/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-podc576cd164244f9e5e46e146c0d642304.slice/cri-containerd-8729d25356d4538d93740e37da5106fbce905d354c50af77aae373ea9d68b010.scope/memory.swap.max: no such file or directory: unknown\"" pod="kube-system/etcd-foo-control-plane" podUID="c576cd164244f9e5e46e146c0d642304"
```
Where this particular example shows the etcd container failing to start.

Furthermore, we can confirm that this error is not present in an earlier k8s version:
```
$ kind create cluster --image kindest/node:v1.27.6 --name test-cluster
Creating cluster "test-cluster" ...
 ✓ Ensuring node image (kindest/node:v1.27.6) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-test-cluster"
You can now use your cluster with:
```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where containers would not start on cgroupv2 systems where swap is disabled.
```

<!--
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->