### PR TITLE
Portforward over WebSockets instead of SPDY

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -621,6 +621,13 @@ const (
 	// Enable users to specify when a Pod is ready for scheduling.
 	PodSchedulingReadiness featuregate.Feature = "PodSchedulingReadiness"
 
+	// owner: @seans3
+	// kep: http://kep.k8s.io/4006
+	// alpha: v1.30
+	//
+	// Enables PortForward to be proxied with a websocket client
+	PortForwardWebsockets featuregate.Feature = "PortForwardWebsockets"
+
 	// owner: @jessfraz
 	// alpha: v1.12
 	//
@@ -1081,6 +1088,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	PodLifecycleSleepAction: {Default: false, PreRelease: featuregate.Alpha},
 
 	PodSchedulingReadiness: {Default: true, PreRelease: featuregate.Beta},
+
+	PortForwardWebsockets: {Default: true, PreRelease: featuregate.Alpha},
 
 	ProcMountType: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/portforward/constants.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/portforward/constants.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+const (
+	PortForwardV1Name = "portforward.k8s.io"
+	PortForwardV2Name = "v2.portforward.k8s.io"
+)

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.3.0
+	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
@@ -77,7 +78,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/btree v1.0.1 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect

--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/portforward/streamtranslator.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/portforward/streamtranslator.go
@@ -1,0 +1,426 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	gwebsocket "github.com/gorilla/websocket"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/httpstream/spdy"
+	constants "k8s.io/apimachinery/pkg/util/portforward"
+	"k8s.io/client-go/tools/portforward"
+	spdytransport "k8s.io/client-go/transport/spdy"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// garbage collection to remove invalid subrequest resources.
+	gcPeriod = 5 * time.Second
+	// time to wait for second subrequest stream to arrive.
+	streamCreateTimeout = 10 * time.Second
+)
+
+// StreamTranslatorHandler is a handler which translates WebSocket stream data
+// to SPDY to proxy to kubelet (and ContainerRuntime).
+type StreamTranslatorHandler struct {
+	// Location is the location of the upstream proxy. It is used as the location to Dial on the upstream server
+	// for upgrade requests.
+	Location *url.URL
+	// Transport provides an optional round tripper to use to proxy. If nil, the default proxy transport is used
+	Transport http.RoundTripper
+	// MaxBytesPerSec throttles stream Reader/Writer if necessary
+	MaxBytesPerSec int64
+	// Server-side of upgraded websocket connection
+	wsConnection *portforward.WebsocketConnection
+	// Client-side of upstream SPDY connection
+	spdyConnection httpstream.Connection
+	// Map of pending subrequests to the streams associated with subrequest.
+	requestStreams *requestStreams
+}
+
+// NewStreamTranslatorHandler creates a new proxy handler, which translates websocket
+// streams/data into SPDY stream/data upstream.
+func NewStreamTranslatorHandler(location *url.URL, transport http.RoundTripper, maxBytesPerSec int64) *StreamTranslatorHandler {
+	return &StreamTranslatorHandler{
+		Location:       location,
+		Transport:      transport,
+		MaxBytesPerSec: maxBytesPerSec,
+		requestStreams: newRequestStreams(),
+	}
+}
+
+// ServeHTTP called to run stream translator proxy. HTTP request is upgraded to websocket
+// streaming connection. An SPDY connection is also created upstream to the kubelet.
+// Responds to websocket streams created on websocket connection by creating and copying
+// data on an associated upstream SPDY stream.
+func (h *StreamTranslatorHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// First, dial upstream server to establish SPDY connection.
+	spdyRoundTripper, err := spdy.NewRoundTripperWithConfig(spdy.RoundTripperConfig{UpgradeTransport: h.Transport})
+	if err != nil {
+		klog.Errorf("error creating spdy roundtripper: %v", err)
+		return
+	}
+	dialer := spdytransport.NewDialer(spdyRoundTripper, &http.Client{Transport: spdyRoundTripper}, req.Method, h.Location)
+	spdyConn, spdyProtocol, err := dialer.Dial(constants.PortForwardV1Name)
+	if err != nil {
+		klog.Errorf("error spdy upgrading connection: %v", err)
+		return
+	}
+	defer spdyConn.Close() //nolint:errcheck
+	klog.V(3).Infof("upstream sdpy connection created: %s", spdyProtocol)
+	h.spdyConnection = spdyConn
+
+	// If SPDY upstream connection was successfully established, then
+	// upgrade the current request to a websocket server connection.
+	var upgrader = gwebsocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool {
+			return true // Accepting all requests
+		},
+		Subprotocols: []string{
+			constants.PortForwardV2Name,
+		},
+	}
+	conn, err := upgrader.Upgrade(w, req, nil)
+	if err != nil {
+		klog.Errorf("error upgrading websocket connection: %v", err)
+		return
+	}
+	defer conn.Close() //nolint:errcheck
+	klog.V(3).Infof("websocket connection created: %s", conn.Subprotocol())
+	h.wsConnection = portforward.NewWebsocketConnection(conn, h.MaxBytesPerSec)
+
+	// Channel for communicating websocket streams.
+	streamCreateCh := make(chan httpstream.Stream)
+	klog.V(3).Infoln("websocket connection read loop starting...")
+	go h.wsConnection.Start(streamCreateCh, portforward.BufferSize, 0, 0) // no hearbeat sent on server-side endpoint
+
+	klog.V(3).Infoln("stream translator starting garbage collection loop...")
+	stopCh := make(chan struct{})
+	go h.garbageCollect(stopCh, gcPeriod, streamCreateTimeout)
+
+	// Loop iterating over websocket streams received from the stream create
+	// channel, until the websocket connection is closed.
+	klog.V(3).Infoln("stream translator starting websocket stream channel reception loop...")
+	for {
+		select {
+		case wsStream := <-streamCreateCh:
+			go func() {
+				requestID, err := getRequestID(wsStream)
+				if err != nil {
+					klog.Errorf("websocket stream created with invalid requestID: %v", err)
+					h.wsConnection.RemoveStreams(wsStream)
+					return
+				}
+				klog.V(5).Infof("websocket stream received from channel: %d", requestID)
+				// Retrieve streams associated with request (or create the structure if it does not exist).
+				streams := h.requestStreams.get(requestID)
+				// Create spdy stream that will be connected to websocket stream.
+				spdyStream, err := h.spdyConnection.CreateStream(wsStream.Headers())
+				if err != nil {
+					klog.Errorf("error creating spdy stream: %v", err)
+					h.requestStreams.remove(requestID)
+					h.spdyConnection.RemoveStreams(streams.getSpdyStreams()...)
+					h.wsConnection.RemoveStreams(append(streams.getWebsocketStreams(), wsStream)...)
+					return
+				}
+				ready, err := streams.addStreamPair(wsStream, spdyStream)
+				if err != nil {
+					klog.Errorf("error adding websocket/spdy data streams: %v", err)
+					h.requestStreams.remove(requestID)
+					h.spdyConnection.RemoveStreams(append(streams.getSpdyStreams(), spdyStream)...)
+					h.wsConnection.RemoveStreams(append(streams.getWebsocketStreams(), wsStream)...)
+					return
+				}
+				// If both the data stream and error stream for a subrequest have been
+				// created, then begin streaming the portforward.
+				if ready {
+					klog.V(4).Infof("stream pairs complete for request (%d)...portforwarding", requestID)
+					h.requestStreams.remove(requestID) // no longer pending--remove
+					streams.portForward()
+					h.spdyConnection.RemoveStreams(streams.getSpdyStreams()...)
+					h.wsConnection.RemoveStreams(streams.getWebsocketStreams()...)
+				}
+			}()
+		case <-h.wsConnection.CloseChan():
+			klog.V(3).Infof("channel closed--port forward connections closing")
+			close(stopCh)            // stop garbage collection
+			h.spdyConnection.Close() //nolint:errcheck
+			h.wsConnection.Close()   //nolint:errcheck
+			return
+		}
+	}
+}
+
+// garbageCollect loops through currently stored subrequests, removing resources
+// for subrequests in an invalid state. "gcPeriod" defines the time between garbage
+// collections, while "streamCreateTimeout" is the amount of time to wait for
+// the second subrequest stream to arrive. Should run in its own goroutine.
+func (h *StreamTranslatorHandler) garbageCollect(stopCh chan struct{}, gcPeriod time.Duration, streamCreateTimeout time.Duration) {
+	ticker := time.NewTicker(gcPeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			klog.V(8).Infof("stream translator garbarge collection...")
+			streamPairs := h.requestStreams.cleanup(streamCreateTimeout)
+			for _, sp := range streamPairs {
+				h.wsConnection.RemoveStreams(sp.getWebsocketStreams()...)
+				h.spdyConnection.RemoveStreams(sp.getSpdyStreams()...)
+			}
+		case <-stopCh:
+			return
+		}
+	}
+}
+
+// requestStreams encapsulates the mapping between a *pending* subrequest
+// (identified by requestID) and the incomplete streams (data and error)
+// associated with the subrequest. Once all the requests streams have arrived,
+// it is no longer pending, and it is safe to remove the entry.
+type requestStreams struct {
+	requestStreamsMap  map[int]*streamPairs
+	requestStreamsLock sync.Mutex
+}
+
+// newRequestStreams returns a pointer to a new, initialized "requestStreams" struct.
+func newRequestStreams() *requestStreams {
+	return &requestStreams{
+		requestStreamsMap:  map[int]*streamPairs{},
+		requestStreamsLock: sync.Mutex{},
+	}
+}
+
+// get returns the streamPairs struct associated with the requestID. If
+// the struct does not exist, it is created.
+func (rs *requestStreams) get(requestID int) *streamPairs {
+	rs.requestStreamsLock.Lock()
+	defer rs.requestStreamsLock.Unlock()
+	_, exists := rs.requestStreamsMap[requestID]
+	if !exists {
+		rs.requestStreamsMap[requestID] = &streamPairs{}
+	}
+	return rs.requestStreamsMap[requestID]
+}
+
+// remove deletes the subrequest from the requestStreamsMap.
+func (rs *requestStreams) remove(requestID int) {
+	rs.requestStreamsLock.Lock()
+	defer rs.requestStreamsLock.Unlock()
+	delete(rs.requestStreamsMap, requestID)
+}
+
+// cleanup loops through the requestStreamsMap, removing subrequests that have
+// not received both sets of streams necessary to portforward before the
+// "streamCreateTimeout" has passed. Returns an array of the streamPairs structs
+// that are timed out (for further cleanup if necessary).
+func (rs *requestStreams) cleanup(streamCreateTimeout time.Duration) []*streamPairs {
+	rs.requestStreamsLock.Lock()
+	defer rs.requestStreamsLock.Unlock()
+	klog.V(8).Infof("starting request streams cleanup...")
+	streams := []*streamPairs{}
+	for requestID, streamPairs := range rs.requestStreamsMap {
+		if streamPairs.isTimedOut(streamCreateTimeout) {
+			klog.Errorf("timeout waiting for second set of streams for request: %d", requestID)
+			delete(rs.requestStreamsMap, requestID)
+			streams = append(streams, streamPairs)
+		}
+	}
+	klog.V(8).Infof("request streams cleanup: %d requests removed", len(streams))
+	return streams
+}
+
+// streamPairs group streams associated with the same portforward subrequest.
+// Each port-forward subrequest requires a data stream and an error stream,
+// and there is both a downstream websocket stream and and upstream
+// spdy stream for each of these stream types.
+type streamPairs struct {
+	// mutually exclusive access to these streams
+	streamPairsLock sync.Mutex
+	// time last pair of streams was added in microseconds since unix epoch
+	lastUpdate int64
+	// websocket/spdy data streams
+	wsDataStream   httpstream.Stream
+	spdyDataStream httpstream.Stream
+	// websocket/spdy error streams
+	wsErrorStream   httpstream.Stream
+	spdyErrorStream httpstream.Stream
+}
+
+// getWebsocketStreams returns the websocket streams stored in the streamPair.
+func (sp *streamPairs) getWebsocketStreams() []httpstream.Stream {
+	sp.streamPairsLock.Lock()
+	defer sp.streamPairsLock.Unlock()
+	wsStreams := []httpstream.Stream{}
+	if sp.wsDataStream != nil {
+		wsStreams = append(wsStreams, sp.wsDataStream)
+	}
+	if sp.wsErrorStream != nil {
+		wsStreams = append(wsStreams, sp.wsErrorStream)
+	}
+	return wsStreams
+}
+
+// getSpdyStreams returns the spdy streams stored in the streamPair.
+func (sp *streamPairs) getSpdyStreams() []httpstream.Stream {
+	sp.streamPairsLock.Lock()
+	defer sp.streamPairsLock.Unlock()
+	spdyStreams := []httpstream.Stream{}
+	if sp.spdyDataStream != nil {
+		spdyStreams = append(spdyStreams, sp.spdyDataStream)
+	}
+	if sp.wsErrorStream != nil {
+		spdyStreams = append(spdyStreams, sp.spdyErrorStream)
+	}
+	return spdyStreams
+}
+
+// addStreamPair stores a websocket and spdy stream *of the same type* (e.g.
+// data or error) returning true if the all four streams are now present
+// (and therefore able to begin portforwarding). Returns false and the error
+// if an error occurs.
+func (sp *streamPairs) addStreamPair(wsStream httpstream.Stream, spdyStream httpstream.Stream) (bool, error) {
+	sp.streamPairsLock.Lock()
+	defer sp.streamPairsLock.Unlock()
+	streamType := wsStream.Headers().Get(v1.StreamType)
+	if streamType != spdyStream.Headers().Get(v1.StreamType) {
+		return false, fmt.Errorf("streams added to streamPair are not the same type")
+	}
+	if streamType == v1.StreamTypeData {
+		if sp.wsDataStream != nil || sp.spdyDataStream != nil {
+			requestID := wsStream.Headers().Get(v1.PortForwardRequestIDHeader)
+			return false, fmt.Errorf("duplicate data streams added to streamPair: %s", requestID)
+		}
+		sp.wsDataStream = wsStream
+		sp.spdyDataStream = spdyStream
+	} else if streamType == v1.StreamTypeError {
+		if sp.wsErrorStream != nil || sp.spdyErrorStream != nil {
+			requestID := wsStream.Headers().Get(v1.PortForwardRequestIDHeader)
+			return false, fmt.Errorf("duplicate error streams added to streamPair: %s", requestID)
+		}
+		sp.wsErrorStream = wsStream
+		sp.spdyErrorStream = spdyStream
+	} else {
+		return false, fmt.Errorf("unknown stream type: %s", streamType)
+	}
+	sp.lastUpdate = time.Now().UnixMicro()
+	// If all four streams are present, then return complete = true.
+	return sp.isComplete(), nil
+}
+
+// isTimedOut returns true if the streamPairs does not have a full
+// complement of streams, and streamCreateTimeout has passed; false
+// otherwise.
+func (sp *streamPairs) isTimedOut(streamCreateTimeout time.Duration) bool {
+	sp.streamPairsLock.Lock()
+	defer sp.streamPairsLock.Unlock()
+	// skip streamPairs that have not had at least one stream update.
+	if sp.lastUpdate != int64(0) && !sp.isComplete() {
+		lastUpdated := time.UnixMicro(sp.lastUpdate)
+		timeout := lastUpdated.Add(streamCreateTimeout)
+		if time.Now().UnixMicro() > timeout.UnixMicro() {
+			return true
+		}
+	}
+	return false
+}
+
+// isComplete returns true if all four streams necessary for portforwarding
+// are present; false otherwise.
+func (sp *streamPairs) isComplete() bool {
+	return (sp.wsDataStream != nil && sp.wsErrorStream != nil &&
+		sp.spdyDataStream != nil && sp.spdyErrorStream != nil)
+}
+
+// portForward connects the websocket and spdy data and error streams, copying
+// in both directions for the data stream, and only one direction (from
+// upstream spdy to downstream websocket) for the error stream. Completes
+// when either 1) an error occurs writing upstream, or 2) the read from
+// spdy to websocket streams completes.
+func (sp *streamPairs) portForward() {
+
+	readingDataDone := make(chan struct{})
+	writingDataError := make(chan struct{})
+
+	go func() {
+		// Copy error from the upstream spdy side to the websocket client.
+		if _, err := io.Copy(sp.wsErrorStream, sp.spdyErrorStream); err != nil && !isClosedConnectionError(err) {
+			klog.Errorf("error copying upstream spdy error stream to websocket stream: %v", err)
+			return
+		}
+		klog.V(2).Infoln("error stream reading complete")
+	}()
+	go func() {
+		// Copy from upstream spdy to the websocket data stream
+		if _, err := io.Copy(sp.wsDataStream, sp.spdyDataStream); err != nil && !isClosedConnectionError(err) {
+			klog.Errorf("error copying upstream spdy data stream to websocket stream: %v", err)
+			return
+		}
+		// Inform the select below that the copy is done
+		klog.V(2).Infoln("datastream reading complete...closing readingDataDone channel")
+		close(readingDataDone)
+	}()
+	go func() {
+		// Inform upstream spdy server we're not sending any more data after copy unblocks
+		defer func() {
+			klog.V(3).Infoln("writing websocket data stream to spdy data stream -- complete")
+			sp.spdyDataStream.Close() //nolint:errcheck
+		}()
+		// Copy from the websocket stream to the upstream spdy endpoint.
+		if _, err := io.Copy(sp.spdyDataStream, sp.wsDataStream); err != nil && !isClosedConnectionError(err) {
+			klog.Errorf("error writing websocket stream data to sdpy data stream: %v", err)
+			// break out of the select below without waiting for the other copy to finish
+			close(writingDataError)
+		}
+	}()
+
+	// Wait for either a websocket->spdy writing error or for
+	// copying from spdy to websocket data streams to finish.
+	select {
+	case <-readingDataDone:
+	case <-writingDataError:
+	}
+}
+
+// getRequestID returns the requestID stored in the stream's headers,
+// or an error if it not possible to parse the requestID header.
+func getRequestID(s httpstream.Stream) (int, error) {
+	headers := s.Headers()
+	requestIDStr := headers.Get(v1.PortForwardRequestIDHeader)
+	return strconv.Atoi(requestIDStr)
+}
+
+// isClosedConnectionError returns true if the error is for using
+// a closed network connection.
+func isClosedConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if strings.Contains(err.Error(), "use of closed network connection") {
+		return true
+	}
+	return false
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/portforward/streamtranslator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/portforward/streamtranslator_test.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestStreamTranslator_RequestStreams(t *testing.T) {
+	rs := newRequestStreams()
+	testRequestID := 1113
+	assert.Equal(t, 0, len(rs.requestStreamsMap), "initially there are no requests in map")
+	sp1 := rs.get(testRequestID)
+	require.NotNil(t, sp1)
+	assert.Equal(t, 1, len(rs.requestStreamsMap), "initial get creates a request")
+	sp2 := rs.get(testRequestID)
+	require.NotNil(t, sp2)
+	assert.Equal(t, 1, len(rs.requestStreamsMap), "retrieving the same request does not create a request")
+	assert.Equal(t, sp1, sp2)
+	anotherRequestID := 32223
+	sp3 := rs.get(anotherRequestID)
+	require.NotNil(t, sp3)
+	assert.Equal(t, 2, len(rs.requestStreamsMap), "retrieving separate request creates the request")
+	rs.remove(testRequestID)
+	assert.Equal(t, 1, len(rs.requestStreamsMap), "removing request should succeed")
+	rs.remove(anotherRequestID)
+	assert.Equal(t, 0, len(rs.requestStreamsMap), "removing another request should succeed")
+}
+
+func TestStreamTranslator_RequestStreamsCleanup(t *testing.T) {
+	rs := newRequestStreams()
+	testRequestID := 352532
+	assert.Equal(t, 0, len(rs.requestStreamsMap))
+	sp := rs.get(testRequestID)
+	require.NotNil(t, sp)
+	assert.Equal(t, 1, len(rs.requestStreamsMap))
+	cleanupStreams := rs.cleanup(100 * time.Second)
+	assert.Equal(t, 0, len(cleanupStreams), "streamPair without lastUpdate time should not timeout")
+	sp.lastUpdate = time.Now().UnixMicro()
+	cleanupStreams = rs.cleanup(1000 * time.Hour)
+	assert.Equal(t, 0, len(cleanupStreams), "streamPair should not have timed out")
+	sp.lastUpdate = int64(319324882000000) // 1980
+	cleanupStreams = rs.cleanup(1 * time.Second)
+	assert.Equal(t, 1, len(cleanupStreams), "streamPairs should have timed out")
+	assert.Equal(t, sp, cleanupStreams[0], "streamPairs to cleanup should be the same")
+}
+
+func TestStreamTranslator_StreamPairsGetStreams(t *testing.T) {
+	sp := &streamPairs{}
+	// Initially there are no streams in the "streamPairs"
+	assert.Equal(t, 0, len(sp.getWebsocketStreams()), "initially should have no websocket streams")
+	assert.Equal(t, 0, len(sp.getSpdyStreams()), "initially should have no spdy streams")
+	// Single pair of streams
+	wsHeaders := http.Header{}
+	wsHeaders.Set(v1.StreamType, v1.StreamTypeError)
+	spdyHeaders := http.Header{}
+	spdyHeaders.Set(v1.StreamType, v1.StreamTypeError)
+	wsStream1 := &fakeStream{id: 1, headers: wsHeaders}
+	spdyStream1 := &fakeStream{id: 2, headers: spdyHeaders}
+	// Add a first pair of streams to the "streamPairs"
+	_, err := sp.addStreamPair(wsStream1, spdyStream1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(sp.getWebsocketStreams()), "should return one websocket stream")
+	assert.Equal(t, 1, len(sp.getSpdyStreams()), "should return one spdy stream")
+	// Add a second pair of streams
+	wsHeaders = http.Header{}
+	wsHeaders.Set(v1.StreamType, v1.StreamTypeData)
+	spdyHeaders = http.Header{}
+	spdyHeaders.Set(v1.StreamType, v1.StreamTypeData)
+	wsStream2 := &fakeStream{id: 3, headers: wsHeaders}
+	spdyStream2 := &fakeStream{id: 4, headers: spdyHeaders}
+	_, err = sp.addStreamPair(wsStream2, spdyStream2)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(sp.getWebsocketStreams()), "should return two websocket streams")
+	assert.Equal(t, 2, len(sp.getSpdyStreams()), "should return two spdy streams")
+}
+
+func TestStreamTranslator_StreamPairsAddStreamPair(t *testing.T) {
+	// Single pair of streams is *not* ready.
+	wsHeaders := http.Header{}
+	wsHeaders.Set(v1.StreamType, v1.StreamTypeError)
+	spdyHeaders := http.Header{}
+	spdyHeaders.Set(v1.StreamType, v1.StreamTypeError)
+	wsStream1 := &fakeStream{id: 1, headers: wsHeaders}
+	spdyStream1 := &fakeStream{id: 2, headers: spdyHeaders}
+	sp := &streamPairs{}
+	ready, err := sp.addStreamPair(wsStream1, spdyStream1)
+	require.NoError(t, err)
+	assert.Equal(t, false, ready, "single stream pair is not ready")
+	// Second pair of streams *is* ready.
+	wsHeaders = http.Header{}
+	wsHeaders.Set(v1.StreamType, v1.StreamTypeData)
+	spdyHeaders = http.Header{}
+	spdyHeaders.Set(v1.StreamType, v1.StreamTypeData)
+	wsStream2 := &fakeStream{id: 3, headers: wsHeaders}
+	spdyStream2 := &fakeStream{id: 4, headers: spdyHeaders}
+	ready, err = sp.addStreamPair(wsStream2, spdyStream2)
+	require.NoError(t, err)
+	assert.Equal(t, true, ready, "both data and error streams means ready to portforward")
+	// Streams with differing stream types is an error.
+	_, err = sp.addStreamPair(wsStream2, spdyStream1)
+	require.Error(t, err, "differing stream types is an error")
+	// Duplicate streams are an error.
+	wsStream3 := &fakeStream{id: 5, headers: wsHeaders}
+	spdyStream3 := &fakeStream{id: 6, headers: spdyHeaders}
+	_, err = sp.addStreamPair(wsStream3, spdyStream3)
+	require.Error(t, err, "duplicate stream pairs should be an error")
+	// Unknown stream types are error.
+	wsHeaders = http.Header{}
+	wsHeaders.Set(v1.StreamType, "unknown")
+	spdyHeaders = http.Header{}
+	spdyHeaders.Set(v1.StreamType, "unknown")
+	unknownStream1 := &fakeStream{id: 7, headers: wsHeaders}
+	unknownStream2 := &fakeStream{id: 8, headers: spdyHeaders}
+	_, err = sp.addStreamPair(unknownStream1, unknownStream2)
+	require.Error(t, err, "unknown stream type is an error")
+	// Stream without type is an error.
+	emptyHeaders := http.Header{}
+	errStream := &fakeStream{id: 9, headers: emptyHeaders}
+	sp = &streamPairs{}
+	_, err = sp.addStreamPair(errStream, spdyStream1)
+	require.Error(t, err, "missing stream type header is error")
+}
+
+func TestStreamTranslator_StreamPairsIsTimedOut(t *testing.T) {
+	sp := &streamPairs{}
+	assert.False(t, sp.isTimedOut(0*time.Second), "if lastUpdate time not set, no timeout")
+	// Add a single set of streams to "streamPairs"
+	wsHeaders := http.Header{}
+	wsHeaders.Set(v1.StreamType, v1.StreamTypeError)
+	spdyHeaders := http.Header{}
+	spdyHeaders.Set(v1.StreamType, v1.StreamTypeError)
+	wsStream1 := &fakeStream{id: 1, headers: wsHeaders}
+	spdyStream1 := &fakeStream{id: 2, headers: spdyHeaders}
+	_, err := sp.addStreamPair(wsStream1, spdyStream1)
+	require.NoError(t, err)
+	// Set calculated timeout to be in distant future -- no timeout.
+	sp.lastUpdate = int64(3285782482000000) // 2075
+	assert.False(t, sp.isTimedOut(1*time.Second), "last update in distant future -- no timeout")
+	// Set calculated timeout to be very long in the past--timeout.
+	sp.lastUpdate = int64(319324882000000) // 1980
+	assert.True(t, sp.isTimedOut(1*time.Second), "last update in distant past -- timeout")
+}
+
+func TestStreamTranslator_StreamPairsIsComplete(t *testing.T) {
+	sp := &streamPairs{}
+	assert.False(t, sp.isComplete(), "no streams means streamPairs is not complete")
+	// Add a single set of streams to "streamPairs"
+	wsHeaders := http.Header{}
+	wsHeaders.Set(v1.StreamType, v1.StreamTypeError)
+	spdyHeaders := http.Header{}
+	spdyHeaders.Set(v1.StreamType, v1.StreamTypeError)
+	wsStream1 := &fakeStream{id: 1, headers: wsHeaders}
+	spdyStream1 := &fakeStream{id: 2, headers: spdyHeaders}
+	_, err := sp.addStreamPair(wsStream1, spdyStream1)
+	require.NoError(t, err)
+	assert.False(t, sp.isComplete(), "one stream pairs means streamPairs is not complete")
+	wsHeaders = http.Header{}
+	wsHeaders.Set(v1.StreamType, v1.StreamTypeData)
+	spdyHeaders = http.Header{}
+	spdyHeaders.Set(v1.StreamType, v1.StreamTypeData)
+	wsStream2 := &fakeStream{id: 3, headers: wsHeaders}
+	spdyStream2 := &fakeStream{id: 4, headers: spdyHeaders}
+	_, err = sp.addStreamPair(wsStream2, spdyStream2)
+	require.NoError(t, err)
+	assert.True(t, sp.isComplete(), "two stream pairs means streamPairs is complete")
+}
+
+func TestStreamTranslator_GetRequestID(t *testing.T) {
+	_, err := getRequestID(&fakeStream{})
+	assert.Error(t, err, "missing requestID header is an error")
+	headers := http.Header{}
+	headers.Set(v1.PortForwardRequestIDHeader, "notaninteger")
+	_, err = getRequestID(&fakeStream{id: 1, headers: headers})
+	assert.Error(t, err, "requestID header not an integer is an error")
+	expected := 3298892
+	headers.Set(v1.PortForwardRequestIDHeader, strconv.Itoa(expected))
+	actual, err := getRequestID(&fakeStream{id: 1, headers: headers})
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual, "requestID's should be the same")
+}
+
+func TestStreamTranslator_IsConnectionClosedError(t *testing.T) {
+	isError := isClosedConnectionError(nil)
+	assert.False(t, isError, "nil error is not connection closed error")
+	isError = isClosedConnectionError(fmt.Errorf("not a connection closed error"))
+	assert.False(t, isError, "error is not connection closed error")
+	isError = isClosedConnectionError(fmt.Errorf("use of closed network connection"))
+	assert.True(t, isError, "error *is* connection closed error")
+}
+
+// fakeStream implements "httpstream.Stream".
+type fakeStream struct {
+	id      int
+	headers http.Header
+	toRead  []byte
+	written []byte
+}
+
+func (fs *fakeStream) Read(p []byte) (n int, err error) {
+	numRead := copy(p, fs.toRead)
+	return numRead, nil
+}
+
+func (fs *fakeStream) Write(p []byte) (n int, err error) {
+	numWritten := copy(fs.written, p)
+	return numWritten, nil
+}
+
+func (fs *fakeStream) Close() error {
+	return nil
+}
+
+func (fs *fakeStream) Reset() error {
+	return nil
+}
+
+func (fs *fakeStream) Headers() http.Header {
+	return fs.headers
+}
+
+func (fs *fakeStream) Identifier() uint32 {
+	return uint32(fs.id)
+}

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7
 	github.com/imdario/mergo v0.3.6
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 	github.com/peterbourgon/diskv v2.0.1+incompatible
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
@@ -49,7 +50,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect

