### PR TITLE
apiserver endpoints reconciler considers healthz

### DIFF
--- a/pkg/controlplane/controller/kubernetesservice/controller.go
+++ b/pkg/controlplane/controller/kubernetesservice/controller.go
@@ -238,7 +238,7 @@ func (c *Controller) CreateOrUpdateMasterServiceIfNeeded(serviceName string, ser
 
 	_, err := c.client.CoreV1().Services(metav1.NamespaceDefault).Create(context.TODO(), svc, metav1.CreateOptions{})
 	if errors.IsAlreadyExists(err) {
-		return c.CreateOrUpdateMasterServiceIfNeeded(serviceName, serviceIP, servicePorts, serviceType, reconcile)
+		return nil
 	}
 	return err
 }


### PR DESCRIPTION

/kind bug
/kind cleanup

apiserver endpoints reconciler considers healthz

The endpoint reconciler adds or removes the existing apiserver endpoint
as the backend of the kubernetes.default service, however, it always
assume that once the apiserver is healthy it will be always be healthy.

Add a check to the healthz endpoint in reach reconcile loop to perform
the corresponding operation, add or remove endpoint, depending on the
apiserver status.

Fixes #119535

```release-note
The endpoint-reconciler takes into account the health of the apiserver to add or remove the corresponding apiserver address as Endpoint of the kubernetes.default Service
```


```
$ go test k8s.io/kubernetes/pkg/controlplane/controller/kubernetesservice -v -count 1 -race -c
$ stress ./kubernetesservice.test -test.run TestUpdateKubernetesService
5s: 192 runs so far, 0 failures
10s: 384 runs so far, 0 failures
15s: 588 runs so far, 0 failures
20s: 816 runs so far, 0 failures
25s: 1016 runs so far, 0 failures
```

/sig api-machinery
