### PR TITLE
add support to create webhook configuration when webhooks is enabled

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -138,6 +138,11 @@ API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,KubeCloudS
 API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,KubeCloudSharedConfiguration,NodeSyncPeriod
 API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,KubeCloudSharedConfiguration,RouteReconciliationPeriod
 API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,KubeCloudSharedConfiguration,UseServiceAccountCredentials
+API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,WebhookConfiguration,CaBundle
+API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,WebhookConfiguration,MutatingWebhookConfiguration
+API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,WebhookConfiguration,ValidatingWebhookConfiguration
+API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,WebhookConfiguration,WebhookAddress
+API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,WebhookConfiguration,WebhookPort
 API rule violation: names_match,k8s.io/cloud-provider/config/v1alpha1,WebhookConfiguration,Webhooks
 API rule violation: names_match,k8s.io/controller-manager/config/v1alpha1,GenericControllerManagerConfiguration,Address
 API rule violation: names_match,k8s.io/controller-manager/config/v1alpha1,GenericControllerManagerConfiguration,ClientConnection

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -56694,10 +56694,48 @@ func schema_k8sio_cloud_provider_config_v1alpha1_WebhookConfiguration(ref common
 							},
 						},
 					},
+					"WebhookPort": {
+						SchemaProps: spec.SchemaProps{
+							Description: "WebhookPort is the port that the controller-manager's webhook service runs on.",
+							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"WebhookAddress": {
+						SchemaProps: spec.SchemaProps{
+							Description: "WebhookAddress is the IP address to serve on.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"CaBundle": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CaBundle is the ca certs to be used by apiserver for validating the webhook server certs.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"ValidatingWebhookConfiguration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ValidatingWebhookConfiguration is the config used for creating validation webhook config object.",
+							Ref:         ref("k8s.io/api/admissionregistration/v1.ValidatingWebhookConfiguration"),
+						},
+					},
+					"MutatingWebhookConfiguration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MutatingWebhookConfiguration is the config used for creating mutating webhook config object.",
+							Ref:         ref("k8s.io/api/admissionregistration/v1.MutatingWebhookConfiguration"),
+						},
+					},
 				},
-				Required: []string{"Webhooks"},
+				Required: []string{"Webhooks", "WebhookPort", "WebhookAddress", "CaBundle", "ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"},
 			},
 		},
+		Dependencies: []string{
+			"k8s.io/api/admissionregistration/v1.MutatingWebhookConfiguration", "k8s.io/api/admissionregistration/v1.ValidatingWebhookConfiguration"},
 	}
 }
 

--- a/staging/src/k8s.io/cloud-provider/app/builder.go
+++ b/staging/src/k8s.io/cloud-provider/app/builder.go
@@ -140,7 +140,8 @@ func (cb *CommandBuilder) BuildCommand() *cobra.Command {
 			cliflag.PrintFlags(cmd.Flags())
 
 			config, err := cb.options.Config(ControllerNames(cb.controllerInitFuncConstructors), ControllersDisabledByDefault.List(),
-				cb.controllerAliases, WebhookNames(cb.webhookConfigs), WebhooksDisabledByDefault.List())
+				cb.controllerAliases, WebhookNamesByType(cb.webhookConfigs, ValidatingWebhook), WebhookNamesByType(cb.webhookConfigs, MutatingWebhook),
+				WebhooksDisabledByDefault.List())
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				return err

