### PR TITLE
e2e: move AllNodesReady check to DeferCleanup

### DIFF
--- a/test/e2e/framework/node/init/init.go
+++ b/test/e2e/framework/node/init/init.go
@@ -30,14 +30,10 @@ import (
 func init() {
 	framework.NewFrameworkExtensions = append(framework.NewFrameworkExtensions,
 		func(f *framework.Framework) {
-			ginkgo.AfterEach(func(ctx context.Context) {
-				if f.ClientSet == nil {
-					// Test didn't reach f.BeforeEach, most
-					// likely because the test got
-					// skipped. Nothing to check...
-					return
-				}
-				e2enode.AllNodesReady(ctx, f.ClientSet, 7*time.Minute)
+			ginkgo.BeforeEach(func() {
+				ginkgo.DeferCleanup(func(ctx context.Context) {
+					framework.ExpectNoError(e2enode.AllNodesReady(ctx, f.ClientSet, 7*time.Minute))
+				})
 			})
 		},
 	)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Some test cases can make nodes not ready and use DeferCleanup to bring nodes back online. Checking if all nodes are online would fail in such cases as `ginkgo.AfterEach` runs before `ginkgo.DeferCleanup`.

Scheduling nodes readines check to DeferCleanup should solve this issue as nodes would be brought back to a `Ready` state before the check.

#### Special notes for your reviewer:

This issue was discovered when working on [DRA: e2e: test non-graceful node shutdown](https://github.com/kubernetes/kubernetes/pull/120965) and the fix was suggested by @pohly

See more details [in this comment](https://github.com/kubernetes/kubernetes/pull/120965#discussion_r1347572940)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
