### PR TITLE
Use k8s.io/utils/ptr in pkg/proxy

### DIFF
--- a/pkg/proxy/apis/config/fuzzer/fuzzer.go
+++ b/pkg/proxy/apis/config/fuzzer/fuzzer.go
@@ -35,16 +35,16 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			c.FuzzNoCustom(obj)
 			obj.BindAddress = fmt.Sprintf("%d.%d.%d.%d", c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(256))
 			obj.ClientConnection.ContentType = c.RandString()
-			obj.Conntrack.MaxPerCore = pointer.Int32(c.Int31())
-			obj.Conntrack.Min = pointer.Int32(c.Int31())
+			obj.Conntrack.MaxPerCore = ptr.To(c.Int31())
+			obj.Conntrack.Min = ptr.To(c.Int31())
 			obj.Conntrack.TCPCloseWaitTimeout = &metav1.Duration{Duration: time.Duration(c.Int63()) * time.Hour}
 			obj.Conntrack.TCPEstablishedTimeout = &metav1.Duration{Duration: time.Duration(c.Int63()) * time.Hour}
 			obj.FeatureGates = map[string]bool{c.RandString(): true}
 			obj.HealthzBindAddress = fmt.Sprintf("%d.%d.%d.%d:%d", c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(65536))
-			obj.IPTables.MasqueradeBit = pointer.Int32(c.Int31())
+			obj.IPTables.MasqueradeBit = ptr.To(c.Int31())
 			obj.IPTables.LocalhostNodePorts = ptr.To(c.RandBool())
 			obj.MetricsBindAddress = fmt.Sprintf("%d.%d.%d.%d:%d", c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(65536))
-			obj.OOMScoreAdj = pointer.Int32(c.Int31())
+			obj.OOMScoreAdj = ptr.To(c.Int31())
 			obj.ClientConnection.ContentType = "bar"
 			obj.NodePortAddresses = []string{"1.2.3.0/24"}
 			if obj.Logging.Format == "" {

--- a/pkg/proxy/apis/config/fuzzer/fuzzer.go
+++ b/pkg/proxy/apis/config/fuzzer/fuzzer.go
@@ -42,7 +42,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.FeatureGates = map[string]bool{c.RandString(): true}
 			obj.HealthzBindAddress = fmt.Sprintf("%d.%d.%d.%d:%d", c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(65536))
 			obj.IPTables.MasqueradeBit = pointer.Int32(c.Int31())
-			obj.IPTables.LocalhostNodePorts = pointer.Bool(c.RandBool())
+			obj.IPTables.LocalhostNodePorts = ptr.To(c.RandBool())
 			obj.MetricsBindAddress = fmt.Sprintf("%d.%d.%d.%d:%d", c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(65536))
 			obj.OOMScoreAdj = pointer.Int32(c.Int31())
 			obj.ClientConnection.ContentType = "bar"

--- a/pkg/proxy/apis/config/fuzzer/fuzzer.go
+++ b/pkg/proxy/apis/config/fuzzer/fuzzer.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // Funcs returns the fuzzer functions for the kube-proxy apis.

--- a/pkg/proxy/apis/config/v1alpha1/defaults.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults.go
@@ -73,10 +73,10 @@ func SetDefaults_KubeProxyConfiguration(obj *kubeproxyconfigv1alpha1.KubeProxyCo
 	}
 
 	if obj.Conntrack.MaxPerCore == nil {
-		obj.Conntrack.MaxPerCore = pointer.Int32(32 * 1024)
+		obj.Conntrack.MaxPerCore = ptr.To[int32](32 * 1024)
 	}
 	if obj.Conntrack.Min == nil {
-		obj.Conntrack.Min = pointer.Int32(128 * 1024)
+		obj.Conntrack.Min = ptr.To[int32](128 * 1024)
 	}
 
 	if obj.IPTables.MasqueradeBit == nil {

--- a/pkg/proxy/apis/config/v1alpha1/defaults.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	netutils "k8s.io/utils/net"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func addDefaultingFuncs(scheme *kruntime.Scheme) error {

--- a/pkg/proxy/apis/config/v1alpha1/defaults.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults.go
@@ -66,7 +66,7 @@ func SetDefaults_KubeProxyConfiguration(obj *kubeproxyconfigv1alpha1.KubeProxyCo
 		obj.IPTables.MinSyncPeriod = metav1.Duration{Duration: 1 * time.Second}
 	}
 	if obj.IPTables.LocalhostNodePorts == nil {
-		obj.IPTables.LocalhostNodePorts = pointer.Bool(true)
+		obj.IPTables.LocalhostNodePorts = ptr.To(true)
 	}
 	if obj.IPVS.SyncPeriod.Duration == 0 {
 		obj.IPVS.SyncPeriod = metav1.Duration{Duration: 30 * time.Second}

--- a/pkg/proxy/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/google/go-cmp/cmp"
 

--- a/pkg/proxy/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults_test.go
@@ -53,7 +53,7 @@ func TestDefaultsKubeProxyConfiguration(t *testing.T) {
 					Burst:       10,
 				},
 				IPTables: kubeproxyconfigv1alpha1.KubeProxyIPTablesConfiguration{
-					MasqueradeBit:      pointer.Int32(14),
+					MasqueradeBit:      ptr.To[int32](14),
 					MasqueradeAll:      false,
 					LocalhostNodePorts: ptr.To(true),
 					SyncPeriod:         metav1.Duration{Duration: 30 * time.Second},
@@ -93,7 +93,7 @@ func TestDefaultsKubeProxyConfiguration(t *testing.T) {
 					Burst:       10,
 				},
 				IPTables: kubeproxyconfigv1alpha1.KubeProxyIPTablesConfiguration{
-					MasqueradeBit:      pointer.Int32(14),
+					MasqueradeBit:      ptr.To[int32](14),
 					MasqueradeAll:      false,
 					LocalhostNodePorts: ptr.To(true),
 					SyncPeriod:         metav1.Duration{Duration: 30 * time.Second},

--- a/pkg/proxy/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults_test.go
@@ -55,7 +55,7 @@ func TestDefaultsKubeProxyConfiguration(t *testing.T) {
 				IPTables: kubeproxyconfigv1alpha1.KubeProxyIPTablesConfiguration{
 					MasqueradeBit:      pointer.Int32(14),
 					MasqueradeAll:      false,
-					LocalhostNodePorts: pointer.Bool(true),
+					LocalhostNodePorts: ptr.To(true),
 					SyncPeriod:         metav1.Duration{Duration: 30 * time.Second},
 					MinSyncPeriod:      metav1.Duration{Duration: 1 * time.Second},
 				},
@@ -95,7 +95,7 @@ func TestDefaultsKubeProxyConfiguration(t *testing.T) {
 				IPTables: kubeproxyconfigv1alpha1.KubeProxyIPTablesConfiguration{
 					MasqueradeBit:      pointer.Int32(14),
 					MasqueradeAll:      false,
-					LocalhostNodePorts: pointer.Bool(true),
+					LocalhostNodePorts: ptr.To(true),
 					SyncPeriod:         metav1.Duration{Duration: 30 * time.Second},
 					MinSyncPeriod:      metav1.Duration{Duration: 1 * time.Second},
 				},

--- a/pkg/proxy/apis/config/validation/validation_test.go
+++ b/pkg/proxy/apis/config/validation/validation_test.go
@@ -54,8 +54,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
 		},
 		Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-			MaxPerCore:            pointer.Int32(1),
-			Min:                   pointer.Int32(1),
+			MaxPerCore:            ptr.To[int32](1),
+			Min:                   ptr.To[int32](1),
 			TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 			TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 		},
@@ -74,8 +74,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 		},
 		Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-			MaxPerCore:            pointer.Int32(1),
-			Min:                   pointer.Int32(1),
+			MaxPerCore:            ptr.To[int32](1),
+			Min:                   ptr.To[int32](1),
 			TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 			TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 		},
@@ -94,8 +94,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 		},
 		Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-			MaxPerCore:            pointer.Int32(1),
-			Min:                   pointer.Int32(1),
+			MaxPerCore:            ptr.To[int32](1),
+			Min:                   ptr.To[int32](1),
 			TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 			TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 		},
@@ -114,8 +114,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 		},
 		Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-			MaxPerCore:            pointer.Int32(1),
-			Min:                   pointer.Int32(1),
+			MaxPerCore:            ptr.To[int32](1),
+			Min:                   ptr.To[int32](1),
 			TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 			TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 		},
@@ -134,8 +134,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 		},
 		Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-			MaxPerCore:            pointer.Int32(1),
-			Min:                   pointer.Int32(1),
+			MaxPerCore:            ptr.To[int32](1),
+			Min:                   ptr.To[int32](1),
 			TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 			TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 		},
@@ -154,8 +154,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 		},
 		Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-			MaxPerCore:            pointer.Int32(1),
-			Min:                   pointer.Int32(1),
+			MaxPerCore:            ptr.To[int32](1),
+			Min:                   ptr.To[int32](1),
 			TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 			TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 		},
@@ -174,8 +174,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 		},
 		Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-			MaxPerCore:            pointer.Int32(1),
-			Min:                   pointer.Int32(1),
+			MaxPerCore:            ptr.To[int32](1),
+			Min:                   ptr.To[int32](1),
 			TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 			TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 		},
@@ -194,8 +194,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 		},
 		Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-			MaxPerCore:            pointer.Int32(1),
-			Min:                   pointer.Int32(1),
+			MaxPerCore:            ptr.To[int32](1),
+			Min:                   ptr.To[int32](1),
 			TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 			TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 		},
@@ -218,8 +218,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 		},
 		Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-			MaxPerCore:            pointer.Int32(1),
-			Min:                   pointer.Int32(1),
+			MaxPerCore:            ptr.To[int32](1),
+			Min:                   ptr.To[int32](1),
 			TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 			TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 		},
@@ -256,8 +256,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 				},
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-					MaxPerCore:            pointer.Int32(1),
-					Min:                   pointer.Int32(1),
+					MaxPerCore:            ptr.To[int32](1),
+					Min:                   ptr.To[int32](1),
 					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				},
@@ -280,8 +280,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 				},
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-					MaxPerCore:            pointer.Int32(1),
-					Min:                   pointer.Int32(1),
+					MaxPerCore:            ptr.To[int32](1),
+					Min:                   ptr.To[int32](1),
 					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				},
@@ -304,8 +304,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 				},
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-					MaxPerCore:            pointer.Int32(1),
-					Min:                   pointer.Int32(1),
+					MaxPerCore:            ptr.To[int32](1),
+					Min:                   ptr.To[int32](1),
 					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				},
@@ -328,8 +328,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 				},
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-					MaxPerCore:            pointer.Int32(1),
-					Min:                   pointer.Int32(1),
+					MaxPerCore:            ptr.To[int32](1),
+					Min:                   ptr.To[int32](1),
 					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				},
@@ -352,8 +352,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 				},
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-					MaxPerCore:            pointer.Int32(1),
-					Min:                   pointer.Int32(1),
+					MaxPerCore:            ptr.To[int32](1),
+					Min:                   ptr.To[int32](1),
 					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				},
@@ -376,8 +376,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 				},
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-					MaxPerCore:            pointer.Int32(1),
-					Min:                   pointer.Int32(1),
+					MaxPerCore:            ptr.To[int32](1),
+					Min:                   ptr.To[int32](1),
 					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				},
@@ -402,8 +402,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 				// not specifying valid period in IPVS mode.
 				Mode: kubeproxyconfig.ProxyModeIPVS,
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-					MaxPerCore:            pointer.Int32(1),
-					Min:                   pointer.Int32(1),
+					MaxPerCore:            ptr.To[int32](1),
+					Min:                   ptr.To[int32](1),
 					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				},
@@ -426,8 +426,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 				},
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-					MaxPerCore:            pointer.Int32(1),
-					Min:                   pointer.Int32(1),
+					MaxPerCore:            ptr.To[int32](1),
+					Min:                   ptr.To[int32](1),
 					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				},
@@ -454,8 +454,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 				},
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-					MaxPerCore:            pointer.Int32(1),
-					Min:                   pointer.Int32(1),
+					MaxPerCore:            ptr.To[int32](1),
+					Min:                   ptr.To[int32](1),
 					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				},
@@ -482,8 +482,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 				},
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-					MaxPerCore:            pointer.Int32(1),
-					Min:                   pointer.Int32(1),
+					MaxPerCore:            ptr.To[int32](1),
+					Min:                   ptr.To[int32](1),
 					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				},
@@ -507,8 +507,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 				},
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
-					MaxPerCore:            pointer.Int32(1),
-					Min:                   pointer.Int32(1),
+					MaxPerCore:            ptr.To[int32](1),
+					Min:                   ptr.To[int32](1),
 					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				},
@@ -557,7 +557,7 @@ func TestValidateKubeProxyIPTablesConfiguration(t *testing.T) {
 		},
 		"valid custom MasqueradeBit": {
 			config: kubeproxyconfig.KubeProxyIPTablesConfiguration{
-				MasqueradeBit: pointer.Int32(5),
+				MasqueradeBit: ptr.To[int32](5),
 				MasqueradeAll: true,
 				SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
 				MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
@@ -575,7 +575,7 @@ func TestValidateKubeProxyIPTablesConfiguration(t *testing.T) {
 		},
 		"MinSyncPeriod must be > 0": {
 			config: kubeproxyconfig.KubeProxyIPTablesConfiguration{
-				MasqueradeBit: pointer.Int32(5),
+				MasqueradeBit: ptr.To[int32](5),
 				MasqueradeAll: true,
 				SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
 				MinSyncPeriod: metav1.Duration{Duration: -1 * time.Second},
@@ -584,7 +584,7 @@ func TestValidateKubeProxyIPTablesConfiguration(t *testing.T) {
 		},
 		"MasqueradeBit cannot be < 0": {
 			config: kubeproxyconfig.KubeProxyIPTablesConfiguration{
-				MasqueradeBit: pointer.Int32(-10),
+				MasqueradeBit: ptr.To[int32](-10),
 				MasqueradeAll: true,
 				SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
 				MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
@@ -593,7 +593,7 @@ func TestValidateKubeProxyIPTablesConfiguration(t *testing.T) {
 		},
 		"SyncPeriod must be >= MinSyncPeriod": {
 			config: kubeproxyconfig.KubeProxyIPTablesConfiguration{
-				MasqueradeBit: pointer.Int32(5),
+				MasqueradeBit: ptr.To[int32](5),
 				MasqueradeAll: true,
 				SyncPeriod:    metav1.Duration{Duration: 1 * time.Second},
 				MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
@@ -723,8 +723,8 @@ func TestValidateKubeProxyConntrackConfiguration(t *testing.T) {
 	}{
 		"valid 5 second timeouts": {
 			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
-				MaxPerCore:            pointer.Int32(1),
-				Min:                   pointer.Int32(1),
+				MaxPerCore:            ptr.To[int32](1),
+				Min:                   ptr.To[int32](1),
 				TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 				TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				UDPTimeout:            metav1.Duration{Duration: 5 * time.Second},
@@ -734,8 +734,8 @@ func TestValidateKubeProxyConntrackConfiguration(t *testing.T) {
 		},
 		"valid duration equal to 0 second timeout": {
 			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
-				MaxPerCore:            pointer.Int32(1),
-				Min:                   pointer.Int32(1),
+				MaxPerCore:            ptr.To[int32](1),
+				Min:                   ptr.To[int32](1),
 				TCPEstablishedTimeout: &metav1.Duration{Duration: 0 * time.Second},
 				TCPCloseWaitTimeout:   &metav1.Duration{Duration: 0 * time.Second},
 				UDPTimeout:            metav1.Duration{Duration: 0 * time.Second},
@@ -745,8 +745,8 @@ func TestValidateKubeProxyConntrackConfiguration(t *testing.T) {
 		},
 		"invalid MaxPerCore < 0": {
 			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
-				MaxPerCore:            pointer.Int32(-1),
-				Min:                   pointer.Int32(1),
+				MaxPerCore:            ptr.To[int32](-1),
+				Min:                   ptr.To[int32](1),
 				TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 				TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				UDPTimeout:            metav1.Duration{Duration: 5 * time.Second},
@@ -756,8 +756,8 @@ func TestValidateKubeProxyConntrackConfiguration(t *testing.T) {
 		},
 		"invalid minimum < 0": {
 			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
-				MaxPerCore:            pointer.Int32(1),
-				Min:                   pointer.Int32(-1),
+				MaxPerCore:            ptr.To[int32](1),
+				Min:                   ptr.To[int32](-1),
 				TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 				TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				UDPTimeout:            metav1.Duration{Duration: 5 * time.Second},
@@ -767,8 +767,8 @@ func TestValidateKubeProxyConntrackConfiguration(t *testing.T) {
 		},
 		"invalid TCPEstablishedTimeout < 0": {
 			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
-				MaxPerCore:            pointer.Int32(1),
-				Min:                   pointer.Int32(1),
+				MaxPerCore:            ptr.To[int32](1),
+				Min:                   ptr.To[int32](1),
 				TCPEstablishedTimeout: &metav1.Duration{Duration: -5 * time.Second},
 				TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				UDPTimeout:            metav1.Duration{Duration: 5 * time.Second},
@@ -778,8 +778,8 @@ func TestValidateKubeProxyConntrackConfiguration(t *testing.T) {
 		},
 		"invalid TCPCloseWaitTimeout < 0": {
 			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
-				MaxPerCore:            pointer.Int32(1),
-				Min:                   pointer.Int32(1),
+				MaxPerCore:            ptr.To[int32](1),
+				Min:                   ptr.To[int32](1),
 				TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 				TCPCloseWaitTimeout:   &metav1.Duration{Duration: -5 * time.Second},
 				UDPTimeout:            metav1.Duration{Duration: 5 * time.Second},
@@ -789,8 +789,8 @@ func TestValidateKubeProxyConntrackConfiguration(t *testing.T) {
 		},
 		"invalid UDPTimeout < 0": {
 			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
-				MaxPerCore:            pointer.Int32(1),
-				Min:                   pointer.Int32(1),
+				MaxPerCore:            ptr.To[int32](1),
+				Min:                   ptr.To[int32](1),
 				TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 				TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				UDPTimeout:            metav1.Duration{Duration: -5 * time.Second},
@@ -800,8 +800,8 @@ func TestValidateKubeProxyConntrackConfiguration(t *testing.T) {
 		},
 		"invalid UDPStreamTimeout < 0": {
 			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
-				MaxPerCore:            pointer.Int32(1),
-				Min:                   pointer.Int32(1),
+				MaxPerCore:            ptr.To[int32](1),
+				Min:                   ptr.To[int32](1),
 				TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 				TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				UDPTimeout:            metav1.Duration{Duration: 5 * time.Second},

--- a/pkg/proxy/apis/config/validation/validation_test.go
+++ b/pkg/proxy/apis/config/validation/validation_test.go
@@ -27,7 +27,7 @@ import (
 	logsapi "k8s.io/component-base/logs/api/v1"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestValidateKubeProxyConfiguration(t *testing.T) {

--- a/pkg/proxy/config/api_test.go
+++ b/pkg/proxy/config/api_test.go
@@ -93,7 +93,7 @@ func TestNewEndpointsSourceApi_UpdatesAndMultipleEndpoints(t *testing.T) {
 			},
 		}},
 		Ports: []discoveryv1.EndpointPort{{
-			Port:     utilpointer.Int32(8080),
+			Port:     ptr.To[int32](8080),
 			Protocol: &tcp,
 		}},
 	}
@@ -107,7 +107,7 @@ func TestNewEndpointsSourceApi_UpdatesAndMultipleEndpoints(t *testing.T) {
 			},
 		}},
 		Ports: []discoveryv1.EndpointPort{{
-			Port:     utilpointer.Int32(8080),
+			Port:     ptr.To[int32](8080),
 			Protocol: &tcp,
 		}},
 	}
@@ -120,7 +120,7 @@ func TestNewEndpointsSourceApi_UpdatesAndMultipleEndpoints(t *testing.T) {
 			},
 		}},
 		Ports: []discoveryv1.EndpointPort{{
-			Port:     utilpointer.Int32(8080),
+			Port:     ptr.To[int32](8080),
 			Protocol: &tcp,
 		}},
 	}

--- a/pkg/proxy/config/api_test.go
+++ b/pkg/proxy/config/api_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestNewServicesSourceApi_UpdatesAndMultipleServices(t *testing.T) {

--- a/pkg/proxy/config/api_test.go
+++ b/pkg/proxy/config/api_test.go
@@ -83,7 +83,6 @@ func TestNewServicesSourceApi_UpdatesAndMultipleServices(t *testing.T) {
 }
 
 func TestNewEndpointsSourceApi_UpdatesAndMultipleEndpoints(t *testing.T) {
-	tcp := v1.ProtocolTCP
 	endpoints1v1 := &discoveryv1.EndpointSlice{
 		ObjectMeta:  metav1.ObjectMeta{Namespace: "testnamespace", Name: "e1"},
 		AddressType: discoveryv1.AddressTypeIPv4,
@@ -94,7 +93,7 @@ func TestNewEndpointsSourceApi_UpdatesAndMultipleEndpoints(t *testing.T) {
 		}},
 		Ports: []discoveryv1.EndpointPort{{
 			Port:     ptr.To[int32](8080),
-			Protocol: &tcp,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}},
 	}
 	endpoints1v2 := &discoveryv1.EndpointSlice{
@@ -108,7 +107,7 @@ func TestNewEndpointsSourceApi_UpdatesAndMultipleEndpoints(t *testing.T) {
 		}},
 		Ports: []discoveryv1.EndpointPort{{
 			Port:     ptr.To[int32](8080),
-			Protocol: &tcp,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}},
 	}
 	endpoints2 := &discoveryv1.EndpointSlice{
@@ -121,7 +120,7 @@ func TestNewEndpointsSourceApi_UpdatesAndMultipleEndpoints(t *testing.T) {
 		}},
 		Ports: []discoveryv1.EndpointPort{{
 			Port:     ptr.To[int32](8080),
-			Protocol: &tcp,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}},
 	}
 

--- a/pkg/proxy/config/config_test.go
+++ b/pkg/proxy/config/config_test.go
@@ -345,7 +345,7 @@ func TestNewEndpointsMultipleHandlersAddedAndNotified(t *testing.T) {
 		}, {
 			Addresses: []string{"2.2.2.2"},
 		}},
-		Ports: []discoveryv1.EndpointPort{{Port: utilpointer.Int32(80)}},
+		Ports: []discoveryv1.EndpointPort{{Port: ptr.To[int32](80)}},
 	}
 	endpoints2 := &discoveryv1.EndpointSlice{
 		ObjectMeta:  metav1.ObjectMeta{Namespace: "testnamespace", Name: "bar"},
@@ -355,7 +355,7 @@ func TestNewEndpointsMultipleHandlersAddedAndNotified(t *testing.T) {
 		}, {
 			Addresses: []string{"4.4.4.4"},
 		}},
-		Ports: []discoveryv1.EndpointPort{{Port: utilpointer.Int32(80)}},
+		Ports: []discoveryv1.EndpointPort{{Port: ptr.To[int32](80)}},
 	}
 	fakeWatch.Add(endpoints1)
 	fakeWatch.Add(endpoints2)
@@ -391,7 +391,7 @@ func TestNewEndpointsMultipleHandlersAddRemoveSetAndNotified(t *testing.T) {
 		}, {
 			Addresses: []string{"2.2.2.2"},
 		}},
-		Ports: []discoveryv1.EndpointPort{{Port: utilpointer.Int32(80)}},
+		Ports: []discoveryv1.EndpointPort{{Port: ptr.To[int32](80)}},
 	}
 	endpoints2 := &discoveryv1.EndpointSlice{
 		ObjectMeta:  metav1.ObjectMeta{Namespace: "testnamespace", Name: "bar"},
@@ -401,7 +401,7 @@ func TestNewEndpointsMultipleHandlersAddRemoveSetAndNotified(t *testing.T) {
 		}, {
 			Addresses: []string{"4.4.4.4"},
 		}},
-		Ports: []discoveryv1.EndpointPort{{Port: utilpointer.Int32(80)}},
+		Ports: []discoveryv1.EndpointPort{{Port: ptr.To[int32](80)}},
 	}
 	fakeWatch.Add(endpoints1)
 	fakeWatch.Add(endpoints2)
@@ -419,7 +419,7 @@ func TestNewEndpointsMultipleHandlersAddRemoveSetAndNotified(t *testing.T) {
 		}, {
 			Addresses: []string{"6.6.6.6"},
 		}},
-		Ports: []discoveryv1.EndpointPort{{Port: utilpointer.Int32(80)}},
+		Ports: []discoveryv1.EndpointPort{{Port: ptr.To[int32](80)}},
 	}
 	fakeWatch.Add(endpoints3)
 	endpoints = []*discoveryv1.EndpointSlice{endpoints2, endpoints1, endpoints3}
@@ -433,7 +433,7 @@ func TestNewEndpointsMultipleHandlersAddRemoveSetAndNotified(t *testing.T) {
 		Endpoints: []discoveryv1.Endpoint{{
 			Addresses: []string{"7.7.7.7"},
 		}},
-		Ports: []discoveryv1.EndpointPort{{Port: utilpointer.Int32(80)}},
+		Ports: []discoveryv1.EndpointPort{{Port: ptr.To[int32](80)}},
 	}
 	fakeWatch.Modify(endpoints1v2)
 	endpoints = []*discoveryv1.EndpointSlice{endpoints2, endpoints1v2, endpoints3}

--- a/pkg/proxy/config/config_test.go
+++ b/pkg/proxy/config/config_test.go
@@ -32,7 +32,7 @@ import (
 	informers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 type sortedServices []*v1.Service

--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -196,7 +196,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To(""),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udp,
 		}}
 	}
@@ -211,7 +211,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To(""),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udp,
 		}}
 	}
@@ -226,7 +226,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To(""),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udp,
 		}}
 	}
@@ -237,7 +237,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To(""),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udp,
 		}}
 	}
@@ -248,7 +248,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udp,
 		}}
 	}
@@ -258,7 +258,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udp,
 		}}
 	}
@@ -268,7 +268,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11-2"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udp,
 		}}
 	}
@@ -278,7 +278,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(22),
+			Port:     ptr.To[int32](22),
 			Protocol: &udp,
 		}}
 	}
@@ -291,11 +291,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udp,
 		}, {
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udp,
 		}}
 	}
