### PR TITLE
Fix panic testing intree vSphere dynamic PV.

### DIFF
--- a/test/e2e/storage/vsphere/vsphere_utils.go
+++ b/test/e2e/storage/vsphere/vsphere_utils.go
@@ -753,13 +753,15 @@ func getUUIDFromProviderID(providerID string) string {
 
 // GetReadySchedulableNodeInfos returns NodeInfo objects for all nodes with Ready and schedulable state
 func GetReadySchedulableNodeInfos(ctx context.Context, c clientset.Interface) []*NodeInfo {
-	nodeList, err := e2enode.GetReadySchedulableNodes(ctx, c)
-	framework.ExpectNoError(err)
 	var nodesInfo []*NodeInfo
-	for _, node := range nodeList.Items {
-		nodeInfo := TestContext.NodeMapper.GetNodeInfo(node.Name)
-		if nodeInfo != nil {
-			nodesInfo = append(nodesInfo, nodeInfo)
+	if TestContext.NodeMapper != nil {
+		nodeList, err := e2enode.GetReadySchedulableNodes(ctx, c)
+		framework.ExpectNoError(err)
+		for _, node := range nodeList.Items {
+			nodeInfo := TestContext.NodeMapper.GetNodeInfo(node.Name)
+			if nodeInfo != nil {
+				nodesInfo = append(nodesInfo, nodeInfo)
+			}
 		}
 	}
 	return nodesInfo


### PR DESCRIPTION
Change-Id: I9d1ee7f49f01c3308b967d84865fa6bcfafc4b0d

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Fix the panic during e2e test against dynamic / ephemeral volume of vSphere intree volume plugin:
```
  [PANICKED] Test Panicked
  In [DeferCleanup (Each)] at: /usr/local/go/src/runtime/panic.go:260 @ 09/14/23 18:40:20.306
  runtime error: invalid memory address or nil pointer dereference
  Full Stack Trace
    k8s.io/kubernetes/test/e2e/storage/vsphere.(*NodeMapper).GetNodeInfo(0x7fd41017ff30?, {0xc0028caec0?, 0x0?})
    	test/e2e/storage/vsphere/nodemapper.go:294 +0x37
    k8s.io/kubernetes/test/e2e/storage/vsphere.GetReadySchedulableNodeInfos({0x7fd41017ff30?, 0xc002593b00?}, {0x7496170?, 0xc001b4cea0?})
    	test/e2e/storage/vsphere/vsphere_utils.go:760 +0xfa
    k8s.io/kubernetes/test/e2e/storage/drivers.(*vSphereDriver).PrepareTest.func1({0x7fd41017ff30, 0xc002593b00})
    	test/e2e/storage/drivers/in_tree.go:1287 +0x33
    reflect.Value.call({0x5fc19e0?, 0xc001121070?, 0xc002844f08?}, {0x6c78c1b, 0x4}, {0xc002844f60, 0x1, 0xc002844eb0?})
    	/usr/local/go/src/reflect/value.go:586 +0xb07
    reflect.Value.Call({0x5fc19e0?, 0xc001121070?, 0x0?}, {0xc002844f60?, 0xc002844ed8?, 0xc0028828f8?})
    	/usr/local/go/src/reflect/value.go:370 +0xbc
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

RCA:
Above panic is introduced by fix in #120101.

VSphere intree storage plugin test invokes `vsphere.GetReadySchedulableNodeInfos` during test teardown, which accesses `TestContext.NodeMapper`.

Note that `TestContext.NodeMapper` is only initialized by `vsphere.Bootstrap`:
https://github.com/kubernetes/kubernetes/blob/3ac83f528dde9d6f37f0ca164d5642226f2380a7/test/e2e/storage/vsphere/bootstrap.go#L54C11-L54C11

and the latter is invoked upon provisioning volumes for pre-provision volume test:
https://github.com/kubernetes/kubernetes/blob/3ac83f528dde9d6f37f0ca164d5642226f2380a7/test/e2e/storage/drivers/in_tree.go#L1305

For vsphere intree storage plugin test against dynamically provisioned volumes or ephemeral volumes, no `Bootstrap` is invoked and the test will then hit this panic:
https://github.com/kubernetes/kubernetes/blob/3ac83f528dde9d6f37f0ca164d5642226f2380a7/test/e2e/storage/framework/driver_operations.go#L41



#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
