### PR TITLE
kubeadm: increase ut converage for bootstraptoken/clusterinfo

### DIFF
--- a/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo_test.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/clusterinfo_test.go
@@ -17,15 +17,20 @@ limitations under the License.
 package clusterinfo
 
 import (
+	"context"
 	"os"
 	"testing"
 	"text/template"
 
+	rbac "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authentication/user"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 )
 
 var testConfigTempl = template.Must(template.New("test").Parse(`apiVersion: v1
@@ -47,25 +52,31 @@ users:
 func TestCreateBootstrapConfigMapIfNotExists(t *testing.T) {
 	tests := []struct {
 		name      string
+		fileExist bool
 		createErr error
-		updateErr error
 		expectErr bool
 	}{
 		{
 			"successful case should have no error",
-			nil,
+			true,
 			nil,
 			false,
 		},
 		{
-			"if both create and update errors, return error",
+			"if configmap already exists, return error",
+			true,
 			apierrors.NewAlreadyExists(schema.GroupResource{Resource: "configmaps"}, "test"),
-			apierrors.NewUnauthorized("go away!"),
 			true,
 		},
 		{
 			"unexpected error should be returned",
+			true,
 			apierrors.NewUnauthorized("go away!"),
+			true,
+		},
+		{
+			"if the file does not exist, return error",
+			false,
 			nil,
 			true,
 		},
@@ -102,7 +113,11 @@ func TestCreateBootstrapConfigMapIfNotExists(t *testing.T) {
 					})
 				}
 
-				err := CreateBootstrapConfigMapIfNotExists(client, file.Name())
+				fileName := file.Name()
+				if !tc.fileExist {
+					fileName = "notexistfile"
+				}
+				err := CreateBootstrapConfigMapIfNotExists(client, fileName)
 				if tc.expectErr && err == nil {
 					t.Errorf("CreateBootstrapConfigMapIfNotExists(%s) wanted error, got nil", tc.name)
 				} else if !tc.expectErr && err != nil {
@@ -111,4 +126,72 @@ func TestCreateBootstrapConfigMapIfNotExists(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestCreateClusterInfoRBACRules(t *testing.T) {
+	tests := []struct {
+		name   string
+		client *clientsetfake.Clientset
+	}{
+		{
+			name:   "the RBAC rules already exist",
+			client: newMockClientForTest(t),
+		},
+		{
+			name:   "the RBAC rules do not exist",
+			client: clientsetfake.NewSimpleClientset(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := CreateClusterInfoRBACRules(tt.client); err != nil {
+				t.Errorf("CreateClusterInfoRBACRules() hits unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func newMockClientForTest(t *testing.T) *clientsetfake.Clientset {
+	client := clientsetfake.NewSimpleClientset()
+
+	_, err := client.RbacV1().Roles(metav1.NamespacePublic).Create(context.TODO(), &rbac.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      BootstrapSignerClusterRoleName,
+			Namespace: metav1.NamespacePublic,
+		},
+		Rules: []rbac.PolicyRule{
+			{
+				Verbs:         []string{"get"},
+				APIGroups:     []string{""},
+				Resources:     []string{"Secret"},
+				ResourceNames: []string{bootstrapapi.ConfigMapClusterInfo},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating role: %v", err)
+	}
+
+	_, err = client.RbacV1().RoleBindings(metav1.NamespacePublic).Create(context.TODO(), &rbac.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      BootstrapSignerClusterRoleName,
+			Namespace: metav1.NamespacePublic,
+		},
+		RoleRef: rbac.RoleRef{
+			APIGroup: rbac.GroupName,
+			Kind:     "Role",
+			Name:     BootstrapSignerClusterRoleName,
+		},
+		Subjects: []rbac.Subject{
+			{
+				Kind: rbac.UserKind,
+				Name: user.Anonymous,
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating rolebinding: %v", err)
+	}
+
+	return client
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

kubeadm: increase ut converage for bootstraptoken/clusterinfo

before:

```
        k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo     coverage: 60.0% of statements
```

after the change:

```
        k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo     coverage: 85.0% of statements
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
