### PR TITLE
remove deprecated framework.ExpectEqual

### DIFF
--- a/test/e2e/framework/expect.go
+++ b/test/e2e/framework/expect.go
@@ -293,13 +293,6 @@ func (f *FailureError) backtrace() {
 //	}
 var ErrFailure error = FailureError{}
 
-// ExpectEqual expects the specified two are the same, otherwise an exception raises
-//
-// Deprecated: use gomega.Expect().To(gomega.Equal())
-func ExpectEqual(actual interface{}, extra interface{}, explain ...interface{}) {
-	gomega.ExpectWithOffset(1, actual).To(gomega.Equal(extra), explain...)
-}
-
 // ExpectNotEqual expects the specified two are not the same, otherwise an exception raises
 //
 // Deprecated: use gomega.Expect().ToNot(gomega.Equal())

--- a/test/e2e/framework/log_test.go
+++ b/test/e2e/framework/log_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
+	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -36,8 +37,7 @@ import (
 // Be careful when moving it around or changing the import statements above.
 // Here are some intentionally blank lines that can be removed to compensate
 // for future additional import statements.
-//
-// This must be line #39.
+// This must be line #40.
 
 // This is included in a stack backtrace.
 func failHelper(msg string) {
@@ -50,7 +50,7 @@ var _ = ginkgo.Describe("log", func() {
 	})
 	ginkgo.AfterEach(func() {
 		framework.Logf("after")
-		framework.ExpectEqual(true, false, "true is never false either")
+		gomega.Expect(true).To(gomega.BeFalse(), "true is never false either")
 	})
 	ginkgo.It("fails", func() {
 		func() {
@@ -58,14 +58,14 @@ var _ = ginkgo.Describe("log", func() {
 		}()
 	})
 	ginkgo.It("asserts", func() {
-		framework.ExpectEqual(false, true, "false is never true")
+		gomega.Expect(false).To(gomega.BeTrue(), "false is never true")
 	})
 	ginkgo.It("error", func() {
 		err := errors.New("an error with a long, useless description")
 		framework.ExpectNoError(err, "hard-coded error")
 	})
 	ginkgo.It("equal", func() {
-		framework.ExpectEqual(0, 1, "of course it's not equal...")
+		gomega.Expect(0).To(gomega.Equal(1), "of course it's not equal...")
 	})
 	ginkgo.It("fails with helper", func() {
 		failHelper("I'm failing with helper.")
@@ -109,8 +109,7 @@ INFO: after
 [FAILED] true is never false either
 Expected
     <bool>: true
-to equal
-    <bool>: false
+to be false
 In [AfterEach] at: log_test.go:53 <time>
 < Exit [AfterEach] log - log_test.go:51 <time>
 `,
@@ -123,8 +122,7 @@ In [AfterEach] at: log_test.go:53 <time>
 						Description: `[FAILED] false is never true
 Expected
     <bool>: false
-to equal
-    <bool>: true
+to be true
 In [It] at: log_test.go:61 <time>
 
 There were additional failures detected after the initial failure. These are visible in the timeline
@@ -137,8 +135,7 @@ INFO: before
 [FAILED] false is never true
 Expected
     <bool>: false
-to equal
-    <bool>: true
+to be true
 In [It] at: log_test.go:61 <time>
 < Exit [It] asserts - log_test.go:60 <time>
 > Enter [AfterEach] log - log_test.go:51 <time>
@@ -146,8 +143,7 @@ INFO: after
 [FAILED] true is never false either
 Expected
     <bool>: true
-to equal
-    <bool>: false
+to be false
 In [AfterEach] at: log_test.go:53 <time>
 < Exit [AfterEach] log - log_test.go:51 <time>
 `,
@@ -181,8 +177,7 @@ INFO: after
 [FAILED] true is never false either
 Expected
     <bool>: true
-to equal
-    <bool>: false
+to be false
 In [AfterEach] at: log_test.go:53 <time>
 < Exit [AfterEach] log - log_test.go:51 <time>
 `,
@@ -218,8 +213,7 @@ INFO: after
 [FAILED] true is never false either
 Expected
     <bool>: true
-to equal
-    <bool>: false
+to be false
 In [AfterEach] at: log_test.go:53 <time>
 < Exit [AfterEach] log - log_test.go:51 <time>
 `,
@@ -247,8 +241,7 @@ INFO: after
 [FAILED] true is never false either
 Expected
     <bool>: true
-to equal
-    <bool>: false
+to be false
 In [AfterEach] at: log_test.go:53 <time>
 < Exit [AfterEach] log - log_test.go:51 <time>
 `,
@@ -261,8 +254,7 @@ In [AfterEach] at: log_test.go:53 <time>
 						Description: `[FAILED] true is never false either
 Expected
     <bool>: true
-to equal
-    <bool>: false
+to be false
 In [AfterEach] at: log_test.go:53 <time>
 `,
 					},
@@ -278,8 +270,7 @@ INFO: after
 [FAILED] true is never false either
 Expected
     <bool>: true
-to equal
-    <bool>: false
+to be false
 In [AfterEach] at: log_test.go:53 <time>
 < Exit [AfterEach] log - log_test.go:51 <time>
 `,

--- a/test/e2e/framework/node/helper.go
+++ b/test/e2e/framework/node/helper.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,7 +64,7 @@ func ExpectNodeHasLabel(ctx context.Context, c clientset.Interface, nodeName str
 	ginkgo.By("verifying the node has the label " + labelKey + " " + labelValue)
 	node, err := c.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	framework.ExpectNoError(err)
-	framework.ExpectEqual(node.Labels[labelKey], labelValue)
+	gomega.Expect(node.Labels).To(gomega.HaveKeyWithValue(labelKey, labelValue))
 }
 
 // RemoveLabelOffNode is for cleaning up labels temporarily added to node,

--- a/test/e2e/framework/security/apparmor.go
+++ b/test/e2e/framework/security/apparmor.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -128,7 +129,7 @@ done`, testCmd)
 
 	// Verify Pod affinity colocated the Pods.
 	loader := getRunningLoaderPod(ctx, nsName, clientset)
-	framework.ExpectEqual(pod.Spec.NodeName, loader.Spec.NodeName)
+	gomega.Expect(pod.Spec.NodeName).To(gomega.Equal(loader.Spec.NodeName))
 
 	return pod
 }

--- a/test/e2e/framework/timer/timer_test.go
+++ b/test/e2e/framework/timer/timer_test.go
@@ -21,8 +21,6 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
-
-	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 var currentTime time.Time
@@ -66,9 +64,9 @@ func TestTimer(t *testing.T) {
 			}
 		]
 	}`))
-	framework.ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 5.5s so far
+	gomega.Expect(timer.PrintHumanReadable()).To(gomega.Equal(`Phase 001-one: 5.5s so far
 Phase 033-two: 3.5s
-`)
+`))
 
 	setCurrentTimeSinceEpoch(7*time.Second + 500*time.Millisecond)
 	phaseOne.End()
