### PR TITLE
update rules to switch from deprecated dir field

### DIFF
--- a/hack/verify-publishing-bot.py
+++ b/hack/verify-publishing-bot.py
@@ -80,7 +80,13 @@ def main():
             continue
 
         for item in rule["branches"]:
-            if not item["source"]["dir"].endswith(rule["destination"]):
+            if "dir" in item["source"]:
+                raise Exception("use of deprecated `dir` field in rules for `%s`" % (rule["destination"]))
+            if len(item["source"]["dirs"]) > 1:
+                raise Exception("cannot have more than one directory (`%s`) per source branch `%s` of `%s`" %
+                                (item["source"]["dirs"], item["source"]["branch"], rule["destination"])
+                                )
+            if not item["source"]["dirs"][0].endswith(rule["destination"]):
                 raise Exception("copy/paste error `%s` refers to `%s`" % (rule["destination"],item["source"]["dir"]))
 
         if branch["name"] != "master":

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -4,53 +4,63 @@ rules:
   - name: master
     source:
       branch: master
-      dir: staging/src/k8s.io/code-generator
+      dirs:
+      - staging/src/k8s.io/code-generator
   - name: release-1.25
     go: 1.20.8
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/code-generator
+      dirs:
+      - staging/src/k8s.io/code-generator
   - name: release-1.26
     go: 1.20.8
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/code-generator
+      dirs:
+      - staging/src/k8s.io/code-generator
   - name: release-1.27
     go: 1.20.8
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/code-generator
+      dirs:
+      - staging/src/k8s.io/code-generator
   - name: release-1.28
     go: 1.20.8
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/code-generator
+      dirs:
+      - staging/src/k8s.io/code-generator
 - destination: apimachinery
   branches:
   - name: master
     source:
       branch: master
-      dir: staging/src/k8s.io/apimachinery
+      dirs:
+      - staging/src/k8s.io/apimachinery
   - name: release-1.25
     go: 1.20.8
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/apimachinery
+      dirs:
+      - staging/src/k8s.io/apimachinery
   - name: release-1.26
     go: 1.20.8
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/apimachinery
+      dirs:
+      - staging/src/k8s.io/apimachinery
   - name: release-1.27
     go: 1.20.8
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/apimachinery
+      dirs:
+      - staging/src/k8s.io/apimachinery
   - name: release-1.28
     go: 1.20.8
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/apimachinery
+      dirs:
+      - staging/src/k8s.io/apimachinery
   library: true
 - destination: api
   branches:
@@ -60,7 +70,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/api
+      dirs:
+      - staging/src/k8s.io/api
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -68,7 +79,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/api
+      dirs:
+      - staging/src/k8s.io/api
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -76,7 +88,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/api
+      dirs:
+      - staging/src/k8s.io/api
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -84,7 +97,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/api
+      dirs:
+      - staging/src/k8s.io/api
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -92,7 +106,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/api
+      dirs:
+      - staging/src/k8s.io/api
   library: true
 - destination: client-go
   branches:
@@ -104,7 +119,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/client-go
+      dirs:
+      - staging/src/k8s.io/client-go
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod ./...
@@ -118,7 +134,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/client-go
+      dirs:
+      - staging/src/k8s.io/client-go
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod ./...
@@ -132,7 +149,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/client-go
+      dirs:
+      - staging/src/k8s.io/client-go
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod ./...
@@ -146,7 +164,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/client-go
+      dirs:
+      - staging/src/k8s.io/client-go
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod ./...
@@ -160,7 +179,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/client-go
+      dirs:
+      - staging/src/k8s.io/client-go
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod ./...
@@ -178,7 +198,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/component-base
+      dirs:
+      - staging/src/k8s.io/component-base
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -190,7 +211,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/component-base
+      dirs:
+      - staging/src/k8s.io/component-base
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -202,7 +224,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/component-base
+      dirs:
+      - staging/src/k8s.io/component-base
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -214,7 +237,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/component-base
+      dirs:
+      - staging/src/k8s.io/component-base
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -226,7 +250,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/component-base
+      dirs:
+      - staging/src/k8s.io/component-base
   library: true
 - destination: component-helpers
   branches:
@@ -240,7 +265,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/component-helpers
+      dirs:
+      - staging/src/k8s.io/component-helpers
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -252,7 +278,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/component-helpers
+      dirs:
+      - staging/src/k8s.io/component-helpers
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -264,7 +291,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/component-helpers
+      dirs:
+      - staging/src/k8s.io/component-helpers
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -276,7 +304,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/component-helpers
+      dirs:
+      - staging/src/k8s.io/component-helpers
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -288,7 +317,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/component-helpers
+      dirs:
+      - staging/src/k8s.io/component-helpers
   library: true
 - destination: kms
   branches:
@@ -302,12 +332,14 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kms
+      dirs:
+      - staging/src/k8s.io/kms
   - name: release-1.26
     go: 1.20.8
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/kms
+      dirs:
+      - staging/src/k8s.io/kms
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -319,7 +351,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/kms
+      dirs:
+      - staging/src/k8s.io/kms
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -331,7 +364,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/kms
+      dirs:
+      - staging/src/k8s.io/kms
   library: true
 - destination: apiserver
   branches:
@@ -349,7 +383,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/apiserver
+      dirs:
+      - staging/src/k8s.io/apiserver
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -363,7 +398,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/apiserver
+      dirs:
+      - staging/src/k8s.io/apiserver
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -379,7 +415,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/apiserver
+      dirs:
+      - staging/src/k8s.io/apiserver
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -395,7 +432,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/apiserver
+      dirs:
+      - staging/src/k8s.io/apiserver
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -411,7 +449,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/apiserver
+      dirs:
+      - staging/src/k8s.io/apiserver
   library: true
 - destination: kube-aggregator
   branches:
@@ -433,7 +472,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-aggregator
+      dirs:
+      - staging/src/k8s.io/kube-aggregator
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -451,7 +491,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/kube-aggregator
+      dirs:
+      - staging/src/k8s.io/kube-aggregator
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -471,7 +512,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/kube-aggregator
+      dirs:
+      - staging/src/k8s.io/kube-aggregator
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -491,7 +533,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/kube-aggregator
+      dirs:
+      - staging/src/k8s.io/kube-aggregator
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -511,7 +554,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/kube-aggregator
+      dirs:
+      - staging/src/k8s.io/kube-aggregator
 - destination: sample-apiserver
   branches:
   - name: master
@@ -532,7 +576,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/sample-apiserver
+      dirs:
+      - staging/src/k8s.io/sample-apiserver
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
@@ -555,7 +600,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/sample-apiserver
+      dirs:
+      - staging/src/k8s.io/sample-apiserver
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
@@ -580,7 +626,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/sample-apiserver
+      dirs:
+      - staging/src/k8s.io/sample-apiserver
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
@@ -605,7 +652,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/sample-apiserver
+      dirs:
+      - staging/src/k8s.io/sample-apiserver
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
@@ -630,7 +678,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/sample-apiserver
+      dirs:
+      - staging/src/k8s.io/sample-apiserver
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
@@ -650,7 +699,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/sample-controller
+      dirs:
+      - staging/src/k8s.io/sample-controller
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
@@ -669,7 +719,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/sample-controller
+      dirs:
+      - staging/src/k8s.io/sample-controller
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
@@ -688,7 +739,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/sample-controller
+      dirs:
+      - staging/src/k8s.io/sample-controller
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
@@ -707,7 +759,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/sample-controller
+      dirs:
+      - staging/src/k8s.io/sample-controller
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
@@ -726,7 +779,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/sample-controller
+      dirs:
+      - staging/src/k8s.io/sample-controller
     required-packages:
     - k8s.io/code-generator
     smoke-test: |
@@ -752,7 +806,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/apiextensions-apiserver
+      dirs:
+      - staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
   - name: release-1.25
@@ -772,7 +827,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/apiextensions-apiserver
+      dirs:
+      - staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
@@ -794,7 +850,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/apiextensions-apiserver
+      dirs:
+      - staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
   - name: release-1.27
@@ -816,7 +873,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/apiextensions-apiserver
+      dirs:
+      - staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
   - name: release-1.28
