### PR TITLE
Automated cherry pick of #120834: Fix panic testing intree vSphere dynamic PV.

### DIFF
--- a/test/e2e/storage/vsphere/vsphere_utils.go
+++ b/test/e2e/storage/vsphere/vsphere_utils.go
@@ -753,13 +753,15 @@ func getUUIDFromProviderID(providerID string) string {
 
 // GetReadySchedulableNodeInfos returns NodeInfo objects for all nodes with Ready and schedulable state
 func GetReadySchedulableNodeInfos(ctx context.Context, c clientset.Interface) []*NodeInfo {
-	nodeList, err := e2enode.GetReadySchedulableNodes(ctx, c)
-	framework.ExpectNoError(err)
 	var nodesInfo []*NodeInfo
-	for _, node := range nodeList.Items {
-		nodeInfo := TestContext.NodeMapper.GetNodeInfo(node.Name)
-		if nodeInfo != nil {
-			nodesInfo = append(nodesInfo, nodeInfo)
+	if TestContext.NodeMapper != nil {
+		nodeList, err := e2enode.GetReadySchedulableNodes(ctx, c)
+		framework.ExpectNoError(err)
+		for _, node := range nodeList.Items {
+			nodeInfo := TestContext.NodeMapper.GetNodeInfo(node.Name)
+			if nodeInfo != nil {
+				nodesInfo = append(nodesInfo, nodeInfo)
+			}
 		}
 	}
 	return nodesInfo


### PR DESCRIPTION
Cherry pick of #120834 on release-1.27.

#120834: Fix panic testing intree vSphere dynamic PV.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```