### PR TITLE
e2e dra: enhance test driver

### DIFF
--- a/test/e2e/dra/deploy.go
+++ b/test/e2e/dra/deploy.go
@@ -136,6 +136,7 @@ func (d *Driver) SetUp(nodes *Nodes, resources app.Resources) {
 	ginkgo.By(fmt.Sprintf("deploying driver on nodes %v", nodes.NodeNames))
 	d.Nodes = map[string]*app.ExamplePlugin{}
 	d.Name = d.f.UniqueName + d.NameSuffix + ".k8s.io"
+	resources.DriverName = d.Name
 
 	ctx, cancel := context.WithCancel(context.Background())
 	if d.NameSuffix != "" {
@@ -147,7 +148,7 @@ func (d *Driver) SetUp(nodes *Nodes, resources app.Resources) {
 	d.cleanup = append(d.cleanup, cancel)
 
 	// The controller is easy: we simply connect to the API server.
-	d.Controller = app.NewController(d.f.ClientSet, d.Name, resources)
+	d.Controller = app.NewController(d.f.ClientSet, resources)
 	d.wg.Add(1)
 	go func() {
 		defer d.wg.Done()

--- a/test/e2e/dra/test-driver/app/server.go
+++ b/test/e2e/dra/test-driver/app/server.go
@@ -81,7 +81,9 @@ func NewCommand() *cobra.Command {
 	profilePath := fs.String("pprof-path", "", "The HTTP path where pprof profiling will be available, disabled if empty.")
 
 	fs = sharedFlagSets.FlagSet("CDI")
-	driverName := fs.String("drivername", "test-driver.cdi.k8s.io", "Resource driver name.")
+	driverNameFlagName := "drivername"
+	driverName := fs.String(driverNameFlagName, "test-driver.cdi.k8s.io", "Resource driver name.")
+	driverNameFlag := fs.Lookup(driverNameFlagName)
 
 	fs = sharedFlagSets.FlagSet("other")
 	featureGate := featuregate.NewFeatureGate()
@@ -192,6 +194,7 @@ func NewCommand() *cobra.Command {
 		"Duration, in seconds, that the acting leader will retry refreshing leadership before giving up.")
 	leaderElectionRetryPeriod := fs.Duration("leader-election-retry-period", 5*time.Second,
 		"Duration, in seconds, the LeaderElector clients should wait between tries of actions.")
+	fs = controllerFlagSets.FlagSet("controller")
 	resourceConfig := fs.String("resource-config", "", "A JSON file containing a Resources struct. Defaults are unshared, network-attached resources.")
 	fs = controller.Flags()
 	for _, f := range controllerFlagSets.FlagSets {
@@ -211,9 +214,12 @@ func NewCommand() *cobra.Command {
 				return fmt.Errorf("parse resource config %q: %w", *resourceConfig, err)
 			}
 		}
+		if resources.DriverName == "" || driverNameFlag.Changed {
+			resources.DriverName = *driverName
+		}
 
 		run := func() {
-			controller := NewController(clientset, *driverName, resources)
+			controller := NewController(clientset, resources)
 			controller.Run(ctx, *workers)
 		}
 

--- a/test/integration/scheduler_perf/dra_test.go
+++ b/test/integration/scheduler_perf/dra_test.go
@@ -192,6 +192,7 @@ func (op *createResourceDriverOp) run(ctx context.Context, tb testing.TB, client
 	// Start the controller side of the DRA test driver such that it simulates
 	// per-node resources.
 	resources := draapp.Resources{
+		DriverName:     op.DriverName,
 		NodeLocal:      true,
 		MaxAllocations: op.MaxClaimsPerNode,
 	}
@@ -210,7 +211,7 @@ func (op *createResourceDriverOp) run(ctx context.Context, tb testing.TB, client
 		}
 	}
 
-	controller := draapp.NewController(clientset, op.DriverName, resources)
+	controller := draapp.NewController(clientset, resources)
 	ctx, cancel := context.WithCancel(ctx)
 	var wg sync.WaitGroup
 	wg.Add(1)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Several enhancements:
- `--resource-config` is now listed under `controller` options instead of `leader election`: merely a cosmetic change
- The driver name can be configured as part of the resource config. The config overrides the command line flag. This makes it possible to pre-define complete driver setups where the name is associated with certain resource availability. This will be used for testing cluster autoscaling.
- The set of nodes where resources are available can optionally be specified via node labels. This will be used for testing cluster autoscaling.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @elazar