### PR TITLE
cache/reflector: Unblock waiters when resource not found

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -536,6 +536,18 @@ func (r *Reflector) list(stopCh <-chan struct{}) error {
 	}
 	initTrace.Step("Objects listed", trace.Field{Key: "error", Value: err})
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// There may be threads waiting for this resource to sync. If the resource wasn't found,
+			// then call sync with an empty list. This will unblock any clients waiting for the
+			// resource to sync, and is as accurate as possible. The server didn't have any of the
+			// requested resource.
+			newErr := r.syncWith([]runtime.Object{}, "")
+			if newErr != nil {
+				klog.Warningf("%s: failed to emergency sync reflector %v: %v",
+					r.name, r.typeDescription, newErr)
+			}
+		}
+
 		klog.Warningf("%s: failed to list %v: %v", r.name, r.typeDescription, err)
 		return fmt.Errorf("failed to list %v: %w", r.typeDescription, err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If a client is waiting for a resource to sync, and that resource is returned as 404 not found, let the clients know. To do this, sync with an empty list. Continue to return the error and print the warning.

This allows a client to watch for two versions of a resource when there was a rename, and not block indefinitely if one of the versions doesn't exist.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
A reflector request that receives a 404 will now sync with the empty list unblocking any clients that were waiting on that resource to sync.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