--- a/staging/src/k8s.io/cloud-provider/app/controllermanager.go
+++ b/staging/src/k8s.io/cloud-provider/app/controllermanager.go
@@ -213,20 +213,20 @@ func createOrUpdateWebhookConfiguration(ctx context.Context, webhooks map[string
 		} else {
 			if !apierrors.IsAlreadyExists(err) {
 				klog.ErrorS(err, "Unable to create validating webhook configuration with API server", "webhookconfiguration", klog.KObj(webhooksConfig.ValidatingWebhookConfiguration))
-				return fmt.Errorf("unable to create validating webhook configuration with API server %v", err)
+				return fmt.Errorf("unable to create validating webhook configuration with API server %w", err)
 			}
 
 			currentConfiguration, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, webhooksConfig.ValidatingWebhookConfiguration.Name, metav1.GetOptions{})
 			if err != nil {
 				klog.ErrorS(err, "Unable to create validating webhook configuration with API server, error getting existing webhook configuration", "webhookconfiguration", webhooksConfig.ValidatingWebhookConfiguration.Name)
-				return fmt.Errorf("unable to get validating webhook configuration from API server %v", err)
+				return fmt.Errorf("unable to get validating webhook configuration from API server %w", err)
 			}
 			currentConfiguration.Webhooks = webhooksConfig.ValidatingWebhookConfiguration.Webhooks
 
 			_, err = kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(ctx, currentConfiguration, metav1.UpdateOptions{})
 			if err != nil {
 				klog.ErrorS(err, "Unable to update validating webhook configuration with API server", "webhookconfiguration", klog.KObj(webhooksConfig.ValidatingWebhookConfiguration))
-				return fmt.Errorf("unable to update validating webhook configuration with API server %v", err)
+				return fmt.Errorf("unable to update validating webhook configuration with API server %w", err)
 			}
 		}
 	}
@@ -238,20 +238,20 @@ func createOrUpdateWebhookConfiguration(ctx context.Context, webhooks map[string
 		} else {
 			if !apierrors.IsAlreadyExists(err) {
 				klog.ErrorS(err, "Unable to create mutating webhook configuration with API server", "webhookconfiguration", klog.KObj(webhooksConfig.MutatingWebhookConfiguration))
-				return fmt.Errorf("unable to create mutating webhook configuration with API server %v", err)
+				return fmt.Errorf("unable to create mutating webhook configuration with API server %w", err)
 			}
 
 			currentConfiguration, err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, webhooksConfig.MutatingWebhookConfiguration.Name, metav1.GetOptions{})
 			if err != nil {
 				klog.ErrorS(err, "Unable to create mutating webhook configuration with API server, error fetching existing webhook configuration", "webhookconfiguration", webhooksConfig.MutatingWebhookConfiguration.Name)
-				return fmt.Errorf("unable to get mutating webhook configuration from API server %v", err)
+				return fmt.Errorf("unable to get mutating webhook configuration from API server %w", err)
 			}
 			currentConfiguration.Webhooks = webhooksConfig.MutatingWebhookConfiguration.Webhooks
 
 			_, err = kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Update(ctx, currentConfiguration, metav1.UpdateOptions{})
 			if err != nil {
 				klog.ErrorS(err, "Unable to update mutating webhook configuration with API server", "webhookconfiguration", klog.KObj(webhooksConfig.MutatingWebhookConfiguration))
-				return fmt.Errorf("unable to update mutating webhook configuration with API server %v", err)
+				return fmt.Errorf("unable to update mutating webhook configuration with API server %w", err)
 			}
 		}
 	}

--- a/staging/src/k8s.io/cloud-provider/config/types.go
+++ b/staging/src/k8s.io/cloud-provider/config/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	nodeconfig "k8s.io/cloud-provider/controllers/node/config"
 	serviceconfig "k8s.io/cloud-provider/controllers/service/config"
@@ -100,4 +101,12 @@ type WebhookConfiguration struct {
 	// '-foo' means "disable 'foo'"
 	// first item for a particular name wins
 	Webhooks []string
+	// WebhookPort is the port that the controller-manager's webhook service runs on.
+	WebhookPort int32
+	// WebhookAddress is the IP address to serve on.
+	WebhookAddress string
+	// CaBundle is the ca certs to be used by apiserver for validating the webhook server certs.
+	CaBundle string
+	// ValidationWebhookConfiguration is the config used for creating validation webhook config object.
+	ValidationWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration
 }

--- a/staging/src/k8s.io/cloud-provider/config/types.go
+++ b/staging/src/k8s.io/cloud-provider/config/types.go
@@ -107,6 +107,9 @@ type WebhookConfiguration struct {
 	WebhookAddress string
 	// CaBundle is the ca certs to be used by apiserver for validating the webhook server certs.
 	CaBundle string
-	// ValidationWebhookConfiguration is the config used for creating validation webhook config object.
-	ValidationWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration
+	// ValidatingWebhookConfiguration is the config used for creating validation webhook config object.
+	ValidatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration
+
+	// MutatingWebhookConfiguration is the config used for creating mutating webhook config object.
+	MutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration
 }