@@ -838,7 +896,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/apiextensions-apiserver
+      dirs:
+      - staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
 - destination: metrics
@@ -855,7 +914,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/metrics
+      dirs:
+      - staging/src/k8s.io/metrics
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -869,7 +929,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/metrics
+      dirs:
+      - staging/src/k8s.io/metrics
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -883,7 +944,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/metrics
+      dirs:
+      - staging/src/k8s.io/metrics
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -897,7 +959,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/metrics
+      dirs:
+      - staging/src/k8s.io/metrics
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -911,7 +974,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/metrics
+      dirs:
+      - staging/src/k8s.io/metrics
   library: true
 - destination: cli-runtime
   branches:
@@ -925,7 +989,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/cli-runtime
+      dirs:
+      - staging/src/k8s.io/cli-runtime
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -937,7 +1002,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/cli-runtime
+      dirs:
+      - staging/src/k8s.io/cli-runtime
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -949,7 +1015,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/cli-runtime
+      dirs:
+      - staging/src/k8s.io/cli-runtime
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -961,7 +1028,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/cli-runtime
+      dirs:
+      - staging/src/k8s.io/cli-runtime
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -973,7 +1041,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/cli-runtime
+      dirs:
+      - staging/src/k8s.io/cli-runtime
   library: true
 - destination: sample-cli-plugin
   branches:
@@ -989,7 +1058,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/sample-cli-plugin
+      dirs:
+      - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -1003,7 +1073,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/sample-cli-plugin
+      dirs:
+      - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -1017,7 +1088,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/sample-cli-plugin
+      dirs:
+      - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -1031,7 +1103,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/sample-cli-plugin
+      dirs:
+      - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -1045,7 +1118,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/sample-cli-plugin
+      dirs:
+      - staging/src/k8s.io/sample-cli-plugin
 - destination: kube-proxy
   branches:
   - name: master
@@ -1060,7 +1134,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-proxy
+      dirs:
+      - staging/src/k8s.io/kube-proxy
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -1074,7 +1149,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/kube-proxy
+      dirs:
+      - staging/src/k8s.io/kube-proxy
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -1088,7 +1164,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/kube-proxy
+      dirs:
+      - staging/src/k8s.io/kube-proxy
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -1102,7 +1179,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/kube-proxy
+      dirs:
+      - staging/src/k8s.io/kube-proxy
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -1116,34 +1194,40 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/kube-proxy
+      dirs:
+      - staging/src/k8s.io/kube-proxy
   library: true
 - destination: cri-api
   branches:
   - name: master
     source:
       branch: master
-      dir: staging/src/k8s.io/cri-api
+      dirs:
+      - staging/src/k8s.io/cri-api
   - name: release-1.25
     go: 1.20.8
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/cri-api
+      dirs:
+      - staging/src/k8s.io/cri-api
   - name: release-1.26
     go: 1.20.8
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/cri-api
+      dirs:
+      - staging/src/k8s.io/cri-api
   - name: release-1.27
     go: 1.20.8
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/cri-api
+      dirs:
+      - staging/src/k8s.io/cri-api
   - name: release-1.28
     go: 1.20.8
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/cri-api
+      dirs:
+      - staging/src/k8s.io/cri-api
   library: true
 - destination: kubelet
   branches:
@@ -1165,7 +1249,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kubelet
+      dirs:
+      - staging/src/k8s.io/kubelet
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -1179,7 +1264,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/kubelet
+      dirs:
+      - staging/src/k8s.io/kubelet
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -1193,7 +1279,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/kubelet
+      dirs:
+      - staging/src/k8s.io/kubelet
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -1207,7 +1294,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/kubelet
+      dirs:
+      - staging/src/k8s.io/kubelet
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -1227,7 +1315,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/kubelet
+      dirs:
+      - staging/src/k8s.io/kubelet
   library: true
 - destination: kube-scheduler
   branches:
