### PR TITLE
Fix AddUpdateAPIService for openapiv2

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
@@ -228,7 +228,7 @@ func (s *specAggregator) AddUpdateAPIService(apiService *v1.APIService, handler 
 		s.openAPIVersionedService.UpdateSpecLazy(s.buildMergeSpecLocked())
 	}
 
-	return s.updateServiceLocked(apiService.Name)
+	return nil
 }
 
 // RemoveAPIService removes an api service from OpenAPI aggregation. If it does not exist, no error is returned.

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
@@ -224,6 +224,7 @@ func (s *specAggregator) AddUpdateAPIService(apiService *v1.APIService, handler 
 			apiService: *apiService,
 			downloader: decorateError(apiService.Name, NewCacheableDownloader(s.downloader, handler)),
 		}
+		s.specByAPIServiceName[apiService.Name].spec.Store(cached.Result[*spec.Swagger]{Err: fmt.Errorf("spec for apiservice %s is not yet available", apiService.Name)})
 		s.openAPIVersionedService.UpdateSpecLazy(s.buildMergeSpecLocked())
 	}
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/downloader.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/downloader.go
@@ -21,32 +21,53 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync/atomic"
 
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/kube-openapi/pkg/cached"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
+
+type CacheableDownloader interface {
+	UpdateHandler(http.Handler)
+	Get() (*spec.Swagger, string, error)
+}
 
 // cacheableDownloader is a downloader that will always return the data
 // and the etag.
 type cacheableDownloader struct {
+	name       string
 	downloader *Downloader
-	handler    http.Handler
-	etag       string
-	spec       *spec.Swagger
+	// handler is the http Handler for the apiservice that can be replaced
+	handler atomic.Pointer[http.Handler]
+	etag    string
+	spec    *spec.Swagger
 }
 
 // NewCacheableDownloader creates a downloader that also returns the etag, making it useful to use as a cached dependency.
