### PR TITLE
kubeadm: clean up unnecessary references to UnknownCRISocket

### DIFF
--- a/cmd/kubeadm/app/cmd/certs.go
+++ b/cmd/kubeadm/app/cmd/certs.go
@@ -134,7 +134,7 @@ func (o *genCSRConfig) addFlagSet(flagSet *pflag.FlagSet) {
 func (o *genCSRConfig) load() (err error) {
 	o.kubeadmConfig, err = configutil.LoadOrDefaultInitConfiguration(
 		o.kubeadmConfigPath,
-		cmdutil.DefaultInitConfiguration(),
+		&kubeadmapiv1.InitConfiguration{},
 		&kubeadmapiv1.ClusterConfiguration{},
 		true, /* skipCRIDetect */
 	)
@@ -354,7 +354,7 @@ func getInternalCfg(cfgPath string, kubeconfigPath string, cfg kubeadmapiv1.Clus
 	}
 
 	// Read config from --config if provided. Otherwise, use the default configuration
-	return configutil.LoadOrDefaultInitConfiguration(cfgPath, cmdutil.DefaultInitConfiguration(), &cfg, true /* skipCRIDetect */)
+	return configutil.LoadOrDefaultInitConfiguration(cfgPath, &kubeadmapiv1.InitConfiguration{}, &cfg, true /* skipCRIDetect */)
 }
 
 // newCmdCertsExpiration creates a new `cert check-expiration` command.

--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -442,7 +442,7 @@ func newCmdConfigImagesList(out io.Writer, mockK8sVersion *string) *cobra.Comman
 
 // NewImagesList returns the underlying struct for the "kubeadm config images list" command
 func NewImagesList(cfgPath string, cfg *kubeadmapiv1old.ClusterConfiguration) (*ImagesList, error) {
-	initcfg, err := configutil.LoadOrDefaultInitConfiguration(cfgPath, cmdutil.DefaultInitConfiguration(), cfg, true /* skipCRIDetect */)
+	initcfg, err := configutil.LoadOrDefaultInitConfiguration(cfgPath, &kubeadmapiv1old.InitConfiguration{}, cfg, true /* skipCRIDetect */)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not convert cfg to an internal cfg")
 	}

--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -82,13 +82,8 @@ func TestImagesListRunWithCustomConfigPath(t *testing.T) {
 			},
 			configContents: []byte(dedent.Dedent(fmt.Sprintf(`
 apiVersion: %s
-kind: InitConfiguration
-nodeRegistration:
-  criSocket: %s
----
-apiVersion: %[1]s
 kind: ClusterConfiguration
-kubernetesVersion: %[3]s`, kubeadmapiv1.SchemeGroupVersion.String(), constants.UnknownCRISocket, constants.CurrentKubernetesVersion))),
+kubernetesVersion: %s`, kubeadmapiv1.SchemeGroupVersion.String(), constants.CurrentKubernetesVersion))),
 		},
 		{
 			name:               "use coredns",
@@ -98,13 +93,8 @@ kubernetesVersion: %[3]s`, kubeadmapiv1.SchemeGroupVersion.String(), constants.U
 			},
 			configContents: []byte(dedent.Dedent(fmt.Sprintf(`
 apiVersion: %s
-kind: InitConfiguration
-nodeRegistration:
-  criSocket: %s
----
-apiVersion: %[1]s
 kind: ClusterConfiguration
-kubernetesVersion: %[3]s`, kubeadmapiv1.SchemeGroupVersion.String(), constants.UnknownCRISocket, constants.MinimumControlPlaneVersion))),
+kubernetesVersion: %s`, kubeadmapiv1.SchemeGroupVersion.String(), constants.MinimumControlPlaneVersion))),
 		},
 	}
 

--- a/cmd/kubeadm/app/cmd/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/kubeconfig.go
@@ -65,7 +65,7 @@ func newCmdKubeConfigUtility(out io.Writer) *cobra.Command {
 // newCmdUserKubeConfig returns sub commands for kubeconfig phase
 func newCmdUserKubeConfig(out io.Writer) *cobra.Command {
 
-	initCfg := cmdutil.DefaultInitConfiguration()
+	initCfg := &kubeadmapiv1.InitConfiguration{}
 	clusterCfg := &kubeadmapiv1.ClusterConfiguration{}
 
 	var (

--- a/cmd/kubeadm/app/cmd/kubeconfig_test.go
+++ b/cmd/kubeadm/app/cmd/kubeconfig_test.go
@@ -45,9 +45,6 @@ func generateTestKubeadmConfig(dir, id, certDir, clusterName string) (string, er
 			AdvertiseAddress: "1.2.3.4",
 			BindPort:         1234,
 		},
-		NodeRegistration: kubeadmapiv1.NodeRegistrationOptions{
-			CRISocket: kubeadmconstants.UnknownCRISocket,
-		},
 	}
 	clusterCfg := kubeadmapiv1.ClusterConfiguration{
 		TypeMeta: metav1.TypeMeta{

--- a/cmd/kubeadm/app/cmd/phases/init/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/init/certs.go
@@ -138,11 +138,12 @@ func getCertPhaseFlags(name string) []string {
 }
 
 func getSANDescription(certSpec *certsphase.KubeadmCert) string {
-	//Defaulted config we will use to get SAN certs
-	defaultConfig := cmdutil.DefaultInitConfiguration()
-	// GetAPIServerAltNames errors without an AdvertiseAddress; this is as good as any.
-	defaultConfig.LocalAPIEndpoint = kubeadmapiv1.APIEndpoint{
-		AdvertiseAddress: "127.0.0.1",
+	// Defaulted config we will use to get SAN certs
+	defaultConfig := &kubeadmapiv1.InitConfiguration{
+		LocalAPIEndpoint: kubeadmapiv1.APIEndpoint{
+			// GetAPIServerAltNames errors without an AdvertiseAddress; this is as good as any.
+			AdvertiseAddress: "127.0.0.1",
+		},
 	}
 
 	defaultInternalConfig := &kubeadmapi.InitConfiguration{}

--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -90,7 +90,7 @@ func newCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 	tokenCmd.PersistentFlags().BoolVar(&dryRun,
 		options.DryRun, dryRun, "Whether to enable dry-run mode or not")
 
-	cfg := cmdutil.DefaultInitConfiguration()
+	cfg := &kubeadmapiv1.InitConfiguration{}
 
 	// Default values for the cobra help text
 	kubeadmscheme.Scheme.Default(cfg)

--- a/cmd/kubeadm/app/cmd/token_test.go
+++ b/cmd/kubeadm/app/cmd/token_test.go
@@ -36,7 +36,6 @@ import (
 	outputapischeme "k8s.io/kubernetes/cmd/kubeadm/app/apis/output/scheme"
 	outputapiv1alpha2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/output/v1alpha2"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/output"
 )
 
@@ -172,9 +171,6 @@ func TestRunCreateToken(t *testing.T) {
 						Usages: tc.usages,
 						Groups: tc.extraGroups,
 					},
-				},
-				NodeRegistration: kubeadmapiv1.NodeRegistrationOptions{
-					CRISocket: constants.UnknownCRISocket,
 				},
 			}
 

--- a/cmd/kubeadm/app/cmd/util/cmdutil.go
+++ b/cmd/kubeadm/app/cmd/util/cmdutil.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
-	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
@@ -101,17 +100,6 @@ func AddCRISocketFlag(flagSet *pflag.FlagSet, criSocket *string) {
 		criSocket, options.NodeCRISocket, *criSocket,
 		"Path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value; use this option only if you have more than one CRI installed or if you have non-standard CRI socket.",
 	)
-}
-
-// DefaultInitConfiguration return default InitConfiguration. Avoid running the CRI auto-detection
-// code as we don't need it.
-func DefaultInitConfiguration() *kubeadmapiv1.InitConfiguration {
-	initCfg := &kubeadmapiv1.InitConfiguration{
-		NodeRegistration: kubeadmapiv1.NodeRegistrationOptions{
-			CRISocket: kubeadmconstants.UnknownCRISocket, // avoid CRI detection
-		},
-	}
-	return initCfg
 }
 
 // InteractivelyConfirmAction asks the user whether they _really_ want to take the action.

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -1072,9 +1072,6 @@ func TestJoinIPCheck(t *testing.T) {
 		t.Skip("not a privileged user")
 	}
 	internalcfg, err := configutil.DefaultedJoinConfiguration(&kubeadmapiv1.JoinConfiguration{
-		NodeRegistration: kubeadmapiv1.NodeRegistrationOptions{
-			CRISocket: constants.UnknownCRISocket,
-		},
 		Discovery: kubeadmapiv1.Discovery{
 			BootstrapToken: &kubeadmapiv1.BootstrapTokenDiscovery{
 				Token:                    configutil.PlaceholderToken.Token.String(),

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -49,9 +49,7 @@ var cfgFiles = map[string][]byte{
 	"InitConfiguration_v1beta3": []byte(fmt.Sprintf(`
 apiVersion: %s
 kind: InitConfiguration