--- a/staging/src/k8s.io/client-go/tools/portforward/fallback_dialer.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/fallback_dialer.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"k8s.io/apimachinery/pkg/util/httpstream"
+)
+
+var _ httpstream.Dialer = &fallbackDialer{}
+
+// fallbackDialer encapsulates a primary and secondary dialer, including
+// the boolean function to determine if the primary dialer failed. Implements
+// the httpstream.Dialer interface.
+type fallbackDialer struct {
+	primary        httpstream.Dialer
+	secondary      httpstream.Dialer
+	shouldFallback func(error) bool
+}
+
+// NewFallbackDialer creates the fallbackDialer with the primary and secondary dialers,
+// as well as the boolean function to determine if the primary dialer failed.
+func NewFallbackDialer(primary, secondary httpstream.Dialer, shouldFallback func(error) bool) httpstream.Dialer {
+	return &fallbackDialer{
+		primary:        primary,
+		secondary:      secondary,
+		shouldFallback: shouldFallback,
+	}
+}
+
+// Dial is the single function necessary to implement the "httpstream.Dialer" interface.
+// It takes the protocol version strings to request, returning an the upgraded
+// httstream.Connection and the negotiated protocol version accepted. If the initial
+// primary dialer fails, this function attempts the secondary dialoer. Returns an error
+// if one occurs.
+func (f *fallbackDialer) Dial(protocols ...string) (httpstream.Connection, string, error) {
+	conn, version, err := f.primary.Dial(protocols...)
+	if f.shouldFallback(err) {
+		return f.secondary.Dial(protocols...)
+	}
+	return conn, version, err
+}

