### PR TITLE
k8s.io/kms: drop direct dependency on klog

### DIFF
--- a/staging/src/k8s.io/kms/go.mod
+++ b/staging/src/k8s.io/kms/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	google.golang.org/grpc v1.55.0
 	k8s.io/apimachinery v0.0.0
-	k8s.io/klog/v2 v2.100.1
 )
 
 require (
@@ -19,6 +18,7 @@ require (
 	golang.org/x/text v0.13.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
+	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 )
 

--- a/staging/src/k8s.io/kms/internal/plugins/_mock/Dockerfile
+++ b/staging/src/k8s.io/kms/internal/plugins/_mock/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20.1-bullseye as builder
+FROM golang:1.21.3-bullseye as builder
 
 WORKDIR /workspace
 

--- a/staging/src/k8s.io/kms/internal/plugins/_mock/go.mod
+++ b/staging/src/k8s.io/kms/internal/plugins/_mock/go.mod
@@ -4,12 +4,10 @@ go 1.19
 
 require (
 	github.com/ThalesIgnite/crypto11 v1.2.5
-	k8s.io/klog/v2 v2.100.1
 	k8s.io/kms v0.0.0-00010101000000-000000000000
 )
 
 require (
-	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f // indirect
@@ -25,6 +23,5 @@ require (
 
 replace (
 	k8s.io/apimachinery => ../../../../apimachinery
-	k8s.io/client-go => ../../../../client-go
 	k8s.io/kms => ../../../../kms
 )

--- a/staging/src/k8s.io/kms/internal/plugins/_mock/go.sum
+++ b/staging/src/k8s.io/kms/internal/plugins/_mock/go.sum
@@ -2,9 +2,7 @@ github.com/ThalesIgnite/crypto11 v1.2.5 h1:1IiIIEqYmBvUYFeMnHqRft4bwf/O36jryEUpY
 github.com/ThalesIgnite/crypto11 v1.2.5/go.mod h1:ILDKtnCKiQ7zRoNxcp36Y1ZR8LBPmR2E23+wTQe/MlE=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
-github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
@@ -68,5 +66,4 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 k8s.io/klog/v2 v2.100.1 h1:7WCHKK6K8fNhTqfBhISHQ97KrnJNFZMcQvKp7gP/tmg=
-k8s.io/klog/v2 v2.100.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=

--- a/staging/src/k8s.io/kms/pkg/service/grpc_service.go
+++ b/staging/src/k8s.io/kms/pkg/service/grpc_service.go
@@ -23,7 +23,6 @@ import (
 
 	"google.golang.org/grpc"
 
-	"k8s.io/klog/v2"
 	kmsapi "k8s.io/kms/apis/v2"
 )
 
@@ -45,8 +44,6 @@ func NewGRPCService(
 
 	kmsService Service,
 ) *GRPCService {
-	klog.V(4).InfoS("KMS plugin configured", "address", address, "timeout", timeout)
-
 	return &GRPCService{
 		addr:       address,
 		timeout:    timeout,
@@ -70,14 +67,12 @@ func (s *GRPCService) ListenAndServe() error {
 
 	kmsapi.RegisterKeyManagementServiceServer(gs, s)
 
-	klog.V(4).InfoS("kms plugin serving", "address", s.addr)
 	return gs.Serve(ln)
 }
 
 // Shutdown performs a graceful shutdown. Doesn't accept new connections and
 // blocks until all pending RPCs are finished.
 func (s *GRPCService) Shutdown() {
-	klog.V(4).InfoS("kms plugin shutdown", "address", s.addr)
 	if s.server != nil {
 		s.server.GracefulStop()
 	}
@@ -86,7 +81,6 @@ func (s *GRPCService) Shutdown() {
 // Close stops the server by closing all connections immediately and cancels
 // all active RPCs.
 func (s *GRPCService) Close() {
-	klog.V(4).InfoS("kms plugin close", "address", s.addr)
 	if s.server != nil {
 		s.server.Stop()
 	}
@@ -108,8 +102,6 @@ func (s *GRPCService) Status(ctx context.Context, _ *kmsapi.StatusRequest) (*kms
 
 // Decrypt sends a decryption request to specified kms service.
 func (s *GRPCService) Decrypt(ctx context.Context, req *kmsapi.DecryptRequest) (*kmsapi.DecryptResponse, error) {
-	klog.V(4).InfoS("decrypt request received", "id", req.Uid)
-
 	plaintext, err := s.kmsService.Decrypt(ctx, req.Uid, &DecryptRequest{
 		Ciphertext:  req.Ciphertext,
 		KeyID:       req.KeyId,
@@ -126,8 +118,6 @@ func (s *GRPCService) Decrypt(ctx context.Context, req *kmsapi.DecryptRequest) (
 
 // Encrypt sends an encryption request to specified kms service.
 func (s *GRPCService) Encrypt(ctx context.Context, req *kmsapi.EncryptRequest) (*kmsapi.EncryptResponse, error) {
-	klog.V(4).InfoS("encrypt request received", "id", req.Uid)
-
 	encRes, err := s.kmsService.Encrypt(ctx, req.Uid, req.Plaintext)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@microsoft.com>

Builds on #120896

This will make #120225 drop `klog` altogether.

/kind cleanup
/assign aramase 

```release-note
NONE
```