### PR TITLE
Add --wait option with 'kubectl logs -f' to wait for the first container to start running, before providing logs

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
@@ -277,13 +277,18 @@ func (o *ClusterInfoDumpOptions) Run() error {
 			}
 
 			for _, request := range requests {
-				data, err := request.DoRaw(context.TODO())
-				if err != nil {
-					// Print error and return.
-					writer.Write([]byte(fmt.Sprintf("Request log error: %s\n", err.Error())))
-					return
+				for _, req := range request {
+					data, err := req.DoRaw(context.TODO())
+					if err != nil {
+						// Print error and return.
+						if _, err := writer.Write([]byte(fmt.Sprintf("Request log error: %s\n", err.Error()))); err != nil {
+							return
+						}
+					}
+					if _, err := writer.Write(data); err != nil {
+						return
+					}
 				}
-				writer.Write(data)
 			}
 		}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
@@ -269,7 +269,7 @@ func (o *ClusterInfoDumpOptions) Run() error {
 			writer.Write([]byte(fmt.Sprintf("==== START logs for container %s of pod %s/%s ====\n", container.Name, pod.Namespace, pod.Name)))
 			defer writer.Write([]byte(fmt.Sprintf("==== END logs for container %s of pod %s/%s ====\n", container.Name, pod.Namespace, pod.Name)))
 
-			requests, err := o.LogsForObject(o.RESTClientGetter, pod, &corev1.PodLogOptions{Container: container.Name}, timeout, false)
+			requests, err := o.LogsForObject(o.RESTClientGetter, pod, &corev1.PodLogOptions{Container: container.Name}, timeout, false, false)
 			if err != nil {
 				// Print error and return.
 				writer.Write([]byte(fmt.Sprintf("Create log request error: %s\n", err.Error())))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -807,8 +807,10 @@ func logOpts(restClientGetter genericclioptions.RESTClientGetter, pod *corev1.Po
 		return err
 	}
 	for _, request := range requests {
-		if err := logs.DefaultConsumeRequest(request, opts.Out); err != nil {
-			return err
+		for _, req := range request {
+			if err := logs.DefaultConsumeRequest(req, opts.Out); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
@@ -51,12 +51,12 @@ func TestLog(t *testing.T) {
 			name: "v1 - pod log",
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
-					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+					logsForObjectRequests: map[corev1.ObjectReference][]restclient.ResponseWrapper{
 						{
 							Kind:      "Pod",
 							Name:      "some-pod",
 							FieldPath: "spec.containers{some-container}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content\n")}},
 					},
 				}
 
@@ -72,12 +72,12 @@ func TestLog(t *testing.T) {
 			name: "pod logs with prefix",
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
-					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+					logsForObjectRequests: map[corev1.ObjectReference][]restclient.ResponseWrapper{
 						{
 							Kind:      "Pod",
 							Name:      "test-pod",
 							FieldPath: "spec.containers{test-container}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content\n")}},
 					},
 				}
 
@@ -94,12 +94,12 @@ func TestLog(t *testing.T) {
 			name: "pod logs with prefix: init container",
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
-					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+					logsForObjectRequests: map[corev1.ObjectReference][]restclient.ResponseWrapper{
 						{
 							Kind:      "Pod",
 							Name:      "test-pod",
 							FieldPath: "spec.initContainers{test-container}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content\n")}},
 					},
 				}
 
@@ -116,12 +116,12 @@ func TestLog(t *testing.T) {
 			name: "pod logs with prefix: ephemeral container",
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
-					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+					logsForObjectRequests: map[corev1.ObjectReference][]restclient.ResponseWrapper{
 						{
 							Kind:      "Pod",
 							Name:      "test-pod",
 							FieldPath: "spec.ephemeralContainers{test-container}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content\n")}},
 					},
 				}
 
@@ -138,22 +138,22 @@ func TestLog(t *testing.T) {
 			name: "get logs from multiple requests sequentially",
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
-					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+					logsForObjectRequests: map[corev1.ObjectReference][]restclient.ResponseWrapper{
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-1",
 							FieldPath: "spec.containers{some-container}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 1\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content from source 1\n")}},
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-2",
 							FieldPath: "spec.containers{some-container}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 2\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content from source 2\n")}},
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-3",
 							FieldPath: "spec.containers{some-container}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 3\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content from source 3\n")}},
 					},
 				}
 
