### PR TITLE
hack: fix update of golangci-lint verify scripts

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -33,8 +33,8 @@ source "${KUBE_ROOT}/third_party/forked/shell2junit/sh2ju.sh"
 EXCLUDED_PATTERNS=(
   "verify-all.sh"                # this script calls the make rule and would cause a loop
   "verify-*-dockerized.sh"       # Don't run any scripts that intended to be run dockerized
-  "verify-golangci-lint-pr.sh"   # Runs in a separate job for PRs.
-  "verify-golangci-lint-hints.sh" # Runs in a separate job for PRs.
+  "verify-golangci-lint-pr.sh"       # Runs in a separate job for PRs.
+  "verify-golangci-lint-pr-hints.sh" # Runs in a separate job for PRs.
   "verify-licenses.sh"           # runs in a separate job to monitor availability of the dependencies periodically
   "verify-openapi-docs-urls.sh"  # Spams docs URLs, don't run in CI.
   )


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

b190ea0c9 accidentally enabled verify-golangci-lint-pr-hints.sh (non-blocking!) in the normal "make verify" (blocking!).

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/pull/121086

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
