### PR TITLE
Make a certain ipv4-vs-ipv6 config error non-fatal, for backward compat

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -678,7 +678,7 @@ func checkIPConfig(s *ProxyServer, dualStackSupported bool) (error, bool) {
 		clusterCIDRs := strings.Split(s.Config.ClusterCIDR, ",")
 		if badCIDRs(clusterCIDRs, badFamily) {
 			errors = append(errors, fmt.Errorf("cluster is %s but clusterCIDRs contains only IPv%s addresses", clusterType, badFamily))
-			if s.Config.DetectLocalMode == kubeproxyconfig.LocalModeClusterCIDR {
+			if s.Config.DetectLocalMode == kubeproxyconfig.LocalModeClusterCIDR && !dualStackSupported {
 				// This has always been a fatal error
 				fatal = true
 			}

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -817,11 +817,12 @@ func Test_detectNodeIPs(t *testing.T) {
 
 func Test_checkIPConfig(t *testing.T) {
 	cases := []struct {
-		name  string
-		proxy *ProxyServer
-		ssErr bool
-		dsErr bool
-		fatal bool
+		name    string
+		proxy   *ProxyServer
+		ssErr   bool
+		ssFatal bool
+		dsErr   bool
+		dsFatal bool
 	}{
 		{
 			name: "empty config",
@@ -874,9 +875,10 @@ func Test_checkIPConfig(t *testing.T) {
 				},
 				PrimaryIPFamily: v1.IPv4Protocol,
 			},
-			ssErr: true,
-			dsErr: true,
-			fatal: false,
+			ssErr:   true,
+			ssFatal: false,
+			dsErr:   true,
+			dsFatal: false,
 		},
 		{
 			name: "wrong-family clusterCIDR when using ClusterCIDR LocalDetector",
@@ -887,9 +889,10 @@ func Test_checkIPConfig(t *testing.T) {
 				},
 				PrimaryIPFamily: v1.IPv4Protocol,
 			},
-			ssErr: true,
-			dsErr: true,
-			fatal: true,
+			ssErr:   true,
+			ssFatal: true,
+			dsErr:   true,
+			dsFatal: false,
 		},
 
 		{
@@ -933,9 +936,10 @@ func Test_checkIPConfig(t *testing.T) {
 				},
 				PrimaryIPFamily: v1.IPv6Protocol,
 			},
-			ssErr: true,
-			dsErr: true,
-			fatal: false,
+			ssErr:   true,
+			ssFatal: false,
+			dsErr:   true,
+			dsFatal: false,
 		},
 
 		{
@@ -983,9 +987,10 @@ func Test_checkIPConfig(t *testing.T) {
 				PrimaryIPFamily: v1.IPv4Protocol,
 				podCIDRs:        []string{"fd01:2345::/64"},
 			},
-			ssErr: true,
-			dsErr: true,
-			fatal: true,
+			ssErr:   true,
+			ssFatal: true,
+			dsErr:   true,
+			dsFatal: true,
 		},
 
 		{
@@ -1011,9 +1016,10 @@ func Test_checkIPConfig(t *testing.T) {
 				},
 				PrimaryIPFamily: v1.IPv4Protocol,
 			},
-			ssErr: true,
-			dsErr: true,
-			fatal: false,
+			ssErr:   true,
+			ssFatal: false,
+			dsErr:   true,
+			dsFatal: false,
 		},
 
 		{
@@ -1057,9 +1063,9 @@ func Test_checkIPConfig(t *testing.T) {
 				},
 				PrimaryIPFamily: v1.IPv6Protocol,
 			},
-			ssErr: true,
-			dsErr: false,
-			fatal: false,
+			ssErr:   true,
+			ssFatal: false,
+			dsErr:   false,
 		},
 
 		{
@@ -1085,9 +1091,9 @@ func Test_checkIPConfig(t *testing.T) {
 				},
 				PrimaryIPFamily: v1.IPv6Protocol,
 			},
-			ssErr: true,
-			dsErr: false,
-			fatal: false,
+			ssErr:   true,
+			ssFatal: false,
+			dsErr:   false,
 		},
 	}
 
@@ -1098,8 +1104,8 @@ func Test_checkIPConfig(t *testing.T) {
 				t.Errorf("unexpected error in single-stack case: %v", err)
 			} else if err == nil && c.ssErr {
 				t.Errorf("unexpected lack of error in single-stack case")
-			} else if fatal != c.fatal {
-				t.Errorf("expected fatal=%v, got %v", c.fatal, fatal)
+			} else if fatal != c.ssFatal {
+				t.Errorf("expected fatal=%v, got %v", c.ssFatal, fatal)
 			}
 
 			err, fatal = checkIPConfig(c.proxy, true)
@@ -1107,8 +1113,8 @@ func Test_checkIPConfig(t *testing.T) {
 				t.Errorf("unexpected error in dual-stack case: %v", err)
 			} else if err == nil && c.dsErr {
 				t.Errorf("unexpected lack of error in dual-stack case")
-			} else if fatal != c.fatal {
-				t.Errorf("expected fatal=%v, got %v", c.fatal, fatal)
+			} else if fatal != c.dsFatal {
+				t.Errorf("expected fatal=%v, got %v", c.dsFatal, fatal)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression
/sig network
/priority important-soon

#### What this PR does / why we need it:
kube-proxy historically allowed badly-mismatched bits of configuration (e.g., specifying an IPv6 `--cluster-cidr` value on a seemingly dual-stack-IPv4-primary node). In 1.28 I consolidated the existing checks and added a bunch more, but I accidentally made one case fatal which had not been fatal in prior releases. This makes it just a warning again.

(It is still fatal to specify an IPv6 `--cluster-cidr` on a _necessarily_ single-stack-IPv4 node (e.g., when kernel IPv6 is disabled).)

#### Which issue(s) this PR fixes:
Fixes #120999

#### Does this PR introduce a user-facing change?
```release-note
Fixed a regression in kube-proxy where it might refuse to start if given
single-stack IPv6 configuration options on a node that has both IPv4 and
IPv6 IPs.
```
