### PR TITLE
Set gate SkipReadOnlyValidationGCE to Deprecated

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -142,7 +142,8 @@ const (
 	// owner: @mfordjody
 	// alpha: v1.26
 	//
-	// Skip validation Enable in next version
+	// Bypasses obsolete validation that GCP volumes are read-only when used in
+	// Deployments.
 	SkipReadOnlyValidationGCE featuregate.Feature = "SkipReadOnlyValidationGCE"
 
 	// owner: @trierra
@@ -1000,7 +1001,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	CSIVolumeHealth: {Default: false, PreRelease: featuregate.Alpha},
 
-	SkipReadOnlyValidationGCE: {Default: false, PreRelease: featuregate.Alpha},
+	SkipReadOnlyValidationGCE: {Default: true, PreRelease: featuregate.Deprecated}, // remove in 1.31
 
 	CloudControllerManagerWebhook: {Default: false, PreRelease: featuregate.Alpha},
 


### PR DESCRIPTION
This was created as alpha (off by default) but should probably have used the "Deprecated" setting.  Changing it now makes it on by default and still disable-able.

There was no KEP for this - it was considered a "cleanup" which we were being somewhat paranoid about.

```release-note
Previous versions of Kubernetes on Google Cloud required that workloads (e.g. Deployments, DaemonSets, etc.) which used PersistentDisk volumes were using them in read-only mode.  This validation provided very little value at relatively host implementation cost, and will no longer be validated.  If this is a problem for a specific use-case, please set the `SkipReadOnlyValidationGCE` gate to false to re-enable the validation, and file a kubernetes bug with details. 
```