@@ -88,7 +86,7 @@ Phase 033-two: 3.5s
 			}
 		]
 	}`))
-	framework.ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 6.5s
+	gomega.Expect(timer.PrintHumanReadable()).To(gomega.Equal(`Phase 001-one: 6.5s
 Phase 033-two: 3.5s
-`)
+`))
 }

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -808,7 +808,7 @@ retriesLoop:
 		if errs.Len() > 0 {
 			Failf("Unexpected error(s): %v", strings.Join(errs.List(), "\n - "))
 		}
-		ExpectEqual(totalValidWatchEvents, len(expectedWatchEvents), "Error: there must be an equal amount of total valid watch events (%d) and expected watch events (%d)", totalValidWatchEvents, len(expectedWatchEvents))
+		gomega.Expect(expectedWatchEvents).To(gomega.HaveLen(totalValidWatchEvents), "Error: there must be an equal amount of total valid watch events (%d) and expected watch events (%d)", totalValidWatchEvents, len(expectedWatchEvents))
 		break retriesLoop
 	}
 }

--- a/test/e2e/framework/volume/fixtures.go
+++ b/test/e2e/framework/volume/fixtures.go
@@ -697,7 +697,7 @@ func VerifyExecInPodFail(f *framework.Framework, pod *v1.Pod, shExec string, exi
 	if err != nil {
 		if exiterr, ok := err.(clientexec.ExitError); ok {
 			actualExitCode := exiterr.ExitStatus()
-			framework.ExpectEqual(actualExitCode, exitCode,
+			gomega.Expect(actualExitCode).To(gomega.Equal(exitCode),
 				"%q should fail with exit code %d, but failed with exit code %d and error message %q\nstdout: %s\nstderr: %s",
 				shExec, exitCode, actualExitCode, exiterr, stdout, stderr)
 		} else {

--- a/test/e2e_node/container_manager_test.go
+++ b/test/e2e_node/container_manager_test.go
@@ -94,7 +94,7 @@ var _ = SIGDescribe("Container Manager Misc [Serial]", func() {
 			ginkgo.It("Kubelet's oom-score-adj should be -999", func(ctx context.Context) {
 				kubeletPids, err := getPidsForProcess(kubeletProcessName, "")
 				framework.ExpectNoError(err, "failed to get list of kubelet pids")
-				framework.ExpectEqual(len(kubeletPids), 1, "expected only one kubelet process; found %d", len(kubeletPids))
+				gomega.Expect(kubeletPids).To(gomega.HaveLen(1), "expected only one kubelet process; found %d", len(kubeletPids))
 				gomega.Eventually(ctx, func() error {
 					return validateOOMScoreAdjSetting(kubeletPids[0], -999)
 				}, 5*time.Minute, 30*time.Second).Should(gomega.BeNil())

--- a/test/e2e_node/density_test.go
+++ b/test/e2e_node/density_test.go
@@ -378,8 +378,8 @@ func runDensityBatchTest(ctx context.Context, f *framework.Framework, rc *Resour
 	)
 
 	for name, create := range createTimes {
-		watch, ok := watchTimes[name]
-		framework.ExpectEqual(ok, true)
+		watch := watchTimes[name]
+		gomega.Expect(watchTimes).To(gomega.HaveKey(name))
 
 		e2eLags = append(e2eLags,
 			e2emetrics.PodLatencyData{Name: name, Latency: watch.Time.Sub(create.Time)})
@@ -513,12 +513,16 @@ func newInformerWatchPod(ctx context.Context, f *framework.Framework, mutex *syn
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				p, ok := obj.(*v1.Pod)
-				framework.ExpectEqual(ok, true)
+				if !ok {
+					framework.Failf("Failed to cast object %T to Pod", obj)
+				}
 				go checkPodRunning(p)
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				p, ok := newObj.(*v1.Pod)
-				framework.ExpectEqual(ok, true)
+				if !ok {
+					framework.Failf("Failed to cast object %T to Pod", newObj)
+				}
 				go checkPodRunning(p)
 			},
 		},
@@ -554,8 +558,8 @@ func createBatchPodSequential(ctx context.Context, f *framework.Framework, pods 
 	}
 
 	for name, create := range createTimes {
-		watch, ok := watchTimes[name]
-		framework.ExpectEqual(ok, true)
+		watch := watchTimes[name]
+		gomega.Expect(watchTimes).To(gomega.HaveKey(name))
 		if !init {
 			if firstCreate.Time.After(create.Time) {
 				firstCreate = create
@@ -635,8 +639,9 @@ func logAndVerifyLatency(ctx context.Context, batchLag time.Duration, e2eLags []
 
 		// check bactch pod creation latency
 		if podBatchStartupLimit > 0 {
-			framework.ExpectEqual(batchLag <= podBatchStartupLimit, true, "Batch creation startup time %v exceed limit %v",
-				batchLag, podBatchStartupLimit)
+			if batchLag > podBatchStartupLimit {
+				framework.Failf("Batch creation startup time %v exceed limit %v", batchLag, podBatchStartupLimit)
+			}
 		}
 	}
 }

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -355,7 +355,7 @@ func getNode(c *clientset.Clientset) (*v1.Node, error) {
 	if nodes == nil {
 		return nil, fmt.Errorf("the node list is nil")
 	}
-	framework.ExpectEqual(len(nodes.Items) > 1, false, "the number of nodes is more than 1.")
+	gomega.Expect(len(nodes.Items)).To(gomega.BeNumerically("<=", 1), "the number of nodes is more than 1.")
 	if len(nodes.Items) == 0 {
 		return nil, fmt.Errorf("empty node list: %+v", nodes)
 	}

--- a/test/e2e_node/memory_manager_test.go
+++ b/test/e2e_node/memory_manager_test.go
@@ -280,7 +280,7 @@ var _ = SIGDescribe("Memory Manager [Disruptive] [Serial] [Feature:MemoryManager
 		currentNUMANodeIDs, err := cpuset.Parse(strings.Trim(output, "\n"))
 		framework.ExpectNoError(err)
 
-		framework.ExpectEqual(numaNodeIDs, currentNUMANodeIDs.List())
+		gomega.Expect(numaNodeIDs).To(gomega.Equal(currentNUMANodeIDs.List()))
 	}
 
 	waitingForHugepages := func(ctx context.Context, hugepagesCount int) {
@@ -394,16 +394,16 @@ var _ = SIGDescribe("Memory Manager [Disruptive] [Serial] [Feature:MemoryManager
 			framework.ExpectNoError(err)
 
 			stateAllocatableMemory := getAllocatableMemoryFromStateFile(stateData)
-			framework.ExpectEqual(len(resp.Memory), len(stateAllocatableMemory))
+			gomega.Expect(resp.Memory).To(gomega.HaveLen(len(stateAllocatableMemory)))
 
 			for _, containerMemory := range resp.Memory {
 				gomega.Expect(containerMemory.Topology).NotTo(gomega.BeNil())
-				framework.ExpectEqual(len(containerMemory.Topology.Nodes), 1)
+				gomega.Expect(containerMemory.Topology.Nodes).To(gomega.HaveLen(1))
 				gomega.Expect(containerMemory.Topology.Nodes[0]).NotTo(gomega.BeNil())
 
 				numaNodeID := int(containerMemory.Topology.Nodes[0].ID)
 				for _, numaStateMemory := range stateAllocatableMemory {
-					framework.ExpectEqual(len(numaStateMemory.NUMAAffinity), 1)
+					gomega.Expect(numaStateMemory.NUMAAffinity).To(gomega.HaveLen(1))
 					if numaNodeID != numaStateMemory.NUMAAffinity[0] {
 						continue
 					}

--- a/test/e2e_node/node_shutdown_linux_test.go
+++ b/test/e2e_node/node_shutdown_linux_test.go
@@ -134,7 +134,7 @@ var _ = SIGDescribe("GracefulNodeShutdown [Serial] [NodeFeature:GracefulNodeShut
 			})
 
 			framework.ExpectNoError(err)
-			framework.ExpectEqual(len(list.Items), len(pods), "the number of pods is not as expected")
+			gomega.Expect(list.Items).To(gomega.HaveLen(len(pods)), "the number of pods is not as expected")
 
 			list, err = e2epod.NewPodClient(f).List(ctx, metav1.ListOptions{
 				FieldSelector: nodeSelector,
@@ -142,7 +142,7 @@ var _ = SIGDescribe("GracefulNodeShutdown [Serial] [NodeFeature:GracefulNodeShut
 			if err != nil {
 				framework.Failf("Failed to start batch pod: %q", err)
 			}
-			framework.ExpectEqual(len(list.Items), len(pods), "the number of pods is not as expected")
+			gomega.Expect(list.Items).To(gomega.HaveLen(len(pods)), "the number of pods is not as expected")
 
 			for _, pod := range list.Items {
 				framework.Logf("Pod (%v/%v) status conditions: %q", pod.Namespace, pod.Name, &pod.Status.Conditions)
@@ -168,7 +168,7 @@ var _ = SIGDescribe("GracefulNodeShutdown [Serial] [NodeFeature:GracefulNodeShut
 				if err != nil {
 					return err
 				}
-				framework.ExpectEqual(len(list.Items), len(pods), "the number of pods is not as expected")
+				gomega.Expect(list.Items).To(gomega.HaveLen(len(pods)), "the number of pods is not as expected")
 
 				for _, pod := range list.Items {
 					if !isPodShutdown(&pod) {
@@ -236,7 +236,7 @@ var _ = SIGDescribe("GracefulNodeShutdown [Serial] [NodeFeature:GracefulNodeShut
 				FieldSelector: nodeSelector,
 			})
 			framework.ExpectNoError(err)
-			framework.ExpectEqual(len(list.Items), len(pods), "the number of pods is not as expected")
+			gomega.Expect(list.Items).To(gomega.HaveLen(len(pods)), "the number of pods is not as expected")
 
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
@@ -286,7 +286,7 @@ var _ = SIGDescribe("GracefulNodeShutdown [Serial] [NodeFeature:GracefulNodeShut
 				if err != nil {
 					return err
 				}
-				framework.ExpectEqual(len(list.Items), len(pods), "the number of pods is not as expected")
+				gomega.Expect(list.Items).To(gomega.HaveLen(len(pods)), "the number of pods is not as expected")
 
 				for _, pod := range list.Items {
 					if kubelettypes.IsCriticalPod(&pod) {
@@ -313,7 +313,7 @@ var _ = SIGDescribe("GracefulNodeShutdown [Serial] [NodeFeature:GracefulNodeShut
 				if err != nil {
 					return err
 				}
-				framework.ExpectEqual(len(list.Items), len(pods), "the number of pods is not as expected")
+				gomega.Expect(list.Items).To(gomega.HaveLen(len(pods)), "the number of pods is not as expected")
 
 				for _, pod := range list.Items {
 					if !isPodShutdown(&pod) {
@@ -514,7 +514,7 @@ var _ = SIGDescribe("GracefulNodeShutdown [Serial] [NodeFeature:GracefulNodeShut
 				FieldSelector: nodeSelector,
 			})
 			framework.ExpectNoError(err)
-			framework.ExpectEqual(len(list.Items), len(pods), "the number of pods is not as expected")
+			gomega.Expect(list.Items).To(gomega.HaveLen(len(pods)), "the number of pods is not as expected")
 
 			ginkgo.By("Verifying batch pods are running")
 			for _, pod := range list.Items {
@@ -537,7 +537,7 @@ var _ = SIGDescribe("GracefulNodeShutdown [Serial] [NodeFeature:GracefulNodeShut
 					if err != nil {
 						return err
 					}
-					framework.ExpectEqual(len(list.Items), len(pods), "the number of pods is not as expected")
+					gomega.Expect(list.Items).To(gomega.HaveLen(len(pods)), "the number of pods is not as expected")
 					for _, pod := range list.Items {
 						shouldShutdown := false
 						for _, podName := range step {
@@ -628,10 +628,14 @@ func getGracePeriodOverrideTestPod(name string, node string, gracePeriod int64, 
 			kubelettypes.ConfigSourceAnnotationKey: kubelettypes.FileSource,
 		}
 		pod.Spec.PriorityClassName = priorityClassName
-		framework.ExpectEqual(kubelettypes.IsCriticalPod(pod), true, "pod should be a critical pod")
+		if !kubelettypes.IsCriticalPod(pod) {
+			framework.Failf("pod %q should be a critical pod", pod.Name)
+		}
 	} else {
 		pod.Spec.PriorityClassName = priorityClassName
-		framework.ExpectEqual(kubelettypes.IsCriticalPod(pod), false, "pod should not be a critical pod")
+		if kubelettypes.IsCriticalPod(pod) {
+			framework.Failf("pod %q should not be a critical pod", pod.Name)
+		}
 	}
 	return pod
 }
@@ -650,7 +654,7 @@ func getNodeReadyStatus(ctx context.Context, f *framework.Framework) bool {
 	nodeList, err := f.ClientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	framework.ExpectNoError(err)
 	// Assuming that there is only one node, because this is a node e2e test.
-	framework.ExpectEqual(len(nodeList.Items), 1)
+	gomega.Expect(nodeList.Items).To(gomega.HaveLen(1), "the number of nodes is not as expected")
 	return isNodeReady(&nodeList.Items[0])
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref https://github.com/kubernetes/kubernetes/pull/115961

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
