### PR TITLE
[KMSv2] Add tracing

### DIFF
--- a/staging/src/k8s.io/component-base/tracing/tracing.go
+++ b/staging/src/k8s.io/component-base/tracing/tracing.go
@@ -68,6 +68,12 @@ func (s *Span) End(logThreshold time.Duration) {
 	}
 }
 
+// RecordError will record err as an exception span event for this span.
+// If this span is not being recorded or err is nil then this method does nothing.
+func (s *Span) RecordError(err error, attributes ...attribute.KeyValue) {
+	s.otelSpan.RecordError(err, trace.WithAttributes(attributes...))
+}
+
 func attributesToFields(attributes []attribute.KeyValue) []utiltrace.Field {
 	fields := make([]utiltrace.Field, len(attributes))
 	for i := range attributes {

--- a/test/integration/apiserver/tracing/tracing_test.go
+++ b/test/integration/apiserver/tracing/tracing_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -37,11 +40,157 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	kmsv2mock "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/testing/v2"
 	client "k8s.io/client-go/kubernetes"
 	utiltesting "k8s.io/client-go/util/testing"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
 )
+
+func TestAPIServerTracingWithKMSv2(t *testing.T) {
+	// Listen for traces from the API Server before starting it, so the
+	// API Server will successfully connect right away during the test.
+	listener, err := net.Listen("tcp", "localhost:")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encryptionConfigFile, err := os.CreateTemp("", "encryption-config.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(encryptionConfigFile.Name())
+
+	if err := os.WriteFile(encryptionConfigFile.Name(), []byte(`
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+    - secrets
+    providers:
+    - kms:
+       apiVersion: v2
+       name: kms-provider
+       endpoint: unix:///@kms-provider.sock`), os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write the configuration for tracing to a file
+	tracingConfigFile, err := os.CreateTemp("", "tracing-config.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tracingConfigFile.Name())
+
+	if err := os.WriteFile(tracingConfigFile.Name(), []byte(fmt.Sprintf(`
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: TracingConfiguration
+samplingRatePerMillion: 1000000
+endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := grpc.NewServer()
+	fakeServer := &traceServer{t: t}
+	fakeServer.resetExpectations([]*spanExpectation{})
+	traceservice.RegisterTraceServiceServer(srv, fakeServer)
+
+	go func() {
+		if err := srv.Serve(listener); err != nil {
+			t.Error(err)
+			return
+		}
+	}()
+	defer srv.Stop()
+
+	_ = kmsv2mock.NewBase64Plugin(t, "@kms-provider.sock")
+
+	// Start the API Server with our tracing configuration
+	testServer := kubeapiservertesting.StartTestServerOrDie(t,
+		kubeapiservertesting.NewDefaultTestServerOptions(),
+		[]string{
+			"--tracing-config-file=" + tracingConfigFile.Name(),
+			"--encryption-provider-config=" + encryptionConfigFile.Name(),
+		},
+		framework.SharedEtcd(),
+	)
+	defer testServer.TearDownFn()
+	clientSet, err := client.NewForConfig(testServer.ClientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		desc          string
+		apiCall       func(client.Interface) error
+		expectedTrace []*spanExpectation
+	}{
+		{
+			desc: "create secret",
+			apiCall: func(c client.Interface) error {
+				_, err = clientSet.CoreV1().Secrets(v1.NamespaceDefault).Create(context.Background(),
+					&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "fake"}, Data: map[string][]byte{"foo": []byte("bar")}}, metav1.CreateOptions{})
+				return err
+			},
+			expectedTrace: []*spanExpectation{
+				{
+					name: "TransformToStorage with envelopeTransformer",
+					attributes: map[string]func(*commonv1.AnyValue) bool{
+						"transformer.provider.name": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() == "kms-provider"
+						},
+					},
+					events: []string{
+						"About to encrypt data using DEK",
+						"Data encryption succeeded",
+						"About to encode encrypted object",
+						"Encoded encrypted object",
+					},
+				},
+			},
+		},
+		{
+			desc: "get secret",
+			apiCall: func(c client.Interface) error {
+				// This depends on the "create secret" step having completed successfully
+				_, err = clientSet.CoreV1().Secrets(v1.NamespaceDefault).Get(context.Background(), "fake", metav1.GetOptions{})
+				return err
+			},
+			expectedTrace: []*spanExpectation{
+				{
+					name: "TransformFromStorage with envelopeTransformer",
+					attributes: map[string]func(*commonv1.AnyValue) bool{
+						"transformer.provider.name": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() == "kms-provider"
+						},
+					},
+					events: []string{
+						"About to decode encrypted object",
+						"Decoded encrypted object",
+						"About to decrypt data using DEK",
+						"Data decryption succeeded",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeServer.resetExpectations(tc.expectedTrace)
+
+			// Make our call to the API server
+			if err := tc.apiCall(clientSet); err != nil {
+				t.Fatal(err)
+			}
+
+			// Wait for a span to be recorded from our request
+			select {
+			case <-fakeServer.traceFound:
+			case <-time.After(30 * time.Second):
+				t.Fatal("Timed out waiting for trace")
+			}
+		})
+	}
+}
 
 func TestAPIServerTracingWithEgressSelector(t *testing.T) {
 	// Listen for traces from the API Server before starting it, so the


### PR DESCRIPTION
- Add tracing for KMSv2 encrypt/decrypt operations

fixes https://github.com/kubernetes/kubernetes/issues/120881

/kind feature
/sig auth
/triage accepted
/milestone v1.29
/priority important-soon

```release-note
Enable traces for KMSv2 encrypt/decrypt operations.
```

```docs
[KEP] https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3299-kms-v2-improvements
```
