### PR TITLE
replacing docker_env_metadata_whitelist with env_metadata_whitelist instead of removing it 

### DIFF
--- a/cmd/kubelet/app/options/globalflags_linux.go
+++ b/cmd/kubelet/app/options/globalflags_linux.go
@@ -50,6 +50,7 @@ func addCadvisorFlags(fs *pflag.FlagSet) {
 	registerDeprecated(global, local, "boot_id_file", deprecated)
 	registerDeprecated(global, local, "container_hints", deprecated)
 	registerDeprecated(global, local, "containerd", deprecated)
+	registerDeprecated(global, local, "env_metadata_whitelist", deprecated)
 	registerDeprecated(global, local, "enable_load_reader", deprecated)
 	registerDeprecated(global, local, "event_storage_age_limit", deprecated)
 	registerDeprecated(global, local, "event_storage_event_limit", deprecated)

--- a/hack/verify-flags/excluded-flags.txt
+++ b/hack/verify-flags/excluded-flags.txt
@@ -2,6 +2,7 @@ check_leaked_resources
 check_node_count
 check_version_skew
 concurrent_rc_syncs
+env_metadata_whitelist
 file_content
 file_mode
 file_owner

--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	// Register supported container handlers.
@@ -50,6 +51,8 @@ type cadvisorClient struct {
 }
 
 var _ Interface = new(cadvisorClient)
+
+var envMetadataWhiteList = flag.String("env_metadata_whitelist", "", "a comma-separated list of environment variable keys matched with specified prefix that needs to be collected for containers, only support containerd and docker runtime for now.")
 
 // TODO(vmarmol): Make configurable.
 // The amount of time for which to keep stats in memory.
@@ -101,9 +104,8 @@ func New(imageFsInfoProvider ImageFsInfoProvider, rootPath string, cgroupRoots [
 		Interval:     &duration,
 		AllowDynamic: pointer.Bool(allowDynamicHousekeeping),
 	}
-
 	// Create the cAdvisor container manager.
-	m, err := manager.New(memory.New(statsCacheDuration, nil), sysFs, housekeepingConfig, includedMetrics, http.DefaultClient, cgroupRoots, nil /* containerEnvMetadataWhiteList */, "" /* perfEventsFile */, time.Duration(0) /*resctrlInterval*/)
+	m, err := manager.New(memory.New(statsCacheDuration, nil), sysFs, housekeepingConfig, includedMetrics, http.DefaultClient, cgroupRoots, strings.Split(*envMetadataWhiteList, ",") /* containerEnvMetadataWhiteList */, "" /* perfEventsFile */, time.Duration(0) /*resctrlInterval*/)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind regression
#### What this PR does / why we need it:
In order to remove dockershim, the Docker-related command lines built-in cadvisor, such as `docker_env_metadata_whitelist`, were removed in PR #97252. However, the command lines related to containerd were retained. Therefore, it is worth considering replacing `docker_env_metadata_whitelist` with `containerd_env_metadata_whitelist` instead of removing it directly. This approach ensures compatibility after runtime switching and maintains management stability.

Although cadvisor provides the `env_metadata_whitelist` command line, it currently supports only two runtimes. Directly replacing it might introduce more vendor code, increasing complexity. Hence, opting to replace it with `containerd_env_metadata_whitelist` is a more cautious and prudent choice.

This method maintains stability at the code level without introducing excessive external dependencies, ensuring system reliability and maintainability.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
replacing docker_env_metadata_whitelist with containerd_env_metadata_whitelist instead of removing it
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
