### PR TITLE
registry: use generic sets replace specified sets

### DIFF
--- a/pkg/registry/authorization/util/helpers_test.go
+++ b/pkg/registry/authorization/util/helpers_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestResourceAttributesFrom(t *testing.T) {
-	knownResourceAttributesNames := sets.NewString(
+	knownResourceAttributesNames := sets.New[string](
 		// Fields we copy in ResourceAttributesFrom
 		"Verb",
 		"Namespace",
@@ -48,7 +48,7 @@ func TestResourceAttributesFrom(t *testing.T) {
 		return false
 	})
 
-	knownAttributesRecordFieldNames := sets.NewString(
+	knownAttributesRecordFieldNames := sets.New[string](
 		// Fields we set in ResourceAttributesFrom
 		"User",
 		"Verb",

--- a/pkg/registry/core/service/allocator/bitmap_test.go
+++ b/pkg/registry/core/service/allocator/bitmap_test.go
@@ -346,11 +346,11 @@ func TestForEach(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			subTests := []sets.Int{
-				sets.NewInt(),
-				sets.NewInt(0),
-				sets.NewInt(0, 2, 5),
-				sets.NewInt(0, 1, 2, 3, 4, 5, 6, 7),
+			subTests := []sets.Set[int]{
+				sets.New[int](),
+				sets.New[int](0),
+				sets.New[int](0, 2, 5),
+				sets.New[int](0, 1, 2, 3, 4, 5, 6, 7),
 			}
 
 			for i, ts := range subTests {
@@ -363,7 +363,7 @@ func TestForEach(t *testing.T) {
 						t.Errorf("[%d] expect offset %v allocated", i, offset)
 					}
 				}
-				calls := sets.NewInt()
+				calls := sets.New[int]()
 				m.ForEach(func(i int) {
 					calls.Insert(i)
 				})
@@ -371,7 +371,7 @@ func TestForEach(t *testing.T) {
 					t.Errorf("[%d] expected %d calls, got %d", i, len(ts), len(calls))
 				}
 				if !calls.Equal(ts) {
-					t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), ts.List())
+					t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, sets.List[int](calls), sets.List[int](ts))
 				}
 			}
 		})

