### PR TITLE
use generic Set instead of sets.String in apis

### DIFF
--- a/pkg/apis/autoscaling/validation/validation.go
+++ b/pkg/apis/autoscaling/validation/validation.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"fmt"
+
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	pathvalidation "k8s.io/apimachinery/pkg/api/validation/path"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -187,8 +188,8 @@ func validateBehavior(behavior *autoscaling.HorizontalPodAutoscalerBehavior, fld
 	return allErrs
 }
 
-var validSelectPolicyTypes = sets.NewString(string(autoscaling.MaxPolicySelect), string(autoscaling.MinPolicySelect), string(autoscaling.DisabledPolicySelect))
-var validSelectPolicyTypesList = validSelectPolicyTypes.List()
+var validSelectPolicyTypes = sets.New[string](string(autoscaling.MaxPolicySelect), string(autoscaling.MinPolicySelect), string(autoscaling.DisabledPolicySelect))
+var validSelectPolicyTypesList = sets.List[string](validSelectPolicyTypes)
 
 func validateScalingRules(rules *autoscaling.HPAScalingRules, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -217,8 +218,8 @@ func validateScalingRules(rules *autoscaling.HPAScalingRules, fldPath *field.Pat
 	return allErrs
 }
 
-var validPolicyTypes = sets.NewString(string(autoscaling.PodsScalingPolicy), string(autoscaling.PercentScalingPolicy))
-var validPolicyTypesList = validPolicyTypes.List()
+var validPolicyTypes = sets.New[string](string(autoscaling.PodsScalingPolicy), string(autoscaling.PercentScalingPolicy))
+var validPolicyTypesList = sets.List[string](validPolicyTypes)
 
 func validateScalingPolicy(policy autoscaling.HPAScalingPolicy, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -238,11 +239,11 @@ func validateScalingPolicy(policy autoscaling.HPAScalingPolicy, fldPath *field.P
 	return allErrs
 }
 
-var validMetricSourceTypes = sets.NewString(
+var validMetricSourceTypes = sets.New[string](
 	string(autoscaling.ObjectMetricSourceType), string(autoscaling.PodsMetricSourceType),
 	string(autoscaling.ResourceMetricSourceType), string(autoscaling.ExternalMetricSourceType),
 	string(autoscaling.ContainerResourceMetricSourceType))
-var validMetricSourceTypesList = validMetricSourceTypes.List()
+var validMetricSourceTypesList = sets.List[string](validMetricSourceTypes)
 
 func validateMetricSpec(spec autoscaling.MetricSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -255,7 +256,7 @@ func validateMetricSpec(spec autoscaling.MetricSpec, fldPath *field.Path) field.
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("type"), spec.Type, validMetricSourceTypesList))
 	}
 
-	typesPresent := sets.NewString()
+	typesPresent := sets.New[string]()
 	if spec.Object != nil {
 		typesPresent.Insert("object")
 		if typesPresent.Len() == 1 {

--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -274,7 +274,7 @@ func validatePodFailurePolicy(spec *batch.JobSpec, fldPath *field.Path) field.Er
 	if len(spec.PodFailurePolicy.Rules) > maxPodFailurePolicyRules {
 		allErrs = append(allErrs, field.TooMany(rulesPath, len(spec.PodFailurePolicy.Rules), maxPodFailurePolicyRules))
 	}
-	containerNames := sets.NewString()
+	containerNames := sets.New[string]()
 	for _, containerSpec := range spec.Template.Spec.Containers {
 		containerNames.Insert(containerSpec.Name)
 	}
@@ -303,7 +303,7 @@ func validatePodReplacementPolicy(spec *batch.JobSpec, fldPath *field.Path) fiel
 	return allErrs
 }
 
-func validatePodFailurePolicyRule(spec *batch.JobSpec, rule *batch.PodFailurePolicyRule, rulePath *field.Path, containerNames sets.String) field.ErrorList {
+func validatePodFailurePolicyRule(spec *batch.JobSpec, rule *batch.PodFailurePolicyRule, rulePath *field.Path, containerNames sets.Set[string]) field.ErrorList {
 	var allErrs field.ErrorList
 	actionPath := rulePath.Child("action")
 	if rule.Action == "" {
@@ -348,7 +348,7 @@ func validatePodFailurePolicyRuleOnPodConditions(onPodConditions []batch.PodFail
 	return allErrs
 }
 
-func validatePodFailurePolicyRuleOnExitCodes(onExitCode *batch.PodFailurePolicyOnExitCodesRequirement, onExitCodesPath *field.Path, containerNames sets.String) field.ErrorList {
+func validatePodFailurePolicyRuleOnExitCodes(onExitCode *batch.PodFailurePolicyOnExitCodesRequirement, onExitCodesPath *field.Path, containerNames sets.Set[string]) field.ErrorList {
 	var allErrs field.ErrorList
 	operatorPath := onExitCodesPath.Child("operator")
 	if onExitCode.Operator == "" {
@@ -402,7 +402,7 @@ func validateJobStatus(status *batch.JobStatus, fldPath *field.Path) field.Error
 	}
 	if status.UncountedTerminatedPods != nil {
 		path := fldPath.Child("uncountedTerminatedPods")
-		seen := sets.NewString()
+		seen := sets.New[string]()
 		for i, k := range status.UncountedTerminatedPods.Succeeded {
 			p := path.Child("succeeded").Index(i)
 			if k == "" {

--- a/pkg/apis/certificates/helpers.go
+++ b/pkg/apis/certificates/helpers.go
@@ -51,21 +51,21 @@ var (
 )
 
 var (
-	kubeletServingRequiredUsages = sets.NewString(
+	kubeletServingRequiredUsages = sets.New[string](
 		string(UsageDigitalSignature),
 		string(UsageKeyEncipherment),
 		string(UsageServerAuth),
 	)
-	kubeletServingRequiredUsagesNoRSA = sets.NewString(
+	kubeletServingRequiredUsagesNoRSA = sets.New[string](
 		string(UsageDigitalSignature),
 		string(UsageServerAuth),
 	)
 )
 
-func IsKubeletServingCSR(req *x509.CertificateRequest, usages sets.String) bool {
+func IsKubeletServingCSR(req *x509.CertificateRequest, usages sets.Set[string]) bool {
 	return ValidateKubeletServingCSR(req, usages) == nil
 }
-func ValidateKubeletServingCSR(req *x509.CertificateRequest, usages sets.String) error {
+func ValidateKubeletServingCSR(req *x509.CertificateRequest, usages sets.Set[string]) error {
 	if !reflect.DeepEqual([]string{"system:nodes"}, req.Subject.Organization) {
 		return organizationNotSystemNodesErr
 	}
@@ -83,7 +83,7 @@ func ValidateKubeletServingCSR(req *x509.CertificateRequest, usages sets.String)
 	}
 
 	if !kubeletServingRequiredUsages.Equal(usages) && !kubeletServingRequiredUsagesNoRSA.Equal(usages) {
-		return fmt.Errorf("usages did not match %v", kubeletServingRequiredUsages.List())
+		return fmt.Errorf("usages did not match %v", sets.List[string](kubeletServingRequiredUsages))
 	}
 
 	if !strings.HasPrefix(req.Subject.CommonName, "system:node:") {
@@ -94,21 +94,21 @@ func ValidateKubeletServingCSR(req *x509.CertificateRequest, usages sets.String)
 }
 
 var (
-	kubeletClientRequiredUsagesNoRSA = sets.NewString(
+	kubeletClientRequiredUsagesNoRSA = sets.New[string](
 		string(UsageDigitalSignature),
 		string(UsageClientAuth),
 	)
-	kubeletClientRequiredUsages = sets.NewString(
+	kubeletClientRequiredUsages = sets.New[string](
 		string(UsageDigitalSignature),
 		string(UsageKeyEncipherment),
 		string(UsageClientAuth),
 	)
 )
 
-func IsKubeletClientCSR(req *x509.CertificateRequest, usages sets.String) bool {
+func IsKubeletClientCSR(req *x509.CertificateRequest, usages sets.Set[string]) bool {
 	return ValidateKubeletClientCSR(req, usages) == nil
 }
-func ValidateKubeletClientCSR(req *x509.CertificateRequest, usages sets.String) error {
+func ValidateKubeletClientCSR(req *x509.CertificateRequest, usages sets.Set[string]) error {
 	if !reflect.DeepEqual([]string{"system:nodes"}, req.Subject.Organization) {
 		return organizationNotSystemNodesErr
 	}
@@ -131,7 +131,7 @@ func ValidateKubeletClientCSR(req *x509.CertificateRequest, usages sets.String) 
 	}
 
 	if !kubeletClientRequiredUsages.Equal(usages) && !kubeletClientRequiredUsagesNoRSA.Equal(usages) {
-		return fmt.Errorf("usages did not match %v", kubeletClientRequiredUsages.List())
+		return fmt.Errorf("usages did not match %v", sets.List[string](kubeletClientRequiredUsages))
 	}
 
 	return nil

--- a/pkg/apis/certificates/v1beta1/defaults.go
+++ b/pkg/apis/certificates/v1beta1/defaults.go
@@ -73,8 +73,8 @@ func IsKubeletClientCSR(req *x509.CertificateRequest, usages []certificatesv1bet
 	return certificates.IsKubeletClientCSR(req, usagesToSet(usages))
 }
 
-func usagesToSet(usages []certificatesv1beta1.KeyUsage) sets.String {
-	result := sets.NewString()
+func usagesToSet(usages []certificatesv1beta1.KeyUsage) sets.Set[string] {
+	result := sets.New[string]()
 	for _, usage := range usages {
 		result.Insert(string(usage))
 	}

--- a/pkg/apis/certificates/validation/validation.go
+++ b/pkg/apis/certificates/validation/validation.go
@@ -37,14 +37,14 @@ import (
 
 var (
 	// trueConditionTypes is the set of condition types which may only have a status of True if present
-	trueConditionTypes = sets.NewString(
+	trueConditionTypes = sets.New[string](
 		string(certificates.CertificateApproved),
 		string(certificates.CertificateDenied),
 		string(certificates.CertificateFailed),
 	)
 
-	trueStatusOnly  = sets.NewString(string(v1.ConditionTrue))
-	allStatusValues = sets.NewString(string(v1.ConditionTrue), string(v1.ConditionFalse), string(v1.ConditionUnknown))
+	trueStatusOnly  = sets.New[string](string(v1.ConditionTrue))
+	allStatusValues = sets.New[string](string(v1.ConditionTrue), string(v1.ConditionFalse), string(v1.ConditionUnknown))
 )
 
 type certificateValidationOptions struct {
@@ -140,7 +140,7 @@ func ValidateCertificateSigningRequestCreate(csr *certificates.CertificateSignin
 }
 
 var (
-	allValidUsages = sets.NewString(
+	allValidUsages = sets.New[string](
 		string(certificates.UsageSigning),
 		string(certificates.UsageDigitalSignature),
 		string(certificates.UsageContentCommitment),
@@ -182,7 +182,7 @@ func validateCertificateSigningRequest(csr *certificates.CertificateSigningReque
 	if !opts.allowUnknownUsages {
 		for i, usage := range csr.Spec.Usages {
 			if !allValidUsages.Has(string(usage)) {
-				allErrs = append(allErrs, field.NotSupported(specPath.Child("usages").Index(i), usage, allValidUsages.List()))
+				allErrs = append(allErrs, field.NotSupported(specPath.Child("usages").Index(i), usage, sets.List[string](allValidUsages)))
 			}
 		}
 	}
@@ -237,7 +237,7 @@ func validateConditions(fldPath *field.Path, csr *certificates.CertificateSignin
 		case c.Status == "":
 			allErrs = append(allErrs, field.Required(fldPath.Index(i).Child("status"), ""))
 		case !allowedStatusValues.Has(string(c.Status)):
-			allErrs = append(allErrs, field.NotSupported(fldPath.Index(i).Child("status"), c.Status, allowedStatusValues.List()))
+			allErrs = append(allErrs, field.NotSupported(fldPath.Index(i).Child("status"), c.Status, sets.List[string](allowedStatusValues)))
 		}
 
 		if !opts.allowBothApprovedAndDenied {

--- a/pkg/apis/certificates/validation/validation_test.go
+++ b/pkg/apis/certificates/validation/validation_test.go
@@ -353,8 +353,8 @@ func TestValidateCertificateSigningRequestCreate(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				field.NotSupported(specPath.Child("usages").Index(0), capi.KeyUsage("unknown"), allValidUsages.List()),
-				field.NotSupported(specPath.Child("usages").Index(1), capi.KeyUsage("unknown"), allValidUsages.List()),
+				field.NotSupported(specPath.Child("usages").Index(0), capi.KeyUsage("unknown"), sets.List[string](allValidUsages)),
+				field.NotSupported(specPath.Child("usages").Index(1), capi.KeyUsage("unknown"), sets.List[string](allValidUsages)),
 				field.Duplicate(specPath.Child("usages").Index(1), capi.KeyUsage("unknown")),
 			},
 		},
@@ -586,15 +586,15 @@ func TestValidateCertificateSigningRequestUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotErrs := sets.NewString()
+			gotErrs := sets.New[string]()
 			for _, err := range ValidateCertificateSigningRequestUpdate(tt.newCSR, tt.oldCSR) {
 				gotErrs.Insert(err.Error())
 			}
-			wantErrs := sets.NewString(tt.errs...)
-			for _, missing := range wantErrs.Difference(gotErrs).List() {
+			wantErrs := sets.New[string](tt.errs...)
+			for _, missing := range sets.List[string](wantErrs.Difference(gotErrs)) {
 				t.Errorf("missing expected error: %s", missing)
 			}
-			for _, unexpected := range gotErrs.Difference(wantErrs).List() {
+			for _, unexpected := range sets.List[string](gotErrs.Difference(wantErrs)) {
 				t.Errorf("unexpected error: %s", unexpected)
 			}
 		})
@@ -722,15 +722,15 @@ func TestValidateCertificateSigningRequestStatusUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotErrs := sets.NewString()
+			gotErrs := sets.New[string]()
 			for _, err := range ValidateCertificateSigningRequestStatusUpdate(tt.newCSR, tt.oldCSR) {
 				gotErrs.Insert(err.Error())
 			}
-			wantErrs := sets.NewString(tt.errs...)
-			for _, missing := range wantErrs.Difference(gotErrs).List() {
+			wantErrs := sets.New[string](tt.errs...)
+			for _, missing := range sets.List[string](wantErrs.Difference(gotErrs)) {
 				t.Errorf("missing expected error: %s", missing)
 			}
-			for _, unexpected := range gotErrs.Difference(wantErrs).List() {
+			for _, unexpected := range sets.List[string](gotErrs.Difference(wantErrs)) {
 				t.Errorf("unexpected error: %s", unexpected)
 			}
 		})
@@ -822,15 +822,15 @@ func TestValidateCertificateSigningRequestApprovalUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotErrs := sets.NewString()
+			gotErrs := sets.New[string]()
 			for _, err := range ValidateCertificateSigningRequestApprovalUpdate(tt.newCSR, tt.oldCSR) {
 				gotErrs.Insert(err.Error())
 			}
-			wantErrs := sets.NewString(tt.errs...)
-			for _, missing := range wantErrs.Difference(gotErrs).List() {
+			wantErrs := sets.New[string](tt.errs...)
+			for _, missing := range sets.List[string](wantErrs.Difference(gotErrs)) {
 				t.Errorf("missing expected error: %s", missing)
 			}
-			for _, unexpected := range gotErrs.Difference(wantErrs).List() {
+			for _, unexpected := range sets.List[string](gotErrs.Difference(wantErrs)) {
 				t.Errorf("unexpected error: %s", unexpected)
 			}
 		})
@@ -1013,7 +1013,7 @@ func Test_validateCertificateSigningRequestOptions(t *testing.T) {
 			}
 
 			// make sure the strict options produce the expected errors
-			gotErrs := sets.NewString()
+			gotErrs := sets.New[string]()
 			for _, err := range validateCertificateSigningRequest(tt.csr, certificateValidationOptions{}) {
 				gotErrs.Insert(err.Error())
 			}
@@ -1021,7 +1021,7 @@ func Test_validateCertificateSigningRequestOptions(t *testing.T) {
 			// filter errors matching strictRegexes and ensure every strictRegex matches at least one error
 			for _, expectedRegex := range tt.strictRegexes {
 				matched := false
-				for _, err := range gotErrs.List() {
+				for _, err := range sets.List[string](gotErrs) {
 					if expectedRegex.MatchString(err) {
 						gotErrs.Delete(err)
 						matched = true
@@ -1032,11 +1032,11 @@ func Test_validateCertificateSigningRequestOptions(t *testing.T) {
 				}
 			}
 
-			wantErrs := sets.NewString(tt.strictErrs...)
-			for _, missing := range wantErrs.Difference(gotErrs).List() {
+			wantErrs := sets.New[string](tt.strictErrs...)
+			for _, missing := range sets.List[string](wantErrs.Difference(gotErrs)) {
 				t.Errorf("missing expected strict error: %s", missing)
 			}
-			for _, unexpected := range gotErrs.Difference(wantErrs).List() {
+			for _, unexpected := range sets.List[string](gotErrs.Difference(wantErrs)) {
 				t.Errorf("unexpected errors: %s", unexpected)
 			}
 		})

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -113,7 +113,7 @@ var Semantic = conversion.EqualitiesOrDie(
 	},
 )
 
-var standardResourceQuotaScopes = sets.NewString(
+var standardResourceQuotaScopes = sets.New[string](
 	string(core.ResourceQuotaScopeTerminating),
 	string(core.ResourceQuotaScopeNotTerminating),
 	string(core.ResourceQuotaScopeBestEffort),
@@ -126,11 +126,11 @@ func IsStandardResourceQuotaScope(str string) bool {
 	return standardResourceQuotaScopes.Has(str) || str == string(core.ResourceQuotaScopeCrossNamespacePodAffinity)
 }
 
-var podObjectCountQuotaResources = sets.NewString(
+var podObjectCountQuotaResources = sets.New[string](
 	string(core.ResourcePods),
 )
 
-var podComputeQuotaResources = sets.NewString(
+var podComputeQuotaResources = sets.New[string](
 	string(core.ResourceCPU),
 	string(core.ResourceMemory),
 	string(core.ResourceLimitsCPU),
@@ -152,7 +152,7 @@ func IsResourceQuotaScopeValidForResource(scope core.ResourceQuotaScope, resourc
 	}
 }
 
-var standardContainerResources = sets.NewString(
+var standardContainerResources = sets.New[string](
 	string(core.ResourceCPU),
 	string(core.ResourceMemory),
 	string(core.ResourceEphemeralStorage),
@@ -196,7 +196,7 @@ func IsOvercommitAllowed(name core.ResourceName) bool {
 		!IsHugePageResourceName(name)
 }
 
-var standardLimitRangeTypes = sets.NewString(
+var standardLimitRangeTypes = sets.New[string](
 	string(core.LimitTypePod),
 	string(core.LimitTypeContainer),
 	string(core.LimitTypePersistentVolumeClaim),
@@ -207,7 +207,7 @@ func IsStandardLimitRangeType(str string) bool {
 	return standardLimitRangeTypes.Has(str)
 }
 
-var standardQuotaResources = sets.NewString(
+var standardQuotaResources = sets.New[string](
 	string(core.ResourceCPU),
 	string(core.ResourceMemory),
 	string(core.ResourceEphemeralStorage),
@@ -235,7 +235,7 @@ func IsStandardQuotaResourceName(str string) bool {
 	return standardQuotaResources.Has(str) || IsQuotaHugePageResourceName(core.ResourceName(str))
 }
 
-var standardResources = sets.NewString(
+var standardResources = sets.New[string](
 	string(core.ResourceCPU),
 	string(core.ResourceMemory),
 	string(core.ResourceEphemeralStorage),
@@ -263,7 +263,7 @@ func IsStandardResourceName(str string) bool {
 	return standardResources.Has(str) || IsQuotaHugePageResourceName(core.ResourceName(str))
 }
 
-var integerResources = sets.NewString(
+var integerResources = sets.New[string](
 	string(core.ResourcePods),
 	string(core.ResourceQuotas),
 	string(core.ResourceServices),
@@ -289,7 +289,7 @@ func IsServiceIPSet(service *core.Service) bool {
 		service.Spec.ClusterIP != core.ClusterIPNone
 }
 
-var standardFinalizers = sets.NewString(
+var standardFinalizers = sets.New[string](
 	string(core.FinalizerKubernetes),
 	metav1.FinalizerOrphanDependents,
 	metav1.FinalizerDeleteDependents,

--- a/pkg/apis/core/helper/qos/qos.go
+++ b/pkg/apis/core/helper/qos/qos.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/core"
 )
 
-var supportedQoSComputeResources = sets.NewString(string(core.ResourceCPU), string(core.ResourceMemory))
+var supportedQoSComputeResources = sets.New[string](string(core.ResourceCPU), string(core.ResourceMemory))
 
 func isSupportedQoSComputeResource(name core.ResourceName) bool {
 	return supportedQoSComputeResources.Has(string(name))
@@ -71,7 +71,7 @@ func ComputePodQOS(pod *core.Pod) core.PodQOSClass {
 			}
 		}
 		// process limits
-		qosLimitsFound := sets.NewString()
+		qosLimitsFound := sets.New[string]()
 		for name, quantity := range container.Resources.Limits {
 			if !isSupportedQoSComputeResource(name) {
 				continue

--- a/pkg/apis/core/v1/helper/qos/qos.go
+++ b/pkg/apis/core/v1/helper/qos/qos.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/core"
 )
 
-var supportedQoSComputeResources = sets.NewString(string(core.ResourceCPU), string(core.ResourceMemory))
+var supportedQoSComputeResources = sets.New[string](string(core.ResourceCPU), string(core.ResourceMemory))
 
 // QOSList is a set of (resource name, QoS class) pairs.
 type QOSList map[v1.ResourceName]v1.PodQOSClass
@@ -71,7 +71,7 @@ func ComputePodQOS(pod *v1.Pod) v1.PodQOSClass {
 			}
 		}
 		// process limits
-		qosLimitsFound := sets.NewString()
+		qosLimitsFound := sets.New[string]()
 		for name, quantity := range container.Resources.Limits {
 			if !isSupportedQoSComputeResource(name) {
 				continue

--- a/pkg/apis/core/v1/validation/validation.go
+++ b/pkg/apis/core/v1/validation/validation.go
@@ -146,7 +146,7 @@ func ValidatePodLogOptions(opts *v1.PodLogOptions) field.ErrorList {
 
 // AccumulateUniqueHostPorts checks all the containers for duplicates ports. Any
 // duplicate port will be returned in the ErrorList.
-func AccumulateUniqueHostPorts(containers []v1.Container, accumulator *sets.String, fldPath *field.Path) field.ErrorList {
+func AccumulateUniqueHostPorts(containers []v1.Container, accumulator *sets.Set[string], fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	for ci, ctr := range containers {

--- a/pkg/apis/core/v1/validation/validation_test.go
+++ b/pkg/apis/core/v1/validation/validation_test.go
@@ -306,7 +306,7 @@ func TestAccumulateUniqueHostPorts(t *testing.T) {
 	successCase := []struct {
 		name        string
 		containers  []v1.Container
-		accumulator *sets.String
+		accumulator *sets.Set[string]
 		fldPath     *field.Path
 	}{{
 		name: "HostPort is not allocated while containers use the same port with different protocol",
@@ -321,7 +321,7 @@ func TestAccumulateUniqueHostPorts(t *testing.T) {
 				Protocol: v1.ProtocolTCP,
 			}},
 		}},
-		accumulator: &sets.String{},
+		accumulator: &sets.Set[string]{},
 		fldPath:     field.NewPath("spec", "containers"),
 	}, {
 		name: "HostPort is not allocated while containers use different ports",
@@ -336,7 +336,7 @@ func TestAccumulateUniqueHostPorts(t *testing.T) {
 				Protocol: v1.ProtocolUDP,
 			}},
 		}},
-		accumulator: &sets.String{},
+		accumulator: &sets.Set[string]{},
 		fldPath:     field.NewPath("spec", "containers"),
 	}}
 	for _, tc := range successCase {
@@ -349,7 +349,7 @@ func TestAccumulateUniqueHostPorts(t *testing.T) {
 	errorCase := []struct {
 		name        string
 		containers  []v1.Container
-		accumulator *sets.String
+		accumulator *sets.Set[string]
 		fldPath     *field.Path
 	}{{
 		name: "HostPort is already allocated while containers use the same port with UDP",
@@ -364,7 +364,7 @@ func TestAccumulateUniqueHostPorts(t *testing.T) {
 				Protocol: v1.ProtocolUDP,
 			}},
 		}},
-		accumulator: &sets.String{},
+		accumulator: &sets.Set[string]{},
 		fldPath:     field.NewPath("spec", "containers"),
 	}, {
 		name: "HostPort is already allocated",
@@ -379,7 +379,7 @@ func TestAccumulateUniqueHostPorts(t *testing.T) {
 				Protocol: v1.ProtocolUDP,
 			}},
 		}},
-		accumulator: &sets.String{"8080/UDP": sets.Empty{}},
+		accumulator: &sets.Set[string]{"8080/UDP": sets.Empty{}},
 		fldPath:     field.NewPath("spec", "containers"),
 	}}
 	for _, tc := range errorCase {

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -105,7 +105,7 @@ var allowedEphemeralContainerFields = map[string]bool{
 // The valid values currently are linux, windows.
 // In future, they can be expanded to values from
 // https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-var validOS = sets.NewString(string(core.Linux), string(core.Windows))
+var validOS = sets.New[string](string(core.Linux), string(core.Windows))
 
 // ValidateHasLabel requires that metav1.ObjectMeta has a Label with key and expectedValue
 func ValidateHasLabel(meta metav1.ObjectMeta, fldPath *field.Path, key, expectedValue string) field.ErrorList {
@@ -388,8 +388,8 @@ func ValidateObjectMetaUpdate(newMeta, oldMeta *metav1.ObjectMeta, fldPath *fiel
 func ValidateVolumes(volumes []core.Volume, podMeta *metav1.ObjectMeta, fldPath *field.Path, opts PodValidationOptions) (map[string]core.VolumeSource, field.ErrorList) {
 	allErrs := field.ErrorList{}
 
-	allNames := sets.String{}
-	allCreatedPVCs := sets.String{}
+	allNames := sets.Set[string]{}
+	allCreatedPVCs := sets.Set[string]{}
 	// Determine which PVCs will be created for this pod. We need
 	// the exact name of the pod for this. Without it, this sanity
 	// check has to be skipped.
@@ -1038,7 +1038,7 @@ func validateFlockerVolumeSource(flocker *core.FlockerVolumeSource, fldPath *fie
 	return allErrs
 }
 
-var validVolumeDownwardAPIFieldPathExpressions = sets.NewString(
+var validVolumeDownwardAPIFieldPathExpressions = sets.New[string](
 	"metadata.name",
 	"metadata.namespace",
 	"metadata.labels",
@@ -1086,7 +1086,7 @@ func validateDownwardAPIVolumeSource(downwardAPIVolume *core.DownwardAPIVolumeSo
 
 func validateProjectionSources(projection *core.ProjectedVolumeSource, projectionMode *int32, fldPath *field.Path, opts PodValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allPaths := sets.String{}
+	allPaths := sets.Set[string]{}
 
 	for i, source := range projection.Sources {
 		numSources := 0
@@ -1174,7 +1174,7 @@ func validateProjectedVolumeSource(projection *core.ProjectedVolumeSource, fldPa
 	return allErrs
 }
 
-var supportedHostPathTypes = sets.NewString(
+var supportedHostPathTypes = sets.New[string](
 	string(core.HostPathUnset),
 	string(core.HostPathDirectoryOrCreate),
 	string(core.HostPathDirectory),
@@ -1188,7 +1188,7 @@ func validateHostPathType(hostPathType *core.HostPathType, fldPath *field.Path) 
 	allErrs := field.ErrorList{}
 
 	if hostPathType != nil && !supportedHostPathTypes.Has(string(*hostPathType)) {
-		allErrs = append(allErrs, field.NotSupported(fldPath, hostPathType, supportedHostPathTypes.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPath, hostPathType, sets.List[string](supportedHostPathTypes)))
 	}
 
 	return allErrs
@@ -1233,9 +1233,9 @@ func validateMountPropagation(mountPropagation *core.MountPropagationMode, conta
 		return allErrs
 	}
 
-	supportedMountPropagations := sets.NewString(string(core.MountPropagationBidirectional), string(core.MountPropagationHostToContainer), string(core.MountPropagationNone))
+	supportedMountPropagations := sets.New[string](string(core.MountPropagationBidirectional), string(core.MountPropagationHostToContainer), string(core.MountPropagationNone))
 	if !supportedMountPropagations.Has(string(*mountPropagation)) {
-		allErrs = append(allErrs, field.NotSupported(fldPath, *mountPropagation, supportedMountPropagations.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPath, *mountPropagation, sets.List[string](supportedMountPropagations)))
 	}
 
 	if container == nil {
@@ -1403,8 +1403,8 @@ func validateAzureFilePV(azure *core.AzureFilePersistentVolumeSource, fldPath *f
 }
 
 func validateAzureDisk(azure *core.AzureDiskVolumeSource, fldPath *field.Path) field.ErrorList {
-	var supportedCachingModes = sets.NewString(string(core.AzureDataDiskCachingNone), string(core.AzureDataDiskCachingReadOnly), string(core.AzureDataDiskCachingReadWrite))
-	var supportedDiskKinds = sets.NewString(string(core.AzureSharedBlobDisk), string(core.AzureDedicatedBlobDisk), string(core.AzureManagedDisk))
+	var supportedCachingModes = sets.New[string](string(core.AzureDataDiskCachingNone), string(core.AzureDataDiskCachingReadOnly), string(core.AzureDataDiskCachingReadWrite))
+	var supportedDiskKinds = sets.New[string](string(core.AzureSharedBlobDisk), string(core.AzureDedicatedBlobDisk), string(core.AzureManagedDisk))
 
 	diskURISupportedManaged := []string{"/subscriptions/{sub-id}/resourcegroups/{group-name}/providers/microsoft.compute/disks/{disk-id}"}
 	diskURISupportedblob := []string{"https://{account-name}.blob.core.windows.net/{container-name}/{disk-name}.vhd"}
@@ -1419,11 +1419,11 @@ func validateAzureDisk(azure *core.AzureDiskVolumeSource, fldPath *field.Path) f
 	}
 
 	if azure.CachingMode != nil && !supportedCachingModes.Has(string(*azure.CachingMode)) {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("cachingMode"), *azure.CachingMode, supportedCachingModes.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("cachingMode"), *azure.CachingMode, sets.List[string](supportedCachingModes)))
 	}
 
 	if azure.Kind != nil && !supportedDiskKinds.Has(string(*azure.Kind)) {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("kind"), *azure.Kind, supportedDiskKinds.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("kind"), *azure.Kind, sets.List[string](supportedDiskKinds)))
 	}
 
 	// validate that DiskUri is the correct format
@@ -1660,11 +1660,11 @@ type PersistentVolumeSpecValidationOptions struct {
 // PersistentVolumeName object.
 var ValidatePersistentVolumeName = apimachineryvalidation.NameIsDNSSubdomain
 
-var supportedAccessModes = sets.NewString(string(core.ReadWriteOnce), string(core.ReadOnlyMany), string(core.ReadWriteMany), string(core.ReadWriteOncePod))
+var supportedAccessModes = sets.New[string](string(core.ReadWriteOnce), string(core.ReadOnlyMany), string(core.ReadWriteMany), string(core.ReadWriteOncePod))
 
-var supportedReclaimPolicy = sets.NewString(string(core.PersistentVolumeReclaimDelete), string(core.PersistentVolumeReclaimRecycle), string(core.PersistentVolumeReclaimRetain))
+var supportedReclaimPolicy = sets.New[string](string(core.PersistentVolumeReclaimDelete), string(core.PersistentVolumeReclaimRecycle), string(core.PersistentVolumeReclaimRetain))
 
-var supportedVolumeModes = sets.NewString(string(core.PersistentVolumeBlock), string(core.PersistentVolumeFilesystem))
+var supportedVolumeModes = sets.New[string](string(core.PersistentVolumeBlock), string(core.PersistentVolumeFilesystem))
 
 func ValidationOptionsForPersistentVolume(pv, oldPv *core.PersistentVolume) PersistentVolumeSpecValidationOptions {
 	return PersistentVolumeSpecValidationOptions{}
@@ -1692,7 +1692,7 @@ func ValidatePersistentVolumeSpec(pvSpec *core.PersistentVolumeSpec, pvName stri
 	foundReadWriteOncePod, foundNonReadWriteOncePod := false, false
 	for _, mode := range pvSpec.AccessModes {
 		if !supportedAccessModes.Has(string(mode)) {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("accessModes"), mode, supportedAccessModes.List()))
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("accessModes"), mode, sets.List[string](supportedAccessModes)))
 		}
 
 		if mode == core.ReadWriteOncePod {
@@ -1727,7 +1727,7 @@ func ValidatePersistentVolumeSpec(pvSpec *core.PersistentVolumeSpec, pvName stri
 			}
 		} else {
 			if !supportedReclaimPolicy.Has(string(pvSpec.PersistentVolumeReclaimPolicy)) {
-				allErrs = append(allErrs, field.NotSupported(fldPath.Child("persistentVolumeReclaimPolicy"), pvSpec.PersistentVolumeReclaimPolicy, supportedReclaimPolicy.List()))
+				allErrs = append(allErrs, field.NotSupported(fldPath.Child("persistentVolumeReclaimPolicy"), pvSpec.PersistentVolumeReclaimPolicy, sets.List[string](supportedReclaimPolicy)))
 			}
 		}
 	}
@@ -1948,7 +1948,7 @@ func ValidatePersistentVolumeSpec(pvSpec *core.PersistentVolumeSpec, pvName stri
 			}
 		} else {
 			if !supportedVolumeModes.Has(string(*pvSpec.VolumeMode)) {
-				allErrs = append(allErrs, field.NotSupported(fldPath.Child("volumeMode"), *pvSpec.VolumeMode, supportedVolumeModes.List()))
+				allErrs = append(allErrs, field.NotSupported(fldPath.Child("volumeMode"), *pvSpec.VolumeMode, sets.List[string](supportedVolumeModes)))
 			}
 		}
 	}
@@ -2145,7 +2145,7 @@ func ValidatePersistentVolumeClaimSpec(spec *core.PersistentVolumeClaimSpec, fld
 	foundReadWriteOncePod, foundNonReadWriteOncePod := false, false
 	for _, mode := range spec.AccessModes {
 		if !supportedAccessModes.Has(string(mode)) {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("accessModes"), mode, supportedAccessModes.List()))
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("accessModes"), mode, sets.List[string](supportedAccessModes)))
 		}
 
 		if mode == core.ReadWriteOncePod {
@@ -2173,7 +2173,7 @@ func ValidatePersistentVolumeClaimSpec(spec *core.PersistentVolumeClaimSpec, fld
 		}
 	}
 	if spec.VolumeMode != nil && !supportedVolumeModes.Has(string(*spec.VolumeMode)) {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("volumeMode"), *spec.VolumeMode, supportedVolumeModes.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("volumeMode"), *spec.VolumeMode, sets.List[string](supportedVolumeModes)))
 	}
 
 	if spec.DataSource != nil {
@@ -2309,7 +2309,7 @@ func validatePersistentVolumeClaimResourceKey(value string, fldPath *field.Path)
 	return allErrs
 }
 
-var resizeStatusSet = sets.NewString(string(core.PersistentVolumeClaimControllerResizeInProgress),
+var resizeStatusSet = sets.New[string](string(core.PersistentVolumeClaimControllerResizeInProgress),
 	string(core.PersistentVolumeClaimControllerResizeFailed),
 	string(core.PersistentVolumeClaimNodeResizePending),
 	string(core.PersistentVolumeClaimNodeResizeInProgress),
@@ -2338,7 +2338,7 @@ func ValidatePersistentVolumeClaimStatusUpdate(newPvc, oldPvc *core.PersistentVo
 					allErrs = append(allErrs, errs...)
 				}
 				if !resizeStatusSet.Has(string(v)) {
-					allErrs = append(allErrs, field.NotSupported(resizeStatusPath, k, resizeStatusSet.List()))
+					allErrs = append(allErrs, field.NotSupported(resizeStatusPath, k, sets.List[string](resizeStatusSet)))
 					continue
 				}
 			}
@@ -2360,12 +2360,12 @@ func ValidatePersistentVolumeClaimStatusUpdate(newPvc, oldPvc *core.PersistentVo
 	return allErrs
 }
 
-var supportedPortProtocols = sets.NewString(string(core.ProtocolTCP), string(core.ProtocolUDP), string(core.ProtocolSCTP))
+var supportedPortProtocols = sets.New[string](string(core.ProtocolTCP), string(core.ProtocolUDP), string(core.ProtocolSCTP))
 
 func validateContainerPorts(ports []core.ContainerPort, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allNames := sets.String{}
+	allNames := sets.Set[string]{}
 	for i, port := range ports {
 		idxPath := fldPath.Index(i)
 		if len(port.Name) > 0 {
@@ -2394,7 +2394,7 @@ func validateContainerPorts(ports []core.ContainerPort, fldPath *field.Path) fie
 		if len(port.Protocol) == 0 {
 			allErrs = append(allErrs, field.Required(idxPath.Child("protocol"), ""))
 		} else if !supportedPortProtocols.Has(string(port.Protocol)) {
-			allErrs = append(allErrs, field.NotSupported(idxPath.Child("protocol"), port.Protocol, supportedPortProtocols.List()))
+			allErrs = append(allErrs, field.NotSupported(idxPath.Child("protocol"), port.Protocol, sets.List[string](supportedPortProtocols)))
 		}
 	}
 	return allErrs
@@ -2418,7 +2418,7 @@ func ValidateEnv(vars []core.EnvVar, fldPath *field.Path, opts PodValidationOpti
 	return allErrs
 }
 
-var validEnvDownwardAPIFieldPathExpressions = sets.NewString(
+var validEnvDownwardAPIFieldPathExpressions = sets.New[string](
 	"metadata.name",
 	"metadata.namespace",
 	"metadata.uid",
@@ -2430,9 +2430,9 @@ var validEnvDownwardAPIFieldPathExpressions = sets.NewString(
 	"status.podIPs",
 )
 
-var validContainerResourceFieldPathExpressions = sets.NewString("limits.cpu", "limits.memory", "limits.ephemeral-storage", "requests.cpu", "requests.memory", "requests.ephemeral-storage")
+var validContainerResourceFieldPathExpressions = sets.New[string]("limits.cpu", "limits.memory", "limits.ephemeral-storage", "requests.cpu", "requests.memory", "requests.ephemeral-storage")
 
-var validContainerResourceFieldPathPrefixesWithDownwardAPIHugePages = sets.NewString(hugepagesRequestsPrefixDownwardAPI, hugepagesLimitsPrefixDownwardAPI)
+var validContainerResourceFieldPathPrefixesWithDownwardAPIHugePages = sets.New[string](hugepagesRequestsPrefixDownwardAPI, hugepagesLimitsPrefixDownwardAPI)
 
 const hugepagesRequestsPrefixDownwardAPI string = `requests.hugepages-`
 const hugepagesLimitsPrefixDownwardAPI string = `limits.hugepages-`
@@ -2478,7 +2478,7 @@ func validateEnvVarValueFrom(ev core.EnvVar, fldPath *field.Path, opts PodValida
 	return allErrs
 }
 
-func validateObjectFieldSelector(fs *core.ObjectFieldSelector, expressions *sets.String, fldPath *field.Path) field.ErrorList {
+func validateObjectFieldSelector(fs *core.ObjectFieldSelector, expressions *sets.Set[string], fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(fs.APIVersion) == 0 {
@@ -2506,7 +2506,7 @@ func validateObjectFieldSelector(fs *core.ObjectFieldSelector, expressions *sets
 			allErrs = append(allErrs, field.Invalid(fldPath, path, "does not support subscript"))
 		}
 	} else if !expressions.Has(path) {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("fieldPath"), path, expressions.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("fieldPath"), path, sets.List[string](*expressions)))
 		return allErrs
 	}
 
@@ -2523,7 +2523,7 @@ func validateDownwardAPIHostIPs(fieldSel *core.ObjectFieldSelector, fldPath *fie
 	return allErrs
 }
 
-func validateContainerResourceFieldSelector(fs *core.ResourceFieldSelector, expressions *sets.String, prefixes *sets.String, fldPath *field.Path, volume bool) field.ErrorList {
+func validateContainerResourceFieldSelector(fs *core.ResourceFieldSelector, expressions *sets.Set[string], prefixes *sets.Set[string], fldPath *field.Path, volume bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if volume && len(fs.ContainerName) == 0 {
@@ -2534,14 +2534,14 @@ func validateContainerResourceFieldSelector(fs *core.ResourceFieldSelector, expr
 		// check if the prefix is present
 		foundPrefix := false
 		if prefixes != nil {
-			for _, prefix := range prefixes.List() {
+			for _, prefix := range sets.List[string](*prefixes) {
 				if strings.HasPrefix(fs.Resource, prefix) {
 					foundPrefix = true
 				}
 			}
 		}
 		if !foundPrefix {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("resource"), fs.Resource, expressions.List()))
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("resource"), fs.Resource, sets.List[string](*expressions)))
 		}
 	}
 	allErrs = append(allErrs, validateContainerResourceDivisor(fs.Resource, fs.Divisor, fldPath)...)
@@ -2601,10 +2601,10 @@ func validateSecretEnvSource(secretSource *core.SecretEnvSource, fldPath *field.
 	return allErrs
 }
 
-var validContainerResourceDivisorForCPU = sets.NewString("1m", "1")
-var validContainerResourceDivisorForMemory = sets.NewString("1", "1k", "1M", "1G", "1T", "1P", "1E", "1Ki", "1Mi", "1Gi", "1Ti", "1Pi", "1Ei")
-var validContainerResourceDivisorForHugePages = sets.NewString("1", "1k", "1M", "1G", "1T", "1P", "1E", "1Ki", "1Mi", "1Gi", "1Ti", "1Pi", "1Ei")
-var validContainerResourceDivisorForEphemeralStorage = sets.NewString("1", "1k", "1M", "1G", "1T", "1P", "1E", "1Ki", "1Mi", "1Gi", "1Ti", "1Pi", "1Ei")
+var validContainerResourceDivisorForCPU = sets.New[string]("1m", "1")
+var validContainerResourceDivisorForMemory = sets.New[string]("1", "1k", "1M", "1G", "1T", "1P", "1E", "1Ki", "1Mi", "1Gi", "1Ti", "1Pi", "1Ei")
+var validContainerResourceDivisorForHugePages = sets.New[string]("1", "1k", "1M", "1G", "1T", "1P", "1E", "1Ki", "1Mi", "1Gi", "1Ti", "1Pi", "1Ei")
+var validContainerResourceDivisorForEphemeralStorage = sets.New[string]("1", "1k", "1M", "1G", "1T", "1P", "1E", "1Ki", "1Mi", "1Gi", "1Ti", "1Pi", "1Ei")
 
 func validateContainerResourceDivisor(rName string, divisor resource.Quantity, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -2692,7 +2692,7 @@ func GetVolumeDeviceMap(devices []core.VolumeDevice) map[string]string {
 
 func ValidateVolumeMounts(mounts []core.VolumeMount, voldevices map[string]string, volumes map[string]core.VolumeSource, container *core.Container, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	mountpoints := sets.NewString()
+	mountpoints := sets.New[string]()
 
 	for i, mnt := range mounts {
 		idxPath := fldPath.Index(i)
@@ -2739,8 +2739,8 @@ func ValidateVolumeMounts(mounts []core.VolumeMount, voldevices map[string]strin
 
 func ValidateVolumeDevices(devices []core.VolumeDevice, volmounts map[string]string, volumes map[string]core.VolumeSource, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	devicepath := sets.NewString()
-	devicename := sets.NewString()
+	devicepath := sets.New[string]()
+	devicename := sets.New[string]()
 
 	for i, dev := range devices {
 		idxPath := fldPath.Index(i)
@@ -2787,7 +2787,7 @@ func ValidateVolumeDevices(devices []core.VolumeDevice, volmounts map[string]str
 
 func validatePodResourceClaims(podMeta *metav1.ObjectMeta, claims []core.PodResourceClaim, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
-	podClaimNames := sets.NewString()
+	podClaimNames := sets.New[string]()
 	for i, claim := range claims {
 		allErrs = append(allErrs, validatePodResourceClaim(podMeta, claim, &podClaimNames, fldPath.Index(i))...)
 	}
@@ -2797,8 +2797,8 @@ func validatePodResourceClaims(podMeta *metav1.ObjectMeta, claims []core.PodReso
 // gatherPodResourceClaimNames returns a set of all non-empty
 // PodResourceClaim.Name values. Validation that those names are valid is
 // handled by validatePodResourceClaims.
-func gatherPodResourceClaimNames(claims []core.PodResourceClaim) sets.String {
-	podClaimNames := sets.String{}
+func gatherPodResourceClaimNames(claims []core.PodResourceClaim) sets.Set[string] {
+	podClaimNames := sets.Set[string]{}
 	for _, claim := range claims {
 		if claim.Name != "" {
 			podClaimNames.Insert(claim.Name)
@@ -2807,7 +2807,7 @@ func gatherPodResourceClaimNames(claims []core.PodResourceClaim) sets.String {
 	return podClaimNames
 }
 
-func validatePodResourceClaim(podMeta *metav1.ObjectMeta, claim core.PodResourceClaim, podClaimNames *sets.String, fldPath *field.Path) field.ErrorList {
+func validatePodResourceClaim(podMeta *metav1.ObjectMeta, claim core.PodResourceClaim, podClaimNames *sets.Set[string], fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if claim.Name == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("name"), ""))
@@ -2990,7 +2990,7 @@ func validateAffinityTimeout(timeout *int32, fldPath *field.Path) field.ErrorLis
 
 // AccumulateUniqueHostPorts extracts each HostPort of each Container,
 // accumulating the results and returning an error if any ports conflict.
-func AccumulateUniqueHostPorts(containers []core.Container, accumulator *sets.String, fldPath *field.Path) field.ErrorList {
+func AccumulateUniqueHostPorts(containers []core.Container, accumulator *sets.Set[string], fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	for ci, ctr := range containers {
@@ -3016,7 +3016,7 @@ func AccumulateUniqueHostPorts(containers []core.Container, accumulator *sets.St
 // checkHostPortConflicts checks for colliding Port.HostPort values across
 // a slice of containers.
 func checkHostPortConflicts(containers []core.Container, fldPath *field.Path) field.ErrorList {
-	allPorts := sets.String{}
+	allPorts := sets.Set[string]{}
 	return AccumulateUniqueHostPorts(containers, &allPorts, fldPath)
 }
 
@@ -3028,7 +3028,7 @@ func validateExecAction(exec *core.ExecAction, fldPath *field.Path) field.ErrorL
 	return allErrors
 }
 
-var supportedHTTPSchemes = sets.NewString(string(core.URISchemeHTTP), string(core.URISchemeHTTPS))
+var supportedHTTPSchemes = sets.New[string](string(core.URISchemeHTTP), string(core.URISchemeHTTPS))
 
 func validateHTTPGetAction(http *core.HTTPGetAction, fldPath *field.Path) field.ErrorList {
 	allErrors := field.ErrorList{}
@@ -3037,7 +3037,7 @@ func validateHTTPGetAction(http *core.HTTPGetAction, fldPath *field.Path) field.
 	}
 	allErrors = append(allErrors, ValidatePortNumOrName(http.Port, fldPath.Child("port"))...)
 	if !supportedHTTPSchemes.Has(string(http.Scheme)) {
-		allErrors = append(allErrors, field.NotSupported(fldPath.Child("scheme"), http.Scheme, supportedHTTPSchemes.List()))
+		allErrors = append(allErrors, field.NotSupported(fldPath.Child("scheme"), http.Scheme, sets.List[string](supportedHTTPSchemes)))
 	}
 	for _, header := range http.HTTPHeaders {
 		for _, msg := range validation.IsHTTPHeaderName(header.Name) {
@@ -3129,7 +3129,7 @@ func validateLifecycle(lifecycle *core.Lifecycle, gracePeriod int64, fldPath *fi
 	return allErrs
 }
 
-var supportedPullPolicies = sets.NewString(string(core.PullAlways), string(core.PullIfNotPresent), string(core.PullNever))
+var supportedPullPolicies = sets.New[string](string(core.PullAlways), string(core.PullIfNotPresent), string(core.PullNever))
 
 func validatePullPolicy(policy core.PullPolicy, fldPath *field.Path) field.ErrorList {
 	allErrors := field.ErrorList{}
@@ -3140,14 +3140,14 @@ func validatePullPolicy(policy core.PullPolicy, fldPath *field.Path) field.Error
 	case "":
 		allErrors = append(allErrors, field.Required(fldPath, ""))
 	default:
-		allErrors = append(allErrors, field.NotSupported(fldPath, policy, supportedPullPolicies.List()))
+		allErrors = append(allErrors, field.NotSupported(fldPath, policy, sets.List[string](supportedPullPolicies)))
 	}
 
 	return allErrors
 }
 
-var supportedResizeResources = sets.NewString(string(core.ResourceCPU), string(core.ResourceMemory))
-var supportedResizePolicies = sets.NewString(string(core.NotRequired), string(core.RestartContainer))
+var supportedResizeResources = sets.New[string](string(core.ResourceCPU), string(core.ResourceMemory))
+var supportedResizePolicies = sets.New[string](string(core.NotRequired), string(core.RestartContainer))
 
 func validateResizePolicy(policyList []core.ContainerResizePolicy, fldPath *field.Path, podRestartPolicy *core.RestartPolicy) field.ErrorList {
 	allErrors := field.ErrorList{}
@@ -3164,14 +3164,14 @@ func validateResizePolicy(policyList []core.ContainerResizePolicy, fldPath *fiel
 		case "":
 			allErrors = append(allErrors, field.Required(fldPath, ""))
 		default:
-			allErrors = append(allErrors, field.NotSupported(fldPath, p.ResourceName, supportedResizeResources.List()))
+			allErrors = append(allErrors, field.NotSupported(fldPath, p.ResourceName, sets.List[string](supportedResizeResources)))
 		}
 		switch p.RestartPolicy {
 		case core.NotRequired, core.RestartContainer:
 		case "":
 			allErrors = append(allErrors, field.Required(fldPath, ""))
 		default:
-			allErrors = append(allErrors, field.NotSupported(fldPath, p.RestartPolicy, supportedResizePolicies.List()))
+			allErrors = append(allErrors, field.NotSupported(fldPath, p.RestartPolicy, sets.List[string](supportedResizePolicies)))
 		}
 
 		if *podRestartPolicy == core.RestartPolicyNever && p.RestartPolicy != core.NotRequired {
@@ -3183,14 +3183,14 @@ func validateResizePolicy(policyList []core.ContainerResizePolicy, fldPath *fiel
 
 // validateEphemeralContainers is called by pod spec and template validation to validate the list of ephemeral containers.
 // Note that this is called for pod template even though ephemeral containers aren't allowed in pod templates.
-func validateEphemeralContainers(ephemeralContainers []core.EphemeralContainer, containers, initContainers []core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.String, fldPath *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy) field.ErrorList {
+func validateEphemeralContainers(ephemeralContainers []core.EphemeralContainer, containers, initContainers []core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.Set[string], fldPath *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if len(ephemeralContainers) == 0 {
 		return allErrs
 	}
 
-	otherNames, allNames := sets.String{}, sets.String{}
+	otherNames, allNames := sets.Set[string]{}, sets.Set[string]{}
 	for _, c := range containers {
 		otherNames.Insert(c.Name)
 		allNames.Insert(c.Name)
@@ -3266,10 +3266,10 @@ func validateFieldAllowList(value interface{}, allowedFields map[string]bool, er
 }
 
 // validateInitContainers is called by pod spec and template validation to validate the list of init containers
-func validateInitContainers(containers []core.Container, regularContainers []core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.String, gracePeriod int64, fldPath *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy) field.ErrorList {
+func validateInitContainers(containers []core.Container, regularContainers []core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.Set[string], gracePeriod int64, fldPath *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy) field.ErrorList {
 	var allErrs field.ErrorList
 
-	allNames := sets.String{}
+	allNames := sets.Set[string]{}
 	for _, ctr := range regularContainers {
 		allNames.Insert(ctr.Name)
 	}
@@ -3332,7 +3332,7 @@ func validateInitContainers(containers []core.Container, regularContainers []cor
 
 // validateContainerCommon applies validation common to all container types. It's called by regular, init, and ephemeral
 // container list validation to require a properly formatted name, image, etc.
-func validateContainerCommon(ctr *core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.String, path *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy) field.ErrorList {
+func validateContainerCommon(ctr *core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.Set[string], path *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy) field.ErrorList {
 	var allErrs field.ErrorList
 
 	namePath := path.Child("name")
@@ -3404,14 +3404,14 @@ func validateHostUsers(spec *core.PodSpec, fldPath *field.Path) field.ErrorList 
 }
 
 // validateContainers is called by pod spec and template validation to validate the list of regular containers.
-func validateContainers(containers []core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.String, gracePeriod int64, fldPath *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy) field.ErrorList {
+func validateContainers(containers []core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.Set[string], gracePeriod int64, fldPath *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(containers) == 0 {
 		return append(allErrs, field.Required(fldPath, ""))
 	}
 
-	allNames := sets.String{}
+	allNames := sets.Set[string]{}
 	for i, ctr := range containers {
 		path := fldPath.Index(i)
 
@@ -3491,12 +3491,12 @@ func validateDNSPolicy(dnsPolicy *core.DNSPolicy, fldPath *field.Path) field.Err
 	return allErrors
 }
 
-var validFSGroupChangePolicies = sets.NewString(string(core.FSGroupChangeOnRootMismatch), string(core.FSGroupChangeAlways))
+var validFSGroupChangePolicies = sets.New[string](string(core.FSGroupChangeOnRootMismatch), string(core.FSGroupChangeAlways))
 
 func validateFSGroupChangePolicy(fsGroupPolicy *core.PodFSGroupChangePolicy, fldPath *field.Path) field.ErrorList {
 	allErrors := field.ErrorList{}
 	if !validFSGroupChangePolicies.Has(string(*fsGroupPolicy)) {
-		allErrors = append(allErrors, field.NotSupported(fldPath, fsGroupPolicy, validFSGroupChangePolicies.List()))
+		allErrors = append(allErrors, field.NotSupported(fldPath, fsGroupPolicy, sets.List[string](validFSGroupChangePolicies)))
 	}
 	return allErrors
 }
@@ -3523,7 +3523,7 @@ func validateReadinessGates(readinessGates []core.PodReadinessGate, fldPath *fie
 func validateSchedulingGates(schedulingGates []core.PodSchedulingGate, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	// There should be no duplicates in the list of scheduling gates.
-	seen := sets.String{}
+	seen := sets.Set[string]{}
 	for i, schedulingGate := range schedulingGates {
 		allErrs = append(allErrs, ValidateQualifiedName(schedulingGate.Name, fldPath.Index(i))...)
 		if seen.Has(schedulingGate.Name) {
@@ -3887,7 +3887,7 @@ func validatePodIPs(pod *core.Pod) field.ErrorList {
 		}
 
 		// There should be no duplicates in list of Pod.PodIPs
-		seen := sets.String{} // := make(map[string]int)
+		seen := sets.Set[string]{} // := make(map[string]int)
 		for i, podIP := range pod.Status.PodIPs {
 			if seen.Has(podIP.IP) {
 				allErrs = append(allErrs, field.Duplicate(podIPsField.Index(i), podIP))
@@ -3925,7 +3925,7 @@ func validateHostIPs(pod *core.Pod) field.ErrorList {
 	// - validate for dual stack
 	// - validate for duplication
 	if len(pod.Status.HostIPs) > 1 {
-		seen := sets.String{}
+		seen := sets.Set[string]{}
 		hostIPs := make([]string, 0, len(pod.Status.HostIPs))
 
 		// There should be no duplicates in list of Pod.HostIPs
@@ -4244,9 +4244,9 @@ func ValidateNodeSelector(nodeSelector *core.NodeSelector, fldPath *field.Path) 
 
 // validateTopologySelectorLabelRequirement tests that the specified TopologySelectorLabelRequirement fields has valid data,
 // and constructs a set containing all of its Values.
-func validateTopologySelectorLabelRequirement(rq core.TopologySelectorLabelRequirement, fldPath *field.Path) (sets.String, field.ErrorList) {
+func validateTopologySelectorLabelRequirement(rq core.TopologySelectorLabelRequirement, fldPath *field.Path) (sets.Set[string], field.ErrorList) {
 	allErrs := field.ErrorList{}
-	valueSet := make(sets.String)
+	valueSet := make(sets.Set[string])
 	valuesPath := fldPath.Child("values")
 	if len(rq.Values) == 0 {
 		allErrs = append(allErrs, field.Required(valuesPath, ""))
@@ -4267,9 +4267,9 @@ func validateTopologySelectorLabelRequirement(rq core.TopologySelectorLabelRequi
 
 // ValidateTopologySelectorTerm tests that the specified topology selector term has valid data,
 // and constructs a map representing the term in raw form.
-func ValidateTopologySelectorTerm(term core.TopologySelectorTerm, fldPath *field.Path) (map[string]sets.String, field.ErrorList) {
+func ValidateTopologySelectorTerm(term core.TopologySelectorTerm, fldPath *field.Path) (map[string]sets.Set[string], field.ErrorList) {
 	allErrs := field.ErrorList{}
-	exprMap := make(map[string]sets.String)
+	exprMap := make(map[string]sets.Set[string])
 	exprPath := fldPath.Child("matchLabelExpressions")
 
 	// Allow empty MatchLabelExpressions, in case this field becomes optional in the future.
@@ -5016,7 +5016,7 @@ func ValidatePodStatusUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions
 // validatePodConditions tests if the custom pod conditions are valid.
 func validatePodConditions(conditions []core.PodCondition, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	systemConditions := sets.NewString(string(core.PodScheduled), string(core.PodReady), string(core.PodInitialized))
+	systemConditions := sets.New[string](string(core.PodScheduled), string(core.PodReady), string(core.PodInitialized))
 	for i, condition := range conditions {
 		if systemConditions.Has(string(condition.Type)) {
 			continue
@@ -5128,14 +5128,14 @@ func ValidatePodTemplateUpdate(newPod, oldPod *core.PodTemplate, opts PodValidat
 	return allErrs
 }
 
-var supportedSessionAffinityType = sets.NewString(string(core.ServiceAffinityClientIP), string(core.ServiceAffinityNone))
-var supportedServiceType = sets.NewString(string(core.ServiceTypeClusterIP), string(core.ServiceTypeNodePort),
+var supportedSessionAffinityType = sets.New[string](string(core.ServiceAffinityClientIP), string(core.ServiceAffinityNone))
+var supportedServiceType = sets.New[string](string(core.ServiceTypeClusterIP), string(core.ServiceTypeNodePort),
 	string(core.ServiceTypeLoadBalancer), string(core.ServiceTypeExternalName))
 
-var supportedServiceInternalTrafficPolicy = sets.NewString(string(core.ServiceInternalTrafficPolicyCluster), string(core.ServiceExternalTrafficPolicyLocal))
+var supportedServiceInternalTrafficPolicy = sets.New[string](string(core.ServiceInternalTrafficPolicyCluster), string(core.ServiceExternalTrafficPolicyLocal))
 
-var supportedServiceIPFamily = sets.NewString(string(core.IPv4Protocol), string(core.IPv6Protocol))
-var supportedServiceIPFamilyPolicy = sets.NewString(string(core.IPFamilyPolicySingleStack), string(core.IPFamilyPolicyPreferDualStack), string(core.IPFamilyPolicyRequireDualStack))
+var supportedServiceIPFamily = sets.New[string](string(core.IPv4Protocol), string(core.IPv6Protocol))
+var supportedServiceIPFamilyPolicy = sets.New[string](string(core.IPFamilyPolicySingleStack), string(core.IPFamilyPolicyPreferDualStack), string(core.IPFamilyPolicyRequireDualStack))
 
 // ValidateService tests if required fields/annotations of a Service are valid.
 func ValidateService(service *core.Service) field.ErrorList {
@@ -5197,7 +5197,7 @@ func ValidateService(service *core.Service) field.ErrorList {
 		}
 	}
 
-	allPortNames := sets.String{}
+	allPortNames := sets.Set[string]{}
 	portsPath := specPath.Child("ports")
 	for i := range service.Spec.Ports {
 		portPath := portsPath.Index(i)
@@ -5211,7 +5211,7 @@ func ValidateService(service *core.Service) field.ErrorList {
 	if len(service.Spec.SessionAffinity) == 0 {
 		allErrs = append(allErrs, field.Required(specPath.Child("sessionAffinity"), ""))
 	} else if !supportedSessionAffinityType.Has(string(service.Spec.SessionAffinity)) {
-		allErrs = append(allErrs, field.NotSupported(specPath.Child("sessionAffinity"), service.Spec.SessionAffinity, supportedSessionAffinityType.List()))
+		allErrs = append(allErrs, field.NotSupported(specPath.Child("sessionAffinity"), service.Spec.SessionAffinity, sets.List[string](supportedSessionAffinityType)))
 	}
 
 	if service.Spec.SessionAffinity == core.ServiceAffinityClientIP {
@@ -5240,7 +5240,7 @@ func ValidateService(service *core.Service) field.ErrorList {
 	if len(service.Spec.Type) == 0 {
 		allErrs = append(allErrs, field.Required(specPath.Child("type"), ""))
 	} else if !supportedServiceType.Has(string(service.Spec.Type)) {
-		allErrs = append(allErrs, field.NotSupported(specPath.Child("type"), service.Spec.Type, supportedServiceType.List()))
+		allErrs = append(allErrs, field.NotSupported(specPath.Child("type"), service.Spec.Type, sets.List[string](supportedServiceType)))
 	}
 
 	if service.Spec.Type == core.ServiceTypeClusterIP {
@@ -5326,7 +5326,7 @@ func ValidateService(service *core.Service) field.ErrorList {
 	return allErrs
 }
 
-func validateServicePort(sp *core.ServicePort, requireName, isHeadlessService bool, allNames *sets.String, fldPath *field.Path) field.ErrorList {
+func validateServicePort(sp *core.ServicePort, requireName, isHeadlessService bool, allNames *sets.Set[string], fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if requireName && len(sp.Name) == 0 {
@@ -5347,7 +5347,7 @@ func validateServicePort(sp *core.ServicePort, requireName, isHeadlessService bo
 	if len(sp.Protocol) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("protocol"), ""))
 	} else if !supportedPortProtocols.Has(string(sp.Protocol)) {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("protocol"), sp.Protocol, supportedPortProtocols.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("protocol"), sp.Protocol, sets.List[string](supportedPortProtocols)))
 	}
 
 	allErrs = append(allErrs, ValidatePortNumOrName(sp.TargetPort, fldPath.Child("targetPort"))...)
@@ -5368,7 +5368,7 @@ func validateServicePort(sp *core.ServicePort, requireName, isHeadlessService bo
 	return allErrs
 }
 
-var validExternalTrafficPolicies = sets.NewString(
+var validExternalTrafficPolicies = sets.New[string](
 	string(core.ServiceExternalTrafficPolicyCluster),
 	string(core.ServiceExternalTrafficPolicyLocal))
 
@@ -5387,7 +5387,7 @@ func validateServiceExternalTrafficPolicy(service *core.Service) field.ErrorList
 			allErrs = append(allErrs, field.Required(fldPath.Child("externalTrafficPolicy"), ""))
 		} else if !validExternalTrafficPolicies.Has(string(service.Spec.ExternalTrafficPolicy)) {
 			allErrs = append(allErrs, field.NotSupported(fldPath.Child("externalTrafficPolicy"),
-				service.Spec.ExternalTrafficPolicy, validExternalTrafficPolicies.List()))
+				service.Spec.ExternalTrafficPolicy, sets.List[string](validExternalTrafficPolicies)))
 		}
 	}
 
@@ -5436,7 +5436,7 @@ func validateServiceInternalTrafficFieldsValue(service *core.Service) field.Erro
 	}
 
 	if service.Spec.InternalTrafficPolicy != nil && !supportedServiceInternalTrafficPolicy.Has(string(*service.Spec.InternalTrafficPolicy)) {
-		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec").Child("internalTrafficPolicy"), *service.Spec.InternalTrafficPolicy, supportedServiceInternalTrafficPolicy.List()))
+		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec").Child("internalTrafficPolicy"), *service.Spec.InternalTrafficPolicy, sets.List[string](supportedServiceInternalTrafficPolicy)))
 	}
 
 	return allErrs
@@ -5644,7 +5644,7 @@ func ValidateTaintsInNodeAnnotations(annotations map[string]string, fldPath *fie
 func validateNodeTaints(taints []core.Taint, fldPath *field.Path) field.ErrorList {
 	allErrors := field.ErrorList{}
 
-	uniqueTaints := map[core.TaintEffect]sets.String{}
+	uniqueTaints := map[core.TaintEffect]sets.Set[string]{}
 
 	for i, currTaint := range taints {
 		idxPath := fldPath.Index(i)
@@ -5667,7 +5667,7 @@ func validateNodeTaints(taints []core.Taint, fldPath *field.Path) field.ErrorLis
 
 		// add taint to existingTaints for uniqueness check
 		if len(uniqueTaints[currTaint.Effect]) == 0 {
-			uniqueTaints[currTaint.Effect] = sets.String{}
+			uniqueTaints[currTaint.Effect] = sets.Set[string]{}
 		}
 		uniqueTaints[currTaint.Effect].Insert(currTaint.Key)
 	}
@@ -5725,7 +5725,7 @@ func ValidateNode(node *core.Node) field.ErrorList {
 			}
 
 			// PodCIDRs must not contain duplicates
-			seen := sets.String{}
+			seen := sets.Set[string]{}
 			for i, value := range node.Spec.PodCIDRs {
 				if seen.Has(value) {
 					allErrs = append(allErrs, field.Duplicate(podCIDRsField.Index(i), value))
@@ -6033,7 +6033,7 @@ func ValidateLimitRange(limitRange *core.LimitRange) field.ErrorList {
 		}
 		limitTypeSet[limit.Type] = true
 
-		keys := sets.String{}
+		keys := sets.Set[string]{}
 		min := map[string]resource.Quantity{}
 		max := map[string]resource.Quantity{}
 		defaults := map[string]resource.Quantity{}
@@ -6320,7 +6320,7 @@ func validateBasicResource(quantity resource.Quantity, fldPath *field.Path) fiel
 }
 
 // Validates resource requirement spec.
-func ValidateResourceRequirements(requirements *core.ResourceRequirements, podClaimNames sets.String, fldPath *field.Path, opts PodValidationOptions) field.ErrorList {
+func ValidateResourceRequirements(requirements *core.ResourceRequirements, podClaimNames sets.Set[string], fldPath *field.Path, opts PodValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 	limPath := fldPath.Child("limits")
 	reqPath := fldPath.Child("requests")
@@ -6328,7 +6328,7 @@ func ValidateResourceRequirements(requirements *core.ResourceRequirements, podCl
 	reqContainsCPUOrMemory := false
 	limContainsHugePages := false
 	reqContainsHugePages := false
-	supportedQoSComputeResources := sets.NewString(string(core.ResourceCPU), string(core.ResourceMemory))
+	supportedQoSComputeResources := sets.New[string](string(core.ResourceCPU), string(core.ResourceMemory))
 	for resourceName, quantity := range requirements.Limits {
 
 		fldPath := limPath.Key(string(resourceName))
@@ -6391,9 +6391,9 @@ func ValidateResourceRequirements(requirements *core.ResourceRequirements, podCl
 // validateResourceClaimNames checks that the names in
 // ResourceRequirements.Claims have a corresponding entry in
 // PodSpec.ResourceClaims.
-func validateResourceClaimNames(claims []core.ResourceClaim, podClaimNames sets.String, fldPath *field.Path) field.ErrorList {
+func validateResourceClaimNames(claims []core.ResourceClaim, podClaimNames sets.Set[string], fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
-	names := sets.String{}
+	names := sets.Set[string]{}
 	for i, claim := range claims {
 		name := claim.Name
 		if name == "" {
@@ -6413,7 +6413,7 @@ func validateResourceClaimNames(claims []core.ResourceClaim, podClaimNames sets.
 				if len(podClaimNames) == 0 {
 					error.Detail += " which is empty"
 				} else {
-					error.Detail += ": " + strings.Join(podClaimNames.List(), ", ")
+					error.Detail += ": " + strings.Join(sets.List[string](podClaimNames), ", ")
 				}
 				allErrs = append(allErrs, error)
 			}
@@ -6440,29 +6440,29 @@ func validateResourceQuotaScopes(resourceQuotaSpec *core.ResourceQuotaSpec, fld 
 	if len(resourceQuotaSpec.Scopes) == 0 {
 		return allErrs
 	}
-	hardLimits := sets.NewString()
+	hardLimits := sets.New[string]()
 	for k := range resourceQuotaSpec.Hard {
 		hardLimits.Insert(string(k))
 	}
 	fldPath := fld.Child("scopes")
-	scopeSet := sets.NewString()
+	scopeSet := sets.New[string]()
 	for _, scope := range resourceQuotaSpec.Scopes {
 		if !helper.IsStandardResourceQuotaScope(string(scope)) {
 			allErrs = append(allErrs, field.Invalid(fldPath, resourceQuotaSpec.Scopes, "unsupported scope"))
 		}
-		for _, k := range hardLimits.List() {
+		for _, k := range sets.List[string](hardLimits) {
 			if helper.IsStandardQuotaResourceName(k) && !helper.IsResourceQuotaScopeValidForResource(scope, k) {
 				allErrs = append(allErrs, field.Invalid(fldPath, resourceQuotaSpec.Scopes, "unsupported scope applied to resource"))
 			}
 		}
 		scopeSet.Insert(string(scope))
 	}
-	invalidScopePairs := []sets.String{
-		sets.NewString(string(core.ResourceQuotaScopeBestEffort), string(core.ResourceQuotaScopeNotBestEffort)),
-		sets.NewString(string(core.ResourceQuotaScopeTerminating), string(core.ResourceQuotaScopeNotTerminating)),
+	invalidScopePairs := []sets.Set[string]{
+		sets.New[string](string(core.ResourceQuotaScopeBestEffort), string(core.ResourceQuotaScopeNotBestEffort)),
+		sets.New[string](string(core.ResourceQuotaScopeTerminating), string(core.ResourceQuotaScopeNotTerminating)),
 	}
 	for _, invalidScopePair := range invalidScopePairs {
-		if scopeSet.HasAll(invalidScopePair.List()...) {
+		if scopeSet.HasAll(sets.List[string](invalidScopePair)...) {
 			allErrs = append(allErrs, field.Invalid(fldPath, resourceQuotaSpec.Scopes, "conflicting scopes"))
 		}
 	}
@@ -6472,17 +6472,17 @@ func validateResourceQuotaScopes(resourceQuotaSpec *core.ResourceQuotaSpec, fld 
 // validateScopedResourceSelectorRequirement tests that the match expressions has valid data
 func validateScopedResourceSelectorRequirement(resourceQuotaSpec *core.ResourceQuotaSpec, fld *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	hardLimits := sets.NewString()
+	hardLimits := sets.New[string]()
 	for k := range resourceQuotaSpec.Hard {
 		hardLimits.Insert(string(k))
 	}
 	fldPath := fld.Child("matchExpressions")
-	scopeSet := sets.NewString()
+	scopeSet := sets.New[string]()
 	for _, req := range resourceQuotaSpec.ScopeSelector.MatchExpressions {
 		if !helper.IsStandardResourceQuotaScope(string(req.ScopeName)) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("scopeName"), req.ScopeName, "unsupported scope"))
 		}
-		for _, k := range hardLimits.List() {
+		for _, k := range sets.List[string](hardLimits) {
 			if helper.IsStandardQuotaResourceName(k) && !helper.IsResourceQuotaScopeValidForResource(req.ScopeName, k) {
 				allErrs = append(allErrs, field.Invalid(fldPath, resourceQuotaSpec.ScopeSelector, "unsupported scope applied to resource"))
 			}
@@ -6511,12 +6511,12 @@ func validateScopedResourceSelectorRequirement(resourceQuotaSpec *core.ResourceQ
 		}
 		scopeSet.Insert(string(req.ScopeName))
 	}
-	invalidScopePairs := []sets.String{
-		sets.NewString(string(core.ResourceQuotaScopeBestEffort), string(core.ResourceQuotaScopeNotBestEffort)),
-		sets.NewString(string(core.ResourceQuotaScopeTerminating), string(core.ResourceQuotaScopeNotTerminating)),
+	invalidScopePairs := []sets.Set[string]{
+		sets.New[string](string(core.ResourceQuotaScopeBestEffort), string(core.ResourceQuotaScopeNotBestEffort)),
+		sets.New[string](string(core.ResourceQuotaScopeTerminating), string(core.ResourceQuotaScopeNotTerminating)),
 	}
 	for _, invalidScopePair := range invalidScopePairs {
-		if scopeSet.HasAll(invalidScopePair.List()...) {
+		if scopeSet.HasAll(sets.List[string](invalidScopePair)...) {
 			allErrs = append(allErrs, field.Invalid(fldPath, resourceQuotaSpec.Scopes, "conflicting scopes"))
 		}
 	}
@@ -6598,8 +6598,8 @@ func ValidateResourceQuotaUpdate(newResourceQuota, oldResourceQuota *core.Resour
 
 	// ensure scopes cannot change, and that resources are still valid for scope
 	fldPath := field.NewPath("spec", "scopes")
-	oldScopes := sets.NewString()
-	newScopes := sets.NewString()
+	oldScopes := sets.New[string]()
+	newScopes := sets.New[string]()
 	for _, scope := range newResourceQuota.Spec.Scopes {
 		newScopes.Insert(string(scope))
 	}
@@ -6804,7 +6804,7 @@ func validateEndpointPort(port *core.EndpointPort, requireName bool, fldPath *fi
 	if len(port.Protocol) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("protocol"), ""))
 	} else if !supportedPortProtocols.Has(string(port.Protocol)) {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("protocol"), port.Protocol, supportedPortProtocols.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("protocol"), port.Protocol, sets.List[string](supportedPortProtocols)))
 	}
 	if port.AppProtocol != nil {
 		allErrs = append(allErrs, ValidateQualifiedName(*port.AppProtocol, fldPath.Child("appProtocol"))...)
@@ -7056,7 +7056,7 @@ func validateOS(podSpec *core.PodSpec, fldPath *field.Path, opts PodValidationOp
 	}
 	osName := string(os.Name)
 	if !validOS.Has(osName) {
-		allErrs = append(allErrs, field.NotSupported(fldPath, osName, validOS.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPath, osName, sets.List[string](validOS)))
 	}
 	return allErrs
 }
@@ -7081,7 +7081,7 @@ func ValidatePodLogOptions(opts *core.PodLogOptions) field.ErrorList {
 }
 
 var (
-	supportedLoadBalancerIPMode = sets.NewString(string(core.LoadBalancerIPModeVIP), string(core.LoadBalancerIPModeProxy))
+	supportedLoadBalancerIPMode = sets.New[string](string(core.LoadBalancerIPModeVIP), string(core.LoadBalancerIPModeProxy))
 )
 
 // ValidateLoadBalancerStatus validates required fields on a LoadBalancerStatus
@@ -7106,7 +7106,7 @@ func ValidateLoadBalancerStatus(status *core.LoadBalancerStatus, fldPath *field.
 			} else if ingress.IPMode != nil && len(ingress.IP) == 0 {
 				allErrs = append(allErrs, field.Forbidden(idxPath.Child("ipMode"), "may not be specified when `ip` is not set"))
 			} else if ingress.IPMode != nil && !supportedLoadBalancerIPMode.Has(string(*ingress.IPMode)) {
-				allErrs = append(allErrs, field.NotSupported(idxPath.Child("ipMode"), ingress.IPMode, supportedLoadBalancerIPMode.List()))
+				allErrs = append(allErrs, field.NotSupported(idxPath.Child("ipMode"), ingress.IPMode, sets.List[string](supportedLoadBalancerIPMode)))
 			}
 
 			if len(ingress.Hostname) > 0 {
@@ -7172,7 +7172,7 @@ func ValidateProcMountType(fldPath *field.Path, procMountType core.ProcMountType
 }
 
 var (
-	supportedScheduleActions = sets.NewString(string(core.DoNotSchedule), string(core.ScheduleAnyway))
+	supportedScheduleActions = sets.New[string](string(core.DoNotSchedule), string(core.ScheduleAnyway))
 )
 
 // validateTopologySpreadConstraints validates given TopologySpreadConstraints.
@@ -7245,7 +7245,7 @@ func ValidateTopologyKey(fldPath *field.Path, topologyKey string) *field.Error {
 // ValidateWhenUnsatisfiable tests that the argument is a valid UnsatisfiableConstraintAction.
 func ValidateWhenUnsatisfiable(fldPath *field.Path, action core.UnsatisfiableConstraintAction) *field.Error {
 	if !supportedScheduleActions.Has(string(action)) {
-		return field.NotSupported(fldPath, action, supportedScheduleActions.List())
+		return field.NotSupported(fldPath, action, sets.List[string](supportedScheduleActions))
 	}
 	return nil
 }
@@ -7263,7 +7263,7 @@ func ValidateSpreadConstraintNotRepeat(fldPath *field.Path, constraint core.Topo
 }
 
 var (
-	supportedPodTopologySpreadNodePolicies = sets.NewString(string(core.NodeInclusionPolicyIgnore), string(core.NodeInclusionPolicyHonor))
+	supportedPodTopologySpreadNodePolicies = sets.New[string](string(core.NodeInclusionPolicyIgnore), string(core.NodeInclusionPolicyHonor))
 )
 
 // validateNodeAffinityPolicy tests that the argument is a valid NodeInclusionPolicy.
@@ -7273,7 +7273,7 @@ func validateNodeInclusionPolicy(fldPath *field.Path, policy *core.NodeInclusion
 	}
 
 	if !supportedPodTopologySpreadNodePolicies.Has(string(*policy)) {
-		return field.NotSupported(fldPath, policy, supportedPodTopologySpreadNodePolicies.List())
+		return field.NotSupported(fldPath, policy, sets.List[string](supportedPodTopologySpreadNodePolicies))
 	}
 	return nil
 }
@@ -7337,7 +7337,7 @@ func validateMatchLabelKeysInTopologySpread(fldPath *field.Path, matchLabelKeys 
 	}
 
 	var allErrs field.ErrorList
-	labelSelectorKeys := sets.String{}
+	labelSelectorKeys := sets.Set[string]{}
 
 	if labelSelector != nil {
 		for key := range labelSelector.MatchLabels {
@@ -7415,10 +7415,10 @@ func ValidateServiceClusterIPsRelatedFields(service *core.Service) field.ErrorLi
 
 	// ipfamilies stand alone validation
 	// must be either IPv4 or IPv6
-	seen := sets.String{}
+	seen := sets.Set[string]{}
 	for i, ipFamily := range service.Spec.IPFamilies {
 		if !supportedServiceIPFamily.Has(string(ipFamily)) {
-			allErrs = append(allErrs, field.NotSupported(ipFamiliesField.Index(i), ipFamily, supportedServiceIPFamily.List()))
+			allErrs = append(allErrs, field.NotSupported(ipFamiliesField.Index(i), ipFamily, sets.List[string](supportedServiceIPFamily)))
 		}
 		// no duplicate check also ensures that ipfamilies is dualstacked, in any order
 		if seen.Has(string(ipFamily)) {
@@ -7432,7 +7432,7 @@ func ValidateServiceClusterIPsRelatedFields(service *core.Service) field.ErrorLi
 	if service.Spec.IPFamilyPolicy != nil {
 		// must have a supported value
 		if !supportedServiceIPFamilyPolicy.Has(string(*(service.Spec.IPFamilyPolicy))) {
-			allErrs = append(allErrs, field.NotSupported(ipFamilyPolicyField, service.Spec.IPFamilyPolicy, supportedServiceIPFamilyPolicy.List()))
+			allErrs = append(allErrs, field.NotSupported(ipFamilyPolicyField, service.Spec.IPFamilyPolicy, sets.List[string](supportedServiceIPFamilyPolicy)))
 		}
 	}
 

--- a/pkg/apis/discovery/validation/validation.go
+++ b/pkg/apis/discovery/validation/validation.go
@@ -31,12 +31,12 @@ import (
 )
 
 var (
-	supportedAddressTypes = sets.NewString(
+	supportedAddressTypes = sets.New[string](
 		string(discovery.AddressTypeIPv4),
 		string(discovery.AddressTypeIPv6),
 		string(discovery.AddressTypeFQDN),
 	)
-	supportedPortProtocols = sets.NewString(
+	supportedPortProtocols = sets.New[string](
 		string(api.ProtocolTCP),
 		string(api.ProtocolUDP),
 		string(api.ProtocolSCTP),
@@ -145,7 +145,7 @@ func validatePorts(endpointPorts []discovery.EndpointPort, fldPath *field.Path) 
 		return allErrs
 	}
 
-	portNames := sets.String{}
+	portNames := sets.Set[string]{}
 	for i, endpointPort := range endpointPorts {
 		idxPath := fldPath.Index(i)
 
@@ -162,7 +162,7 @@ func validatePorts(endpointPorts []discovery.EndpointPort, fldPath *field.Path) 
 		if endpointPort.Protocol == nil {
 			allErrs = append(allErrs, field.Required(idxPath.Child("protocol"), ""))
 		} else if !supportedPortProtocols.Has(string(*endpointPort.Protocol)) {
-			allErrs = append(allErrs, field.NotSupported(idxPath.Child("protocol"), *endpointPort.Protocol, supportedPortProtocols.List()))
+			allErrs = append(allErrs, field.NotSupported(idxPath.Child("protocol"), *endpointPort.Protocol, sets.List[string](supportedPortProtocols)))
 		}
 
 		if endpointPort.AppProtocol != nil {
@@ -179,7 +179,7 @@ func validateAddressType(addressType discovery.AddressType) field.ErrorList {
 	if addressType == "" {
 		allErrs = append(allErrs, field.Required(field.NewPath("addressType"), ""))
 	} else if !supportedAddressTypes.Has(string(addressType)) {
-		allErrs = append(allErrs, field.NotSupported(field.NewPath("addressType"), addressType, supportedAddressTypes.List()))
+		allErrs = append(allErrs, field.NotSupported(field.NewPath("addressType"), addressType, sets.List[string](supportedAddressTypes)))
 	}
 
 	return allErrs
@@ -194,7 +194,7 @@ func validateHints(endpointHints *discovery.EndpointHints, fldPath *field.Path) 
 		return allErrs
 	}
 
-	zoneNames := sets.String{}
+	zoneNames := sets.Set[string]{}
 	for i, forZone := range endpointHints.ForZones {
 		zonePath := fzPath.Index(i).Child("name")
 		if zoneNames.Has(forZone.Name) {

--- a/pkg/apis/flowcontrol/validation/validation_test.go
+++ b/pkg/apis/flowcontrol/validation/validation_test.go
@@ -28,6 +28,7 @@ import (
 	flowcontrolv1beta3 "k8s.io/api/flowcontrol/v1beta3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/kubernetes/pkg/apis/flowcontrol"
@@ -443,7 +444,7 @@ func TestFlowSchemaValidation(t *testing.T) {
 			},
 		},
 		expectedErrors: field.ErrorList{
-			field.NotSupported(field.NewPath("spec").Child("rules").Index(0).Child("subjects").Index(0).Child("kind"), flowcontrol.SubjectKind("FooKind"), supportedSubjectKinds.List()),
+			field.NotSupported(field.NewPath("spec").Child("rules").Index(0).Child("subjects").Index(0).Child("kind"), flowcontrol.SubjectKind("FooKind"), sets.List[string](supportedSubjectKinds)),
 		},
 	}, {
 		name: "flow-schema w/ invalid verb should fail",
@@ -471,7 +472,7 @@ func TestFlowSchemaValidation(t *testing.T) {
 			},
 		},
 		expectedErrors: field.ErrorList{
-			field.NotSupported(field.NewPath("spec").Child("rules").Index(0).Child("resourceRules").Index(0).Child("verbs"), []string{"feed"}, supportedVerbs.List()),
+			field.NotSupported(field.NewPath("spec").Child("rules").Index(0).Child("resourceRules").Index(0).Child("verbs"), []string{"feed"}, sets.List[string](supportedVerbs)),
 		},
 	}, {
 		name: "flow-schema w/ invalid priority level configuration name should fail",
@@ -556,7 +557,7 @@ func TestFlowSchemaValidation(t *testing.T) {
 			},
 		},
 		expectedErrors: field.ErrorList{
-			field.NotSupported(field.NewPath("spec").Child("rules").Index(0).Child("subjects").Index(0).Child("kind"), flowcontrol.SubjectKind(""), supportedSubjectKinds.List()),
+			field.NotSupported(field.NewPath("spec").Child("rules").Index(0).Child("subjects").Index(0).Child("kind"), flowcontrol.SubjectKind(""), sets.List[string](supportedSubjectKinds)),
 		},
 	}, {
 		name: "Omitted ResourceRule.Namespaces should fail",

--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -41,7 +41,7 @@ const (
 )
 
 var (
-	supportedPathTypes = sets.NewString(
+	supportedPathTypes = sets.New[string](
 		string(networking.PathTypeExact),
 		string(networking.PathTypePrefix),
 		string(networking.PathTypeImplementationSpecific),
@@ -49,7 +49,7 @@ var (
 	invalidPathSequences = []string{"//", "/./", "/../", "%2f", "%2F"}
 	invalidPathSuffixes  = []string{"/..", "/."}
 
-	supportedIngressClassParametersReferenceScopes = sets.NewString(
+	supportedIngressClassParametersReferenceScopes = sets.New[string](
 		networking.IngressClassParametersReferenceScopeNamespace,
 		networking.IngressClassParametersReferenceScopeCluster,
 	)
@@ -168,7 +168,7 @@ func ValidateNetworkPolicySpec(spec *networking.NetworkPolicySpec, opts NetworkP
 		}
 	}
 	// Validate PolicyTypes
-	allowed := sets.NewString(string(networking.PolicyTypeIngress), string(networking.PolicyTypeEgress))
+	allowed := sets.New[string](string(networking.PolicyTypeIngress), string(networking.PolicyTypeEgress))
 	if len(spec.PolicyTypes) > len(allowed) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("policyTypes"), &spec.PolicyTypes, "may not specify more than two policyTypes"))
 		return allErrs
@@ -453,7 +453,7 @@ func validateHTTPIngressPath(path *networking.HTTPIngressPath, fldPath *field.Pa
 			}
 		}
 	default:
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("pathType"), *path.PathType, supportedPathTypes.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("pathType"), *path.PathType, sets.List[string](supportedPathTypes)))
 	}
 	allErrs = append(allErrs, validateIngressBackend(&path.Backend, fldPath.Child("backend"), opts)...)
 	return allErrs
@@ -597,7 +597,7 @@ func validateIngressClassParametersReference(params *networking.IngressClassPara
 
 	if !supportedIngressClassParametersReferenceScopes.Has(scope) {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("scope"), scope,
-			supportedIngressClassParametersReferenceScopes.List()))
+			sets.List[string](supportedIngressClassParametersReferenceScopes)))
 	} else {
 		if scope == networking.IngressClassParametersReferenceScopeNamespace {
 			if params.Namespace == nil {

--- a/pkg/apis/policy/validation/validation.go
+++ b/pkg/apis/policy/validation/validation.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/policy"
 )
 
-var supportedUnhealthyPodEvictionPolicies = sets.NewString(
+var supportedUnhealthyPodEvictionPolicies = sets.New[string](
 	string(policy.IfHealthyBudget),
 	string(policy.AlwaysAllow),
 )
@@ -69,7 +69,7 @@ func ValidatePodDisruptionBudgetSpec(spec policy.PodDisruptionBudgetSpec, opts P
 	allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(spec.Selector, labelSelectorValidationOptions, fldPath.Child("selector"))...)
 
 	if spec.UnhealthyPodEvictionPolicy != nil && !supportedUnhealthyPodEvictionPolicies.Has(string(*spec.UnhealthyPodEvictionPolicy)) {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("unhealthyPodEvictionPolicy"), *spec.UnhealthyPodEvictionPolicy, supportedUnhealthyPodEvictionPolicies.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("unhealthyPodEvictionPolicy"), *spec.UnhealthyPodEvictionPolicy, sets.List[string](supportedUnhealthyPodEvictionPolicies)))
 	}
 
 	return allErrs

--- a/pkg/apis/rbac/helpers.go
+++ b/pkg/apis/rbac/helpers.go
@@ -122,7 +122,7 @@ type PolicyRuleBuilder struct {
 // NewRule returns new PolicyRule made by input verbs.
 func NewRule(verbs ...string) *PolicyRuleBuilder {
 	return &PolicyRuleBuilder{
-		PolicyRule: PolicyRule{Verbs: sets.NewString(verbs...).List()},
+		PolicyRule: PolicyRule{Verbs: sets.List[string](sets.New[string](verbs...))},
 	}
 }
 
@@ -160,9 +160,9 @@ func (r *PolicyRuleBuilder) RuleOrDie() PolicyRule {
 }
 
 func combine(s1, s2 []string) []string {
-	s := sets.NewString(s1...)
+	s := sets.New[string](s1...)
 	s.Insert(s2...)
-	return s.List()
+	return sets.List[string](s)
 }
 
 // Rule returns PolicyRule and error.

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -43,12 +43,12 @@ func validateResourceClaimSpec(spec *resource.ResourceClaimSpec, fldPath *field.
 	}
 	allErrs = append(allErrs, validateResourceClaimParameters(spec.ParametersRef, fldPath.Child("parametersRef"))...)
 	if !supportedAllocationModes.Has(string(spec.AllocationMode)) {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("allocationMode"), spec.AllocationMode, supportedAllocationModes.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("allocationMode"), spec.AllocationMode, sets.List[string](supportedAllocationModes)))
 	}
 	return allErrs
 }
 
-var supportedAllocationModes = sets.NewString(string(resource.AllocationModeImmediate), string(resource.AllocationModeWaitForFirstConsumer))
+var supportedAllocationModes = sets.New[string](string(resource.AllocationModeImmediate), string(resource.AllocationModeWaitForFirstConsumer))
 
 // It would have been nice to use Go generics to reuse the same validation
 // function for Kind and Name in both types, but generics cannot be used to
@@ -300,7 +300,7 @@ func validatePodSchedulingStatus(status *resource.PodSchedulingContextStatus, fl
 
 func validatePodSchedulingClaims(claimStatuses []resource.ResourceClaimSchedulingStatus, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
-	names := sets.NewString()
+	names := sets.New[string]()
 	for i, claimStatus := range claimStatuses {
 		allErrs = append(allErrs, validatePodSchedulingClaim(claimStatus, fldPath.Index(i))...)
 		if names.Has(claimStatus.Name) {

--- a/pkg/apis/resource/validation/validation_resourceclaim_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaim_test.go
@@ -25,6 +25,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/resource"
@@ -199,7 +200,7 @@ func TestValidateClaim(t *testing.T) {
 			}(),
 		},
 		"bad-mode": {
-			wantFailures: field.ErrorList{field.NotSupported(field.NewPath("spec", "allocationMode"), invalidMode, supportedAllocationModes.List())},
+			wantFailures: field.ErrorList{field.NotSupported(field.NewPath("spec", "allocationMode"), invalidMode, sets.List[string](supportedAllocationModes))},
 			claim: func() *resource.ResourceClaim {
 				claim := testClaim(goodName, goodNS, goodClaimSpec)
 				claim.Spec.AllocationMode = invalidMode

--- a/pkg/apis/resource/validation/validation_resourceclaimtemplate_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaimtemplate_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/resource"
 	"k8s.io/utils/pointer"
@@ -197,7 +198,7 @@ func TestValidateClaimTemplate(t *testing.T) {
 			}(),
 		},
 		"bad-mode": {
-			wantFailures: field.ErrorList{field.NotSupported(field.NewPath("spec", "spec", "allocationMode"), invalidMode, supportedAllocationModes.List())},
+			wantFailures: field.ErrorList{field.NotSupported(field.NewPath("spec", "spec", "allocationMode"), invalidMode, sets.List[string](supportedAllocationModes))},
 			template: func() *resource.ResourceClaimTemplate {
 				template := testClaimTemplate(goodName, goodNS, goodClaimSpec)
 				template.Spec.Spec.AllocationMode = invalidMode

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -117,7 +117,7 @@ func validateParameters(params map[string]string, fldPath *field.Path) field.Err
 	return allErrs
 }
 
-var supportedReclaimPolicy = sets.NewString(string(api.PersistentVolumeReclaimDelete), string(api.PersistentVolumeReclaimRetain))
+var supportedReclaimPolicy = sets.New[string](string(api.PersistentVolumeReclaimDelete), string(api.PersistentVolumeReclaimRetain))
 
 // validateReclaimPolicy tests that the reclaim policy is one of the supported. It is up to the volume plugin to reject
 // provisioning for storage classes with impossible reclaim policies, e.g. EBS is not Recyclable
@@ -125,7 +125,7 @@ func validateReclaimPolicy(reclaimPolicy *api.PersistentVolumeReclaimPolicy, fld
 	allErrs := field.ErrorList{}
 	if len(string(*reclaimPolicy)) > 0 {
 		if !supportedReclaimPolicy.Has(string(*reclaimPolicy)) {
-			allErrs = append(allErrs, field.NotSupported(fldPath, reclaimPolicy, supportedReclaimPolicy.List()))
+			allErrs = append(allErrs, field.NotSupported(fldPath, reclaimPolicy, sets.List[string](supportedReclaimPolicy)))
 		}
 	}
 	return allErrs
@@ -248,7 +248,7 @@ func ValidateVolumeAttachmentUpdate(new, old *storage.VolumeAttachment) field.Er
 	return allErrs
 }
 
-var supportedVolumeBindingModes = sets.NewString(string(storage.VolumeBindingImmediate), string(storage.VolumeBindingWaitForFirstConsumer))
+var supportedVolumeBindingModes = sets.New[string](string(storage.VolumeBindingImmediate), string(storage.VolumeBindingWaitForFirstConsumer))
 
 // validateVolumeBindingMode tests that VolumeBindingMode specifies valid values.
 func validateVolumeBindingMode(mode *storage.VolumeBindingMode, fldPath *field.Path) field.ErrorList {
@@ -256,7 +256,7 @@ func validateVolumeBindingMode(mode *storage.VolumeBindingMode, fldPath *field.P
 	if mode == nil {
 		allErrs = append(allErrs, field.Required(fldPath, ""))
 	} else if !supportedVolumeBindingModes.Has(string(*mode)) {
-		allErrs = append(allErrs, field.NotSupported(fldPath, mode, supportedVolumeBindingModes.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPath, mode, sets.List[string](supportedVolumeBindingModes)))
 	}
 
 	return allErrs
@@ -270,7 +270,7 @@ func validateAllowedTopologies(topologies []api.TopologySelectorTerm, fldPath *f
 		return allErrs
 	}
 
-	rawTopologies := make([]map[string]sets.String, len(topologies))
+	rawTopologies := make([]map[string]sets.Set[string], len(topologies))
 	for i, term := range topologies {
 		idxPath := fldPath.Index(i)
 		exprMap, termErrs := apivalidation.ValidateTopologySelectorTerm(term, fldPath.Index(i))
@@ -467,7 +467,7 @@ func validateStorageCapacity(storageCapacity *bool, fldPath *field.Path) field.E
 	return allErrs
 }
 
-var supportedFSGroupPolicy = sets.NewString(string(storage.ReadWriteOnceWithFSTypeFSGroupPolicy), string(storage.FileFSGroupPolicy), string(storage.NoneFSGroupPolicy))
+var supportedFSGroupPolicy = sets.New[string](string(storage.ReadWriteOnceWithFSTypeFSGroupPolicy), string(storage.FileFSGroupPolicy), string(storage.NoneFSGroupPolicy))
 
 // validateFSGroupPolicy tests if FSGroupPolicy contains an appropriate value.
 func validateFSGroupPolicy(fsGroupPolicy *storage.FSGroupPolicy, fldPath *field.Path) field.ErrorList {
@@ -478,7 +478,7 @@ func validateFSGroupPolicy(fsGroupPolicy *storage.FSGroupPolicy, fldPath *field.
 	}
 
 	if !supportedFSGroupPolicy.Has(string(*fsGroupPolicy)) {
-		allErrs = append(allErrs, field.NotSupported(fldPath, fsGroupPolicy, supportedFSGroupPolicy.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPath, fsGroupPolicy, sets.List[string](supportedFSGroupPolicy)))
 	}
 
 	return allErrs

--- a/pkg/controller/certificates/approver/sarapprove.go
+++ b/pkg/controller/certificates/approver/sarapprove.go
@@ -162,8 +162,8 @@ func isSelfNodeClientCert(csr *capi.CertificateSigningRequest, x509cr *x509.Cert
 	return isNodeClientCert(csr, x509cr)
 }
 
-func usagesToSet(usages []capi.KeyUsage) sets.String {
-	result := sets.NewString()
+func usagesToSet(usages []capi.KeyUsage) sets.Set[string] {
+	result := sets.New[string]()
 	for _, usage := range usages {
 		result.Insert(string(usage))
 	}

--- a/pkg/controller/certificates/signer/signer.go
+++ b/pkg/controller/certificates/signer/signer.go
@@ -298,8 +298,8 @@ func validAPIServerClientUsages(usages []capi.KeyUsage) error {
 	return nil
 }
 
-func usagesToSet(usages []capi.KeyUsage) sets.String {
-	result := sets.NewString()
+func usagesToSet(usages []capi.KeyUsage) sets.Set[string] {
+	result := sets.New[string]()
 	for _, usage := range usages {
 		result.Insert(string(usage))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
According to https://github.com/kubernetes/apimachinery/blob/master/pkg/util/sets/string.go#L25
```
// String is a set of strings, implemented via map[string]struct{} for minimal memory consumption.
//
// Deprecated: use generic Set instead.
// new ways:
// s1 := Set[string]{}
// s2 := New[string]()
type String map[string]Empty

```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