@@ -305,7 +305,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udp,
 		}}
 	}
@@ -315,7 +315,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udp,
 		}}
 	}
@@ -325,7 +325,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udp,
 		}}
 	}
@@ -336,7 +336,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udp,
 		}}
 	}
@@ -347,11 +347,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udp,
 		}, {
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udp,
 		}}
 	}
@@ -361,7 +361,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p13"),
-			Port:     pointer.Int32(13),
+			Port:     ptr.To[int32](13),
 			Protocol: &udp,
 		}}
 	}
@@ -374,11 +374,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udp,
 		}, {
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udp,
 		}}
 	}
@@ -391,11 +391,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p13"),
-			Port:     pointer.Int32(13),
+			Port:     ptr.To[int32](13),
 			Protocol: &udp,
 		}, {
 			Name:     ptr.To("p14"),
-			Port:     pointer.Int32(14),
+			Port:     ptr.To[int32](14),
 			Protocol: &udp,
 		}}
 	}
@@ -408,11 +408,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p21"),
-			Port:     pointer.Int32(21),
+			Port:     ptr.To[int32](21),
 			Protocol: &udp,
 		}, {
 			Name:     ptr.To("p22"),
-			Port:     pointer.Int32(22),
+			Port:     ptr.To[int32](22),
 			Protocol: &udp,
 		}}
 	}
@@ -422,7 +422,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udp,
 		}}
 	}
@@ -436,7 +436,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p22"),
-			Port:     pointer.Int32(22),
+			Port:     ptr.To[int32](22),
 			Protocol: &udp,
 		}}
 	}
@@ -447,7 +447,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p23"),
-			Port:     pointer.Int32(23),
+			Port:     ptr.To[int32](23),
 			Protocol: &udp,
 		}}
 	}
@@ -461,7 +461,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
-			Port:     pointer.Int32(44),
+			Port:     ptr.To[int32](44),
 			Protocol: &udp,
 		}}
 	}
@@ -472,7 +472,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p45"),
-			Port:     pointer.Int32(45),
+			Port:     ptr.To[int32](45),
 			Protocol: &udp,
 		}}
 	}
@@ -484,7 +484,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udp,
 		}}
 	}
@@ -494,11 +494,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udp,
 		}, {
 			Name:     ptr.To("p122"),
-			Port:     pointer.Int32(122),
+			Port:     ptr.To[int32](122),
 			Protocol: &udp,
 		}}
 	}
@@ -508,7 +508,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p33"),
-			Port:     pointer.Int32(33),
+			Port:     ptr.To[int32](33),
 			Protocol: &udp,
 		}}
 	}
@@ -519,7 +519,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
-			Port:     pointer.Int32(44),
+			Port:     ptr.To[int32](44),
 			Protocol: &udp,
 		}}
 	}
@@ -1217,7 +1217,7 @@ func TestLastChangeTriggerTime(t *testing.T) {
 			}},
 			Ports: []discovery.EndpointPort{{
 				Name:     ptr.To("p11"),
-				Port:     pointer.Int32(11),
+				Port:     ptr.To[int32](11),
 				Protocol: &tcp,
 			}},
 		}
@@ -1335,7 +1335,7 @@ func TestLastChangeTriggerTime(t *testing.T) {
 }
 
 func TestEndpointSliceUpdate(t *testing.T) {
-	fqdnSlice := generateEndpointSlice("svc1", "ns1", 2, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)})
+	fqdnSlice := generateEndpointSlice("svc1", "ns1", 2, 5, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)})
 	fqdnSlice.AddressType = discovery.AddressTypeFQDN
 
 	testCases := map[string]struct {
@@ -1353,7 +1353,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			startingSlices:         []*discovery.EndpointSlice{},
 			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       false,
 			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
@@ -1373,11 +1373,11 @@ func TestEndpointSliceUpdate(t *testing.T) {
 		// test no modification to state - current change should be nil as nothing changes
 		"add the same slice that already exists": {
 			startingSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
 			endpointsChangeTracker:   NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
 			namespacedName:           types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:       generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramEndpointSlice:       generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:         false,
 			expectedReturnVal:        false,
 			expectedCurrentChange:    nil,
@@ -1386,7 +1386,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 		// ensure that only valide address types are processed
 		"add an FQDN slice (invalid address type)": {
 			startingSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
 			endpointsChangeTracker:   NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
 			namespacedName:           types.NamespacedName{Name: "svc1", Namespace: "ns1"},
@@ -1399,12 +1399,12 @@ func TestEndpointSliceUpdate(t *testing.T) {
 		// test additions to existing state
 		"add a slice that overlaps with existing state": {
 			startingSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
+				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
 			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       false,
 			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
@@ -1432,12 +1432,12 @@ func TestEndpointSliceUpdate(t *testing.T) {
 		// test additions to existing state with partially overlapping slices and ports
 		"add a slice that overlaps with existing state and partial ports": {
 			startingSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
+				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
 			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:     generateEndpointSliceWithOffset("svc1", "ns1", 3, 1, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80)}),
+			paramEndpointSlice:     generateEndpointSliceWithOffset("svc1", "ns1", 3, 1, 5, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80)}),
 			paramRemoveSlice:       false,
 			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
@@ -1463,12 +1463,12 @@ func TestEndpointSliceUpdate(t *testing.T) {
 		// test deletions from existing state with partially overlapping slices and ports
 		"remove a slice that overlaps with existing state": {
 			startingSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
+				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
 			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       true,
 			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
@@ -1486,12 +1486,12 @@ func TestEndpointSliceUpdate(t *testing.T) {
 		// ensure a removal that has no effect turns into a no-op
 		"remove a slice that doesn't even exist in current state": {
 			startingSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+				generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
+				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
 			endpointsChangeTracker:   NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
 			namespacedName:           types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:       generateEndpointSlice("svc1", "ns1", 3, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramEndpointSlice:       generateEndpointSlice("svc1", "ns1", 3, 5, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:         true,
 			expectedReturnVal:        false,
 			expectedCurrentChange:    nil,
@@ -1500,11 +1500,11 @@ func TestEndpointSliceUpdate(t *testing.T) {
 		// start with all endpoints ready, transition to no endpoints ready
 		"transition all endpoints to unready state": {
 			startingSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
 			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 1, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 1, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       false,
 			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
@@ -1524,11 +1524,11 @@ func TestEndpointSliceUpdate(t *testing.T) {
 		// start with no endpoints ready, transition to all endpoints ready
 		"transition all endpoints to ready state": {
 			startingSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 2, 1, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+				generateEndpointSlice("svc1", "ns1", 1, 2, 1, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
 			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 2, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 2, 999, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       false,
 			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
@@ -1546,12 +1546,12 @@ func TestEndpointSliceUpdate(t *testing.T) {
 		// start with some endpoints ready, transition to more endpoints ready
 		"transition some endpoints to ready state": {
 			startingSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 2, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-				generateEndpointSlice("svc1", "ns1", 2, 2, 2, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 2, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
+				generateEndpointSlice("svc1", "ns1", 2, 2, 2, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
 			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 3, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 3, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       false,
 			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
@@ -1575,12 +1575,12 @@ func TestEndpointSliceUpdate(t *testing.T) {
 		// start with some endpoints ready, transition to some terminating
 		"transition some endpoints to terminating state": {
 			startingSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 2, 2, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-				generateEndpointSlice("svc1", "ns1", 2, 2, 2, 2, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 2, 2, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
+				generateEndpointSlice("svc1", "ns1", 2, 2, 2, 2, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
 			endpointsChangeTracker: NewEndpointsChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
 			namespacedName:         types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 3, 2, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramEndpointSlice:     generateEndpointSlice("svc1", "ns1", 1, 3, 3, 2, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			paramRemoveSlice:       false,
 			expectedReturnVal:      true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
@@ -1663,7 +1663,7 @@ func TestCheckoutChanges(t *testing.T) {
 			}},
 			appliedSlices: []*discovery.EndpointSlice{},
 			pendingSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 3, 2, []string{"host1"}, []*int32{pointer.Int32(80)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 3, 2, []string{"host1"}, []*int32{ptr.To[int32](80)}),
 			},
 		},
 		"removing port in update": {
@@ -1690,10 +1690,10 @@ func TestCheckoutChanges(t *testing.T) {
 				},
 			}},
 			appliedSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 3, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 3, 999, []string{"host1"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
 			pendingSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 3, 999, []string{"host1"}, []*int32{pointer.Int32(80)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 3, 999, []string{"host1"}, []*int32{ptr.To[int32](80)}),
 			},
 		},
 	}

--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -195,7 +195,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.1"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String(""),
+			Name:     ptr.To(""),
 			Port:     pointer.Int32(11),
 			Protocol: &udp,
 		}}
@@ -204,13 +204,13 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"1.1.1.1"},
 			Conditions: discovery.EndpointConditions{
-				Ready:       pointer.Bool(true),
-				Serving:     pointer.Bool(true),
-				Terminating: pointer.Bool(false),
+				Ready:       ptr.To(true),
+				Serving:     ptr.To(true),
+				Terminating: ptr.To(false),
 			},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String(""),
+			Name:     ptr.To(""),
 			Port:     pointer.Int32(11),
 			Protocol: &udp,
 		}}
@@ -219,13 +219,13 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"1.1.1.1"},
 			Conditions: discovery.EndpointConditions{
-				Ready:       pointer.Bool(false),
-				Serving:     pointer.Bool(true),
-				Terminating: pointer.Bool(true),
+				Ready:       ptr.To(false),
+				Serving:     ptr.To(true),
+				Terminating: ptr.To(true),
 			},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String(""),
+			Name:     ptr.To(""),
 			Port:     pointer.Int32(11),
 			Protocol: &udp,
 		}}
@@ -236,7 +236,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String(""),
+			Name:     ptr.To(""),
 			Port:     pointer.Int32(11),
 			Protocol: &udp,
 		}}
@@ -247,7 +247,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udp,
 		}}
@@ -257,7 +257,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.1"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udp,
 		}}
@@ -267,7 +267,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.1"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11-2"),
+			Name:     ptr.To("p11-2"),
 			Port:     pointer.Int32(11),
 			Protocol: &udp,
 		}}
@@ -277,7 +277,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.1"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(22),
 			Protocol: &udp,
 		}}
@@ -290,11 +290,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udp,
 		}, {
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udp,
 		}}
@@ -304,7 +304,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.1"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udp,
 		}}
@@ -314,7 +314,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.2"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udp,
 		}}
@@ -324,7 +324,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.1"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udp,
 		}}
@@ -335,7 +335,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udp,
 		}}
@@ -346,11 +346,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udp,
 		}, {
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udp,
 		}}
@@ -360,7 +360,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.3"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p13"),
+			Name:     ptr.To("p13"),
 			Port:     pointer.Int32(13),
 			Protocol: &udp,
 		}}
@@ -373,11 +373,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udp,
 		}, {
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udp,
 		}}
@@ -390,11 +390,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p13"),
+			Name:     ptr.To("p13"),
 			Port:     pointer.Int32(13),
 			Protocol: &udp,
 		}, {
-			Name:     pointer.String("p14"),
+			Name:     ptr.To("p14"),
 			Port:     pointer.Int32(14),
 			Protocol: &udp,
 		}}
@@ -407,11 +407,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p21"),
+			Name:     ptr.To("p21"),
 			Port:     pointer.Int32(21),
 			Protocol: &udp,
 		}, {
-			Name:     pointer.String("p22"),
+			Name:     ptr.To("p22"),
 			Port:     pointer.Int32(22),
 			Protocol: &udp,
 		}}
@@ -421,7 +421,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.1"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udp,
 		}}
@@ -435,7 +435,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p22"),
+			Name:     ptr.To("p22"),
 			Port:     pointer.Int32(22),
 			Protocol: &udp,
 		}}
@@ -446,7 +446,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p23"),
+			Name:     ptr.To("p23"),
 			Port:     pointer.Int32(23),
 			Protocol: &udp,
 		}}
@@ -460,7 +460,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p44"),
+			Name:     ptr.To("p44"),
 			Port:     pointer.Int32(44),
 			Protocol: &udp,
 		}}
@@ -471,7 +471,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p45"),
+			Name:     ptr.To("p45"),
 			Port:     pointer.Int32(45),
 			Protocol: &udp,
 		}}
@@ -483,7 +483,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.11"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udp,
 		}}
@@ -493,11 +493,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.2"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udp,
 		}, {
-			Name:     pointer.String("p122"),
+			Name:     ptr.To("p122"),
 			Port:     pointer.Int32(122),
 			Protocol: &udp,
 		}}
@@ -507,7 +507,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"3.3.3.3"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p33"),
+			Name:     ptr.To("p33"),
 			Port:     pointer.Int32(33),
 			Protocol: &udp,
 		}}
@@ -518,7 +518,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p44"),
+			Name:     ptr.To("p44"),
 			Port:     pointer.Int32(44),
 			Protocol: &udp,
 		}}
@@ -1216,7 +1216,7 @@ func TestLastChangeTriggerTime(t *testing.T) {
 				Addresses: []string{"1.1.1.1"},
 			}},
 			Ports: []discovery.EndpointPort{{
-				Name:     pointer.String("p11"),
+				Name:     ptr.To("p11"),
 				Port:     pointer.Int32(11),
 				Protocol: &tcp,
 			}},

