### PR TITLE
Fix change Headless Service to normal service without error

### DIFF
--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	core "k8s.io/api/core/v1"
 	"math/rand"
 	"net"
 	"net/http"
@@ -641,7 +642,7 @@ func patchAllocatedValues(after After, before Before) {
 }
 
 func needsClusterIP(svc *api.Service) bool {
-	if svc.Spec.Type == api.ServiceTypeExternalName {
+	if svc.Spec.Type == api.ServiceTypeExternalName || svc.Spec.ClusterIP == core.ClusterIPNone {
 		return false
 	}
 	return true

--- a/pkg/registry/core/service/storage/storage_test.go
+++ b/pkg/registry/core/service/storage/storage_test.go
@@ -502,6 +502,24 @@ func TestPatchAllocatedValues(t *testing.T) {
 		update: svctest.MakeService("foo",
 			svctest.SetTypeExternalName,
 			svctest.SetExternalTrafficPolicy(api.ServiceExternalTrafficPolicyLocal)),
+	}, {
+		name: "Headless_Service_patched",
+		before: svctest.MakeService("foo",
+			svctest.SetTypeExternalName,
+			// these are not valid, but prove the test
+			svctest.SetExternalTrafficPolicy(api.ServiceExternalTrafficPolicyLocal),
+			svctest.SetClusterIPs("None"),
+			svctest.SetUniqueNodePorts,
+			svctest.SetHealthCheckNodePort(31234)),
+		update: svctest.MakeService("foo",
+			svctest.SetTypeExternalName,
+			// these are not valid, but prove the test
+			svctest.SetExternalTrafficPolicy(api.ServiceExternalTrafficPolicyLocal),
+			svctest.SetClusterIPs(""),
+			svctest.SetUniqueNodePorts,
+			svctest.SetHealthCheckNodePort(31234)),
+		expectSameNodePort: true,
+		expectSameHCNP:     true,
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We used the empty `spec.clusterIP` field to update the `Headless Service` successfully and the type of the service is still `Headless Service`; we expect that the update process should fail and return an error

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #120937

#### Special notes for your reviewer:

The `spec.clusterIP` field of the service was immutable in versions prior to 1.20, and any changes to `spec.clusterIP` would be rejected.

But in version 1.20, we introduced [dual stack services](https://github.com/kubernetes/kubernetes/pull/91824), which made spec.clusterIP mutable, but still rejected by the code in the [validateService](https://github.com/kubernetes/kubernetes/blob/622509830c1038535e539f7d364f5cd7c3b38791/pkg/apis/core/validation/validation.go#L7322-L7334).

I see that we have made some [changes](https://github.com/kubernetes/kubernetes/pull/96684) to the patch service process (or maybe it was the original logic), if the `spec.clusterIP` field of the new service is empty, we overwrite it with the `spec.clusterIP` of the old service, but doing so can cause unexpected problems when the service is headless(if we change the value of spec.clusterIP to empty, it will still think it's a `Headless Service`, but in reality we're trying to change the service to a normal `ClusterIP Service`)

I think any changes we make to the clusterIP should be considered as changing the service from a `Headless Service` to a normal `ClusterIP Service`, although it will be rejected by the validateService during the change process and return an error


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
