### PR TITLE
WIP: scheduler framework: support simulating cluster changes during autoscaling

### DIFF
--- a/pkg/scheduler/framework/cycle_state.go
+++ b/pkg/scheduler/framework/cycle_state.go
@@ -32,7 +32,8 @@ var (
 type StateData interface {
 	// Clone is an interface to make a copy of StateData. For performance reasons,
 	// clone should make shallow copies for members (e.g., slices or maps) that are not
-	// impacted by PreFilter's optional AddPod/RemovePod methods.
+	// impacted by PreFilter's optional AddPod/RemovePod methods or by
+	// ClusterAutoscalerPlugin's SimulateBindPod.
 	Clone() StateData
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The assumption so far was that plugins which are active during cluster autoscaling can do their work exclusively based on the information maintained by cluster autoscaler about nodes and pods on those nodes. This assumption doesn't hold for plugins which need to observe and potentially modified other cluster state, like the dynamic resource allocation plugin.

Such plugins need a way to do its own snapshotting of the cluster state at the start of a simulation and then update that snapshotting while the cluster autoscaler simulates the placement of pods on nodes.

The new ClusterAutoScalerPlugin interface provides a mechanism for this. It is not used anywhere in kube-scheduler itself, but has to be defined here because plugins cannot get it from k8s.io/autoscaler (circular dependency) and creating a new repo seems overkill.


#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/issues/118612

#### Special notes for your reviewer:

This needs to be reviewed in combination with the corresponding change in cluster autoscaler.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3063
```

/cc @mwielgus @alculquicondor @MaciekPytel 