--- a/staging/src/k8s.io/cloud-provider/config/v1alpha1/defaults.go
+++ b/staging/src/k8s.io/cloud-provider/config/v1alpha1/defaults.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"time"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	nodeconfigv1alpha1 "k8s.io/cloud-provider/controllers/node/config/v1alpha1"
@@ -67,5 +68,80 @@ func SetDefaults_KubeCloudSharedConfiguration(obj *KubeCloudSharedConfiguration)
 	}
 	if obj.RouteReconciliationPeriod == zero {
 		obj.RouteReconciliationPeriod = metav1.Duration{Duration: 10 * time.Second}
+	}
+}
+
+// SetDefaults_ValidatingWebhook sets defaults for webhook validating. This function
+// is duplicated from "k8s.io/kubernetes/pkg/apis/admissionregistration/v1/defaults.go"
+// in order for in-tree cloud providers to not depend on internal packages.
+func SetDefaults_ValidatingWebhook(obj *admissionregistrationv1.ValidatingWebhook) {
+	if obj.FailurePolicy == nil {
+		policy := admissionregistrationv1.Fail
+		obj.FailurePolicy = &policy
+	}
+	if obj.MatchPolicy == nil {
+		policy := admissionregistrationv1.Equivalent
+		obj.MatchPolicy = &policy
+	}
+	if obj.NamespaceSelector == nil {
+		selector := metav1.LabelSelector{}
+		obj.NamespaceSelector = &selector
+	}
+	if obj.ObjectSelector == nil {
+		selector := metav1.LabelSelector{}
+		obj.ObjectSelector = &selector
+	}
+	if obj.TimeoutSeconds == nil {
+		obj.TimeoutSeconds = new(int32)
+		*obj.TimeoutSeconds = 10
+	}
+}
+
+// SetDefaults_MutatingWebhook sets defaults for webhook mutating This function
+// is duplicated from "k8s.io/kubernetes/pkg/apis/admissionregistration/v1/defaults.go"
+// in order for in-tree cloud providers to not depend on internal packages.
+func SetDefaults_MutatingWebhook(obj *admissionregistrationv1.MutatingWebhook) {
+	if obj.FailurePolicy == nil {
+		policy := admissionregistrationv1.Fail
+		obj.FailurePolicy = &policy
+	}
+	if obj.MatchPolicy == nil {
+		policy := admissionregistrationv1.Equivalent
+		obj.MatchPolicy = &policy
+	}
+	if obj.NamespaceSelector == nil {
+		selector := metav1.LabelSelector{}
+		obj.NamespaceSelector = &selector
+	}
+	if obj.ObjectSelector == nil {
+		selector := metav1.LabelSelector{}
+		obj.ObjectSelector = &selector
+	}
+	if obj.TimeoutSeconds == nil {
+		obj.TimeoutSeconds = new(int32)
+		*obj.TimeoutSeconds = 10
+	}
+	if obj.ReinvocationPolicy == nil {
+		never := admissionregistrationv1.NeverReinvocationPolicy
+		obj.ReinvocationPolicy = &never
+	}
+}
+
+// SetDefaults_Rule sets defaults for webhook rule This function
+// is duplicated from "k8s.io/kubernetes/pkg/apis/admissionregistration/v1/defaults.go"
+// in order for in-tree cloud providers to not depend on internal packages.
+func SetDefaults_Rule(obj *admissionregistrationv1.Rule) {
+	if obj.Scope == nil {
+		s := admissionregistrationv1.AllScopes
+		obj.Scope = &s
+	}
+}
+
+// SetDefaults_ServiceReference sets defaults for Webhook's ServiceReference This function
+// is duplicated from "k8s.io/kubernetes/pkg/apis/admissionregistration/v1/defaults.go"
+// in order for in-tree cloud providers to not depend on internal packages.
+func SetDefaults_ServiceReference(obj *admissionregistrationv1.ServiceReference) {
+	if obj.Port == nil {
+		obj.Port = utilpointer.Int32(443)
 	}
 }

--- a/staging/src/k8s.io/cloud-provider/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/cloud-provider/config/v1alpha1/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	nodeconfigv1alpha1 "k8s.io/cloud-provider/controllers/node/config/v1alpha1"
 	serviceconfigv1alpha1 "k8s.io/cloud-provider/controllers/service/config/v1alpha1"
