### PR TITLE
controller/clusterauthenticationtrust: complete event filter

### DIFF
--- a/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller.go
+++ b/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller.go
@@ -106,11 +106,11 @@ func NewClusterAuthenticationTrustController(requiredAuthenticationData ClusterA
 	kubeSystemConfigMapInformer.AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
 			if cast, ok := obj.(*corev1.ConfigMap); ok {
-				return cast.Name == configMapName
+				return cast.Namespace == configMapNamespace && cast.Name == configMapName
 			}
 			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 				if cast, ok := tombstone.Obj.(*corev1.ConfigMap); ok {
-					return cast.Name == configMapName
+					return cast.Namespace == configMapNamespace && cast.Name == configMapName
 				}
 			}
 			return true // always return true just in case.  The checks are fairly cheap


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Little cosmetic, the cluster auth trust controller filters by its configmap name, but not by the namespace. This PR completes that check.

```release-note
NONE
```