### PR TITLE
controlplane/apiserver: don't crash if authz or other options are explicitly disabled in options

### DIFF
--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -152,7 +152,7 @@ func BuildGenericConfig(
 		lastErr = fmt.Errorf("invalid authorization config: %v", err)
 		return
 	}
-	if !sets.NewString(s.Authorization.Modes...).Has(modes.ModeRBAC) {
+	if s.Authorization != nil && !sets.NewString(s.Authorization.Modes...).Has(modes.ModeRBAC) {
 		genericConfig.DisabledPostStartHooks.Insert(rbacrest.PostStartHookName)
 	}
 
@@ -172,11 +172,14 @@ func BuildGenericConfig(
 	return
 }
 
-// BuildAuthorizer constructs the authorizer
+// BuildAuthorizer constructs the authorizer. If authorization is not set in s, it returns nil, nil, nil
 func BuildAuthorizer(s controlplaneapiserver.CompletedOptions, EgressSelector *egressselector.EgressSelector, versionedInformers clientgoinformers.SharedInformerFactory) (authorizer.Authorizer, authorizer.RuleResolver, error) {
 	authorizationConfig, err := s.Authorization.ToAuthorizationConfig(versionedInformers)
 	if err != nil {
 		return nil, nil, err
+	}
+	if authorizationConfig == nil {
+		return nil, nil, nil
 	}
 
 	if EgressSelector != nil {

--- a/pkg/controlplane/apiserver/options/options.go
+++ b/pkg/controlplane/apiserver/options/options.go
@@ -42,6 +42,8 @@ import (
 	"k8s.io/kubernetes/pkg/serviceaccount"
 )
 
+// Options define the flags and validation for a generic controlplane. If the
+// structs are nil, the options are not added to the command line and not validated.
 type Options struct {
 	GenericServerRunOptions *genericoptions.ServerRunOptions
 	Etcd                    *genericoptions.EtcdOptions

--- a/pkg/kubeapiserver/options/admission.go
+++ b/pkg/kubeapiserver/options/admission.go
@@ -67,6 +67,9 @@ func NewAdmissionOptions() *AdmissionOptions {
 
 // AddFlags adds flags related to admission for kube-apiserver to the specified FlagSet
 func (a *AdmissionOptions) AddFlags(fs *pflag.FlagSet) {
+	if a == nil {
+		return
+	}
 	fs.StringSliceVar(&a.PluginNames, "admission-control", a.PluginNames, ""+
 		"Admission is divided into two phases. "+
 		"In the first phase, only mutating admission plugins run. "+

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -210,6 +210,10 @@ func (o *BuiltInAuthenticationOptions) WithWebHook() *BuiltInAuthenticationOptio
 
 // Validate checks invalid config combination
 func (o *BuiltInAuthenticationOptions) Validate() []error {
+	if o == nil {
+		return nil
+	}
+
 	var allErrors []error
 
 	allErrors = append(allErrors, o.validateOIDCOptions()...)
@@ -270,6 +274,10 @@ func (o *BuiltInAuthenticationOptions) Validate() []error {
 
 // AddFlags returns flags of authentication for a API Server
 func (o *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
+	if o == nil {
+		return
+	}
+
 	fs.StringSliceVar(&o.APIAudiences, "api-audiences", o.APIAudiences, ""+
 		"Identifiers of the API. The service account token authenticator will validate that "+
 		"tokens used against the API are bound to at least one of these audiences. If the "+
@@ -416,8 +424,13 @@ func (o *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 	}
 }
 
-// ToAuthenticationConfig convert BuiltInAuthenticationOptions to kubeauthenticator.Config
+// ToAuthenticationConfig convert BuiltInAuthenticationOptions to kubeauthenticator.Config. Returns
+// an empty config if o is nil.
 func (o *BuiltInAuthenticationOptions) ToAuthenticationConfig() (kubeauthenticator.Config, error) {
+	if o == nil {
+		return kubeauthenticator.Config{}, nil
+	}
+
 	ret := kubeauthenticator.Config{
 		TokenSuccessCacheTTL: o.TokenSuccessCacheTTL,
 		TokenFailureCacheTTL: o.TokenFailureCacheTTL,

--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -29,6 +29,7 @@ import (
 	authzconfig "k8s.io/apiserver/pkg/apis/apiserver"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	versionedinformers "k8s.io/client-go/informers"
+
 	"k8s.io/kubernetes/pkg/kubeapiserver/authorizer"
 	authzmodes "k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes"
 )
@@ -106,6 +107,10 @@ func (o *BuiltInAuthorizationOptions) Validate() []error {
 
 // AddFlags returns flags of authorization for a API Server
 func (o *BuiltInAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
+	if o == nil {
+		return
+	}
+
 	fs.StringSliceVar(&o.Modes, "authorization-mode", o.Modes, ""+
 		"Ordered list of plug-ins to do authorization on secure port. Comma-delimited list of: "+
 		strings.Join(authzmodes.AuthorizationModeChoices, ",")+".")
@@ -130,14 +135,17 @@ func (o *BuiltInAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 }
 
 // ToAuthorizationConfig convert BuiltInAuthorizationOptions to authorizer.Config
-func (o *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFactory versionedinformers.SharedInformerFactory) (authorizer.Config, error) {
+func (o *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFactory versionedinformers.SharedInformerFactory) (*authorizer.Config, error) {
+	if o == nil {
+		return nil, nil
+	}
 
 	authzConfiguration, err := o.buildAuthorizationConfiguration()
 	if err != nil {
-		return authorizer.Config{}, fmt.Errorf("failed to build authorization config: %s", err)
+		return nil, fmt.Errorf("failed to build authorization config: %s", err)
 	}
 
-	return authorizer.Config{
+	return &authorizer.Config{
 		PolicyFile:               o.PolicyFile,
 		VersionedInformerFactory: versionedInformerFactory,
 		WebhookRetryBackoff:      o.WebhookRetryBackoff,

--- a/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement.go
@@ -42,6 +42,9 @@ func NewAPIEnablementOptions() *APIEnablementOptions {
 
 // AddFlags adds flags for a specific APIServer to the specified FlagSet
 func (s *APIEnablementOptions) AddFlags(fs *pflag.FlagSet) {
+	if s == nil {
+		return
+	}
 	fs.Var(&s.RuntimeConfig, "runtime-config", ""+
 		"A set of key=value pairs that enable or disable built-in APIs. Supported options are:\n"+
 		"v1=true|false for the core API group\n"+
@@ -87,7 +90,6 @@ func (s *APIEnablementOptions) Validate(registries ...GroupRegistry) []error {
 
 // ApplyTo override MergedResourceConfig with defaults and registry
 func (s *APIEnablementOptions) ApplyTo(c *server.Config, defaultResourceConfig *serverstore.ResourceConfig, registry resourceconfig.GroupVersionRegistry) error {
-
 	if s == nil {
 		return nil
 	}

--- a/staging/src/k8s.io/component-base/metrics/options.go
+++ b/staging/src/k8s.io/component-base/metrics/options.go
@@ -40,6 +40,10 @@ func NewOptions() *Options {
 
 // Validate validates metrics flags options.
 func (o *Options) Validate() []error {
+	if o == nil {
+		return nil
+	}
+
 	var errs []error
 	err := validateShowHiddenMetricsVersion(parseVersion(version.Get()), o.ShowHiddenMetricsForVersion)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The apiserver plumbing panics today when the (builtin) authorization or a few others are disabled explicitly in the options. This is wrong as these sub-options are supposed to be optional.

Towards https://github.com/kubernetes/enhancements/issues/4080.

```release-note
NONE
```