### PR TITLE
Add an option to use `RenewTime` in leader election

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -349,7 +349,7 @@ func (le *LeaderElector) tryAcquireOrRenew(ctx context.Context) bool {
 		le.observedRawRecord = oldLeaderElectionRawRecord
 	}
 	if len(oldLeaderElectionRecord.HolderIdentity) > 0 &&
-		le.observedTime.Add(time.Second*time.Duration(oldLeaderElectionRecord.LeaseDurationSeconds)).After(now.Time) &&
+		oldLeaderElectionRecord.AcquireTime.Add(time.Second*time.Duration(oldLeaderElectionRecord.LeaseDurationSeconds)).After(now.Time) &&
 		!le.IsLeader() {
 		klog.V(4).Infof("lock is held by %v and has not yet expired", oldLeaderElectionRecord.HolderIdentity)
 		return false

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -29,7 +29,7 @@ limitations under the License.
 //
 // In a scenario where the clock skew within candidates is bounded by a given threshold
 // `ClockSkewToleration`, it is possible to set `UseRenewTime` to decide if the
-// candidate should try to acquire the object.
+// candidate should try to acquire the object based on the timestamp of the leader token.
 //
 // However the level of tolerance to skew rate can be configured by setting
 // RenewDeadline and LeaseDuration appropriately. The tolerance expressed as a

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -349,7 +349,7 @@ func (le *LeaderElector) tryAcquireOrRenew(ctx context.Context) bool {
 		le.observedRawRecord = oldLeaderElectionRawRecord
 	}
 	if len(oldLeaderElectionRecord.HolderIdentity) > 0 &&
-		oldLeaderElectionRecord.AcquireTime.Add(time.Second*time.Duration(oldLeaderElectionRecord.LeaseDurationSeconds)).After(now.Time) &&
+		oldLeaderElectionRecord.RenewTime.Add(time.Second*time.Duration(oldLeaderElectionRecord.LeaseDurationSeconds)).After(now.Time) &&
 		!le.IsLeader() {
 		klog.V(4).Infof("lock is held by %v and has not yet expired", oldLeaderElectionRecord.HolderIdentity)
 		return false

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
@@ -83,7 +83,6 @@ func testTryAcquireOrRenew(t *testing.T, objectType string) {
 	tests := []struct {
 		name           string
 		observedRecord rl.LeaderElectionRecord
-		observedTime   time.Time
 		retryAfter     time.Duration
 		reactors       []Reactor
 		expectedEvents []string
@@ -195,8 +194,7 @@ func testTryAcquireOrRenew(t *testing.T, objectType string) {
 					},
 				},
 			},
-			observedRecord: rl.LeaderElectionRecord{HolderIdentity: "bing"},
-			observedTime:   past,
+			observedRecord: rl.LeaderElectionRecord{HolderIdentity: "bing", AcquireTime: metav1.NewTime(past)},
 
 			expectSuccess:    true,
 			transitionLeader: true,
@@ -218,7 +216,7 @@ func testTryAcquireOrRenew(t *testing.T, objectType string) {
 					},
 				},
 			},
-			observedTime: future,
+			observedRecord: rl.LeaderElectionRecord{HolderIdentity: "baz", AcquireTime: metav1.NewTime(future)},
 
 			expectSuccess:    true,
 			transitionLeader: true,
@@ -234,7 +232,7 @@ func testTryAcquireOrRenew(t *testing.T, objectType string) {
 					},
 				},
 			},
-			observedTime: future,
+			observedRecord: rl.LeaderElectionRecord{HolderIdentity: "baz", AcquireTime: metav1.NewTime(future)},
 
 			expectSuccess: false,
 			outHolder:     "bing",
@@ -255,8 +253,7 @@ func testTryAcquireOrRenew(t *testing.T, objectType string) {
 					},
 				},
 			},
-			observedTime:   future,
-			observedRecord: rl.LeaderElectionRecord{HolderIdentity: "baz"},
+			observedRecord: rl.LeaderElectionRecord{HolderIdentity: "baz", AcquireTime: metav1.NewTime(future)},
 
 			expectSuccess: true,
 			outHolder:     "baz",
@@ -313,7 +310,6 @@ func testTryAcquireOrRenew(t *testing.T, objectType string) {
 				config:            lec,
 				observedRecord:    test.observedRecord,
 				observedRawRecord: observedRawRecord,
-				observedTime:      test.observedTime,
 				clock:             clock,
 			}
 			if test.expectSuccess != le.tryAcquireOrRenew(context.Background()) {
@@ -401,7 +397,6 @@ func testReleaseLease(t *testing.T, objectType string) {
 	tests := []struct {
 		name           string
 		observedRecord rl.LeaderElectionRecord
-		observedTime   time.Time
 		reactors       []Reactor
 		expectedEvents []string
 
@@ -489,7 +484,6 @@ func testReleaseLease(t *testing.T, objectType string) {
 				config:            lec,
 				observedRecord:    test.observedRecord,
 				observedRawRecord: observedRawRecord,
-				observedTime:      test.observedTime,
 				clock:             clock.RealClock{},
 			}
 			if !le.tryAcquireOrRenew(context.Background()) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR proposes an option to use the lease field `RenewTime` to choose if a leader should be replaced.
Currently, we use the `observedTime` for this decision which is tolerant to clock skew within a same cluster. It means that even if the lease has expired, candidates that observe it for the first time won't try to acquire it.
It could be observed with a simple new test case under `testTryAcquireOrRenew` which doesn't pass on the current master branch:
```
		{
			name: "first acquisition of expired object",
			reactors: []Reactor{
				{
					verb: "get",
					reaction: func(action fakeclient.Action) (handled bool, ret runtime.Object, err error) {
						return true, createLockObject(t, objectType, action.GetNamespace(), action.(fakeclient.GetAction).GetName(), &rl.LeaderElectionRecord{HolderIdentity: "bing", AcquireTime: metav1.NewTime(past), RenewTime: metav1.NewTime(past)}), nil
					},
				},
				{
					verb: "update",
					reaction: func(action fakeclient.Action) (handled bool, ret runtime.Object, err error) {
						return true, action.(fakeclient.CreateAction).GetObject(), nil
					},
				},
			},
			expectSuccess:    true,
			transitionLeader: true,
			outHolder:        "baz",
		},
```
This behavior is desirable in a scenario where the different nodes of a same cluster might be out of sync. However, for many use cases, we can assume that the clock skew is bounded.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