--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func (proxier *FakeProxier) addEndpointSlice(slice *discovery.EndpointSlice) {

--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -184,8 +184,6 @@ func makeTestEndpointSlice(namespace, name string, slice int, epsFunc func(*disc
 }
 
 func TestUpdateEndpointsMap(t *testing.T) {
-	var nodeName = testHostname
-
 	emptyEndpoint := func(eps *discovery.EndpointSlice) {
 		eps.Endpoints = []discovery.Endpoint{}
 	}
@@ -232,7 +230,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 	unnamedPortLocal := func(eps *discovery.EndpointSlice) {
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"1.1.1.1"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To(""),
@@ -243,7 +241,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 	namedPortLocal := func(eps *discovery.EndpointSlice) {
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"1.1.1.1"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
@@ -286,7 +284,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.1"},
 		}, {
 			Addresses: []string{"1.1.1.2"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
@@ -331,7 +329,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 	multipleSubsetsWithLocal_s2 := func(eps *discovery.EndpointSlice) {
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"1.1.1.2"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
@@ -342,7 +340,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 	multipleSubsetsMultiplePortsLocal_s1 := func(eps *discovery.EndpointSlice) {
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"1.1.1.1"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
@@ -369,7 +367,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.1"},
 		}, {
 			Addresses: []string{"1.1.1.2"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
@@ -386,7 +384,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.3"},
 		}, {
 			Addresses: []string{"1.1.1.4"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p13"),
@@ -403,7 +401,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"2.2.2.1"},
 		}, {
 			Addresses: []string{"2.2.2.2"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p21"),
@@ -428,10 +426,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 	complexBefore2_s1 := func(eps *discovery.EndpointSlice) {
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"2.2.2.2"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}, {
 			Addresses: []string{"2.2.2.22"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p22"),
@@ -442,7 +440,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 	complexBefore2_s2 := func(eps *discovery.EndpointSlice) {
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"2.2.2.3"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p23"),
@@ -453,10 +451,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 	complexBefore4_s1 := func(eps *discovery.EndpointSlice) {
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"4.4.4.4"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}, {
 			Addresses: []string{"4.4.4.5"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
@@ -467,7 +465,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 	complexBefore4_s2 := func(eps *discovery.EndpointSlice) {
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"4.4.4.6"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p45"),
@@ -514,7 +512,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 	complexAfter4 := func(eps *discovery.EndpointSlice) {
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"4.4.4.4"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
@@ -1111,7 +1109,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 	for tci, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fp := newFakeProxier(v1.IPv4Protocol, time.Time{})
-			fp.hostname = nodeName
+			fp.hostname = testHostname
 
 			// First check that after adding all previous versions of endpoints,
 			// the fp.previousEndpointsMap is as we expect.

--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -185,7 +185,6 @@ func makeTestEndpointSlice(namespace, name string, slice int, epsFunc func(*disc
 
 func TestUpdateEndpointsMap(t *testing.T) {
 	var nodeName = testHostname
-	udp := v1.ProtocolUDP
 
 	emptyEndpoint := func(eps *discovery.EndpointSlice) {
 		eps.Endpoints = []discovery.Endpoint{}
@@ -197,7 +196,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To(""),
 			Port:     ptr.To[int32](11),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	unnamedPortReady := func(eps *discovery.EndpointSlice) {
@@ -212,7 +211,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To(""),
 			Port:     ptr.To[int32](11),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	unnamedPortTerminating := func(eps *discovery.EndpointSlice) {
@@ -227,7 +226,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To(""),
 			Port:     ptr.To[int32](11),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	unnamedPortLocal := func(eps *discovery.EndpointSlice) {
@@ -238,7 +237,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To(""),
 			Port:     ptr.To[int32](11),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	namedPortLocal := func(eps *discovery.EndpointSlice) {
@@ -249,7 +248,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	namedPort := func(eps *discovery.EndpointSlice) {
@@ -259,7 +258,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	namedPortRenamed := func(eps *discovery.EndpointSlice) {
@@ -269,7 +268,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11-2"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	namedPortRenumbered := func(eps *discovery.EndpointSlice) {
@@ -279,7 +278,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](22),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	namedPortsLocalNoLocal := func(eps *discovery.EndpointSlice) {
@@ -292,11 +291,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	multipleSubsets_s1 := func(eps *discovery.EndpointSlice) {
@@ -306,7 +305,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	multipleSubsets_s2 := func(eps *discovery.EndpointSlice) {
@@ -316,7 +315,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	multipleSubsetsWithLocal_s1 := func(eps *discovery.EndpointSlice) {
@@ -326,7 +325,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	multipleSubsetsWithLocal_s2 := func(eps *discovery.EndpointSlice) {
@@ -337,7 +336,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	multipleSubsetsMultiplePortsLocal_s1 := func(eps *discovery.EndpointSlice) {
@@ -348,11 +347,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	multipleSubsetsMultiplePortsLocal_s2 := func(eps *discovery.EndpointSlice) {
@@ -362,7 +361,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p13"),
 			Port:     ptr.To[int32](13),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	multipleSubsetsIPsPorts1_s1 := func(eps *discovery.EndpointSlice) {
@@ -375,11 +374,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	multipleSubsetsIPsPorts1_s2 := func(eps *discovery.EndpointSlice) {
@@ -392,11 +391,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p13"),
 			Port:     ptr.To[int32](13),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p14"),
 			Port:     ptr.To[int32](14),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	multipleSubsetsIPsPorts2 := func(eps *discovery.EndpointSlice) {
@@ -409,11 +408,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p21"),
 			Port:     ptr.To[int32](21),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p22"),
 			Port:     ptr.To[int32](22),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexBefore1 := func(eps *discovery.EndpointSlice) {
@@ -423,7 +422,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexBefore2_s1 := func(eps *discovery.EndpointSlice) {
@@ -437,7 +436,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p22"),
 			Port:     ptr.To[int32](22),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexBefore2_s2 := func(eps *discovery.EndpointSlice) {
@@ -448,7 +447,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p23"),
 			Port:     ptr.To[int32](23),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexBefore4_s1 := func(eps *discovery.EndpointSlice) {
@@ -462,7 +461,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
 			Port:     ptr.To[int32](44),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexBefore4_s2 := func(eps *discovery.EndpointSlice) {
@@ -473,7 +472,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p45"),
 			Port:     ptr.To[int32](45),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexAfter1_s1 := func(eps *discovery.EndpointSlice) {
@@ -485,7 +484,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexAfter1_s2 := func(eps *discovery.EndpointSlice) {
@@ -495,11 +494,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p122"),
 			Port:     ptr.To[int32](122),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexAfter3 := func(eps *discovery.EndpointSlice) {
@@ -509,7 +508,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p33"),
 			Port:     ptr.To[int32](33),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexAfter4 := func(eps *discovery.EndpointSlice) {
@@ -520,7 +519,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
 			Port:     ptr.To[int32](44),
-			Protocol: &udp,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 
@@ -1199,7 +1198,6 @@ func TestLastChangeTriggerTime(t *testing.T) {
 	t3 := t2.Add(time.Second)
 
 	createEndpoints := func(namespace, name string, triggerTime time.Time) *discovery.EndpointSlice {
-		tcp := v1.ProtocolTCP
 		return &discovery.EndpointSlice{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -1218,7 +1216,7 @@ func TestLastChangeTriggerTime(t *testing.T) {
 			Ports: []discovery.EndpointPort{{
 				Name:     ptr.To("p11"),
 				Port:     ptr.To[int32](11),
-				Protocol: &tcp,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}},
 		}
 	}

--- a/pkg/proxy/endpointslicecache_test.go
+++ b/pkg/proxy/endpointslicecache_test.go
@@ -318,8 +318,8 @@ func TestEsInfoChanged(t *testing.T) {
 	p80 := int32(80)
 	p443 := int32(443)
 	tcpProto := v1.ProtocolTCP
-	port80 := discovery.EndpointPort{Port: &p80, Name: pointer.String("http"), Protocol: &tcpProto}
-	port443 := discovery.EndpointPort{Port: &p443, Name: pointer.String("https"), Protocol: &tcpProto}
+	port80 := discovery.EndpointPort{Port: &p80, Name: ptr.To("http"), Protocol: &tcpProto}
+	port443 := discovery.EndpointPort{Port: &p443, Name: ptr.To("https"), Protocol: &tcpProto}
 	endpoint1 := discovery.Endpoint{Addresses: []string{"10.0.1.0"}}
 	endpoint2 := discovery.Endpoint{Addresses: []string{"10.0.1.1"}}
 
@@ -469,7 +469,7 @@ func generateEndpointSliceWithOffset(serviceName, namespace string, sliceNum, of
 
 	for i, portNum := range portNums {
 		endpointSlice.Ports = append(endpointSlice.Ports, discovery.EndpointPort{
-			Name:     pointer.String(fmt.Sprintf("port-%d", i)),
+			Name:     ptr.To(fmt.Sprintf("port-%d", i)),
 			Port:     portNum,
 			Protocol: &tcpProtocol,
 		})
@@ -479,9 +479,9 @@ func generateEndpointSliceWithOffset(serviceName, namespace string, sliceNum, of
 		readyCondition := i%unreadyMod != 0
 		terminatingCondition := i%terminatingMod == 0
 
-		ready := pointer.Bool(readyCondition && !terminatingCondition)
-		serving := pointer.Bool(readyCondition)
-		terminating := pointer.Bool(terminatingCondition)
+		ready := ptr.To(readyCondition && !terminatingCondition)
+		serving := ptr.To(readyCondition)
+		terminating := ptr.To(terminatingCondition)
 
 		endpoint := discovery.Endpoint{
 			Addresses: []string{fmt.Sprintf("10.0.%d.%d", offset, i)},

--- a/pkg/proxy/endpointslicecache_test.go
+++ b/pkg/proxy/endpointslicecache_test.go
@@ -40,7 +40,7 @@ func TestEndpointsMapFromESC(t *testing.T) {
 			namespacedName: types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			hostname:       "host1",
 			endpointSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80), ptr.To[int32](443)}),
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
@@ -58,8 +58,8 @@ func TestEndpointsMapFromESC(t *testing.T) {
 		"2 slices, same port": {
 			namespacedName: types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			endpointSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{}, []*int32{pointer.Int32(80)}),
-				generateEndpointSlice("svc1", "ns1", 2, 3, 999, 999, []string{}, []*int32{pointer.Int32(80)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{}, []*int32{ptr.To[int32](80)}),
+				generateEndpointSlice("svc1", "ns1", 2, 3, 999, 999, []string{}, []*int32{ptr.To[int32](80)}),
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
@@ -77,8 +77,8 @@ func TestEndpointsMapFromESC(t *testing.T) {
 		"2 overlapping slices, same port": {
 			namespacedName: types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			endpointSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{}, []*int32{pointer.Int32(80)}),
-				generateEndpointSlice("svc1", "ns1", 1, 4, 999, 999, []string{}, []*int32{pointer.Int32(80)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{}, []*int32{ptr.To[int32](80)}),
+				generateEndpointSlice("svc1", "ns1", 1, 4, 999, 999, []string{}, []*int32{ptr.To[int32](80)}),
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
@@ -96,8 +96,8 @@ func TestEndpointsMapFromESC(t *testing.T) {
 		"2 slices, overlapping endpoints, some endpoints unready in 1 or both": {
 			namespacedName: types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			endpointSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 10, 3, 999, []string{}, []*int32{pointer.Int32(80)}),
-				generateEndpointSlice("svc1", "ns1", 1, 10, 6, 999, []string{}, []*int32{pointer.Int32(80)}),
+				generateEndpointSlice("svc1", "ns1", 1, 10, 3, 999, []string{}, []*int32{ptr.To[int32](80)}),
+				generateEndpointSlice("svc1", "ns1", 1, 10, 6, 999, []string{}, []*int32{ptr.To[int32](80)}),
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
@@ -118,8 +118,8 @@ func TestEndpointsMapFromESC(t *testing.T) {
 		"2 slices, overlapping endpoints, some endpoints unready and some endpoints terminating": {
 			namespacedName: types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			endpointSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 10, 3, 5, []string{}, []*int32{pointer.Int32(80)}),
-				generateEndpointSlice("svc1", "ns1", 1, 10, 6, 5, []string{}, []*int32{pointer.Int32(80)}),
+				generateEndpointSlice("svc1", "ns1", 1, 10, 3, 5, []string{}, []*int32{ptr.To[int32](80)}),
+				generateEndpointSlice("svc1", "ns1", 1, 10, 6, 5, []string{}, []*int32{ptr.To[int32](80)}),
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
@@ -139,8 +139,8 @@ func TestEndpointsMapFromESC(t *testing.T) {
 		"2 slices, overlapping endpoints, all unready": {
 			namespacedName: types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			endpointSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 10, 1, 999, []string{}, []*int32{pointer.Int32(80)}),
-				generateEndpointSlice("svc1", "ns1", 1, 10, 1, 999, []string{}, []*int32{pointer.Int32(80)}),
+				generateEndpointSlice("svc1", "ns1", 1, 10, 1, 999, []string{}, []*int32{ptr.To[int32](80)}),
+				generateEndpointSlice("svc1", "ns1", 1, 10, 1, 999, []string{}, []*int32{ptr.To[int32](80)}),
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
@@ -160,9 +160,9 @@ func TestEndpointsMapFromESC(t *testing.T) {
 		"3 slices with different services and namespaces": {
 			namespacedName: types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			endpointSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{}, []*int32{pointer.Int32(80)}),
-				generateEndpointSlice("svc2", "ns1", 2, 3, 999, 999, []string{}, []*int32{pointer.Int32(80)}),
-				generateEndpointSlice("svc1", "ns2", 3, 3, 999, 999, []string{}, []*int32{pointer.Int32(80)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{}, []*int32{ptr.To[int32](80)}),
+				generateEndpointSlice("svc2", "ns1", 2, 3, 999, 999, []string{}, []*int32{ptr.To[int32](80)}),
+				generateEndpointSlice("svc1", "ns2", 3, 3, 999, 999, []string{}, []*int32{ptr.To[int32](80)}),
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
@@ -188,8 +188,8 @@ func TestEndpointsMapFromESC(t *testing.T) {
 			namespacedName: types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			hostname:       "host1",
 			endpointSlices: []*discovery.EndpointSlice{
-				generateEndpointSliceWithOffset("svc1", "ns1", 1, 1, 2, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80)}),
-				generateEndpointSliceWithOffset("svc1", "ns1", 2, 1, 2, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(8080)}),
+				generateEndpointSliceWithOffset("svc1", "ns1", 1, 1, 2, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80)}),
+				generateEndpointSliceWithOffset("svc1", "ns1", 2, 1, 2, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](8080)}),
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
@@ -228,7 +228,7 @@ func TestEndpointInfoByServicePort(t *testing.T) {
 			namespacedName: types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			hostname:       "host1",
 			endpointSlices: []*discovery.EndpointSlice{
-				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80)}),
+				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80)}),
 			},
 			expectedMap: spToEndpointMap{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
@@ -260,8 +260,8 @@ func TestEndpointInfoByServicePort(t *testing.T) {
 			namespacedName: types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			hostname:       "host1",
 			endpointSlices: []*discovery.EndpointSlice{
-				generateEndpointSliceWithOffset("svc1", "ns1", 1, 1, 2, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80)}),
-				generateEndpointSliceWithOffset("svc1", "ns1", 2, 1, 2, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(8080)}),
+				generateEndpointSliceWithOffset("svc1", "ns1", 1, 1, 2, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](80)}),
+				generateEndpointSliceWithOffset("svc1", "ns1", 2, 1, 2, 999, 999, []string{"host1", "host2"}, []*int32{ptr.To[int32](8080)}),
 			},
 			expectedMap: spToEndpointMap{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {

--- a/pkg/proxy/endpointslicecache_test.go
+++ b/pkg/proxy/endpointslicecache_test.go
@@ -317,9 +317,8 @@ func TestEndpointInfoByServicePort(t *testing.T) {
 func TestEsInfoChanged(t *testing.T) {
 	p80 := int32(80)
 	p443 := int32(443)
-	tcpProto := v1.ProtocolTCP
-	port80 := discovery.EndpointPort{Port: &p80, Name: ptr.To("http"), Protocol: &tcpProto}
-	port443 := discovery.EndpointPort{Port: &p443, Name: ptr.To("https"), Protocol: &tcpProto}
+	port80 := discovery.EndpointPort{Port: &p80, Name: ptr.To("http"), Protocol: ptr.To(v1.ProtocolTCP)}
+	port443 := discovery.EndpointPort{Port: &p443, Name: ptr.To("https"), Protocol: ptr.To(v1.ProtocolTCP)}
 	endpoint1 := discovery.Endpoint{Addresses: []string{"10.0.1.0"}}
 	endpoint2 := discovery.Endpoint{Addresses: []string{"10.0.1.1"}}
 
@@ -454,8 +453,6 @@ func TestEsInfoChanged(t *testing.T) {
 }
 
 func generateEndpointSliceWithOffset(serviceName, namespace string, sliceNum, offset, numEndpoints, unreadyMod int, terminatingMod int, hosts []string, portNums []*int32) *discovery.EndpointSlice {
-	tcpProtocol := v1.ProtocolTCP
-
 	endpointSlice := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%d", serviceName, sliceNum),
@@ -471,7 +468,7 @@ func generateEndpointSliceWithOffset(serviceName, namespace string, sliceNum, of
 		endpointSlice.Ports = append(endpointSlice.Ports, discovery.EndpointPort{
 			Name:     ptr.To(fmt.Sprintf("port-%d", i)),
 			Port:     portNum,
-			Protocol: &tcpProtocol,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		})
 	}
 

--- a/pkg/proxy/endpointslicecache_test.go
+++ b/pkg/proxy/endpointslicecache_test.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestEndpointsMapFromESC(t *testing.T) {

--- a/pkg/proxy/iptables/number_generated_rules_test.go
+++ b/pkg/proxy/iptables/number_generated_rules_test.go
@@ -371,7 +371,7 @@ func generateServiceEndpoints(nServices, nEndpoints int, epsFunc func(eps *disco
 		AddressType: discovery.AddressTypeIPv4,
 		Endpoints:   []discovery.Endpoint{},
 		Ports: []discovery.EndpointPort{{
-			Name:     pointer.String(fmt.Sprintf("%d", epPort)),
+			Name:     ptr.To(fmt.Sprintf("%d", epPort)),
 			Port:     pointer.Int32(int32(epPort)),
 			Protocol: &tcpProtocol,
 		}},

--- a/pkg/proxy/iptables/number_generated_rules_test.go
+++ b/pkg/proxy/iptables/number_generated_rules_test.go
@@ -361,8 +361,6 @@ func generateServiceEndpoints(nServices, nEndpoints int, epsFunc func(eps *disco
 	baseEp := netutils.BigForIP(netutils.ParseIPSloppy("172.16.0.1"))
 	epPort := 8080
 
-	tcpProtocol := v1.ProtocolTCP
-
 	eps := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ep",
@@ -373,7 +371,7 @@ func generateServiceEndpoints(nServices, nEndpoints int, epsFunc func(eps *disco
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(fmt.Sprintf("%d", epPort)),
 			Port:     ptr.To(int32(epPort)),
-			Protocol: &tcpProtocol,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}},
 	}
 

--- a/pkg/proxy/iptables/number_generated_rules_test.go
+++ b/pkg/proxy/iptables/number_generated_rules_test.go
@@ -372,7 +372,7 @@ func generateServiceEndpoints(nServices, nEndpoints int, epsFunc func(eps *disco
 		Endpoints:   []discovery.Endpoint{},
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(fmt.Sprintf("%d", epPort)),
-			Port:     pointer.Int32(int32(epPort)),
+			Port:     ptr.To(int32(epPort)),
 			Protocol: &tcpProtocol,
 		}},
 	}

--- a/pkg/proxy/iptables/number_generated_rules_test.go
+++ b/pkg/proxy/iptables/number_generated_rules_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	iptablestest "k8s.io/kubernetes/pkg/util/iptables/testing"
 	netutils "k8s.io/utils/net"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // kube-proxy generates iptables rules to forward traffic from Services to Endpoints

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -2314,7 +2314,7 @@ func TestLoadBalancer(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -2836,7 +2836,7 @@ func TestExternalTrafficPolicyLocal(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -2953,7 +2953,7 @@ func TestExternalTrafficPolicyCluster(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -4415,7 +4415,7 @@ func TestProxierDeleteNodePortStaleUDP(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &udpProtocol,
 			}}
 		}),
@@ -4438,7 +4438,7 @@ func TestProxierDeleteNodePortStaleUDP(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &udpProtocol,
 			}}
 		}),
@@ -4528,7 +4528,7 @@ func TestProxierMetricsIptablesTotalRules(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
 		}),

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -6944,9 +6944,6 @@ func TestNoEndpointsMetric(t *testing.T) {
 }
 
 func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
-	ipModeProxy := v1.LoadBalancerIPModeProxy
-	ipModeVIP := v1.LoadBalancerIPModeVIP
-
 	testCases := []struct {
 		name          string
 		ipModeEnabled bool
@@ -6961,7 +6958,7 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 			ipModeEnabled: false,
 			svcIP:         "10.20.30.41",
 			svcLBIP:       "1.2.3.4",
-			ipMode:        &ipModeProxy,
+			ipMode:        ptr.To(v1.LoadBalancerIPModeProxy),
 			expectedRule:  true,
 		},
 		{
@@ -6969,7 +6966,7 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 			ipModeEnabled: false,
 			svcIP:         "10.20.30.42",
 			svcLBIP:       "1.2.3.5",
-			ipMode:        &ipModeVIP,
+			ipMode:        ptr.To(v1.LoadBalancerIPModeVIP),
 			expectedRule:  true,
 		},
 		{
@@ -6986,7 +6983,7 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 			ipModeEnabled: true,
 			svcIP:         "10.20.30.41",
 			svcLBIP:       "1.2.3.4",
-			ipMode:        &ipModeProxy,
+			ipMode:        ptr.To(v1.LoadBalancerIPModeProxy),
 			expectedRule:  false,
 		},
 		{
@@ -6994,7 +6991,7 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 			ipModeEnabled: true,
 			svcIP:         "10.20.30.42",
 			svcLBIP:       "1.2.3.5",
-			ipMode:        &ipModeVIP,
+			ipMode:        ptr.To(v1.LoadBalancerIPModeVIP),
 			expectedRule:  true,
 		},
 		{

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -4553,9 +4553,6 @@ func TestInternalTrafficPolicy(t *testing.T) {
 		hostname string
 	}
 
-	cluster := v1.ServiceInternalTrafficPolicyCluster
-	local := v1.ServiceInternalTrafficPolicyLocal
-
 	testCases := []struct {
 		name                  string
 		line                  int
@@ -4566,7 +4563,7 @@ func TestInternalTrafficPolicy(t *testing.T) {
 		{
 			name:                  "internalTrafficPolicy is cluster",
 			line:                  getLine(),
-			internalTrafficPolicy: &cluster,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyCluster),
 			endpoints: []endpoint{
 				{"10.0.1.1", testHostname},
 				{"10.0.1.2", "host1"},
@@ -4586,7 +4583,7 @@ func TestInternalTrafficPolicy(t *testing.T) {
 		{
 			name:                  "internalTrafficPolicy is local and there is one local endpoint",
 			line:                  getLine(),
-			internalTrafficPolicy: &local,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyLocal),
 			endpoints: []endpoint{
 				{"10.0.1.1", testHostname},
 				{"10.0.1.2", "host1"},
@@ -4606,7 +4603,7 @@ func TestInternalTrafficPolicy(t *testing.T) {
 		{
 			name:                  "internalTrafficPolicy is local and there are multiple local endpoints",
 			line:                  getLine(),
-			internalTrafficPolicy: &local,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyLocal),
 			endpoints: []endpoint{
 				{"10.0.1.1", testHostname},
 				{"10.0.1.2", testHostname},
@@ -4626,7 +4623,7 @@ func TestInternalTrafficPolicy(t *testing.T) {
 		{
 			name:                  "internalTrafficPolicy is local and there are no local endpoints",
 			line:                  getLine(),
-			internalTrafficPolicy: &local,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyLocal),
 			endpoints: []endpoint{
 				{"10.0.1.1", "host0"},
 				{"10.0.1.2", "host1"},
@@ -5380,8 +5377,6 @@ func TestInternalExternalMasquerade(t *testing.T) {
 	// (Put the test setup code in an internal function so we can have it here at the
 	// top, before the test cases that will be run against it.)
 	setupTest := func(fp *Proxier) {
-		local := v1.ServiceInternalTrafficPolicyLocal
-
 		makeServiceMap(fp,
 			makeTestService("ns1", "svc1", func(svc *v1.Service) {
 				svc.Spec.Type = "LoadBalancer"
@@ -5422,7 +5417,7 @@ func TestInternalExternalMasquerade(t *testing.T) {
 					NodePort: int32(3003),
 				}}
 				svc.Spec.HealthCheckNodePort = 30003
-				svc.Spec.InternalTrafficPolicy = &local
+				svc.Spec.InternalTrafficPolicy = ptr.To(v1.ServiceInternalTrafficPolicyLocal)
 				svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{
 					IP: "9.10.11.12",
 				}}
@@ -6797,9 +6792,6 @@ func TestNoEndpointsMetric(t *testing.T) {
 		hostname string
 	}
 
-	internalTrafficPolicyLocal := v1.ServiceInternalTrafficPolicyLocal
-	externalTrafficPolicyLocal := v1.ServiceExternalTrafficPolicyLocal
-
 	metrics.RegisterMetrics()
 	testCases := []struct {
 		name                                                string
@@ -6811,7 +6803,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 	}{
 		{
 			name:                  "internalTrafficPolicy is set and there are local endpoints",
-			internalTrafficPolicy: &internalTrafficPolicyLocal,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyLocal),
 			endpoints: []endpoint{
 				{"10.0.1.1", testHostname},
 				{"10.0.1.2", "host1"},
@@ -6820,7 +6812,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 		},
 		{
 			name:                  "externalTrafficPolicy is set and there are local endpoints",
-			externalTrafficPolicy: externalTrafficPolicyLocal,
+			externalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
 			endpoints: []endpoint{
 				{"10.0.1.1", testHostname},
 				{"10.0.1.2", "host1"},
@@ -6829,8 +6821,8 @@ func TestNoEndpointsMetric(t *testing.T) {
 		},
 		{
 			name:                  "both policies are set and there are local endpoints",
-			internalTrafficPolicy: &internalTrafficPolicyLocal,
-			externalTrafficPolicy: externalTrafficPolicyLocal,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyLocal),
+			externalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
 			endpoints: []endpoint{
 				{"10.0.1.1", testHostname},
 				{"10.0.1.2", "host1"},
@@ -6839,7 +6831,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 		},
 		{
 			name:                  "internalTrafficPolicy is set and there are no local endpoints",
-			internalTrafficPolicy: &internalTrafficPolicyLocal,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyLocal),
 			endpoints: []endpoint{
 				{"10.0.1.1", "host0"},
 				{"10.0.1.2", "host1"},
@@ -6849,7 +6841,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 		},
 		{
 			name:                  "externalTrafficPolicy is set and there are no local endpoints",
-			externalTrafficPolicy: externalTrafficPolicyLocal,
+			externalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
 			endpoints: []endpoint{
 				{"10.0.1.1", "host0"},
 				{"10.0.1.2", "host1"},
@@ -6859,8 +6851,8 @@ func TestNoEndpointsMetric(t *testing.T) {
 		},
 		{
 			name:                  "both policies are set and there are no local endpoints",
-			internalTrafficPolicy: &internalTrafficPolicyLocal,
-			externalTrafficPolicy: externalTrafficPolicyLocal,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyLocal),
+			externalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
 			endpoints: []endpoint{
 				{"10.0.1.1", "host0"},
 				{"10.0.1.2", "host1"},
@@ -6871,8 +6863,8 @@ func TestNoEndpointsMetric(t *testing.T) {
 		},
 		{
 			name:                  "both policies are set and there are no endpoints at all",
-			internalTrafficPolicy: &internalTrafficPolicyLocal,
-			externalTrafficPolicy: externalTrafficPolicyLocal,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyLocal),
+			externalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
 			endpoints:             []endpoint{},
 			expectedSyncProxyRulesNoLocalEndpointsTotalInternal: 0,
 			expectedSyncProxyRulesNoLocalEndpointsTotalExternal: 0,

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -1821,10 +1821,11 @@ func TestOverallIPTablesRules(t *testing.T) {
 			// in a crash, for backward compatibility.
 			svc.Spec.LoadBalancerSourceRanges = []string{" 203.0.113.0/25"}
 
-			svcSessionAffinityTimeout := int32(10800)
 			svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
 			svc.Spec.SessionAffinityConfig = &v1.SessionAffinityConfig{
-				ClientIP: &v1.ClientIPConfig{TimeoutSeconds: &svcSessionAffinityTimeout},
+				ClientIP: &v1.ClientIPConfig{
+					TimeoutSeconds: ptr.To[int32](10800),
+				},
 			}
 		}),
 		// create ClusterIP service with no endpoints

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -3390,8 +3390,6 @@ func checkEndpointExpectations(t *testing.T, tci int, newMap proxy.EndpointsMap,
 }
 
 func TestUpdateEndpointsMap(t *testing.T) {
-	var nodeName = testHostname
-
 	emptyEndpointSlices := []*discovery.EndpointSlice{
 		makeTestEndpointSlice("ns1", "ep1", 1, func(*discovery.EndpointSlice) {}),
 	}
@@ -3423,7 +3421,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				eps.AddressType = discovery.AddressTypeIPv4
 				eps.Endpoints = []discovery.Endpoint{{
 					Addresses: []string{"10.1.1.1"},
-					NodeName:  &nodeName,
+					NodeName:  ptr.To(testHostname),
 				}}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
@@ -3471,7 +3469,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 					Addresses: []string{"10.1.1.1"},
 				}, {
 					Addresses: []string{"10.1.1.2"},
-					NodeName:  &nodeName,
+					NodeName:  ptr.To(testHostname),
 				}}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
@@ -3492,7 +3490,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.AddressType = discovery.AddressTypeIPv4
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"10.1.1.2"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
@@ -3508,7 +3506,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.AddressType = discovery.AddressTypeIPv4
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"10.1.1.1"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
@@ -3541,7 +3539,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"10.1.1.1"},
 		}, {
 			Addresses: []string{"10.1.1.2"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
@@ -3559,7 +3557,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"10.1.1.3"},
 		}, {
 			Addresses: []string{"10.1.1.4"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p13"),
@@ -3577,7 +3575,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"10.2.2.1"},
 		}, {
 			Addresses: []string{"10.2.2.2"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p21"),
@@ -3598,10 +3596,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.AddressType = discovery.AddressTypeIPv4
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"10.2.2.2"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}, {
 			Addresses: []string{"10.2.2.22"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p22"),
@@ -3613,7 +3611,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.AddressType = discovery.AddressTypeIPv4
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"10.2.2.3"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p23"),
@@ -3625,10 +3623,10 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.AddressType = discovery.AddressTypeIPv4
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"10.4.4.4"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}, {
 			Addresses: []string{"10.4.4.5"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
@@ -3640,7 +3638,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.AddressType = discovery.AddressTypeIPv4
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"10.4.4.6"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p45"),
@@ -3691,7 +3689,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.AddressType = discovery.AddressTypeIPv4
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"10.4.4.4"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
@@ -4153,7 +4151,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ipt := iptablestest.NewFake()
 			fp := NewFakeProxier(ipt)
-			fp.hostname = nodeName
+			fp.hostname = testHostname
 
 			// First check that after adding all previous versions of endpoints,
 			// the fp.oldEndpoints is as we expect.

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -220,7 +220,7 @@ func TestDeleteEndpointConnections(t *testing.T) {
 				}}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p80"),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &tc.protocol,
 				}}
 			})
@@ -1854,7 +1854,7 @@ func TestOverallIPTablesRules(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
-				Port:     pointer.Int32(80),
+				Port:     ptr.To[int32](80),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -1867,7 +1867,7 @@ func TestOverallIPTablesRules(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
-				Port:     pointer.Int32(80),
+				Port:     ptr.To[int32](80),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -1879,7 +1879,7 @@ func TestOverallIPTablesRules(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
-				Port:     pointer.Int32(80),
+				Port:     ptr.To[int32](80),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -1894,7 +1894,7 @@ func TestOverallIPTablesRules(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
-				Port:     pointer.Int32(80),
+				Port:     ptr.To[int32](80),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -1906,7 +1906,7 @@ func TestOverallIPTablesRules(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
-				Port:     pointer.Int32(80),
+				Port:     ptr.To[int32](80),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -2156,7 +2156,7 @@ func TestClusterIPGeneral(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("http"),
-				Port:     pointer.Int32(80),
+				Port:     ptr.To[int32](80),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -2175,22 +2175,22 @@ func TestClusterIPGeneral(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{
 				{
 					Name:     ptr.To("http"),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &tcpProtocol,
 				},
 				{
 					Name:     ptr.To("https"),
-					Port:     pointer.Int32(8443),
+					Port:     ptr.To[int32](8443),
 					Protocol: &tcpProtocol,
 				},
 				{
 					Name:     ptr.To("dns-sctp"),
-					Port:     pointer.Int32(53),
+					Port:     ptr.To[int32](53),
 					Protocol: &sctpProtocol,
 				},
 				{
 					Name:     ptr.To("dns-tcp"),
-					Port:     pointer.Int32(5353),
+					Port:     ptr.To[int32](5353),
 					Protocol: &tcpProtocol,
 				},
 			}
@@ -2571,7 +2571,7 @@ func TestNodePorts(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
-						Port:     pointer.Int32(80),
+						Port:     ptr.To[int32](80),
 						Protocol: &tcpProtocol,
 					}}
 				}),
@@ -3409,7 +3409,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3420,7 +3420,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3434,7 +3434,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				}}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
-					Port:     pointer.Int32(11),
+					Port:     ptr.To[int32](11),
 					Protocol: &udpProtocol,
 				}}
 			}),
@@ -3451,7 +3451,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				}}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11-2"),
-					Port:     pointer.Int32(11),
+					Port:     ptr.To[int32](11),
 					Protocol: &udpProtocol,
 				}}
 			}),
@@ -3465,7 +3465,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				}}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
-					Port:     pointer.Int32(22),
+					Port:     ptr.To[int32](22),
 					Protocol: &udpProtocol,
 				}}
 			}),
@@ -3482,11 +3482,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				}}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
-					Port:     pointer.Int32(11),
+					Port:     ptr.To[int32](11),
 					Protocol: &udpProtocol,
 				}, {
 					Name:     ptr.To("p12"),
-					Port:     pointer.Int32(12),
+					Port:     ptr.To[int32](12),
 					Protocol: &udpProtocol,
 				}}
 			}),
@@ -3503,7 +3503,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3519,11 +3519,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udpProtocol,
 		}, {
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3534,7 +3534,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p13"),
-			Port:     pointer.Int32(13),
+			Port:     ptr.To[int32](13),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3552,11 +3552,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udpProtocol,
 		}, {
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3570,11 +3570,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p13"),
-			Port:     pointer.Int32(13),
+			Port:     ptr.To[int32](13),
 			Protocol: &udpProtocol,
 		}, {
 			Name:     ptr.To("p14"),
-			Port:     pointer.Int32(14),
+			Port:     ptr.To[int32](14),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3588,11 +3588,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p21"),
-			Port:     pointer.Int32(21),
+			Port:     ptr.To[int32](21),
 			Protocol: &udpProtocol,
 		}, {
 			Name:     ptr.To("p22"),
-			Port:     pointer.Int32(22),
+			Port:     ptr.To[int32](22),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3612,7 +3612,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p22"),
-			Port:     pointer.Int32(22),
+			Port:     ptr.To[int32](22),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3624,7 +3624,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p23"),
-			Port:     pointer.Int32(23),
+			Port:     ptr.To[int32](23),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3639,7 +3639,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
-			Port:     pointer.Int32(44),
+			Port:     ptr.To[int32](44),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3651,7 +3651,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p45"),
-			Port:     pointer.Int32(45),
+			Port:     ptr.To[int32](45),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3664,7 +3664,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3675,11 +3675,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udpProtocol,
 		}, {
 			Name:     ptr.To("p122"),
-			Port:     pointer.Int32(122),
+			Port:     ptr.To[int32](122),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3690,7 +3690,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p33"),
-			Port:     pointer.Int32(33),
+			Port:     ptr.To[int32](33),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3702,7 +3702,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
-			Port:     pointer.Int32(44),
+			Port:     ptr.To[int32](44),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -4255,7 +4255,7 @@ func TestHealthCheckNodePortWhenTerminating(t *testing.T) {
 		},
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
-			Port:     pointer.Int32(80),
+			Port:     ptr.To[int32](80),
 			Protocol: &tcpProtocol,
 		}},
 		AddressType: discovery.AddressTypeIPv4,
@@ -4294,7 +4294,7 @@ func TestHealthCheckNodePortWhenTerminating(t *testing.T) {
 		},
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
-			Port:     pointer.Int32(80),
+			Port:     ptr.To[int32](80),
 			Protocol: &tcpProtocol,
 		}},
 		AddressType: discovery.AddressTypeIPv4,
@@ -4685,7 +4685,7 @@ func TestInternalTrafficPolicy(t *testing.T) {
 				},
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &tcpProtocol,
 				}},
 				AddressType: discovery.AddressTypeIPv4,
@@ -4762,7 +4762,7 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 				},
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &tcpProtocol,
 				}},
 				AddressType: discovery.AddressTypeIPv4,
@@ -4847,7 +4847,7 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 				},
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &tcpProtocol,
 				}},
 				AddressType: discovery.AddressTypeIPv4,
@@ -4924,7 +4924,7 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 				},
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &tcpProtocol,
 				}},
 				AddressType: discovery.AddressTypeIPv4,
@@ -4970,7 +4970,7 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 				},
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &tcpProtocol,
 				}},
 				AddressType: discovery.AddressTypeIPv4,
@@ -5096,7 +5096,7 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 				},
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &tcpProtocol,
 				}},
 				AddressType: discovery.AddressTypeIPv4,
@@ -5180,7 +5180,7 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 				},
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &tcpProtocol,
 				}},
 				AddressType: discovery.AddressTypeIPv4,
@@ -5257,7 +5257,7 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 				},
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &tcpProtocol,
 				}},
 				AddressType: discovery.AddressTypeIPv4,
@@ -5303,7 +5303,7 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 				},
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &tcpProtocol,
 				}},
 				AddressType: discovery.AddressTypeIPv4,
@@ -5453,7 +5453,7 @@ func TestInternalExternalMasquerade(t *testing.T) {
 				}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p80"),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &tcpProtocol,
 				}}
 			}),
@@ -5471,7 +5471,7 @@ func TestInternalExternalMasquerade(t *testing.T) {
 				}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p80"),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &tcpProtocol,
 				}}
 			}),
@@ -5489,7 +5489,7 @@ func TestInternalExternalMasquerade(t *testing.T) {
 				}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p80"),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &tcpProtocol,
 				}}
 			}),
@@ -6019,7 +6019,7 @@ func TestSyncProxyRulesLargeClusterMode(t *testing.T) {
 			}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
-				Port:     pointer.Int32(80),
+				Port:     ptr.To[int32](80),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -6031,7 +6031,7 @@ func TestSyncProxyRulesLargeClusterMode(t *testing.T) {
 			}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p8080"),
-				Port:     pointer.Int32(8080),
+				Port:     ptr.To[int32](8080),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -6060,7 +6060,7 @@ func TestSyncProxyRulesLargeClusterMode(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p8081"),
-			Port:     pointer.Int32(8081),
+			Port:     ptr.To[int32](8081),
 			Protocol: &tcpProtocol,
 		}}
 	}))
