### PR TITLE
Remove terminating count from rmAtLeast

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1490,7 +1490,7 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 		}
 	}
 
-	rmAtLeast := active + terminating - wantActive
+	rmAtLeast := active - wantActive
 	if rmAtLeast < 0 {
 		rmAtLeast = 0
 	}

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -357,9 +357,10 @@ func TestControllerSyncJob(t *testing.T) {
 			jobPodReplacementPolicy: true,
 			terminatingPods:         1,
 			expectedTerminating:     ptr.To[int32](1),
-			expectedPodPatches:      2,
-			expectedDeletions:       1,
-			expectedFailed:          1,
+			// Removes finalizer and deletes one failed pod
+			expectedPodPatches: 1,
+			expectedFailed:     1,
+			expectedActive:     1,
 		},
 		"WQ job: recreate pods when terminating or failed": {
 			parallelism:             1,
@@ -375,7 +376,20 @@ func TestControllerSyncJob(t *testing.T) {
 			expectedPodPatches:      2,
 			expectedFailed:          2,
 		},
-
+		"more terminating pods than parallelism": {
+			parallelism:             1,
+			completions:             1,
+			backoffLimit:            6,
+			activePods:              2,
+			failedPods:              0,
+			terminatingPods:         4,
+			podReplacementPolicy:    podReplacementPolicy(batch.Failed),
+			jobPodReplacementPolicy: true,
+			expectedTerminating:     ptr.To[int32](4),
+			expectedActive:          1,
+			expectedDeletions:       1,
+			expectedPodPatches:      1,
+		},
 		"too few active pods and active back-off": {
 			parallelism:  1,
 			completions:  1,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
PodReplacementPolicy was enabled in 1.28 and it tracks the number of terminating pods.  If Failed is specified, then we will halt replacement until the pod is fully terminal.  

We discovered a bug where we were tracking (terminating + active) and using that index to access the active pods list.  If there are more terminating pods than active, it is possible to hit an out of bounds error.  

@mimowo pointed out that we don't need the terminating count as we don't need to delete the terminating pods.  

This PR drops terminating so we are only counting active.  

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix panic in Job controller when podRecreationPolicy: Failed is used, and the number of terminating pods exceeds parallelism.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
