### PR TITLE
KCCM: fix GCP ILB by reintroducing readiness predicate for eTP:Local

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -1002,6 +1002,7 @@ var (
 	etpLocalNodePredicates []NodeConditionPredicate = []NodeConditionPredicate{
 		nodeIncludedPredicate,
 		nodeUnTaintedPredicate,
+		nodeReadyPredicate,
 	}
 	stableNodeSetPredicates []NodeConditionPredicate = []NodeConditionPredicate{
 		nodeNotDeletedPredicate,

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
@@ -523,6 +523,8 @@ func TestNodeChangesForExternalTrafficPolicyLocalServices(t *testing.T) {
 			},
 		},
 		expectedUpdateCalls: []fakecloud.UpdateBalancerCall{
+			{Service: etpLocalservice1, Hosts: []*v1.Node{node1, node3}},
+			{Service: etpLocalservice2, Hosts: []*v1.Node{node1, node3}},
 			{Service: service3, Hosts: []*v1.Node{node1, node3}},
 		},
 	}, {
@@ -547,6 +549,8 @@ func TestNodeChangesForExternalTrafficPolicyLocalServices(t *testing.T) {
 			},
 		},
 		expectedUpdateCalls: []fakecloud.UpdateBalancerCall{
+			{Service: etpLocalservice1, Hosts: []*v1.Node{node1, node2, node3}},
+			{Service: etpLocalservice2, Hosts: []*v1.Node{node1, node2, node3}},
 			{Service: service3, Hosts: []*v1.Node{node1, node2, node3}},
 		},
 	}, {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

As mentioned in the linked issue: service exposed through GCP ILBs might have their SLOs impacted as a consequence of applying a different set of predicates to different services (eTP: Cluster/Local), since all load balancers point to the same InstanceGroup. The fix here is therefore that we re-introduce the readiness predicate for eTP:Local services so that the predicates align across all classes of services. We can't do the inverse and remove the readiness predicate for eTP:Cluster, because that's the KEP-3458.  

/sig network
/sig cloud-provider
/assign @thockin 
/cc @aojea 

This PR should have no effect on >= 1.27 since the predicates are already aligned under the feature gate `StableLoadBalancerNodeSet`, but this should get in so that we guard against the broken behaviour should someone turn that feature gate off. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #121094

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix 121094 by re-introducing the readiness predicate for externalTrafficPolicy: Local services. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