@@ -6112,7 +6112,7 @@ func TestSyncProxyRulesLargeClusterMode(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p8082"),
-			Port:     pointer.Int32(8082),
+			Port:     ptr.To[int32](8082),
 			Protocol: &tcpProtocol,
 		}}
 	}))
@@ -6198,7 +6198,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
-				Port:     pointer.Int32(80),
+				Port:     ptr.To[int32](80),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -6209,7 +6209,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p8080"),
-				Port:     pointer.Int32(8080),
+				Port:     ptr.To[int32](8080),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -6293,7 +6293,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
-				Port:     pointer.Int32(80),
+				Port:     ptr.To[int32](80),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -6468,7 +6468,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
-				Port:     pointer.Int32(80),
+				Port:     ptr.To[int32](80),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -6924,7 +6924,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 				},
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &tcpProtocol,
 				}},
 				AddressType: discovery.AddressTypeIPv4,
@@ -7063,7 +7063,7 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
-						Port:     pointer.Int32(80),
+						Port:     ptr.To[int32](80),
 						Protocol: &tcpProtocol,
 					}}
 				}),

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -219,7 +219,7 @@ func TestDeleteEndpointConnections(t *testing.T) {
 					Addresses: []string{endpointIP},
 				}}
 				eps.Ports = []discovery.EndpointPort{{
-					Name:     pointer.String("p80"),
+					Name:     ptr.To("p80"),
 					Port:     pointer.Int32(80),
 					Protocol: &tc.protocol,
 				}}
@@ -1853,7 +1853,7 @@ func TestOverallIPTablesRules(t *testing.T) {
 				Addresses: []string{"10.180.0.1"},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String("p80"),
+				Name:     ptr.To("p80"),
 				Port:     pointer.Int32(80),
 				Protocol: &tcpProtocol,
 			}}
@@ -1866,7 +1866,7 @@ func TestOverallIPTablesRules(t *testing.T) {
 				Addresses: []string{"10.180.0.2"},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String("p80"),
+				Name:     ptr.To("p80"),
 				Port:     pointer.Int32(80),
 				Protocol: &tcpProtocol,
 			}}
@@ -1878,7 +1878,7 @@ func TestOverallIPTablesRules(t *testing.T) {
 				Addresses: []string{"10.180.0.3"},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String("p80"),
+				Name:     ptr.To("p80"),
 				Port:     pointer.Int32(80),
 				Protocol: &tcpProtocol,
 			}}
@@ -1890,10 +1890,10 @@ func TestOverallIPTablesRules(t *testing.T) {
 				Addresses: []string{"10.180.0.4"},
 			}, {
 				Addresses: []string{"10.180.0.5"},
-				NodeName:  pointer.String(testHostname),
+				NodeName:  ptr.To(testHostname),
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String("p80"),
+				Name:     ptr.To("p80"),
 				Port:     pointer.Int32(80),
 				Protocol: &tcpProtocol,
 			}}
@@ -1905,7 +1905,7 @@ func TestOverallIPTablesRules(t *testing.T) {
 				Addresses: []string{"10.180.0.3"},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String("p80"),
+				Name:     ptr.To("p80"),
 				Port:     pointer.Int32(80),
 				Protocol: &tcpProtocol,
 			}}
@@ -2152,10 +2152,10 @@ func TestClusterIPGeneral(t *testing.T) {
 			eps.AddressType = discovery.AddressTypeIPv4
 			eps.Endpoints = []discovery.Endpoint{{
 				Addresses: []string{"10.180.0.1"},
-				NodeName:  pointer.String(testHostname),
+				NodeName:  ptr.To(testHostname),
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String("http"),
+				Name:     ptr.To("http"),
 				Port:     pointer.Int32(80),
 				Protocol: &tcpProtocol,
 			}}
@@ -2165,31 +2165,31 @@ func TestClusterIPGeneral(t *testing.T) {
 			eps.Endpoints = []discovery.Endpoint{
 				{
 					Addresses: []string{"10.180.0.1"},
-					NodeName:  pointer.String(testHostname),
+					NodeName:  ptr.To(testHostname),
 				},
 				{
 					Addresses: []string{"10.180.2.1"},
-					NodeName:  pointer.String("host2"),
+					NodeName:  ptr.To("host2"),
 				},
 			}
 			eps.Ports = []discovery.EndpointPort{
 				{
-					Name:     pointer.String("http"),
+					Name:     ptr.To("http"),
 					Port:     pointer.Int32(80),
 					Protocol: &tcpProtocol,
 				},
 				{
-					Name:     pointer.String("https"),
+					Name:     ptr.To("https"),
 					Port:     pointer.Int32(8443),
 					Protocol: &tcpProtocol,
 				},
 				{
-					Name:     pointer.String("dns-sctp"),
+					Name:     ptr.To("dns-sctp"),
 					Port:     pointer.Int32(53),
 					Protocol: &sctpProtocol,
 				},
 				{
-					Name:     pointer.String("dns-tcp"),
+					Name:     ptr.To("dns-tcp"),
 					Port:     pointer.Int32(5353),
 					Protocol: &tcpProtocol,
 				},
@@ -2313,7 +2313,7 @@ func TestLoadBalancer(t *testing.T) {
 				Addresses: []string{epIP},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
@@ -2567,10 +2567,10 @@ func TestNodePorts(t *testing.T) {
 						NodeName:  nil,
 					}, {
 						Addresses: []string{epIP2},
-						NodeName:  pointer.String(testHostname),
+						NodeName:  ptr.To(testHostname),
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p80"),
+						Name:     ptr.To("p80"),
 						Port:     pointer.Int32(80),
 						Protocol: &tcpProtocol,
 					}}
@@ -2832,10 +2832,10 @@ func TestExternalTrafficPolicyLocal(t *testing.T) {
 				Addresses: []string{epIP1},
 			}, {
 				Addresses: []string{epIP2},
-				NodeName:  pointer.String(testHostname),
+				NodeName:  ptr.To(testHostname),
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
@@ -2949,10 +2949,10 @@ func TestExternalTrafficPolicyCluster(t *testing.T) {
 				NodeName:  nil,
 			}, {
 				Addresses: []string{epIP2},
-				NodeName:  pointer.String(testHostname),
+				NodeName:  ptr.To(testHostname),
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
@@ -3408,7 +3408,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"10.1.1.1"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udpProtocol,
 		}}
@@ -3419,7 +3419,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"10.1.1.2"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udpProtocol,
 		}}
@@ -3433,7 +3433,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 					NodeName:  &nodeName,
 				}}
 				eps.Ports = []discovery.EndpointPort{{
-					Name:     pointer.String("p11"),
+					Name:     ptr.To("p11"),
 					Port:     pointer.Int32(11),
 					Protocol: &udpProtocol,
 				}}
@@ -3450,7 +3450,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 					Addresses: []string{"10.1.1.1"},
 				}}
 				eps.Ports = []discovery.EndpointPort{{
-					Name:     pointer.String("p11-2"),
+					Name:     ptr.To("p11-2"),
 					Port:     pointer.Int32(11),
 					Protocol: &udpProtocol,
 				}}
@@ -3464,7 +3464,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 					Addresses: []string{"10.1.1.1"},
 				}}
 				eps.Ports = []discovery.EndpointPort{{
-					Name:     pointer.String("p11"),
+					Name:     ptr.To("p11"),
 					Port:     pointer.Int32(22),
 					Protocol: &udpProtocol,
 				}}
@@ -3481,11 +3481,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 					NodeName:  &nodeName,
 				}}
 				eps.Ports = []discovery.EndpointPort{{
-					Name:     pointer.String("p11"),
+					Name:     ptr.To("p11"),
 					Port:     pointer.Int32(11),
 					Protocol: &udpProtocol,
 				}, {
-					Name:     pointer.String("p12"),
+					Name:     ptr.To("p12"),
 					Port:     pointer.Int32(12),
 					Protocol: &udpProtocol,
 				}}
@@ -3502,7 +3502,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udpProtocol,
 		}}
@@ -3518,11 +3518,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udpProtocol,
 		}, {
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udpProtocol,
 		}}
@@ -3533,7 +3533,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"10.1.1.3"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p13"),
+			Name:     ptr.To("p13"),
 			Port:     pointer.Int32(13),
 			Protocol: &udpProtocol,
 		}}
@@ -3551,11 +3551,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udpProtocol,
 		}, {
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udpProtocol,
 		}}
@@ -3569,11 +3569,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p13"),
+			Name:     ptr.To("p13"),
 			Port:     pointer.Int32(13),
 			Protocol: &udpProtocol,
 		}, {
-			Name:     pointer.String("p14"),
+			Name:     ptr.To("p14"),
 			Port:     pointer.Int32(14),
 			Protocol: &udpProtocol,
 		}}
@@ -3587,11 +3587,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p21"),
+			Name:     ptr.To("p21"),
 			Port:     pointer.Int32(21),
 			Protocol: &udpProtocol,
 		}, {
-			Name:     pointer.String("p22"),
+			Name:     ptr.To("p22"),
 			Port:     pointer.Int32(22),
 			Protocol: &udpProtocol,
 		}}
@@ -3611,7 +3611,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p22"),
+			Name:     ptr.To("p22"),
 			Port:     pointer.Int32(22),
 			Protocol: &udpProtocol,
 		}}
@@ -3623,7 +3623,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p23"),
+			Name:     ptr.To("p23"),
 			Port:     pointer.Int32(23),
 			Protocol: &udpProtocol,
 		}}
@@ -3638,7 +3638,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p44"),
+			Name:     ptr.To("p44"),
 			Port:     pointer.Int32(44),
 			Protocol: &udpProtocol,
 		}}
@@ -3650,7 +3650,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p45"),
+			Name:     ptr.To("p45"),
 			Port:     pointer.Int32(45),
 			Protocol: &udpProtocol,
 		}}
@@ -3663,7 +3663,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"10.1.1.11"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udpProtocol,
 		}}
@@ -3674,11 +3674,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"10.1.1.2"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udpProtocol,
 		}, {
-			Name:     pointer.String("p122"),
+			Name:     ptr.To("p122"),
 			Port:     pointer.Int32(122),
 			Protocol: &udpProtocol,
 		}}
@@ -3689,7 +3689,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			Addresses: []string{"10.3.3.3"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p33"),
+			Name:     ptr.To("p33"),
 			Port:     pointer.Int32(33),
 			Protocol: &udpProtocol,
 		}}
@@ -3701,7 +3701,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p44"),
+			Name:     ptr.To("p44"),
 			Port:     pointer.Int32(44),
 			Protocol: &udpProtocol,
 		}}
@@ -4254,27 +4254,27 @@ func TestHealthCheckNodePortWhenTerminating(t *testing.T) {
 			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 		},
 		Ports: []discovery.EndpointPort{{
-			Name:     pointer.String(""),
+			Name:     ptr.To(""),
 			Port:     pointer.Int32(80),
 			Protocol: &tcpProtocol,
 		}},
 		AddressType: discovery.AddressTypeIPv4,
 		Endpoints: []discovery.Endpoint{{
 			Addresses:  []string{"10.0.1.1"},
-			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
-			NodeName:   pointer.String(testHostname),
+			Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+			NodeName:   ptr.To(testHostname),
 		}, {
 			Addresses:  []string{"10.0.1.2"},
-			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
-			NodeName:   pointer.String(testHostname),
+			Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+			NodeName:   ptr.To(testHostname),
 		}, {
 			Addresses:  []string{"10.0.1.3"},
-			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
-			NodeName:   pointer.String(testHostname),
+			Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+			NodeName:   ptr.To(testHostname),
 		}, { // not ready endpoints should be ignored
 			Addresses:  []string{"10.0.1.4"},
-			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(false)},
-			NodeName:   pointer.String(testHostname),
+			Conditions: discovery.EndpointConditions{Ready: ptr.To(false)},
+			NodeName:   ptr.To(testHostname),
 		}},
 	}
 
@@ -4293,7 +4293,7 @@ func TestHealthCheckNodePortWhenTerminating(t *testing.T) {
 			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 		},
 		Ports: []discovery.EndpointPort{{
-			Name:     pointer.String(""),
+			Name:     ptr.To(""),
 			Port:     pointer.Int32(80),
 			Protocol: &tcpProtocol,
 		}},
@@ -4301,35 +4301,35 @@ func TestHealthCheckNodePortWhenTerminating(t *testing.T) {
 		Endpoints: []discovery.Endpoint{{
 			Addresses: []string{"10.0.1.1"},
 			Conditions: discovery.EndpointConditions{
-				Ready:       pointer.Bool(false),
-				Serving:     pointer.Bool(true),
-				Terminating: pointer.Bool(false),
+				Ready:       ptr.To(false),
+				Serving:     ptr.To(true),
+				Terminating: ptr.To(false),
 			},
-			NodeName: pointer.String(testHostname),
+			NodeName: ptr.To(testHostname),
 		}, {
 			Addresses: []string{"10.0.1.2"},
 			Conditions: discovery.EndpointConditions{
-				Ready:       pointer.Bool(false),
-				Serving:     pointer.Bool(true),
-				Terminating: pointer.Bool(true),
+				Ready:       ptr.To(false),
+				Serving:     ptr.To(true),
+				Terminating: ptr.To(true),
 			},
-			NodeName: pointer.String(testHostname),
+			NodeName: ptr.To(testHostname),
 		}, {
 			Addresses: []string{"10.0.1.3"},
 			Conditions: discovery.EndpointConditions{
-				Ready:       pointer.Bool(false),
-				Serving:     pointer.Bool(true),
-				Terminating: pointer.Bool(true),
+				Ready:       ptr.To(false),
+				Serving:     ptr.To(true),
+				Terminating: ptr.To(true),
 			},
-			NodeName: pointer.String(testHostname),
+			NodeName: ptr.To(testHostname),
 		}, { // not ready endpoints should be ignored
 			Addresses: []string{"10.0.1.4"},
 			Conditions: discovery.EndpointConditions{
-				Ready:       pointer.Bool(false),
-				Serving:     pointer.Bool(false),
-				Terminating: pointer.Bool(true),
+				Ready:       ptr.To(false),
+				Serving:     ptr.To(false),
+				Terminating: ptr.To(true),
 			},
-			NodeName: pointer.String(testHostname),
+			NodeName: ptr.To(testHostname),
 		}},
 	}
 
@@ -4410,11 +4410,11 @@ func TestProxierDeleteNodePortStaleUDP(t *testing.T) {
 			eps.Endpoints = []discovery.Endpoint{{
 				Addresses: []string{epIP},
 				Conditions: discovery.EndpointConditions{
-					Serving: pointer.Bool(false),
+					Serving: ptr.To(false),
 				},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &udpProtocol,
 			}}
@@ -4433,11 +4433,11 @@ func TestProxierDeleteNodePortStaleUDP(t *testing.T) {
 			eps.Endpoints = []discovery.Endpoint{{
 				Addresses: []string{epIP},
 				Conditions: discovery.EndpointConditions{
-					Serving: pointer.Bool(true),
+					Serving: ptr.To(true),
 				},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &udpProtocol,
 			}}
@@ -4527,7 +4527,7 @@ func TestProxierMetricsIptablesTotalRules(t *testing.T) {
 				Addresses: []string{"10.0.0.5"},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
@@ -4684,7 +4684,7 @@ func TestInternalTrafficPolicy(t *testing.T) {
 					Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 				},
 				Ports: []discovery.EndpointPort{{
-					Name:     pointer.String(""),
+					Name:     ptr.To(""),
 					Port:     pointer.Int32(80),
 					Protocol: &tcpProtocol,
 				}},
@@ -4693,8 +4693,8 @@ func TestInternalTrafficPolicy(t *testing.T) {
 			for _, ep := range tc.endpoints {
 				endpointSlice.Endpoints = append(endpointSlice.Endpoints, discovery.Endpoint{
 					Addresses:  []string{ep.ip},
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
-					NodeName:   pointer.String(ep.hostname),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+					NodeName:   ptr.To(ep.hostname),
 				})
 			}
 
@@ -4761,7 +4761,7 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 					Labels:    map[string]string{discovery.LabelServiceName: "svc1"},
 				},
 				Ports: []discovery.EndpointPort{{
-					Name:     pointer.String(""),
+					Name:     ptr.To(""),
 					Port:     pointer.Int32(80),
 					Protocol: &tcpProtocol,
 				}},
@@ -4770,50 +4770,50 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 					{
 						Addresses: []string{"10.0.1.1"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						NodeName: pointer.String(testHostname),
+						NodeName: ptr.To(testHostname),
 					},
 					{
 						Addresses: []string{"10.0.1.2"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						NodeName: pointer.String(testHostname),
+						NodeName: ptr.To(testHostname),
 					},
 					{
 						// this endpoint should be ignored for external since there are ready non-terminating endpoints
 						Addresses: []string{"10.0.1.3"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String(testHostname),
+						NodeName: ptr.To(testHostname),
 					},
 					{
 						// this endpoint should be ignored for external since there are ready non-terminating endpoints
 						Addresses: []string{"10.0.1.4"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(false),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(false),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String(testHostname),
+						NodeName: ptr.To(testHostname),
 					},
 					{
 						// this endpoint should be ignored for external since it's not local
 						Addresses: []string{"10.0.1.5"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						NodeName: pointer.String("host-1"),
+						NodeName: ptr.To("host-1"),
 					},
 				},
 			},
@@ -4846,7 +4846,7 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 					Labels:    map[string]string{discovery.LabelServiceName: "svc1"},
 				},
 				Ports: []discovery.EndpointPort{{
-					Name:     pointer.String(""),
+					Name:     ptr.To(""),
 					Port:     pointer.Int32(80),
 					Protocol: &tcpProtocol,
 				}},
@@ -4856,41 +4856,41 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 						// this endpoint should be used since there are only ready terminating endpoints
 						Addresses: []string{"10.0.1.2"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String(testHostname),
+						NodeName: ptr.To(testHostname),
 					},
 					{
 						// this endpoint should be used since there are only ready terminating endpoints
 						Addresses: []string{"10.0.1.3"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String(testHostname),
+						NodeName: ptr.To(testHostname),
 					},
 					{
 						// this endpoint should not be used since it is both terminating and not ready.
 						Addresses: []string{"10.0.1.4"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(false),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(false),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String(testHostname),
+						NodeName: ptr.To(testHostname),
 					},
 					{
 						// this endpoint should be ignored for external since it's not local
 						Addresses: []string{"10.0.1.5"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						NodeName: pointer.String("host-1"),
+						NodeName: ptr.To("host-1"),
 					},
 				},
 			},
@@ -4923,7 +4923,7 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 					Labels:    map[string]string{discovery.LabelServiceName: "svc1"},
 				},
 				Ports: []discovery.EndpointPort{{
-					Name:     pointer.String(""),
+					Name:     ptr.To(""),
 					Port:     pointer.Int32(80),
 					Protocol: &tcpProtocol,
 				}},
@@ -4934,11 +4934,11 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 						// but it will prevent a REJECT rule from being created
 						Addresses: []string{"10.0.1.5"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String("host-1"),
+						NodeName: ptr.To("host-1"),
 					},
 				},
 			},
@@ -4969,7 +4969,7 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 					Labels:    map[string]string{discovery.LabelServiceName: "svc1"},
 				},
 				Ports: []discovery.EndpointPort{{
-					Name:     pointer.String(""),
+					Name:     ptr.To(""),
 					Port:     pointer.Int32(80),
 					Protocol: &tcpProtocol,
 				}},
@@ -4979,21 +4979,21 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 						// Local but not ready or serving
 						Addresses: []string{"10.0.1.5"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(false),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(false),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String(testHostname),
+						NodeName: ptr.To(testHostname),
 					},
 					{
 						// Remote and not ready or serving
 						Addresses: []string{"10.0.1.5"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(false),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(false),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String("host-1"),
+						NodeName: ptr.To("host-1"),
 					},
 				},
 			},
@@ -5095,7 +5095,7 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 					Labels:    map[string]string{discovery.LabelServiceName: "svc1"},
 				},
 				Ports: []discovery.EndpointPort{{
-					Name:     pointer.String(""),
+					Name:     ptr.To(""),
 					Port:     pointer.Int32(80),
 					Protocol: &tcpProtocol,
 				}},
@@ -5104,49 +5104,49 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 					{
 						Addresses: []string{"10.0.1.1"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						NodeName: pointer.String(testHostname),
+						NodeName: ptr.To(testHostname),
 					},
 					{
 						Addresses: []string{"10.0.1.2"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						NodeName: pointer.String(testHostname),
+						NodeName: ptr.To(testHostname),
 					},
 					{
 						// this endpoint should be ignored since there are ready non-terminating endpoints
 						Addresses: []string{"10.0.1.3"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String("another-host"),
+						NodeName: ptr.To("another-host"),
 					},
 					{
 						// this endpoint should be ignored since it is not "serving"
 						Addresses: []string{"10.0.1.4"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(false),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(false),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String("another-host"),
+						NodeName: ptr.To("another-host"),
 					},
 					{
 						Addresses: []string{"10.0.1.5"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(true),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(false),
+							Ready:       ptr.To(true),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(false),
 						},
-						NodeName: pointer.String("another-host"),
+						NodeName: ptr.To("another-host"),
 					},
 				},
 			},
@@ -5179,7 +5179,7 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 					Labels:    map[string]string{discovery.LabelServiceName: "svc1"},
 				},
 				Ports: []discovery.EndpointPort{{
-					Name:     pointer.String(""),
+					Name:     ptr.To(""),
 					Port:     pointer.Int32(80),
 					Protocol: &tcpProtocol,
 				}},
@@ -5189,41 +5189,41 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 						// this endpoint should be used since there are only ready terminating endpoints
 						Addresses: []string{"10.0.1.2"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String(testHostname),
+						NodeName: ptr.To(testHostname),
 					},
 					{
 						// this endpoint should be used since there are only ready terminating endpoints
 						Addresses: []string{"10.0.1.3"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String(testHostname),
+						NodeName: ptr.To(testHostname),
 					},
 					{
 						// this endpoint should not be used since it is both terminating and not ready.
 						Addresses: []string{"10.0.1.4"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(false),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(false),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String("another-host"),
+						NodeName: ptr.To("another-host"),
 					},
 					{
 						// this endpoint should be used since there are only ready terminating endpoints
 						Addresses: []string{"10.0.1.5"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String("another-host"),
+						NodeName: ptr.To("another-host"),
 					},
 				},
 			},
@@ -5256,7 +5256,7 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 					Labels:    map[string]string{discovery.LabelServiceName: "svc1"},
 				},
 				Ports: []discovery.EndpointPort{{
-					Name:     pointer.String(""),
+					Name:     ptr.To(""),
 					Port:     pointer.Int32(80),
 					Protocol: &tcpProtocol,
 				}},
@@ -5265,11 +5265,11 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 					{
 						Addresses: []string{"10.0.1.5"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(true),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(true),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String("host-1"),
+						NodeName: ptr.To("host-1"),
 					},
 				},
 			},
@@ -5302,7 +5302,7 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 					Labels:    map[string]string{discovery.LabelServiceName: "svc1"},
 				},
 				Ports: []discovery.EndpointPort{{
-					Name:     pointer.String(""),
+					Name:     ptr.To(""),
 					Port:     pointer.Int32(80),
 					Protocol: &tcpProtocol,
 				}},
@@ -5312,21 +5312,21 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 						// Local, not ready or serving
 						Addresses: []string{"10.0.1.5"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(false),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(false),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String(testHostname),
+						NodeName: ptr.To(testHostname),
 					},
 					{
 						// Remote, not ready or serving
 						Addresses: []string{"10.0.1.5"},
 						Conditions: discovery.EndpointConditions{
-							Ready:       pointer.Bool(false),
-							Serving:     pointer.Bool(false),
-							Terminating: pointer.Bool(true),
+							Ready:       ptr.To(false),
+							Serving:     ptr.To(false),
+							Terminating: ptr.To(true),
 						},
-						NodeName: pointer.String("host-1"),
+						NodeName: ptr.To("host-1"),
 					},
 				},
 			},
