### PR TITLE
Add volume plugin label to SELinux metrics

### DIFF
--- a/pkg/kubelet/volumemanager/cache/desired_state_of_wold_selinux_metrics.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_wold_selinux_metrics.go
@@ -49,24 +49,30 @@ var (
 			Help:           "Number of errors when a Pod defines different SELinux contexts for its containers that use the same volume. They are not errors yet, but they will become real errors when SELinuxMountReadWriteOncePod feature is expanded to all volume access modes.",
 			StabilityLevel: compbasemetrics.ALPHA,
 		})
-	seLinuxVolumeContextMismatchErrors = compbasemetrics.NewGauge(
+	seLinuxVolumeContextMismatchErrors = compbasemetrics.NewGaugeVec(
 		&compbasemetrics.GaugeOpts{
 			Name:           "volume_manager_selinux_volume_context_mismatch_errors_total",
 			Help:           "Number of errors when a Pod uses a volume that is already mounted with a different SELinux context than the Pod needs. Kubelet can't start such a Pod then and it will retry, therefore value of this metric may not represent the actual nr. of Pods.",
 			StabilityLevel: compbasemetrics.ALPHA,
-		})
-	seLinuxVolumeContextMismatchWarnings = compbasemetrics.NewGauge(
+		},
+		[]string{"volume_plugin"},
+	)
+	seLinuxVolumeContextMismatchWarnings = compbasemetrics.NewGaugeVec(
 		&compbasemetrics.GaugeOpts{
 			Name:           "volume_manager_selinux_volume_context_mismatch_warnings_total",
 			Help:           "Number of errors when a Pod uses a volume that is already mounted with a different SELinux context than the Pod needs. They are not errors yet, but they will become real errors when SELinuxMountReadWriteOncePod feature is expanded to all volume access modes.",
 			StabilityLevel: compbasemetrics.ALPHA,
-		})
-	seLinuxVolumesAdmitted = compbasemetrics.NewGauge(
+		},
+		[]string{"volume_plugin"},
+	)
+	seLinuxVolumesAdmitted = compbasemetrics.NewGaugeVec(
 		&compbasemetrics.GaugeOpts{
 			Name:           "volume_manager_selinux_volumes_admitted_total",
 			Help:           "Number of volumes whose SELinux context was fine and will be mounted with mount -o context option.",
 			StabilityLevel: compbasemetrics.ALPHA,
-		})
+		},
+		[]string{"volume_plugin"},
+	)
 
 	registerMetrics sync.Once
 )

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/metrics"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/volume/csi"
 
 	resourcehelper "k8s.io/kubernetes/pkg/api/v1/resource"
 	"k8s.io/kubernetes/pkg/features"
@@ -273,6 +274,7 @@ func (dsw *desiredStateOfWorld) AddPodToVolume(
 			volumeSpec.Name(),
 			err)
 	}
+	volumePluginName := getVolumePluginNameWithDriver(volumePlugin, volumeSpec)
 
 	var volumeName v1.UniqueVolumeName
 
@@ -326,7 +328,7 @@ func (dsw *desiredStateOfWorld) AddPodToVolume(
 			effectiveSELinuxMountLabel = ""
 		}
 		if seLinuxFileLabel != "" {
-			seLinuxVolumesAdmitted.Add(1.0)
+			seLinuxVolumesAdmitted.WithLabelValues(volumePluginName).Add(1.0)
 		}
 		vmt := volumeToMount{
 			volumeName:                     volumeName,
@@ -355,7 +357,12 @@ func (dsw *desiredStateOfWorld) AddPodToVolume(
 				// TODO: update the error message after tests, e.g. add at least the conflicting pod names.
 				fullErr := fmt.Errorf("conflicting SELinux labels of volume %s: %q and %q", volumeSpec.Name(), vol.originalSELinuxLabel, seLinuxFileLabel)
 				supported := util.VolumeSupportsSELinuxMount(volumeSpec)
-				if err := handleSELinuxMetricError(fullErr, supported, seLinuxVolumeContextMismatchWarnings, seLinuxVolumeContextMismatchErrors); err != nil {
+				err := handleSELinuxMetricError(
+					fullErr,
+					supported,
+					seLinuxVolumeContextMismatchWarnings.WithLabelValues(volumePluginName),
+					seLinuxVolumeContextMismatchErrors.WithLabelValues(volumePluginName))
+				if err != nil {
 					return "", err
 				}
 			}
@@ -646,7 +653,7 @@ func (dsw *desiredStateOfWorld) getSELinuxMountSupport(volumeSpec *volume.Spec) 
 }
 
 // Based on isRWOP, bump the right warning / error metric and either consume the error or return it.
-func handleSELinuxMetricError(err error, seLinuxSupported bool, warningMetric, errorMetric *metrics.Gauge) error {
+func handleSELinuxMetricError(err error, seLinuxSupported bool, warningMetric, errorMetric metrics.GaugeMetric) error {
 	if seLinuxSupported {
 		errorMetric.Add(1.0)
 		return err
@@ -656,4 +663,22 @@ func handleSELinuxMetricError(err error, seLinuxSupported bool, warningMetric, e
 	warningMetric.Add(1.0)
 	klog.V(4).ErrorS(err, "Please report this error in https://github.com/kubernetes/enhancements/issues/1710, together with full Pod yaml file")
 	return nil
+}
+
+// Return the volume plugin name, together with the CSI driver name if it's a CSI volume.
+func getVolumePluginNameWithDriver(plugin volume.VolumePlugin, spec *volume.Spec) string {
+	pluginName := plugin.GetPluginName()
+	if pluginName != csi.CSIPluginName {
+		return pluginName
+	}
+
+	// It's a CSI volume
+	driverName, err := csi.GetCSIDriverName(spec)
+	if err != nil {
+		// In theory this is unreachable - such volume would not pass validation.
+		klog.V(4).ErrorS(err, "failed to get CSI driver name from volume spec")
+		driverName = "unknown"
+	}
+	// `/` is used to separate plugin + CSI driver in util.GetUniqueVolumeName() too
+	return pluginName + "/" + driverName
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Record volume plugin name when a volume in a Pod needs a different `"mount -o context"` value than the actually mounted one.

We expect that NFS, CIFS and CephFS volumes would be able to mount such volumes just fine with multiple `"-o context" ` values.

We know that the block-volume based ones (ext4, xfs, btrfs, ...) cannot do that.

Therefore I want to distinguish the volume plugin in metrics, anything block-volume based could break an existing application.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling
```
