### PR TITLE
component-base/featuregate: introduce EnvVarFeatureGate

### DIFF
--- a/staging/src/k8s.io/component-base/featuregate/env_var_feature_gate.go
+++ b/staging/src/k8s.io/component-base/featuregate/env_var_feature_gate.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package featuregate
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	"k8s.io/apimachinery/pkg/util/naming"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// Reader indicates whether a given feature is enabled or not.
+type Reader interface {
+	// Enabled returns true if the key is enabled.
+	Enabled(key Feature) bool
+
+	// KnownFeatures returns a slice of strings describing the FeatureGate's known features.
+	KnownFeatures() []string
+}
+
+var _ Reader = &envVarFeatureGate{}
+
+// NewEnvVarFeatureGate creates a feature gate that allows for registration
+// of features and checking if the features are enabled.
+// On the first check, it reads environment variables prefixed
+// with "KUBE_FEATURE_" and the feature name to determine the feature's state.
+//
+// For example, if you have a feature named "MyFeature,"
+// setting an environmental variable "KUBE_FEATURE_MyFeature"
+// will allow you to configure the state of that feature.
+//
+// Please note that environmental variables can only be set to a boolean type.
+// Incorrect values will be ignored and logged.
+func NewEnvVarFeatureGate() *envVarFeatureGate {
+	known := map[Feature]FeatureSpec{}
+	knownValue := &atomic.Value{}
+	knownValue.Store(known)
+
+	enabled := map[Feature]bool{}
+	enabledValue := &atomic.Value{}
+	enabledValue.Store(enabled)
+
+	f := &envVarFeatureGate{
+		envVarFeatureGateName: naming.GetNameFromCallsite(internalPackages...),
+		known:                 knownValue,
+		enabled:               enabledValue,
+	}
+	return f
+}
+
+// envVarFeatureGate implements Reader and allows for feature registration.
+type envVarFeatureGate struct {
+	// envVarFeatureGateName holds the name of the file
+	// that created this instance
+	envVarFeatureGateName string
+
+	// readEnvVarsOnce guards reading environmental variables
+	readEnvVarsOnce sync.Once
+
+	// lock guards writes to known, enabled
+	lock sync.Mutex
+
+	// known holds a map[Feature]FeatureSpec
+	known *atomic.Value
+
+	// enabled holds a map[Feature]bool
+	// holds values set explicitly via env var
+	enabled *atomic.Value
+}
+
+// Add adds features to the envVarFeatureGate.
+func (f *envVarFeatureGate) Add(features map[Feature]FeatureSpec) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	known := map[Feature]FeatureSpec{}
+	for k, v := range f.getKnownFeatures() {
+		known[k] = v
+	}
+
+	for name, spec := range features {
+		if existingSpec, found := known[name]; found {
+			if existingSpec == spec {
+				continue
+			}
+			return fmt.Errorf("feature gate %q with different spec already exists: %v", name, existingSpec)
+		}
+		known[name] = spec
+	}
+
+	f.known.Store(known)
+	return nil
+}
+
+// Enabled returns true if the key is enabled.  If the key is not known, this call will panic.
+func (f *envVarFeatureGate) Enabled(key Feature) bool {
+	if v, ok := f.getEnabledMapFromEnvVar()[key]; ok {
+		return v
+	}
+	if v, ok := f.getKnownFeatures()[key]; ok {
+		return v.Default
+	}
+	panic(fmt.Errorf("feature %q is not registered in FeatureGate %q", key, f.envVarFeatureGateName))
+}
+
+// KnownFeatures returns a slice of strings describing the FeatureGate's known features.
+// Deprecated and GA features are hidden from the list.
+func (f *envVarFeatureGate) KnownFeatures() []string {
+	var known []string
+	for k, v := range f.getKnownFeatures() {
+		if v.PreRelease == GA || v.PreRelease == Deprecated {
+			continue
+		}
+		known = append(known, fmt.Sprintf("%s=true|false (%s - default=%t)", k, v.PreRelease, v.Default))
+	}
+	sort.Strings(known)
+	return known
+}
+
+// getEnabledMapFromEnvVar will fill the enabled map on the first call.
+// This is the only time a known feature can be set to a value
+// read from the corresponding environmental variable.
+func (f *envVarFeatureGate) getEnabledMapFromEnvVar() map[Feature]bool {
+	f.readEnvVarsOnce.Do(func() {
+		featureGateState := map[Feature]bool{}
+		for feature, featureSpec := range f.getKnownFeatures() {
+			featureState, featureStateSet := os.LookupEnv(fmt.Sprintf("KUBE_FEATURE_%s", feature))
+			if !featureStateSet {
+				continue
+			}
+			boolVal, boolErr := strconv.ParseBool(featureState)
+			switch {
+			case boolErr != nil:
+				utilruntime.HandleError(fmt.Errorf("cannot set feature gate %v to %v, due to %v", feature, featureState, boolErr))
+			case featureSpec.LockToDefault:
+				if boolVal != featureSpec.Default {
+					utilruntime.HandleError(fmt.Errorf("cannot set feature gate %v to %v, feature is locked to %v", feature, featureState, featureSpec.Default))
+					break
+				}
+				featureGateState[feature] = featureSpec.Default
+			default:
+				featureGateState[feature] = boolVal
+			}
+		}
+		f.enabled.Store(featureGateState)
+	})
+	return f.enabled.Load().(map[Feature]bool)
+}
+
+// getKnownFeatures returns a copy of the map of known feature names to feature specs.
+func (f *envVarFeatureGate) getKnownFeatures() map[Feature]FeatureSpec {
+	retval := map[Feature]FeatureSpec{}
+	for k, v := range f.known.Load().(map[Feature]FeatureSpec) {
+		retval[k] = v
+	}
+	return retval
+}

