### PR TITLE
pod garbage collector won't delete pods that fail status update

### DIFF
--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -366,7 +366,6 @@ func (gcc *PodGCController) markFailedAndDeletePodWithCondition(ctx context.Cont
 			}
 			if _, err := gcc.kubeClient.CoreV1().Pods(pod.Namespace).ApplyStatus(ctx, podApply, metav1.ApplyOptions{FieldManager: fieldManager, Force: true}); err != nil {
 				klog.Info("PodGC could not apply status to Pod, continuing with force deleting Pod", "status", v1.PodFailed, "pod", klog.KObj(pod))
-
 			}
 		}
 	}

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -365,7 +365,8 @@ func (gcc *PodGCController) markFailedAndDeletePodWithCondition(ctx context.Cont
 				podApply.Status.WithConditions(condition)
 			}
 			if _, err := gcc.kubeClient.CoreV1().Pods(pod.Namespace).ApplyStatus(ctx, podApply, metav1.ApplyOptions{FieldManager: fieldManager, Force: true}); err != nil {
-				return err
+				klog.Info("PodGC could not apply status to Pod, continuing with force deleting Pod", "status", v1.PodFailed, "pod", klog.KObj(pod))
+
 			}
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Instead of blocking on an error to update the status of the pod being deleted, print it and continue. Due to `PodDisruptionConditions` feature-gate getting enabled by default in 1.26
If a pod is created with the same keys in its spec, ex:
```
...
spec:
  containers:
  - image: registry.k8s.io/hpa-example
    imagePullPolicy: Always
    name: php-apache
    env:
      - name: hi
        value: hi
      - name: hi
        value: hi
...
```
The user will receive a warning `Warning: spec.containers[0].env[1].name: duplicate name "hi"` but the pod will still be created. However, when the pod becomes a candidate for garbage collection, it won't be deleted as it will continuously fail to apply the status with error `failed to create manager for existing fields: failed to convert new object (default/php-apache; /v1, Kind=Pod) to smd typed: .spec.containers[name="php-apache"].env: duplicate entries for key [name="hi"]` 
This will cause the ghost pod(s) to remain there indefinitely. This can be a problem for deployments with the old pods not getting clean up new ones won't spin up. 
```
dev-dsk-luukasz-2b-3776d48b % kubectl get pods,nodes -A
NAMESPACE     NAME                           READY   STATUS    RESTARTS   AGE
default       pod/php-apache                 1/1     Running   0          3m12s
kube-system   pod/coredns-6ff9c46cd8-6v7d8   0/1     Pending   0          40s
```
This is the "simple" fix for covering this bug, alternatively we could change the validation of the pod, but that seems like a much bigger lift. 

#### Special notes for your reviewer:
Tested in 1.28 / 1.27, but most likely in 1.26 as well. Can be re-produced by spinning up a pod with the env mentioned above and then deleting the hosting worker node.
#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