-func NewCacheableDownloader(downloader *Downloader, handler http.Handler) cached.Value[*spec.Swagger] {
-	return &cacheableDownloader{
+func NewCacheableDownloader(apiServiceName string, downloader *Downloader, handler http.Handler) CacheableDownloader {
+	c := &cacheableDownloader{
+		name:       apiServiceName,
 		downloader: downloader,
-		handler:    handler,
 	}
+	c.handler.Store(&handler)
+	return c
+}
+func (d *cacheableDownloader) UpdateHandler(handler http.Handler) {
+	d.handler.Store(&handler)
 }
 
 func (d *cacheableDownloader) Get() (*spec.Swagger, string, error) {
-	swagger, etag, status, err := d.downloader.Download(d.handler, d.etag)
+	spec, etag, err := d.get()
+	if err != nil {
+		return spec, etag, fmt.Errorf("failed to download %v: %v", d.name, err)
+	}
+	return spec, etag, err
+}
+
+func (d *cacheableDownloader) get() (*spec.Swagger, string, error) {
+	h := *d.handler.Load()
+	swagger, etag, status, err := d.downloader.Download(h, d.etag)
 	if err != nil {
 		return nil, "", err
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/controller.go
@@ -139,7 +139,10 @@ func (c *AggregationController) AddAPIService(handler http.Handler, apiService *
 
 // UpdateAPIService updates API Service's info and handler.
 func (c *AggregationController) UpdateAPIService(handler http.Handler, apiService *v1.APIService) {
-	if err := c.openAPIAggregationManager.AddUpdateAPIService(apiService, handler); err != nil {
+	if apiService.Spec.Service == nil {
+		return
+	}
+	if err := c.openAPIAggregationManager.UpdateAPIServiceSpec(apiService.Name); err != nil {
 		utilruntime.HandleError(fmt.Errorf("Error updating APIService %q with err: %v", apiService.Name, err))
 	}
 	key := apiService.Name

--- a/test/integration/apiserver/openapi/openapi_apiservice_test.go
+++ b/test/integration/apiserver/openapi/openapi_apiservice_test.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openapi
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	kubernetes "k8s.io/client-go/kubernetes"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	aggregator "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	testdiscovery "k8s.io/kubernetes/test/integration/apiserver/discovery"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestSlowAPIServiceOpenAPIDoesNotBlockHealthCheck(t *testing.T) {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	etcd := framework.SharedEtcd()
+	setupServer := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, etcd)
+	client := generateTestClient(t, setupServer)
+
+	service := testdiscovery.NewFakeService("test-server", client, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/openapi/v2" {
+			return
+		}
+		// Effectively let the APIService block until request timeout.
+		<-ctx.Done()
+		openapi := &spec.Swagger{
+			SwaggerProps: spec.SwaggerProps{
+				Paths: &spec.Paths{
+					Paths: map[string]spec.PathItem{
+						"/apis/wardle.example.com/v1alpha1": {},
+					},
+				},
+			},
+		}
+		data, err := openapi.MarshalJSON()
+		if err != nil {
+			t.Error(err)
+		}
+		http.ServeContent(w, r, "/openapi/v2", time.Now(), bytes.NewReader(data))
+	}))
+	go func() {
+		require.NoError(t, service.Run(ctx))
+	}()
+	require.NoError(t, service.WaitForReady(ctx))
+
+	groupVersion := metav1.GroupVersion{
+		Group:   "wardle.example.com",
+		Version: "v1alpha1",
+	}
+
+	require.NoError(t, registerAPIService(ctx, client, groupVersion, service))
+
+	setupServer.TearDownFn()
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, etcd)
+	t.Cleanup(server.TearDownFn)
+	client2 := generateTestClient(t, server)
+
+	err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 1*time.Second, true, func(context.Context) (bool, error) {
+		var statusCode int
+		client2.AdmissionregistrationV1().RESTClient().Get().AbsPath("/healthz").Do(context.TODO()).StatusCode(&statusCode)
+		if statusCode == 200 {
+			return true, nil
+		}
+		return false, nil
+	})
+	require.NoError(t, err)
+}
+
+func TestFetchingOpenAPIBeforeReady(t *testing.T) {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	defer cancelCtx()
+
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	t.Cleanup(server.TearDownFn)
+	client := generateTestClient(t, server)
+
+	readyCh := make(chan bool)
+	defer close(readyCh)
+	go func() {
+		select {
+		case <-readyCh:
+		default:
+			_, _ = client.Discovery().RESTClient().Get().AbsPath("/openapi/v2").Do(context.TODO()).Raw()
+		}
+	}()
+
+	service := testdiscovery.NewFakeService("test-server", client, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		openapi := &spec.Swagger{
+			SwaggerProps: spec.SwaggerProps{
+				Paths: &spec.Paths{
+					Paths: map[string]spec.PathItem{
+						"/apis/wardle.example.com/v1alpha1": {},
+					},
+				},
+			},
+		}
+		data, err := openapi.MarshalJSON()
+		if err != nil {
+			t.Error(err)
+		}
+		http.ServeContent(w, r, "/openapi/v2", time.Now(), bytes.NewReader(data))
+	}))
+	go func() {
+		require.NoError(t, service.Run(ctx))
+	}()
+	require.NoError(t, service.WaitForReady(ctx))
+
+	groupVersion := metav1.GroupVersion{
+		Group:   "wardle.example.com",
+		Version: "v1alpha1",
+	}
+
+	require.NoError(t, registerAPIService(ctx, client, groupVersion, service))
+	defer func() {
+		require.NoError(t, unregisterAPIService(ctx, client, groupVersion))
+	}()
+
+	err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, time.Second, true, func(context.Context) (bool, error) {
+		b, err := client.Discovery().RESTClient().Get().AbsPath("/openapi/v2").Do(context.TODO()).Raw()
+		require.NoError(t, err)
+		var openapi spec.Swagger
+		require.NoError(t, openapi.UnmarshalJSON(b))
+		if _, ok := openapi.Paths.Paths["/apis/wardle.example.com/v1alpha1"]; ok {
+			return true, nil
+		}
+		return false, nil
+	})
+	require.NoError(t, err)
+
+}
+
+// These definitions were copied from k8s.io/kubernetes/test/integation/apiserver/discovery
+// and should be consolidated.
+type kubeClientSet = kubernetes.Interface
+
+type aggegatorClientSet = aggregator.Interface
+
+type apiextensionsClientSet = apiextensions.Interface
+
+type dynamicClientset = dynamic.Interface
+
+type testClientSet struct {
+	kubeClientSet
+	aggegatorClientSet
+	apiextensionsClientSet
+	dynamicClientset
+}
+
+type testClient interface {
+	kubernetes.Interface
+	aggregator.Interface
+	apiextensions.Interface
+	dynamic.Interface
+}
+
+var _ testClient = testClientSet{}
+
+func (t testClientSet) Discovery() discovery.DiscoveryInterface {
+	return t.kubeClientSet.Discovery()
+}
+
+func generateTestClient(t *testing.T, server *kubeapiservertesting.TestServer) testClient {
+	kubeClientSet, err := kubernetes.NewForConfig(server.ClientConfig)
+	require.NoError(t, err)
+
+	aggegatorClientSet, err := aggregator.NewForConfig(server.ClientConfig)
+	require.NoError(t, err)
+
+	apiextensionsClientSet, err := apiextensions.NewForConfig(server.ClientConfig)
+	require.NoError(t, err)
+
+	dynamicClientset, err := dynamic.NewForConfig(server.ClientConfig)
+	require.NoError(t, err)
+
+	client := testClientSet{
+		kubeClientSet:          kubeClientSet,
+		aggegatorClientSet:     aggegatorClientSet,
+		apiextensionsClientSet: apiextensionsClientSet,
+		dynamicClientset:       dynamicClientset,
+	}
+	return client
+}
+
+func registerAPIService(ctx context.Context, client aggregator.Interface, gv metav1.GroupVersion, service testdiscovery.FakeService) error {
+	port := service.Port()
+	if port == nil {
+		return errors.New("service not yet started")
+	}
+	// Register the APIService
+	patch := apiregistrationv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: gv.Version + "." + gv.Group,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "APIService",
+			APIVersion: "apiregistration.k8s.io/v1",
+		},
+		Spec: apiregistrationv1.APIServiceSpec{
+			Group:                 gv.Group,
+			Version:               gv.Version,
+			InsecureSkipTLSVerify: true,
+			GroupPriorityMinimum:  1000,
+			VersionPriority:       15,
+			Service: &apiregistrationv1.ServiceReference{
+				Namespace: "default",
+				Name:      service.Name(),
+				Port:      port,
+			},
+		},
+	}
+
+	_, err := client.
+		ApiregistrationV1().
+		APIServices().
+		Create(context.TODO(), &patch, metav1.CreateOptions{FieldManager: "test-manager"})
+	return err
+}
+
+func unregisterAPIService(ctx context.Context, client aggregator.Interface, gv metav1.GroupVersion) error {
+	return client.ApiregistrationV1().APIServices().Delete(ctx, gv.Version+"."+gv.Group, metav1.DeleteOptions{})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

A couple of issues were discovered and they've been combined into this PR since they all need a backport.

For https://github.com/kubernetes/kubernetes/issues/120758: Triggered by a race when a GET to /openapi/v2 is called between https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go#L227 and https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go#L230

Fix is to initialize the cache with empty data so aggregation won't have problems.

For https://github.com/kubernetes/kubernetes/issues/120739: AddUpdateAPIService was adding and also updating the apiservice spec. The apiservice spec update should be done async by the controller.

Fix is to not update the spec in the addupdateapiservice flow during startup. This is handled async by the openapi controller.

I've discovered https://github.com/kubernetes/kubernetes/issues/120878 while working on the above two issues: The code path when an apiservice exists and needs to be updated was not handled properly. I've refactored the CacheableDownloader to have an new function `UpdateHandler()` and call that in `AddUpdateAPIService()` if the apiservice already exists. I've also removed the `decorateError` function and integrated the better logging directly in the downloader.

I've fixed the `AddUpdateAPIService` flow and added integration tests to simulate the cases described in #120758 and #120739. Added additional unit tests to catch #120878. Tried to keep the changes self contained since we need to backport.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/120758
Fixes https://github.com/kubernetes/kubernetes/issues/120739
Fixes https://github.com/kubernetes/kubernetes/issues/120878

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix regression with adding aggregated apiservices panicking and affected health check introduced in release v1.28.0
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
