### PR TITLE
WIP: Add stateful set test reproducing issue with Failed pods

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -375,20 +375,14 @@ func (ssc *defaultStatefulSetControl) processReplica(
 	replicas []*v1.Pod,
 	i int) (bool, error) {
 	logger := klog.FromContext(ctx)
-	logger.Info("MYDEBUG processReplica", "i", i)
-	defer func() {
-		logger.Info("MYDEBUG processReplica DONE", "i", i)
-	}()
 	// delete and recreate failed pods
 	if isFailed(replicas[i]) {
-		logger.Info("MYDEBUG processReplica isFailed", "i", i)
 		ssc.recorder.Eventf(set, v1.EventTypeWarning, "RecreatingFailedPod",
 			"StatefulSet %s/%s is recreating failed Pod %s",
 			set.Namespace,
 			set.Name,
 			replicas[i].Name)
 		if err := ssc.podControl.DeleteStatefulPod(set, replicas[i]); err != nil {
-			logger.Info("MYDEBUG processReplica DELETION FAILED", "i", i)
 			return true, err
 		}
 		replicaOrd := i + getStartOrdinal(set)
@@ -401,7 +395,6 @@ func (ssc *defaultStatefulSetControl) processReplica(
 	}
 	// If we find a Pod that has not been created we create the Pod
 	if !isCreated(replicas[i]) {
-		logger.Info("MYDEBUG processReplica !isCreated", "i", i)
 		if utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoDeletePVC) {
 			if isStale, err := ssc.podControl.PodClaimIsStale(set, replicas[i]); err != nil {
 				return true, err
@@ -411,7 +404,6 @@ func (ssc *defaultStatefulSetControl) processReplica(
 			}
 		}
 		if err := ssc.podControl.CreateStatefulPod(ctx, set, replicas[i]); err != nil {
-			logger.Info("MYDEBUG processReplica CREATION FAILED", "i", i)
 			return true, err
 		}
 		if monotonic {

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -378,14 +378,13 @@ var _ = SIGDescribe("StatefulSet", func() {
 						}
 						ginkgo.By(fmt.Sprintf("StatefulSet status fields: CurrentReplicas=%v, UpdatedReplicas=%v, CurrentRevision=%v, UpdateRevision=%v", e.Status.CurrentReplicas, e.Status.UpdatedReplicas, e.Status.CurrentRevision, e.Status.UpdateRevision))
 						if e.Status.UpdatedReplicas == 2 && e.Status.Replicas == 3 {
-							ginkgo.By("Marking pod0 as  Failed")
+							ginkgo.By("Marking pod0 as Failed")
 							pod0 := pods.Items[0]
 							pod0name := pod0.Name
 							err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-								ginkgo.By("Retrying to set the phase on POD")
 								pod0, err := c.CoreV1().Pods(ss.Namespace).Get(ctx, pod0name, metav1.GetOptions{})
 								if err != nil {
-									ginkgo.By(fmt.Sprintf("Retrying to set the phase on POD: %v", err))
+									ginkgo.By(fmt.Sprintf("Failed retrying to set the phase on pod0: %v", err))
 									return nil
 								}
 								pod0.Status.Phase = v1.PodFailed
@@ -446,6 +445,103 @@ var _ = SIGDescribe("StatefulSet", func() {
 					updateRevision))
 			}
 			wg.Wait()
+		})
+
+		ginkgo.It("xyz-finalizer", func(ctx context.Context) {
+			ginkgo.By("Creating a new StatefulSet")
+
+			ss := e2estatefulset.NewStatefulSet("ss-failing-pods", ns, headlessSvcName, 3, nil, nil, labels)
+			ss.Labels = make(map[string]string)
+			ss.Labels["e2e"] = "testing"
+
+			setHTTPProbe(ss)
+			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
+			ss = waitForStatus(ctx, c, ss)
+			currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
+			framework.ExpectEqual(currentRevision, updateRevision, fmt.Sprintf("StatefulSet %s/%s created with update revision %s not equal to current revision %s",
+				ss.Namespace, ss.Name, updateRevision, currentRevision))
+			pods := e2estatefulset.GetPodList(ctx, c, ss)
+			for i := range pods.Items {
+				framework.ExpectEqual(pods.Items[i].Labels[appsv1.StatefulSetRevisionLabel], currentRevision, fmt.Sprintf("Pod %s/%s revision %s is not equal to current revision %s",
+					pods.Items[i].Namespace,
+					pods.Items[i].Name,
+					pods.Items[i].Labels[appsv1.StatefulSetRevisionLabel],
+					currentRevision))
+			}
+			e2estatefulset.SortStatefulPods(pods)
+			err = breakPodHTTPProbe(ss, &pods.Items[1])
+			framework.ExpectNoError(err)
+			ss, _ = waitForPodNotReady(ctx, c, ss, pods.Items[1].Name)
+			newImage := NewWebserverImage
+			oldImage := ss.Spec.Template.Spec.Containers[0].Image
+
+			ginkgo.By("ADDING FINALIZER to POD0")
+			pod0 := &pods.Items[0]
+			pod0.Finalizers = []string{"example.com/myfinalizer"}
+			pod0, err = c.CoreV1().Pods(ss.Namespace).Update(ctx, pod0, metav1.UpdateOptions{})
+			framework.ExpectNoError(err)
+			pods.Items[0] = *pod0
+
+			defer func() {
+				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					ginkgo.By("REMOVING FINALIZER to POD0 - trying")
+					pod0, err := c.CoreV1().Pods(ss.Namespace).Get(ctx, pod0.Name, metav1.GetOptions{})
+					if err != nil {
+						ginkgo.By(fmt.Sprintf("Failed retrying to set the phase on pod0: %v", err))
+						return nil
+					}
+					pod0.Finalizers = []string{}
+					pod0, err = c.CoreV1().Pods(ss.Namespace).Update(ctx, pod0, metav1.UpdateOptions{})
+					if err == nil {
+						ginkgo.By("REMOVING FINALIZER to POD0 - success")
+					}
+					return err
+				})
+				framework.ExpectNoError(err)
+			}()
+
+			ginkgo.By(fmt.Sprintf("Updating StatefulSet template: update image from %s to %s", oldImage, newImage))
+			gomega.Expect(oldImage).NotTo(gomega.Equal(newImage), "Incorrect test setup: should update to a different image")
+
+			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
+				update.Spec.Template.Spec.Containers[0].Image = newImage
+			})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Creating a new revision")
+			ss = waitForStatus(ctx, c, ss)
+			currentRevision, updateRevision = ss.Status.CurrentRevision, ss.Status.UpdateRevision
+			gomega.Expect(currentRevision).NotTo(gomega.Equal(updateRevision), "Current revision should not equal update revision during rolling update")
+
+			ginkgo.By("Updating Pods in reverse ordinal order")
+			pods = e2estatefulset.GetPodList(ctx, c, ss)
+			e2estatefulset.SortStatefulPods(pods)
+
+			ginkgo.By("WaitForPodReady")
+			err = restorePodHTTPProbe(ss, &pods.Items[1])
+			framework.ExpectNoError(err)
+			ss, _ = e2estatefulset.WaitForPodReady(ctx, c, ss, pods.Items[1].Name)
+			ss, pods = waitForRollingUpdate(ctx, c, ss)
+
+			framework.ExpectEqual(ss.Status.CurrentRevision, updateRevision, fmt.Sprintf("StatefulSet %s/%s current revision %s does not equal update revision %s on update completion",
+				ss.Namespace,
+				ss.Name,
+				ss.Status.CurrentRevision,
+				updateRevision))
+			for i := range pods.Items {
+				framework.ExpectEqual(pods.Items[i].Spec.Containers[0].Image, newImage, fmt.Sprintf(" Pod %s/%s has image %s not have new image %s",
+					pods.Items[i].Namespace,
+					pods.Items[i].Name,
+					pods.Items[i].Spec.Containers[0].Image,
+					newImage))
+				framework.ExpectEqual(pods.Items[i].Labels[appsv1.StatefulSetRevisionLabel], updateRevision, fmt.Sprintf("Pod %s/%s revision %s is not equal to update revision %s",
+					pods.Items[i].Namespace,
+					pods.Items[i].Name,
+					pods.Items[i].Labels[appsv1.StatefulSetRevisionLabel],
+					updateRevision))
+			}
 		})
 
 		ginkgo.It("should perform rolling updates of template modifications when the pod exits with Failed phase, failed container", func(ctx context.Context) {

--- a/test/integration/statefulset/statefulset_test.go
+++ b/test/integration/statefulset/statefulset_test.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -486,6 +487,151 @@ func TestAutodeleteOwnerRefs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestDeletingPodForRollingUpdatePartition(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	closeFn, rm, informers, c := scSetup(ctx, t)
+	defer closeFn()
+	ns := framework.CreateNamespaceOrDie(c, "test-deleting-and-failed-pods", t)
+	defer framework.DeleteNamespaceOrDie(c, ns, t)
+	cancel := runControllerAndInformers(rm, informers)
+	defer cancel()
+
+	labelMap := labelMap()
+	sts := newSTS("sts", ns.Name, 2)
+	sts.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
+		Type: appsv1.RollingUpdateStatefulSetStrategyType,
+		RollingUpdate: func() *appsv1.RollingUpdateStatefulSetStrategy {
+			return &appsv1.RollingUpdateStatefulSetStrategy{
+				Partition: ptr.To[int32](1),
+			}
+		}(),
+	}
+	stss := createSTSs(t, c, []*appsv1.StatefulSet{sts})
+	sts = stss[0]
+	waitSTSStable(t, c, sts)
+
+	// Verify STS creates 2 pods
+	podClient := c.CoreV1().Pods(ns.Name)
+	pods := getPods(t, podClient, labelMap)
+	if len(pods.Items) != 2 {
+		t.Fatalf("len(pods) = %d, want %d", len(pods.Items), sts.Spec.Replicas)
+	}
+	// Setting all pods in Running, Ready, and Available
+	// by setting LastTransitionTime to more than 3600 seconds ago
+	setPodsReadyCondition(t, c, &v1.PodList{Items: pods.Items}, v1.ConditionTrue, time.Now().Add(-120*time.Minute))
+
+	// 1. Roll out a new image.
+	oldImage := sts.Spec.Template.Spec.Containers[0].Image
+	newImage := "new-image"
+	if oldImage == newImage {
+		t.Fatalf("bad test setup, statefulSet %s roll out with the same image", sts.Name)
+	}
+
+	// Set finalizers for the pod to trigger pod recreation failure while the status UpdateRevision is bumped
+	pod0 := &pods.Items[0]
+	updatePod(t, podClient, pod0.Name, func(pod *v1.Pod) {
+		pod.Finalizers = []string{"fake.example.com/blockDeletion"}
+	})
+
+	// Set the new image on the stateful set
+	stsClient := c.AppsV1().StatefulSets(ns.Name)
+	_ = updateSTS(t, stsClient, sts.Name, func(sts *appsv1.StatefulSet) {
+		sts.Spec.Template.Spec.Containers[0].Image = newImage
+	})
+
+	// Await for the pods 1 and 2 to be recreated, while pod0 remains running
+	if err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, false, func(ctx context.Context) (bool, error) {
+		ss, err := stsClient.Get(ctx, sts.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		pods := getPods(t, podClient, labelMap)
+		recreatedPods := v1.PodList{}
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == v1.PodPending {
+				recreatedPods.Items = append(recreatedPods.Items, pod)
+			}
+		}
+		setPodsReadyCondition(t, c, &v1.PodList{Items: recreatedPods.Items}, v1.ConditionTrue, time.Now().Add(-120*time.Minute))
+		return ss.Status.UpdatedReplicas == *ss.Spec.Replicas-1 && ss.Status.Replicas == *ss.Spec.Replicas && ss.Status.ReadyReplicas == *ss.Spec.Replicas, nil
+	}); err != nil {
+		t.Fatalf("failed to verify .Spec.Template.Spec.Containers[0].Image is updated for sts %s: %v", sts.Name, err)
+	}
+
+	// mark pod0 as terminal and not ready
+	updatePodStatus(t, podClient, pod0.Name, func(pod *v1.Pod) {
+		pod.Status.Phase = v1.PodFailed
+		_, condition := podutil.GetPodCondition(&pod.Status, v1.PodReady)
+		if condition != nil {
+			condition.Status = v1.ConditionFalse
+			condition.LastTransitionTime = metav1.Now()
+		}
+	})
+
+	// make sure pod0 gets deletion timestamp so that it is recreated
+	err := podClient.Delete(ctx, pod0.Name, *&metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Failed to delete the pod0: %v", err)
+	}
+
+	// await for pod0 to be not ready
+	if err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, false, func(ctx context.Context) (bool, error) {
+		ss, err := stsClient.Get(ctx, sts.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return ss.Status.ReadyReplicas == *ss.Spec.Replicas-1, nil
+	}); err != nil {
+		t.Fatalf("failed to verify .Spec.Template.Spec.Containers[0].Image is updated for sts %s: %v", sts.Name, err)
+	}
+
+	// remove the finalizer to allow recreation
+	updatePod(t, podClient, pod0.Name, func(pod *v1.Pod) {
+		pod.Finalizers = []string{}
+	})
+
+	// await for pod0 to be recreated and make it running
+	if err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, false, func(ctx context.Context) (bool, error) {
+		pods := getPods(t, podClient, labelMap)
+		recreatedPods := v1.PodList{}
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == v1.PodPending {
+				recreatedPods.Items = append(recreatedPods.Items, pod)
+			}
+		}
+		setPodsReadyCondition(t, c, &v1.PodList{Items: recreatedPods.Items}, v1.ConditionTrue, time.Now().Add(-120*time.Minute))
+		return len(recreatedPods.Items) > 0, nil
+	}); err != nil {
+		t.Fatalf("failed to verify .Spec.Template.Spec.Containers[0].Image is updated for sts %s: %v", sts.Name, err)
+	}
+
+	// await for all stateful set status to record all replicas as ready
+	if err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, false, func(ctx context.Context) (bool, error) {
+		ss, err := stsClient.Get(ctx, sts.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return ss.Status.ReadyReplicas == *ss.Spec.Replicas, nil
+	}); err != nil {
+		t.Fatalf("failed to verify .Spec.Template.Spec.Containers[0].Image is updated for sts %s: %v", sts.Name, err)
+	}
+
+	// Verify 3 pods exist
+	pods = getPods(t, podClient, labelMap)
+	if len(pods.Items) != int(*sts.Spec.Replicas) {
+		t.Fatalf("Unexpected number of pods")
+	}
+	// Verify pod[1] image is changed to newImage
+	if pods.Items[1].Spec.Containers[0].Image != newImage {
+		t.Fatalf("Unexpected image for pod 1, it should be new image")
+	}
+	// Verify pod[1] image is not changed to newImage
+	// Immediately return false with an error if pods.Items[0] image is changed
+	if pods.Items[0].Spec.Containers[0].Image == newImage {
+		t.Fatalf("Unexpected image for pod 0, it should be old image")
 	}
 }
 

--- a/test/integration/statefulset/statefulset_test.go
+++ b/test/integration/statefulset/statefulset_test.go
@@ -572,7 +572,7 @@ func TestDeletingPodForRollingUpdatePartition(t *testing.T) {
 	})
 
 	// make sure pod0 gets deletion timestamp so that it is recreated
-	err := podClient.Delete(ctx, pod0.Name, *&metav1.DeleteOptions{})
+	err := podClient.Delete(ctx, pod0.Name, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Failed to delete the pod0: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This is an e2e that demonstrates that fails occasionally for Failed pods, demonstrating that the functionality is broken also for pods which end with Failed phase. Even though it was observed for pods ending in Succeeded phase here: https://github.com/kubernetes/kubernetes/issues/120700.

Here is an example failed run from my local kind: https://gist.github.com/mimowo/0e6e874ca36cf18f0d57aed3f956d81f. The failure rate is around 1/10.

The fix for this flaky test is the same as for: https://github.com/kubernetes/kubernetes/pull/120731. 

We may consider adding an integration test as well to fail 100% times.  


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
