### PR TITLE
Standardize variable naming conventions in pkg/volume/util/atomic_writer.go to avoid CI build failures

### DIFF
--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -146,31 +146,31 @@ func (w *AtomicWriter) Write(payload map[string]FileProjection, setPerms func(su
 
 	// (2)
 	dataDirPath := filepath.Join(w.targetDir, dataDirName)
-	oldTsDir, err := os.Readlink(dataDirPath)
+	oldTSDir, err := os.Readlink(dataDirPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			klog.Errorf("%s: error reading link for data directory: %v", w.logContext, err)
 			return err
 		}
 		// although Readlink() returns "" on err, don't be fragile by relying on it (since it's not specified in docs)
-		// empty oldTsDir indicates that it didn't exist
-		oldTsDir = ""
+		// empty oldTSDir indicates that it didn't exist
+		oldTSDir = ""
 	}
-	oldTsPath := filepath.Join(w.targetDir, oldTsDir)
+	oldTSPath := filepath.Join(w.targetDir, oldTSDir)
 
 	var pathsToRemove sets.Set[string]
 	shouldWrite := true
 	// if there was no old version, there's nothing to remove
-	if len(oldTsDir) != 0 {
+	if len(oldTSDir) != 0 {
 		// (3)
-		pathsToRemove, err = w.pathsToRemove(cleanPayload, oldTsPath)
+		pathsToRemove, err = w.pathsToRemove(cleanPayload, oldTSPath)
 		if err != nil {
 			klog.Errorf("%s: error determining user-visible files to remove: %v", w.logContext, err)
 			return err
 		}
 
 		// (4)
-		if should, err := shouldWritePayload(cleanPayload, oldTsPath); err != nil {
+		if should, err := shouldWritePayload(cleanPayload, oldTSPath); err != nil {
 			klog.Errorf("%s: error determining whether payload should be written to disk: %v", w.logContext, err)
 			return err
 		} else if !should && len(pathsToRemove) == 0 {
@@ -257,9 +257,9 @@ func (w *AtomicWriter) Write(payload map[string]FileProjection, setPerms func(su
 	}
 
 	// (12)
-	if len(oldTsDir) > 0 {
-		if err = os.RemoveAll(oldTsPath); err != nil {
-			klog.Errorf("%s: error removing old data directory %s: %v", w.logContext, oldTsDir, err)
+	if len(oldTSDir) > 0 {
+		if err = os.RemoveAll(oldTSPath); err != nil {
+			klog.Errorf("%s: error removing old data directory %s: %v", w.logContext, oldTSDir, err)
 			return err
 		}
 	}
@@ -322,9 +322,9 @@ func validatePath(targetPath string) error {
 }
 
 // shouldWritePayload returns whether the payload should be written to disk.
-func shouldWritePayload(payload map[string]FileProjection, oldTsDir string) (bool, error) {
+func shouldWritePayload(payload map[string]FileProjection, oldTSDir string) (bool, error) {
 	for userVisiblePath, fileProjection := range payload {
-		shouldWrite, err := shouldWriteFile(filepath.Join(oldTsDir, userVisiblePath), fileProjection.Data)
+		shouldWrite, err := shouldWriteFile(filepath.Join(oldTSDir, userVisiblePath), fileProjection.Data)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
CI failure because of the variable naming
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/120845/pull-kubernetes-verify-lint/1749609288822689792
```
running /home/prow/go/src/k8s.io/kubernetes/_output/local/bin/golangci-lint run --new --new-from-rev=445869a59bdbd1c587b72b52c5da94c1d1c316a1 --config=/home/prow/go/src/k8s.io/kubernetes/hack/golangci-strict.yaml ./...
ERROR: pkg/volume/util/atomic_writer.go:340:73: ST1003: method parameter oldTsDir should be oldTSDir (stylecheck)
ERROR: func (w *AtomicWriter) pathsToRemove(payload map[string]FileProjection, oldTsDir string) (sets.Set[string], error) {
ERROR:                                                                         ^
running ( cd /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/api; /home/prow/go/src/k8s.io/kubernetes/_output/local/bin/golangci-lint run --new --new-from-rev=445869a59bdbd1c587b72b52c5da94c1d1c316a1 --config=/home/prow/go/src/k8s.io/kubernetes/hack/golangci-strict.yaml --path-prefix staging/src/k8s.io/api ./... )
running ( cd /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver; /home/prow/go/src/k8s.io/kubernetes/_output/local/bin/golangci-lint run --new --new-from-rev=445869a59bdbd1c587b72b52c5da94c1d1c316a1 --config=/home/prow/go/src/k8s.io/kubernetes/hack/golangci-strict.yaml --path-prefix staging/src/k8s.io/apiextensions-apiserver ./... )
running ( cd /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apimachinery; /home/prow/go/src/k8s.io/kubernetes/_output/local/bin/golangci-lint run --new --new-from-rev=445869a59bdbd1c587b72b52c5da94c1d1c316a1 --config=/home/prow/go/src/k8s.io/kubernetes/hack/golangci-strict.yaml --path-prefix staging/src/k8s.io/apimachinery ./... )
running ( cd /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/apiserver; /home/prow/go/src/k8s.io/kubernetes/_output/local/bin/golangci-lint run --new --new-from-rev=445869a59bdbd1c587b72b52c5da94c1d1c316a1 --config=/home/prow/go/src/k8s.io/kubernetes/hack/golangci-strict.yaml --path-prefix staging/src/k8s.io/apiserver ./... )
running ( cd /home/prow/go/src/k8s.io/kubernetes/staging/src/k8s.io/cli-runtime; /home/prow/go/src/k8s.io/kubernetes/_output/local/bin/golangci-lint run --new --new-from-rev=445869a59bdbd1c587b72b52c5da94c1d1c316a1 --config=/home/prow/go/src/k8s.io/kubernetes/hack/golangci-strict.yaml --path-prefix staging/src/k8s.io/cli-runtime ./... )
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
ref #120845
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
