### PR TITLE
Remove an old compatibility check/warning

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -201,7 +201,6 @@ var ipsetWithIptablesChain = []struct {
 
 // In IPVS proxy mode, the following flags need to be set
 const (
-	sysctlBridgeCallIPTables      = "net/bridge/bridge-nf-call-iptables"
 	sysctlVSConnTrack             = "net/ipv4/vs/conntrack"
 	sysctlConnReuse               = "net/ipv4/vs/conn_reuse_mode"
 	sysctlExpireNoDestConn        = "net/ipv4/vs/expire_nodest_conn"
@@ -330,13 +329,6 @@ func NewProxier(ipFamily v1.IPFamily,
 	nodePortAddressStrings []string,
 	kernelHandler KernelHandler,
 ) (*Proxier, error) {
-	// Proxy needs br_netfilter and bridge-nf-call-iptables=1 when containers
-	// are connected to a Linux bridge (but not SDN bridges).  Until most
-	// plugins handle this, log when config is missing
-	if val, err := sysctl.GetSysctl(sysctlBridgeCallIPTables); err == nil && val != 1 {
-		klog.InfoS("Missing br-netfilter module or unset sysctl br-nf-call-iptables, proxy may not work as intended")
-	}
-
 	// Set the conntrack sysctl we need for
 	if err := proxyutil.EnsureSysctl(sysctl, sysctlVSConnTrack, 1); err != nil {
 		return nil, err


### PR DESCRIPTION
 What type of PR is this?

/kind cleanup
/sig network
/area ipvs
/area kube-proxy

What this PR does / why we need it:
kube-proxy used to unconditionally load the br-netfilter kernel module and set the bridge-nf-call-iptables sysctl. In https://github.com/kubernetes/kubernetes/pull/20647 this was moved to the kubenet plugin instead (since it is not needed and not wanted for some other network plugins), and kube-proxy was changed to just warn if br-netfilter was not loaded / bridge-nf-call-iptables was not set, with the comment "Until most plugins handle this, log when config is missing". That was seven and a half years ago. Presumably everyone got the message by now.

(Note also that the check and the warning are both IPv4-specific; to make kube-proxy work correctly with linux-bridge-based plugins under IPv6, you need to set bridge-nf-call-ip6tables instead. e.g., this was fixed in kubeadm in https://github.com/kubernetes/kubernetes/issues/53013, but no one ever suggested that maybe kube-proxy should warn people about that...)

Which issue(s) this PR fixes:
Fixes #120849 

 Does this PR introduce a user-facing change?

```NONE```
