### PR TITLE
Automated cherry pick of #120784: Use local isCgroup2UnifiedMode consistently

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -320,7 +320,7 @@ func swapControllerAvailable() bool {
 	swapControllerAvailabilityOnce.Do(func() {
 		const warn = "Failed to detect the availability of the swap controller, assuming not available"
 		p := "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes"
-		if libcontainercgroups.IsCgroup2UnifiedMode() {
+		if isCgroup2UnifiedMode() {
 			// memory.swap.max does not exist in the cgroup root, so we check /sys/fs/cgroup/<SELF>/memory.swap.max
 			_, unified, err := cgroups.ParseCgroupFileUnified("/proc/self/cgroup")
 			if err != nil {

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -107,18 +107,8 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(pod *v1.Pod,
 
 	lcr.HugepageLimits = GetHugepageLimitsFromResources(container.Resources)
 
-	if swapConfigurationHelper := newSwapConfigurationHelper(*m.machineInfo); utilfeature.DefaultFeatureGate.Enabled(kubefeatures.NodeSwap) {
-		// NOTE(ehashman): Behaviour is defined in the opencontainers runtime spec:
-		// https://github.com/opencontainers/runtime-spec/blob/1c3f411f041711bbeecf35ff7e93461ea6789220/config-linux.md#memory
-		switch m.memorySwapBehavior {
-		case kubelettypes.LimitedSwap:
-			swapConfigurationHelper.ConfigureLimitedSwap(lcr, pod, container)
-		default:
-			swapConfigurationHelper.ConfigureUnlimitedSwap(lcr)
-		}
-	} else {
-		swapConfigurationHelper.ConfigureNoSwap(lcr)
-	}
+	// Configure swap for the container
+	m.configureContainerSwapResources(lcr, pod, container)
 
 	// Set memory.min and memory.high to enforce MemoryQoS
 	if enforceMemoryQoS {
@@ -168,6 +158,30 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(pod *v1.Pod,
 	}
 
 	return lcr
+}
+
+// configureContainerSwapResources configures the swap resources for a specified (linux) container.
+// Swap is only configured if a swap cgroup controller is available and the NodeSwap feature gate is enabled.
+func (m *kubeGenericRuntimeManager) configureContainerSwapResources(lcr *runtimeapi.LinuxContainerResources, pod *v1.Pod, container *v1.Container) {
+	if !swapControllerAvailable() {
+		klog.InfoS("No swap cgroup controller present", "swapBehavior", m.memorySwapBehavior, "pod", klog.KObj(pod), "containerName", container.Name)
+		return
+	}
+	swapConfigurationHelper := newSwapConfigurationHelper(*m.machineInfo)
+
+	if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.NodeSwap) {
+		swapConfigurationHelper.ConfigureNoSwap(lcr)
+		return
+	}
+
+	// NOTE(ehashman): Behavior is defined in the opencontainers runtime spec:
+	// https://github.com/opencontainers/runtime-spec/blob/1c3f411f041711bbeecf35ff7e93461ea6789220/config-linux.md#memory
+	switch m.memorySwapBehavior {
+	case kubelettypes.LimitedSwap:
+		swapConfigurationHelper.ConfigureLimitedSwap(lcr, pod, container)
+	default:
+		swapConfigurationHelper.ConfigureUnlimitedSwap(lcr)
+	}
 }
 
 // generateContainerResources generates platform specific (linux) container resources config for runtime
@@ -315,7 +329,10 @@ var (
 	swapControllerAvailabilityOnce sync.Once
 )
 
-func swapControllerAvailable() bool {
+// Note: this function variable is being added here so it would be possible to mock
+// the swap controller availability for unit tests by assigning a new function to it. Without it,
+// the swap controller availability would solely depend on the environment running the test.
+var swapControllerAvailable = func() bool {
 	// See https://github.com/containerd/containerd/pull/7838/
 	swapControllerAvailabilityOnce.Do(func() {
 		const warn = "Failed to detect the availability of the swap controller, assuming not available"


### PR DESCRIPTION
Cherry pick of #120784 on release-1.28.

#120784: Use local isCgroup2UnifiedMode consistently

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a bug where containers would not start on cgroupv2 systems where swap is disabled.
```