--- a/pkg/registry/core/service/ipallocator/bitmap_test.go
+++ b/pkg/registry/core/service/ipallocator/bitmap_test.go
@@ -105,7 +105,7 @@ func TestAllocate(t *testing.T) {
 			if f := r.Used(); f != 0 {
 				t.Errorf("[%s]: wrong used: expected %d, got %d", tc.name, 0, f)
 			}
-			found := sets.NewString()
+			found := sets.New[string]()
 			count := 0
 			for r.Free() > 0 {
 				ip, err := r.AllocateNext()
@@ -252,7 +252,7 @@ func TestAllocateSmall(t *testing.T) {
 	if f := r.Free(); f != 2 {
 		t.Errorf("expected free equal to 2 got: %d", f)
 	}
-	found := sets.NewString()
+	found := sets.New[string]()
 	for i := 0; i < 2; i++ {
 		ip, err := r.AllocateNext()
 		if err != nil {
@@ -292,11 +292,11 @@ func TestForEach(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testCases := []sets.String{
-		sets.NewString(),
-		sets.NewString("192.168.1.1"),
-		sets.NewString("192.168.1.1", "192.168.1.254"),
-		sets.NewString("192.168.1.1", "192.168.1.128", "192.168.1.254"),
+	testCases := []sets.Set[string]{
+		sets.New[string](),
+		sets.New[string]("192.168.1.1"),
+		sets.New[string]("192.168.1.1", "192.168.1.254"),
+		sets.New[string]("192.168.1.1", "192.168.1.128", "192.168.1.254"),
 	}
 
 	for i, tc := range testCases {
@@ -313,7 +313,7 @@ func TestForEach(t *testing.T) {
 				t.Errorf("[%d] expected IP %v allocated", i, ip)
 			}
 		}
-		calls := sets.NewString()
+		calls := sets.New[string]()
 		r.ForEach(func(ip net.IP) {
 			calls.Insert(ip.String())
 		})
@@ -321,7 +321,7 @@ func TestForEach(t *testing.T) {
 			t.Errorf("[%d] expected %d calls, got %d", i, len(tc), len(calls))
 		}
 		if !calls.Equal(tc) {
-			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), tc.List())
+			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, sets.List[string](calls), sets.List[string](tc))
 		}
 	}
 }
@@ -466,7 +466,7 @@ func TestClusterIPMetrics(t *testing.T) {
 	expectMetrics(t, cidrIPv6, em)
 
 	// allocate 2 IPv4 addresses
-	found := sets.NewString()
+	found := sets.New[string]()
 	for i := 0; i < 2; i++ {
 		ip, err := a.AllocateNext()
 		if err != nil {
@@ -562,7 +562,7 @@ func TestClusterIPAllocatedMetrics(t *testing.T) {
 	expectMetrics(t, cidrIPv4, em)
 
 	// allocate 2 dynamic IPv4 addresses
-	found := sets.NewString()
+	found := sets.New[string]()
 	for i := 0; i < 2; i++ {
 		ip, err := a.AllocateNext()
 		if err != nil {

--- a/pkg/registry/core/service/ipallocator/ipallocator_test.go
+++ b/pkg/registry/core/service/ipallocator/ipallocator_test.go
@@ -126,7 +126,7 @@ func TestAllocateIPAllocator(t *testing.T) {
 			if f := r.Used(); f != 0 {
 				t.Errorf("[%s]: wrong used: expected %d, got %d", tc.name, 0, f)
 			}
-			found := sets.NewString()
+			found := sets.New[string]()
 			count := 0
 			for r.Free() > 0 {
 				ip, err := r.AllocateNext()
@@ -283,7 +283,7 @@ func TestAllocateSmallIPAllocator(t *testing.T) {
 	if f := r.Free(); f != 2 {
 		t.Errorf("expected free equal to 2 got: %d", f)
 	}
-	found := sets.NewString()
+	found := sets.New[string]()
 	for i := 0; i < 2; i++ {
 		ip, err := r.AllocateNext()
 		if err != nil {
@@ -319,11 +319,11 @@ func TestForEachIPAllocator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	testCases := []sets.String{
-		sets.NewString(),
-		sets.NewString("192.168.1.1"),
-		sets.NewString("192.168.1.1", "192.168.1.254"),
-		sets.NewString("192.168.1.1", "192.168.1.128", "192.168.1.254"),
+	testCases := []sets.Set[string]{
+		sets.New[string](),
+		sets.New[string]("192.168.1.1"),
+		sets.New[string]("192.168.1.1", "192.168.1.254"),
+		sets.New[string]("192.168.1.1", "192.168.1.128", "192.168.1.254"),
 	}
 
 	for i, tc := range testCases {
@@ -342,7 +342,7 @@ func TestForEachIPAllocator(t *testing.T) {
 				t.Errorf("[%d] expected IP %v allocated", i, ip)
 			}
 		}
-		calls := sets.NewString()
+		calls := sets.New[string]()
 		r.ForEach(func(ip net.IP) {
 			calls.Insert(ip.String())
 		})
@@ -350,7 +350,7 @@ func TestForEachIPAllocator(t *testing.T) {
 			t.Errorf("[%d] expected %d calls, got %d", i, len(tc), len(calls))
 		}
 		if !calls.Equal(tc) {
-			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), tc.List())
+			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, sets.List[string](calls), sets.List[string](tc))
 		}
 	}
 }
@@ -391,7 +391,7 @@ func TestIPAllocatorClusterIPMetrics(t *testing.T) {
 	expectMetrics(t, cidrIPv6, em)
 
 	// allocate 2 IPv4 addresses
-	found := sets.NewString()
+	found := sets.New[string]()
 	for i := 0; i < 2; i++ {
 		ip, err := a.AllocateNext()
 		if err != nil {
@@ -487,7 +487,7 @@ func TestIPAllocatorClusterIPAllocatedMetrics(t *testing.T) {
 	expectMetrics(t, cidrIPv4, em)
 
 	// allocate 2 dynamic IPv4 addresses
-	found := sets.NewString()
+	found := sets.New[string]()
 	for i := 0; i < 2; i++ {
 		ip, err := a.AllocateNext()
 		if err != nil {

--- a/pkg/registry/core/service/portallocator/allocator_test.go
+++ b/pkg/registry/core/service/portallocator/allocator_test.go
@@ -44,7 +44,7 @@ func TestAllocate(t *testing.T) {
 	if f := r.Used(); f != 0 {
 		t.Errorf("unexpected used %d", f)
 	}
-	found := sets.NewString()
+	found := sets.New[string]()
 	count := 0
 	for r.Free() > 0 {
 		p, err := r.AllocateNext()
@@ -179,11 +179,11 @@ func TestForEach(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testCases := []sets.Int{
-		sets.NewInt(),
-		sets.NewInt(10000),
-		sets.NewInt(10000, 10200),
-		sets.NewInt(10000, 10099, 10200),
+	testCases := []sets.Set[int]{
+		sets.New[int](),
+		sets.New[int](10000),
+		sets.New[int](10000, 10200),
+		sets.New[int](10000, 10099, 10200),
 	}
 
 	for i, tc := range testCases {
@@ -201,7 +201,7 @@ func TestForEach(t *testing.T) {
 			}
 		}
 
-		calls := sets.NewInt()
+		calls := sets.New[int]()
 		r.ForEach(func(port int) {
 			calls.Insert(port)
 		})
@@ -209,7 +209,7 @@ func TestForEach(t *testing.T) {
 			t.Errorf("[%d] expected %d calls, got %d", i, len(tc), len(calls))
 		}
 		if !calls.Equal(tc) {
-			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, calls.List(), tc.List())
+			t.Errorf("[%d] expected calls to equal testcase: %v vs %v", i, sets.List[int](calls), sets.List[int](tc))
 		}
 	}
 }
@@ -432,7 +432,7 @@ func TestNodePortMetrics(t *testing.T) {
 	expectMetrics(t, em)
 
 	// allocate 2 ports
-	found := sets.NewInt()
+	found := sets.New[int]()
 	for i := 0; i < 2; i++ {
 		port, err := a.AllocateNext()
 		if err != nil {
@@ -525,7 +525,7 @@ func TestNodePortAllocatedMetrics(t *testing.T) {
 	expectMetrics(t, em)
 
 	// allocate 2 dynamic port
-	found := sets.NewInt()
+	found := sets.New[int]()
 	for i := 0; i < 2; i++ {
 		port, err := a.AllocateNext()
 		if err != nil {

--- a/pkg/registry/core/service/portallocator/controller/repair.go
+++ b/pkg/registry/core/service/portallocator/controller/repair.go
@@ -218,7 +218,7 @@ func (c *Repair) doRunOnce() error {
 func collectServiceNodePorts(service *corev1.Service) []int {
 	var servicePorts []int
 	// map from nodePort to set of protocols
-	seen := make(map[int]sets.String)
+	seen := make(map[int]sets.Set[string])
 	for _, port := range service.Spec.Ports {
 		nodePort := int(port.NodePort)
 		if nodePort == 0 {
@@ -227,7 +227,7 @@ func collectServiceNodePorts(service *corev1.Service) []int {
 		proto := string(port.Protocol)
 		s := seen[nodePort]
 		if s == nil { // have not seen this nodePort before
-			s = sets.NewString(proto)
+			s = sets.New[string](proto)
 			servicePorts = append(servicePorts, nodePort)
 		} else if s.Has(proto) { // same nodePort with same protocol
 			servicePorts = append(servicePorts, nodePort)

--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -597,8 +597,8 @@ func patchAllocatedValues(after After, before Before) {
 	}
 
 	if needsNodePort(oldSvc) && needsNodePort(newSvc) {
-		nodePortsUsed := func(svc *api.Service) sets.Int32 {
-			used := sets.NewInt32()
+		nodePortsUsed := func(svc *api.Service) sets.Set[int32] {
+			used := sets.New[int32]()
 			for _, p := range svc.Spec.Ports {
 				if p.NodePort != 0 {
 					used.Insert(p.NodePort)

--- a/pkg/registry/core/service/strategy.go
+++ b/pkg/registry/core/service/strategy.go
@@ -330,8 +330,8 @@ func needsNodePort(svc *api.Service) bool {
 
 func sameNodePorts(oldSvc, newSvc *api.Service) bool {
 	// Helper to make a set of NodePort values.
-	allNodePorts := func(svc *api.Service) sets.Int {
-		out := sets.NewInt()
+	allNodePorts := func(svc *api.Service) sets.Set[int] {
+		out := sets.New[int]()
 		for i := range svc.Spec.Ports {
 			if svc.Spec.Ports[i].NodePort != 0 {
 				out.Insert(int(svc.Spec.Ports[i].NodePort))

--- a/pkg/registry/core/serviceaccount/storage/storage.go
+++ b/pkg/registry/core/serviceaccount/storage/storage.go
@@ -66,7 +66,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter, issuer token.TokenGenerator, 
 			secrets:              secretStorage,
 			issuer:               issuer,
 			auds:                 auds,
-			audsSet:              sets.NewString(auds...),
+			audsSet:              sets.New[string](auds...),
 			maxExpirationSeconds: int64(max.Seconds()),
 			extendExpiration:     extendExpiration,
 		}

--- a/pkg/registry/core/serviceaccount/storage/token.go
+++ b/pkg/registry/core/serviceaccount/storage/token.go
@@ -55,7 +55,7 @@ type TokenREST struct {
 	secrets              rest.Getter
 	issuer               token.TokenGenerator
 	auds                 authenticator.Audiences
-	audsSet              sets.String
+	audsSet              sets.Set[string]
 	maxExpirationSeconds int64
 	extendExpiration     bool
 }

--- a/pkg/registry/discovery/endpointslice/strategy.go
+++ b/pkg/registry/discovery/endpointslice/strategy.go
@@ -199,15 +199,15 @@ func dropTopologyOnV1(ctx context.Context, oldEPS, newEPS *discovery.EndpointSli
 
 // getDeprecatedTopologyNodeNames returns a set of node names present in
 // deprecatedTopology fields within the provided EndpointSlice.
-func getDeprecatedTopologyNodeNames(eps *discovery.EndpointSlice) sets.String {
+func getDeprecatedTopologyNodeNames(eps *discovery.EndpointSlice) sets.Set[string] {
 	if eps == nil {
 		return nil
 	}
-	var names sets.String
+	var names sets.Set[string]
 	for _, ep := range eps.Endpoints {
 		if nodeName, ok := ep.DeprecatedTopology[corev1.LabelHostname]; ok && len(nodeName) > 0 {
 			if names == nil {
-				names = sets.NewString()
+				names = sets.New[string]()
 			}
 			names.Insert(nodeName)
 		}

--- a/pkg/registry/discovery/endpointslice/strategy_test.go
+++ b/pkg/registry/discovery/endpointslice/strategy_test.go
@@ -933,7 +933,7 @@ func Test_getDeprecatedTopologyNodeNames(t *testing.T) {
 	testcases := []struct {
 		name              string
 		endpointSlice     *discovery.EndpointSlice
-		expectedNodeNames sets.String
+		expectedNodeNames sets.Set[string]
 	}{
 		{
 			name: "2 nodes",
@@ -943,7 +943,7 @@ func Test_getDeprecatedTopologyNodeNames(t *testing.T) {
 					{DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-2"}},
 				},
 			},
-			expectedNodeNames: sets.NewString("node-1", "node-2"),
+			expectedNodeNames: sets.New[string]("node-1", "node-2"),
 		},
 		{
 			name: "duplicate values",
@@ -954,7 +954,7 @@ func Test_getDeprecatedTopologyNodeNames(t *testing.T) {
 					{DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-3"}},
 				},
 			},
-			expectedNodeNames: sets.NewString("node-1", "node-3"),
+			expectedNodeNames: sets.New[string]("node-1", "node-3"),
 		},
 		{
 			name: "unset",
@@ -965,7 +965,7 @@ func Test_getDeprecatedTopologyNodeNames(t *testing.T) {
 					{DeprecatedTopology: nil},
 				},
 			},
-			expectedNodeNames: sets.NewString(),
+			expectedNodeNames: sets.New[string](),
 		},
 	}
 

--- a/pkg/registry/flowcontrol/ensurer/strategy.go
+++ b/pkg/registry/flowcontrol/ensurer/strategy.go
@@ -353,8 +353,8 @@ func RemoveUnwantedObjects[ObjectType configurationObjectType](ctx context.Conte
 	return nil
 }
 
-func namesOfBootstrapObjects[ObjectType configurationObjectType](bos []ObjectType) sets.String {
-	names := sets.NewString()
+func namesOfBootstrapObjects[ObjectType configurationObjectType](bos []ObjectType) sets.Set[string] {
+	names := sets.New[string]()
 	for _, bo := range bos {
 		names.Insert(bo.GetName())
 	}

--- a/pkg/registry/rbac/validation/rule.go
+++ b/pkg/registry/rbac/validation/rule.go
@@ -73,12 +73,12 @@ func ConfirmNoEscalation(ctx context.Context, ruleResolver AuthorizationRuleReso
 			compactMissingRights = compact
 		}
 
-		missingDescriptions := sets.NewString()
+		missingDescriptions := sets.New[string]()
 		for _, missing := range compactMissingRights {
 			missingDescriptions.Insert(rbacv1helpers.CompactString(missing))
 		}
 
-		msg := fmt.Sprintf("user %q (groups=%q) is attempting to grant RBAC permissions not currently held:\n%s", user.GetName(), user.GetGroups(), strings.Join(missingDescriptions.List(), "\n"))
+		msg := fmt.Sprintf("user %q (groups=%q) is attempting to grant RBAC permissions not currently held:\n%s", user.GetName(), user.GetGroups(), strings.Join(sets.List[string](missingDescriptions), "\n"))
 		if len(ruleResolutionErrors) > 0 {
 			msg = msg + fmt.Sprintf("; resolution errors: %v", ruleResolutionErrors)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
According to https://github.com/kubernetes/apimachinery/blob/master/pkg/util/sets/string.go#L25
```
// String is a set of strings, implemented via map[string]struct{} for minimal memory consumption.
//
// Deprecated: use generic Set instead.
// new ways:
// s1 := Set[string]{}
// s2 := New[string]()
type String map[string]Empty
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