@@ -5444,15 +5444,15 @@ func TestInternalExternalMasquerade(t *testing.T) {
 				eps.Endpoints = []discovery.Endpoint{
 					{
 						Addresses: []string{"10.180.0.1"},
-						NodeName:  pointer.String(testHostname),
+						NodeName:  ptr.To(testHostname),
 					},
 					{
 						Addresses: []string{"10.180.1.1"},
-						NodeName:  pointer.String("remote"),
+						NodeName:  ptr.To("remote"),
 					},
 				}
 				eps.Ports = []discovery.EndpointPort{{
-					Name:     pointer.String("p80"),
+					Name:     ptr.To("p80"),
 					Port:     pointer.Int32(80),
 					Protocol: &tcpProtocol,
 				}}
@@ -5462,15 +5462,15 @@ func TestInternalExternalMasquerade(t *testing.T) {
 				eps.Endpoints = []discovery.Endpoint{
 					{
 						Addresses: []string{"10.180.0.2"},
-						NodeName:  pointer.String(testHostname),
+						NodeName:  ptr.To(testHostname),
 					},
 					{
 						Addresses: []string{"10.180.1.2"},
-						NodeName:  pointer.String("remote"),
+						NodeName:  ptr.To("remote"),
 					},
 				}
 				eps.Ports = []discovery.EndpointPort{{
-					Name:     pointer.String("p80"),
+					Name:     ptr.To("p80"),
 					Port:     pointer.Int32(80),
 					Protocol: &tcpProtocol,
 				}}
@@ -5480,15 +5480,15 @@ func TestInternalExternalMasquerade(t *testing.T) {
 				eps.Endpoints = []discovery.Endpoint{
 					{
 						Addresses: []string{"10.180.0.3"},
-						NodeName:  pointer.String(testHostname),
+						NodeName:  ptr.To(testHostname),
 					},
 					{
 						Addresses: []string{"10.180.1.3"},
-						NodeName:  pointer.String("remote"),
+						NodeName:  ptr.To("remote"),
 					},
 				}
 				eps.Ports = []discovery.EndpointPort{{
-					Name:     pointer.String("p80"),
+					Name:     ptr.To("p80"),
 					Port:     pointer.Int32(80),
 					Protocol: &tcpProtocol,
 				}}
@@ -5843,31 +5843,31 @@ func TestInternalExternalMasquerade(t *testing.T) {
 				// ClusterIP is assumed to be from a pod, and thus to not
 				// require masquerading.
 				"node to ClusterIP": {
-					masq: pointer.Bool(false),
+					masq: ptr.To(false),
 				},
 				"node to ClusterIP with eTP:Local": {
-					masq: pointer.Bool(false),
+					masq: ptr.To(false),
 				},
 				"node to ClusterIP with iTP:Local": {
-					masq: pointer.Bool(false),
+					masq: ptr.To(false),
 				},
 				"external to ClusterIP": {
-					masq: pointer.Bool(false),
+					masq: ptr.To(false),
 				},
 				"external to ClusterIP with eTP:Local": {
-					masq: pointer.Bool(false),
+					masq: ptr.To(false),
 				},
 				"external to ClusterIP with iTP:Local": {
-					masq: pointer.Bool(false),
+					masq: ptr.To(false),
 				},
 
 				// And there's no eTP:Local short-circuit for pod traffic,
 				// so pods get only the local endpoints.
 				"pod to NodePort with eTP:Local": {
-					output: pointer.String("10.180.0.2:80"),
+					output: ptr.To("10.180.0.2:80"),
 				},
 				"pod to LB with eTP:Local": {
-					output: pointer.String("10.180.0.2:80"),
+					output: ptr.To("10.180.0.2:80"),
 				},
 			},
 		},
@@ -5880,13 +5880,13 @@ func TestInternalExternalMasquerade(t *testing.T) {
 				// All "to ClusterIP" traffic gets masqueraded when using
 				// --masquerade-all.
 				"pod to ClusterIP": {
-					masq: pointer.Bool(true),
+					masq: ptr.To(true),
 				},
 				"pod to ClusterIP with eTP:Local": {
-					masq: pointer.Bool(true),
+					masq: ptr.To(true),
 				},
 				"pod to ClusterIP with iTP:Local": {
-					masq: pointer.Bool(true),
+					masq: ptr.To(true),
 				},
 			},
 		},
@@ -5898,21 +5898,21 @@ func TestInternalExternalMasquerade(t *testing.T) {
 			overrides: map[string]packetFlowTestOverride{
 				// As in "masqueradeAll"
 				"pod to ClusterIP": {
-					masq: pointer.Bool(true),
+					masq: ptr.To(true),
 				},
 				"pod to ClusterIP with eTP:Local": {
-					masq: pointer.Bool(true),
+					masq: ptr.To(true),
 				},
 				"pod to ClusterIP with iTP:Local": {
-					masq: pointer.Bool(true),
+					masq: ptr.To(true),
 				},
 
 				// As in "no LocalTrafficDetector"
 				"pod to NodePort with eTP:Local": {
-					output: pointer.String("10.180.0.2:80"),
+					output: ptr.To("10.180.0.2:80"),
 				},
 				"pod to LB with eTP:Local": {
-					output: pointer.String("10.180.0.2:80"),
+					output: ptr.To("10.180.0.2:80"),
 				},
 			},
 		},
@@ -6018,7 +6018,7 @@ func TestSyncProxyRulesLargeClusterMode(t *testing.T) {
 				eps.Endpoints[i].Addresses = []string{fmt.Sprintf("10.0.%d.%d", i%256, i/256)}
 			}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String("p80"),
+				Name:     ptr.To("p80"),
 				Port:     pointer.Int32(80),
 				Protocol: &tcpProtocol,
 			}}
@@ -6030,7 +6030,7 @@ func TestSyncProxyRulesLargeClusterMode(t *testing.T) {
 				eps.Endpoints[i].Addresses = []string{fmt.Sprintf("10.1.%d.%d", i%256, i/256)}
 			}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String("p8080"),
+				Name:     ptr.To("p8080"),
 				Port:     pointer.Int32(8080),
 				Protocol: &tcpProtocol,
 			}}
@@ -6059,7 +6059,7 @@ func TestSyncProxyRulesLargeClusterMode(t *testing.T) {
 			Addresses: []string{"203.0.113.12"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p8081"),
+			Name:     ptr.To("p8081"),
 			Port:     pointer.Int32(8081),
 			Protocol: &tcpProtocol,
 		}}
@@ -6111,7 +6111,7 @@ func TestSyncProxyRulesLargeClusterMode(t *testing.T) {
 			Addresses: []string{"10.4.0.1"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p8082"),
+			Name:     ptr.To("p8082"),
 			Port:     pointer.Int32(8082),
 			Protocol: &tcpProtocol,
 		}}
@@ -6197,7 +6197,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 				Addresses: []string{"10.0.1.1"},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String("p80"),
+				Name:     ptr.To("p80"),
 				Port:     pointer.Int32(80),
 				Protocol: &tcpProtocol,
 			}}
@@ -6208,7 +6208,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 				Addresses: []string{"10.0.2.1"},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String("p8080"),
+				Name:     ptr.To("p8080"),
 				Port:     pointer.Int32(8080),
 				Protocol: &tcpProtocol,
 			}}
@@ -6292,7 +6292,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 				Addresses: []string{"10.0.3.1"},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String("p80"),
+				Name:     ptr.To("p80"),
 				Port:     pointer.Int32(80),
 				Protocol: &tcpProtocol,
 			}}
@@ -6467,7 +6467,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 				Addresses: []string{"10.0.4.1"},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String("p80"),
+				Name:     ptr.To("p80"),
 				Port:     pointer.Int32(80),
 				Protocol: &tcpProtocol,
 			}}
@@ -6923,7 +6923,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 					Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 				},
 				Ports: []discovery.EndpointPort{{
-					Name:     pointer.String(""),
+					Name:     ptr.To(""),
 					Port:     pointer.Int32(80),
 					Protocol: &tcpProtocol,
 				}},
@@ -6932,8 +6932,8 @@ func TestNoEndpointsMetric(t *testing.T) {
 			for _, ep := range tc.endpoints {
 				endpointSlice.Endpoints = append(endpointSlice.Endpoints, discovery.Endpoint{
 					Addresses:  []string{ep.ip},
-					Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
-					NodeName:   pointer.String(ep.hostname),
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+					NodeName:   ptr.To(ep.hostname),
 				})
 			}
 
@@ -7062,7 +7062,7 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 						Addresses: []string{"10.180.0.1"},
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p80"),
+						Name:     ptr.To("p80"),
 						Port:     pointer.Int32(80),
 						Protocol: &tcpProtocol,
 					}}

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -57,7 +57,7 @@ import (
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
 	netutils "k8s.io/utils/net"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // (Note that we don't use UDP ports in most of the tests here, because if you create UDP

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -60,12 +60,6 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// (Note that we don't use UDP ports in most of the tests here, because if you create UDP
-// services you have to deal with setting up the FakeExec correctly for the conntrack
-// cleanup calls.)
-var tcpProtocol = v1.ProtocolTCP
-var sctpProtocol = v1.ProtocolSCTP
-
 func TestDeleteEndpointConnections(t *testing.T) {
 	const (
 		UDP  = v1.ProtocolUDP
@@ -221,7 +215,7 @@ func TestDeleteEndpointConnections(t *testing.T) {
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p80"),
 					Port:     ptr.To[int32](80),
-					Protocol: &tc.protocol,
+					Protocol: ptr.To(tc.protocol),
 				}}
 			})
 
@@ -1855,7 +1849,7 @@ func TestOverallIPTablesRules(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
 				Port:     ptr.To[int32](80),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 		// create Local LoadBalancer endpoints. Note that since we aren't setting
@@ -1868,7 +1862,7 @@ func TestOverallIPTablesRules(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
 				Port:     ptr.To[int32](80),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 		// create NodePort service endpoints
@@ -1880,7 +1874,7 @@ func TestOverallIPTablesRules(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
 				Port:     ptr.To[int32](80),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 		// create ExternalIP service endpoints
@@ -1895,7 +1889,7 @@ func TestOverallIPTablesRules(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
 				Port:     ptr.To[int32](80),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 		// create Cluster LoadBalancer endpoints
@@ -1907,7 +1901,7 @@ func TestOverallIPTablesRules(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
 				Port:     ptr.To[int32](80),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -2157,7 +2151,7 @@ func TestClusterIPGeneral(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("http"),
 				Port:     ptr.To[int32](80),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 		makeTestEndpointSlice("ns2", "svc2", 1, func(eps *discovery.EndpointSlice) {
@@ -2176,22 +2170,22 @@ func TestClusterIPGeneral(t *testing.T) {
 				{
 					Name:     ptr.To("http"),
 					Port:     ptr.To[int32](80),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				},
 				{
 					Name:     ptr.To("https"),
 					Port:     ptr.To[int32](8443),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				},
 				{
 					Name:     ptr.To("dns-sctp"),
 					Port:     ptr.To[int32](53),
-					Protocol: &sctpProtocol,
+					Protocol: ptr.To(v1.ProtocolSCTP),
 				},
 				{
 					Name:     ptr.To("dns-tcp"),
 					Port:     ptr.To[int32](5353),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				},
 			}
 		}),
@@ -2315,7 +2309,7 @@ func TestLoadBalancer(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -2572,7 +2566,7 @@ func TestNodePorts(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
 						Port:     ptr.To[int32](80),
-						Protocol: &tcpProtocol,
+						Protocol: ptr.To(v1.ProtocolTCP),
 					}}
 				}),
 			)
@@ -2837,7 +2831,7 @@ func TestExternalTrafficPolicyLocal(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -2954,7 +2948,7 @@ func TestExternalTrafficPolicyCluster(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -3397,7 +3391,6 @@ func checkEndpointExpectations(t *testing.T, tci int, newMap proxy.EndpointsMap,
 
 func TestUpdateEndpointsMap(t *testing.T) {
 	var nodeName = testHostname
-	udpProtocol := v1.ProtocolUDP
 
 	emptyEndpointSlices := []*discovery.EndpointSlice{
 		makeTestEndpointSlice("ns1", "ep1", 1, func(*discovery.EndpointSlice) {}),
@@ -3410,7 +3403,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	subset2 := func(eps *discovery.EndpointSlice) {
@@ -3421,7 +3414,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	namedPortLocal := []*discovery.EndpointSlice{
@@ -3435,7 +3428,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
 					Port:     ptr.To[int32](11),
-					Protocol: &udpProtocol,
+					Protocol: ptr.To(v1.ProtocolUDP),
 				}}
 			}),
 	}
@@ -3452,7 +3445,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11-2"),
 					Port:     ptr.To[int32](11),
-					Protocol: &udpProtocol,
+					Protocol: ptr.To(v1.ProtocolUDP),
 				}}
 			}),
 	}
@@ -3466,7 +3459,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
 					Port:     ptr.To[int32](22),
-					Protocol: &udpProtocol,
+					Protocol: ptr.To(v1.ProtocolUDP),
 				}}
 			}),
 	}
@@ -3483,11 +3476,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
 					Port:     ptr.To[int32](11),
-					Protocol: &udpProtocol,
+					Protocol: ptr.To(v1.ProtocolUDP),
 				}, {
 					Name:     ptr.To("p12"),
 					Port:     ptr.To[int32](12),
-					Protocol: &udpProtocol,
+					Protocol: ptr.To(v1.ProtocolUDP),
 				}}
 			}),
 	}
@@ -3504,7 +3497,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	multipleSubsetsWithLocal := []*discovery.EndpointSlice{
@@ -3520,11 +3513,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	subset3 := func(eps *discovery.EndpointSlice) {
@@ -3535,7 +3528,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p13"),
 			Port:     ptr.To[int32](13),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	multipleSubsetsMultiplePortsLocal := []*discovery.EndpointSlice{
@@ -3553,11 +3546,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	subsetMultipleIPsPorts2 := func(eps *discovery.EndpointSlice) {
@@ -3571,11 +3564,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p13"),
 			Port:     ptr.To[int32](13),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p14"),
 			Port:     ptr.To[int32](14),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	subsetMultipleIPsPorts3 := func(eps *discovery.EndpointSlice) {
@@ -3589,11 +3582,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p21"),
 			Port:     ptr.To[int32](21),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p22"),
 			Port:     ptr.To[int32](22),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	multipleSubsetsIPsPorts := []*discovery.EndpointSlice{
@@ -3613,7 +3606,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p22"),
 			Port:     ptr.To[int32](22),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexSubset2 := func(eps *discovery.EndpointSlice) {
@@ -3625,7 +3618,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p23"),
 			Port:     ptr.To[int32](23),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexSubset3 := func(eps *discovery.EndpointSlice) {
@@ -3640,7 +3633,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
 			Port:     ptr.To[int32](44),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexSubset4 := func(eps *discovery.EndpointSlice) {
@@ -3652,7 +3645,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p45"),
 			Port:     ptr.To[int32](45),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexSubset5 := func(eps *discovery.EndpointSlice) {
@@ -3665,7 +3658,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexSubset6 := func(eps *discovery.EndpointSlice) {
@@ -3676,11 +3669,11 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p122"),
 			Port:     ptr.To[int32](122),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexSubset7 := func(eps *discovery.EndpointSlice) {
@@ -3691,7 +3684,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p33"),
 			Port:     ptr.To[int32](33),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexSubset8 := func(eps *discovery.EndpointSlice) {
@@ -3703,7 +3696,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
 			Port:     ptr.To[int32](44),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexBefore := []*discovery.EndpointSlice{
@@ -4256,7 +4249,7 @@ func TestHealthCheckNodePortWhenTerminating(t *testing.T) {
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
 			Port:     ptr.To[int32](80),
-			Protocol: &tcpProtocol,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}},
 		AddressType: discovery.AddressTypeIPv4,
 		Endpoints: []discovery.Endpoint{{
@@ -4295,7 +4288,7 @@ func TestHealthCheckNodePortWhenTerminating(t *testing.T) {
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
 			Port:     ptr.To[int32](80),
-			Protocol: &tcpProtocol,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}},
 		AddressType: discovery.AddressTypeIPv4,
 		Endpoints: []discovery.Endpoint{{
@@ -4403,7 +4396,6 @@ func TestProxierDeleteNodePortStaleUDP(t *testing.T) {
 	}
 
 	epIP := "10.180.0.1"
-	udpProtocol := v1.ProtocolUDP
 	populateEndpointSlices(fp,
 		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
 			eps.AddressType = discovery.AddressTypeIPv4
@@ -4416,7 +4408,7 @@ func TestProxierDeleteNodePortStaleUDP(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &udpProtocol,
+				Protocol: ptr.To(v1.ProtocolUDP),
 			}}
 		}),
 	)
@@ -4439,7 +4431,7 @@ func TestProxierDeleteNodePortStaleUDP(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &udpProtocol,
+				Protocol: ptr.To(v1.ProtocolUDP),
 			}}
 		}),
 	)
@@ -4529,7 +4521,7 @@ func TestProxierMetricsIptablesTotalRules(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -4686,7 +4678,7 @@ func TestInternalTrafficPolicy(t *testing.T) {
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
 					Port:     ptr.To[int32](80),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				}},
 				AddressType: discovery.AddressTypeIPv4,
 			}
@@ -4763,7 +4755,7 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
 					Port:     ptr.To[int32](80),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				}},
 				AddressType: discovery.AddressTypeIPv4,
 				Endpoints: []discovery.Endpoint{
@@ -4848,7 +4840,7 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
 					Port:     ptr.To[int32](80),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				}},
 				AddressType: discovery.AddressTypeIPv4,
 				Endpoints: []discovery.Endpoint{
@@ -4925,7 +4917,7 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
 					Port:     ptr.To[int32](80),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				}},
 				AddressType: discovery.AddressTypeIPv4,
 				Endpoints: []discovery.Endpoint{
@@ -4971,7 +4963,7 @@ func TestTerminatingEndpointsTrafficPolicyLocal(t *testing.T) {
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
 					Port:     ptr.To[int32](80),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				}},
 				AddressType: discovery.AddressTypeIPv4,
 				Endpoints: []discovery.Endpoint{
@@ -5097,7 +5089,7 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
 					Port:     ptr.To[int32](80),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				}},
 				AddressType: discovery.AddressTypeIPv4,
 				Endpoints: []discovery.Endpoint{
@@ -5181,7 +5173,7 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
 					Port:     ptr.To[int32](80),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				}},
 				AddressType: discovery.AddressTypeIPv4,
 				Endpoints: []discovery.Endpoint{
@@ -5258,7 +5250,7 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
 					Port:     ptr.To[int32](80),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				}},
 				AddressType: discovery.AddressTypeIPv4,
 				Endpoints: []discovery.Endpoint{
@@ -5304,7 +5296,7 @@ func TestTerminatingEndpointsTrafficPolicyCluster(t *testing.T) {
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
 					Port:     ptr.To[int32](80),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				}},
 				AddressType: discovery.AddressTypeIPv4,
 				Endpoints: []discovery.Endpoint{
@@ -5454,7 +5446,7 @@ func TestInternalExternalMasquerade(t *testing.T) {
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p80"),
 					Port:     ptr.To[int32](80),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				}}
 			}),
 			makeTestEndpointSlice("ns2", "svc2", 1, func(eps *discovery.EndpointSlice) {
@@ -5472,7 +5464,7 @@ func TestInternalExternalMasquerade(t *testing.T) {
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p80"),
 					Port:     ptr.To[int32](80),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				}}
 			}),
 			makeTestEndpointSlice("ns3", "svc3", 1, func(eps *discovery.EndpointSlice) {
@@ -5490,7 +5482,7 @@ func TestInternalExternalMasquerade(t *testing.T) {
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p80"),
 					Port:     ptr.To[int32](80),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				}}
 			}),
 		)
@@ -6020,7 +6012,7 @@ func TestSyncProxyRulesLargeClusterMode(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
 				Port:     ptr.To[int32](80),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 		makeTestEndpointSlice("ns2", "svc2", 1, func(eps *discovery.EndpointSlice) {
@@ -6032,7 +6024,7 @@ func TestSyncProxyRulesLargeClusterMode(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p8080"),
 				Port:     ptr.To[int32](8080),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -6061,7 +6053,7 @@ func TestSyncProxyRulesLargeClusterMode(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p8081"),
 			Port:     ptr.To[int32](8081),
-			Protocol: &tcpProtocol,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}}
 	}))
 	fp.syncProxyRules()
@@ -6113,7 +6105,7 @@ func TestSyncProxyRulesLargeClusterMode(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p8082"),
 			Port:     ptr.To[int32](8082),
-			Protocol: &tcpProtocol,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}}
 	}))
 	fp.syncProxyRules()
@@ -6199,7 +6191,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
 				Port:     ptr.To[int32](80),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 		makeTestEndpointSlice("ns2", "svc2", 1, func(eps *discovery.EndpointSlice) {
@@ -6210,7 +6202,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p8080"),
 				Port:     ptr.To[int32](8080),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -6294,7 +6286,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
 				Port:     ptr.To[int32](80),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -6469,7 +6461,7 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
 				Port:     ptr.To[int32](80),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -6925,7 +6917,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 				Ports: []discovery.EndpointPort{{
 					Name:     ptr.To(""),
 					Port:     ptr.To[int32](80),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				}},
 				AddressType: discovery.AddressTypeIPv4,
 			}
@@ -7054,7 +7046,6 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 				}),
 			)
 
-			tcpProtocol := v1.ProtocolTCP
 			populateEndpointSlices(fp,
 				makeTestEndpointSlice("ns1", "svc1", 1, func(eps *discovery.EndpointSlice) {
 					eps.AddressType = discovery.AddressTypeIPv4
@@ -7064,7 +7055,7 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
 						Port:     ptr.To[int32](80),
-						Protocol: &tcpProtocol,
+						Protocol: ptr.To(v1.ProtocolTCP),
 					}}
 				}),
 			)

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -263,7 +263,6 @@ func TestCleanupLeftovers(t *testing.T) {
 		}),
 	)
 	epIP := "10.180.0.1"
-	tcpProtocol := v1.ProtocolTCP
 	populateEndpointSlices(fp,
 		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
 			eps.AddressType = discovery.AddressTypeIPv4
@@ -273,7 +272,7 @@ func TestCleanupLeftovers(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -434,9 +433,6 @@ func TestGetNodeIPs(t *testing.T) {
 }
 
 func TestNodePortIPv4(t *testing.T) {
-	tcpProtocol := v1.ProtocolTCP
-	udpProtocol := v1.ProtocolUDP
-	sctpProtocol := v1.ProtocolSCTP
 	tests := []struct {
 		name                   string
 		services               []*v1.Service
@@ -470,7 +466,7 @@ func TestNodePortIPv4(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
 						Port:     ptr.To[int32](80),
-						Protocol: &tcpProtocol,
+						Protocol: ptr.To(v1.ProtocolTCP),
 					}}
 				}),
 				makeTestEndpointSlice("ns1", "svc1", 2, func(eps *discovery.EndpointSlice) {
@@ -481,7 +477,7 @@ func TestNodePortIPv4(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
 						Port:     ptr.To[int32](80),
-						Protocol: &tcpProtocol,
+						Protocol: ptr.To(v1.ProtocolTCP),
 					}}
 				}),
 			},
@@ -559,7 +555,7 @@ func TestNodePortIPv4(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
 						Port:     ptr.To[int32](80),
-						Protocol: &udpProtocol,
+						Protocol: ptr.To(v1.ProtocolUDP),
 					}}
 				}),
 			},
@@ -714,7 +710,7 @@ func TestNodePortIPv4(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
 						Port:     ptr.To[int32](80),
-						Protocol: &sctpProtocol,
+						Protocol: ptr.To(v1.ProtocolSCTP),
 					}}
 				}),
 			},
@@ -868,7 +864,7 @@ func TestNodePortIPv4(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
 						Port:     ptr.To[int32](80),
-						Protocol: &sctpProtocol,
+						Protocol: ptr.To(v1.ProtocolSCTP),
 					}}
 				}),
 			},
@@ -988,9 +984,6 @@ func TestNodePortIPv4(t *testing.T) {
 }
 
 func TestNodePortIPv6(t *testing.T) {
-	tcpProtocol := v1.ProtocolTCP
-	udpProtocol := v1.ProtocolUDP
-	sctpProtocol := v1.ProtocolSCTP
 	tests := []struct {
 		name                   string
 		services               []*v1.Service
@@ -1024,7 +1017,7 @@ func TestNodePortIPv6(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
 						Port:     ptr.To[int32](80),
-						Protocol: &tcpProtocol,
+						Protocol: ptr.To(v1.ProtocolTCP),
 					}}
 				}),
 				makeTestEndpointSlice("ns1", "svc1", 2, func(eps *discovery.EndpointSlice) {
@@ -1035,7 +1028,7 @@ func TestNodePortIPv6(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
 						Port:     ptr.To[int32](80),
-						Protocol: &tcpProtocol,
+						Protocol: ptr.To(v1.ProtocolTCP),
 					}}
 				}),
 			},
@@ -1115,7 +1108,7 @@ func TestNodePortIPv6(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
 						Port:     ptr.To[int32](80),
-						Protocol: &udpProtocol,
+						Protocol: ptr.To(v1.ProtocolUDP),
 					}}
 				}),
 			},
@@ -1208,7 +1201,7 @@ func TestNodePortIPv6(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
 						Port:     ptr.To[int32](80),
-						Protocol: &sctpProtocol,
+						Protocol: ptr.To(v1.ProtocolSCTP),
 					}}
 				}),
 			},
@@ -1333,8 +1326,6 @@ func TestNodePortIPv6(t *testing.T) {
 }
 
 func Test_syncEndpoint_updateWeightsOnRestart(t *testing.T) {
-	tcpProtocol := v1.ProtocolTCP
-
 	ipt := iptablestest.NewFake()
 	ipvs := ipvstest.NewFake()
 	ipset := ipsettest.NewFake(testIPSetVersion)
@@ -1356,7 +1347,7 @@ func Test_syncEndpoint_updateWeightsOnRestart(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p80"),
 			Port:     ptr.To[int32](80),
-			Protocol: &tcpProtocol,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}}
 	})
 
@@ -1368,7 +1359,7 @@ func Test_syncEndpoint_updateWeightsOnRestart(t *testing.T) {
 	serv := &utilipvs.VirtualServer{
 		Address:   netutils.ParseIPSloppy("10.20.30.41"),
 		Port:      uint16(80),
-		Protocol:  string(tcpProtocol),
+		Protocol:  string(v1.ProtocolTCP),
 		Scheduler: fp.ipvsScheduler,
 	}
 
@@ -1396,7 +1387,7 @@ func Test_syncEndpoint_updateWeightsOnRestart(t *testing.T) {
 			Namespace: "ns1",
 		},
 		Port:     "80",
-		Protocol: tcpProtocol,
+		Protocol: v1.ProtocolTCP,
 	}, true, vs)
 	if err != nil {
 		t.Errorf("failed to sync endpoint, err: %v", err)
@@ -1415,7 +1406,6 @@ func Test_syncEndpoint_updateWeightsOnRestart(t *testing.T) {
 }
 
 func TestIPv4Proxier(t *testing.T) {
-	tcpProtocol := v1.ProtocolTCP
 	tests := []struct {
 		name         string
 		services     []*v1.Service
@@ -1451,7 +1441,7 @@ func TestIPv4Proxier(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
 						Port:     ptr.To[int32](80),
-						Protocol: &tcpProtocol,
+						Protocol: ptr.To(v1.ProtocolTCP),
 					}}
 				}),
 				makeTestEndpointSlice("ns2", "svc2", 1, func(eps *discovery.EndpointSlice) {
@@ -1462,7 +1452,7 @@ func TestIPv4Proxier(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p8080"),
 						Port:     ptr.To[int32](8080),
-						Protocol: &tcpProtocol,
+						Protocol: ptr.To(v1.ProtocolTCP),
 					}}
 				}),
 			},
@@ -1553,7 +1543,6 @@ func TestIPv4Proxier(t *testing.T) {
 }
 
 func TestIPv6Proxier(t *testing.T) {
-	tcpProtocol := v1.ProtocolTCP
 	tests := []struct {
 		name         string
 		services     []*v1.Service
@@ -1589,7 +1578,7 @@ func TestIPv6Proxier(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
 						Port:     ptr.To[int32](80),
-						Protocol: &tcpProtocol,
+						Protocol: ptr.To(v1.ProtocolTCP),
 					}}
 				}),
 				makeTestEndpointSlice("ns2", "svc2", 1, func(eps *discovery.EndpointSlice) {
@@ -1600,7 +1589,7 @@ func TestIPv6Proxier(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p8080"),
 						Port:     ptr.To[int32](8080),
-						Protocol: &tcpProtocol,
+						Protocol: ptr.To(v1.ProtocolTCP),
 					}}
 				}),
 			},
