### PR TITLE
Fix kubectl in-cluster namespace defaulting logic

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -586,12 +586,6 @@ func (config *inClusterClientConfig) Namespace() (string, bool, error) {
 		return ns, false, nil
 	}
 
-	// If a kubeconfig file is specified and it doesn't contains the namespace attribute,
-	// it returns the default namespace to keep the namespace defaulting logic consistent.
-	if config.overrides != nil && config.overrides.Context.Namespace == "" {
-		return "default", false, nil
-	}
-
 	// Fall back to the namespace associated with the service account token, if available
 	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -586,6 +586,12 @@ func (config *inClusterClientConfig) Namespace() (string, bool, error) {
 		return ns, false, nil
 	}
 
+	// If a kubeconfig file is specified and it doesn't contains the namespace attribute,
+	// it returns the default namespace to keep the namespace defaulting logic consistent.
+	if config.overrides != nil && config.overrides.Context.Namespace == "" {
+		return "default", false, nil
+	}
+
 	// Fall back to the namespace associated with the service account token, if available
 	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {

--- a/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
@@ -141,6 +141,11 @@ func (config *DeferredLoadingClientConfig) Namespace() (string, bool, error) {
 		return ns, overridden, err
 	}
 
+	if !config.icc.Possible() && config.overrides != nil && config.overrides.Context.Namespace == "" {
+		// If the kubeconfig doesn't contain any namespace, use the default namespace
+		return "default", false, nil
+	}
+
 	if len(ns) > 0 {
 		// if we got a non-default namespace from the kubeconfig, use it
 		if ns != "default" {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig cli


#### What this PR does / why we need it:
This PR makes the kubectl in-cluster namespace defaulting logic consistent. 


#### Which issue(s) this PR fixes:
Closes #118693

#### Does this PR introduce a user-facing change?

```release-note
NONE
```