### PR TITLE
bump etcd cluster image to 3.5.9

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -80,7 +80,7 @@ dependencies:
       match: configs\[Etcd\] = Config{list\.GcEtcdRegistry, "etcd", "\d+\.\d+.\d+(-(alpha|beta|rc).\d+)?(-\d+)?"}
 
   - name: "etcd-image"
-    version: 3.5.7
+    version: 3.5.9
     refPaths:
     - path: cluster/images/etcd/Makefile
       match: BUNDLED_ETCD_VERSIONS\?|LATEST_ETCD_VERSION\?

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -26,7 +26,7 @@
 # Except from etcd-$(version) and etcdctl-$(version) binaries, we also
 # need etcd and etcdctl binaries for backward compatibility reasons.
 # That binary will be set to the last version from $(BUNDLED_ETCD_VERSIONS).
-BUNDLED_ETCD_VERSIONS?=3.0.17 3.1.20 3.2.32 3.3.17 3.4.18 3.5.7
+BUNDLED_ETCD_VERSIONS?=3.0.17 3.1.20 3.2.32 3.3.17 3.4.18 3.5.9
 
 # LATEST_ETCD_VERSION identifies the most recent etcd version available.
 LATEST_ETCD_VERSION?=3.5.7

--- a/cluster/images/etcd/migrate/options.go
+++ b/cluster/images/etcd/migrate/options.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	supportedEtcdVersions = []string{"3.0.17", "3.1.20", "3.2.32", "3.3.17", "3.4.18", "3.5.7"}
+	supportedEtcdVersions = []string{"3.0.17", "3.1.20", "3.2.32", "3.3.17", "3.4.18", "3.5.9"}
 )
 
 const (


### PR DESCRIPTION
Etcd version has been bumped in `master ,1.28, 1.27` branches to 3.5.9 however  `cluster image` reference has been kept in `<=1.27`  branches on older version. This commit bump the same to 3.5.9 to make it consistent.

All other references are on 3.5.9 in this branch:
```
cluster/gce/upgrade-aliases.sh:export ETCD_IMAGE=3.5.9-0
cluster/gce/upgrade-aliases.sh:export ETCD_VERSION=3.5.9
cluster/gce/manifests/etcd.manifest:    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.5.9-0') }}",
cluster/gce/manifests/etcd.manifest:        "value": "{{ pillar.get('etcd_version', '3.5.9') }}"
```

NOTE for reviewer/approver:

Release 1.28 and master cluster images are on 1.28 https://github.com/kubernetes/kubernetes/blob/release-1.28/build/dependencies.yaml#L83. 


/kind cleanup

This has to be back ported to `release-1.25` and `release-1.26` branches too.


```release-note
NONE
```


```docs

```
