### PR TITLE
[StructuredAuthorizationConfiguration] staging/apiserver: correct KubeConfig type name in authorization types

### DIFF
--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -169,7 +169,7 @@ func (o *BuiltInAuthorizationOptions) buildAuthorizationConfiguration() (*authzc
 					FailurePolicy:              authzconfig.FailurePolicyNoOpinion,
 					SubjectAccessReviewVersion: o.WebhookVersion,
 					ConnectionInfo: authzconfig.WebhookConnectionInfo{
-						Type:           authzconfig.AuthorizationWebhookConnectionInfoTypeKubeConfig,
+						Type:           authzconfig.AuthorizationWebhookConnectionInfoTypeKubeConfigFile,
 						KubeConfigFile: &o.WebhookConfigFile,
 					},
 				},

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
@@ -212,11 +212,11 @@ type AuthorizationConfiguration struct {
 }
 
 const (
-	TypeWebhook                                      AuthorizerType = "Webhook"
-	FailurePolicyNoOpinion                           string         = "NoOpinion"
-	FailurePolicyDeny                                string         = "Deny"
-	AuthorizationWebhookConnectionInfoTypeKubeConfig string         = "KubeConfigFile"
-	AuthorizationWebhookConnectionInfoTypeInCluster  string         = "InClusterConfig"
+	TypeWebhook                                          AuthorizerType = "Webhook"
+	FailurePolicyNoOpinion                               string         = "NoOpinion"
+	FailurePolicyDeny                                    string         = "Deny"
+	AuthorizationWebhookConnectionInfoTypeKubeConfigFile string         = "KubeConfigFile"
+	AuthorizationWebhookConnectionInfoTypeInCluster      string         = "InClusterConfig"
 )
 
 type AuthorizerType string
@@ -294,7 +294,7 @@ type WebhookConfiguration struct {
 type WebhookConnectionInfo struct {
 	// Controls how the webhook should communicate with the server.
 	// Valid values:
-	// - KubeConfig: use the file specified in kubeConfigFile to locate the
+	// - KubeConfigFile: use the file specified in kubeConfigFile to locate the
 	//   server.
 	// - InClusterConfig: use the in-cluster configuration to call the
 	//   SubjectAccessReview API hosted by kube-apiserver. This mode is not

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
@@ -282,11 +282,11 @@ type AuthorizationConfiguration struct {
 }
 
 const (
-	TypeWebhook                                      AuthorizerType = "Webhook"
-	FailurePolicyNoOpinion                           string         = "NoOpinion"
-	FailurePolicyDeny                                string         = "Deny"
-	AuthorizationWebhookConnectionInfoTypeKubeConfig string         = "KubeConfigFile"
-	AuthorizationWebhookConnectionInfoTypeInCluster  string         = "InClusterConfig"
+	TypeWebhook                                          AuthorizerType = "Webhook"
+	FailurePolicyNoOpinion                               string         = "NoOpinion"
+	FailurePolicyDeny                                    string         = "Deny"
+	AuthorizationWebhookConnectionInfoTypeKubeConfigFile string         = "KubeConfigFile"
+	AuthorizationWebhookConnectionInfoTypeInCluster      string         = "InClusterConfig"
 )
 
 type AuthorizerType string
@@ -365,7 +365,7 @@ type WebhookConfiguration struct {
 type WebhookConnectionInfo struct {
 	// Controls how the webhook should communicate with the server.
 	// Valid values:
-	// - KubeConfig: use the file specified in kubeConfigFile to locate the
+	// - KubeConfigFile: use the file specified in kubeConfigFile to locate the
 	//   server.
 	// - InClusterConfig: use the in-cluster configuration to call the
 	//   SubjectAccessReview API hosted by kube-apiserver. This mode is not

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
@@ -319,7 +319,7 @@ func ValidateWebhookConfiguration(fldPath *field.Path, c *api.WebhookConfigurati
 		if c.ConnectionInfo.KubeConfigFile != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("connectionInfo", "kubeConfigFile"), *c.ConnectionInfo.KubeConfigFile, "can only be set when type=KubeConfigFile"))
 		}
-	case api.AuthorizationWebhookConnectionInfoTypeKubeConfig:
+	case api.AuthorizationWebhookConnectionInfoTypeKubeConfigFile:
 		if c.ConnectionInfo.KubeConfigFile == nil || *c.ConnectionInfo.KubeConfigFile == "" {
 			allErrs = append(allErrs, field.Required(fldPath.Child("connectionInfo", "kubeConfigFile"), ""))
 		} else if !filepath.IsAbs(*c.ConnectionInfo.KubeConfigFile) {
@@ -330,7 +330,7 @@ func ValidateWebhookConfiguration(fldPath *field.Path, c *api.WebhookConfigurati
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("connectionInfo", "kubeConfigFile"), *c.ConnectionInfo.KubeConfigFile, "must be a regular file"))
 		}
 	default:
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("connectionInfo", "type"), c.ConnectionInfo, []string{"InClusterConfig", "KubeConfigFile"}))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("connectionInfo", "type"), c.ConnectionInfo, []string{api.AuthorizationWebhookConnectionInfoTypeInCluster, api.AuthorizationWebhookConnectionInfoTypeKubeConfigFile}))
 	}
 
 	// TODO: Remove this check and ensure that correct validations below for MatchConditions are added


### PR DESCRIPTION
Found a mismatch in the KubeConfig ConnectionInfo type value that was agreed upon in the KEP while writing integration tests.

/sig auth
/assign @liggitt @ritazh @enj 
/priority critical-urgent
/kind bug