@@ -1243,7 +1332,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-scheduler
+      dirs:
+      - staging/src/k8s.io/kube-scheduler
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -1257,7 +1347,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/kube-scheduler
+      dirs:
+      - staging/src/k8s.io/kube-scheduler
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -1271,7 +1362,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/kube-scheduler
+      dirs:
+      - staging/src/k8s.io/kube-scheduler
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -1285,7 +1377,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/kube-scheduler
+      dirs:
+      - staging/src/k8s.io/kube-scheduler
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -1299,7 +1392,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/kube-scheduler
+      dirs:
+      - staging/src/k8s.io/kube-scheduler
   library: true
 - destination: controller-manager
   branches:
@@ -1319,7 +1413,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/controller-manager
+      dirs:
+      - staging/src/k8s.io/controller-manager
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -1335,7 +1430,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/controller-manager
+      dirs:
+      - staging/src/k8s.io/controller-manager
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -1353,7 +1449,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/controller-manager
+      dirs:
+      - staging/src/k8s.io/controller-manager
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -1371,7 +1468,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/controller-manager
+      dirs:
+      - staging/src/k8s.io/controller-manager
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -1389,7 +1487,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/controller-manager
+      dirs:
+      - staging/src/k8s.io/controller-manager
   library: true
 - destination: cloud-provider
   branches:
@@ -1413,7 +1512,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/cloud-provider
+      dirs:
+      - staging/src/k8s.io/cloud-provider
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -1433,7 +1533,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/cloud-provider
+      dirs:
+      - staging/src/k8s.io/cloud-provider
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -1455,7 +1556,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/cloud-provider
+      dirs:
+      - staging/src/k8s.io/cloud-provider
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -1477,7 +1579,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/cloud-provider
+      dirs:
+      - staging/src/k8s.io/cloud-provider
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -1499,7 +1602,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/cloud-provider
+      dirs:
+      - staging/src/k8s.io/cloud-provider
   library: true
 - destination: kube-controller-manager
   branches:
@@ -1525,7 +1629,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kube-controller-manager
+      dirs:
+      - staging/src/k8s.io/kube-controller-manager
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -1547,7 +1652,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/kube-controller-manager
+      dirs:
+      - staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -1571,7 +1677,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/kube-controller-manager
+      dirs:
+      - staging/src/k8s.io/kube-controller-manager
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -1595,7 +1702,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/kube-controller-manager
+      dirs:
+      - staging/src/k8s.io/kube-controller-manager
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -1619,7 +1727,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/kube-controller-manager
+      dirs:
+      - staging/src/k8s.io/kube-controller-manager
   library: true
 - destination: cluster-bootstrap
   branches:
@@ -1631,7 +1740,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/cluster-bootstrap
+      dirs:
+      - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -1641,7 +1751,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/cluster-bootstrap
+      dirs:
+      - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -1651,7 +1762,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/cluster-bootstrap
+      dirs:
+      - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -1661,7 +1773,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/cluster-bootstrap
+      dirs:
+      - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -1671,7 +1784,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/cluster-bootstrap
+      dirs:
+      - staging/src/k8s.io/cluster-bootstrap
   library: true
 - destination: csi-translation-lib
   branches:
@@ -1683,7 +1797,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/csi-translation-lib
+      dirs:
+      - staging/src/k8s.io/csi-translation-lib
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -1693,7 +1808,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/csi-translation-lib
+      dirs:
+      - staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -1703,7 +1819,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/csi-translation-lib
+      dirs:
+      - staging/src/k8s.io/csi-translation-lib
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -1713,7 +1830,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/csi-translation-lib
+      dirs:
+      - staging/src/k8s.io/csi-translation-lib
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -1723,34 +1841,40 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/csi-translation-lib
+      dirs:
+      - staging/src/k8s.io/csi-translation-lib
   library: true
 - destination: mount-utils
   branches:
   - name: master
     source:
       branch: master
-      dir: staging/src/k8s.io/mount-utils
+      dirs:
+      - staging/src/k8s.io/mount-utils
   - name: release-1.25
     go: 1.20.8
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/mount-utils
+      dirs:
+      - staging/src/k8s.io/mount-utils
   - name: release-1.26
     go: 1.20.8
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/mount-utils
+      dirs:
+      - staging/src/k8s.io/mount-utils
   - name: release-1.27
     go: 1.20.8
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/mount-utils
+      dirs:
+      - staging/src/k8s.io/mount-utils
   - name: release-1.28
     go: 1.20.8
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/mount-utils
+      dirs:
+      - staging/src/k8s.io/mount-utils
   library: true
 - destination: legacy-cloud-providers
   branches:
