### PR TITLE
Handle the case where container resource and request set to minimum values

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -45,7 +45,6 @@ import (
 	"k8s.io/component-base/logs/logreduction"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
-
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/credentialprovider"
@@ -80,6 +79,11 @@ const (
 	identicalErrorDelay = 1 * time.Minute
 	// OpenTelemetry instrumentation scope name
 	instrumentationScope = "k8s.io/kubernetes/pkg/kubelet/kuberuntime"
+
+	// runtimeMinimumCPULimit is the minimum cpu in milli value set for CPU quota in cgroup.
+	runtimeMinimumCPULimit = 10
+	// runtimeMinimumCPURequest is the minimum cpu in milli value set for CPU share in cgroup.
+	runtimeMinimumCPURequest = 2
 )
 
 var (
@@ -580,10 +584,24 @@ func (m *kubeGenericRuntimeManager) computePodResizeAction(pod *v1.Pod, containe
 			currentMemoryLimit = kubeContainerStatus.Resources.MemoryLimit.Value()
 		}
 		if kubeContainerStatus.Resources.CPULimit != nil {
-			currentCPULimit = kubeContainerStatus.Resources.CPULimit.MilliValue()
+			runtimeReportedCPULimit := kubeContainerStatus.Resources.CPULimit.MilliValue()
+			// For any limit value set within runtimeMinimumCPULimit, minimum value set by runtime is runtimeMinimumCPULimit.
+			// If user tries to change values within runtimeMinimumCPULimit, set current limit as desired limit to avoid inifinite reconciliation as desiredCPULimit never be equall to runtimeReportedCPULimit.
+			if desiredCPULimit <= runtimeMinimumCPULimit && runtimeReportedCPULimit <= runtimeMinimumCPULimit {
+				currentCPULimit = desiredCPULimit
+			} else {
+				currentCPULimit = runtimeReportedCPULimit
+			}
 		}
 		if kubeContainerStatus.Resources.CPURequest != nil {
-			currentCPURequest = kubeContainerStatus.Resources.CPURequest.MilliValue()
+			runtimeReportedCPURequest := kubeContainerStatus.Resources.CPURequest.MilliValue()
+			// For any request value set within runtimeMinimumCPURequest, minimum value set by runtime is runtimeMinimumCPURequest.
+			// If user tries to change values within runtimeMinimumCPURequest, set current request as desired request to avoid inifinite reconciliation as desiredCPURequest never be equall to runtimeReportedCPURequest.
+			if desiredCPURequest <= runtimeMinimumCPURequest && runtimeReportedCPURequest <= runtimeMinimumCPURequest {
+				currentCPURequest = desiredCPURequest
+			} else {
+				currentCPURequest = runtimeReportedCPURequest
+			}
 		}
 	}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -180,7 +180,7 @@ func makeFakeContainer(t *testing.T, m *kubeGenericRuntimeManager, template cont
 	podSandboxID := apitest.BuildSandboxName(sandboxConfig.Metadata)
 	containerID := apitest.BuildContainerName(containerConfig.Metadata, podSandboxID)
 	imageRef := containerConfig.Image.Image
-	return &apitest.FakeContainer{
+	fakeContainer := &apitest.FakeContainer{
 		ContainerStatus: runtimeapi.ContainerStatus{
 			Id:          containerID,
 			Metadata:    containerConfig.Metadata,
@@ -194,6 +194,12 @@ func makeFakeContainer(t *testing.T, m *kubeGenericRuntimeManager, template cont
 		},
 		SandboxID: podSandboxID,
 	}
+	if containerConfig.Linux != nil {
+		fakeContainer.ContainerStatus.Resources = &runtimeapi.ContainerResources{
+			Linux: containerConfig.Linux.GetResources(),
+		}
+	}
+	return fakeContainer
 }
 
 // makeFakeContainers creates a group of fake containers based on the container templates.
@@ -2162,6 +2168,9 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 	m.machineInfo.MemoryCapacity = 17179860387 // 16GB
 	assert.NoError(t, err)
 
+	cpu1m := resource.MustParse("1m")
+	cpu2m := resource.MustParse("2m")
+	cpu10m := resource.MustParse("10m")
 	cpu100m := resource.MustParse("100m")
 	cpu200m := resource.MustParse("200m")
 	mem100M := resource.MustParse("100Mi")
@@ -2172,9 +2181,11 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 	memPolicyRestartRequired := v1.ContainerResizePolicy{ResourceName: v1.ResourceMemory, RestartPolicy: v1.RestartContainer}
 
 	for desc, test := range map[string]struct {
-		podResizePolicyFn       func(*v1.Pod)
-		mutatePodFn             func(*v1.Pod)
-		getExpectedPodActionsFn func(*v1.Pod, *kubecontainer.PodStatus) *podActions
+		podResizePolicyFn         func(*v1.Pod)
+		mutatePodFn               func(*v1.Pod)
+		updateContainerResourceFn func(*v1.Pod)
+		getExpectedPodActionsFn   func(*v1.Pod, *kubecontainer.PodStatus) *podActions
+		enableCFSQuota            bool
 	}{
 		"Update container CPU and memory resources": {
 			mutatePodFn: func(pod *v1.Pod) {
@@ -2462,7 +2473,126 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 				return &pa
 			},
 		},
+		"Update container CPU resources with values less than 2": {
+			enableCFSQuota: true,
+			mutatePodFn: func(pod *v1.Pod) {
+				pod.Spec.Containers[1].Resources = v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: cpu1m},
+					Limits:   v1.ResourceList{v1.ResourceCPU: cpu1m},
+				}
+				pod.Status.ContainerStatuses[1].Resources = &v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: cpu200m},
+					Limits:   v1.ResourceList{v1.ResourceCPU: cpu200m},
+				}
+				pod.Status.ContainerStatuses[1].AllocatedResources = v1.ResourceList{v1.ResourceCPU: cpu1m}
+			},
+			updateContainerResourceFn: func(pod *v1.Pod) {
+				pod.Spec.Containers[1].Resources = v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: cpu200m},
+					Limits:   v1.ResourceList{v1.ResourceCPU: cpu200m},
+				}
+			},
+			getExpectedPodActionsFn: func(pod *v1.Pod, podStatus *kubecontainer.PodStatus) *podActions {
+				kcs := podStatus.FindContainerStatusByName(pod.Spec.Containers[1].Name)
+				pa := podActions{
+					SandboxID:         podStatus.SandboxStatuses[0].Id,
+					ContainersToKill:  getKillMap(pod, podStatus, []int{}),
+					ContainersToStart: []int{},
+					ContainersToUpdate: map[v1.ResourceName][]containerToUpdateInfo{
+						v1.ResourceCPU: {
+							{
+								apiContainerIdx: 1,
+								kubeContainerID: kcs.ID,
+								desiredContainerResources: containerResources{
+									cpuRequest: cpu1m.MilliValue(),
+									cpuLimit:   cpu1m.MilliValue(),
+								},
+								currentContainerResources: &containerResources{
+									cpuRequest: cpu200m.MilliValue(),
+									cpuLimit:   cpu200m.MilliValue(),
+								},
+							},
+						},
+					},
+				}
+				return &pa
+			},
+		},
+		"Update container CPU resources when current values are minimal": {
+			enableCFSQuota: true,
+			mutatePodFn: func(pod *v1.Pod) {
+				pod.Spec.Containers[1].Resources = v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: cpu200m},
+					Limits:   v1.ResourceList{v1.ResourceCPU: cpu200m},
+				}
+				pod.Status.ContainerStatuses[1].Resources = &v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: cpu2m},
+					Limits:   v1.ResourceList{v1.ResourceCPU: cpu10m},
+				}
+				pod.Status.ContainerStatuses[1].AllocatedResources = v1.ResourceList{v1.ResourceCPU: cpu200m}
+			},
+			updateContainerResourceFn: func(pod *v1.Pod) {
+				pod.Spec.Containers[1].Resources = v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: cpu2m},
+					Limits:   v1.ResourceList{v1.ResourceCPU: cpu10m},
+				}
+			},
+			getExpectedPodActionsFn: func(pod *v1.Pod, podStatus *kubecontainer.PodStatus) *podActions {
+				kcs := podStatus.FindContainerStatusByName(pod.Spec.Containers[1].Name)
+				pa := podActions{
+					SandboxID:         podStatus.SandboxStatuses[0].Id,
+					ContainersToKill:  getKillMap(pod, podStatus, []int{}),
+					ContainersToStart: []int{},
+					ContainersToUpdate: map[v1.ResourceName][]containerToUpdateInfo{
+						v1.ResourceCPU: {
+							{
+								apiContainerIdx: 1,
+								kubeContainerID: kcs.ID,
+								desiredContainerResources: containerResources{
+									cpuRequest: cpu200m.MilliValue(),
+									cpuLimit:   cpu200m.MilliValue(),
+								},
+								currentContainerResources: &containerResources{
+									cpuRequest: cpu2m.MilliValue(),
+									cpuLimit:   cpu10m.MilliValue(),
+								},
+							},
+						},
+					},
+				}
+				return &pa
+			},
+		},
+		"Shoud not update container CPU when updating within minimal values": {
+			enableCFSQuota: true,
+			mutatePodFn: func(pod *v1.Pod) {
+				pod.Spec.Containers[1].Resources = v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: cpu1m},
+					Limits:   v1.ResourceList{v1.ResourceCPU: cpu1m},
+				}
+				pod.Status.ContainerStatuses[1].Resources = &v1.ResourceRequirements{
+					Limits: v1.ResourceList{v1.ResourceCPU: cpu10m},
+				}
+				pod.Status.ContainerStatuses[1].AllocatedResources = v1.ResourceList{v1.ResourceCPU: cpu1m}
+			},
+			updateContainerResourceFn: func(pod *v1.Pod) {
+				pod.Spec.Containers[1].Resources = v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: cpu1m},
+					Limits:   v1.ResourceList{v1.ResourceCPU: cpu10m},
+				}
+			},
+			getExpectedPodActionsFn: func(pod *v1.Pod, podStatus *kubecontainer.PodStatus) *podActions {
+				pa := podActions{
+					SandboxID:          podStatus.SandboxStatuses[0].Id,
+					ContainersToKill:   getKillMap(pod, podStatus, []int{}),
+					ContainersToStart:  []int{},
+					ContainersToUpdate: map[v1.ResourceName][]containerToUpdateInfo{},
+				}
+				return &pa
+			},
+		},
 	} {
+		m.cpuCFSQuota = test.enableCFSQuota
 		pod, kps := makeBasePodAndStatus()
 		for idx := range pod.Spec.Containers {
 			// default resize policy when pod resize feature is enabled
@@ -2470,6 +2600,9 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 		}
 		if test.podResizePolicyFn != nil {
 			test.podResizePolicyFn(pod)
+		}
+		if test.updateContainerResourceFn != nil {
+			test.updateContainerResourceFn(pod)
 		}
 		for idx := range pod.Spec.Containers {
 			// compute hash


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR contains the changes to handle the case in which the container resource request and limit set to minimum value.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #114123

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: [<link>]
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

Alpha feature code isse in KEP: https://github.com/kubernetes/enhancements/issues/1287
Previous code review discussion: https://github.com/kubernetes/kubernetes/pull/102884#discussion_r662552642

pod.yaml
```
apiVersion: v1
kind: Pod
metadata:
  name: cpu1
spec:
  containers:
  - name: ubunutu
    image: ppc64le/ubuntu:latest
    command: [ "tail", "-f", "/dev/null" ]
    resizePolicy:
    - resourceName: "memory"
      restartPolicy: "RestartContainer"
    resources:
      limits:
        cpu: "1m"
      requests:
        cpu: "1m"

```

Current behavior
```
spec:
  containers:
  - command:
    - tail
    - -f
    - /dev/null
    image: ppc64le/ubuntu:latest
    imagePullPolicy: Always
    name: ubunutu
    resizePolicy:
    - resourceName: memory
      restartPolicy: RestartContainer
    - resourceName: cpu
      restartPolicy: NotRequired
    resources:
      limits:
        cpu: 1m
      requests:
        cpu: 1m
status:
  .
  .
  .
  containerStatuses:
  - allocatedResources:
      cpu: 1m
    containerID: containerd://43baca32c3f20362057917d8ae22d8e6f820ae5320849a08304ec5891ef9215a
    image: docker.io/ppc64le/ubuntu:latest
    imageID: docker.io/ppc64le/ubuntu@sha256:de1fcbe2d7e928d0be9476e3079df8e69072dfb140be94f5d34091f09f6917dd
    lastState: {}
    name: ubunutu
    ready: true
    resources:
      limits:
        cpu: 10m
      requests:
        cpu: 2m
    restartCount: 0
```

With this PR changes
```
spec:
  containers:
  - command:
    - tail
    - -f
    - /dev/null
    image: ppc64le/ubuntu:latest
    imagePullPolicy: Always
    name: ubunutu
    resizePolicy:
    - resourceName: memory
      restartPolicy: RestartContainer
    - resourceName: cpu
      restartPolicy: NotRequired
    resources:
      limits:
        cpu: 1m
      requests:
        cpu: 1m
status:
  .
  .
  .
  containerStatuses:
  - allocatedResources:
      cpu: 1m
    containerID: containerd://20d925e79d30da8daebe343babe11b8a63bfbb5e7d864d3fa455636496790083
    image: docker.io/ppc64le/ubuntu:latest
    imageID: docker.io/ppc64le/ubuntu@sha256:de1fcbe2d7e928d0be9476e3079df8e69072dfb140be94f5d34091f09f6917dd
    lastState: {}
    name: ubunutu
    ready: true
    resources:
      limits:
        cpu: 1m
      requests:
        cpu: 1m
    restartCount: 0
    started: true
```