### PR TITLE
[StructuredAuthorizationConfiguration] Fix the level at which authorizer name is surfaced

### DIFF
--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -167,8 +167,8 @@ func (o *BuiltInAuthorizationOptions) buildAuthorizationConfiguration() (*authzc
 		case authzmodes.ModeWebhook:
 			authorizers = append(authorizers, authzconfig.AuthorizerConfiguration{
 				Type: authzconfig.TypeWebhook,
+				Name: defaultWebhookName,
 				Webhook: &authzconfig.WebhookConfiguration{
-					Name:            defaultWebhookName,
 					AuthorizedTTL:   metav1.Duration{Duration: o.WebhookCacheAuthorizedTTL},
 					UnauthorizedTTL: metav1.Duration{Duration: o.WebhookCacheUnauthorizedTTL},
 					// Timeout and FailurePolicy are required for the new configuration.
@@ -183,9 +183,18 @@ func (o *BuiltInAuthorizationOptions) buildAuthorizationConfiguration() (*authzc
 				},
 			})
 		default:
-			authorizers = append(authorizers, authzconfig.AuthorizerConfiguration{Type: authzconfig.AuthorizerType(mode)})
+			authorizers = append(authorizers, authzconfig.AuthorizerConfiguration{
+				Type: authzconfig.AuthorizerType(mode),
+				Name: getNameForAuthorizerMode(mode),
+			})
 		}
 	}
 
 	return &authzconfig.AuthorizationConfiguration{Authorizers: authorizers}, nil
+}
+
+// getNameForAuthorizerMode returns the name to be set for the mode in AuthorizationConfiguration
+// For now, lower cases the mode name
+func getNameForAuthorizerMode(mode string) string {
+	return strings.ToLower(mode)
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
@@ -228,18 +228,19 @@ type AuthorizerConfiguration struct {
 	// types like Node, RBAC, ABAC, etc.
 	Type AuthorizerType
 
+	// Name used to describe the webhook
+	// This is explicitly used in monitoring machinery for metrics
+	// Note: Names must be DNS1123 labels like `myauthorizername` or
+	//		 subdomains like `myauthorizer.example.domain`
+	// Required, with no default
+	Name string
+
 	// Webhook defines the configuration for a Webhook authorizer
 	// Must be defined when Type=Webhook
 	Webhook *WebhookConfiguration
 }
 
 type WebhookConfiguration struct {
-	// Name used to describe the webhook
-	// This is explicitly used in monitoring machinery for metrics
-	// Note: Names must be DNS1123 labels like `mywebhookname` or
-	//		 subdomains like `webhookname.example.domain`
-	// Required, with no default
-	Name string
 	// The duration to cache 'authorized' responses from the webhook
 	// authorizer.
 	// Same as setting `--authorization-webhook-cache-authorized-ttl` flag

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
@@ -298,6 +298,13 @@ type AuthorizerConfiguration struct {
 	// types like Node, RBAC, ABAC, etc.
 	Type string `json:"type"`
 
+	// Name used to describe the webhook
+	// This is explicitly used in monitoring machinery for metrics
+	// Note: Names must be DNS1123 labels like `myauthorizername` or
+	//		 subdomains like `myauthorizer.example.domain`
+	// Required, with no default
+	Name string `json:"name"`
+
 	// Webhook defines the configuration for a Webhook authorizer
 	// Must be defined when Type=Webhook
 	// Must not be defined when Type!=Webhook
@@ -305,12 +312,6 @@ type AuthorizerConfiguration struct {
 }
 
 type WebhookConfiguration struct {
-	// Name used to describe the webhook
-	// This is explicitly used in monitoring machinery for metrics
-	// Note: Names must be DNS1123 labels like `mywebhookname` or
-	//		 subdomains like `webhookname.example.domain`
-	// Required, with no default
-	Name string `json:"name"`
 	// The duration to cache 'authorized' responses from the webhook
 	// authorizer.
 	// Same as setting `--authorization-webhook-cache-authorized-ttl` flag

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
@@ -335,6 +335,7 @@ func Convert_apiserver_AuthorizationConfiguration_To_v1alpha1_AuthorizationConfi
 
 func autoConvert_v1alpha1_AuthorizerConfiguration_To_apiserver_AuthorizerConfiguration(in *AuthorizerConfiguration, out *apiserver.AuthorizerConfiguration, s conversion.Scope) error {
 	out.Type = apiserver.AuthorizerType(in.Type)
+	out.Name = in.Name
 	out.Webhook = (*apiserver.WebhookConfiguration)(unsafe.Pointer(in.Webhook))
 	return nil
 }
@@ -346,6 +347,7 @@ func Convert_v1alpha1_AuthorizerConfiguration_To_apiserver_AuthorizerConfigurati
 
 func autoConvert_apiserver_AuthorizerConfiguration_To_v1alpha1_AuthorizerConfiguration(in *apiserver.AuthorizerConfiguration, out *AuthorizerConfiguration, s conversion.Scope) error {
 	out.Type = string(in.Type)
+	out.Name = in.Name
 	out.Webhook = (*WebhookConfiguration)(unsafe.Pointer(in.Webhook))
 	return nil
 }
@@ -677,7 +679,6 @@ func Convert_apiserver_UDSTransport_To_v1alpha1_UDSTransport(in *apiserver.UDSTr
 }
 
 func autoConvert_v1alpha1_WebhookConfiguration_To_apiserver_WebhookConfiguration(in *WebhookConfiguration, out *apiserver.WebhookConfiguration, s conversion.Scope) error {
-	out.Name = in.Name
 	out.AuthorizedTTL = in.AuthorizedTTL
 	out.UnauthorizedTTL = in.UnauthorizedTTL
 	out.Timeout = in.Timeout
@@ -697,7 +698,6 @@ func Convert_v1alpha1_WebhookConfiguration_To_apiserver_WebhookConfiguration(in 
 }
 
 func autoConvert_apiserver_WebhookConfiguration_To_v1alpha1_WebhookConfiguration(in *apiserver.WebhookConfiguration, out *WebhookConfiguration, s conversion.Scope) error {
-	out.Name = in.Name
 	out.AuthorizedTTL = in.AuthorizedTTL
 	out.UnauthorizedTTL = in.UnauthorizedTTL
 	out.Timeout = in.Timeout


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- k8s.io/apiserver: fix levelling of the name field in AuthorizationConfiguration
- pkg/kubeapiserver: pass authorizer in top level while building from legacy options

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/kubernetes/issues/118872

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://features.k8s.io/3221
```

/sig auth
/priority important-soon
/assign @liggitt @ritazh 