### PR TITLE
kube-proxy: Optionally do privileged configs only

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -125,7 +125,7 @@ func (s *ProxyServer) platformCheckSupported() (ipv4Supported, ipv6Supported, du
 }
 
 // createProxier creates the proxy.Provider
-func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguration, dualStack bool) (proxy.Provider, error) {
+func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguration, dualStack, initOnly bool) (proxy.Provider, error) {
 	var proxier proxy.Provider
 	var err error
 
@@ -175,6 +175,7 @@ func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguratio
 				s.Recorder,
 				s.HealthzServer,
 				config.NodePortAddresses,
+				initOnly,
 			)
 		} else {
 			// Create a single-stack proxier if and only if the node does not support dual-stack (i.e, no iptables support).
@@ -201,6 +202,7 @@ func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguratio
 				s.Recorder,
 				s.HealthzServer,
 				config.NodePortAddresses,
+				initOnly,
 			)
 		}
 
@@ -247,6 +249,7 @@ func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguratio
 				config.IPVS.Scheduler,
 				config.NodePortAddresses,
 				kernelHandler,
+				initOnly,
 			)
 		} else {
 			var localDetector proxyutiliptables.LocalTrafficDetector
@@ -279,6 +282,7 @@ func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguratio
 				config.IPVS.Scheduler,
 				config.NodePortAddresses,
 				kernelHandler,
+				initOnly,
 			)
 		}
 		if err != nil {

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -79,7 +79,10 @@ func (s *ProxyServer) platformCheckSupported() (ipv4Supported, ipv6Supported, du
 }
 
 // createProxier creates the proxy.Provider
-func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguration, dualStackMode bool) (proxy.Provider, error) {
+func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguration, dualStackMode, initOnly bool) (proxy.Provider, error) {
+	if initOnly {
+		return nil, fmt.Errorf("--init-only is not implemented on Windows")
+	}
 	var healthzPort int
 	if len(config.HealthzBindAddress) > 0 {
 		_, port, _ := net.SplitHostPort(config.HealthzBindAddress)

--- a/pkg/proxy/kubemark/hollow_proxy.go
+++ b/pkg/proxy/kubemark/hollow_proxy.go
@@ -109,6 +109,7 @@ func NewHollowProxyOrDie(
 			recorder,
 			nil,
 			[]string{},
+			false,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create proxier: %v", err)


### PR DESCRIPTION
A new `--init-only` flag is added that makes `kube-proxy` perform configuration that requires privileged mode and exit. It is intended to be executed in a privileged `initContainer`, while the main container may run with a stricter securityContext

#### What type of PR is this?

/kind feature
/sig network
/area kube-proxy

#### What this PR does / why we need it:

Users don't like containers running with `privileged: true`. This PR allows the configs that _requires_ `privileged: true` to run in an `initContainer`.

#### Which issue(s) this PR fixes:

Fixes #112171

Well, it solves the problem, but nothing documented (yet)

#### Special notes for your reviewer:

Tested with an `initContainer` similar to
```yaml
initContainers:
  - name: kube-proxy-init
    command:
    - /usr/local/bin/kube-proxy
    - --config=/var/lib/kube-proxy/config.conf
    - --init-only
    image: registry.k8s.io/kube-proxy:local
    imagePullPolicy: IfNotPresent
    securityContext:
      privileged: true
    volumeMounts:
    - mountPath: /var/lib/kube-proxy
      name: kube-proxy
```
And the main kube-proxy container runs with:
```yaml
        securityContext:
          capabilities:
            add: ["NET_ADMIN", "SYS_RESOURCE"]
```

#### Does this PR introduce a user-facing change?


```release-note
Added a new `--init-only` command line flag to `kube-proxy`. Setting the flag makes `kube-proxy` perform its initial configuration that requires privileged mode, and then exit. The `--init-only` mode is intended to be executed in a privileged init container, so that the main container may run with a stricter `securityContext`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

