### PR TITLE
DeclarativeValidation: Add Library for Validating Native Objects

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/adaptor.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/adaptor.go
@@ -54,6 +54,13 @@ func (s *Structural) Format() string {
 	return s.Structural.ValueValidation.Format
 }
 
+func (s *Structural) Pattern() string {
+	if s.Structural.ValueValidation == nil {
+		return ""
+	}
+	return s.Structural.ValueValidation.Pattern
+}
+
 func (s *Structural) Items() common.Schema {
 	return &Structural{Structural: s.Structural.Items}
 }
@@ -81,6 +88,48 @@ func (s *Structural) Default() any {
 	return s.Structural.Default.Object
 }
 
+func (s *Structural) Minimum() *float64 {
+	if s.Structural.ValueValidation == nil {
+		return nil
+	}
+	return s.Structural.ValueValidation.Minimum
+}
+
+func (s *Structural) IsExclusiveMinimum() bool {
+	if s.Structural.ValueValidation == nil {
+		return false
+	}
+	return s.Structural.ValueValidation.ExclusiveMinimum
+}
+
+func (s *Structural) Maximum() *float64 {
+	if s.Structural.ValueValidation == nil {
+		return nil
+	}
+	return s.Structural.ValueValidation.Maximum
+}
+
+func (s *Structural) IsExclusiveMaximum() bool {
+	if s.Structural.ValueValidation == nil {
+		return false
+	}
+	return s.Structural.ValueValidation.ExclusiveMaximum
+}
+
+func (s *Structural) MultipleOf() *float64 {
+	if s.Structural.ValueValidation == nil {
+		return nil
+	}
+	return s.Structural.ValueValidation.MultipleOf
+}
+
+func (s *Structural) MinItems() *int64 {
+	if s.Structural.ValueValidation == nil {
+		return nil
+	}
+	return s.Structural.ValueValidation.MinItems
+}
+
 func (s *Structural) MaxItems() *int64 {
 	if s.Structural.ValueValidation == nil {
 		return nil
@@ -88,11 +137,25 @@ func (s *Structural) MaxItems() *int64 {
 	return s.Structural.ValueValidation.MaxItems
 }
 
+func (s *Structural) MinLength() *int64 {
+	if s.Structural.ValueValidation == nil {
+		return nil
+	}
+	return s.Structural.ValueValidation.MinLength
+}
+
 func (s *Structural) MaxLength() *int64 {
 	if s.Structural.ValueValidation == nil {
 		return nil
 	}
 	return s.Structural.ValueValidation.MaxLength
+}
+
+func (s *Structural) MinProperties() *int64 {
+	if s.Structural.ValueValidation == nil {
+		return nil
+	}
+	return s.Structural.ValueValidation.MinProperties
 }
 
 func (s *Structural) MaxProperties() *int64 {
@@ -107,6 +170,12 @@ func (s *Structural) Required() []string {
 		return nil
 	}
 	return s.Structural.ValueValidation.Required
+}
+
+func (s *Structural) UniqueItems() bool {
+	// This field is forbidden in structural schema.
+	// but you can just you x-kubernetes-list-type:set to get around it :)
+	return false
 }
 
 func (s *Structural) Enum() []any {
@@ -143,8 +212,104 @@ func (s *Structural) XListType() string {
 	return *s.Structural.XListType
 }
 
+func (s *Structural) XMapType() string {
+	if s.Structural.XMapType == nil {
+		return ""
+	}
+	return *s.Structural.XMapType
+}
+
 func (s *Structural) XListMapKeys() []string {
 	return s.Structural.XListMapKeys
+}
+
+func (s *Structural) AllOf() []common.Schema {
+	var res []common.Schema
+	for _, subSchema := range s.Structural.ValueValidation.AllOf {
+		subSchema := subSchema
+		res = append(res, nestedValueValidationToStructural(&subSchema))
+	}
+	return res
+}
+
+func (s *Structural) AnyOf() []common.Schema {
+	var res []common.Schema
+	for _, subSchema := range s.Structural.ValueValidation.AnyOf {
+		subSchema := subSchema
+		res = append(res, nestedValueValidationToStructural(&subSchema))
+	}
+	return res
+}
+
+func (s *Structural) OneOf() []common.Schema {
+	var res []common.Schema
+	for _, subSchema := range s.Structural.ValueValidation.OneOf {
+		subSchema := subSchema
+		res = append(res, nestedValueValidationToStructural(&subSchema))
+	}
+	return res
+}
+
+func (s *Structural) Not() common.Schema {
+	if s.Structural.ValueValidation.Not == nil {
+		return nil
+	}
+	return nestedValueValidationToStructural(s.Structural.ValueValidation.Not)
+}
+
+// !TODO: This lets us avoid needing a separate adaptor for the nested value
+// validations but is likely more expensive
+func nestedValueValidationToStructural(nvv *schema.NestedValueValidation) *Structural {
+	var newItems *schema.Structural
+	if nvv.Items != nil {
+		newItems = nestedValueValidationToStructural(nvv.Items).Structural
+	}
+
+	var newProperties map[string]schema.Structural
+	for k, v := range nvv.Properties {
+		if newProperties == nil {
+			newProperties = make(map[string]schema.Structural)
+		}
+
+		v := v
+		newProperties[k] = *nestedValueValidationToStructural(&v).Structural
+	}
+
+	return &Structural{
+		Structural: &schema.Structural{
+			Items:           newItems,
+			Properties:      newProperties,
+			ValueValidation: &nvv.ValueValidation,
+		},
+	}
+}
+
+type StructuralValidationRule struct {
+	rule, message, messageExpression, fieldPath string
+}
+
+func (s *StructuralValidationRule) Rule() string {
+	return s.rule
+}
+func (s *StructuralValidationRule) Message() string {
+	return s.message
+}
+func (s *StructuralValidationRule) FieldPath() string {
+	return s.fieldPath
+}
+func (s *StructuralValidationRule) MessageExpression() string {
+	return s.messageExpression
+}
+
+func (s *Structural) XValidations() []common.ValidationRule {
+	if len(s.Structural.XValidations) == 0 {
+		return nil
+	}
+	result := make([]common.ValidationRule, len(s.Structural.XValidations))
+	for i, v := range s.Structural.XValidations {
+		result[i] = &StructuralValidationRule{rule: v.Rule, message: v.Message, messageExpression: v.MessageExpression, fieldPath: v.FieldPath}
+	}
+	return result
 }
 
 func (s *Structural) WithTypeAndObjectMeta() common.Schema {

--- a/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/cel_compile.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/cel_compile.go
@@ -1,0 +1,361 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apivalidation
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/checker"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	celconfig "k8s.io/apiserver/pkg/apis/cel"
+	apiservercel "k8s.io/apiserver/pkg/cel"
+	"k8s.io/apiserver/pkg/cel/common"
+	"k8s.io/apiserver/pkg/cel/environment"
+	"k8s.io/apiserver/pkg/cel/library"
+	"k8s.io/apiserver/pkg/cel/metrics"
+)
+
+// This file is a direct copy & paste of
+// k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
+// With structural.Schema replaced with common.Schema, and unused functions
+// removed
+
+const (
+	// ScopedVarName is the variable name assigned to the locally scoped data element of a CEL validation
+	// expression.
+	ScopedVarName = "self"
+
+	// OldScopedVarName is the variable name assigned to the existing value of the locally scoped data element of a
+	// CEL validation expression.
+	OldScopedVarName = "oldSelf"
+)
+
+// CompilationResult represents the cel compilation result for one rule
+type CompilationResult struct {
+	Program cel.Program
+	Error   *apiservercel.Error
+	// If true, the compiled expression contains a reference to the identifier "oldSelf", and its corresponding rule
+	// is implicitly a transition rule.
+	TransitionRule bool
+	// Represents the worst-case cost of the compiled expression in terms of CEL's cost units, as used by cel.EstimateCost.
+	MaxCost uint64
+	// MaxCardinality represents the worse case number of times this validation rule could be invoked if contained under an
+	// unbounded map or list in an OpenAPIv3 schema.
+	MaxCardinality uint64
+	// MessageExpression represents the cel Program that should be evaluated to generate an error message if the rule
+	// fails to validate. If no MessageExpression was given, or if this expression failed to compile, this will be nil.
+	MessageExpression cel.Program
+	// MessageExpressionError represents an error encountered during compilation of MessageExpression. If no error was
+	// encountered, this will be nil.
+	MessageExpressionError *apiservercel.Error
+	// MessageExpressionMaxCost represents the worst-case cost of the compiled MessageExpression in terms of CEL's cost units,
+	// as used by cel.EstimateCost.
+	MessageExpressionMaxCost uint64
+	// NormalizedRuleFieldPath represents the relative fieldPath specified by user after normalization.
+	NormalizedRuleFieldPath string
+}
+
+// EnvLoader delegates the decision of which CEL environment to use for each expression.
+// Callers should return the appropriate CEL environment based on the guidelines from
+// environment.NewExpressions and environment.StoredExpressions.
+type EnvLoader interface {
+	// RuleEnv returns the appropriate environment from the EnvSet for the given CEL rule.
+	RuleEnv(envSet *environment.EnvSet, expression string) *cel.Env
+	// MessageExpressionEnv returns the appropriate environment from the EnvSet for the given
+	// CEL messageExpressions.
+	MessageExpressionEnv(envSet *environment.EnvSet, expression string) *cel.Env
+}
+
+// NewExpressionsEnvLoader creates an EnvLoader that always uses the NewExpressions environment type.
+func NewExpressionsEnvLoader() EnvLoader {
+	return alwaysNewEnvLoader{loadFn: func(envSet *environment.EnvSet) *cel.Env {
+		return envSet.NewExpressionsEnv()
+	}}
+}
+
+// StoredExpressionsEnvLoader creates an EnvLoader that always uses the StoredExpressions environment type.
+func StoredExpressionsEnvLoader() EnvLoader {
+	return alwaysNewEnvLoader{loadFn: func(envSet *environment.EnvSet) *cel.Env {
+		return envSet.StoredExpressionsEnv()
+	}}
+}
+
+type alwaysNewEnvLoader struct {
+	loadFn func(envSet *environment.EnvSet) *cel.Env
+}
+
+func (pe alwaysNewEnvLoader) RuleEnv(envSet *environment.EnvSet, _ string) *cel.Env {
+	return pe.loadFn(envSet)
+}
+
+func (pe alwaysNewEnvLoader) MessageExpressionEnv(envSet *environment.EnvSet, _ string) *cel.Env {
+	return pe.loadFn(envSet)
+}
+
+// compile compiles all the XValidations rules (without recursing into the schema) and returns a slice containing a
+// CompilationResult for each ValidationRule, or an error. declType is expected to be a CEL DeclType corresponding
+// to the structural schema.
+// Each CompilationResult may contain:
+//   - non-nil Program, nil Error: The program was compiled successfully
+//   - nil Program, non-nil Error: Compilation resulted in an error
+//   - nil Program, nil Error: The provided rule was empty so compilation was not attempted
+//
+// perCallLimit was added for testing purpose only. Callers should always use const PerCallLimit from k8s.io/apiserver/pkg/apis/cel/config.go as input.
+// baseEnv is used as the base CEL environment, see common.BaseEnvironment.
+func compile(s common.Schema, declType *apiservercel.DeclType, perCallLimit uint64, baseEnvSet *environment.EnvSet, envLoader EnvLoader) ([]CompilationResult, error) {
+	t := time.Now()
+	defer func() {
+		metrics.Metrics.ObserveCompilation(time.Since(t))
+	}()
+
+	celRules := s.XValidations()
+	if len(celRules) == 0 {
+		return nil, nil
+	}
+
+	envSet, err := prepareEnvSet(baseEnvSet, declType)
+	if err != nil {
+		return nil, err
+	}
+	estimator := newCostEstimator(declType)
+	// compResults is the return value which saves a list of compilation results in the same order as x-kubernetes-validations rules.
+	compResults := make([]CompilationResult, len(celRules))
+	maxCardinality := maxCardinality(declType.MinSerializedSize)
+	for i, rule := range celRules {
+		compResults[i] = compileRule(s, rule, envSet, envLoader, estimator, maxCardinality, perCallLimit)
+	}
+
+	return compResults, nil
+}
+
+func prepareEnvSet(baseEnvSet *environment.EnvSet, declType *apiservercel.DeclType) (*environment.EnvSet, error) {
+	scopedType := declType.MaybeAssignTypeName(generateUniqueSelfTypeName())
+	return baseEnvSet.Extend(
+		environment.VersionedOptions{
+			// Feature epoch was actually 1.23, but we artificially set it to 1.0 because these
+			// options should always be present.
+			IntroducedVersion: version.MajorMinor(1, 0),
+			EnvOptions: []cel.EnvOption{
+				cel.Variable(ScopedVarName, scopedType.CelType()),
+			},
+			DeclTypes: []*apiservercel.DeclType{
+				scopedType,
+			},
+		},
+		environment.VersionedOptions{
+			IntroducedVersion: version.MajorMinor(1, 24),
+			EnvOptions: []cel.EnvOption{
+				cel.Variable(OldScopedVarName, scopedType.CelType()),
+			},
+		},
+	)
+}
+
+func compileRule(s common.Schema, rule common.ValidationRule, envSet *environment.EnvSet, envLoader EnvLoader, estimator *library.CostEstimator, maxCardinality uint64, perCallLimit uint64) (compilationResult CompilationResult) {
+	if len(strings.TrimSpace(rule.Rule())) == 0 {
+		// include a compilation result, but leave both program and error nil per documented return semantics of this
+		// function
+		return
+	}
+	ruleEnv := envLoader.RuleEnv(envSet, rule.Rule())
+	ast, issues := ruleEnv.Compile(rule.Rule())
+	if issues != nil {
+		compilationResult.Error = &apiservercel.Error{Type: apiservercel.ErrorTypeInvalid, Detail: "compilation failed: " + issues.String()}
+		return
+	}
+	if ast.OutputType() != cel.BoolType {
+		compilationResult.Error = &apiservercel.Error{Type: apiservercel.ErrorTypeInvalid, Detail: "cel expression must evaluate to a bool"}
+		return
+	}
+
+	checkedExpr, err := cel.AstToCheckedExpr(ast)
+	if err != nil {
+		// should be impossible since env.Compile returned no issues
+		compilationResult.Error = &apiservercel.Error{Type: apiservercel.ErrorTypeInternal, Detail: "unexpected compilation error: " + err.Error()}
+		return
+	}
+	for _, ref := range checkedExpr.ReferenceMap {
+		if ref.Name == OldScopedVarName {
+			compilationResult.TransitionRule = true
+			break
+		}
+	}
+
+	// TODO: Ideally we could configure the per expression limit at validation time and set it to the remaining overall budget, but we would either need a way to pass in a limit at evaluation time or move program creation to validation time
+	prog, err := ruleEnv.Program(ast,
+		cel.CostLimit(perCallLimit),
+		cel.CostTracking(estimator),
+		cel.InterruptCheckFrequency(celconfig.CheckFrequency),
+	)
+	if err != nil {
+		compilationResult.Error = &apiservercel.Error{Type: apiservercel.ErrorTypeInvalid, Detail: "program instantiation failed: " + err.Error()}
+		return
+	}
+	costEst, err := ruleEnv.EstimateCost(ast, estimator)
+	if err != nil {
+		compilationResult.Error = &apiservercel.Error{Type: apiservercel.ErrorTypeInternal, Detail: "cost estimation failed: " + err.Error()}
+		return
+	}
+	compilationResult.MaxCost = costEst.Max
+	compilationResult.MaxCardinality = maxCardinality
+	compilationResult.Program = prog
+	if messageExpression := rule.MessageExpression(); messageExpression != "" {
+		messageEnv := envLoader.MessageExpressionEnv(envSet, messageExpression)
+		ast, issues := messageEnv.Compile(messageExpression)
+		if issues != nil {
+			compilationResult.MessageExpressionError = &apiservercel.Error{Type: apiservercel.ErrorTypeInvalid, Detail: "messageExpression compilation failed: " + issues.String()}
+			return
+		}
+		if ast.OutputType() != cel.StringType {
+			compilationResult.MessageExpressionError = &apiservercel.Error{Type: apiservercel.ErrorTypeInvalid, Detail: "messageExpression must evaluate to a string"}
+			return
+		}
+
+		_, err := cel.AstToCheckedExpr(ast)
+		if err != nil {
+			compilationResult.MessageExpressionError = &apiservercel.Error{Type: apiservercel.ErrorTypeInternal, Detail: "unexpected messageExpression compilation error: " + err.Error()}
+			return
+		}
+
+		msgProg, err := messageEnv.Program(ast,
+			cel.CostLimit(perCallLimit),
+			cel.CostTracking(estimator),
+			cel.InterruptCheckFrequency(celconfig.CheckFrequency),
+		)
+		if err != nil {
+			compilationResult.MessageExpressionError = &apiservercel.Error{Type: apiservercel.ErrorTypeInvalid, Detail: "messageExpression instantiation failed: " + err.Error()}
+			return
+		}
+		costEst, err := messageEnv.EstimateCost(ast, estimator)
+		if err != nil {
+			compilationResult.MessageExpressionError = &apiservercel.Error{Type: apiservercel.ErrorTypeInternal, Detail: "cost estimation failed for messageExpression: " + err.Error()}
+			return
+		}
+		compilationResult.MessageExpression = msgProg
+		compilationResult.MessageExpressionMaxCost = costEst.Max
+	}
+	if fieldPath := rule.FieldPath(); fieldPath != "" {
+		validFieldPath, err := ValidFieldPath(fieldPath, s)
+		if err == nil {
+			compilationResult.NormalizedRuleFieldPath = validFieldPath.String()
+		}
+	}
+	return
+}
+
+// generateUniqueSelfTypeName creates a placeholder type name to use in a CEL programs for cases
+// where we do not wish to expose a stable type name to CEL validator rule authors. For this to effectively prevent
+// developers from depending on the generated name (i.e. using it in CEL programs), it must be changed each time a
+// CRD is created or updated.
+func generateUniqueSelfTypeName() string {
+	return fmt.Sprintf("selfType%d", time.Now().Nanosecond())
+}
+
+func newCostEstimator(root *apiservercel.DeclType) *library.CostEstimator {
+	return &library.CostEstimator{SizeEstimator: &sizeEstimator{root: root}}
+}
+
+type sizeEstimator struct {
+	root *apiservercel.DeclType
+}
+
+func (c *sizeEstimator) EstimateSize(element checker.AstNode) *checker.SizeEstimate {
+	if len(element.Path()) == 0 {
+		// Path() can return an empty list, early exit if it does since we can't
+		// provide size estimates when that happens
+		return nil
+	}
+	currentNode := c.root
+	// cut off "self" from path, since we always start there
+	for _, name := range element.Path()[1:] {
+		switch name {
+		case "@items", "@values":
+			if currentNode.ElemType == nil {
+				return nil
+			}
+			currentNode = currentNode.ElemType
+		case "@keys":
+			if currentNode.KeyType == nil {
+				return nil
+			}
+			currentNode = currentNode.KeyType
+		default:
+			field, ok := currentNode.Fields[name]
+			if !ok {
+				return nil
+			}
+			if field.Type == nil {
+				return nil
+			}
+			currentNode = field.Type
+		}
+	}
+	return &checker.SizeEstimate{Min: 0, Max: uint64(currentNode.MaxElements)}
+}
+
+func (c *sizeEstimator) EstimateCallCost(function, overloadID string, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+	return nil
+}
+
+// maxCardinality returns the maximum number of times data conforming to the minimum size given could possibly exist in
+// an object serialized to JSON. For cases where a schema is contained under map or array schemas of unbounded
+// size, this can be used as an estimate as the worst case number of times data matching the schema could be repeated.
+// Note that this only assumes a single comma between data elements, so if the schema is contained under only maps,
+// this estimates a higher cardinality that would be possible. DeclType.MinSerializedSize is meant to be passed to
+// this function.
+func maxCardinality(minSize int64) uint64 {
+	sz := minSize + 1 // assume at least one comma between elements
+	return uint64(celconfig.MaxRequestSizeBytes / sz)
+}
+
+var unescapeMatcher = regexp.MustCompile(`\\.`)
+
+func unescapeSingleQuote(s string) (string, error) {
+	var err error
+	unescaped := unescapeMatcher.ReplaceAllStringFunc(s, func(matchStr string) string {
+		directive := matchStr[1]
+		switch directive {
+		case 'a':
+			return "\a"
+		case 'b':
+			return "\b"
+		case 'f':
+			return "\f"
+		case 'n':
+			return "\n"
+		case 'r':
+			return "\r"
+		case 't':
+			return "\t"
+		case 'v':
+			return "\v"
+		case '\'':
+			return "'"
+		case '\\':
+			return "\\"
+		default:
+			err = fmt.Errorf("invalid escape char %s", matchStr)
+			return ""
+		}
+	})
+	return unescaped, err
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/cel_validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/cel_validate.go
@@ -1,0 +1,358 @@
+package apivalidation
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+
+	celgo "github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/interpreter"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	celconfig "k8s.io/apiserver/pkg/apis/cel"
+	"k8s.io/apiserver/pkg/cel"
+	"k8s.io/apiserver/pkg/cel/common"
+)
+
+// This file is mostly a copy & paste of k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
+// With structural.Schema replaced with common.Schema, and unused functions
+// removed
+func validateExpressions(ctx context.Context, result *ValidationContext, sts common.Schema, compiledRules []CompilationResult, remainingCostBudget int64) (remainingBudget int64) {
+	remainingBudget = remainingCostBudget
+	fldPath := result.Path
+	if result.Value.IsNull() {
+		// We only validate non-null values. Rules that need to check for the state of a nullable value or the presence of an optional
+		// field must do so from the surrounding schema. E.g. if an array has nullable string items, a rule on the array
+		// schema can check if items are null, but a rule on the nullable string schema only validates the non-null strings.
+		return remainingBudget
+	} else if len(compiledRules) == 0 {
+		// nothing to do
+		return remainingBudget
+	} else if remainingBudget <= 0 {
+		result.AddErrors(field.Invalid(fldPath, sts.Type(), fmt.Sprintf("validation failed due to running out of cost budget, no further validation rules will be run")))
+		return -1
+	} else if result.IsRoot() || sts.IsXEmbeddedResource() {
+		sts = sts.WithTypeAndObjectMeta()
+	}
+
+	usesOldSelf := false
+	for _, compiled := range compiledRules {
+		if compiled.TransitionRule {
+			usesOldSelf = true
+			break
+		}
+	}
+
+	var activation interpreter.Activation
+	if usesOldSelf && result.OldValue != nil {
+		activation = validationActivationWithOldSelf(sts, result.Value.Unstructured(), result.OldValue.Unstructured())
+	} else {
+		activation = validationActivationWithoutOldSelf(sts, result.Value.Unstructured(), nil)
+	}
+
+	for i, compiled := range compiledRules {
+		rule := sts.XValidations()[i]
+		if compiled.Error != nil {
+			result.AddErrors(field.Invalid(fldPath, sts.Type(), fmt.Sprintf("rule compile error: %v", compiled.Error)))
+			continue
+		}
+		if compiled.Program == nil {
+			// rule is empty
+			continue
+		}
+		//!TODO: classify transition rule errors as UPDATE ERRORS
+		if compiled.TransitionRule && result.OldValue == nil {
+			// transition rules are evaluated only if there is a comparable existing value
+			continue
+		}
+		evalResult, evalDetails, err := compiled.Program.ContextEval(ctx, activation)
+		if evalDetails == nil {
+			result.AddErrors(field.InternalError(fldPath, fmt.Errorf("runtime cost could not be calculated for validation rule: %v, no further validation rules will be run", ruleErrorString(rule))))
+			return -1
+		} else {
+			rtCost := evalDetails.ActualCost()
+			if rtCost == nil {
+				result.AddErrors(field.Invalid(fldPath, sts.Type(), fmt.Sprintf("runtime cost could not be calculated for validation rule: %v, no further validation rules will be run", ruleErrorString(rule))))
+				return -1
+			} else {
+				if *rtCost > math.MaxInt64 || int64(*rtCost) > remainingBudget {
+					result.AddErrors(field.Invalid(fldPath, sts.Type(), fmt.Sprintf("validation failed due to running out of cost budget, no further validation rules will be run")))
+					return -1
+				}
+				remainingBudget -= int64(*rtCost)
+			}
+		}
+		if err != nil {
+			// see types.Err for list of well defined error types
+			if strings.HasPrefix(err.Error(), "no such overload") {
+				// Most overload errors are caught by the compiler, which provides details on where exactly in the rule
+				// error was found. Here, an overload error has occurred at runtime no details are provided, so we
+				// append a more descriptive error message. This error can only occur when static type checking has
+				// been bypassed. int-or-string is typed as dynamic and so bypasses compiler type checking.
+				result.AddErrors(field.Invalid(fldPath, sts.Type(), fmt.Sprintf("'%v': call arguments did not match a supported operator, function or macro signature for rule: %v", err, ruleErrorString(rule))))
+			} else if strings.HasPrefix(err.Error(), "operation cancelled: actual cost limit exceeded") {
+				result.AddErrors(field.Invalid(fldPath, sts.Type(), fmt.Sprintf("'%v': no further validation rules will be run due to call cost exceeds limit for rule: %v", err, ruleErrorString(rule))))
+				return -1
+			} else {
+				// no such key: {key}, index out of bounds: {index}, integer overflow, division by zero, ...
+				result.AddErrors(field.Invalid(fldPath, sts.Type(), fmt.Sprintf("%v evaluating rule: %v", err, ruleErrorString(rule))))
+			}
+			continue
+		}
+		if evalResult != types.True {
+			if compiled.MessageExpression != nil {
+				messageExpression, newRemainingBudget, msgErr := evalMessageExpression(ctx, compiled.MessageExpression, rule.MessageExpression(), activation, remainingBudget)
+				if msgErr != nil {
+					if msgErr.Type == cel.ErrorTypeInternal {
+						result.AddErrors(field.InternalError(fldPath, msgErr))
+						return -1
+					} else if msgErr.Type == cel.ErrorTypeInvalid {
+						result.AddErrors(field.Invalid(fldPath, sts.Type(), msgErr.Error()))
+						return -1
+					} else {
+						result.AddErrors(field.Invalid(fldPath, sts.Type(), ruleMessageOrDefault(rule)))
+						remainingBudget = newRemainingBudget
+					}
+				} else {
+					result.AddErrors(field.Invalid(fldPath, sts.Type(), messageExpression))
+					remainingBudget = newRemainingBudget
+				}
+			} else {
+				result.AddErrors(field.Invalid(fldPath, sts.Type(), ruleMessageOrDefault(rule)))
+			}
+		}
+	}
+	return remainingBudget
+}
+
+// ValidFieldPath validates that jsonPath is a valid JSON Path containing only field and map accessors
+// that are valid for the given schema, and returns a field.Path representation of the validated jsonPath or an error.
+func ValidFieldPath(jsonPath string, schema common.Schema) (validFieldPath *field.Path, err error) {
+	appendToPath := func(name string, isNamed bool) error {
+		if !isNamed {
+			validFieldPath = validFieldPath.Key(name)
+			schema = schema.AdditionalProperties().Schema()
+		} else {
+			validFieldPath = validFieldPath.Child(name)
+			val, ok := schema.Properties()[name]
+			if !ok {
+				return fmt.Errorf("does not refer to a valid field")
+			}
+			schema = val
+		}
+		return nil
+	}
+
+	validFieldPath = nil
+
+	scanner := bufio.NewScanner(strings.NewReader(jsonPath))
+
+	// configure the scanner to split the string into tokens.
+	// The three delimiters ('.', '[', ']') will be returned as single char tokens.
+	// All other text between delimiters is returned as string tokens.
+	scanner.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if len(data) > 0 {
+			for i := 0; i < len(data); i++ {
+				// If in a single quoted string, look for the end of string
+				// ignoring delimiters.
+				if data[0] == '\'' {
+					if i > 0 && data[i] == '\'' && data[i-1] != '\\' {
+						// Return quoted string
+						return i + 1, data[:i+1], nil
+					}
+					continue
+				}
+				switch data[i] {
+				case '.', '[', ']': // delimiters
+					if i == 0 {
+						// Return the delimiter.
+						return 1, data[:1], nil
+					} else {
+						// Return identifier leading up to the delimiter.
+						// The next call to split will return the delimiter.
+						return i, data[:i], nil
+					}
+				}
+			}
+			if atEOF {
+				// Return the string.
+				return len(data), data, nil
+			}
+		}
+		return 0, nil, nil
+	})
+
+	var tok string
+	var isNamed bool
+	for scanner.Scan() {
+		tok = scanner.Text()
+		switch tok {
+		case "[":
+			if !scanner.Scan() {
+				return nil, fmt.Errorf("unexpected end of JSON path")
+			}
+			tok = scanner.Text()
+			if len(tok) < 2 || tok[0] != '\'' || tok[len(tok)-1] != '\'' {
+				return nil, fmt.Errorf("expected single quoted string but got %s", tok)
+			}
+			unescaped, err := unescapeSingleQuote(tok[1 : len(tok)-1])
+			if err != nil {
+				return nil, fmt.Errorf("invalid string literal: %v", err)
+			}
+
+			if schema.Properties() != nil {
+				isNamed = true
+			} else if schema.AdditionalProperties() != nil {
+				isNamed = false
+			} else {
+				return nil, fmt.Errorf("does not refer to a valid field")
+			}
+			if err := appendToPath(unescaped, isNamed); err != nil {
+				return nil, err
+			}
+			if !scanner.Scan() {
+				return nil, fmt.Errorf("unexpected end of JSON path")
+			}
+			tok = scanner.Text()
+			if tok != "]" {
+				return nil, fmt.Errorf("expected ] but got %s", tok)
+			}
+		case ".":
+			if !scanner.Scan() {
+				return nil, fmt.Errorf("unexpected end of JSON path")
+			}
+			tok = scanner.Text()
+			if schema.Properties() != nil {
+				isNamed = true
+			} else if schema.AdditionalProperties() != nil {
+				isNamed = false
+			} else {
+				return nil, fmt.Errorf("does not refer to a valid field")
+			}
+			if err := appendToPath(tok, isNamed); err != nil {
+				return nil, err
+			}
+		default:
+			return nil, fmt.Errorf("expected [ or . but got: %s", tok)
+		}
+	}
+	return validFieldPath, nil
+}
+
+// evalMessageExpression evaluates the given message expression and returns the evaluated string form and the remaining budget, or an error if one
+// occurred during evaluation.
+func evalMessageExpression(ctx context.Context, expr celgo.Program, exprSrc string, activation interpreter.Activation, remainingBudget int64) (string, int64, *cel.Error) {
+	evalResult, evalDetails, err := expr.ContextEval(ctx, activation)
+	if evalDetails == nil {
+		return "", -1, &cel.Error{
+			Type:   cel.ErrorTypeInternal,
+			Detail: fmt.Sprintf("runtime cost could not be calculated for messageExpression: %q", exprSrc),
+		}
+	}
+	rtCost := evalDetails.ActualCost()
+	if rtCost == nil {
+		return "", -1, &cel.Error{
+			Type:   cel.ErrorTypeInternal,
+			Detail: fmt.Sprintf("runtime cost could not be calculated for messageExpression: %q", exprSrc),
+		}
+	} else if *rtCost > math.MaxInt64 || int64(*rtCost) > remainingBudget {
+		return "", -1, &cel.Error{
+			Type:   cel.ErrorTypeInvalid,
+			Detail: "messageExpression evaluation failed due to running out of cost budget, no further validation rules will be run",
+		}
+	}
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "operation cancelled: actual cost limit exceeded") {
+			return "", -1, &cel.Error{
+				Type:   cel.ErrorTypeInvalid,
+				Detail: fmt.Sprintf("no further validation rules will be run due to call cost exceeds limit for messageExpression: %q", exprSrc),
+			}
+		}
+		return "", remainingBudget - int64(*rtCost), &cel.Error{
+			Detail: fmt.Sprintf("messageExpression evaluation failed due to: %v", err.Error()),
+		}
+	}
+	messageStr, ok := evalResult.Value().(string)
+	if !ok {
+		return "", remainingBudget - int64(*rtCost), &cel.Error{
+			Detail: "messageExpression failed to convert to string",
+		}
+	}
+	trimmedMsgStr := strings.TrimSpace(messageStr)
+	if len(trimmedMsgStr) > celconfig.MaxEvaluatedMessageExpressionSizeBytes {
+		return "", remainingBudget - int64(*rtCost), &cel.Error{
+			Detail: fmt.Sprintf("messageExpression beyond allowable length of %d", celconfig.MaxEvaluatedMessageExpressionSizeBytes),
+		}
+	} else if hasNewlines(trimmedMsgStr) {
+		return "", remainingBudget - int64(*rtCost), &cel.Error{
+			Detail: "messageExpression should not contain line breaks",
+		}
+	} else if len(trimmedMsgStr) == 0 {
+		return "", remainingBudget - int64(*rtCost), &cel.Error{
+			Detail: "messageExpression should evaluate to a non-empty string",
+		}
+	}
+	return trimmedMsgStr, remainingBudget - int64(*rtCost), nil
+}
+
+var newlineMatcher = regexp.MustCompile(`[\n]+`)
+
+func hasNewlines(s string) bool {
+	return newlineMatcher.MatchString(s)
+}
+
+func ruleMessageOrDefault(rule common.ValidationRule) string {
+	if len(rule.Message()) == 0 {
+		return fmt.Sprintf("failed rule: %s", ruleErrorString(rule))
+	} else {
+		return strings.TrimSpace(rule.Message())
+	}
+}
+
+func ruleErrorString(rule common.ValidationRule) string {
+	if len(rule.Message()) > 0 {
+		return strings.TrimSpace(rule.Message())
+	}
+	return strings.TrimSpace(rule.Rule())
+}
+
+type validationActivation struct {
+	self, oldSelf ref.Val
+	hasOldSelf    bool
+}
+
+func validationActivationWithOldSelf(sts common.Schema, obj, oldObj interface{}) interpreter.Activation {
+	va := &validationActivation{
+		self: common.UnstructuredToVal(obj, sts),
+	}
+	if oldObj != nil {
+		va.oldSelf = common.UnstructuredToVal(oldObj, sts) // +k8s:verify-mutation:reason=clone
+		va.hasOldSelf = true                               // +k8s:verify-mutation:reason=clone
+	}
+	return va
+}
+
+func validationActivationWithoutOldSelf(sts common.Schema, obj, _ interface{}) interpreter.Activation {
+	return &validationActivation{
+		self: common.UnstructuredToVal(obj, sts),
+	}
+}
+
+func (a *validationActivation) ResolveName(name string) (interface{}, bool) {
+	switch name {
+	case ScopedVarName:
+		return a.self, true
+	case OldScopedVarName:
+		return a.oldSelf, a.hasOldSelf
+	default:
+		return nil, false
+	}
+}
+
+func (a *validationActivation) Parent() interpreter.Activation {
+	return nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/constants.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/constants.go
@@ -1,0 +1,27 @@
+package apivalidation
+
+import (
+	"k8s.io/apiserver/pkg/cel/common"
+	"k8s.io/apiserver/pkg/cel/openapi"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// Validation library for a schema
+// against a typed or unstructured object
+type OpenAPISchemaType string
+
+const (
+	SchemaTypeString  OpenAPISchemaType = "string"
+	SchemaTypeNumber  OpenAPISchemaType = "number"
+	SchemaTypeInteger OpenAPISchemaType = "integer"
+	SchemaTypeArray   OpenAPISchemaType = "array"
+	SchemaTypeObject  OpenAPISchemaType = "object"
+	SchemaTypeBool    OpenAPISchemaType = "boolean"
+	SchemaTypeNull    OpenAPISchemaType = "null"
+)
+
+var WildcardSchema common.Schema = &openapi.Schema{Schema: &spec.Schema{VendorExtensible: spec.VendorExtensible{
+	Extensions: spec.Extensions{
+		"x-kubernetes-preserve-unknown-fields": true,
+	},
+}}}

--- a/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/default.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/default.go
@@ -1,0 +1,11 @@
+package apivalidation
+
+import (
+	"k8s.io/apiserver/pkg/cel/apivalidation/defaulting"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
+)
+
+func (v *ValidationSchema) ApplyDefaults(val value.Value) {
+	//!TODO: Move this to deserializer code?
+	defaulting.Default(val, v.Schema)
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/defaulting/algorithm.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/defaulting/algorithm.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaulting
+
+import (
+	"k8s.io/apiserver/pkg/cel/common"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
+)
+
+// isNonNullalbeNull returns true if the item is nil AND it's nullable
+func isNonNullableNull(x value.Value, s common.Schema) bool {
+	return (x == nil || x.IsNull()) && s != nil && s.Nullable() == false
+}
+
+// Default does defaulting of x depending on default values in s.
+// Default values from s are deep-copied.
+//
+// PruneNonNullableNullsWithoutDefaults has left the non-nullable nulls
+// that have a default here.
+func Default(x value.Value, s common.Schema) {
+	if s == nil {
+		return
+	}
+
+	switch {
+	case x.IsMap():
+		asMap := x.AsMap()
+		properties := s.Properties()
+		for k, prop := range properties {
+			def := prop.Default()
+			if def == nil {
+				continue
+			}
+
+			if v, found := asMap.Get(k); !found || isNonNullableNull(v, prop) {
+				asMap.Set(k, value.NewValueInterface(def))
+			}
+		}
+
+		asMap.Iterate(func(k string, v value.Value) bool {
+			if prop, found := properties[k]; found {
+				Default(v, prop)
+			} else if add := s.AdditionalProperties(); add != nil {
+				if isNonNullableNull(v, add.Schema()) {
+					asMap.Set(k, value.NewValueInterface(add.Schema().Default()))
+				}
+
+				Default(v, add.Schema())
+			}
+			return true
+		})
+	case x.IsList():
+		asList := x.AsList()
+		iter := asList.Range()
+
+		for iter.Next() {
+			i, v := iter.Item()
+			if isNonNullableNull(v, s.Items()) {
+				asList.Set(i, value.NewValueInterface(s.Items().Default()))
+			}
+			Default(v, s.Items())
+		}
+	default:
+		// scalars, do nothing
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/defaulting/prunenulls.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/defaulting/prunenulls.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaulting
+
+import (
+	"k8s.io/apiserver/pkg/cel/common"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
+)
+
+func isNonNullableNonDefaultableNull(x interface{}, s common.Schema) bool {
+	return x == nil && s != nil && s.Nullable() == false && s.Default() == nil
+}
+
+func getSchemaForField(field string, s common.Schema) common.Schema {
+	if s == nil {
+		return nil
+	}
+	schema, ok := s.Properties()[field]
+	if ok {
+		return schema
+	}
+	if add := s.AdditionalProperties(); add != nil {
+		if addSchema := add.Schema(); add != nil {
+			return addSchema
+		} else if add.Allows() {
+			panic("TODO: return wildcard schema")
+		}
+	}
+	return nil
+}
+
+// PruneNonNullableNullsWithoutDefaults removes non-nullable
+// non-defaultable null values from object.
+//
+// Non-nullable nulls that have a default are left alone here and will
+// be defaulted later.
+func PruneNonNullableNullsWithoutDefaults(x value.Value, s common.Schema) {
+	switch {
+	case x.IsMap():
+		asMap := x.AsMap()
+		asMap.Iterate(func(k string, v value.Value) bool {
+			schema := getSchemaForField(k, s)
+			if isNonNullableNonDefaultableNull(v, schema) {
+				asMap.Delete(k)
+			} else {
+				PruneNonNullableNullsWithoutDefaults(v, schema)
+			}
+			return true
+		})
+	case x.IsList():
+		var schema common.Schema
+		if s != nil {
+			schema = s.Items()
+		}
+
+		asList := x.AsList()
+		iter := asList.Range()
+
+		for iter.Next() {
+			_, v := iter.Item()
+			PruneNonNullableNullsWithoutDefaults(v, schema)
+		}
+	default:
+		// scalars, do nothing
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/errors.go
@@ -1,0 +1,98 @@
+package apivalidation
+
+import (
+	"encoding/json"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	openapierrors "k8s.io/kube-openapi/pkg/validation/errors"
+)
+
+// Copied from staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
+func kubeOpenAPIErrorToFieldError(fldPath *field.Path, err error) *field.Error {
+	switch err := err.(type) {
+	case *field.Error:
+		if err == nil {
+			return nil
+		}
+		if err.Field == "<nil>" {
+			err.Field = fldPath.String()
+		}
+		return err
+	case *openapierrors.Validation:
+		if err == nil {
+			return nil
+		}
+		errPath := fldPath
+		if len(err.Name) > 0 && err.Name != "." {
+			errPath = errPath.Child(strings.TrimPrefix(err.Name, "."))
+		}
+
+		switch err.Code() {
+		case openapierrors.RequiredFailCode:
+			return field.Required(errPath, "")
+
+		case openapierrors.EnumFailCode:
+			values := []string{}
+			for _, allowedValue := range err.Values {
+				if s, ok := allowedValue.(string); ok {
+					values = append(values, s)
+				} else {
+					allowedJSON, _ := json.Marshal(allowedValue)
+					values = append(values, string(allowedJSON))
+				}
+			}
+			return field.NotSupported(errPath, err.Value, values)
+
+		case openapierrors.TooLongFailCode:
+			value := interface{}("")
+			if err.Value != nil {
+				value = err.Value
+			}
+			max := int64(-1)
+			if i, ok := err.Valid.(int64); ok {
+				max = i
+			}
+			return field.TooLongMaxLength(errPath, value, int(max))
+
+		case openapierrors.MaxItemsFailCode:
+			actual := int64(-1)
+			if i, ok := err.Value.(int64); ok {
+				actual = i
+			}
+			max := int64(-1)
+			if i, ok := err.Valid.(int64); ok {
+				max = i
+			}
+			return field.TooMany(errPath, int(actual), int(max))
+
+		case openapierrors.TooManyPropertiesCode:
+			actual := int64(-1)
+			if i, ok := err.Value.(int64); ok {
+				actual = i
+			}
+			max := int64(-1)
+			if i, ok := err.Valid.(int64); ok {
+				max = i
+			}
+			return field.TooMany(errPath, int(actual), int(max))
+
+		case openapierrors.InvalidTypeCode:
+			value := interface{}("")
+			if err.Value != nil {
+				value = err.Value
+			}
+			return field.TypeInvalid(errPath, value, err.Error())
+
+		default:
+			value := interface{}("")
+			if err.Value != nil {
+				value = err.Value
+			}
+			return field.Invalid(errPath, value, err.Error())
+		}
+
+	default:
+		return field.Invalid(fldPath, "", err.Error())
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/lazy.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/lazy.go
@@ -1,0 +1,22 @@
+package apivalidation
+
+import "sync"
+
+type Lazy[T any] struct {
+	Calculate func() T
+	value     T
+	once      sync.Once
+}
+
+func NewLazy[T any](calc func() T) Lazy[T] {
+	return Lazy[T]{
+		Calculate: calc,
+	}
+}
+
+func (l *Lazy[T]) Value() T {
+	l.once.Do(func() {
+		l.value = l.Calculate()
+	})
+	return l.value
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/pruning/algorithm.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/pruning/algorithm.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pruning
+
+import (
+	"sort"
+
+	"k8s.io/apiserver/pkg/cel/common"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
+)
+
+// PruneWithOptions removes object fields in obj which are not specified in s. It skips TypeMeta
+// and ObjectMeta fields if XEmbeddedResource is set to true, or for the root if isResourceRoot=true,
+// i.e. it does not prune unknown metadata fields.
+// It returns the set of fields that it prunes if opts.TrackUnknownFieldPaths is true
+func PruneWithOptions(obj value.Value, s common.Schema, isResourceRoot bool, opts UnknownFieldPathOptions) []string {
+	// if isResourceRoot {
+	// 	if s == nil {
+	// 		s = &structuralschema.Structural{}
+	// 	}
+	// 	if !s.IsXEmbeddedResource() {
+	// 		clone := *s
+	// 		clone.XEmbeddedResource = true
+	// 		s = &clone
+	// 	}
+	// }
+	prune(obj, s, &opts)
+	sort.Strings(opts.UnknownFieldPaths)
+	return opts.UnknownFieldPaths
+}
+
+// Prune is equivalent to
+// PruneWithOptions(obj, s, isResourceRoot, UnknownFieldPathOptions{})
+func Prune(obj value.Value, s common.Schema, isResourceRoot bool) {
+	PruneWithOptions(obj, s, isResourceRoot, UnknownFieldPathOptions{})
+}
+
+var metaFields = map[string]bool{
+	"apiVersion": true,
+	"kind":       true,
+	"metadata":   true,
+}
+
+func prune(x interface{}, s common.Schema, opts *UnknownFieldPathOptions) {
+	if s != nil && s.IsXPreserveUnknownFields() {
+		skipPrune(x, s, opts)
+		return
+	}
+
+	origPathLen := len(opts.ParentPath)
+	defer func() {
+		opts.ParentPath = opts.ParentPath[:origPathLen]
+	}()
+	switch x := x.(type) {
+	case map[string]interface{}:
+		if s == nil {
+			for k := range x {
+				opts.RecordUnknownField(k)
+				delete(x, k)
+			}
+			return
+		}
+		for k, v := range x {
+			if s.IsXEmbeddedResource() && metaFields[k] {
+				continue
+			}
+			prop, ok := s.Properties()[k]
+			if ok {
+				opts.AppendKey(k)
+				prune(v, prop, opts)
+				opts.ParentPath = opts.ParentPath[:origPathLen]
+			} else if s.AdditionalProperties() != nil {
+				opts.AppendKey(k)
+				prune(v, s.AdditionalProperties().Schema(), opts)
+				opts.ParentPath = opts.ParentPath[:origPathLen]
+			} else {
+				if !metaFields[k] || len(opts.ParentPath) > 0 {
+					opts.RecordUnknownField(k)
+				}
+				delete(x, k)
+			}
+		}
+	case []interface{}:
+		if s == nil {
+			for i, v := range x {
+				opts.AppendIndex(i)
+				prune(v, nil, opts)
+				opts.ParentPath = opts.ParentPath[:origPathLen]
+			}
+			return
+		}
+		for i, v := range x {
+			opts.AppendIndex(i)
+			prune(v, s.Items(), opts)
+			opts.ParentPath = opts.ParentPath[:origPathLen]
+		}
+	default:
+		// scalars, do nothing
+	}
+}
+
+func skipPrune(x interface{}, s common.Schema, opts *UnknownFieldPathOptions) {
+	if s == nil {
+		return
+	}
+	origPathLen := len(opts.ParentPath)
+	defer func() {
+		opts.ParentPath = opts.ParentPath[:origPathLen]
+	}()
+
+	switch x := x.(type) {
+	case map[string]interface{}:
+		for k, v := range x {
+			if s.IsXEmbeddedResource() && metaFields[k] {
+				continue
+			}
+			if prop, ok := s.Properties()[k]; ok {
+				opts.AppendKey(k)
+				prune(v, prop, opts)
+				opts.ParentPath = opts.ParentPath[:origPathLen]
+			} else if s.AdditionalProperties() != nil {
+				opts.AppendKey(k)
+				prune(v, s.AdditionalProperties().Schema(), opts)
+				opts.ParentPath = opts.ParentPath[:origPathLen]
+			}
+		}
+	case []interface{}:
+		for i, v := range x {
+			opts.AppendIndex(i)
+			skipPrune(v, s.Items(), opts)
+			opts.ParentPath = opts.ParentPath[:origPathLen]
+		}
+	default:
+		// scalars, do nothing
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/pruning/options.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/pruning/options.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pruning
+
+import (
+	"strconv"
+	"strings"
+)
+
+// UnknownFieldPathOptions allow for tracking paths to unknown fields.
+type UnknownFieldPathOptions struct {
+	// TrackUnknownFieldPaths determines whether or not unknown field
+	// paths should be stored or not.
+	TrackUnknownFieldPaths bool
+	// ParentPath builds the path to unknown fields as the object
+	// is recursively traversed.
+	ParentPath []string
+	// UnknownFieldPaths is the list of all unknown fields identified.
+	UnknownFieldPaths []string
+}
+
+// RecordUnknownFields adds a path to an unknown field to the
+// record of UnknownFieldPaths, if TrackUnknownFieldPaths is true
+func (o *UnknownFieldPathOptions) RecordUnknownField(field string) {
+	if !o.TrackUnknownFieldPaths {
+		return
+	}
+	l := len(o.ParentPath)
+	o.AppendKey(field)
+	o.UnknownFieldPaths = append(o.UnknownFieldPaths, strings.Join(o.ParentPath, ""))
+	o.ParentPath = o.ParentPath[:l]
+}
+
+// AppendKey adds a key (i.e. field) to the current parent
+// path, if TrackUnknownFieldPaths is true.
+func (o *UnknownFieldPathOptions) AppendKey(key string) {
+	if !o.TrackUnknownFieldPaths {
+		return
+	}
+	if len(o.ParentPath) > 0 {
+		o.ParentPath = append(o.ParentPath, ".")
+	}
+	o.ParentPath = append(o.ParentPath, key)
+}
+
+// AppendIndex adds an index to the most recent field of
+// the current parent path, if TrackUnknownFieldPaths is true.
+func (o *UnknownFieldPathOptions) AppendIndex(index int) {
+	if !o.TrackUnknownFieldPaths {
+		return
+	}
+	o.ParentPath = append(o.ParentPath, "[", strconv.Itoa(index), "]")
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/result.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/result.go
@@ -1,0 +1,38 @@
+package apivalidation
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// Follows the structure of the schema representing validation state at
+// each node
+type Result struct {
+	Errors       []*field.Error
+	Warnings     []*field.Error
+	UpdateErrors []*field.Error
+	Path         *field.Path
+}
+
+func (r *Result) AddErrors(errs ...error) {
+	for _, e := range errs {
+		// This will not catch errors that are backed by nil pointer...
+		if e == nil {
+			continue
+		}
+		r.Errors = append(r.Errors, kubeOpenAPIErrorToFieldError(r.Path, e))
+	}
+}
+
+func (r *Result) IsValid() bool {
+	return len(r.Errors)+len(r.UpdateErrors) == 0
+}
+
+func (r *Result) Merge(other *Result) {
+	r.Errors = append(r.Errors, other.Errors...)
+	r.Warnings = append(r.Warnings, other.Warnings...)
+	r.UpdateErrors = append(r.UpdateErrors, other.UpdateErrors...)
+}
+
+func NewResult() *Result {
+	return &Result{}
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/schema.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/schema.go
@@ -1,0 +1,198 @@
+package apivalidation
+
+import (
+	"k8s.io/apiserver/pkg/cel/common"
+	"k8s.io/apiserver/pkg/cel/openapi"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+func NewValidationSchema(sch common.Schema) *ValidationSchema {
+	return &ValidationSchema{
+		Schema:  sch,
+		visited: map[*spec.Schema]*ValidationSchema{},
+	}
+}
+
+// ValidationSchema wraps a common.Schema to precompute & cache the results of
+// its subschema accessors and associated expensive-to-compute data associated
+// with a node in the schema such as CEL expressions.
+// !TODO: Lazy[T] everything
+type ValidationSchema struct {
+	common.Schema
+
+	celRules []CompilationResult
+	celError error
+
+	properties           map[string]common.Schema
+	additionalProperties common.SchemaOrBool
+	items                common.Schema
+
+	allOf []common.Schema
+	anyOf []common.Schema
+	oneOf []common.Schema
+	not   common.Schema
+
+	// OpenAPI schemas have the possibility of being recursive via shared
+	// references. We account for this by storing a pointer to the previously
+	// result into the map. That way we don't cache the same CEL expressions
+	// multiple times.
+	visited map[*spec.Schema]*ValidationSchema
+}
+
+func (v *ValidationSchema) Properties() map[string]common.Schema {
+	if v.properties != nil {
+		return v.properties
+	}
+
+	props := v.Schema.Properties()
+	newProps := make(map[string]common.Schema, len(props))
+	for k, value := range props {
+		newProps[k] = v.newValidationSchemaNode(value)
+	}
+	v.properties = newProps
+	return newProps
+}
+
+// AdditionalProperties returns the OpenAPI additional properties field,
+// or nil if this field does not exist.
+func (v *ValidationSchema) AdditionalProperties() common.SchemaOrBool {
+	if v.additionalProperties != nil {
+		return v.additionalProperties
+	}
+
+	var result common.SchemaOrBool
+	if additionalProperties := v.Schema.AdditionalProperties(); additionalProperties != nil {
+		if additionalPropertiesSchema := additionalProperties.Schema(); additionalPropertiesSchema != nil {
+			result = &SchemaOrBool{Value: v.newValidationSchemaNode(additionalPropertiesSchema)}
+		} else if additionalProperties.Allows() {
+			result = &SchemaOrBool{v.newValidationSchemaNode(WildcardSchema)}
+		}
+	}
+	v.additionalProperties = result
+	return result
+}
+
+func (v *ValidationSchema) Items() common.Schema {
+	if v.items != nil {
+		return v.items
+	}
+
+	nested := v.Schema.Items()
+	if nested == nil {
+		return nil
+	}
+
+	result := v.newValidationSchemaNode(nested)
+	v.items = result
+	return result
+}
+
+func (v *ValidationSchema) AllOf() []common.Schema {
+	if v.allOf != nil {
+		return v.allOf
+	}
+	nested := v.Schema.AllOf()
+	if nested == nil {
+		return nil
+	}
+
+	result := make([]common.Schema, 0, len(nested))
+	for _, value := range nested {
+		result = append(result, v.newValidationSchemaNode(value))
+	}
+	v.allOf = result
+	return result
+}
+
+func (v *ValidationSchema) OneOf() []common.Schema {
+	if v.oneOf != nil {
+		return v.oneOf
+	}
+
+	nested := v.Schema.OneOf()
+	if nested == nil {
+		return nil
+	}
+
+	result := make([]common.Schema, 0, len(nested))
+	for _, value := range nested {
+		result = append(result, v.newValidationSchemaNode(value))
+	}
+	v.oneOf = result
+	return result
+}
+
+func (v *ValidationSchema) AnyOf() []common.Schema {
+	if v.anyOf != nil {
+		return v.anyOf
+	}
+
+	nested := v.Schema.AnyOf()
+	if nested == nil {
+		return nil
+	}
+
+	result := make([]common.Schema, 0, len(nested))
+	for _, value := range nested {
+		result = append(result, v.newValidationSchemaNode(value))
+	}
+	v.anyOf = result
+	return result
+}
+func (v *ValidationSchema) Not() common.Schema {
+	if v.not != nil {
+		return v.not
+	}
+
+	nested := v.Schema.Not()
+	if nested == nil {
+		return nil
+	}
+	result := v.newValidationSchemaNode(nested)
+	v.not = result
+	return result
+}
+
+func (v *ValidationSchema) CELRules() ([]CompilationResult, error) {
+	if v.celRules != nil {
+		return v.celRules, v.celError
+	}
+	// Compile cel rules
+	compiledRules, compilationError := CompileSchema(v.Schema)
+	v.celRules = compiledRules
+	v.celError = compilationError
+	return compiledRules, compilationError
+}
+
+func (v *ValidationSchema) newValidationSchemaNode(sch common.Schema) *ValidationSchema {
+	specSchema, isKubeOpenAPI := sch.(*openapi.Schema)
+	if isKubeOpenAPI {
+		if previous, hasVisited := v.visited[specSchema.Schema]; hasVisited {
+			return previous
+		}
+	}
+
+	// Build schema validator
+	res := &ValidationSchema{
+		Schema:  sch,
+		visited: v.visited,
+	}
+
+	if isKubeOpenAPI {
+		v.visited[specSchema.Schema] = res
+	}
+
+	return res
+}
+
+type SchemaOrBool struct {
+	Value common.Schema
+}
+
+func (sb *SchemaOrBool) Schema() common.Schema {
+	return sb.Value
+}
+
+func (sb *SchemaOrBool) Allows() bool {
+	return sb.Value != nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/testing/framework.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/testing/framework.go
@@ -1,0 +1,156 @@
+package testing
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/cel/apivalidation"
+	"k8s.io/apiserver/pkg/cel/openapi"
+	"k8s.io/apiserver/pkg/cel/openapi/resolver"
+)
+
+type TestCase[T runtime.Object, O any] struct {
+	// Regex patterns of errors expected in any order
+	Name           string
+	ExpectedErrors []string
+	Object         T
+	OldObject      T
+	Options        O
+}
+
+// Matches the list of expected errors against the provided error list
+func (t TestCase[T, O]) Verify(errors field.ErrorList) error {
+	if len(t.ExpectedErrors) != len(errors) {
+		return fmt.Errorf("expected %d errors, got %d", len(t.ExpectedErrors), len(errors))
+	}
+	return nil
+}
+
+func TestValidate[T runtime.Object, O any](t *testing.T, scheme *runtime.Scheme, defs *resolver.DefinitionsSchemaResolver, validator func(T, O) field.ErrorList, cases ...TestCase[T, O]) {
+	// Run standard validation test
+	// namer := openapinamer.NewDefinitionNamer(scheme)
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			nativeErrors := validator(c.Object, c.Options)
+			if err := c.Verify(nativeErrors); err != nil {
+				t.Fatal(fmt.Errorf("native object validation failed: %w", err))
+			}
+
+			// Convert via the scheme the type to its versioned type
+			gvks, _, err := scheme.ObjectKinds(c.Object)
+			if err != nil {
+				t.Fatal(err)
+
+			}
+
+			//!TODO: multiple gvs?
+			for _, gvk := range gvks {
+				groupVersions := scheme.VersionsForGroupKind(gvk.GroupKind())
+				for _, gv := range groupVersions {
+					if gv.Version == runtime.APIVersionInternal {
+						continue
+					}
+
+					t.Run(gv.WithKind(gvk.Kind).String(), func(t *testing.T) {
+						// Look up its versioned type in the schema using the definition namer
+						converted, err := scheme.ConvertToVersion(c.Object, gv)
+						if err != nil {
+							t.Fatal(err)
+						}
+
+						k := reflect.TypeOf(converted).Elem().PkgPath() + "." + gvk.Kind
+						sch := defs.LookupSchema(k)
+						if sch == nil {
+							t.Fatal("definition not found")
+						}
+
+						vSch := apivalidation.NewValidationSchema(&openapi.Schema{Schema: sch})
+						schemaErrors := vSch.Validate(converted, apivalidation.ValidationOptions{})
+						if err := c.Verify(schemaErrors); err != nil {
+							t.Error(err)
+						}
+
+						if err := CompareErrorLists(nativeErrors, schemaErrors); err != nil {
+							t.Error(err)
+						}
+					})
+				}
+			}
+
+		})
+	}
+}
+
+// Compares a declarative validation error list with a legit one and
+// returns the diff
+func CompareErrorLists(lhs field.ErrorList, rhs field.ErrorList) error {
+	// Categorize each error by field path
+	// Make sure each field path list has matching errors
+	fieldsToErrorsLHS := map[string]field.ErrorList{}
+	fieldsToErrorsRHS := map[string]field.ErrorList{}
+	for _, v := range lhs {
+		if existing, exists := fieldsToErrorsLHS[v.Field]; exists {
+			fieldsToErrorsLHS[v.Field] = append(existing, v)
+		} else {
+			fieldsToErrorsLHS[v.Field] = field.ErrorList{v}
+		}
+	}
+
+	for _, v := range rhs {
+		if existing, exists := fieldsToErrorsRHS[v.Field]; exists {
+			fieldsToErrorsRHS[v.Field] = append(existing, v)
+		} else {
+			fieldsToErrorsRHS[v.Field] = field.ErrorList{v}
+		}
+	}
+
+	// Sort
+	for _, v := range fieldsToErrorsLHS {
+		sort.SliceStable(v, func(i, j int) bool {
+			iV := v[i]
+			jV := v[j]
+
+			if iV.Type < jV.Type {
+				return true
+			} else if iV.Type > jV.Type {
+				return false
+			} else if iV.Detail < jV.Detail {
+				return true
+			} else if iV.Detail > jV.Detail {
+				return false
+			}
+			return false
+		})
+	}
+
+	for _, v := range fieldsToErrorsRHS {
+		sort.SliceStable(v, func(i, j int) bool {
+			iV := v[i]
+			jV := v[j]
+
+			if iV.Type < jV.Type {
+				return true
+			} else if iV.Type > jV.Type {
+				return false
+			} else if iV.Detail < jV.Detail {
+				return true
+			} else if iV.Detail > jV.Detail {
+				return false
+			}
+			return false
+		})
+	}
+
+	// Diff
+	if diff := cmp.Diff(fieldsToErrorsLHS, fieldsToErrorsRHS); len(diff) != 0 {
+		return errors.New(diff)
+	}
+	return nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/validation.go
@@ -1,0 +1,872 @@
+package apivalidation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/apis/cel"
+	celconfig "k8s.io/apiserver/pkg/apis/cel"
+	"k8s.io/apiserver/pkg/cel/common"
+	"k8s.io/apiserver/pkg/cel/environment"
+	"k8s.io/kube-openapi/pkg/validation/errors"
+	"k8s.io/kube-openapi/pkg/validation/strfmt"
+	"k8s.io/kube-openapi/pkg/validation/validate"
+	"sigs.k8s.io/structured-merge-diff/v4/value"
+)
+
+type ValidationOptions struct {
+	PreserveUnknownFields bool
+	Ratcheting            bool
+	Allocator             value.Allocator
+	Registry              strfmt.Registry
+	CELCostBudget         *int64
+}
+
+type ChildKey struct {
+	Key   string
+	Index int
+}
+
+func (c ChildKey) String() string {
+	if len(c.Key) > 0 {
+		return c.Key
+	}
+	return strconv.Itoa(c.Index)
+}
+
+// ValidationContext represents the result of validating a value. The tree
+// follows the structure of the value and stores the correlated old value, if
+// possible.
+type ValidationContext struct {
+	Result
+	ValidationOptions
+
+	Value    value.Value
+	OldValue value.Value
+
+	// TODO: enum
+	Children map[ChildKey]*ValidationContext
+
+	hasParent        bool
+	comparisonResult *bool
+}
+
+func (v *ValidationSchema) Validate(new interface{}, options ValidationOptions) field.ErrorList {
+	value, err := toSMDValue(new)
+	if err != nil {
+		return field.ErrorList{field.InternalError(nil, err)}
+	}
+
+	if options.CELCostBudget == nil {
+		budget := int64(cel.RuntimeCELCostBudget)
+		options.CELCostBudget = &budget
+	}
+
+	if options.Registry == nil {
+		options.Registry = strfmt.Default
+	}
+
+	result := &ValidationContext{
+		Value:             value,
+		ValidationOptions: options,
+	}
+	validateNode(result, v)
+	res, _, _ := result.ErrorList()
+	return res
+}
+
+func (v *ValidationSchema) ValidateUpdate(new, old interface{}, options ValidationOptions) field.ErrorList {
+	value, err := toSMDValue(new)
+	if err != nil {
+		return field.ErrorList{field.InternalError(nil, err)}
+	}
+	oldValue, err := toSMDValue(old)
+	if err != nil {
+		return field.ErrorList{field.InternalError(nil, err)}
+	}
+
+	if options.CELCostBudget == nil {
+		budget := int64(cel.RuntimeCELCostBudget)
+		options.CELCostBudget = &budget
+	}
+	result := &ValidationContext{
+		Value:             value,
+		OldValue:          oldValue,
+		ValidationOptions: options,
+	}
+	validateNode(result, v)
+	res, updateErrors, _ := result.ErrorList()
+	return append(res, updateErrors...)
+}
+
+func toSMDValue(v interface{}) (value.Value, error) {
+	if val, ok := v.(value.Value); ok {
+		return val, nil
+	}
+
+	vT := reflect.ValueOf(&v)
+	for vT.Kind() == reflect.Interface || vT.Kind() == reflect.Pointer {
+		vT = vT.Elem()
+	}
+
+	if vT.Kind() == reflect.Struct {
+		if res, err := value.NewValueReflect(vT.Addr().Interface()); err == nil {
+			return res, nil
+		} else {
+			return nil, err
+		}
+	}
+
+	return value.NewValueInterface(v), nil
+}
+
+// Returns a validator that is capable of recursively validating the
+// given quantifier for the provided schemas
+func validateNode(result *ValidationContext, sch common.Schema) {
+	// Convert to SMD value
+	if result.Value.IsNull() {
+		validateType(result, sch)
+		validateEnum(result, sch)
+		return
+	}
+
+	// Common Validations
+	validateType(result, sch)
+	validateEnum(result, sch)
+	validateFormat(result, sch)
+
+	// Type-specific validations
+	validateString(result, sch)
+	validateNumber(result, sch)
+	validateSlice(result, sch)
+	validateMap(result, sch)
+	validateQuantifiers(result, sch)
+	validateCEL(result, sch)
+}
+
+func validateType(result *ValidationContext, sch common.Schema) {
+	typ := OpenAPISchemaType(sch.Type())
+	if len(typ) == 0 {
+		return
+	}
+
+	if expectedType := schemaTypeForValue(result.Value); expectedType != typ {
+		if (typ == SchemaTypeNumber && expectedType == SchemaTypeInteger) || (typ == SchemaTypeInteger && expectedType == SchemaTypeNumber) {
+			//!TODO: check if provided value is convertible to the expected type
+			// without loss of precision
+		} else if result.Value.IsNull() && sch.Nullable() {
+			// Don't throw an error if the value was null and the schema is nullable
+		} else {
+			result.AddErrors(errors.InvalidType("", "", string(typ), expectedType))
+
+		}
+	}
+}
+
+func validateEnum(result *ValidationContext, sch common.Schema) {
+	if enums := sch.Enum(); len(enums) > 0 {
+		matched := false
+		for _, enumValue := range enums {
+			smdEnumValue := value.NewValueInterface(enumValue)
+			if value.Equals(smdEnumValue, result.Value) {
+				matched = true
+				break
+			}
+		}
+
+		if !matched {
+			result.AddErrors(errors.EnumFail("", "", result.Value.Unstructured(), enums))
+		}
+	}
+}
+
+func validateFormat(result *ValidationContext, sch common.Schema) {
+	switch {
+	case result.Value.IsString():
+		// Ignore unrecognized formats in schemas.
+		// Formats that do not match the type of their schema should be checked
+		// during validation of the schema itself. This validator assumes the
+		// schema is valid.
+		if result.Registry.ContainsName(sch.Format()) {
+			if err := validate.FormatOf("", "", sch.Format(), result.Value.AsString(), result.Registry); err != nil {
+				result.AddErrors(err)
+			}
+		}
+	case result.Value.IsInt():
+		//!TODO: ensure format isn't float
+		//!TODO: int32, int64 format range validation
+	case result.Value.IsFloat():
+		//!TODO: ensure format isn't integer
+		//!TODO: float32, float64 format range validation
+	}
+}
+
+func validateNumber(result *ValidationContext, sch common.Schema) {
+	if !result.Value.IsFloat() && !result.Value.IsInt() {
+		return
+	}
+
+	var asFloat float64 = 0
+	if result.Value.IsFloat() {
+		asFloat = result.Value.AsFloat()
+	} else {
+		asFloat = float64(result.Value.AsInt())
+	}
+
+	if multiple := sch.MultipleOf(); multiple != nil {
+		// Is the constraint specifier within the range of the specific numeric type and format?
+		if err := validate.IsValueValidAgainstRange(*multiple, sch.Type(), sch.Format(), "MultipleOf", ""); err == nil {
+			result.AddErrors(validate.MultipleOfNativeType("", "", result.Value.Unstructured(), *multiple))
+		} else {
+			// Constraint nevertheless validated, converted as general number
+			result.AddErrors(err, validate.MultipleOf("", "", asFloat, *multiple))
+		}
+	}
+
+	if maximum := sch.Maximum(); maximum != nil {
+		// Is the constraint specifier within the range of the specific numeric type and format?
+		if err := validate.IsValueValidAgainstRange(*maximum, sch.Type(), sch.Format(), "Maximum boundary", ""); err == nil {
+			// Constraint validated with compatible types
+			result.AddErrors(validate.MaximumNativeType("", "", result.Value.Unstructured(), *maximum, sch.IsExclusiveMaximum()))
+
+		} else {
+			// Constraint nevertheless validated, converted as general number
+			result.AddErrors(err, validate.Maximum("", "", asFloat, *maximum, sch.IsExclusiveMaximum()))
+		}
+	}
+
+	if minimum := sch.Minimum(); minimum != nil {
+		// Is the constraint specifier within the range of the specific numeric type and format?
+		if err := validate.IsValueValidAgainstRange(*minimum, sch.Type(), sch.Format(), "Minimum boundary", ""); err == nil {
+			// Constraint validated with compatible types
+			result.AddErrors(validate.MinimumNativeType("", "", result.Value.Unstructured(), *minimum, sch.IsExclusiveMinimum()))
+
+		} else {
+			// Constraint nevertheless validated, converted as general number
+			result.AddErrors(err, validate.Minimum("", "", asFloat, *minimum, sch.IsExclusiveMinimum()))
+		}
+	}
+}
+
+func validateString(result *ValidationContext, sch common.Schema) {
+	if !result.Value.IsString() {
+		return
+	}
+
+	data := result.Value.AsString()
+
+	if max := sch.MaxLength(); max != nil {
+		result.AddErrors(validate.MaxLength("", "", data, *max))
+	}
+
+	if min := sch.MinLength(); min != nil {
+		result.AddErrors(validate.MinLength("", "", data, *min))
+	}
+
+	if pattern := sch.Pattern(); len(pattern) > 0 {
+		result.AddErrors(validate.Pattern("", "", data, pattern))
+	}
+}
+
+func findDuplicates(fldPath *field.Path, list value.List) ([]int, *field.Error) {
+	if list.Length() <= 1 {
+		return nil, nil
+	}
+
+	seenScalars := make(map[interface{}]int, list.Length())
+	seenCompounds := make(map[string]int, list.Length())
+	var nonUniqueIndices []int
+	for iter := list.Range(); iter.Next(); {
+		i, item := iter.Item()
+		x := item.Unstructured()
+		switch x.(type) {
+		case map[string]interface{}, []interface{}:
+			bs, err := json.Marshal(x)
+			if err != nil {
+				return nil, field.Invalid(fldPath.Index(i), x, "internal error")
+			}
+			s := string(bs)
+			if times, seen := seenCompounds[s]; !seen {
+				seenCompounds[s] = 1
+			} else {
+				seenCompounds[s]++
+				if times == 1 {
+					nonUniqueIndices = append(nonUniqueIndices, i)
+				}
+			}
+		default:
+			if times, seen := seenScalars[x]; !seen {
+				seenScalars[x] = 1
+			} else {
+				seenScalars[x]++
+				if times == 1 {
+					nonUniqueIndices = append(nonUniqueIndices, i)
+				}
+			}
+		}
+	}
+
+	return nonUniqueIndices, nil
+}
+
+func validateXListTypeSet(result *ValidationContext, list value.List) {
+	nonUnique, err := findDuplicates(result.Path, list)
+	if err != nil {
+		result.AddErrors(err)
+	} else {
+		for _, i := range nonUnique {
+			result.Index(i, nil, nil).AddErrors(field.Duplicate(nil, list.At(i).Unstructured()))
+		}
+	}
+}
+
+// !TODO: This should not be validated on the non-structural portions of the
+// schema
+func validateXListTypeMapKeys(result *ValidationContext, list value.List, mapKeys []string) {
+	// only allow nil and objects
+	for iter := list.Range(); iter.Next(); {
+		i, item := iter.Item()
+		if !item.IsNull() && !item.IsMap() {
+			result.Index(i, item, nil).AddErrors(field.Invalid(nil, item.Unstructured(), "must be an object for an array of list-type map"))
+			return
+		}
+	}
+
+	if list.Length() <= 1 {
+		return
+	}
+
+	// optimize simple case of one key
+	if len(mapKeys) == 1 {
+		type unspecifiedKeyValue struct{}
+
+		keyField := mapKeys[0]
+		keys := make([]interface{}, 0, list.Length())
+		for iter := list.Range(); iter.Next(); {
+			_, x := iter.Item()
+			if x.IsNull() {
+				keys = append(keys, unspecifiedKeyValue{}) // nil object means unspecified key
+				continue
+			}
+
+			xMap := x.AsMap()
+
+			// undefined key?
+			key, ok := xMap.Get(keyField)
+			if !ok {
+				keys = append(keys, unspecifiedKeyValue{})
+				continue
+			}
+
+			keys = append(keys, key.Unstructured())
+		}
+
+		nonUnique, err := findDuplicates(result.Path, value.NewValueInterface(keys).AsList())
+		if err != nil {
+			result.AddErrors(err)
+			return
+		}
+
+		for _, i := range nonUnique {
+			switch keys[i] {
+			case unspecifiedKeyValue{}:
+				result.Index(i, nil, nil).AddErrors(field.Duplicate(nil, map[string]interface{}{}))
+			default:
+				result.Index(i, nil, nil).AddErrors(field.Duplicate(nil, map[string]interface{}{keyField: keys[i]}))
+			}
+		}
+	}
+
+	// multiple key fields
+	keys := make([]interface{}, 0, list.Length())
+	for iter := list.Range(); iter.Next(); {
+		_, item := iter.Item()
+		key := map[string]interface{}{}
+		if item.IsNull() {
+			keys = append(keys, key)
+			continue
+		}
+
+		asMap := item.AsMap()
+		for _, keyField := range mapKeys {
+			if k, ok := asMap.Get(keyField); ok {
+				key[keyField] = k.Unstructured()
+			}
+		}
+
+		keys = append(keys, key)
+	}
+
+	nonUnique, err := findDuplicates(result.Path, value.NewValueInterface(keys).AsList())
+	if err != nil {
+		result.AddErrors(err)
+		return
+	}
+
+	for _, i := range nonUnique {
+		result.Index(i, nil, nil).AddErrors(field.Duplicate(nil, keys[i]))
+	}
+}
+
+func validateSlice(result *ValidationContext, sch common.Schema) {
+	if !result.Value.IsList() {
+		return
+	}
+
+	asList := result.Value.AsList()
+	asListLength := int64(asList.Length())
+
+	// Validate Properties on the node before recursing
+	if minimum := sch.MinItems(); minimum != nil && asListLength < *minimum {
+		result.AddErrors(errors.TooFewItems("", "", *minimum, asListLength))
+	}
+
+	if maximum := sch.MaxItems(); maximum != nil && asListLength < *maximum {
+		result.AddErrors(errors.TooManyItems("", "", *maximum, asListLength))
+	}
+
+	if sch.UniqueItems() || sch.XListType() == "set" {
+		validateXListTypeSet(result, asList)
+	}
+
+	if sch.XListType() == "map" {
+		validateXListTypeMapKeys(result, asList, sch.XListMapKeys())
+	}
+
+	var oldList common.MapList
+	if result.OldValue != nil && result.OldValue.IsList() {
+		oldAsList := result.OldValue.AsList()
+		oldItems := make([]interface{}, oldAsList.Length())
+		for i := 0; i < oldAsList.Length(); i++ {
+			oldItems = append(oldItems, oldAsList.At(i))
+		}
+		oldList = common.MakeMapList(sch, oldItems)
+	}
+
+	if items := sch.Items(); items != nil {
+		iter := asList.Range()
+		for iter.Next() {
+			idx, item := iter.Item()
+			var oldItemValue value.Value
+			if oldList != nil {
+				if oldItemValueValue := oldList.Get(result.Value); oldItemValueValue != nil {
+					oldItemValue, _ = oldItemValueValue.(value.Value)
+				}
+			}
+			validateNode(result.Index(idx, item, oldItemValue), items)
+		}
+	} else if !result.PreserveUnknownFields && sch.Type() == string(SchemaTypeArray) {
+		// Array with no items is an error without preserveunknownfields
+		//!TODO: This error is not thrown by earlier k8s validators.
+		// maybe do away with it?
+		// CRDs will never hit this, since they are validated not to
+		// native type schemas also wont hit it, since they are generated
+		// such that arrays always have items.
+		// leave here for sanity?
+		result.AddErrors(errors.PropertyNotAllowed("", "", ""))
+	} else {
+		// No schema for non-array is fine. A type error is thrown elsewhere.
+	}
+}
+
+func validateMap(result *ValidationContext, sch common.Schema) {
+	if !result.Value.IsMap() {
+		return
+	}
+
+	asMap := result.Value.AsMap()
+	asMapLength := int64(asMap.Length())
+
+	if minimum := sch.MinProperties(); minimum != nil && asMapLength < *minimum {
+		result.AddErrors(errors.TooFewProperties("", "", *minimum, int64(asMapLength)))
+	}
+
+	if maximum := sch.MaxProperties(); maximum != nil && asMapLength > *maximum {
+		result.AddErrors(errors.TooManyProperties("", "", *maximum, int64(asMapLength)))
+	}
+
+	var oldMap value.Map
+	if result.OldValue != nil && result.OldValue.IsMap() {
+		oldMap = result.OldValue.AsMap()
+	}
+
+	properties := sch.Properties()
+	additionalProperties := sch.AdditionalProperties()
+
+	asMap.Iterate(func(key string, fieldValue value.Value) bool {
+		var oldValue value.Value
+		if oldMap != nil {
+			oldValue, _ = oldMap.Get(key)
+		}
+
+		var childResult *ValidationContext
+		childSchema, hasChildSchema := properties[key]
+		if hasChildSchema {
+			childResult = result.Child(key, fieldValue, oldValue)
+		} else if additionalProperties != nil {
+			childResult = result.Key(key, fieldValue, oldValue)
+
+			if additionalPropertiesSchema := additionalProperties.Schema(); additionalPropertiesSchema != nil {
+				childSchema = additionalPropertiesSchema
+			} else if additionalProperties.Allows() {
+				childSchema = WildcardSchema
+			}
+		} else {
+			childResult = result.Key(key, fieldValue, oldValue)
+		}
+
+		if childSchema == nil {
+			childResult.AddErrors(errors.PropertyNotAllowed("", "", ""))
+		} else {
+			validateNode(childResult, childSchema)
+		}
+
+		return true
+	})
+
+	for _, key := range sch.Required() {
+		if !asMap.Has(key) {
+			var oldValue value.Value
+			if oldMap != nil {
+				oldValue, _ = oldMap.Get(key)
+			}
+			result.Child(key, value.NewValueInterface(nil), oldValue).AddErrors(errors.Required("", ""))
+		}
+	}
+}
+
+func validateQuantifiers(result *ValidationContext, sch common.Schema) {
+	if allOf := sch.AllOf(); len(allOf) > 0 {
+
+		numSuccess := 0
+		for _, s := range sch.AllOf() {
+			quantorResult := result.Clone()
+
+			validateNode(quantorResult, s)
+			if quantorResult.IsValid() {
+				numSuccess += 1
+			}
+			result.Merge(quantorResult)
+		}
+		if numSuccess != len(allOf) {
+			msg := ""
+			if numSuccess == 0 {
+				msg = ". None validated"
+			}
+			result.AddErrors(errors.New(errors.CompositeErrorCode, validate.MustValidateAllSchemasError, "", msg))
+		}
+	}
+
+	if anyOf := sch.AnyOf(); len(anyOf) > 0 {
+		var bestAnyOfFailure *ValidationContext
+		bestAnyofDepth := 0
+		var firstSuccess *ValidationContext
+		for _, s := range sch.AnyOf() {
+			quantorResult := result.Clone()
+			validateNode(quantorResult, s)
+
+			if quantorResult.IsValid() {
+				bestAnyOfFailure = nil
+				firstSuccess = quantorResult
+				break
+			}
+
+			if bestAnyOfFailure == nil {
+				bestAnyOfFailure = quantorResult
+				bestAnyofDepth = quantorResult.Depth()
+			} else if d := quantorResult.Depth(); d > bestAnyofDepth {
+				bestAnyOfFailure = quantorResult
+				bestAnyofDepth = d
+			}
+		}
+
+		if firstSuccess == nil {
+			result.AddErrors(errors.New(errors.CompositeErrorCode, validate.MustValidateAtLeastOneSchemaError, ""))
+			result.Merge(bestAnyOfFailure)
+		} else {
+			result.Merge(firstSuccess)
+		}
+	}
+
+	if oneOf := sch.OneOf(); len(oneOf) > 0 {
+		numOneOfValid := 0
+		var firstSuccess *ValidationContext
+		var bestOneOfFailure *ValidationContext
+		bestOneOfFailureDepth := 0
+
+		for _, s := range oneOf {
+			quantorResult := result.Clone()
+			validateNode(quantorResult, s)
+			if quantorResult.IsValid() {
+				numOneOfValid += 1
+				firstSuccess = quantorResult
+			} else if bestOneOfFailure == nil {
+				bestOneOfFailure = quantorResult
+				bestOneOfFailureDepth = quantorResult.Depth()
+			} else if d := quantorResult.Depth(); d > bestOneOfFailureDepth {
+				bestOneOfFailure = quantorResult
+				bestOneOfFailureDepth = d
+			}
+		}
+
+		if numOneOfValid == 1 {
+			result.Merge(firstSuccess)
+		} else if numOneOfValid == 0 {
+			result.Merge(bestOneOfFailure)
+			result.AddErrors(errors.New(errors.CompositeErrorCode, validate.MustValidateOnlyOneSchemaError, "", "Found none valid"))
+		} else {
+			result.AddErrors(errors.New(errors.CompositeErrorCode, validate.MustValidateOnlyOneSchemaError, "", fmt.Sprintf("Found %d alternatives", numOneOfValid)))
+		}
+	}
+
+	if not := sch.Not(); not != nil {
+		quantorResult := result.Clone()
+		validateNode(quantorResult, not)
+
+		// We keep inner IMPORTANT! errors no matter what MatchCount tells us
+		if quantorResult.IsValid() {
+			result.AddErrors(errors.New(errors.CompositeErrorCode, validate.MustNotValidateSchemaError, ""))
+		}
+	}
+}
+
+func CompileSchema(s common.Schema) ([]CompilationResult, error) {
+	// Todo: mative ypes should use new expressions env
+	// crds should use storedexpressions env
+	//!TODO: resource root argument is wrong
+	//!TODO: i dont like that we even inject type meta at all.
+	return compile(
+		s,
+		common.SchemaDeclType(s, s.IsXEmbeddedResource()),
+		celconfig.PerCallLimit,
+		environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion()),
+		StoredExpressionsEnvLoader(),
+	)
+}
+
+func validateCEL(result *ValidationContext, sch common.Schema) {
+	if result.CELCostBudget == nil {
+		return
+	}
+
+	var compiledRules []CompilationResult
+	var compilationError error
+
+	if vSch, ok := sch.(*ValidationSchema); ok {
+		compiledRules, compilationError = vSch.CELRules()
+	} else {
+		compiledRules, compilationError = CompileSchema(sch)
+	}
+
+	if compilationError != nil {
+		result.AddErrors(field.Invalid(result.Path, sch.Type(), fmt.Sprintf("rule compiler initialization error: %v", compilationError)))
+		return
+	} else if len(compiledRules) == 0 {
+		return
+	}
+
+	*result.CELCostBudget = validateExpressions(context.TODO(), result, sch, compiledRules, *result.CELCostBudget)
+}
+
+func schemaTypeForValue(val value.Value) OpenAPISchemaType {
+	switch {
+	case val.IsBool():
+		return SchemaTypeBool
+	case val.IsString():
+		return SchemaTypeString
+	case val.IsInt():
+		return SchemaTypeInteger
+	case val.IsFloat():
+		return SchemaTypeNumber
+	case val.IsMap():
+		return SchemaTypeObject
+	case val.IsList():
+		return SchemaTypeArray
+	case val.IsNull():
+		return SchemaTypeNull
+	default:
+		return SchemaTypeObject
+	}
+}
+
+func (r *ValidationContext) Merge(other *ValidationContext) {
+	r.Result.Merge(&other.Result)
+
+	for k, c := range other.Children {
+		if existing, exists := r.Children[k]; exists {
+			existing.Merge(c)
+		} else {
+			r.Children[k] = c
+		}
+	}
+}
+
+func (r *ValidationContext) Key(k string, value, oldValue value.Value) *ValidationContext {
+	key := ChildKey{Key: k}
+	if existing, exists := r.Children[key]; exists {
+		return existing
+	}
+	ret := &ValidationContext{
+		ValidationOptions: r.ValidationOptions,
+		Value:             value,
+		OldValue:          oldValue,
+		Result: Result{
+			Path: r.Path.Key(k),
+		},
+	}
+	if r.Children == nil {
+		r.Children = map[ChildKey]*ValidationContext{}
+	}
+	r.Children[key] = ret
+	return ret
+}
+
+func (r *ValidationContext) Index(index int, value, oldValue value.Value) *ValidationContext {
+	key := ChildKey{Index: index}
+	if existing, exists := r.Children[key]; exists {
+		if value != nil && existing.Value == nil {
+			existing.Value = value
+		}
+		if oldValue != nil && existing.OldValue == nil {
+			existing.Value = value
+		}
+		return existing
+	}
+	ret := &ValidationContext{
+		ValidationOptions: r.ValidationOptions,
+		Value:             value,
+		OldValue:          oldValue,
+		Result: Result{
+			Path: r.Path.Index(index),
+		},
+	}
+	if r.Children == nil {
+		r.Children = map[ChildKey]*ValidationContext{}
+	}
+	r.Children[key] = ret
+	return ret
+}
+
+func (r *ValidationContext) Child(k string, value, oldValue value.Value) *ValidationContext {
+	key := ChildKey{Key: k}
+	if existing, exists := r.Children[key]; exists {
+		return existing
+	}
+	ret := &ValidationContext{
+		ValidationOptions: r.ValidationOptions,
+		Value:             value,
+		OldValue:          oldValue,
+		Result: Result{
+			Path: r.Path.Child(k),
+		},
+	}
+	if r.Children == nil {
+		r.Children = map[ChildKey]*ValidationContext{}
+	}
+	r.Children[key] = ret
+	return ret
+}
+
+func (r *ValidationContext) IsRoot() bool {
+	//!TODO: would be cool if field.Path had more accessors and we could remove
+	// this field
+	return r.hasParent
+}
+
+func (r *ValidationContext) Clone() *ValidationContext {
+	return &ValidationContext{
+		Value:             r.Value,
+		OldValue:          r.OldValue,
+		ValidationOptions: r.ValidationOptions,
+		hasParent:         r.hasParent,
+		Result: Result{
+			Path: r.Path,
+		},
+	}
+}
+func (r *ValidationContext) IsValid() bool {
+	if !r.Result.IsValid() {
+		return false
+	}
+
+	for _, c := range r.Children {
+		if !c.IsValid() {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *ValidationContext) Depth() int {
+	maxChildDepth := 0
+	for _, c := range r.Children {
+		if d := c.Depth(); d > maxChildDepth {
+			maxChildDepth = d
+		}
+	}
+	return 1 + maxChildDepth
+}
+
+// CachedDeepEqual is equivalent to reflect.DeepEqual, but caches the
+// results in the tree of ratchetInvocationScratch objects on the way:
+//
+// For objects and arrays, this function will make a best effort to make
+// use of past DeepEqual checks performed by this Node's children, if available.
+//
+// If a lazy computation could not be found for all children possibly due
+// to validation logic short circuiting and skipping the children, then
+// this function simply defers to reflect.DeepEqual.
+func (r *ValidationContext) CachedDeepEqual() (res bool) {
+	if r.comparisonResult != nil {
+		return *r.comparisonResult
+	}
+
+	defer func() {
+		r.comparisonResult = &res
+	}()
+
+	if r.Value == nil && r.OldValue == nil {
+		return true
+	} else if r.Value == nil || r.OldValue == nil {
+		return false
+	} else if len(r.Children) == 0 {
+		return value.Equals(r.Value, r.OldValue)
+	}
+
+	// Correctly considers map-type lists due to fact that index here
+	// is only used for numbering. The correlation is stored in the
+	// childInvocation itself
+	//
+	// NOTE: This does not consider sets, since we don't correlate them.
+	for _, child := range r.Children {
+		// Query for child
+		if !child.CachedDeepEqual() {
+			// If one child is not equal the entire object is not equal
+			return false
+		}
+	}
+	return true
+}
+
+func (r *ValidationContext) ErrorList() (errors field.ErrorList, updateErrors field.ErrorList, warnings field.ErrorList) {
+	errors = append(errors, r.Errors...)
+	errors = append(errors, r.UpdateErrors...)
+	warnings = append(warnings, r.Warnings...)
+	for _, c := range r.Children {
+		childErrors, childUpdateErrors, childWarnings := c.ErrorList()
+		errors = append(errors, childErrors...)
+		updateErrors = append(updateErrors, childUpdateErrors...)
+		warnings = append(warnings, childWarnings...)
+	}
+
+	if r.OldValue != nil && len(errors) > 0 && r.Ratcheting && r.CachedDeepEqual() {
+		warnings = append(warnings, errors...)
+		errors = nil
+	}
+
+	return errors, updateErrors, warnings
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/apivalidation/validation_test.go
@@ -1,0 +1,7 @@
+package apivalidation_test
+
+import "testing"
+
+func TestValidation(t *testing.T) {
+
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/adaptor.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/adaptor.go
@@ -56,12 +56,27 @@ type Schema interface {
 
 // Validations contains OpenAPI validation that the CEL library uses.
 type Validations interface {
+	Pattern() string
+	Minimum() *float64
+	IsExclusiveMinimum() bool
+	Maximum() *float64
+	IsExclusiveMaximum() bool
+	MultipleOf() *float64
+	MinItems() *int64
 	MaxItems() *int64
+	MinLength() *int64
 	MaxLength() *int64
+	MinProperties() *int64
 	MaxProperties() *int64
 	Required() []string
 	Enum() []any
 	Nullable() bool
+	UniqueItems() bool
+
+	AllOf() []Schema
+	OneOf() []Schema
+	AnyOf() []Schema
+	Not() Schema
 }
 
 // KubeExtensions contains Kubernetes-specific extensions to the OpenAPI schema.
@@ -71,6 +86,16 @@ type KubeExtensions interface {
 	IsXPreserveUnknownFields() bool
 	XListType() string
 	XListMapKeys() []string
+	XMapType() string
+	XValidations() []ValidationRule
+}
+
+// ValidationRule represents a single x-kubernetes-validations rule.
+type ValidationRule interface {
+	Rule() string
+	Message() string
+	MessageExpression() string
+	FieldPath() string
 }
 
 // SchemaOrBool contains either a schema or a boolean indicating if the object

--- a/staging/src/k8s.io/apiserver/pkg/cel/openapi/adaptor.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/openapi/adaptor.go
@@ -54,6 +54,10 @@ func (s *Schema) Format() string {
 	return s.Schema.Format
 }
 
+func (s *Schema) Pattern() string {
+	return s.Schema.Pattern
+}
+
 func (s *Schema) Items() common.Schema {
 	if s.Schema.Items == nil || s.Schema.Items.Schema == nil {
 		return nil
@@ -86,12 +90,48 @@ func (s *Schema) Default() any {
 	return s.Schema.Default
 }
 
+func (s *Schema) Minimum() *float64 {
+	return s.Schema.Minimum
+}
+
+func (s *Schema) IsExclusiveMinimum() bool {
+	return s.Schema.ExclusiveMinimum
+}
+
+func (s *Schema) Maximum() *float64 {
+	return s.Schema.Maximum
+}
+
+func (s *Schema) IsExclusiveMaximum() bool {
+	return s.Schema.ExclusiveMaximum
+}
+
+func (s *Schema) MultipleOf() *float64 {
+	return s.Schema.MultipleOf
+}
+
+func (s *Schema) UniqueItems() bool {
+	return s.Schema.UniqueItems
+}
+
+func (s *Schema) MinItems() *int64 {
+	return s.Schema.MinItems
+}
+
 func (s *Schema) MaxItems() *int64 {
 	return s.Schema.MaxItems
 }
 
+func (s *Schema) MinLength() *int64 {
+	return s.Schema.MinLength
+}
+
 func (s *Schema) MaxLength() *int64 {
 	return s.Schema.MaxLength
+}
+
+func (s *Schema) MinProperties() *int64 {
+	return s.Schema.MinProperties
 }
 
 func (s *Schema) MaxProperties() *int64 {
@@ -110,6 +150,40 @@ func (s *Schema) Nullable() bool {
 	return s.Schema.Nullable
 }
 
+func (s *Schema) AllOf() []common.Schema {
+	var res []common.Schema
+	for _, nestedSchema := range s.Schema.AllOf {
+		nestedSchema := nestedSchema
+		res = append(res, &Schema{&nestedSchema})
+	}
+	return res
+}
+
+func (s *Schema) AnyOf() []common.Schema {
+	var res []common.Schema
+	for _, nestedSchema := range s.Schema.AnyOf {
+		nestedSchema := nestedSchema
+		res = append(res, &Schema{&nestedSchema})
+	}
+	return res
+}
+
+func (s *Schema) OneOf() []common.Schema {
+	var res []common.Schema
+	for _, nestedSchema := range s.Schema.OneOf {
+		nestedSchema := nestedSchema
+		res = append(res, &Schema{&nestedSchema})
+	}
+	return res
+}
+
+func (s *Schema) Not() common.Schema {
+	if s.Schema.Not == nil {
+		return nil
+	}
+	return &Schema{s.Schema.Not}
+}
+
 func (s *Schema) IsXIntOrString() bool {
 	return isXIntOrString(s.Schema)
 }
@@ -126,8 +200,16 @@ func (s *Schema) XListType() string {
 	return getXListType(s.Schema)
 }
 
+func (s *Schema) XMapType() string {
+	return getXMapType(s.Schema)
+}
+
 func (s *Schema) XListMapKeys() []string {
 	return getXListMapKeys(s.Schema)
+}
+
+func (s *Schema) XValidations() []common.ValidationRule {
+	return getXValidations(s.Schema)
 }
 
 func (s *Schema) WithTypeAndObjectMeta() common.Schema {

--- a/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/definitions.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/openapi/resolver/definitions.go
@@ -57,6 +57,25 @@ func NewDefinitionsSchemaResolver(scheme *runtime.Scheme, getDefinitions common.
 	}
 }
 
+func (d *DefinitionsSchemaResolver) LookupSchema(name string) *spec.Schema {
+	if res, ok := d.defs[name]; ok {
+		s, err := populateRefs(func(ref string) (*spec.Schema, bool) {
+			// find the schema by the ref string, and return a deep copy
+			def, ok := d.defs[ref]
+			if !ok {
+				return nil, false
+			}
+			s := def.Schema
+			return &s, true
+		}, &res.Schema)
+		if err != nil {
+			return nil
+		}
+		return s
+	}
+	return nil
+}
+
 func (d *DefinitionsSchemaResolver) ResolveSchema(gvk schema.GroupVersionKind) (*spec.Schema, error) {
 	s, ok := d.gvkToSchema[gvk]
 	if !ok {

--- a/test/integration/apimachinery/apivalidation_test.go
+++ b/test/integration/apimachinery/apivalidation_test.go
@@ -1,0 +1,51 @@
+package apimachinery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/cel/apivalidation"
+	"k8s.io/apiserver/pkg/cel/openapi"
+	openapiresolver "k8s.io/apiserver/pkg/cel/openapi/resolver"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/kube-openapi/pkg/validation/strfmt"
+	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
+)
+
+func TestSchemaValidation(t *testing.T) {
+	// My dude what a cool validator...can you validate a config map tho?
+	schemaResolver := openapiresolver.NewDefinitionsSchemaResolver(scheme.Scheme, generatedopenapi.GetOpenAPIDefinitions)
+	configMapSchema, err := schemaResolver.ResolveSchema(
+		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+	)
+	require.NoError(t, err)
+	validationSchema := apivalidation.NewValidationSchema(&openapi.Schema{Schema: configMapSchema})
+	options := apivalidation.ValidationOptions{
+		Ratcheting: true,
+		Registry:   strfmt.Default,
+	}
+	value := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					ResizePolicy: []v1.ContainerResizePolicy{
+						{
+							RestartPolicy: v1.ResourceResizeRestartPolicy("INVALID HAHA"),
+						},
+					},
+				},
+			},
+		},
+	}
+	scheme.Scheme.Default(value)
+
+	errs := validationSchema.Validate(value, options)
+	assert.Empty(t, errs)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a library that allows validation of native objects against a spec.Schema without modification. The library is mirrored off of the one in `kube-openapi` for unstructured and CRD's. It merges the functionality of the separate kube-openapi validator, listsetmaps, ratcheting.

KEP explains why a new library is used over modifying the existing ones:
- Existing validation libraries require structural.Schema, which our native types do not conform to.
- kube-openapi library is based off unstructured, we want to use `value.Value` to avoid unstructured conversion. 
- More control over error messages

So far the library has been tested to have near perfect parity with the existing suite when used against CRDs with `kubectl-validates` test cases. Near perfect because the error messages have been cleaned up a bit

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/4153
```