@@ -173,22 +173,22 @@ func TestLog(t *testing.T) {
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				wg := &sync.WaitGroup{}
 				mock := &logTestMock{
-					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+					logsForObjectRequests: map[corev1.ObjectReference][]restclient.ResponseWrapper{
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-1",
 							FieldPath: "spec.containers{some-container-1}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 1\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content from source 1\n")}},
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-2",
 							FieldPath: "spec.containers{some-container-2}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 2\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content from source 2\n")}},
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-3",
 							FieldPath: "spec.containers{some-container-3}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 3\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content from source 3\n")}},
 					},
 					wg: wg,
 				}
@@ -211,22 +211,22 @@ func TestLog(t *testing.T) {
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				wg := &sync.WaitGroup{}
 				mock := &logTestMock{
-					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+					logsForObjectRequests: map[corev1.ObjectReference][]restclient.ResponseWrapper{
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-1",
 							FieldPath: "spec.containers{test-container-1}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content\n")}},
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-2",
 							FieldPath: "spec.containers{test-container-2}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content\n")}},
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-3",
 							FieldPath: "spec.containers{test-container-3}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content\n")}},
 					},
 					wg: wg,
 				}
@@ -245,7 +245,7 @@ func TestLog(t *testing.T) {
 			name: "fail if LogsForObject fails",
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				o := NewLogsOptions(streams, false)
-				o.LogsForObject = func(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool, wait bool) (map[corev1.ObjectReference]restclient.ResponseWrapper, error) {
+				o.LogsForObject = func(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool, wait bool) (map[corev1.ObjectReference][]restclient.ResponseWrapper, error) {
 					return nil, errors.New("Error from the LogsForObject")
 				}
 				return o
@@ -256,17 +256,17 @@ func TestLog(t *testing.T) {
 			name: "fail to get logs, if ConsumeRequestFn fails",
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
-					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+					logsForObjectRequests: map[corev1.ObjectReference][]restclient.ResponseWrapper{
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-1",
 							FieldPath: "spec.containers{test-container-1}",
-						}: &responseWrapperMock{},
+						}: {&responseWrapperMock{}},
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-2",
 							FieldPath: "spec.containers{test-container-1}",
-						}: &responseWrapperMock{},
+						}: {&responseWrapperMock{}},
 					},
 				}
 
@@ -284,22 +284,22 @@ func TestLog(t *testing.T) {
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				wg := &sync.WaitGroup{}
 				mock := &logTestMock{
-					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+					logsForObjectRequests: map[corev1.ObjectReference][]restclient.ResponseWrapper{
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-1",
 							FieldPath: "spec.containers{test-container-1}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 1\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content from source 1\n")}},
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-2",
 							FieldPath: "spec.containers{test-container-2}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 2\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content from source 2\n")}},
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-3",
 							FieldPath: "spec.containers{test-container-3}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 3\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content from source 3\n")}},
 					},
 					wg: wg,
 				}
@@ -323,22 +323,22 @@ func TestLog(t *testing.T) {
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				wg := &sync.WaitGroup{}
 				mock := &logTestMock{
-					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+					logsForObjectRequests: map[corev1.ObjectReference][]restclient.ResponseWrapper{
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-1",
 							FieldPath: "spec.containers{test-container-1}",
-						}: &responseWrapperMock{},
+						}: {&responseWrapperMock{}},
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-2",
 							FieldPath: "spec.containers{test-container-2}",
-						}: &responseWrapperMock{},
+						}: {&responseWrapperMock{}},
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-3",
 							FieldPath: "spec.containers{test-container-3}",
-						}: &responseWrapperMock{},
+						}: {&responseWrapperMock{}},
 					},
 					wg: wg,
 				}
@@ -358,12 +358,12 @@ func TestLog(t *testing.T) {
 			name: "fail to follow logs, if ConsumeRequestFn fails",
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
-					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+					logsForObjectRequests: map[corev1.ObjectReference][]restclient.ResponseWrapper{
 						{
 							Kind:      "Pod",
 							Name:      "test-pod-1",
 							FieldPath: "spec.containers{test-container-1}",
-						}: &responseWrapperMock{},
+						}: {&responseWrapperMock{}},
 					},
 				}
 
