### PR TITLE
deflake TestWebSocketClient_HeartbeatSucceeds

### DIFF
--- a/staging/src/k8s.io/client-go/tools/remotecommand/websocket_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/websocket_test.go
@@ -1057,8 +1057,7 @@ func TestWebSocketClient_HeartbeatSucceeds(t *testing.T) {
 		for {
 			_, _, err := conn.ReadMessage()
 			if err != nil {
-				t.Logf("server err reading message: %v", err)
-				return
+				break
 			}
 		}
 	}))
@@ -1085,7 +1084,11 @@ func TestWebSocketClient_HeartbeatSucceeds(t *testing.T) {
 		return pongHandler(msg)
 	})
 	go heartbeat.start()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
 			_, _, err := client.ReadMessage()
 			if err != nil {
@@ -1107,6 +1110,7 @@ func TestWebSocketClient_HeartbeatSucceeds(t *testing.T) {
 		close(heartbeat.closer)
 		t.Errorf("unexpected heartbeat timeout")
 	}
+	wg.Wait()
 }
 
 func TestWebSocketClient_StreamsAndExpectedErrors(t *testing.T) {


### PR DESCRIPTION
/kind flake
```release-note
NONE
```

Tests panic if they try to log after the test has ended, to avoid that don't log on the handler since the shutdown waits for all connections to be closed and can be racy, and also wait for the client goroutine to finish

With this change
```
go test -timeout 30s -run ^TestWebSocketClient_HeartbeatSucceeds$ k8s.io/client-go/tools/remotecommand -v -count 1 -race -c
aojea@aojea:~/src/kubernetes$ stress ./remotecommand.test -test.run ^TestWebSocketClient_HeartbeatSucceeds$
5s: 144 runs so far, 0 failures
10s: 336 runs so far, 0 failures
15s: 528 runs so far, 0 failures
20s: 720 runs so far, 0 failures
25s: 864 runs so far, 0 failures
30s: 1056 runs so far, 0 failures
35s: 1248 runs so far, 0 failures
40s: 1440 runs so far, 0 failures
45s: 1632 runs so far, 0 failures
50s: 1776 runs so far, 0 failures
...
28m55s: 63237 runs so far, 0 failures
29m0s: 63420 runs so far, 0 failures
29m5s: 63604 runs so far, 0 failures
29m10s: 63792 runs so far, 0 failures
```

Fixes: #120684