### PR TITLE
Default clientset_pkg and clientset_name variables

### DIFF
--- a/staging/src/k8s.io/code-generator/generate-internal-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-internal-groups.sh
@@ -120,6 +120,9 @@ for GVs in ${GROUPS_WITH_VERSIONS}; do
   done
 done
 
+CLIENTSET_PKG="${CLIENTSET_PKG_NAME:-clientset}"
+CLIENTSET_NAME="${CLIENTSET_NAME_VERSIONED:-versioned}"
+
 if grep -qw "deepcopy" <<<"${GENS}"; then
   # Nuke existing files
   for dir in $(GO111MODULE=on go list -f '{{.Dir}}' "${ALL_FQ_APIS[@]}"); do
@@ -187,9 +190,6 @@ if grep -qw "applyconfiguration" <<<"${GENS}"; then
 fi
 
 if grep -qw "client" <<<"${GENS}"; then
-  CLIENTSET_PKG="${CLIENTSET_PKG_NAME:-clientset}"
-  CLIENTSET_NAME="${CLIENTSET_NAME_VERSIONED:-versioned}"
-
   # Nuke existing files
   root="$(GO111MODULE=on go list -f '{{.Dir}}' "${OUTPUT_PKG}/${CLIENTSET_PKG}/${CLIENTSET_NAME}" 2>/dev/null || true)"
   if [ -n "${root}" ]; then


### PR DESCRIPTION
/kind bug
/kind regression

#### What this PR does / why we need it:
Looks like during refactoring in https://github.com/kubernetes/kubernetes/pull/117262 something was missed.
Now when I use the deprecated script I'm getting:
```
Generating listers for apiserver:v1 at github.com/openshift/client-go/apiserver/listers
Generating informers for apiserver:v1 at github.com/openshift/client-go/apiserver/informers
/home/maszulik/workspace/origin/src/github.com/openshift/client-go/vendor/k8s.io/code-generator/generate-internal-groups.sh: line 249: CLIENTSET_PKG: unbound variable
make: *** [Makefile:32: generate] Error 1
```
This PR adds the missing defaulting where it should be.

#### Special notes for your reviewer:
/assign @thockin @liggitt 

#### Does this PR introduce a user-facing change?
```release-note
Fixes a regression (CLIENTSET_PKG: unbound variable) when invoking deprecated generate-groups.sh script 
```