--- a/staging/src/k8s.io/client-go/tools/portforward/websocket_connection.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/websocket_connection.go
@@ -1,0 +1,390 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	gwebsocket "github.com/gorilla/websocket"
+	"github.com/mxk/go-flowrate/flowrate"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/klog/v2"
+)
+
+// streamType constants used in websocket stream headers
+const (
+	StreamData   = 1
+	StreamClose  = 255
+	StreamCreate = 254
+
+	BufferSize = 32 * 1024
+)
+
+var _ httpstream.Connection = &WebsocketConnection{}
+
+// WebsocketConnection implements the "httpstream.Connection" interface, wrapping
+// a websocket connection and its streams.
+type WebsocketConnection struct {
+	conn           *gwebsocket.Conn
+	connWriteLock  sync.Mutex
+	streams        map[int]*wsStream
+	streamsMu      sync.Mutex
+	streamID       int
+	streamIDLock   sync.Mutex
+	closeChan      chan bool
+	maxBytesPerSec int64
+}
+
+// NewWebsocketConnection wraps the passed gorilla/websockets connection
+// with the WebsocketConnection struct (implementing httpstream.Connection).
+func NewWebsocketConnection(conn *gwebsocket.Conn, maxBytesPerSec int64) *WebsocketConnection {
+	closeChan := make(chan bool)
+	wsConn := &WebsocketConnection{
+		conn:           conn,
+		streams:        map[int]*wsStream{},
+		closeChan:      closeChan,
+		maxBytesPerSec: maxBytesPerSec,
+	}
+	// Close channel when detecting close connection.
+	closeHandler := conn.CloseHandler()
+	conn.SetCloseHandler(func(code int, text string) error {
+		klog.V(3).Infof("websocket conn close: %d--%s", code, text)
+		close(closeChan)
+		err := closeHandler(code, text)
+		return err
+	})
+	return wsConn
+}
+
+func (c *WebsocketConnection) getStream(id int) *wsStream {
+	c.streamsMu.Lock()
+	defer c.streamsMu.Unlock()
+	return c.streams[id]
+}
+
+func (c *WebsocketConnection) setStream(id int, s *wsStream) {
+	c.streamsMu.Lock()
+	defer c.streamsMu.Unlock()
+	c.streams[id] = s
+}
+
+func (c *WebsocketConnection) removeStream(s httpstream.Stream) {
+	c.streamsMu.Lock()
+	defer c.streamsMu.Unlock()
+	delete(c.streams, int(s.Identifier()))
+}
+
+// nextStreamID generates a monotonically increasing set of
+// unique identifers for websocket streams.
+func (c *WebsocketConnection) nextStreamID() int {
+	c.streamIDLock.Lock()
+	defer c.streamIDLock.Unlock()
+	id := c.streamID
+	c.streamID++
+	return id
+}
+
+// CreateStream uses id from passed headers to create a stream over "c.conn" connection.
+// Returns a Stream structure or nil and an error if one occurred.
+func (c *WebsocketConnection) CreateStream(headers http.Header) (httpstream.Stream, error) {
+	c.connWriteLock.Lock()
+	defer c.connWriteLock.Unlock()
+	s, err := c.createStream(headers)
+	if err != nil {
+		return nil, err
+	}
+	// Signal the other connection endpoint that a stream was created.
+	klog.V(5).Infof("Signaling StreamCreate to other endpoint: %d", s.id)
+	_, err = s.writeWithHeaders([]byte{}, StreamCreate, headers)
+	return s, err
+}
+
+// createStream creates the websocket stream (which implements httpstream.Stream)
+// structure, storing metadata within the connection. Returns an error if one occurs.
+func (c *WebsocketConnection) createStream(headers http.Header) (*wsStream, error) {
+	id := c.nextStreamID()
+	if s := c.getStream(id); s != nil {
+		return nil, fmt.Errorf("duplicate stream for type %d", id)
+	}
+	klog.V(4).Infof("CreateStream: %d", id)
+	reader, writer := io.Pipe()
+	s := &wsStream{
+		id:             id,
+		headers:        headers,
+		readPipe:       reader,
+		writePipe:      writer,
+		conn:           c.conn,
+		connWriteLock:  &c.connWriteLock,
+		maxBytesPerSec: c.maxBytesPerSec,
+	}
+	c.setStream(id, s)
+	return s, nil
+}
+
+func (c *WebsocketConnection) Close() error {
+	klog.V(4).Infof("Connection Close(); closing streams...")
+	c.closeAllStreamReaders(nil)
+	// Signal other endpoint that websocket connection is closing.
+	c.conn.WriteControl(gwebsocket.CloseMessage, []byte{}, time.Now().Add(writeDeadline)) //nolint:errcheck
+	return c.conn.Close()
+}
+
+func (c *WebsocketConnection) CloseChan() <-chan bool {
+	return c.closeChan
+}
+
+func (c *WebsocketConnection) SetIdleTimeout(timeout time.Duration) {}
+
+func (c *WebsocketConnection) RemoveStreams(streams ...httpstream.Stream) {
+	for _, stream := range streams {
+		klog.V(4).Infof("RemoveStream: %d", stream.Identifier())
+		stream.Close() //nolint:errcheck
+		c.removeStream(stream)
+	}
+}
+
+// Start is the reading processor for this endpoint of the websocket
+// connection. This loop reads the connection, and demultiplexes the data
+// into one of the individual stream pipes (by checking the stream id). This
+// loop can *not* be run concurrently, because there can only be one websocket
+// connection reader at a time (a read mutex would provide no benefit). The passed
+// stream creation channel is used to communicate dynamically created streams,
+// if the websocket connection detects a stream creation signal.
+func (c *WebsocketConnection) Start(streamCreateCh chan httpstream.Stream, bufferSize int, period time.Duration, deadline time.Duration) {
+	// Initialize and start the ping/pong heartbeat, if necessary. Only client-side connection
+	// needs to run the heartbeat.
+	if period > 0 && deadline > 0 {
+		h := newHeartbeat(c.conn, period, deadline)
+		// Set initial timeout for websocket connection reading.
+		if err := c.conn.SetReadDeadline(time.Now().Add(deadline)); err != nil {
+			klog.Errorf("Websocket initial setting read deadline failed %v", err)
+			return
+		}
+		go h.start()
+	}
+	// Buffer size must correspond to the same size allocated
+	// for the read buffer during websocket client creation. A
+	// difference can cause incomplete connection reads.
+	readBuffer := make([]byte, bufferSize)
+	for {
+		// NextReader() only returns data messages (BinaryMessage or Text
+		// Message). Even though this call will never return control frames
+		// such as ping, pong, or close, this call is necessary for these
+		// message types to be processed. There can only be one reader
+		// at a time, so this reader loop must *not* be run concurrently;
+		// there is no lock for reading. Calling "NextReader()" before the
+		// current reader has been processed will close the current reader.
+		// If the heartbeat read deadline times out, this "NextReader()" will
+		// return an i/o error, and error handling will clean up.
+		messageType, r, err := c.conn.NextReader()
+		if err != nil {
+			var wsCloseErr *gwebsocket.CloseError
+			if !errors.As(err, &wsCloseErr) || wsCloseErr.Code != gwebsocket.CloseNormalClosure {
+				c.closeAllStreamReaders(fmt.Errorf("next reader: %w", err))
+			}
+			return
+		}
+		// Throttle reading from the websocket connection (note: only one Reader
+		// on the connection can be active at a time).
+		if c.maxBytesPerSec > 0 {
+			r = flowrate.NewReader(r, c.maxBytesPerSec)
+		}
+		// All remote command protocols send/receive only binary data messages.
+		if messageType != gwebsocket.BinaryMessage {
+			c.closeAllStreamReaders(fmt.Errorf("unexpected message type: %d", messageType))
+			return
+		}
+		// Initially, read the websocket stream headers.
+		wsStreamHeaders, err := readWsStreamHeaders(r)
+		if err != nil {
+			c.closeAllStreamReaders(fmt.Errorf("read stream id: %w", err))
+			return
+		}
+		klog.V(5).Infof("websocket stream headers read: %s", wsStreamHeaders.String())
+		streamType := wsStreamHeaders.StreamType
+		streamID := wsStreamHeaders.StreamID
+		// StreamCreate signal means the other websocket connection endpoint
+		// has created a new stream.
+		if streamType == StreamCreate {
+			klog.V(4).Infof("stream create signal: %d", streamID)
+			// Create the stream, but do not send StreamCreate signal.
+			stream, err := c.createStream(wsStreamHeaders.Headers)
+			if err != nil {
+				c.closeAllStreamReaders(fmt.Errorf("creating websocket stream: %w", err))
+				return
+			}
+			// Queue newly created websocket stream onto channel.
+			klog.V(5).Infof("queueing stream on channel: %d", streamID)
+			streamCreateCh <- stream
+			continue
+		} else if streamType == StreamClose {
+			// Read the next byte, which is the stream id.
+			klog.V(5).Infof("stream close signal: %d", streamID)
+			s := c.getStream(streamID)
+			if s != nil {
+				s.writePipe.Close() //nolint:errcheck
+			} else {
+				klog.V(6).Infof("Unknown stream id during close %d--discarding message", streamID)
+			}
+			continue
+		}
+		// Retrieve stream from connection. If stream is nil (not found)
+		// we *must* still drain the Reader before the next iteration.
+		klog.V(5).Infof("received stream %d", streamID)
+		s := c.getStream(streamID)
+		for {
+			klog.V(6).Infof("reading into buffer (%d)", streamID)
+			nr, errRead := r.Read(readBuffer)
+			if nr > 0 {
+				if s != nil {
+					klog.V(6).Infof("writing into stream pipe (%d)", streamID)
+					_, errWrite := s.writePipe.Write(readBuffer[:nr])
+					if errWrite != nil {
+						// Pipe must have been closed by the stream user.
+						// Nothing to do, discard the message.
+						break
+					}
+				} else {
+					klog.Errorf("Unknown stream id %d, discarding message", streamID)
+				}
+			}
+			if errRead != nil {
+				if errRead == io.EOF {
+					break
+				}
+				c.closeAllStreamReaders(fmt.Errorf("read message: %w", err))
+				return
+			}
+		}
+	}
+}
+
+// closeAllStreamReaders closes readers in all streams.
+// This unblocks all stream.Read() calls.
+func (c *WebsocketConnection) closeAllStreamReaders(err error) {
+	c.streamsMu.Lock()
+	defer c.streamsMu.Unlock()
+	for _, s := range c.streams {
+		// Closing writePipe unblocks all readPipe.Read() callers and prevents any future writes.
+		s.writePipe.CloseWithError(err) //nolint:errcheck
+	}
+}
+
+// TODO(seans): Refactor the "heartbeat" code which is shared with RemoteCommand.
+
+// heartbeat encasulates data necessary for the websocket ping/pong heartbeat. This
+// heartbeat works by setting a read deadline on the websocket connection, then
+// pushing this deadline into the future for every successful heartbeat. If the
+// heartbeat "pong" fails to respond within the deadline, then the "NextReader()" call
+// inside the "readDemuxLoop" will return an i/o error prompting a connection close
+// and cleanup.
+type heartbeat struct {
+	conn *gwebsocket.Conn
+	// period defines how often a "ping" heartbeat message is sent to the other endpoint
+	period time.Duration
+	// closing the "closer" channel will clean up the heartbeat timers
+	closer chan struct{}
+	// optional data to send with "ping" message
+	message []byte
+	// optionally received data message with "pong" message, same as sent with ping
+	pongMessage []byte
+}
+
+// newHeartbeat creates heartbeat structure encapsulating fields necessary to
+// run the websocket connection ping/pong mechanism and sets up handlers on
+// the websocket connection.
+func newHeartbeat(conn *gwebsocket.Conn, period time.Duration, deadline time.Duration) *heartbeat {
+	h := &heartbeat{
+		conn:   conn,
+		period: period,
+		closer: make(chan struct{}),
+	}
+	// Set up handler for receiving returned "pong" message from other endpoint
+	// by pushing the read deadline into the future. The "msg" received could
+	// be empty.
+	h.conn.SetPongHandler(func(msg string) error {
+		// Push the read deadline into the future.
+		klog.V(8).Infof("Pong message received (%s)--resetting read deadline", msg)
+		err := h.conn.SetReadDeadline(time.Now().Add(deadline))
+		if err != nil {
+			klog.Errorf("Websocket setting read deadline failed %v", err)
+			return err
+		}
+		if len(msg) > 0 {
+			h.pongMessage = []byte(msg)
+		}
+		return nil
+	})
+	// Set up handler to cleanup timers when this endpoint receives "Close" message.
+	closeHandler := h.conn.CloseHandler()
+	h.conn.SetCloseHandler(func(code int, text string) error {
+		close(h.closer)
+		return closeHandler(code, text)
+	})
+	return h
+}
+
+// TODO(sean): uncomment this unused method when adding unit tests.
+// setMessage is optional data sent with "ping" heartbeat. According to the websocket RFC
+// this data sent with "ping" message should be returned in "pong" message.
+// func (h *heartbeat) setMessage(msg string) {
+// 	h.message = []byte(msg)
+// }
+
+// start the heartbeat by setting up necesssary handlers and looping by sending "ping"
+// message every "period" until the "closer" channel is closed.
+func (h *heartbeat) start() {
+	// Loop to continually send "ping" message through websocket connection every "period".
+	t := time.NewTicker(h.period)
+	defer t.Stop()
+	for {
+		select {
+		case <-h.closer:
+			klog.V(8).Infof("closed channel--returning")
+			return
+		case <-t.C:
+			// "WriteControl" does not need to be protected by a mutex. According to
+			// gorilla/websockets library docs: "The Close and WriteControl methods can
+			// be called concurrently with all other methods."
+			if err := h.conn.WriteControl(gwebsocket.PingMessage, h.message, time.Now().Add(writeDeadline)); err == nil {
+				klog.V(8).Infof("Websocket Ping succeeeded")
+			} else {
+				klog.Errorf("Websocket Ping failed: %v", err)
+				var netErr net.Error
+				if errors.Is(err, gwebsocket.ErrCloseSent) {
+					// we continue because c.conn.CloseChan will manage closing the connection already
+					continue
+				} else if errors.As(err, &netErr) && netErr.Timeout() {
+					// Continue, in case this is a transient failure.
+					// c.conn.CloseChan above will tell us when the connection is
+					// actually closed.
+					// If Temporary function hadn't been deprecated, we would have used it.
+					// But most of temporary errors are timeout errors anyway.
+					continue
+				}
+				return
+			}
+		}
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/portforward/websocket_dialer.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/websocket_dialer.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/portforward"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/transport/websocket"
+	"k8s.io/klog/v2"
+)
+
+// wsDialer implements "httpstream.Dial" interface
+type wsDialer struct {
+	url       *url.URL
+	transport http.RoundTripper
+	holder    websocket.ConnectionHolder
+	ports     []string
+}
+
+// NewWebSocketDialer creates and returns the wsDialer structure which implemements the "httpstream.Dialer"
+// interface. The dialer can upgrade a websocket request, creating a websocket connection. This function
+// returns an error if one occurs.
+func NewWebSocketDialer(url *url.URL, config *restclient.Config, ports []string) (httpstream.Dialer, error) {
+	if len(ports) == 0 {
+		return nil, fmt.Errorf("you must specify at least 1 port")
+	}
+	transport, holder, err := websocket.RoundTripperFor(config)
+	if err != nil {
+		return nil, err
+	}
+	return &wsDialer{
+		url:       url,
+		transport: transport,
+		holder:    holder,
+		ports:     ports,
+	}, nil
+}
+
+// Dial upgrades a websocket request, returning a websocket connection (wrapped
+// by an "httpstream.Connection"), the negotiated protocol, or an error if one occurred.
+func (d *wsDialer) Dial(protocols ...string) (httpstream.Connection, string, error) {
+	// There is no passed context, so skip the context when creating request for now.
+	// Websockets requires "GET" method: RFC 6455 Sec. 4.1 (page 17).
+	req, err := http.NewRequest("GET", d.url.String(), nil)
+	if err != nil {
+		return nil, "", err
+	}
+	// Add the port(s) as request query params.
+	forwardedPorts, err := parsePorts(d.ports)
+	if err != nil {
+		return nil, "", err
+	}
+	for _, port := range forwardedPorts {
+		query := req.URL.Query()
+		remotePort := int(port.Remote)
+		klog.V(4).Infof("Remote Port: %d", remotePort)
+		query.Set("ports", strconv.Itoa(remotePort))
+		req.URL.RawQuery = query.Encode()
+	}
+	// Hard-code the v2 portforward protocol for the websocket dialer for now.
+	websocketProtocols := []string{portforward.PortForwardV2Name}
+	klog.V(4).Infoln("Before WebSocket Upgrade Connection...")
+	conn, err := websocket.Negotiate(d.transport, d.holder, req, websocketProtocols...)
+	if err != nil {
+		return nil, "", err
+	}
+	if conn == nil {
+		return nil, "", fmt.Errorf("negotiated websocket connection is nil")
+	}
+	protocol := conn.Subprotocol()
+	klog.V(4).Infof("negotiated protocol: %s", protocol)
+
+	// Encapsulate the websocket connection and start the reading loop. This client
+	// endpoint does not throttle stream reading/writing.
+	wsConn := NewWebsocketConnection(conn, 0)
+	go func() {
+		heartbeatPeriod := 5 * time.Second
+		heartbeatDeadline := heartbeatPeriod * 5
+		// nil channel means this endpoint does not handle the "StreamCreate" signal.
+		wsConn.Start(nil, BufferSize, heartbeatPeriod, heartbeatDeadline)
+	}()
+
+	return wsConn, protocol, nil
+}

--- a/staging/src/k8s.io/client-go/tools/portforward/websocket_stream.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/websocket_stream.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/gob"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	gwebsocket "github.com/gorilla/websocket"
+	"github.com/mxk/go-flowrate/flowrate"
+
+	"k8s.io/klog/v2"
+)
+
+const writeDeadline = 2 * time.Second
+
+type wsStream struct {
+	id        int
+	headers   http.Header
+	readPipe  *io.PipeReader
+	writePipe *io.PipeWriter
+	// conn is used for writing directly into the connection.
+	// Is nil after Close() / Reset() to prevent future writes.
+	conn *gwebsocket.Conn
+	// connWriteLock protects conn against concurrent write operations. There must be a single writer and a single reader only.
+	// The mutex is shared across all streams because the underlying connection is shared.
+	connWriteLock *sync.Mutex
+	// Used to throttle stream writing.
+	maxBytesPerSec int64
+}
+
+const (
+	// headerSizeBytes is the number of bytes to store the encoded header size.
+	// A uint16 requires 2 bytes.
+	headerSizeBytes = 2
+	// maxHeaderSize equals the largest websocket stream header allowed.
+	maxHeaderSize = 4 * 1024
+)
+
+// wsStreamHeader encloses the metadata prepended to a websocket binary message.
+type wsStreamHeader struct {
+	StreamType int // Data, Close, or Create
+	StreamID   int
+	Headers    http.Header
+}
+
+// String returns the websocket stream header as a string.
+func (wsh *wsStreamHeader) String() string {
+	return fmt.Sprintf("%d/%d", wsh.StreamID, wsh.StreamType)
+}
+
+// encodeStreamHeaders returns an encoded wsStreamHeader struct as a byte
+// array. The first two bytes of the array are an integer representing the size
+// of the encodeWsStreamHeaders. Returns an error if one occurs.
+func encodeWsStreamHeaders(streamType int, streamID int, headers http.Header) ([]byte, error) {
+	// Encode the wsStreamHeader struct using the passed parameters.
+	var buf bytes.Buffer
+	wsHeader := wsStreamHeader{
+		StreamType: streamType,
+		StreamID:   streamID,
+		Headers:    headers,
+	}
+	enc := gob.NewEncoder(&buf)
+	err := enc.Encode(&wsHeader)
+	if err != nil {
+		klog.Errorf("Error encoding websocket stream headers: %v", err)
+		return []byte{}, err
+	}
+	numBytes := uint16(len(buf.Bytes()))
+	klog.V(5).Infof("Websocket stream header size: %d", numBytes)
+	headerBuffer := make([]byte, headerSizeBytes)
+	binary.LittleEndian.PutUint16(headerBuffer, numBytes)
+	// Prepend the size of the encoded wsStreamHeader as a two byte
+	// integer to the returned byte array.
+	headerBuffer = append(headerBuffer, buf.Bytes()...)
+	return headerBuffer, nil
+}
+
+// readWsStreamHeaders reads, decodes, and returns a pointer
+// to a wsStreamHeader struct (or an error if one occurs). If
+// successful, the reader parameter "r" points past the websocket
+// stream header after the function returns (points to the beginning
+// of the websocket binary data message).
+func readWsStreamHeaders(r io.Reader) (*wsStreamHeader, error) {
+	// Read the first two bytes containing an integer representing the
+	// size of the encoded wsStreamHeader struct.
+	headerBuffer := make([]byte, maxHeaderSize)
+	_, err := io.ReadFull(r, headerBuffer[:headerSizeBytes])
+	if err != nil {
+		return nil, err
+	}
+	headerSize := binary.LittleEndian.Uint16(headerBuffer)
+	// Read the next "headerSize" bytes into the headerBuffer
+	_, err = io.ReadFull(r, headerBuffer[:headerSize])
+	if err != nil {
+		return nil, err
+	}
+	reader := bytes.NewReader(headerBuffer)
+	dec := gob.NewDecoder(reader)
+	// Decode these headerBuffer bytes into a wsStreamHeader struct.
+	var wsHeaders wsStreamHeader
+	err = dec.Decode(&wsHeaders)
+	if err != nil {
+		klog.Errorf("Error decoding wsStreamHeader: %v", err)
+		return nil, err
+	}
+	return &wsHeaders, nil
+}
+
+// Read fills the passed "p" byte slice by reading from the stream's pipe. Another goroutine
+// fills the pipe by writing the to the pipe in connection read loop after we have determined
+// what stream to write to by inspecting the prepended stream id. Returns the number of
+// bytes read or an error if one occurred reading the pipe.
+func (s *wsStream) Read(p []byte) (n int, err error) {
+	klog.V(5).Infof("Read() stream %d", s.id)
+	defer klog.V(5).Infof("Read() done on stream %d", s.id)
+	return s.readPipe.Read(p)
+}
+
+// Write writes directly to the underlying WebSocket connection.
+func (s *wsStream) Write(p []byte) (n int, err error) {
+	klog.V(5).Infof("Write() on stream %d", s.id)
+	defer klog.V(5).Infof("Write() done on stream %d", s.id)
+	s.connWriteLock.Lock()
+	defer s.connWriteLock.Unlock()
+	return s.writeWithHeaders(p, StreamData, http.Header{})
+}
+
+// writeWithHeaders writes the (possibly empty) byte array "p" plus stream headers including
+// "messageType" (e.g. StreamData, StreamCreate) and "headers". Returns the number
+// of bytes written (not including headers) or an error if one occurs. Important: There
+// can only be one websocket connection writer active at a time.
+func (s *wsStream) writeWithHeaders(p []byte, messageType int, headers http.Header) (n int, err error) {
+	if s.conn == nil {
+		return 0, fmt.Errorf("write on closed stream %d", s.id)
+	}
+	err = s.conn.SetWriteDeadline(time.Now().Add(writeDeadline))
+	if err != nil {
+		klog.V(4).Infof("Websocket setting write deadline failed %v", err)
+		return 0, err
+	}
+	// Message writer buffers the message data, so we don't need to do that ourselves.
+	// Just write id and the data as two separate writes to avoid allocating an
+	// intermediate buffer. Only one writer can be active at a time.
+	w, err := s.conn.NextWriter(gwebsocket.BinaryMessage)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if w != nil {
+			w.Close() //nolint:errcheck
+		}
+	}()
+	// Throttle rate of writing to websocket connection (there is only one Writer
+	// that can be active on the connection at a time).
+	if s.maxBytesPerSec > 0 {
+		w = flowrate.NewWriter(w, s.maxBytesPerSec)
+	}
+	// Prepend the websocket stream headers to the writer.
+	header, err := encodeWsStreamHeaders(messageType, s.id, headers)
+	if err != nil {
+		return 0, err
+	}
+	_, err = w.Write(header)
+	if err != nil {
+		return 0, err
+	}
+	// Next, write the passed data in "p".
+	n, err = w.Write(p)
+	if err != nil {
+		return n, err
+	}
+	err = w.Close()
+	w = nil
+	return n, err
+}
+
+// Close half-closes the stream, indicating this side is finished with the stream.
+func (s *wsStream) Close() error {
+	klog.V(5).Infof("Close() on stream %d", s.id)
+	defer klog.V(5).Infof("Close() done on stream %d", s.id)
+	s.connWriteLock.Lock()
+	defer s.connWriteLock.Unlock()
+	if s.conn == nil {
+		return fmt.Errorf("Close() on already closed stream %d", s.id)
+	}
+	// Send close signal to other endpoint.
+	s.writeWithHeaders([]byte{}, StreamClose, http.Header{}) //nolint:errcheck
+	s.conn = nil
+	return s.writePipe.Close()
+}
+
+func (s *wsStream) Reset() error {
+	klog.V(5).Infof("Reset() on stream %d", s.id)
+	defer klog.V(5).Infof("Reset() done on stream %d", s.id)
+	s.Close() //nolint:errcheck
+	return s.writePipe.Close()
+}
+
+func (s *wsStream) Headers() http.Header {
+	return s.headers
+}
+
+func (s *wsStream) Identifier() uint32 {
+	return uint32(s.id)
+}