@@ -381,22 +381,22 @@ func TestLog(t *testing.T) {
 			name: "get logs from multiple requests and ignores the error if the container fails",
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
-					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+					logsForObjectRequests: map[corev1.ObjectReference][]restclient.ResponseWrapper{
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-error-container",
 							FieldPath: "spec.containers{some-container}",
-						}: &responseWrapperMock{err: errors.New("error-container")},
+						}: {&responseWrapperMock{err: errors.New("error-container")}},
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-1",
 							FieldPath: "spec.containers{some-container}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 1\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content from source 1\n")}},
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-2",
 							FieldPath: "spec.containers{some-container}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 2\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content from source 2\n")}},
 					},
 				}
 
@@ -416,17 +416,17 @@ func TestLog(t *testing.T) {
 			name: "get logs from multiple requests and an container fails",
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
-					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+					logsForObjectRequests: map[corev1.ObjectReference][]restclient.ResponseWrapper{
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-error-container",
 							FieldPath: "spec.containers{some-container}",
-						}: &responseWrapperMock{err: errors.New("error-container")},
+						}: {&responseWrapperMock{err: errors.New("error-container")}},
 						{
 							Kind:      "Pod",
 							Name:      "some-pod",
 							FieldPath: "spec.containers{some-container}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content from source\n")}},
 					},
 				}
 
@@ -441,22 +441,22 @@ func TestLog(t *testing.T) {
 			name: "follow logs from multiple requests and ignores the error if the container fails",
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
-					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+					logsForObjectRequests: map[corev1.ObjectReference][]restclient.ResponseWrapper{
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-error-container",
 							FieldPath: "spec.containers{some-container}",
-						}: &responseWrapperMock{err: errors.New("error-container")},
+						}: {&responseWrapperMock{err: errors.New("error-container")}},
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-1",
 							FieldPath: "spec.containers{some-container}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 1\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content from source 1\n")}},
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-2",
 							FieldPath: "spec.containers{some-container}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source 2\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content from source 2\n")}},
 					},
 				}
 
@@ -477,17 +477,17 @@ func TestLog(t *testing.T) {
 			name: "follow logs from multiple requests and an container fails",
 			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
 				mock := &logTestMock{
-					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
+					logsForObjectRequests: map[corev1.ObjectReference][]restclient.ResponseWrapper{
 						{
 							Kind:      "Pod",
 							Name:      "some-pod-error-container",
 							FieldPath: "spec.containers{some-container}",
-						}: &responseWrapperMock{err: errors.New("error-container")},
+						}: {&responseWrapperMock{err: errors.New("error-container")}},
 						{
 							Kind:      "Pod",
 							Name:      "some-pod",
 							FieldPath: "spec.containers{some-container}",
-						}: &responseWrapperMock{data: strings.NewReader("test log content from source\n")},
+						}: {&responseWrapperMock{data: strings.NewReader("test log content from source\n")}},
 					},
 				}
 
@@ -662,23 +662,6 @@ func TestValidateLogOptions(t *testing.T) {
 			},
 			args:     []string{"my-pod", "my-container"},
 			expected: "only one of -c or an inline",