@@ -1776,7 +1900,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/legacy-cloud-providers
+      dirs:
+      - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -1802,7 +1927,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/legacy-cloud-providers
+      dirs:
+      - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -1830,7 +1956,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/legacy-cloud-providers
+      dirs:
+      - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -1854,7 +1981,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/legacy-cloud-providers
+      dirs:
+      - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -1878,7 +2006,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/legacy-cloud-providers
+      dirs:
+      - staging/src/k8s.io/legacy-cloud-providers
   library: true
 - destination: kubectl
   branches:
@@ -1902,7 +2031,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/kubectl
+      dirs:
+      - staging/src/k8s.io/kubectl
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -1924,7 +2054,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/kubectl
+      dirs:
+      - staging/src/k8s.io/kubectl
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -1946,7 +2077,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/kubectl
+      dirs:
+      - staging/src/k8s.io/kubectl
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -1968,7 +2100,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/kubectl
+      dirs:
+      - staging/src/k8s.io/kubectl
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -1990,7 +2123,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/kubectl
+      dirs:
+      - staging/src/k8s.io/kubectl
   library: true
 - destination: pod-security-admission
   branches:
@@ -2010,7 +2144,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/pod-security-admission
+      dirs:
+      - staging/src/k8s.io/pod-security-admission
   - name: release-1.25
     go: 1.20.8
     dependencies:
@@ -2026,7 +2161,8 @@ rules:
       branch: release-1.25
     source:
       branch: release-1.25
-      dir: staging/src/k8s.io/pod-security-admission
+      dirs:
+      - staging/src/k8s.io/pod-security-admission
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -2044,7 +2180,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/pod-security-admission
+      dirs:
+      - staging/src/k8s.io/pod-security-admission
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -2062,7 +2199,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/pod-security-admission
+      dirs:
+      - staging/src/k8s.io/pod-security-admission
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -2080,7 +2218,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/pod-security-admission
+      dirs:
+      - staging/src/k8s.io/pod-security-admission
   library: true
 - destination: dynamic-resource-allocation
   branches:
@@ -2102,7 +2241,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/dynamic-resource-allocation
+      dirs:
+      - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
     go: 1.20.8
     dependencies:
@@ -2118,7 +2258,8 @@ rules:
       branch: release-1.26
     source:
       branch: release-1.26
-      dir: staging/src/k8s.io/dynamic-resource-allocation
+      dirs:
+      - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.27
     go: 1.20.8
     dependencies:
@@ -2134,7 +2275,8 @@ rules:
       branch: release-1.27
     source:
       branch: release-1.27
-      dir: staging/src/k8s.io/dynamic-resource-allocation
+      dirs:
+      - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -2154,7 +2296,8 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/dynamic-resource-allocation
+      dirs:
+      - staging/src/k8s.io/dynamic-resource-allocation
 - destination: endpointslice
   branches:
   - name: master
@@ -2169,7 +2312,8 @@ rules:
       branch: master
     source:
       branch: master
-      dir: staging/src/k8s.io/endpointslice
+      dirs:
+      - staging/src/k8s.io/endpointslice
   - name: release-1.28
     go: 1.20.8
     dependencies:
@@ -2183,7 +2327,9 @@ rules:
       branch: release-1.28
     source:
       branch: release-1.28
-      dir: staging/src/k8s.io/endpointslice
+      dirs:
+      - staging/src/k8s.io/endpointslice
 recursive-delete-patterns:
 - '*/.gitattributes'
 default-go-version: 1.21.1
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`dir` field has been deprecated in favour of `dirs` field, so that multiple directories can be specified in the rules in future
when publishing-bot moves from filter-branch to filter-repo.  The change was introduced in publishing bot in https://github.com/kubernetes/publishing-bot/pull/337

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This change will be made to the rules file, next time `update-rules` command will be run for adding branch / go version upgrade. Making this change now so that, the diff is smaller and review becomes easier.  Even without this update the bot will continue to function as is. But making sure that the deprecated fields are not used anywhere. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