--- a/staging/src/k8s.io/client-go/tools/portforward/websocket_test.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/websocket_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	gwebsocket "github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	constants "k8s.io/apimachinery/pkg/util/portforward"
+	"k8s.io/client-go/rest"
+)
+
+// TestWebSocketConnection_CreateSteramPropagatedToServer ensures the "CreateStream"
+// call on the client endpoint of the websocket server propagates the newly created
+// websocket stream to the server. Validates random data written to the client
+// websocket stream is received on the websocket server stream.
+func TestWebSocketConnection_CreateStreamPropagatedToServer(t *testing.T) {
+	// Create fake WebSocket server with a stream creation channel.
+	streamCh := make(chan httpstream.Stream)
+	closeCh := make(chan bool)
+	websocketServer := createWebSocketServer(streamCh, closeCh)
+	require.NotNil(t, websocketServer)
+	defer func() {
+		close(closeCh)
+		websocketServer.Close()
+	}()
+	// Create the WebSocketDialer.
+	websocketLocation, err := url.Parse(websocketServer.URL)
+	require.NoError(t, err)
+	wsDialer, err := NewWebSocketDialer(websocketLocation, &rest.Config{Host: websocketLocation.Host}, []string{"80"})
+	require.NoError(t, err)
+	// Create the websocket client connection by dialing to the websocket server.
+	wsClientConn, protocol, err := wsDialer.Dial(constants.PortForwardV2Name)
+	require.NoError(t, err)
+	require.NotNil(t, wsClientConn)
+	defer wsClientConn.Close() //nolint:errcheck
+	// Validate the negotiated portforward protocol is V2.
+	assert.Equal(t, constants.PortForwardV2Name, protocol)
+	// Create a stream on the client websocket connection.
+	headers := http.Header{}
+	headers.Set("foo", "bar")
+	headers.Set("requestID", "88888")
+	clientWsStream, err := wsClientConn.CreateStream(headers)
+	require.NoError(t, err)
+	defer wsClientConn.RemoveStreams(clientWsStream)
+	// Retrieve the stream created at the websocket server, and validate it is the same
+	// stream created on the websocket client connection endpoint.
+	serverWsStream := <-streamCh
+	require.NotNil(t, serverWsStream)
+	assert.Equal(t, clientWsStream.Identifier(), serverWsStream.Identifier())
+	assert.Equal(t, clientWsStream.Headers(), serverWsStream.Headers())
+	// Send random data on the client stream, and validate the server stream receives it.
+	randomSize := 1024 * 1024
+	randomData := make([]byte, randomSize)
+	_, err = rand.Read(randomData)
+	require.NoError(t, err)
+	randReader := bytes.NewReader(randomData)
+	go func() {
+		// Write the random data into the client websocket stream.
+		if _, err = io.Copy(clientWsStream, randReader); err != nil {
+			t.Errorf("Error during io.Copy()")
+			return
+		}
+		clientWsStream.Close() //nolint:errcheck
+	}()
+	// Read the server websocket stream, and validate the data is the same
+	// as from the client stream.
+	serverReceived, err := io.ReadAll(serverWsStream)
+	assert.NoError(t, err)
+	assert.Equal(t, randomData, serverReceived)
+}
+
+// TestWebSocketDialer_DialCreatesWebSocketClient tests the Dialer can
+// successfully dial to create the client websocket connection.
+func TestWebSocketDialer_DialCreatesWebSocketClient(t *testing.T) {
+	// Create fake WebSocket server without stream creation channel.
+	closeCh := make(chan bool)
+	websocketServer := createWebSocketServer(nil, closeCh)
+	require.NotNil(t, websocketServer)
+	defer func() {
+		close(closeCh)
+		websocketServer.Close()
+	}()
+	// Create the WebSocketDialer.
+	websocketLocation, err := url.Parse(websocketServer.URL)
+	require.NoError(t, err)
+	wsDialer, err := NewWebSocketDialer(websocketLocation, &rest.Config{Host: websocketLocation.Host}, []string{"80"})
+	require.NoError(t, err)
+	// Create the websocket client connection by dialing to the websocket server.
+	wsClientConn, protocol, err := wsDialer.Dial(constants.PortForwardV2Name)
+	require.NoError(t, err)
+	require.NotNil(t, wsClientConn)
+	defer wsClientConn.Close() //nolint:errcheck
+	// Validate the negotiated portforward protocol is V2.
+	assert.Equal(t, constants.PortForwardV2Name, protocol)
+}
+
+// TestWebSocketDialoer_MissingPortParameterIsError validates the port parameter to the
+// websocket dialer is correctly checked.
+func TestWebSocketDialer_MissingPortParameterIsError(t *testing.T) {
+	websocketServerURL := "http://127.0.0.1:8080"
+	websocketLocation, err := url.Parse(websocketServerURL)
+	require.NoError(t, err)
+	emptyPortParameters := []string{}
+	_, err = NewWebSocketDialer(websocketLocation, &rest.Config{Host: websocketLocation.Host}, emptyPortParameters)
+	require.Error(t, err, "expected error from empty port parameter in websocket dialer constructor")
+}
+
+// TestWebSocketDialer_InvalidPortParameterIsError ensures correct validation
+// of the websocket dialer passed port parameter.
+func TestWebSocketDialer_InvalidPortParameterIsError(t *testing.T) {
+	// Create fake WebSocket server without stream creation channel.
+	closeCh := make(chan bool)
+	websocketServer := createWebSocketServer(nil, closeCh)
+	defer func() {
+		close(closeCh)
+		websocketServer.Close()
+	}()
+	// Create the WebSocketDialer.
+	websocketServerURL := "http://127.0.0.1:8080"
+	websocketLocation, err := url.Parse(websocketServerURL)
+	require.NoError(t, err)
+	wsDialer, err := NewWebSocketDialer(websocketLocation, &rest.Config{Host: websocketLocation.Host}, []string{"INVALID_PORT"})
+	require.NoError(t, err)
+	// Create the websocket client connection by dialing to the websocket server--error
+	wsClientConn, protocol, err := wsDialer.Dial(constants.PortForwardV2Name)
+	require.Error(t, err)
+	require.Nil(t, wsClientConn)
+	assert.Equal(t, "", protocol)
+}
+
+// createWebSocketServer takes two channels, and constructs a test Server as
+// the websocket endpoint. The two channels are: 1) the stream creation channel, and 2)
+// the websocket server close channel. The stream creation channel will receive the
+// websocket stream created by the websocket server read loop, handling the "StreamCreate"
+// signal. Closing the "closeCh" will stop the websocket server. The heartbeat is not created
+// on the server side of the websocket connection.
+func createWebSocketServer(streamCh chan httpstream.Stream, closeCh chan bool) *httptest.Server {
+	return createWebSocketServerWithProtocols(streamCh, closeCh, []string{constants.PortForwardV2Name})
+}
+
+// createWebSocketServerWithProtocols creates a websocket server that will successfully negotiate
+// the passed protocols; otherwise an "UpgradeFailure" error will be returned when attempting
+// to upgrade the http connection.
+func createWebSocketServerWithProtocols(streamCh chan httpstream.Stream, closeCh chan bool, protocols []string) *httptest.Server {
+	websocketServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var upgrader = gwebsocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool {
+				return true // Accepting all requests
+			},
+			Subprotocols: protocols,
+		}
+		conn, err := upgrader.Upgrade(w, req, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()                              //nolint:errcheck
+		wsServerConn := NewWebsocketConnection(conn, 0) // zero means no throttling stream read/writes.
+		defer wsServerConn.Close()                      //nolint:errcheck
+		// Start the websocket connection reading loop.
+		go func() {
+			wsServerConn.Start(streamCh, BufferSize, 0, 0) // no hearbeat on server-side endpoint
+		}()
+		<-closeCh // Wait on the closing of the channel.
+	}))
+	return websocketServer
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -430,6 +430,7 @@ const (
 	InteractiveDelete       FeatureGate = "KUBECTL_INTERACTIVE_DELETE"
 	OpenAPIV3Patch          FeatureGate = "KUBECTL_OPENAPIV3_PATCH"
 	RemoteCommandWebsockets FeatureGate = "KUBECTL_REMOTE_COMMAND_WEBSOCKETS"
+	PortForwardWebsockets   FeatureGate = "KUBECTL_PORT_FORWARD_WEBSOCKETS"
 )
 
 // IsEnabled returns true iff environment variable is set to true.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1340,6 +1340,7 @@ k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/net
 k8s.io/apimachinery/pkg/util/net/testing