-		},
-		{
-			name: "--wait not combined with --follow",
-			opts: func(streams genericiooptions.IOStreams) *LogsOptions {
-				o := NewLogsOptions(streams, false)
-				o.Wait = true
-
-				var err error
-				o.Options, err = o.ToLogOptions()
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				return o
-			},
-			args:     []string{"my-pod", "my-container"},
-			expected: "--wait should be used only with --follow",
 		},
 	}
 	for _, test := range tests {
@@ -865,7 +848,7 @@ func (r *responseWrapperMock) Stream(context.Context) (io.ReadCloser, error) {
 }
 
 type logTestMock struct {
-	logsForObjectRequests map[corev1.ObjectReference]restclient.ResponseWrapper
+	logsForObjectRequests map[corev1.ObjectReference][]restclient.ResponseWrapper
 
 	// We need a WaitGroup in some test cases to make sure that we fetch logs concurrently.
 	// These test cases will finish successfully without the WaitGroup, but the WaitGroup
@@ -890,7 +873,7 @@ func (l *logTestMock) mockConsumeRequest(request restclient.ResponseWrapper, out
 	return err
 }
 
-func (l *logTestMock) mockLogsForObject(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool, wait bool) (map[corev1.ObjectReference]restclient.ResponseWrapper, error) {
+func (l *logTestMock) mockLogsForObject(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool, wait bool) (map[corev1.ObjectReference][]restclient.ResponseWrapper, error) {
 	switch object.(type) {
 	case *corev1.Pod:
 		_, ok := options.(*corev1.PodLogOptions)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -520,8 +520,10 @@ func logOpts(restClientGetter genericclioptions.RESTClientGetter, pod *corev1.Po
 		return err
 	}
 	for _, request := range requests {
-		if err := logs.DefaultConsumeRequest(request, opts.Out); err != nil {
-			return err
+		for _, req := range request {
+			if err := logs.DefaultConsumeRequest(req, opts.Out); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -515,7 +515,7 @@ func logOpts(restClientGetter genericclioptions.RESTClientGetter, pod *corev1.Po
 		return err
 	}
 
-	requests, err := polymorphichelpers.LogsForObjectFn(restClientGetter, pod, &corev1.PodLogOptions{Container: ctrName}, opts.GetPodTimeout, false)
+	requests, err := polymorphichelpers.LogsForObjectFn(restClientGetter, pod, &corev1.PodLogOptions{Container: ctrName}, opts.GetPodTimeout, false, false)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/podcmd/podcmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/podcmd/podcmd.go
@@ -102,3 +102,15 @@ func AllContainerNames(pod *v1.Pod) string {
 	}
 	return strings.Join(containers, ", ")
 }
+
+func GetContainerStatusByName(pod *v1.Pod, containerName string) *v1.ContainerStatus {
+	allContainerStatus := [][]v1.ContainerStatus{pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses, pod.Status.EphemeralContainerStatuses}
+	for _, statusSlice := range allContainerStatus {
+		for i := range statusSlice {
+			if statusSlice[i].Name == containerName {
+				return &statusSlice[i]
+			}
+		}
+	}
+	return nil
+}

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/interface.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/interface.go
@@ -19,7 +19,7 @@ package polymorphichelpers
 import (
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,7 +28,7 @@ import (
 )
 
 // LogsForObjectFunc is a function type that can tell you how to get logs for a runtime.object
-type LogsForObjectFunc func(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool) (map[v1.ObjectReference]rest.ResponseWrapper, error)
+type LogsForObjectFunc func(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool, wait bool) (map[v1.ObjectReference]rest.ResponseWrapper, error)
 
 // LogsForObjectFn gives a way to easily override the function for unit testing if needed.
 var LogsForObjectFn LogsForObjectFunc = logsForObject

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/interface.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/interface.go
@@ -28,7 +28,7 @@ import (
 )
 
 // LogsForObjectFunc is a function type that can tell you how to get logs for a runtime.object
-type LogsForObjectFunc func(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool, wait bool) (map[v1.ObjectReference]rest.ResponseWrapper, error)
+type LogsForObjectFunc func(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool, wait bool) (map[v1.ObjectReference][]rest.ResponseWrapper, error)
 
 // LogsForObjectFn gives a way to easily override the function for unit testing if needed.
 var LogsForObjectFn LogsForObjectFunc = logsForObject

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject.go
@@ -17,6 +17,7 @@ limitations under the License.
 package polymorphichelpers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -24,17 +25,26 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	errorsapi "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/reference"
+	watchtools "k8s.io/client-go/tools/watch"
+	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/cmd/util/podcmd"
 	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util/interrupt"
 	"k8s.io/kubectl/pkg/util/podutils"
 )
 
-func logsForObject(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool) (map[corev1.ObjectReference]rest.ResponseWrapper, error) {
+func logsForObject(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool, wait bool) (map[corev1.ObjectReference]rest.ResponseWrapper, error) {
 	clientConfig, err := restClientGetter.ToRESTConfig()
 	if err != nil {
 		return nil, err
@@ -44,11 +54,11 @@ func logsForObject(restClientGetter genericclioptions.RESTClientGetter, object, 
 	if err != nil {
 		return nil, err
 	}
-	return logsForObjectWithClient(clientset, object, options, timeout, allContainers)
+	return logsForObjectWithClient(clientset, object, options, timeout, allContainers, wait)
 }
 
 // this is split for easy test-ability
-func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, options runtime.Object, timeout time.Duration, allContainers bool) (map[corev1.ObjectReference]rest.ResponseWrapper, error) {
+func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, options runtime.Object, timeout time.Duration, allContainers bool, wait bool) (map[corev1.ObjectReference]rest.ResponseWrapper, error) {
 	opts, ok := options.(*corev1.PodLogOptions)
 	if !ok {
 		return nil, errors.New("provided options object is not a PodLogOptions")
@@ -58,7 +68,7 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 	case *corev1.PodList:
 		ret := make(map[corev1.ObjectReference]rest.ResponseWrapper)
 		for i := range t.Items {
-			currRet, err := logsForObjectWithClient(clientset, &t.Items[i], options, timeout, allContainers)
+			currRet, err := logsForObjectWithClient(clientset, &t.Items[i], options, timeout, allContainers, wait)
 			if err != nil {
 				return nil, err
 			}
@@ -98,7 +108,6 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 					fmt.Fprintf(os.Stderr, "Defaulted container %q out of: %s\n", currOpts.Container, podcmd.AllContainerNames(t))
 				}
 			}
-
 			container, fieldPath := podcmd.FindContainerByName(t, currOpts.Container)
 			if container == nil {
 				return nil, fmt.Errorf("container %s is not valid for pod %s", currOpts.Container, t.Name)
@@ -106,6 +115,13 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 			ref, err := reference.GetPartialReference(scheme.Scheme, t, fieldPath)
 			if err != nil {
 				return nil, fmt.Errorf("Unable to construct reference to '%#v': %v", t, err)
+			}
+
+			if wait {
+				errFromContainer := waitForContainer(clientset, t.Namespace, t.Name, currOpts.Container)
+				if errFromContainer != nil {
+					return nil, errFromContainer
+				}
 			}
 
 			ret := make(map[corev1.ObjectReference]rest.ResponseWrapper, 1)
@@ -117,7 +133,7 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 		for _, c := range t.Spec.InitContainers {
 			currOpts := opts.DeepCopy()
 			currOpts.Container = c.Name
-			currRet, err := logsForObjectWithClient(clientset, t, currOpts, timeout, false)
+			currRet, err := logsForObjectWithClient(clientset, t, currOpts, timeout, false, wait)
 			if err != nil {
 				return nil, err
 			}
@@ -128,7 +144,7 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 		for _, c := range t.Spec.Containers {
 			currOpts := opts.DeepCopy()
 			currOpts.Container = c.Name
-			currRet, err := logsForObjectWithClient(clientset, t, currOpts, timeout, false)
+			currRet, err := logsForObjectWithClient(clientset, t, currOpts, timeout, false, wait)
 			if err != nil {
 				return nil, err
 			}
@@ -139,7 +155,7 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 		for _, c := range t.Spec.EphemeralContainers {
 			currOpts := opts.DeepCopy()
 			currOpts.Container = c.Name
-			currRet, err := logsForObjectWithClient(clientset, t, currOpts, timeout, false)
+			currRet, err := logsForObjectWithClient(clientset, t, currOpts, timeout, false, wait)
 			if err != nil {
 				return nil, err
 			}
@@ -165,5 +181,55 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 		fmt.Fprintf(os.Stderr, "Found %v pods, using pod/%v\n", numPods, pod.Name)
 	}
 
-	return logsForObjectWithClient(clientset, pod, options, timeout, allContainers)
+	return logsForObjectWithClient(clientset, pod, options, timeout, allContainers, wait)
+}
+
+// waitForContainer watches the given pod until the container is running
+func waitForContainer(clientset corev1client.CoreV1Interface, ns string, podName string, containerName string) error {
+	// TODO: expose the timeout
+	ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), 0*time.Second)
+	defer cancel()
+
+	fieldSelector := fields.OneTermEqualSelector("metadata.name", podName).String()
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fieldSelector
+			return clientset.Pods(ns).List(ctx, options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = fieldSelector
+			return clientset.Pods(ns).Watch(ctx, options)
+		},
+	}
+
+	intr := interrupt.New(nil, cancel)
+	err := intr.Run(func() error {
+		_, err := watchtools.UntilWithSync(ctx, lw, &corev1.Pod{}, nil, func(ev watch.Event) (bool, error) {
+			klog.V(2).Infof("watch received event %q with object %T", ev.Type, ev.Object)
+			if ev.Type == watch.Deleted {
+				return false, errorsapi.NewNotFound(schema.GroupResource{Resource: "pods"}, "")
+			}
+
+			p, ok := ev.Object.(*corev1.Pod)
+			if !ok {
+				return false, fmt.Errorf("watch did not return a pod: %v", ev.Object)
+			}
+
+			s := podcmd.GetContainerStatusByName(p, containerName)
+			if s == nil {
+				return false, nil
+			}
+			klog.V(2).Infof("debug container status is %v", s)
+			if s.State.Running != nil || s.State.Terminated != nil {
+				return true, nil
+			}
+			if s.State.Waiting != nil && s.State.Waiting.Message != "" {
+				klog.V(2).Infof("container %s: %s", containerName, s.State.Waiting.Message)
+			}
+			return false, nil
+		})
+		return err
+	})
+
+	return err
 }

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
@@ -51,6 +51,7 @@ func TestLogsForObject(t *testing.T) {
 
 		expectedErr     string
 		expectedSources []corev1.ObjectReference
+		wait            bool
 	}{
 		{
 			name: "pod logs",
@@ -385,7 +386,7 @@ func TestLogsForObject(t *testing.T) {
 
 	for _, test := range tests {
 		fakeClientset := fakeexternal.NewSimpleClientset(test.clientsetPods...)
-		responses, err := logsForObjectWithClient(fakeClientset.CoreV1(), test.obj, test.opts, 20*time.Second, test.allContainers)
+		responses, err := logsForObjectWithClient(fakeClientset.CoreV1(), test.obj, test.opts, 20*time.Second, test.allContainers, test.wait)
 		if test.expectedErr == "" && err != nil {
 			t.Errorf("%s: unexpected error: %v", test.name, err)
 			continue
@@ -505,6 +506,7 @@ func TestLogsForObjectWithClient(t *testing.T) {
 		expectedFieldPath string
 		allContainers     bool
 		expectedError     string
+		wait              bool
 	}{
 		{
 			name:              "two container pod without default container selected should default to the first one",
@@ -561,7 +563,7 @@ func TestLogsForObjectWithClient(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pod := tc.podFn()
 			fakeClientset := fakeexternal.NewSimpleClientset(pod)
-			responses, err := logsForObjectWithClient(fakeClientset.CoreV1(), pod, tc.podLogOptions, 20*time.Second, tc.allContainers)
+			responses, err := logsForObjectWithClient(fakeClientset.CoreV1(), pod, tc.podLogOptions, 20*time.Second, tc.allContainers, tc.wait)
 			if err != nil {
 				if len(tc.expectedError) > 0 {
 					if err.Error() == tc.expectedError {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`kubectl logs -f` fails when no container is ready to provide logs.
```
$ kubectl logs -f test -c nginx
Error from server (BadRequest): container "nginx" in pod "test" is waiting to start: CreateContainerConfigError
```
This PR adds a new flag `-F` to `kubectl logs`. This flag is supposed to follow the semantics of `tail -F`
Via this PR, if `-F` flag is used, 'kubectl logs` does not exit with 'Error from server...' message, instead waits for the first/all container/s to be running and then starts giving logs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1227, https://github.com/kubernetes/kubernetes/issues/79547

#### Special notes for your reviewer:
The new flag '-F' waits for the container to be running before providing logs.

When used with '-p', i.e., '-p -F', it prints the previous logs and then continues streaming current logs. Currently '-p -f' behaves similar to '-p'. Hence, the combination of '-p -F' is implemented such that two API calls are made - first with '-p' and second with '-f'.

Along with the primary changes, I have moved `getContainerStatusByName` function out of 'staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go' to 'staging/src/k8s.io/kubectl/pkg/cmd/util/podcmd/podcmd.go', for easy reusability in other files. I, however, cannot move `waitForContainer`, since it performs some extra checks specific to flags used with `kubectl debug` in 'staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go'.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