-nodeRegistration:
-  criSocket: %s
-`, kubeadmapiv1.SchemeGroupVersion.String(), kubeadmconstants.UnknownCRISocket)),
+`, kubeadmapiv1.SchemeGroupVersion.String())),
 	"ClusterConfiguration_v1beta3": []byte(fmt.Sprintf(`
 apiVersion: %s
 kind: ClusterConfiguration

--- a/cmd/kubeadm/app/util/config/initconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration_test.go
@@ -126,9 +126,6 @@ func TestDefaultTaintsMarshaling(t *testing.T) {
 					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
 					Kind:       constants.InitConfigurationKind,
 				},
-				NodeRegistration: kubeadmapiv1.NodeRegistrationOptions{
-					CRISocket: constants.UnknownCRISocket,
-				},
 			},
 			expectedTaintCnt: 1,
 		},
@@ -138,9 +135,6 @@ func TestDefaultTaintsMarshaling(t *testing.T) {
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
 					Kind:       constants.InitConfigurationKind,
-				},
-				NodeRegistration: kubeadmapiv1.NodeRegistrationOptions{
-					CRISocket: constants.UnknownCRISocket,
 				},
 			},
 			expectedTaintCnt: 1,
@@ -153,8 +147,7 @@ func TestDefaultTaintsMarshaling(t *testing.T) {
 					Kind:       constants.InitConfigurationKind,
 				},
 				NodeRegistration: kubeadmapiv1.NodeRegistrationOptions{
-					Taints:    []v1.Taint{},
-					CRISocket: constants.UnknownCRISocket,
+					Taints: []v1.Taint{},
 				},
 			},
 			expectedTaintCnt: 0,
@@ -171,7 +164,6 @@ func TestDefaultTaintsMarshaling(t *testing.T) {
 						{Key: "taint1"},
 						{Key: "taint2"},
 					},
-					CRISocket: constants.UnknownCRISocket,
 				},
 			},
 			expectedTaintCnt: 2,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Since #120828 has been merged, we are able to control whether to perform CRI detection by parameters, and pre-fill the `CRISocket` field of `InitConfiguration` is no longer needed.

This PR tries to clean up unnecessary references to `constants.UnknownCRISocket`.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #117614 #97625

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