@@ -1804,7 +1793,6 @@ func TestExternalIPs(t *testing.T) {
 	)
 
 	epIP := "10.180.0.1"
-	udpProtocol := v1.ProtocolUDP
 	populateEndpointSlices(fp,
 		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
 			eps.AddressType = discovery.AddressTypeIPv4
@@ -1814,7 +1802,7 @@ func TestExternalIPs(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &udpProtocol,
+				Protocol: ptr.To(v1.ProtocolUDP),
 			}}
 		}),
 	)
@@ -1878,7 +1866,6 @@ func TestOnlyLocalExternalIPs(t *testing.T) {
 	epIP1 := "10.180.1.1"
 	thisHostname := testHostname
 	otherHostname := "other-hostname"
-	tcpProtocol := v1.ProtocolTCP
 	populateEndpointSlices(fp,
 		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
 			eps.AddressType = discovery.AddressTypeIPv4
@@ -1893,7 +1880,7 @@ func TestOnlyLocalExternalIPs(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -1957,7 +1944,6 @@ func TestLoadBalancer(t *testing.T) {
 	)
 
 	epIP := "10.180.0.1"
-	udpProtocol := v1.ProtocolUDP
 	populateEndpointSlices(fp,
 		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
 			eps.AddressType = discovery.AddressTypeIPv4
@@ -1967,7 +1953,7 @@ func TestLoadBalancer(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &udpProtocol,
+				Protocol: ptr.To(v1.ProtocolUDP),
 			}}
 		}),
 	)
@@ -2045,7 +2031,6 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 	epIP1 := "10.180.1.1"
 	thisHostname := testHostname
 	otherHostname := "other-hostname"
-	tcpProtocol := v1.ProtocolTCP
 
 	populateEndpointSlices(fp,
 		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
@@ -2060,7 +2045,7 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -2202,7 +2187,6 @@ func TestLoadBalancerSourceRanges(t *testing.T) {
 		Port:           "p80",
 	}
 	epIP := "10.180.0.1"
-	tcpProtocol := v1.ProtocolTCP
 
 	makeServiceMap(fp,
 		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
@@ -2230,7 +2214,7 @@ func TestLoadBalancerSourceRanges(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -2334,7 +2318,6 @@ func TestAcceptIPVSTraffic(t *testing.T) {
 			}),
 		)
 
-		udpProtocol := v1.ProtocolUDP
 		populateEndpointSlices(fp,
 			makeTestEndpointSlice("ns1", "p80", 1, func(eps *discovery.EndpointSlice) {
 				eps.Endpoints = []discovery.Endpoint{{
@@ -2343,7 +2326,7 @@ func TestAcceptIPVSTraffic(t *testing.T) {
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p80"),
 					Port:     ptr.To[int32](80),
-					Protocol: &udpProtocol,
+					Protocol: ptr.To(v1.ProtocolUDP),
 				}}
 			}),
 		)
@@ -2400,7 +2383,6 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 	epIP1 := "10.180.1.1"
 	thisHostname := testHostname
 	otherHostname := "other-hostname"
-	tcpProtocol := v1.ProtocolTCP
 
 	populateEndpointSlices(fp,
 		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
@@ -2417,7 +2399,7 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -2816,7 +2798,6 @@ func makeServicePortName(ns, name, port string, protocol v1.Protocol) proxy.Serv
 
 func Test_updateEndpointsMap(t *testing.T) {
 	var nodeName = testHostname
-	udpProtocol := v1.ProtocolUDP
 
 	emptyEndpointSlices := []*discovery.EndpointSlice{
 		makeTestEndpointSlice("ns1", "ep1", 1, func(*discovery.EndpointSlice) {}),
@@ -2829,7 +2810,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	subset2 := func(eps *discovery.EndpointSlice) {
@@ -2840,7 +2821,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	namedPortLocal := []*discovery.EndpointSlice{
@@ -2854,7 +2835,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
 					Port:     ptr.To[int32](11),
-					Protocol: &udpProtocol,
+					Protocol: ptr.To(v1.ProtocolUDP),
 				}}
 			}),
 	}
@@ -2871,7 +2852,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11-2"),
 					Port:     ptr.To[int32](11),
-					Protocol: &udpProtocol,
+					Protocol: ptr.To(v1.ProtocolUDP),
 				}}
 			}),
 	}
@@ -2885,7 +2866,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
 					Port:     ptr.To[int32](22),
-					Protocol: &udpProtocol,
+					Protocol: ptr.To(v1.ProtocolUDP),
 				}}
 			}),
 	}
@@ -2902,11 +2883,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
 					Port:     ptr.To[int32](11),
-					Protocol: &udpProtocol,
+					Protocol: ptr.To(v1.ProtocolUDP),
 				}, {
 					Name:     ptr.To("p12"),
 					Port:     ptr.To[int32](12),
-					Protocol: &udpProtocol,
+					Protocol: ptr.To(v1.ProtocolUDP),
 				}}
 			}),
 	}
@@ -2923,7 +2904,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	multipleSubsetsWithLocal := []*discovery.EndpointSlice{
@@ -2939,11 +2920,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	subset3 := func(eps *discovery.EndpointSlice) {
@@ -2954,7 +2935,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p13"),
 			Port:     ptr.To[int32](13),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	multipleSubsetsMultiplePortsLocal := []*discovery.EndpointSlice{
@@ -2972,11 +2953,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	subsetMultipleIPsPorts2 := func(eps *discovery.EndpointSlice) {
@@ -2990,11 +2971,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p13"),
 			Port:     ptr.To[int32](13),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p14"),
 			Port:     ptr.To[int32](14),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	subsetMultipleIPsPorts3 := func(eps *discovery.EndpointSlice) {
@@ -3008,11 +2989,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p21"),
 			Port:     ptr.To[int32](21),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p22"),
 			Port:     ptr.To[int32](22),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	multipleSubsetsIPsPorts := []*discovery.EndpointSlice{
@@ -3032,7 +3013,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p22"),
 			Port:     ptr.To[int32](22),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexSubset2 := func(eps *discovery.EndpointSlice) {
@@ -3044,7 +3025,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p23"),
 			Port:     ptr.To[int32](23),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexSubset3 := func(eps *discovery.EndpointSlice) {
@@ -3059,7 +3040,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
 			Port:     ptr.To[int32](44),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexSubset4 := func(eps *discovery.EndpointSlice) {
@@ -3071,7 +3052,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p45"),
 			Port:     ptr.To[int32](45),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexSubset5 := func(eps *discovery.EndpointSlice) {
@@ -3084,7 +3065,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
 			Port:     ptr.To[int32](11),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexSubset6 := func(eps *discovery.EndpointSlice) {
@@ -3095,11 +3076,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
 			Port:     ptr.To[int32](12),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}, {
 			Name:     ptr.To("p122"),
 			Port:     ptr.To[int32](122),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexSubset7 := func(eps *discovery.EndpointSlice) {
@@ -3110,7 +3091,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p33"),
 			Port:     ptr.To[int32](33),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexSubset8 := func(eps *discovery.EndpointSlice) {
@@ -3122,7 +3103,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
 			Port:     ptr.To[int32](44),
-			Protocol: &udpProtocol,
+			Protocol: ptr.To(v1.ProtocolUDP),
 		}}
 	}
 	complexBefore := []*discovery.EndpointSlice{
@@ -4383,7 +4364,6 @@ func TestEndpointSliceE2E(t *testing.T) {
 	})
 
 	// Add initial endpoint slice
-	tcpProtocol := v1.ProtocolTCP
 	endpointSlice := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-1", serviceName),
@@ -4393,7 +4373,7 @@ func TestEndpointSliceE2E(t *testing.T) {
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
 			Port:     ptr.To[int32](80),
-			Protocol: &tcpProtocol,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}},
 		AddressType: discovery.AddressTypeIPv4,
 		Endpoints: []discovery.Endpoint{{
@@ -4523,7 +4503,6 @@ func Test_HealthCheckNodePortWhenTerminating(t *testing.T) {
 		},
 	})
 
-	tcpProtocol := v1.ProtocolTCP
 	endpointSlice := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-1", serviceName),
@@ -4533,7 +4512,7 @@ func Test_HealthCheckNodePortWhenTerminating(t *testing.T) {
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
 			Port:     ptr.To[int32](80),
-			Protocol: &tcpProtocol,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}},
 		AddressType: discovery.AddressTypeIPv4,
 		Endpoints: []discovery.Endpoint{{
@@ -4571,7 +4550,7 @@ func Test_HealthCheckNodePortWhenTerminating(t *testing.T) {
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
 			Port:     ptr.To[int32](80),
-			Protocol: &tcpProtocol,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}},
 		AddressType: discovery.AddressTypeIPv4,
 		Endpoints: []discovery.Endpoint{{
@@ -4781,7 +4760,6 @@ func TestTestInternalTrafficPolicyE2E(t *testing.T) {
 		fp.OnServiceAdd(svc)
 
 		// Add initial endpoint slice
-		tcpProtocol := v1.ProtocolTCP
 		endpointSlice := &discovery.EndpointSlice{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-1", serviceName),
@@ -4791,7 +4769,7 @@ func TestTestInternalTrafficPolicyE2E(t *testing.T) {
 			Ports: []discovery.EndpointPort{{
 				Name:     ptr.To(""),
 				Port:     ptr.To[int32](80),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}},
 			AddressType: discovery.AddressTypeIPv4,
 		}
@@ -4888,7 +4866,6 @@ func Test_EndpointSliceReadyAndTerminatingCluster(t *testing.T) {
 	})
 
 	// Add initial endpoint slice
-	tcpProtocol := v1.ProtocolTCP
 	endpointSlice := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-1", serviceName),
@@ -4898,7 +4875,7 @@ func Test_EndpointSliceReadyAndTerminatingCluster(t *testing.T) {
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
 			Port:     ptr.To[int32](80),
-			Protocol: &tcpProtocol,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}},
 		AddressType: discovery.AddressTypeIPv4,
 		Endpoints: []discovery.Endpoint{
@@ -5064,7 +5041,6 @@ func Test_EndpointSliceReadyAndTerminatingLocal(t *testing.T) {
 	})
 
 	// Add initial endpoint slice
-	tcpProtocol := v1.ProtocolTCP
 	endpointSlice := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-1", serviceName),
@@ -5074,7 +5050,7 @@ func Test_EndpointSliceReadyAndTerminatingLocal(t *testing.T) {
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
 			Port:     ptr.To[int32](80),
-			Protocol: &tcpProtocol,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}},
 		AddressType: discovery.AddressTypeIPv4,
 		Endpoints: []discovery.Endpoint{
@@ -5239,7 +5215,6 @@ func Test_EndpointSliceOnlyReadyAndTerminatingCluster(t *testing.T) {
 	})
 
 	// Add initial endpoint slice
-	tcpProtocol := v1.ProtocolTCP
 	endpointSlice := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-1", serviceName),
@@ -5249,7 +5224,7 @@ func Test_EndpointSliceOnlyReadyAndTerminatingCluster(t *testing.T) {
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
 			Port:     ptr.To[int32](80),
-			Protocol: &tcpProtocol,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}},
 		AddressType: discovery.AddressTypeIPv4,
 		Endpoints: []discovery.Endpoint{
@@ -5414,7 +5389,6 @@ func Test_EndpointSliceOnlyReadyAndTerminatingLocal(t *testing.T) {
 	})
 
 	// Add initial endpoint slice
-	tcpProtocol := v1.ProtocolTCP
 	endpointSlice := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-1", serviceName),
@@ -5424,7 +5398,7 @@ func Test_EndpointSliceOnlyReadyAndTerminatingLocal(t *testing.T) {
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
 			Port:     ptr.To[int32](80),
-			Protocol: &tcpProtocol,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}},
 		AddressType: discovery.AddressTypeIPv4,
 		Endpoints: []discovery.Endpoint{
@@ -5756,7 +5730,6 @@ func TestNoEndpointsMetric(t *testing.T) {
 		fp.OnServiceAdd(svc)
 
 		// Add initial endpoint slice
-		tcpProtocol := v1.ProtocolTCP
 		endpointSlice := &discovery.EndpointSlice{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-1", serviceName),
@@ -5766,7 +5739,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 			Ports: []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
 				Port:     ptr.To[int32](80),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}},
 			AddressType: discovery.AddressTypeIPv4,
 		}
@@ -5935,7 +5908,6 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 				}),
 			)
 
-			tcpProtocol := v1.ProtocolTCP
 			makeEndpointSliceMap(fp,
 				makeTestEndpointSlice("ns1", "svc1", 1, func(eps *discovery.EndpointSlice) {
 					eps.AddressType = discovery.AddressTypeIPv4
@@ -5945,7 +5917,7 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
 						Port:     ptr.To[int32](80),
-						Protocol: &tcpProtocol,
+						Protocol: ptr.To(v1.ProtocolTCP),
 					}}
 				}),
 			)

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -469,7 +469,7 @@ func TestNodePortIPv4(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
-						Port:     pointer.Int32(80),
+						Port:     ptr.To[int32](80),
 						Protocol: &tcpProtocol,
 					}}
 				}),
@@ -480,7 +480,7 @@ func TestNodePortIPv4(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
-						Port:     pointer.Int32(80),
+						Port:     ptr.To[int32](80),
 						Protocol: &tcpProtocol,
 					}}
 				}),
@@ -558,7 +558,7 @@ func TestNodePortIPv4(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
-						Port:     pointer.Int32(80),
+						Port:     ptr.To[int32](80),
 						Protocol: &udpProtocol,
 					}}
 				}),
@@ -713,7 +713,7 @@ func TestNodePortIPv4(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
-						Port:     pointer.Int32(80),
+						Port:     ptr.To[int32](80),
 						Protocol: &sctpProtocol,
 					}}
 				}),
@@ -867,7 +867,7 @@ func TestNodePortIPv4(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
-						Port:     pointer.Int32(80),
+						Port:     ptr.To[int32](80),
 						Protocol: &sctpProtocol,
 					}}
 				}),
@@ -1023,7 +1023,7 @@ func TestNodePortIPv6(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
-						Port:     pointer.Int32(80),
+						Port:     ptr.To[int32](80),
 						Protocol: &tcpProtocol,
 					}}
 				}),
@@ -1034,7 +1034,7 @@ func TestNodePortIPv6(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
-						Port:     pointer.Int32(80),
+						Port:     ptr.To[int32](80),
 						Protocol: &tcpProtocol,
 					}}
 				}),
@@ -1114,7 +1114,7 @@ func TestNodePortIPv6(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
-						Port:     pointer.Int32(80),
+						Port:     ptr.To[int32](80),
 						Protocol: &udpProtocol,
 					}}
 				}),
@@ -1207,7 +1207,7 @@ func TestNodePortIPv6(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
-						Port:     pointer.Int32(80),
+						Port:     ptr.To[int32](80),
 						Protocol: &sctpProtocol,
 					}}
 				}),
@@ -1355,7 +1355,7 @@ func Test_syncEndpoint_updateWeightsOnRestart(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p80"),
-			Port:     pointer.Int32(80),
+			Port:     ptr.To[int32](80),
 			Protocol: &tcpProtocol,
 		}}
 	})
@@ -1450,7 +1450,7 @@ func TestIPv4Proxier(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
-						Port:     pointer.Int32(80),
+						Port:     ptr.To[int32](80),
 						Protocol: &tcpProtocol,
 					}}
 				}),
@@ -1461,7 +1461,7 @@ func TestIPv4Proxier(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p8080"),
-						Port:     pointer.Int32(8080),
+						Port:     ptr.To[int32](8080),
 						Protocol: &tcpProtocol,
 					}}
 				}),
@@ -1588,7 +1588,7 @@ func TestIPv6Proxier(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
-						Port:     pointer.Int32(80),
+						Port:     ptr.To[int32](80),
 						Protocol: &tcpProtocol,
 					}}
 				}),
@@ -1599,7 +1599,7 @@ func TestIPv6Proxier(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p8080"),
-						Port:     pointer.Int32(8080),
+						Port:     ptr.To[int32](8080),
 						Protocol: &tcpProtocol,
 					}}
 				}),
@@ -2342,7 +2342,7 @@ func TestAcceptIPVSTraffic(t *testing.T) {
 				}}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p80"),
-					Port:     pointer.Int32(80),
+					Port:     ptr.To[int32](80),
 					Protocol: &udpProtocol,
 				}}
 			}),
@@ -2828,7 +2828,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -2839,7 +2839,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -2853,7 +2853,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 				}}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
-					Port:     pointer.Int32(11),
+					Port:     ptr.To[int32](11),
 					Protocol: &udpProtocol,
 				}}
 			}),
@@ -2870,7 +2870,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 				}}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11-2"),
-					Port:     pointer.Int32(11),
+					Port:     ptr.To[int32](11),
 					Protocol: &udpProtocol,
 				}}
 			}),
@@ -2884,7 +2884,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 				}}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
-					Port:     pointer.Int32(22),
+					Port:     ptr.To[int32](22),
 					Protocol: &udpProtocol,
 				}}
 			}),
@@ -2901,11 +2901,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 				}}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
-					Port:     pointer.Int32(11),
+					Port:     ptr.To[int32](11),
 					Protocol: &udpProtocol,
 				}, {
 					Name:     ptr.To("p12"),
-					Port:     pointer.Int32(12),
+					Port:     ptr.To[int32](12),
 					Protocol: &udpProtocol,
 				}}
 			}),
@@ -2922,7 +2922,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -2938,11 +2938,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udpProtocol,
 		}, {
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -2953,7 +2953,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p13"),
-			Port:     pointer.Int32(13),
+			Port:     ptr.To[int32](13),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -2971,11 +2971,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udpProtocol,
 		}, {
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -2989,11 +2989,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p13"),
-			Port:     pointer.Int32(13),
+			Port:     ptr.To[int32](13),
 			Protocol: &udpProtocol,
 		}, {
 			Name:     ptr.To("p14"),
-			Port:     pointer.Int32(14),
+			Port:     ptr.To[int32](14),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3007,11 +3007,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p21"),
-			Port:     pointer.Int32(21),
+			Port:     ptr.To[int32](21),
 			Protocol: &udpProtocol,
 		}, {
 			Name:     ptr.To("p22"),
-			Port:     pointer.Int32(22),
+			Port:     ptr.To[int32](22),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3031,7 +3031,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p22"),
-			Port:     pointer.Int32(22),
+			Port:     ptr.To[int32](22),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3043,7 +3043,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p23"),
-			Port:     pointer.Int32(23),
+			Port:     ptr.To[int32](23),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3058,7 +3058,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
-			Port:     pointer.Int32(44),
+			Port:     ptr.To[int32](44),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3070,7 +3070,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p45"),
-			Port:     pointer.Int32(45),
+			Port:     ptr.To[int32](45),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3083,7 +3083,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
-			Port:     pointer.Int32(11),
+			Port:     ptr.To[int32](11),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3094,11 +3094,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
-			Port:     pointer.Int32(12),
+			Port:     ptr.To[int32](12),
 			Protocol: &udpProtocol,
 		}, {
 			Name:     ptr.To("p122"),
-			Port:     pointer.Int32(122),
+			Port:     ptr.To[int32](122),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3109,7 +3109,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p33"),
-			Port:     pointer.Int32(33),
+			Port:     ptr.To[int32](33),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -3121,7 +3121,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
-			Port:     pointer.Int32(44),
+			Port:     ptr.To[int32](44),
 			Protocol: &udpProtocol,
 		}}
 	}
@@ -4392,7 +4392,7 @@ func TestEndpointSliceE2E(t *testing.T) {
 		},
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
-			Port:     pointer.Int32(80),
+			Port:     ptr.To[int32](80),
 			Protocol: &tcpProtocol,
 		}},
 		AddressType: discovery.AddressTypeIPv4,
@@ -4532,7 +4532,7 @@ func Test_HealthCheckNodePortWhenTerminating(t *testing.T) {
 		},
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
-			Port:     pointer.Int32(80),
+			Port:     ptr.To[int32](80),
 			Protocol: &tcpProtocol,
 		}},
 		AddressType: discovery.AddressTypeIPv4,
@@ -4570,7 +4570,7 @@ func Test_HealthCheckNodePortWhenTerminating(t *testing.T) {
 		},
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
-			Port:     pointer.Int32(80),
+			Port:     ptr.To[int32](80),
 			Protocol: &tcpProtocol,
 		}},
 		AddressType: discovery.AddressTypeIPv4,
@@ -4790,7 +4790,7 @@ func TestTestInternalTrafficPolicyE2E(t *testing.T) {
 			},
 			Ports: []discovery.EndpointPort{{
 				Name:     ptr.To(""),
-				Port:     pointer.Int32(80),
+				Port:     ptr.To[int32](80),
 				Protocol: &tcpProtocol,
 			}},
 			AddressType: discovery.AddressTypeIPv4,
@@ -4897,7 +4897,7 @@ func Test_EndpointSliceReadyAndTerminatingCluster(t *testing.T) {
 		},
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
-			Port:     pointer.Int32(80),
+			Port:     ptr.To[int32](80),
 			Protocol: &tcpProtocol,
 		}},
 		AddressType: discovery.AddressTypeIPv4,
@@ -5073,7 +5073,7 @@ func Test_EndpointSliceReadyAndTerminatingLocal(t *testing.T) {
 		},
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
-			Port:     pointer.Int32(80),
+			Port:     ptr.To[int32](80),
 			Protocol: &tcpProtocol,
 		}},
 		AddressType: discovery.AddressTypeIPv4,
@@ -5248,7 +5248,7 @@ func Test_EndpointSliceOnlyReadyAndTerminatingCluster(t *testing.T) {
 		},
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
-			Port:     pointer.Int32(80),
+			Port:     ptr.To[int32](80),
 			Protocol: &tcpProtocol,
 		}},
 		AddressType: discovery.AddressTypeIPv4,
@@ -5423,7 +5423,7 @@ func Test_EndpointSliceOnlyReadyAndTerminatingLocal(t *testing.T) {
 		},
 		Ports: []discovery.EndpointPort{{
 			Name:     ptr.To(""),
-			Port:     pointer.Int32(80),
+			Port:     ptr.To[int32](80),
 			Protocol: &tcpProtocol,
 		}},
 		AddressType: discovery.AddressTypeIPv4,
@@ -5765,7 +5765,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 			},
 			Ports: []discovery.EndpointPort{{
 				Name:     ptr.To("p80"),
-				Port:     pointer.Int32(80),
+				Port:     ptr.To[int32](80),
 				Protocol: &tcpProtocol,
 			}},
 			AddressType: discovery.AddressTypeIPv4,
@@ -5944,7 +5944,7 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 					}}
 					eps.Ports = []discovery.EndpointPort{{
 						Name:     ptr.To("p80"),
-						Port:     pointer.Int32(80),
+						Port:     ptr.To[int32](80),
 						Protocol: &tcpProtocol,
 					}}
 				}),

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -5797,9 +5797,6 @@ func TestDismissLocalhostRuleExist(t *testing.T) {
 }
 
 func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
