### PR TITLE
Remove an old compatibility check/warning

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -91,7 +91,6 @@ const (
 )
 
 const sysctlRouteLocalnet = "net/ipv4/conf/all/route_localnet"
-const sysctlBridgeCallIPTables = "net/bridge/bridge-nf-call-iptables"
 const sysctlNFConntrackTCPBeLiberal = "net/netfilter/nf_conntrack_tcp_be_liberal"
 
 // internal struct for string service information
@@ -253,12 +252,6 @@ func NewProxier(ipFamily v1.IPFamily,
 	if val, err := sysctl.GetSysctl(sysctlNFConntrackTCPBeLiberal); err == nil && val != 0 {
 		conntrackTCPLiberal = true
 		klog.InfoS("nf_conntrack_tcp_be_liberal set, not installing DROP rules for INVALID packets")
-	}
-	// Proxy needs br_netfilter and bridge-nf-call-iptables=1 when containers
-	// are connected to a Linux bridge (but not SDN bridges).  Until most
-	// plugins handle this, log when config is missing
-	if val, err := sysctl.GetSysctl(sysctlBridgeCallIPTables); err == nil && val != 1 {
-		klog.InfoS("Missing br-netfilter module or unset sysctl br-nf-call-iptables, proxy may not work as intended")
 	}
 
 	// Generate the masquerade mark to use for SNAT rules.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig network
/priority backlog

#### What this PR does / why we need it:
kube-proxy used to unconditionally load the `br-netfilter` kernel module and set the `bridge-nf-call-iptables` sysctl. In #20647 this was moved to the kubenet plugin instead (since it is not needed and not wanted for some other network plugins), and kube-proxy was changed to just warn if `br-netfilter` was not loaded / `bridge-nf-call-iptables` was not set, with the comment "Until most plugins handle this, log when config is missing". That was seven and a half years ago. Presumably everyone got the message by now.

(Note also that the check and the warning are both IPv4-specific; to make kube-proxy work correctly with linux-bridge-based plugins under IPv6, you need to set `bridge-nf-call-ip6tables` instead. e.g., this was fixed in kubeadm in #53013, but no one ever suggested that maybe kube-proxy should warn people about that...)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

cc @dcbw 