+k8s.io/apimachinery/pkg/util/portforward
 k8s.io/apimachinery/pkg/util/proxy
 k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/remotecommand
@@ -1524,6 +1525,7 @@ k8s.io/apiserver/pkg/util/openapi
 k8s.io/apiserver/pkg/util/peerproxy
 k8s.io/apiserver/pkg/util/peerproxy/metrics
 k8s.io/apiserver/pkg/util/proxy
+k8s.io/apiserver/pkg/util/proxy/portforward
 k8s.io/apiserver/pkg/util/shufflesharding
 k8s.io/apiserver/pkg/util/webhook
 k8s.io/apiserver/pkg/util/x509metrics


### PR DESCRIPTION
* Implements `kubectl port-forward` over WebSockets instead of SPDY.
  * Based on initial code from @ardaguclu 

* Creates a `StreamTranslator` proxy within the apiserver to translate websocket data to/from the client to the upstream server on the container runtime using a SPDY connection. The proxy is protected by a feature flag (`PortForwardWebsockets`) and it is only executed for the websocket connection upgrade request with a new `v2.portforward.k8s.io` subprotocol header.
* Another feature flag exists for `kubectl` to request a websocket connection: `KUBECTL_PORT_FORWARD_WEBSOCKETS`.
* Three types of streaming functionality (which already exist in SPDY) are implemented using websockets:
  * **StreamCreation** signaling from one endpoint to the other websocket connection endpoint.
  * **StreamClose** signaling to the other websocket connection endpoint when one end of a websocket stream is finished.
  * A larger stream identifier space.

PortForward requires two steps:
* Step 1: Listen on local ports, and set up the upgraded streaming websocket and SPDY connections to the target (a container, a service, etc.).
`$ kubectl port-forward nginx 8080:80`
At this point no data is being forwarded, and no streams exist over the connections.
* Step 2: Make one or more requests on the ports locally listened to (in this case port 8080).
`$ curl http://localhost:8080/index.html`
Handling this port-forward request dynamically creates the streams necessary to satisfy the request within the proxy, as well copying the data between the streams. Once the results of the request are complete, the streams are removed.

**NOTE** The case where multiple concurrent requests to the same local port must be successfully handled. For example, the command `$ curl http://localhost:8080/index.html` can be submitted at the same time from different terminals.

/kind feature

```release-note
NONE
```

- [KEP Transition from SPDY to WebSockets - 4006](https://github.com/kubernetes/enhancements/issues/4006)