-	ipModeProxy := v1.LoadBalancerIPModeProxy
-	ipModeVIP := v1.LoadBalancerIPModeVIP
-
 	testCases := []struct {
 		name             string
 		ipModeEnabled    bool
@@ -5814,7 +5811,7 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 			ipModeEnabled:    false,
 			svcIP:            "10.20.30.41",
 			svcLBIP:          "1.2.3.4",
-			ipMode:           &ipModeProxy,
+			ipMode:           ptr.To(v1.LoadBalancerIPModeProxy),
 			expectedServices: 2,
 		},
 		{
@@ -5822,7 +5819,7 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 			ipModeEnabled:    false,
 			svcIP:            "10.20.30.42",
 			svcLBIP:          "1.2.3.5",
-			ipMode:           &ipModeVIP,
+			ipMode:           ptr.To(v1.LoadBalancerIPModeVIP),
 			expectedServices: 2,
 		},
 		{
@@ -5839,7 +5836,7 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 			ipModeEnabled:    true,
 			svcIP:            "10.20.30.41",
 			svcLBIP:          "1.2.3.4",
-			ipMode:           &ipModeProxy,
+			ipMode:           ptr.To(v1.LoadBalancerIPModeProxy),
 			expectedServices: 1,
 		},
 		{
@@ -5847,7 +5844,7 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 			ipModeEnabled:    true,
 			svcIP:            "10.20.30.42",
 			svcLBIP:          "1.2.3.5",
-			ipMode:           &ipModeVIP,
+			ipMode:           ptr.To(v1.LoadBalancerIPModeVIP),
 			expectedServices: 2,
 		},
 		{

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -4650,9 +4650,6 @@ func TestTestInternalTrafficPolicyE2E(t *testing.T) {
 		hostname string
 	}
 
-	cluster := v1.ServiceInternalTrafficPolicyCluster
-	local := v1.ServiceInternalTrafficPolicyLocal
-
 	testCases := []struct {
 		name                     string
 		internalTrafficPolicy    *v1.ServiceInternalTrafficPolicy
@@ -4664,7 +4661,7 @@ func TestTestInternalTrafficPolicyE2E(t *testing.T) {
 	}{
 		{
 			name:                  "internalTrafficPolicy is cluster with non-zero local endpoints",
-			internalTrafficPolicy: &cluster,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyCluster),
 			endpoints: []endpoint{
 				{"10.0.1.1", testHostname},
 				{"10.0.1.2", "host1"},
@@ -4681,7 +4678,7 @@ func TestTestInternalTrafficPolicyE2E(t *testing.T) {
 		},
 		{
 			name:                  "internalTrafficPolicy is cluster with zero local endpoints",
-			internalTrafficPolicy: &cluster,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyCluster),
 			endpoints: []endpoint{
 				{"10.0.1.1", "host0"},
 				{"10.0.1.2", "host1"},
@@ -4698,7 +4695,7 @@ func TestTestInternalTrafficPolicyE2E(t *testing.T) {
 		},
 		{
 			name:                  "internalTrafficPolicy is local with non-zero local endpoints",
-			internalTrafficPolicy: &local,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyLocal),
 			endpoints: []endpoint{
 				{"10.0.1.1", testHostname},
 				{"10.0.1.2", "host1"},
@@ -4713,7 +4710,7 @@ func TestTestInternalTrafficPolicyE2E(t *testing.T) {
 		},
 		{
 			name:                  "internalTrafficPolicy is local with zero local endpoints",
-			internalTrafficPolicy: &local,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyLocal),
 			endpoints: []endpoint{
 				{"10.0.1.1", "host0"},
 				{"10.0.1.2", "host1"},
@@ -4831,8 +4828,6 @@ func Test_EndpointSliceReadyAndTerminatingCluster(t *testing.T) {
 	// fp.endpointsSynced = true
 	fp.endpointSlicesSynced = true
 
-	clusterInternalTrafficPolicy := v1.ServiceInternalTrafficPolicyCluster
-
 	serviceName := "svc1"
 	// Add initial service
 	namespaceName := "ns1"
@@ -4843,7 +4838,7 @@ func Test_EndpointSliceReadyAndTerminatingCluster(t *testing.T) {
 			Selector:              map[string]string{"foo": "bar"},
 			Type:                  v1.ServiceTypeNodePort,
 			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyCluster,
-			InternalTrafficPolicy: &clusterInternalTrafficPolicy,
+			InternalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyCluster),
 			ExternalIPs: []string{
 				"1.2.3.4",
 			},
@@ -5006,8 +5001,6 @@ func Test_EndpointSliceReadyAndTerminatingLocal(t *testing.T) {
 	// fp.endpointsSynced = true
 	fp.endpointSlicesSynced = true
 
-	clusterInternalTrafficPolicy := v1.ServiceInternalTrafficPolicyCluster
-
 	serviceName := "svc1"
 	// Add initial service
 	namespaceName := "ns1"
@@ -5018,7 +5011,7 @@ func Test_EndpointSliceReadyAndTerminatingLocal(t *testing.T) {
 			Selector:              map[string]string{"foo": "bar"},
 			Type:                  v1.ServiceTypeNodePort,
 			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
-			InternalTrafficPolicy: &clusterInternalTrafficPolicy,
+			InternalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyCluster),
 			ExternalIPs: []string{
 				"1.2.3.4",
 			},
@@ -5180,8 +5173,6 @@ func Test_EndpointSliceOnlyReadyAndTerminatingCluster(t *testing.T) {
 	// fp.endpointsSynced = true
 	fp.endpointSlicesSynced = true
 
-	clusterInternalTrafficPolicy := v1.ServiceInternalTrafficPolicyCluster
-
 	// Add initial service
 	serviceName := "svc1"
 	namespaceName := "ns1"
@@ -5192,7 +5183,7 @@ func Test_EndpointSliceOnlyReadyAndTerminatingCluster(t *testing.T) {
 			Selector:              map[string]string{"foo": "bar"},
 			Type:                  v1.ServiceTypeNodePort,
 			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyCluster,
-			InternalTrafficPolicy: &clusterInternalTrafficPolicy,
+			InternalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyCluster),
 			ExternalIPs: []string{
 				"1.2.3.4",
 			},
@@ -5354,8 +5345,6 @@ func Test_EndpointSliceOnlyReadyAndTerminatingLocal(t *testing.T) {
 	// fp.endpointsSynced = true
 	fp.endpointSlicesSynced = true
 
-	clusterInternalTrafficPolicy := v1.ServiceInternalTrafficPolicyCluster
-
 	// Add initial service
 	serviceName := "svc1"
 	namespaceName := "ns1"
@@ -5366,7 +5355,7 @@ func Test_EndpointSliceOnlyReadyAndTerminatingLocal(t *testing.T) {
 			Selector:              map[string]string{"foo": "bar"},
 			Type:                  v1.ServiceTypeNodePort,
 			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
-			InternalTrafficPolicy: &clusterInternalTrafficPolicy,
+			InternalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyCluster),
 			ExternalIPs: []string{
 				"1.2.3.4",
 			},
@@ -5610,8 +5599,6 @@ func TestNoEndpointsMetric(t *testing.T) {
 		hostname string
 	}
 
-	internalTrafficPolicyLocal := v1.ServiceInternalTrafficPolicyLocal
-	externalTrafficPolicyLocal := v1.ServiceExternalTrafficPolicyLocal
 	metrics.RegisterMetrics()
 
 	testCases := []struct {
@@ -5624,7 +5611,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 	}{
 		{
 			name:                  "internalTrafficPolicy is set and there are local endpoints",
-			internalTrafficPolicy: &internalTrafficPolicyLocal,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyLocal),
 			endpoints: []endpoint{
 				{"10.0.1.1", testHostname},
 				{"10.0.1.2", "host1"},
@@ -5633,7 +5620,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 		},
 		{
 			name:                  "externalTrafficPolicy is set and there are local endpoints",
-			externalTrafficPolicy: externalTrafficPolicyLocal,
+			externalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
 			endpoints: []endpoint{
 				{"10.0.1.1", testHostname},
 				{"10.0.1.2", "host1"},
@@ -5642,8 +5629,8 @@ func TestNoEndpointsMetric(t *testing.T) {
 		},
 		{
 			name:                  "both policies are set and there are local endpoints",
-			internalTrafficPolicy: &internalTrafficPolicyLocal,
-			externalTrafficPolicy: externalTrafficPolicyLocal,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyLocal),
+			externalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
 			endpoints: []endpoint{
 				{"10.0.1.1", testHostname},
 				{"10.0.1.2", "host1"},
@@ -5652,7 +5639,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 		},
 		{
 			name:                  "internalTrafficPolicy is set and there are no local endpoints",
-			internalTrafficPolicy: &internalTrafficPolicyLocal,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyLocal),
 			endpoints: []endpoint{
 				{"10.0.1.1", "host0"},
 				{"10.0.1.2", "host1"},
@@ -5662,7 +5649,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 		},
 		{
 			name:                  "externalTrafficPolicy is set and there are no local endpoints",
-			externalTrafficPolicy: externalTrafficPolicyLocal,
+			externalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
 			endpoints: []endpoint{
 				{"10.0.1.1", "host0"},
 				{"10.0.1.2", "host1"},
@@ -5672,8 +5659,8 @@ func TestNoEndpointsMetric(t *testing.T) {
 		},
 		{
 			name:                  "Both policies are set and there are no local endpoints",
-			internalTrafficPolicy: &internalTrafficPolicyLocal,
-			externalTrafficPolicy: externalTrafficPolicyLocal,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyLocal),
+			externalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
 			endpoints: []endpoint{
 				{"10.0.1.1", "host0"},
 				{"10.0.1.2", "host1"},
@@ -5684,8 +5671,8 @@ func TestNoEndpointsMetric(t *testing.T) {
 		},
 		{
 			name:                  "Both policies are set and there are no endpoints at all",
-			internalTrafficPolicy: &internalTrafficPolicyLocal,
-			externalTrafficPolicy: externalTrafficPolicyLocal,
+			internalTrafficPolicy: ptr.To(v1.ServiceInternalTrafficPolicyLocal),
+			externalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
 			endpoints:             []endpoint{},
 			expectedSyncProxyRulesNoLocalEndpointsTotalInternal: 0,
 			expectedSyncProxyRulesNoLocalEndpointsTotalExternal: 0,

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -272,7 +272,7 @@ func TestCleanupLeftovers(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -1813,7 +1813,7 @@ func TestExternalIPs(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &udpProtocol,
 			}}
 		}),
@@ -1892,7 +1892,7 @@ func TestOnlyLocalExternalIPs(t *testing.T) {
 				}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -1966,7 +1966,7 @@ func TestLoadBalancer(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &udpProtocol,
 			}}
 		}),
@@ -2059,7 +2059,7 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -2229,7 +2229,7 @@ func TestLoadBalancerSourceRanges(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -2416,7 +2416,7 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 				}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
 		}),

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -2749,7 +2749,6 @@ func TestSessionAffinity(t *testing.T) {
 		NamespacedName: makeNSN("ns1", "svc1"),
 		Port:           "p80",
 	}
-	timeoutSeconds := v1.DefaultClientIPServiceAffinitySeconds
 
 	makeServiceMap(fp,
 		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
@@ -2759,7 +2758,7 @@ func TestSessionAffinity(t *testing.T) {
 			svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
 			svc.Spec.SessionAffinityConfig = &v1.SessionAffinityConfig{
 				ClientIP: &v1.ClientIPConfig{
-					TimeoutSeconds: &timeoutSeconds,
+					TimeoutSeconds: ptr.To[int32](v1.DefaultClientIPServiceAffinitySeconds),
 				},
 			}
 			svc.Spec.Ports = []v1.ServicePort{{

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -57,7 +57,7 @@ import (
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
 	netutils "k8s.io/utils/net"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const testHostname = "test-hostname"

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -271,7 +271,7 @@ func TestCleanupLeftovers(t *testing.T) {
 				Addresses: []string{epIP},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
@@ -468,7 +468,7 @@ func TestNodePortIPv4(t *testing.T) {
 						Addresses: []string{"10.180.0.1"},
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p80"),
+						Name:     ptr.To("p80"),
 						Port:     pointer.Int32(80),
 						Protocol: &tcpProtocol,
 					}}
@@ -479,7 +479,7 @@ func TestNodePortIPv4(t *testing.T) {
 						Addresses: []string{"1002:ab8::2:10"},
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p80"),
+						Name:     ptr.To("p80"),
 						Port:     pointer.Int32(80),
 						Protocol: &tcpProtocol,
 					}}
@@ -557,7 +557,7 @@ func TestNodePortIPv4(t *testing.T) {
 						Addresses: []string{"10.180.0.1"},
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p80"),
+						Name:     ptr.To("p80"),
 						Port:     pointer.Int32(80),
 						Protocol: &udpProtocol,
 					}}
@@ -712,7 +712,7 @@ func TestNodePortIPv4(t *testing.T) {
 						Addresses: []string{"10.180.0.1"},
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p80"),
+						Name:     ptr.To("p80"),
 						Port:     pointer.Int32(80),
 						Protocol: &sctpProtocol,
 					}}
@@ -860,13 +860,13 @@ func TestNodePortIPv4(t *testing.T) {
 					eps.AddressType = discovery.AddressTypeIPv4
 					eps.Endpoints = []discovery.Endpoint{{
 						Addresses: []string{"10.180.0.1"},
-						NodeName:  pointer.String(testHostname),
+						NodeName:  ptr.To(testHostname),
 					}, {
 						Addresses: []string{"10.180.1.1"},
-						NodeName:  pointer.String("otherHost"),
+						NodeName:  ptr.To("otherHost"),
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p80"),
+						Name:     ptr.To("p80"),
 						Port:     pointer.Int32(80),
 						Protocol: &sctpProtocol,
 					}}
@@ -1022,7 +1022,7 @@ func TestNodePortIPv6(t *testing.T) {
 						Addresses: []string{"10.180.0.1"},
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p80"),
+						Name:     ptr.To("p80"),
 						Port:     pointer.Int32(80),
 						Protocol: &tcpProtocol,
 					}}
@@ -1033,7 +1033,7 @@ func TestNodePortIPv6(t *testing.T) {
 						Addresses: []string{"1002:ab8::2:10"},
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p80"),
+						Name:     ptr.To("p80"),
 						Port:     pointer.Int32(80),
 						Protocol: &tcpProtocol,
 					}}
@@ -1113,7 +1113,7 @@ func TestNodePortIPv6(t *testing.T) {
 						Addresses: []string{"10.180.0.1"},
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p80"),
+						Name:     ptr.To("p80"),
 						Port:     pointer.Int32(80),
 						Protocol: &udpProtocol,
 					}}
@@ -1206,7 +1206,7 @@ func TestNodePortIPv6(t *testing.T) {
 						Addresses: []string{"2001::1"},
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p80"),
+						Name:     ptr.To("p80"),
 						Port:     pointer.Int32(80),
 						Protocol: &sctpProtocol,
 					}}
@@ -1354,7 +1354,7 @@ func Test_syncEndpoint_updateWeightsOnRestart(t *testing.T) {
 			Addresses: []string{"10.180.0.1"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.StringPtr("p80"),
+			Name:     ptr.To("p80"),
 			Port:     pointer.Int32(80),
 			Protocol: &tcpProtocol,
 		}}
@@ -1449,7 +1449,7 @@ func TestIPv4Proxier(t *testing.T) {
 						Addresses: []string{"10.180.0.1"},
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p80"),
+						Name:     ptr.To("p80"),
 						Port:     pointer.Int32(80),
 						Protocol: &tcpProtocol,
 					}}
@@ -1460,7 +1460,7 @@ func TestIPv4Proxier(t *testing.T) {
 						Addresses: []string{"1009:ab8::5:6"},
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p8080"),
+						Name:     ptr.To("p8080"),
 						Port:     pointer.Int32(8080),
 						Protocol: &tcpProtocol,
 					}}
@@ -1587,7 +1587,7 @@ func TestIPv6Proxier(t *testing.T) {
 						Addresses: []string{"10.180.0.1"},
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p80"),
+						Name:     ptr.To("p80"),
 						Port:     pointer.Int32(80),
 						Protocol: &tcpProtocol,
 					}}
@@ -1598,7 +1598,7 @@ func TestIPv6Proxier(t *testing.T) {
 						Addresses: []string{"1009:ab8::5:6"},
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p8080"),
+						Name:     ptr.To("p8080"),
 						Port:     pointer.Int32(8080),
 						Protocol: &tcpProtocol,
 					}}
@@ -1812,7 +1812,7 @@ func TestExternalIPs(t *testing.T) {
 				Addresses: []string{epIP},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &udpProtocol,
 			}}
@@ -1884,14 +1884,14 @@ func TestOnlyLocalExternalIPs(t *testing.T) {
 			eps.AddressType = discovery.AddressTypeIPv4
 			eps.Endpoints = []discovery.Endpoint{{
 				Addresses: []string{epIP},
-				NodeName:  pointer.String(thisHostname),
+				NodeName:  ptr.To(thisHostname),
 			},
 				{
 					Addresses: []string{epIP1},
-					NodeName:  pointer.String(otherHostname),
+					NodeName:  ptr.To(otherHostname),
 				}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
@@ -1965,7 +1965,7 @@ func TestLoadBalancer(t *testing.T) {
 				Addresses: []string{epIP},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &udpProtocol,
 			}}
@@ -2058,7 +2058,7 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 				NodeName:  &otherHostname,
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
@@ -2228,7 +2228,7 @@ func TestLoadBalancerSourceRanges(t *testing.T) {
 				Addresses: []string{epIP},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
@@ -2341,7 +2341,7 @@ func TestAcceptIPVSTraffic(t *testing.T) {
 					Addresses: []string{svcInfo.epIP},
 				}}
 				eps.Ports = []discovery.EndpointPort{{
-					Name:     pointer.String("p80"),
+					Name:     ptr.To("p80"),
 					Port:     pointer.Int32(80),
 					Protocol: &udpProtocol,
 				}}
@@ -2415,7 +2415,7 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 					NodeName:  &otherHostname,
 				}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
@@ -2827,7 +2827,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.1"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udpProtocol,
 		}}
@@ -2838,7 +2838,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.2"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udpProtocol,
 		}}
@@ -2852,7 +2852,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 					NodeName:  &nodeName,
 				}}
 				eps.Ports = []discovery.EndpointPort{{
-					Name:     pointer.String("p11"),
+					Name:     ptr.To("p11"),
 					Port:     pointer.Int32(11),
 					Protocol: &udpProtocol,
 				}}
@@ -2869,7 +2869,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 					Addresses: []string{"1.1.1.1"},
 				}}
 				eps.Ports = []discovery.EndpointPort{{
-					Name:     pointer.String("p11-2"),
+					Name:     ptr.To("p11-2"),
 					Port:     pointer.Int32(11),
 					Protocol: &udpProtocol,
 				}}
@@ -2883,7 +2883,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 					Addresses: []string{"1.1.1.1"},
 				}}
 				eps.Ports = []discovery.EndpointPort{{
-					Name:     pointer.String("p11"),
+					Name:     ptr.To("p11"),
 					Port:     pointer.Int32(22),
 					Protocol: &udpProtocol,
 				}}
@@ -2900,11 +2900,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 					NodeName:  &nodeName,
 				}}
 				eps.Ports = []discovery.EndpointPort{{
-					Name:     pointer.String("p11"),
+					Name:     ptr.To("p11"),
 					Port:     pointer.Int32(11),
 					Protocol: &udpProtocol,
 				}, {
-					Name:     pointer.String("p12"),
+					Name:     ptr.To("p12"),
 					Port:     pointer.Int32(12),
 					Protocol: &udpProtocol,
 				}}
@@ -2921,7 +2921,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udpProtocol,
 		}}
@@ -2937,11 +2937,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udpProtocol,
 		}, {
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udpProtocol,
 		}}
@@ -2952,7 +2952,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.3"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p13"),
+			Name:     ptr.To("p13"),
 			Port:     pointer.Int32(13),
 			Protocol: &udpProtocol,
 		}}
@@ -2970,11 +2970,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udpProtocol,
 		}, {
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udpProtocol,
 		}}
@@ -2988,11 +2988,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p13"),
+			Name:     ptr.To("p13"),
 			Port:     pointer.Int32(13),
 			Protocol: &udpProtocol,
 		}, {
-			Name:     pointer.String("p14"),
+			Name:     ptr.To("p14"),
 			Port:     pointer.Int32(14),
 			Protocol: &udpProtocol,
 		}}
@@ -3006,11 +3006,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p21"),
+			Name:     ptr.To("p21"),
 			Port:     pointer.Int32(21),
 			Protocol: &udpProtocol,
 		}, {
-			Name:     pointer.String("p22"),
+			Name:     ptr.To("p22"),
 			Port:     pointer.Int32(22),
 			Protocol: &udpProtocol,
 		}}
@@ -3030,7 +3030,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p22"),
+			Name:     ptr.To("p22"),
 			Port:     pointer.Int32(22),
 			Protocol: &udpProtocol,
 		}}
@@ -3042,7 +3042,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p23"),
+			Name:     ptr.To("p23"),
 			Port:     pointer.Int32(23),
 			Protocol: &udpProtocol,
 		}}
@@ -3057,7 +3057,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p44"),
+			Name:     ptr.To("p44"),
 			Port:     pointer.Int32(44),
 			Protocol: &udpProtocol,
 		}}
@@ -3069,7 +3069,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p45"),
+			Name:     ptr.To("p45"),
 			Port:     pointer.Int32(45),
 			Protocol: &udpProtocol,
 		}}
@@ -3082,7 +3082,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.11"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p11"),
+			Name:     ptr.To("p11"),
 			Port:     pointer.Int32(11),
 			Protocol: &udpProtocol,
 		}}
@@ -3093,11 +3093,11 @@ func Test_updateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.2"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p12"),
+			Name:     ptr.To("p12"),
 			Port:     pointer.Int32(12),
 			Protocol: &udpProtocol,
 		}, {
-			Name:     pointer.String("p122"),
+			Name:     ptr.To("p122"),
 			Port:     pointer.Int32(122),
 			Protocol: &udpProtocol,
 		}}
@@ -3108,7 +3108,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			Addresses: []string{"3.3.3.3"},
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p33"),
+			Name:     ptr.To("p33"),
 			Port:     pointer.Int32(33),
 			Protocol: &udpProtocol,
 		}}
@@ -3120,7 +3120,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			NodeName:  &nodeName,
 		}}
 		eps.Ports = []discovery.EndpointPort{{
-			Name:     pointer.String("p44"),
+			Name:     ptr.To("p44"),
 			Port:     pointer.Int32(44),
 			Protocol: &udpProtocol,
 		}}
@@ -4391,27 +4391,27 @@ func TestEndpointSliceE2E(t *testing.T) {
 			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 		},
 		Ports: []discovery.EndpointPort{{
-			Name:     pointer.String(""),
+			Name:     ptr.To(""),
 			Port:     pointer.Int32(80),
 			Protocol: &tcpProtocol,
 		}},
 		AddressType: discovery.AddressTypeIPv4,
 		Endpoints: []discovery.Endpoint{{
 			Addresses:  []string{"10.0.1.1"},
-			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
-			NodeName:   pointer.String(testHostname),
+			Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+			NodeName:   ptr.To(testHostname),
 		}, {
 			Addresses:  []string{"10.0.1.2"},
-			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
-			NodeName:   pointer.String("node2"),
+			Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+			NodeName:   ptr.To("node2"),
 		}, {
 			Addresses:  []string{"10.0.1.3"},
-			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
-			NodeName:   pointer.String("node3"),
+			Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+			NodeName:   ptr.To("node3"),
 		}, { // not ready endpoints should be ignored
 			Addresses:  []string{"10.0.1.4"},
-			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(false)},
-			NodeName:   pointer.String("node3"),
+			Conditions: discovery.EndpointConditions{Ready: ptr.To(false)},
+			NodeName:   ptr.To("node3"),
 		}},
 	}
 
@@ -4531,26 +4531,26 @@ func Test_HealthCheckNodePortWhenTerminating(t *testing.T) {
 			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 		},
 		Ports: []discovery.EndpointPort{{
-			Name:     pointer.String(""),
+			Name:     ptr.To(""),
 			Port:     pointer.Int32(80),
 			Protocol: &tcpProtocol,
 		}},
 		AddressType: discovery.AddressTypeIPv4,
 		Endpoints: []discovery.Endpoint{{
 			Addresses:  []string{"10.0.1.1"},
-			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
-			NodeName:   pointer.String(testHostname),
+			Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+			NodeName:   ptr.To(testHostname),
 		}, {
 			Addresses:  []string{"10.0.1.2"},
-			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
-			NodeName:   pointer.String(testHostname),
+			Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+			NodeName:   ptr.To(testHostname),
 		}, {
 			Addresses:  []string{"10.0.1.3"},
-			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+			Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 		}, { // not ready endpoints should be ignored
 			Addresses:  []string{"10.0.1.4"},
-			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(false)},
-			NodeName:   pointer.String(testHostname),
+			Conditions: discovery.EndpointConditions{Ready: ptr.To(false)},
+			NodeName:   ptr.To(testHostname),
 		}},
 	}
 
@@ -4569,7 +4569,7 @@ func Test_HealthCheckNodePortWhenTerminating(t *testing.T) {
 			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 		},
 		Ports: []discovery.EndpointPort{{
-			Name:     pointer.String(""),
+			Name:     ptr.To(""),
 			Port:     pointer.Int32(80),
 			Protocol: &tcpProtocol,
 		}},
@@ -4577,35 +4577,35 @@ func Test_HealthCheckNodePortWhenTerminating(t *testing.T) {
 		Endpoints: []discovery.Endpoint{{
 			Addresses: []string{"10.0.1.1"},
 			Conditions: discovery.EndpointConditions{
-				Ready:       pointer.Bool(false),
-				Serving:     pointer.Bool(true),
-				Terminating: pointer.Bool(false),
+				Ready:       ptr.To(false),
+				Serving:     ptr.To(true),
+				Terminating: ptr.To(false),
 			},
-			NodeName: pointer.String(testHostname),
+			NodeName: ptr.To(testHostname),
 		}, {
 			Addresses: []string{"10.0.1.2"},
 			Conditions: discovery.EndpointConditions{
-				Ready:       pointer.Bool(false),
-				Serving:     pointer.Bool(true),
-				Terminating: pointer.Bool(true),
+				Ready:       ptr.To(false),
+				Serving:     ptr.To(true),
+				Terminating: ptr.To(true),
 			},
-			NodeName: pointer.String(testHostname),
+			NodeName: ptr.To(testHostname),
 		}, {
 			Addresses: []string{"10.0.1.3"},
 			Conditions: discovery.EndpointConditions{
-				Ready:       pointer.Bool(false),
-				Serving:     pointer.Bool(true),
-				Terminating: pointer.Bool(true),
+				Ready:       ptr.To(false),
+				Serving:     ptr.To(true),
+				Terminating: ptr.To(true),
 			},
-			NodeName: pointer.String(testHostname),
+			NodeName: ptr.To(testHostname),
 		}, { // not ready endpoints should be ignored
 			Addresses: []string{"10.0.1.4"},
 			Conditions: discovery.EndpointConditions{
-				Ready:       pointer.Bool(false),
-				Serving:     pointer.Bool(false),
-				Terminating: pointer.Bool(true),
+				Ready:       ptr.To(false),
+				Serving:     ptr.To(false),
+				Terminating: ptr.To(true),
 			},
-			NodeName: pointer.String(testHostname),
+			NodeName: ptr.To(testHostname),
 		}},
 	}
 
@@ -4789,7 +4789,7 @@ func TestTestInternalTrafficPolicyE2E(t *testing.T) {
 				Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 			},
 			Ports: []discovery.EndpointPort{{
-				Name:     pointer.String(""),
+				Name:     ptr.To(""),
 				Port:     pointer.Int32(80),
 				Protocol: &tcpProtocol,
 			}},
