### PR TITLE
cleanup:test/integration: stop using deprecated wait.ErrWaitTimeout

### DIFF
--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -732,7 +732,7 @@ func TestUpdateVeryLargeObject(t *testing.T) {
 		updateErr = err
 		return false, nil
 	})
-	if pollErr == wait.ErrWaitTimeout {
+	if wait.Interrupted(pollErr) {
 		t.Errorf("unable to update configMap: %v", updateErr)
 	}
 

--- a/test/integration/apiserver/watchcache_test.go
+++ b/test/integration/apiserver/watchcache_test.go
@@ -160,7 +160,7 @@ func TestWatchCacheUpdatedByEtcd(t *testing.T) {
 			return false, nil
 		}
 		return res.ResourceVersion == se.ResourceVersion, nil
-	}); err == nil || err != wait.ErrWaitTimeout {
+	}); err == nil || !wait.Interrupted(err) {
 		t.Errorf("Events watchcache unexpected synced: %v", err)
 	}
 }

--- a/test/integration/certificates/controller_approval_test.go
+++ b/test/integration/certificates/controller_approval_test.go
@@ -174,7 +174,7 @@ func ensureCertificateRequestNotApproved(client clientset.Interface, name string
 	// There is currently no way to explicitly check if the CSR has been rejected for auto-approval.
 	err := waitForCertificateRequestApproved(client, name)
 	switch {
-	case err == wait.ErrWaitTimeout:
+	case wait.Interrupted(err):
 		return nil
 	case err == nil:
 		return fmt.Errorf("CertificateSigningRequest was auto-approved")

--- a/test/integration/client/exec_test.go
+++ b/test/integration/client/exec_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -598,7 +597,7 @@ func (is *informerSpy) waitForEvents(t *testing.T, wantEvents bool) {
 		waitTimeout = time.Second * 15
 	}
 
-	err := wait.PollImmediate(time.Second, waitTimeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), time.Second, waitTimeout, true, func(ctx context.Context) (bool, error) {
 		is.mu.Lock()
 		defer is.mu.Unlock()
 		return len(is.adds) > 0 && len(is.updates) > 0 && len(is.deletes) > 0, nil
@@ -608,7 +607,7 @@ func (is *informerSpy) waitForEvents(t *testing.T, wantEvents bool) {
 			t.Fatalf("wanted events, but got error: %v", err)
 		}
 	} else {
-		if !errors.Is(err, wait.ErrWaitTimeout) {
+		if !wait.Interrupted(err) {
 			if err != nil {
 				t.Fatalf("wanted no events, but got error: %v", err)
 			} else {

--- a/test/integration/controlplane/transformation/kms_transformation_test.go
+++ b/test/integration/controlplane/transformation/kms_transformation_test.go
@@ -1062,7 +1062,7 @@ func verifyIfKMSTransformersSwapped(t *testing.T, wantPrefix, wantPrefixForEncry
 
 		return true, nil
 	})
-	if pollErr == wait.ErrWaitTimeout {
+	if wait.Interrupted(pollErr) {
 		t.Fatalf("failed to verify if kms transformers swapped, err: %v", swapErr)
 	}
 }

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -410,7 +410,7 @@ func testCrossNamespaceReferences(t *testing.T, watchCache bool) {
 			return false, nil
 		}
 		return true, nil
-	}); err != nil && err != wait.ErrWaitTimeout {
+	}); err != nil && !wait.Interrupted(err) {
 		t.Error(err)
 	}
 
@@ -424,7 +424,7 @@ func testCrossNamespaceReferences(t *testing.T, watchCache bool) {
 			return false, fmt.Errorf("expected %d valid children, got %d", validChildrenCount, len(children.Items))
 		}
 		return false, nil
-	}); err != nil && err != wait.ErrWaitTimeout {
+	}); err != nil && !wait.Interrupted(err) {
 		t.Error(err)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
cleanup:test/integration: stop using deprecated wait.ErrWaitTimeout

#### Which issue(s) this PR fixes:
Fixes  https://github.com/kubernetes/kubernetes/pull/107826

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
None
```
