### PR TITLE
integration/apimachinery: add TestReflectorWatchListFallback integration test

### DIFF
--- a/test/integration/apimachinery/watchlist_test.go
+++ b/test/integration/apimachinery/watchlist_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apimachinery
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestReflectorWatchListFallback(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Log("Starting etcd that will be used by two different instances of kube-apiserver")
+	etcdURL, etcdTearDownFn, err := framework.RunCustomEtcd("etcd_watchlist", []string{"--experimental-watch-progress-notify-interval", "1s"}, nil)
+	require.NoError(t, err)
+	defer etcdTearDownFn()
+	etcdOptions := framework.DefaultEtcdOptions()
+	etcdOptions.StorageConfig.Transport.ServerList = []string{etcdURL}
+
+	t.Log("Starting the first server with the WatchList feature enabled")
+	server1 := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--feature-gates=WatchList=true"}, &etcdOptions.StorageConfig)
+	defer server1.TearDownFn()
+	clientSet, err := kubernetes.NewForConfig(server1.ClientConfig)
+	require.NoError(t, err)
+
+	ns := framework.CreateNamespaceOrDie(clientSet, "reflector-fallback-watchlist", t)
+	defer framework.DeleteNamespaceOrDie(clientSet, ns, t)
+
+	t.Logf("Adding 5 secrets to %s namespace", ns.Name)
+	for i := 1; i <= 5; i++ {
+		_, err := clientSet.CoreV1().Secrets(ns.Name).Create(ctx, newSecret(fmt.Sprintf("secret-%d", i)), metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	t.Log("Creating a secret reflector that will use the WatchList feature to synchronise the store")
+	store := &wrappedStore{Store: cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)}
+	lw := &wrappedListWatch{&cache.ListWatch{}}
+	lw.SetClient(ctx, clientSet, ns)
+	target := cache.NewReflector(lw, &v1.Secret{}, store, time.Duration(0))
+	target.UseWatchList = true
+
+	t.Log("Waiting until the secret reflector synchronises to the store (call to the Replace method)")
+	reflectorCtx, reflectorCtxCancel := context.WithCancel(context.Background())
+	defer reflectorCtxCancel()
+	store.setCancelOnReplace(reflectorCtxCancel)
+	err = target.ListAndWatch(reflectorCtx.Done())
+	require.NoError(t, err)
+
+	t.Log("Verifying if the secret reflector was properly synchronised")
+	verifyStore(t, ctx, clientSet, store, ns)
+
+	t.Log("Starting the second server with the WatchList feature disabled")
+	server2 := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--feature-gates=WatchList=false"}, &etcdOptions.StorageConfig)
+	defer server2.TearDownFn()
+	clientSet2, err := kubernetes.NewForConfig(server2.ClientConfig)
+	require.NoError(t, err)
+
+	t.Log("Pointing the ListWatcher used by the secret reflector to the second server (with the WatchList feature disabled)")
+	lw.SetClient(ctx, clientSet2, ns)
+	reflectorCtx, reflectorCtxCancel = context.WithCancel(context.Background())
+	defer reflectorCtxCancel()
+	store.setCancelOnReplace(reflectorCtxCancel)
+	err = target.ListAndWatch(reflectorCtx.Done())
+	require.NoError(t, err)
+
+	t.Log("Verifying if the secret reflector was properly synchronised")
+	verifyStore(t, ctx, clientSet, store, ns)
+}
+
+// TODO(#115478): refactor with e2e/apimachinery/watchlist
+func verifyStore(t *testing.T, ctx context.Context, clientSet kubernetes.Interface, store cache.Store, namespace *v1.Namespace) {
+	t.Logf("Listing secrets directly from the server from %s namespace", namespace.Name)
+	expectedSecretsList, err := clientSet.CoreV1().Secrets(namespace.Name).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	expectedSecrets := expectedSecretsList.Items
+
+	err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (done bool, err error) {
+		t.Log("Comparing secrets retrieved directly from the server with the ones that have been streamed to the secret reflector")
+		rawStreamedSecrets := store.List()
+		streamedSecrets := make([]v1.Secret, 0, len(rawStreamedSecrets))
+		for _, rawSecret := range rawStreamedSecrets {
+			streamedSecrets = append(streamedSecrets, *rawSecret.(*v1.Secret))
+		}
+		sort.Sort(byName(expectedSecrets))
+		sort.Sort(byName(streamedSecrets))
+		return cmp.Equal(expectedSecrets, streamedSecrets), nil
+	})
+	require.NoError(t, err)
+}
+
+type byName []v1.Secret
+
+func (a byName) Len() int           { return len(a) }
+func (a byName) Less(i, j int) bool { return a[i].Name < a[j].Name }
+func (a byName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
+func newSecret(name string) *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+}
+
+type wrappedStore struct {
+	cache.Store
+	ctxCancel context.CancelFunc
+}
+
+func (s *wrappedStore) Replace(items []interface{}, rv string) error {
+	s.ctxCancel()
+	return s.Store.Replace(items, rv)
+}
+
+func (s *wrappedStore) setCancelOnReplace(ctxCancel context.CancelFunc) {
+	s.ctxCancel = ctxCancel
+}
+
+type wrappedListWatch struct {
+	*cache.ListWatch
+}
+
+func (lw *wrappedListWatch) SetClient(ctx context.Context, clientSet kubernetes.Interface, ns *v1.Namespace) {
+	lw.ListFunc = func(options metav1.ListOptions) (runtime.Object, error) {
+		return clientSet.CoreV1().Secrets(ns.Name).List(ctx, options)
+	}
+	lw.WatchFunc = func(options metav1.ListOptions) (watch.Interface, error) {
+		return clientSet.CoreV1().Secrets(ns.Name).Watch(ctx, options)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
adds an integration test that verifies the fallback mechanism of the reflector when interacting with servers that has the WatchList feature enabled/disabled.

xref: https://github.com/kubernetes/enhancements/issues/3157

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