@@ -4799,8 +4799,8 @@ func TestTestInternalTrafficPolicyE2E(t *testing.T) {
 		for _, ep := range tc.endpoints {
 			endpointSlice.Endpoints = append(endpointSlice.Endpoints, discovery.Endpoint{
 				Addresses:  []string{ep.ip},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
-				NodeName:   pointer.String(ep.hostname),
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+				NodeName:   ptr.To(ep.hostname),
 			})
 		}
 
@@ -4896,7 +4896,7 @@ func Test_EndpointSliceReadyAndTerminatingCluster(t *testing.T) {
 			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 		},
 		Ports: []discovery.EndpointPort{{
-			Name:     pointer.String(""),
+			Name:     ptr.To(""),
 			Port:     pointer.Int32(80),
 			Protocol: &tcpProtocol,
 		}},
@@ -4905,47 +4905,47 @@ func Test_EndpointSliceReadyAndTerminatingCluster(t *testing.T) {
 			{
 				Addresses: []string{"10.0.1.1"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
-				NodeName: pointer.String(testHostname),
+				NodeName: ptr.To(testHostname),
 			},
 			{
 				Addresses: []string{"10.0.1.2"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
-				NodeName: pointer.String(testHostname),
+				NodeName: ptr.To(testHostname),
 			},
 			{
 				Addresses: []string{"10.0.1.3"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(true),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(true),
 				},
-				NodeName: pointer.String(testHostname),
+				NodeName: ptr.To(testHostname),
 			},
 			{
 				Addresses: []string{"10.0.1.4"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(false),
-					Terminating: pointer.Bool(true),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(false),
+					Terminating: ptr.To(true),
 				},
-				NodeName: pointer.String(testHostname),
+				NodeName: ptr.To(testHostname),
 			},
 			{
 				Addresses: []string{"10.0.1.5"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
-				NodeName: pointer.String("another-host"),
+				NodeName: ptr.To("another-host"),
 			},
 		},
 	}
@@ -5072,7 +5072,7 @@ func Test_EndpointSliceReadyAndTerminatingLocal(t *testing.T) {
 			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 		},
 		Ports: []discovery.EndpointPort{{
-			Name:     pointer.String(""),
+			Name:     ptr.To(""),
 			Port:     pointer.Int32(80),
 			Protocol: &tcpProtocol,
 		}},
@@ -5081,47 +5081,47 @@ func Test_EndpointSliceReadyAndTerminatingLocal(t *testing.T) {
 			{
 				Addresses: []string{"10.0.1.1"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
-				NodeName: pointer.String(testHostname),
+				NodeName: ptr.To(testHostname),
 			},
 			{
 				Addresses: []string{"10.0.1.2"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
-				NodeName: pointer.String(testHostname),
+				NodeName: ptr.To(testHostname),
 			},
 			{
 				Addresses: []string{"10.0.1.3"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(true),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(true),
 				},
-				NodeName: pointer.String(testHostname),
+				NodeName: ptr.To(testHostname),
 			},
 			{
 				Addresses: []string{"10.0.1.4"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(false),
-					Terminating: pointer.Bool(true),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(false),
+					Terminating: ptr.To(true),
 				},
-				NodeName: pointer.String(testHostname),
+				NodeName: ptr.To(testHostname),
 			},
 			{
 				Addresses: []string{"10.0.1.5"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
-				NodeName: pointer.String("another-host"),
+				NodeName: ptr.To("another-host"),
 			},
 		},
 	}
@@ -5247,7 +5247,7 @@ func Test_EndpointSliceOnlyReadyAndTerminatingCluster(t *testing.T) {
 			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 		},
 		Ports: []discovery.EndpointPort{{
-			Name:     pointer.String(""),
+			Name:     ptr.To(""),
 			Port:     pointer.Int32(80),
 			Protocol: &tcpProtocol,
 		}},
@@ -5256,47 +5256,47 @@ func Test_EndpointSliceOnlyReadyAndTerminatingCluster(t *testing.T) {
 			{
 				Addresses: []string{"10.0.1.1"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(true),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(true),
 				},
-				NodeName: pointer.String(testHostname),
+				NodeName: ptr.To(testHostname),
 			},
 			{
 				Addresses: []string{"10.0.1.2"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(true),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(true),
 				},
-				NodeName: pointer.String(testHostname),
+				NodeName: ptr.To(testHostname),
 			},
 			{
 				Addresses: []string{"10.0.1.3"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(false),
-					Terminating: pointer.Bool(true),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(false),
+					Terminating: ptr.To(true),
 				},
-				NodeName: pointer.String(testHostname),
+				NodeName: ptr.To(testHostname),
 			},
 			{
 				Addresses: []string{"10.0.1.4"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(true),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(true),
 				},
-				NodeName: pointer.String("another-host"),
+				NodeName: ptr.To("another-host"),
 			},
 			{
 				Addresses: []string{"10.0.1.5"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(false),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(false),
+					Terminating: ptr.To(false),
 				},
-				NodeName: pointer.String("another-host"),
+				NodeName: ptr.To("another-host"),
 			},
 		},
 	}
@@ -5422,7 +5422,7 @@ func Test_EndpointSliceOnlyReadyAndTerminatingLocal(t *testing.T) {
 			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 		},
 		Ports: []discovery.EndpointPort{{
-			Name:     pointer.String(""),
+			Name:     ptr.To(""),
 			Port:     pointer.Int32(80),
 			Protocol: &tcpProtocol,
 		}},
@@ -5431,47 +5431,47 @@ func Test_EndpointSliceOnlyReadyAndTerminatingLocal(t *testing.T) {
 			{
 				Addresses: []string{"10.0.1.1"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(true),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(true),
 				},
-				NodeName: pointer.String(testHostname),
+				NodeName: ptr.To(testHostname),
 			},
 			{
 				Addresses: []string{"10.0.1.2"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(true),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(true),
 				},
-				NodeName: pointer.String(testHostname),
+				NodeName: ptr.To(testHostname),
 			},
 			{
 				Addresses: []string{"10.0.1.3"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(false),
-					Terminating: pointer.Bool(true),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(false),
+					Terminating: ptr.To(true),
 				},
-				NodeName: pointer.String(testHostname),
+				NodeName: ptr.To(testHostname),
 			},
 			{
 				Addresses: []string{"10.0.1.4"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(false),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(true),
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(true),
 				},
-				NodeName: pointer.String("another-host"),
+				NodeName: ptr.To("another-host"),
 			},
 			{
 				Addresses: []string{"10.0.1.5"},
 				Conditions: discovery.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       ptr.To(true),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(false),
 				},
-				NodeName: pointer.String("another-host"),
+				NodeName: ptr.To("another-host"),
 			},
 		},
 	}
@@ -5764,7 +5764,7 @@ func TestNoEndpointsMetric(t *testing.T) {
 				Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 			},
 			Ports: []discovery.EndpointPort{{
-				Name:     pointer.String("p80"),
+				Name:     ptr.To("p80"),
 				Port:     pointer.Int32(80),
 				Protocol: &tcpProtocol,
 			}},
@@ -5774,8 +5774,8 @@ func TestNoEndpointsMetric(t *testing.T) {
 		for _, ep := range tc.endpoints {
 			endpointSlice.Endpoints = append(endpointSlice.Endpoints, discovery.Endpoint{
 				Addresses:  []string{ep.ip},
-				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
-				NodeName:   pointer.String(ep.hostname),
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+				NodeName:   ptr.To(ep.hostname),
 			})
 		}
 
@@ -5943,7 +5943,7 @@ func TestLoadBalancerIngressRouteTypeProxy(t *testing.T) {
 						Addresses: []string{"10.180.0.1"},
 					}}
 					eps.Ports = []discovery.EndpointPort{{
-						Name:     pointer.String("p80"),
+						Name:     ptr.To("p80"),
 						Port:     pointer.Int32(80),
 						Protocol: &tcpProtocol,
 					}}

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -2029,18 +2029,16 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 
 	epIP := "10.180.0.1"
 	epIP1 := "10.180.1.1"
-	thisHostname := testHostname
-	otherHostname := "other-hostname"
 
 	populateEndpointSlices(fp,
 		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
 			eps.AddressType = discovery.AddressTypeIPv4
 			eps.Endpoints = []discovery.Endpoint{{
 				Addresses: []string{epIP},
-				NodeName:  &thisHostname,
+				NodeName:  ptr.To(testHostname),
 			}, {
 				Addresses: []string{epIP1},
-				NodeName:  &otherHostname,
+				NodeName:  ptr.To("other-hostname"),
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
@@ -2381,8 +2379,6 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 
 	epIP := "10.180.0.1"
 	epIP1 := "10.180.1.1"
-	thisHostname := testHostname
-	otherHostname := "other-hostname"
 
 	populateEndpointSlices(fp,
 		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
@@ -2390,11 +2386,11 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 			eps.Endpoints = []discovery.Endpoint{
 				{ // **local** endpoint address, should be added as RS
 					Addresses: []string{epIP},
-					NodeName:  &thisHostname,
+					NodeName:  ptr.To(testHostname),
 				},
 				{ // **remote** endpoint address, should not be added as RS
 					Addresses: []string{epIP1},
-					NodeName:  &otherHostname,
+					NodeName:  ptr.To("other-hostname"),
 				}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
@@ -2797,8 +2793,6 @@ func makeServicePortName(ns, name, port string, protocol v1.Protocol) proxy.Serv
 }
 
 func Test_updateEndpointsMap(t *testing.T) {
-	var nodeName = testHostname
-
 	emptyEndpointSlices := []*discovery.EndpointSlice{
 		makeTestEndpointSlice("ns1", "ep1", 1, func(*discovery.EndpointSlice) {}),
 	}
@@ -2830,7 +2824,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 				eps.AddressType = discovery.AddressTypeIPv4
 				eps.Endpoints = []discovery.Endpoint{{
 					Addresses: []string{"1.1.1.1"},
-					NodeName:  &nodeName,
+					NodeName:  ptr.To(testHostname),
 				}}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
@@ -2878,7 +2872,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 					Addresses: []string{"1.1.1.1"},
 				}, {
 					Addresses: []string{"1.1.1.2"},
-					NodeName:  &nodeName,
+					NodeName:  ptr.To(testHostname),
 				}}
 				eps.Ports = []discovery.EndpointPort{{
 					Name:     ptr.To("p11"),
@@ -2899,7 +2893,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.AddressType = discovery.AddressTypeIPv4
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"1.1.1.2"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p12"),
@@ -2915,7 +2909,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.AddressType = discovery.AddressTypeIPv4
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"1.1.1.1"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
@@ -2948,7 +2942,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.1"},
 		}, {
 			Addresses: []string{"1.1.1.2"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p11"),
@@ -2966,7 +2960,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			Addresses: []string{"1.1.1.3"},
 		}, {
 			Addresses: []string{"1.1.1.4"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p13"),
@@ -2984,7 +2978,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			Addresses: []string{"2.2.2.1"},
 		}, {
 			Addresses: []string{"2.2.2.2"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p21"),
@@ -3005,10 +2999,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.AddressType = discovery.AddressTypeIPv4
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"2.2.2.2"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}, {
 			Addresses: []string{"2.2.2.22"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p22"),
@@ -3020,7 +3014,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.AddressType = discovery.AddressTypeIPv4
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"2.2.2.3"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p23"),
@@ -3032,10 +3026,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.AddressType = discovery.AddressTypeIPv4
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"4.4.4.4"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}, {
 			Addresses: []string{"4.4.4.5"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
@@ -3047,7 +3041,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.AddressType = discovery.AddressTypeIPv4
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"4.4.4.6"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p45"),
@@ -3098,7 +3092,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		eps.AddressType = discovery.AddressTypeIPv4
 		eps.Endpoints = []discovery.Endpoint{{
 			Addresses: []string{"4.4.4.4"},
-			NodeName:  &nodeName,
+			NodeName:  ptr.To(testHostname),
 		}}
 		eps.Ports = []discovery.EndpointPort{{
 			Name:     ptr.To("p44"),
@@ -3562,7 +3556,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			ipvs := ipvstest.NewFake()
 			ipset := ipsettest.NewFake(testIPSetVersion)
 			fp := NewFakeProxier(ipt, ipvs, ipset, nil, nil, v1.IPv4Protocol)
-			fp.hostname = nodeName
+			fp.hostname = testHostname
 
 			// First check that after adding all previous versions of endpoints,
 			// the fp.oldEndpoints is as we expect.

--- a/pkg/proxy/kubemark/hollow_proxy.go
+++ b/pkg/proxy/kubemark/hollow_proxy.go
@@ -130,7 +130,7 @@ func NewHollowProxyOrDie(
 			Config: &proxyconfigapi.KubeProxyConfiguration{
 				Mode:             proxyconfigapi.ProxyMode("fake"),
 				ConfigSyncPeriod: metav1.Duration{Duration: 30 * time.Second},
-				OOMScoreAdj:      utilpointer.Int32Ptr(0),
+				OOMScoreAdj:      ptr.To[int32](0),
 			},
 
 			Client:      client,

--- a/pkg/proxy/kubemark/hollow_proxy.go
+++ b/pkg/proxy/kubemark/hollow_proxy.go
@@ -38,7 +38,7 @@ import (
 	utilnode "k8s.io/kubernetes/pkg/util/node"
 	utilexec "k8s.io/utils/exec"
 	netutils "k8s.io/utils/net"
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"k8s.io/klog/v2"
 )

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -221,7 +221,7 @@ func TestCreateRemoteEndpointOverlay(t *testing.T) {
 				Addresses: []string{epIpAddressRemote},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
@@ -287,7 +287,7 @@ func TestCreateRemoteEndpointL2Bridge(t *testing.T) {
 				Addresses: []string{epIpAddressRemote},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
@@ -369,7 +369,7 @@ func TestSharedRemoteEndpointDelete(t *testing.T) {
 				Addresses: []string{epIpAddressRemote},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName1.Port),
+				Name:     ptr.To(svcPortName1.Port),
 				Port:     pointer.Int32(int32(svcPort1)),
 				Protocol: &tcpProtocol,
 			}}
@@ -380,7 +380,7 @@ func TestSharedRemoteEndpointDelete(t *testing.T) {
 				Addresses: []string{epIpAddressRemote},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName2.Port),
+				Name:     ptr.To(svcPortName2.Port),
 				Port:     pointer.Int32(int32(svcPort2)),
 				Protocol: &tcpProtocol,
 			}}
@@ -428,7 +428,7 @@ func TestSharedRemoteEndpointDelete(t *testing.T) {
 				Addresses: []string{epIpAddressRemote},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName2.Port),
+				Name:     ptr.To(svcPortName2.Port),
 				Port:     pointer.Int32(int32(svcPort2)),
 				Protocol: &tcpProtocol,
 			}}
@@ -513,7 +513,7 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 				Addresses: []string{epIpAddressRemote},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName1.Port),
+				Name:     ptr.To(svcPortName1.Port),
 				Port:     pointer.Int32(int32(svcPort1)),
 				Protocol: &tcpProtocol,
 			}}
@@ -524,7 +524,7 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 				Addresses: []string{epIpAddressRemote},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName2.Port),
+				Name:     ptr.To(svcPortName2.Port),
 				Port:     pointer.Int32(int32(svcPort2)),
 				Protocol: &tcpProtocol,
 			}}
@@ -583,7 +583,7 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 				Addresses: []string{epIpAddressRemote},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName1.Port),
+				Name:     ptr.To(svcPortName1.Port),
 				Port:     pointer.Int32(int32(svcPort1)),
 				Protocol: &tcpProtocol,
 			}}
@@ -594,12 +594,12 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 				Addresses: []string{epIpAddressRemote},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName1.Port),
+				Name:     ptr.To(svcPortName1.Port),
 				Port:     pointer.Int32(int32(svcPort1)),
 				Protocol: &tcpProtocol,
 			},
 				{
-					Name:     pointer.String("p443"),
+					Name:     ptr.To("p443"),
 					Port:     pointer.Int32(int32(443)),
 					Protocol: &tcpProtocol,
 				}}
@@ -668,7 +668,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 				Addresses: []string{epIpAddressRemote},
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
@@ -729,10 +729,10 @@ func TestCreateDsrLoadBalancer(t *testing.T) {
 			eps.AddressType = discovery.AddressTypeIPv4
 			eps.Endpoints = []discovery.Endpoint{{
 				Addresses: []string{epIpAddressRemote},
-				NodeName:  pointer.String("testhost"),
+				NodeName:  ptr.To("testhost"),
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.String(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
@@ -809,10 +809,10 @@ func TestClusterIPLBInCreateDsrLoadBalancer(t *testing.T) {
 			eps.AddressType = discovery.AddressTypeIPv4
 			eps.Endpoints = []discovery.Endpoint{{
 				Addresses: []string{epIpAddressRemote},
-				NodeName:  pointer.StringPtr("testhost2"), // This will make this endpoint as a remote endpoint
+				NodeName:  ptr.To("testhost2"), // This will make this endpoint as a remote endpoint
 			}}
 			eps.Ports = []discovery.EndpointPort{{
-				Name:     pointer.StringPtr(svcPortName.Port),
+				Name:     ptr.To(svcPortName.Port),
 				Port:     pointer.Int32(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
@@ -892,8 +892,8 @@ func TestEndpointSlice(t *testing.T) {
 		AddressType: discovery.AddressTypeIPv4,
 		Endpoints: []discovery.Endpoint{{
 			Addresses:  []string{"192.168.2.3"},
-			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
-			NodeName:   pointer.String("testhost2"),
+			Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+			NodeName:   ptr.To("testhost2"),
 		}},
 	}
 

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -146,7 +146,6 @@ func TestCreateServiceVip(t *testing.T) {
 		Port:           "p80",
 		Protocol:       v1.ProtocolTCP,
 	}
-	timeoutSeconds := v1.DefaultClientIPServiceAffinitySeconds
 
 	makeServiceMap(proxier,
 		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
@@ -156,7 +155,7 @@ func TestCreateServiceVip(t *testing.T) {
 			svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
 			svc.Spec.SessionAffinityConfig = &v1.SessionAffinityConfig{
 				ClientIP: &v1.ClientIPConfig{
-					TimeoutSeconds: &timeoutSeconds,
+					TimeoutSeconds: ptr.To[int32](v1.DefaultClientIPServiceAffinitySeconds),
 				},
 			}
 			svc.Spec.Ports = []v1.ServicePort{{

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -600,7 +600,7 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 			},
 				{
 					Name:     ptr.To("p443"),
-					Port:     pointer.Int32(int32(443)),
+					Port:     ptr.To[int32](443),
 					Protocol: &tcpProtocol,
 				}}
 		}))

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -200,7 +200,6 @@ func TestCreateRemoteEndpointOverlay(t *testing.T) {
 		Port:           "p80",
 		Protocol:       v1.ProtocolTCP,
 	}
-	tcpProtocol := v1.ProtocolTCP
 
 	makeServiceMap(proxier,
 		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
@@ -223,7 +222,7 @@ func TestCreateRemoteEndpointOverlay(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -258,14 +257,13 @@ func TestCreateRemoteEndpointL2Bridge(t *testing.T) {
 		t.Error()
 	}
 
-	tcpProtocol := v1.ProtocolTCP
 	svcIP := "10.20.30.41"
 	svcPort := 80
 	svcNodePort := 3001
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
 		Port:           "p80",
-		Protocol:       tcpProtocol,
+		Protocol:       v1.ProtocolTCP,
 	}
 
 	makeServiceMap(proxier,
@@ -275,7 +273,7 @@ func TestCreateRemoteEndpointL2Bridge(t *testing.T) {
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:     svcPortName.Port,
 				Port:     int32(svcPort),
-				Protocol: tcpProtocol,
+				Protocol: v1.ProtocolTCP,
 				NodePort: int32(svcNodePort),
 			}}
 		}),
@@ -289,7 +287,7 @@ func TestCreateRemoteEndpointL2Bridge(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -316,7 +314,6 @@ func TestCreateRemoteEndpointL2Bridge(t *testing.T) {
 }
 func TestSharedRemoteEndpointDelete(t *testing.T) {
 	syncPeriod := 30 * time.Second
-	tcpProtocol := v1.ProtocolTCP
 	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", netutils.ParseIPSloppy("10.0.0.1"), "L2Bridge")
 	if proxier == nil {
 		t.Error()
@@ -371,7 +368,7 @@ func TestSharedRemoteEndpointDelete(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName1.Port),
 				Port:     ptr.To(int32(svcPort1)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 		makeTestEndpointSlice(svcPortName2.Namespace, svcPortName2.Name, 1, func(eps *discovery.EndpointSlice) {
@@ -382,7 +379,7 @@ func TestSharedRemoteEndpointDelete(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName2.Port),
 				Port:     ptr.To(int32(svcPort2)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -430,7 +427,7 @@ func TestSharedRemoteEndpointDelete(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName2.Port),
 				Port:     ptr.To(int32(svcPort2)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -505,7 +502,6 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 		}),
 	)
 
-	tcpProtocol := v1.ProtocolTCP
 	populateEndpointSlices(proxier,
 		makeTestEndpointSlice(svcPortName1.Namespace, svcPortName1.Name, 1, func(eps *discovery.EndpointSlice) {
 			eps.AddressType = discovery.AddressTypeIPv4
@@ -515,7 +511,7 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName1.Port),
 				Port:     ptr.To(int32(svcPort1)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 		makeTestEndpointSlice(svcPortName2.Namespace, svcPortName2.Name, 1, func(eps *discovery.EndpointSlice) {
@@ -526,7 +522,7 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName2.Port),
 				Port:     ptr.To(int32(svcPort2)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -585,7 +581,7 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName1.Port),
 				Port:     ptr.To(int32(svcPort1)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 		makeTestEndpointSlice(svcPortName1.Namespace, svcPortName1.Name, 1, func(eps *discovery.EndpointSlice) {
@@ -596,12 +592,12 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName1.Port),
 				Port:     ptr.To(int32(svcPort1)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			},
 				{
 					Name:     ptr.To("p443"),
 					Port:     ptr.To[int32](443),
-					Protocol: &tcpProtocol,
+					Protocol: ptr.To(v1.ProtocolTCP),
 				}}
 		}))
 
@@ -634,7 +630,6 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 }
 func TestCreateLoadBalancer(t *testing.T) {
 	syncPeriod := 30 * time.Second
-	tcpProtocol := v1.ProtocolTCP
 	proxier := NewFakeProxier(syncPeriod, syncPeriod, clusterCIDR, "testhost", netutils.ParseIPSloppy("10.0.0.1"), NETWORK_TYPE_OVERLAY)
 	if proxier == nil {
 		t.Error()
@@ -670,7 +665,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -723,7 +718,6 @@ func TestCreateDsrLoadBalancer(t *testing.T) {
 			}}
 		}),
 	)
-	tcpProtocol := v1.ProtocolTCP
 	populateEndpointSlices(proxier,
 		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
 			eps.AddressType = discovery.AddressTypeIPv4
@@ -734,7 +728,7 @@ func TestCreateDsrLoadBalancer(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -803,7 +797,6 @@ func TestClusterIPLBInCreateDsrLoadBalancer(t *testing.T) {
 			}}
 		}),
 	)
-	tcpProtocol := v1.ProtocolTCP
 	populateEndpointSlices(proxier,
 		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
 			eps.AddressType = discovery.AddressTypeIPv4
@@ -814,7 +807,7 @@ func TestClusterIPLBInCreateDsrLoadBalancer(t *testing.T) {
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
 				Port:     ptr.To(int32(svcPort)),
-				Protocol: &tcpProtocol,
+				Protocol: ptr.To(v1.ProtocolTCP),
 			}}
 		}),
 	)
@@ -877,7 +870,6 @@ func TestEndpointSlice(t *testing.T) {
 	})
 
 	// Add initial endpoint slice
-	tcpProtocol := v1.ProtocolTCP
 	endpointSlice := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-1", svcPortName.Name),
@@ -887,7 +879,7 @@ func TestEndpointSlice(t *testing.T) {
 		Ports: []discovery.EndpointPort{{
 			Name:     &svcPortName.Port,
 			Port:     ptr.To[int32](80),
-			Protocol: &tcpProtocol,
+			Protocol: ptr.To(v1.ProtocolTCP),
 		}},
 		AddressType: discovery.AddressTypeIPv4,
 		Endpoints: []discovery.Endpoint{{

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -886,7 +886,7 @@ func TestEndpointSlice(t *testing.T) {
 		},
 		Ports: []discovery.EndpointPort{{
 			Name:     &svcPortName.Port,
-			Port:     pointer.Int32(80),
+			Port:     ptr.To[int32](80),
 			Protocol: &tcpProtocol,
 		}},
 		AddressType: discovery.AddressTypeIPv4,

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	fakehcn "k8s.io/kubernetes/pkg/proxy/winkernel/testing"
 	netutils "k8s.io/utils/net"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -222,7 +222,7 @@ func TestCreateRemoteEndpointOverlay(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -288,7 +288,7 @@ func TestCreateRemoteEndpointL2Bridge(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -370,7 +370,7 @@ func TestSharedRemoteEndpointDelete(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName1.Port),
-				Port:     pointer.Int32(int32(svcPort1)),
+				Port:     ptr.To(int32(svcPort1)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -381,7 +381,7 @@ func TestSharedRemoteEndpointDelete(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName2.Port),
-				Port:     pointer.Int32(int32(svcPort2)),
+				Port:     ptr.To(int32(svcPort2)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -429,7 +429,7 @@ func TestSharedRemoteEndpointDelete(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName2.Port),
-				Port:     pointer.Int32(int32(svcPort2)),
+				Port:     ptr.To(int32(svcPort2)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -514,7 +514,7 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName1.Port),
-				Port:     pointer.Int32(int32(svcPort1)),
+				Port:     ptr.To(int32(svcPort1)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -525,7 +525,7 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName2.Port),
-				Port:     pointer.Int32(int32(svcPort2)),
+				Port:     ptr.To(int32(svcPort2)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -584,7 +584,7 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName1.Port),
-				Port:     pointer.Int32(int32(svcPort1)),
+				Port:     ptr.To(int32(svcPort1)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -595,7 +595,7 @@ func TestSharedRemoteEndpointUpdate(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName1.Port),
-				Port:     pointer.Int32(int32(svcPort1)),
+				Port:     ptr.To(int32(svcPort1)),
 				Protocol: &tcpProtocol,
 			},
 				{
@@ -669,7 +669,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -733,7 +733,7 @@ func TestCreateDsrLoadBalancer(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
 		}),
@@ -813,7 +813,7 @@ func TestClusterIPLBInCreateDsrLoadBalancer(t *testing.T) {
 			}}
 			eps.Ports = []discovery.EndpointPort{{
 				Name:     ptr.To(svcPortName.Port),
-				Port:     pointer.Int32(int32(svcPort)),
+				Port:     ptr.To(int32(svcPort)),
 				Protocol: &tcpProtocol,
 			}}
 		}),


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig network
/label tide/merge-method-squash

#### What this PR does / why we need it:
#121046 is failing lint because the "new" code (copied from `pkg/proxy/iptables`) uses `k8s.io/utils/pointer` instead of `k8s.io/utils/ptr`. So let's fix the existing code...

This is not _just_ porting existing `pointer` code to use `ptr`, it also gets rid of a lot of temporary variables we had been creating so we could then take pointers to them, in most cases because we needed pointers of specific types (like `*v1.Protocol`) which the pre-generics `pointer` package didn't do. But now we can do that, so let's do that, to make things more consistent.

I did this as multiple commits for ease of review but they're intended to be squashed (and in particular, the first commit mostly exists just to provide the overall commit message and is not intended to be internally-consistent).

#### Special notes for your reviewer:
See https://github.com/kubernetes/utils/pull/283

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