--- a/staging/src/k8s.io/component-base/featuregate/env_var_feature_gate_test.go
+++ b/staging/src/k8s.io/component-base/featuregate/env_var_feature_gate_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package featuregate
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvVarFeatureGate(t *testing.T) {
+	defaultTestFeatures := map[Feature]FeatureSpec{
+		"TestAlpha": {
+			Default:       false,
+			LockToDefault: false,
+			PreRelease:    "Alpha",
+		},
+		"TestBeta": {
+			Default:       true,
+			LockToDefault: false,
+			PreRelease:    "Beta",
+		},
+	}
+	expectedDefaultFeaturesState := map[Feature]bool{"TestAlpha": false, "TestBeta": true}
+
+	copyExpectedStateMap := func(toCopy map[Feature]bool) map[Feature]bool {
+		m := map[Feature]bool{}
+		for k, v := range toCopy {
+			m[k] = v
+		}
+		return m
+	}
+
+	scenarios := []struct {
+		name                                string
+		features                            map[Feature]FeatureSpec
+		envVariables                        map[string]string
+		expectedFeaturesState               map[Feature]bool
+		expectedInternalEnabledFeatureState map[Feature]bool
+	}{
+		{
+			name: "can add empty features",
+		},
+		{
+			name:                  "no env var, features get Defaults assigned",
+			features:              defaultTestFeatures,
+			expectedFeaturesState: expectedDefaultFeaturesState,
+		},
+		{
+			name:                  "incorrect env var, feature gets Default assigned",
+			features:              defaultTestFeatures,
+			envVariables:          map[string]string{"TestAlpha": "true"},
+			expectedFeaturesState: expectedDefaultFeaturesState,
+		},
+		{
+			name:         "correct env var changes the feature gets state",
+			features:     defaultTestFeatures,
+			envVariables: map[string]string{"KUBE_FEATURE_TestAlpha": "true"},
+			expectedFeaturesState: func() map[Feature]bool {
+				expectedDefaultFeaturesStateCopy := copyExpectedStateMap(expectedDefaultFeaturesState)
+				expectedDefaultFeaturesStateCopy["TestAlpha"] = true
+				return expectedDefaultFeaturesStateCopy
+			}(),
+			expectedInternalEnabledFeatureState: map[Feature]bool{"TestAlpha": true},
+		},
+		{
+			name:                  "incorrect env var value gets ignored",
+			features:              defaultTestFeatures,
+			envVariables:          map[string]string{"KUBE_FEATURE_TestAlpha": "TrueFalse"},
+			expectedFeaturesState: expectedDefaultFeaturesState,
+		},
+		{
+			name:                  "empty env var value gets ignored",
+			features:              defaultTestFeatures,
+			envVariables:          map[string]string{"KUBE_FEATURE_TestAlpha": ""},
+			expectedFeaturesState: expectedDefaultFeaturesState,
+		},
+		{
+			name: "a feature LockToDefault wins",
+			features: map[Feature]FeatureSpec{
+				"TestAlpha": {
+					Default:       true,
+					LockToDefault: true,
+					PreRelease:    "Alpha",
+				},
+			},
+			envVariables:          map[string]string{"KUBE_FEATURE_TestAlpha": "False"},
+			expectedFeaturesState: map[Feature]bool{"TestAlpha": true},
+		},
+		{
+			name: "setting a feature to LockToDefault changes the internal state",
+			features: map[Feature]FeatureSpec{
+				"TestAlpha": {
+					Default:       true,
+					LockToDefault: true,
+					PreRelease:    "Alpha",
+				},
+			},
+			envVariables:                        map[string]string{"KUBE_FEATURE_TestAlpha": "True"},
+			expectedFeaturesState:               map[Feature]bool{"TestAlpha": true},
+			expectedInternalEnabledFeatureState: map[Feature]bool{"TestAlpha": true},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			for k, v := range scenario.envVariables {
+				os.Setenv(k, v)
+			}
+			defer func() {
+				for k := range scenario.envVariables {
+					os.Unsetenv(k)
+				}
+			}()
+			target := NewEnvVarFeatureGate()
+			err := target.Add(scenario.features)
+			require.NoError(t, err)
+
+			for expectedFeature, expectedValue := range scenario.expectedFeaturesState {
+				actualValue := target.Enabled(expectedFeature)
+				require.Equal(t, actualValue, expectedValue, "expected feature=%v, to be=%v, not=%v", expectedFeature, expectedValue, actualValue)
+			}
+
+			enabledInternalMap := target.enabled.Load().(map[Feature]bool)
+			require.Len(t, enabledInternalMap, len(scenario.expectedInternalEnabledFeatureState))
+
+			for expectedFeature, expectedInternalPresence := range scenario.expectedInternalEnabledFeatureState {
+				featureInternalValue, featureSet := enabledInternalMap[expectedFeature]
+				require.Equal(t, expectedInternalPresence, featureSet, "feature %v present = %v, expected = %v", expectedFeature, featureSet, expectedInternalPresence)
+
+				expectedFeatureInternalValue := scenario.expectedFeaturesState[expectedFeature]
+				require.Equal(t, expectedFeatureInternalValue, featureInternalValue)
+			}
+		})
+	}
+}
+
+func TestEnvVarFeatureGateAddError(t *testing.T) {
+	feature := map[Feature]FeatureSpec{
+		"TestAlpha": {
+			Default:       true,
+			LockToDefault: true,
+			PreRelease:    "Alpha",
+		},
+	}
+	target := NewEnvVarFeatureGate()
+	err := target.Add(feature)
+	require.NoError(t, err)
+
+	alphaSpec := feature["TestAlpha"]
+	alphaSpec.Default = false
+	feature["TestAlpha"] = alphaSpec
+	err = target.Add(feature)
+	require.NotNilf(t, err, "expected an error but got none")
+}
+
+func TestEnvVarFeatureGateEnabledPanic(t *testing.T) {
+	target := NewEnvVarFeatureGate()
+	require.Panics(t, func() { target.Enabled("UnknownFeature") })
+}
+
+func TestEnvVarFeatureGateKnownFeatures(t *testing.T) {
+	var (
+		testAlphaGate      Feature = "TestAlpha"
+		testBetaGate       Feature = "TestBeta"
+		testGAGate         Feature = "TestGA"
+		testDeprecatedGate Feature = "TestDeprecated"
+	)
+
+	target := NewEnvVarFeatureGate()
+	err := target.Add(map[Feature]FeatureSpec{
+		testAlphaGate:      {Default: false, PreRelease: Alpha},
+		testBetaGate:       {Default: true, PreRelease: Beta},
+		testGAGate:         {Default: true, PreRelease: GA},
+		testDeprecatedGate: {Default: false, PreRelease: Deprecated},
+	})
+	require.NoError(t, err)
+
+	known := strings.Join(target.KnownFeatures(), " ")
+
+	require.Contains(t, known, testAlphaGate)
+	require.Contains(t, known, testBetaGate)
+	require.NotContains(t, known, testGAGate)
+	require.NotContains(t, known, testDeprecatedGate)
+}

