### PR TITLE
[WIP] Use pager in kubectl

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/interrupt"
+	"k8s.io/kubectl/pkg/util/pager"
 	"k8s.io/kubectl/pkg/util/slice"
 	"k8s.io/kubectl/pkg/util/templates"
 	utilpointer "k8s.io/utils/pointer"
@@ -168,7 +169,12 @@ func NewCmdGet(parent string, f cmdutil.Factory, streams genericiooptions.IOStre
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())
-			cmdutil.CheckErr(o.Run(f, args))
+
+			pager := pager.GetOutputPager(o.IOStreams)
+			cmdutil.CheckErr(pager.Start(&o.IOStreams))
+			err := o.Run(f, args)
+			pager.Done()
+			cmdutil.CheckErr(err)
 		},
 		SuggestFor: []string{"list", "ps"},
 	}

--- a/staging/src/k8s.io/kubectl/pkg/util/pager/pager.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/pager/pager.go
@@ -1,0 +1,45 @@
+package pager
+
+import (
+	"os"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/util/term"
+)
+
+type OutputPager interface {
+	Start(*genericclioptions.IOStreams) error
+	Done() error
+}
+
+func GetOutputPager(streams genericclioptions.IOStreams) OutputPager {
+	if !term.IsTerminal(streams.Out) {
+		return &catOutputPager{}
+	}
+	pagerExecutable, shouldUsePager := getPagerExecutable()
+	if shouldUsePager {
+		return newCustomOutputPager(pagerExecutable)
+	} else {
+		return &catOutputPager{}
+	}
+}
+
+func getPagerExecutable() (string, bool) {
+	for _, envName := range pagerEnvs() {
+		if value, ok := os.LookupEnv(envName); ok {
+			if value == "" {
+				return "", false
+			} else {
+				return value, true
+			}
+		}
+	}
+	return "", false
+}
+
+func pagerEnvs() []string {
+	return []string{
+		"KUBE_PAGER",
+		"PAGER",
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/util/pager/pager_cat.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/pager/pager_cat.go
@@ -1,0 +1,13 @@
+package pager
+
+import "k8s.io/cli-runtime/pkg/genericclioptions"
+
+type catOutputPager struct{}
+
+func (p *catOutputPager) Start(streams *genericclioptions.IOStreams) error {
+	return nil
+}
+
+func (p *catOutputPager) Done() error {
+	return nil
+}

--- a/staging/src/k8s.io/kubectl/pkg/util/pager/pager_custom.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/pager/pager_custom.go
@@ -1,0 +1,65 @@
+package pager
+
+import (
+	"errors"
+	"io"
+	"os/exec"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/util/term"
+)
+
+type customOutputPager struct {
+	pagerCmd            *exec.Cmd
+	terminalOutput      io.Writer
+	programStdoutWriter io.WriteCloser
+	programStdoutReader io.Reader
+}
+
+func newCustomOutputPager(pagerCmdStr string) *customOutputPager {
+	return &customOutputPager{
+		pagerCmd: exec.Command(pagerCmdStr),
+	}
+}
+
+func (p *customOutputPager) Start(streams *genericclioptions.IOStreams) error {
+	if err := p.transformIOStreams(streams); err != nil {
+		return err
+	}
+
+	p.pagerCmd.Stdout = p.terminalOutput
+	p.pagerCmd.Stdin = p.programStdoutReader
+
+	if err := p.pagerCmd.Start(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *customOutputPager) Done() error {
+	p.programStdoutWriter.Close()
+	if err := p.pagerCmd.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *customOutputPager) transformIOStreams(streams *genericclioptions.IOStreams) error {
+	reader, writer := io.Pipe()
+	p.programStdoutReader = reader
+	p.programStdoutWriter = writer
+
+	if term.IsTerminal(streams.Out) {
+		p.terminalOutput = streams.Out
+		streams.Out = writer
+	} else {
+		return errors.New("streams.Out must be a terminal")
+	}
+
+	if term.IsTerminal(streams.ErrOut) {
+		streams.ErrOut = writer
+	}
+
+	return nil
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This is discussed in [here](https://github.com/kubernetes/kubectl/issues/1489). Users can use `PAGER` and `KUBE_PAGER` environment variables in order to see a paged version of kubectl's output.

#### Which issue(s) this PR fixes:
Fixes kubernetes/kubectl#1489

#### Special notes for your reviewer:
This is a PoC for the mentioned issue. I need to receive some feedbacks before continuing. So, tell me if you think any thing is wrong with this solution or I can do something better, or even that we're not going to add such a feature to kubectl and I should close this PR.
If everything is right, I will use the pager for other kubectl subcommands and add some tests before merge.

#### Does this PR introduce a user-facing change?
```release-note
kubectl uses the `PAGER` and `KUBE_PAGER` environment variables in order to print paged output.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A