@@ -98,4 +99,15 @@ type WebhookConfiguration struct {
 	// '-foo' means "disable 'foo'"
 	// first item for a particular name wins
 	Webhooks []string
+	// WebhookPort is the port that the controller-manager's webhook service runs on.
+	WebhookPort int32
+	// WebhookAddress is the IP address to serve on.
+	WebhookAddress string
+	// CaBundle is the ca certs to be used by apiserver for validating the webhook server certs.
+	CaBundle string
+	// ValidatingWebhookConfiguration is the config used for creating validation webhook config object.
+	ValidatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration
+
+	// MutatingWebhookConfiguration is the config used for creating mutating webhook config object.
+	MutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration
 }

--- a/staging/src/k8s.io/cloud-provider/config/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/cloud-provider/config/v1alpha1/zz_generated.conversion.go
@@ -24,6 +24,7 @@ package v1alpha1
 import (
 	unsafe "unsafe"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -187,6 +188,11 @@ func autoConvert_config_KubeCloudSharedConfiguration_To_v1alpha1_KubeCloudShared
 
 func autoConvert_v1alpha1_WebhookConfiguration_To_config_WebhookConfiguration(in *WebhookConfiguration, out *config.WebhookConfiguration, s conversion.Scope) error {
 	out.Webhooks = *(*[]string)(unsafe.Pointer(&in.Webhooks))
+	out.WebhookPort = in.WebhookPort
+	out.WebhookAddress = in.WebhookAddress
+	out.CaBundle = in.CaBundle
+	out.ValidatingWebhookConfiguration = (*admissionregistrationv1.ValidatingWebhookConfiguration)(unsafe.Pointer(in.ValidatingWebhookConfiguration))
+	out.MutatingWebhookConfiguration = (*admissionregistrationv1.MutatingWebhookConfiguration)(unsafe.Pointer(in.MutatingWebhookConfiguration))
 	return nil
 }
 
@@ -197,6 +203,11 @@ func Convert_v1alpha1_WebhookConfiguration_To_config_WebhookConfiguration(in *We
 
 func autoConvert_config_WebhookConfiguration_To_v1alpha1_WebhookConfiguration(in *config.WebhookConfiguration, out *WebhookConfiguration, s conversion.Scope) error {
 	out.Webhooks = *(*[]string)(unsafe.Pointer(&in.Webhooks))
+	out.WebhookPort = in.WebhookPort
+	out.WebhookAddress = in.WebhookAddress
+	out.CaBundle = in.CaBundle
+	out.ValidatingWebhookConfiguration = (*admissionregistrationv1.ValidatingWebhookConfiguration)(unsafe.Pointer(in.ValidatingWebhookConfiguration))
+	out.MutatingWebhookConfiguration = (*admissionregistrationv1.MutatingWebhookConfiguration)(unsafe.Pointer(in.MutatingWebhookConfiguration))
 	return nil
 }
 

--- a/staging/src/k8s.io/cloud-provider/config/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/cloud-provider/config/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v1 "k8s.io/api/admissionregistration/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -104,6 +105,16 @@ func (in *WebhookConfiguration) DeepCopyInto(out *WebhookConfiguration) {
 		in, out := &in.Webhooks, &out.Webhooks
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.ValidatingWebhookConfiguration != nil {
+		in, out := &in.ValidatingWebhookConfiguration, &out.ValidatingWebhookConfiguration
+		*out = new(v1.ValidatingWebhookConfiguration)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.MutatingWebhookConfiguration != nil {
+		in, out := &in.MutatingWebhookConfiguration, &out.MutatingWebhookConfiguration
+		*out = new(v1.MutatingWebhookConfiguration)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/cloud-provider/config/v1alpha1/zz_generated.defaults.go
+++ b/staging/src/k8s.io/cloud-provider/config/v1alpha1/zz_generated.defaults.go
@@ -38,4 +38,30 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 func SetObjectDefaults_CloudControllerManagerConfiguration(in *CloudControllerManagerConfiguration) {
 	SetDefaults_CloudControllerManagerConfiguration(in)
 	SetDefaults_KubeCloudSharedConfiguration(&in.KubeCloudShared)
+	if in.Webhook.ValidatingWebhookConfiguration != nil {
+		for i := range in.Webhook.ValidatingWebhookConfiguration.Webhooks {
+			a := &in.Webhook.ValidatingWebhookConfiguration.Webhooks[i]
+			SetDefaults_ValidatingWebhook(a)
+			if a.ClientConfig.Service != nil {
+				SetDefaults_ServiceReference(a.ClientConfig.Service)
+			}
+			for j := range a.Rules {
+				b := &a.Rules[j]
+				SetDefaults_Rule(&b.Rule)
+			}
+		}
+	}
+	if in.Webhook.MutatingWebhookConfiguration != nil {
+		for i := range in.Webhook.MutatingWebhookConfiguration.Webhooks {
+			a := &in.Webhook.MutatingWebhookConfiguration.Webhooks[i]
+			SetDefaults_MutatingWebhook(a)
+			if a.ClientConfig.Service != nil {
+				SetDefaults_ServiceReference(a.ClientConfig.Service)
+			}
+			for j := range a.Rules {
+				b := &a.Rules[j]
+				SetDefaults_Rule(&b.Rule)
+			}
+		}
+	}
 }

--- a/staging/src/k8s.io/cloud-provider/config/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/cloud-provider/config/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package config
 
 import (
+	v1 "k8s.io/api/admissionregistration/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -99,6 +100,16 @@ func (in *WebhookConfiguration) DeepCopyInto(out *WebhookConfiguration) {
 		in, out := &in.Webhooks, &out.Webhooks
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.ValidatingWebhookConfiguration != nil {
+		in, out := &in.ValidatingWebhookConfiguration, &out.ValidatingWebhookConfiguration
+		*out = new(v1.ValidatingWebhookConfiguration)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.MutatingWebhookConfiguration != nil {
+		in, out := &in.MutatingWebhookConfiguration, &out.MutatingWebhookConfiguration
+		*out = new(v1.MutatingWebhookConfiguration)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/cloud-provider/options/options.go
+++ b/staging/src/k8s.io/cloud-provider/options/options.go
@@ -200,7 +200,7 @@ func (o *CloudControllerManagerOptions) ApplyTo(c *config.Config, allControllers
 		}
 	}
 	if o.WebhookServing != nil {
-		if err = o.WebhookServing.ApplyTo(&c.WebhookSecureServing); err != nil {
+		if err = o.WebhookServing.ApplyTo(&c.ComponentConfig.Webhook, &c.WebhookSecureServing); err != nil {
 			return err
 		}
 	}
@@ -290,12 +290,6 @@ func (o *CloudControllerManagerOptions) Config(allControllers []string, disabled
 
 	if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{netutils.ParseIPSloppy("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
-	}
-
-	if o.WebhookServing != nil {
-		if err := o.WebhookServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{netutils.ParseIPSloppy("127.0.0.1")}); err != nil {
-			return nil, fmt.Errorf("error creating self-signed certificates for webhook: %v", err)
-		}
 	}
 
 	c := &config.Config{}

--- a/staging/src/k8s.io/cloud-provider/options/options.go
+++ b/staging/src/k8s.io/cloud-provider/options/options.go
@@ -247,7 +247,7 @@ func (o *CloudControllerManagerOptions) ApplyTo(c *config.Config, allControllers
 }
 
 // Validate is used to validate config before launching the cloud controller manager
-func (o *CloudControllerManagerOptions) Validate(allControllers []string, disabledByDefaultControllers []string, controllerAliases map[string]string, allWebhooks, disabledByDefaultWebhooks []string) error {
+func (o *CloudControllerManagerOptions) Validate(allControllers []string, disabledByDefaultControllers []string, controllerAliases map[string]string, validatingWebhooks, mutatingWebhooks, disabledByDefaultWebhooks []string) error {
 	errors := []error{}
 
 	errors = append(errors, o.Generic.Validate(allControllers, disabledByDefaultControllers, controllerAliases)...)
@@ -258,7 +258,7 @@ func (o *CloudControllerManagerOptions) Validate(allControllers []string, disabl
 	errors = append(errors, o.Authorization.Validate()...)
 
 	if o.Webhook != nil {
-		errors = append(errors, o.Webhook.Validate(allWebhooks, disabledByDefaultWebhooks)...)
+		errors = append(errors, o.Webhook.Validate(validatingWebhooks, mutatingWebhooks, disabledByDefaultWebhooks)...)
 	}
 	if o.WebhookServing != nil {
 		errors = append(errors, o.WebhookServing.Validate()...)
@@ -283,8 +283,8 @@ func resyncPeriod(c *config.Config) func() time.Duration {
 }
 
 // Config return a cloud controller manager config objective
-func (o *CloudControllerManagerOptions) Config(allControllers []string, disabledByDefaultControllers []string, controllerAliases map[string]string, allWebhooks, disabledByDefaultWebhooks []string) (*config.Config, error) {
-	if err := o.Validate(allControllers, disabledByDefaultControllers, controllerAliases, allWebhooks, disabledByDefaultWebhooks); err != nil {
+func (o *CloudControllerManagerOptions) Config(allControllers []string, disabledByDefaultControllers []string, controllerAliases map[string]string, validatingWebhooks, mutatingWebhooks, disabledByDefaultWebhooks []string) (*config.Config, error) {
+	if err := o.Validate(allControllers, disabledByDefaultControllers, controllerAliases, validatingWebhooks, mutatingWebhooks, disabledByDefaultWebhooks); err != nil {
 		return nil, err
 	}
 

--- a/staging/src/k8s.io/cloud-provider/options/options_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/options_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/pflag"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiserver "k8s.io/apiserver/pkg/server"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
@@ -333,6 +334,7 @@ func TestCreateConfig(t *testing.T) {
 
 	args := []string{
 		"--webhooks=foo,bar,-baz",
+		"--validating-webhook-config-file=testdata/validatingwebhookconfiguration.yaml",
 		"--allocate-node-cidrs=true",
 		"--authorization-always-allow-paths=",
 		"--bind-address=0.0.0.0",
@@ -371,9 +373,11 @@ func TestCreateConfig(t *testing.T) {
 		fmt.Printf("%s: %s\n", f.Name, f.Value)
 	})
 
-	c, err := s.Config([]string{"foo", "bar"}, []string{}, nil, []string{"foo", "bar", "baz"}, []string{})
+	c, err := s.Config([]string{"foo", "bar"}, []string{}, nil, []string{"foo", "bar"}, []string{"baz"}, []string{})
 	assert.Nil(t, err, "unexpected error: %s", err)
 
+	failurePolicy := admissionregistrationv1.Fail
+	webhookScope := admissionregistrationv1.AllScopes
 	expected := &appconfig.Config{
 		ComponentConfig: cpconfig.CloudControllerManagerConfiguration{
 			Generic: cmconfig.GenericControllerManagerConfiguration{
@@ -421,6 +425,33 @@ func TestCreateConfig(t *testing.T) {
 			NodeStatusUpdateFrequency: metav1.Duration{Duration: 10 * time.Minute},
 			Webhook: cpconfig.WebhookConfiguration{
 				Webhooks: []string{"foo", "bar", "-baz"},
+				ValidatingWebhookConfiguration: &admissionregistrationv1.ValidatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cloud-controller-validating-webhook",
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ValidatingWebhookConfiguration",
+						APIVersion: "admissionregistration.k8s.io/v1",
+					},
+					Webhooks: []admissionregistrationv1.ValidatingWebhook{
+						{
+							Name: "validating-webhook.aws.io",
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Operations: []admissionregistrationv1.OperationType{"CREATE"},
+									Rule: admissionregistrationv1.Rule{
+										APIGroups:   []string{""},
+										APIVersions: []string{"v1"},
+										Resources:   []string{"pods"},
+										Scope:       &webhookScope,
+									},
+								},
+							},
+							FailurePolicy:           &failurePolicy,
+							AdmissionReviewVersions: []string{"v1"},
+						},
+					},
+				},
 			},
 		},
 		SecureServing:        nil,
@@ -442,6 +473,9 @@ func TestCreateConfig(t *testing.T) {
 	c.Kubeconfig = nil
 	c.Client = nil
 	c.LoopbackClientConfig = nil
+	c.ComponentConfig.Webhook.WebhookPort = 0
+	c.ComponentConfig.Webhook.WebhookAddress = ""
+	c.ComponentConfig.Webhook.CaBundle = ""
 
 	if !reflect.DeepEqual(expected, c) {
 		t.Errorf("Got different config than expected.\nDifference detected on:\n%s", cmp.Diff(expected, c))
@@ -471,7 +505,7 @@ func TestCloudControllerManagerAliases(t *testing.T) {
 		"cloud-node-lifecycle": "cloud-node-lifecycle-controller",
 	}
 
-	if err := opts.Validate(allControllers, disabledByDefaultControllers, controllerAliases, nil, nil); err != nil {
+	if err := opts.Validate(allControllers, disabledByDefaultControllers, controllerAliases, nil, nil, nil); err != nil {
 		t.Errorf("expected no error, error found %v", err)
 	}
 

--- a/staging/src/k8s.io/cloud-provider/options/testdata/validatingwebhookconfiguration.yaml
+++ b/staging/src/k8s.io/cloud-provider/options/testdata/validatingwebhookconfiguration.yaml
@@ -1,0 +1,19 @@
+kind: ValidatingWebhookConfiguration
+apiVersion: admissionregistration.k8s.io/v1
+metadata:
+  name: cloud-controller-validating-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1
+  failurePolicy: Fail
+  name: validating-webhook.aws.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+    scope: '*'

--- a/staging/src/k8s.io/cloud-provider/options/webhook_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/webhook_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestWebhookOptions_Validate(t *testing.T) {
+	type args struct {
+		allWebhooks               []string
+		disabledByDefaultWebhooks []string
+	}
+	tests := []struct {
+		name  string
+		input *WebhookOptions
+		args  args
+		want  []error
+	}{
+		{
+			name: "Unknown Webhook",
+			input: &WebhookOptions{
+				Webhooks:                        []string{"test.ccm.io"},
+				ValidatingWebhookConfigFilePath: "test.txt",
+			},
+			args: args{
+				allWebhooks:               []string{"test1.ccm.io"},
+				disabledByDefaultWebhooks: []string{},
+			},
+			want: []error{fmt.Errorf("%q is not in the list of known webhooks", "test.ccm.io")},
+		},
+		{
+			name: "Webhook Configuration Missing",
+			input: &WebhookOptions{
+				Webhooks: []string{"test.ccm.io"},
+			},
+			args: args{
+				allWebhooks:               []string{"test.ccm.io"},
+				disabledByDefaultWebhooks: []string{},
+			},
+			want: []error{errors.New("webhooks are enabled but the webhook configuration path is empty")},
+		},
+		{
+			name: "Missing Webhook Configuration",
+			input: &WebhookOptions{
+				Webhooks:                        []string{"test.ccm.io"},
+				ValidatingWebhookConfigFilePath: "test.txt",
+				validationWebhookConfiguration: &admissionregistrationv1.ValidatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					Webhooks: []admissionregistrationv1.ValidatingWebhook{},
+				},
+			},
+			args: args{
+				allWebhooks:               []string{"test.ccm.io"},
+				disabledByDefaultWebhooks: []string{},
+			},
+			want: []error{errors.New("webhook test.ccm.io is enabled but is not present in the webhook configuration")},
+		},
+		{
+			name: "Extra Webhook Configuration",
+			input: &WebhookOptions{
+				Webhooks:                        []string{"test.ccm.io"},
+				ValidatingWebhookConfigFilePath: "test.txt",
+				validationWebhookConfiguration: &admissionregistrationv1.ValidatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					Webhooks: []admissionregistrationv1.ValidatingWebhook{
+						{
+							Name: "test.ccm.io",
+						},
+						{
+							Name: "test1.ccm.io",
+						},
+					},
+				},
+			},
+			args: args{
+				allWebhooks:               []string{"test.ccm.io"},
+				disabledByDefaultWebhooks: []string{},
+			},
+			want: []error{errors.New("webhook configuration is present for webhooks map[test1.ccm.io:{}] but the webhooks are not present/disabled")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.input.Validate(tt.args.allWebhooks, tt.args.disabledByDefaultWebhooks); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("WebhookOptions.Validate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

The changes would create/update the validation webhook configuration if webhooks are enabled as part of the cloud controller and is an extension of https://github.com/kubernetes/kubernetes/pull/108838. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added the ability to create a validating webhook configuration as part of the cloud controller manager bootstrap.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: [KEP-2699](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cloud-provider/2699-add-webhook-hosting-to-ccm)
```