--- a/staging/src/k8s.io/component-base/featuregate/feature_gate.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate.go
@@ -158,7 +158,7 @@ var _ pflag.Value = &featureGate{}
 
 // internalPackages are packages that ignored when creating a name for featureGates. These packages are in the common
 // call chains, so they'd be unhelpful as names.
-var internalPackages = []string{"k8s.io/component-base/featuregate/feature_gate.go"}
+var internalPackages = []string{"k8s.io/component-base/featuregate/feature_gate.go", "k8s.io/component-base/featuregate/env_var_feature_gate.go"}
 
 func NewFeatureGate() *featureGate {
 	known := map[Feature]FeatureSpec{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
NewEnvVarFeatureGate creates a feature gate that allows for registration of features and checking if the features are enabled. On the first check, it reads environment variables prefixed with "KUBE_FEATURE_" and the feature name to determine the feature's state.

For example, if you have a feature named "MyFeature," setting an environmental variable "KUBE_FEATURE_MyFeature" will allow you to configure the state of that feature.

Please note that environmental variables can only be set to a boolean type. Incorrect values will be ignored and reported to stdout

xref: https://github.com/kubernetes/enhancements/issues/3157
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Heavily based on https://github.com/kubernetes/kubernetes/pull/120972
All credit goes to @deads2k 

I'm also planning to prepare a second PR that will use the new feature gate.
We can wait until the second PR will be ready.
But I would like to get a review as soon as possible.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
