### PR TITLE
hack: update golangci-lint verify scripts

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -33,7 +33,8 @@ source "${KUBE_ROOT}/third_party/forked/shell2junit/sh2ju.sh"
 EXCLUDED_PATTERNS=(
   "verify-all.sh"                # this script calls the make rule and would cause a loop
   "verify-*-dockerized.sh"       # Don't run any scripts that intended to be run dockerized
-  "verify-golangci-lint-pr.sh"   # Don't run this as part of the block pull-kubernetes-verify yet. TODO(pohly): try this in a non-blocking job and then reconsider this.
+  "verify-golangci-lint-pr.sh"   # Runs in a separate job for PRs.
+  "verify-golangci-lint-hints.sh" # Runs in a separate job for PRs.
   "verify-licenses.sh"           # runs in a separate job to monitor availability of the dependencies periodically
   "verify-openapi-docs-urls.sh"  # Spams docs URLs, don't run in CI.
   )

--- a/hack/verify-golangci-lint-pr-hints.sh
+++ b/hack/verify-golangci-lint-pr-hints.sh
@@ -28,4 +28,4 @@ fi
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
-"${KUBE_ROOT}/hack/verify-golangci-lint.sh" -r "${PULL_BASE_SHA}" -s
+"${KUBE_ROOT}/hack/verify-golangci-lint.sh" -r "${PULL_BASE_SHA}" -n


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Instead of invoking verify-golangci-lint.sh directly from Prow jobs, those Prow jobs should use "make verify WHAT=...". The advantage is that the common code for running verify targets will be used, which includes producing JUnit files.

Providing simple wrappers for strict linting of PRs (= verify-golangci-lint-pr.sh) and event stricter linting of PRs with hints enabled (= verify-golangci-lint-pr-hints.sh) enables those WHAT targets.

#### Special notes for your reviewer:

Right now the Prow jobs call verify-golangci-lint.sh directly. This will be changed after merging this PR.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
