### PR TITLE
k8s.io/dynamic-resource-allocation: fix potential scheduling deadlock

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/controller/controller_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/controller/controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,6 +65,10 @@ func TestController(t *testing.T) {
 	otherNodeName := "worker-2"
 	unsuitableNodes := []string{otherNodeName}
 	potentialNodes := []string{nodeName, otherNodeName}
+	maxNodes := make([]string, resourcev1alpha2.PodSchedulingNodeListMaxSize)
+	for i := range maxNodes {
+		maxNodes[i] = fmt.Sprintf("node-%d", i)
+	}
 	withDeletionTimestamp := func(claim *resourcev1alpha2.ResourceClaim) *resourcev1alpha2.ResourceClaim {
 		var deleted metav1.Time
 		claim = claim.DeepCopy()
@@ -101,17 +106,23 @@ func TestController(t *testing.T) {
 		podSchedulingCtx.Spec.SelectedNode = nodeName
 		return podSchedulingCtx
 	}
-	withUnsuitableNodes := func(podSchedulingCtx *resourcev1alpha2.PodSchedulingContext) *resourcev1alpha2.PodSchedulingContext {
+	withSpecificUnsuitableNodes := func(podSchedulingCtx *resourcev1alpha2.PodSchedulingContext, unsuitableNodes []string) *resourcev1alpha2.PodSchedulingContext {
 		podSchedulingCtx = podSchedulingCtx.DeepCopy()
 		podSchedulingCtx.Status.ResourceClaims = append(podSchedulingCtx.Status.ResourceClaims,
 			resourcev1alpha2.ResourceClaimSchedulingStatus{Name: podClaimName, UnsuitableNodes: unsuitableNodes},
 		)
 		return podSchedulingCtx
 	}
-	withPotentialNodes := func(podSchedulingCtx *resourcev1alpha2.PodSchedulingContext) *resourcev1alpha2.PodSchedulingContext {
+	withUnsuitableNodes := func(podSchedulingCtx *resourcev1alpha2.PodSchedulingContext) *resourcev1alpha2.PodSchedulingContext {
+		return withSpecificUnsuitableNodes(podSchedulingCtx, unsuitableNodes)
+	}
+	withSpecificPotentialNodes := func(podSchedulingCtx *resourcev1alpha2.PodSchedulingContext, potentialNodes []string) *resourcev1alpha2.PodSchedulingContext {
 		podSchedulingCtx = podSchedulingCtx.DeepCopy()
 		podSchedulingCtx.Spec.PotentialNodes = potentialNodes
 		return podSchedulingCtx
+	}
+	withPotentialNodes := func(podSchedulingCtx *resourcev1alpha2.PodSchedulingContext) *resourcev1alpha2.PodSchedulingContext {
+		return withSpecificPotentialNodes(podSchedulingCtx, potentialNodes)
 	}
 
 	var m mockDriver
@@ -374,6 +385,48 @@ func TestController(t *testing.T) {
 				expectUnsuitableNodes(map[string][]string{podClaimName: unsuitableNodes}, nil).
 				expectAllocate(map[string]allocate{claimName: {allocResult: &allocation, selectedNode: nodeName, allocErr: nil}}),
 			expectedSchedulingCtx: withUnsuitableNodes(withSelectedNode(withPotentialNodes(podSchedulingCtx))),
+			expectedError:         errPeriodic.Error(),
+		},
+		// pod with delayed allocation, potential nodes, selected node, all unsuitable -> update unsuitable nodes
+		"pod-selected-is-potential-node": {
+			key:           podKey,
+			classes:       classes,
+			claim:         delayedClaim,
+			expectedClaim: delayedClaim,
+			pod:           podWithClaim,
+			schedulingCtx: withPotentialNodes(withSelectedNode(withPotentialNodes(podSchedulingCtx))),
+			driver: m.expectClassParameters(map[string]interface{}{className: 1}).
+				expectClaimParameters(map[string]interface{}{claimName: 2}).
+				expectUnsuitableNodes(map[string][]string{podClaimName: potentialNodes}, nil),
+			expectedSchedulingCtx: withSpecificUnsuitableNodes(withSelectedNode(withPotentialNodes(podSchedulingCtx)), potentialNodes),
+			expectedError:         errPeriodic.Error(),
+		},
+		// pod with delayed allocation, max potential nodes, other selected node, all unsuitable -> update unsuitable nodes with truncation at start
+		"pod-selected-is-potential-node-truncate-first": {
+			key:           podKey,
+			classes:       classes,
+			claim:         delayedClaim,
+			expectedClaim: delayedClaim,
+			pod:           podWithClaim,
+			schedulingCtx: withSpecificPotentialNodes(withSelectedNode(withSpecificPotentialNodes(podSchedulingCtx, maxNodes)), maxNodes),
+			driver: m.expectClassParameters(map[string]interface{}{className: 1}).
+				expectClaimParameters(map[string]interface{}{claimName: 2}).
+				expectUnsuitableNodes(map[string][]string{podClaimName: append(maxNodes, nodeName)}, nil),
+			expectedSchedulingCtx: withSpecificUnsuitableNodes(withSelectedNode(withSpecificPotentialNodes(podSchedulingCtx, maxNodes)), append(maxNodes[1:], nodeName)),
+			expectedError:         errPeriodic.Error(),
+		},
+		// pod with delayed allocation, max potential nodes, other selected node, all unsuitable (but in reverse order) -> update unsuitable nodes with truncation at end
+		"pod-selected-is-potential-node-truncate-last": {
+			key:           podKey,
+			classes:       classes,
+			claim:         delayedClaim,
+			expectedClaim: delayedClaim,
+			pod:           podWithClaim,
+			schedulingCtx: withSpecificPotentialNodes(withSelectedNode(withSpecificPotentialNodes(podSchedulingCtx, maxNodes)), maxNodes),
+			driver: m.expectClassParameters(map[string]interface{}{className: 1}).
+				expectClaimParameters(map[string]interface{}{claimName: 2}).
+				expectUnsuitableNodes(map[string][]string{podClaimName: append([]string{nodeName}, maxNodes...)}, nil),
+			expectedSchedulingCtx: withSpecificUnsuitableNodes(withSelectedNode(withSpecificPotentialNodes(podSchedulingCtx, maxNodes)), append([]string{nodeName}, maxNodes[:len(maxNodes)-1]...)),
 			expectedError:         errPeriodic.Error(),
 		},
 	} {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When handling a PodSchedulingContext object, the code first checked for unsuitable nodes and then tried to allocate if (and only if) the selected node hadn't been found to be unsuitable.

If for whatever reason the selected node wasn't listed as potential node, then scheduling got stuck because the allocation would fail and cause a return with an error instead of updating the list of unsuitable nodes. This would be retried with the same result.

To avoid this scenario, the selected node now also gets checked. This is better than assuming a certain kube-scheduler behavior.

#### Special notes for your reviewer:

This problem occurred when experimenting with cluster autoscaling:

    spec:
      potentialNodes:
      - gke-cluster-pohly-pool-dra-69b88e1e-bz6c
      - gke-cluster-pohly-pool-dra-69b88e1e-fpvh
      selectedNode: gke-cluster-pohly-default-pool-c9f60a43-6kxh

Why the scheduler wrote a spec like this is unclear. This was with Kubernetes 1.27 and the code has been updated since then, so perhaps it's resolved.

#### Does this PR introduce a user-facing change?
```release-note
k8s.io/dynamic-resource-allocation: handle a selected node which isn't listed as potential node
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3063
```
