### PR TITLE
WIP: node: metrics: memorymanager: add metrics about pinning

### DIFF
--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -116,6 +116,10 @@ const (
 	orphanPodCleanedVolumesKey       = "orphan_pod_cleaned_volumes"
 	orphanPodCleanedVolumesErrorsKey = "orphan_pod_cleaned_volumes_errors"
 
+	// Metrics to track the Memory Manager Behavior
+	MemoryManagerPinningRequestsTotalKey = "memory_manager_pinning_requests_total"
+	MemoryManagerPinningErrorsTotalKey   = "memory_manager_pinning_errors_total"
+
 	// Values used in metric labels
 	Container          = "container"
 	InitContainer      = "init_container"
@@ -738,6 +742,26 @@ var (
 			Subsystem:      KubeletSubsystem,
 			Name:           orphanPodCleanedVolumesErrorsKey,
 			Help:           "The number of orphaned Pods whose volumes failed to be cleaned in the last periodic sweep.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	// MemoryManagerPinningRequestsTotal tracks the number of times the pod spec will cause the memory manager to pin memory areas.
+	MemoryManagerPinningRequestsTotal = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           MemoryManagerPinningRequestsTotalKey,
+			Help:           "The number of memory areas allocations which required pinning.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	// MemoryManagerPinningErrorsTotal tracks the number of times the pod spec required the memory manager to pin memory areas, but the allocation failed
+	MemoryManagerPinningErrorsTotal = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           MemoryManagerPinningErrorsTotalKey,
+			Help:           "The number of memory areas allocations which required pinning failed.",
 			StabilityLevel: metrics.ALPHA,
 		},
 	)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Add metrics to track the memory manager allocation/pinning behavior and failures,
following the same approach of #112855.

#### Which issue(s) this PR fixes:
Fixes #120986

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Add kubelet metrics to track the memory manager allocations and pinnings.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
Availability of metrics is a common GA prerequisite (and almost always helpful for better observability in general).
Memory manager is going to be GA'd: https://github.com/kubernetes/enhancements/pull/4251