### PR TITLE
Close websocket heartbeat explicitly when unexpected closure received

### DIFF
--- a/staging/src/k8s.io/client-go/tools/remotecommand/websocket.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/websocket.go
@@ -18,8 +18,10 @@ package remotecommand
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -476,12 +478,18 @@ func (h *heartbeat) start() {
 				klog.V(8).Infof("Websocket Ping succeeeded")
 			} else {
 				klog.Errorf("Websocket Ping failed: %v", err)
-				if gwebsocket.IsUnexpectedCloseError(err, gwebsocket.CloseGoingAway, gwebsocket.CloseAbnormalClosure) {
-					return
+				if errors.Is(err, gwebsocket.ErrCloseSent) {
+					// we continue because c.conn.CloseChan will manage closing the connection already
+					continue
+				} else if e, ok := err.(net.Error); ok && e.Timeout() {
+					// Continue, in case this is a transient failure.
+					// c.conn.CloseChan above will tell us when the connection is
+					// actually closed.
+					// If Temporary function hadn't been deprecated, we would have used it.
+					// But most of temporary errors are timeout errors anyway.
+					continue
 				}
-				// Continue, in case this is a transient failure.
-				// c.conn.CloseChan above will tell us when the connection is
-				// actually closed.
+				return
 			}
 		}
 	}

--- a/staging/src/k8s.io/client-go/tools/remotecommand/websocket.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/websocket.go
@@ -18,8 +18,10 @@ package remotecommand
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -476,9 +478,15 @@ func (h *heartbeat) start() {
 				klog.V(8).Infof("Websocket Ping succeeeded")
 			} else {
 				klog.Errorf("Websocket Ping failed: %v", err)
-				// Continue, in case this is a transient failure.
-				// c.conn.CloseChan above will tell us when the connection is
-				// actually closed.
+				if errors.Is(err, gwebsocket.ErrCloseSent) {
+					continue
+				} else if e, ok := err.(net.Error); ok && e.Temporary() {
+					// Continue, in case this is a transient failure.
+					// c.conn.CloseChan above will tell us when the connection is
+					// actually closed.
+					continue
+				}
+				return
 			}
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In remotecommand/websockets, heartbeat goroutine relies on closed handler in websocket library to exit. However, closed handler is not triggered https://github.com/gorilla/websocket/blob/666c197fc9157896b57515c3a3326c3f8c8319fe/conn.go#L983 when some exit codes like `CloseAbnormalClosure` https://github.com/gorilla/websocket/blob/666c197fc9157896b57515c3a3326c3f8c8319fe/conn.go#L219 raises. This results in goroutine leakage and heartbeat desperately sends ping messages to already closed connection.

This PR adds gracefully termination of heartbeat goroutine when unexpected closures received. We can continue relying on closed handler for other type of errors codes because they continue triggering closed handler.

#### Which issue(s) this PR fixes:
Fixes part of #120967

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```