### PR TITLE
Update publishing-bot rules for active release branches that uses go120 to Go 1.20.10

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,25 +7,25 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.25
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.28
       dirs:
@@ -38,25 +38,25 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.25
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.28
       dirs:
@@ -73,7 +73,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -82,7 +82,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -91,7 +91,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -100,7 +100,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -126,7 +126,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -141,7 +141,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -156,7 +156,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -171,7 +171,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -201,7 +201,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -214,7 +214,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -227,7 +227,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -240,7 +240,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -268,7 +268,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -281,7 +281,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -294,7 +294,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -307,7 +307,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -331,13 +331,13 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -350,7 +350,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -382,7 +382,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -397,7 +397,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -414,7 +414,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -431,7 +431,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -471,7 +471,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -490,7 +490,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -511,7 +511,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -532,7 +532,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -580,7 +580,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -604,7 +604,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -630,7 +630,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -656,7 +656,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -703,7 +703,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -723,7 +723,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -743,7 +743,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -763,7 +763,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -807,7 +807,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -828,7 +828,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -851,7 +851,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -874,7 +874,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -913,7 +913,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -928,7 +928,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -943,7 +943,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -958,7 +958,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -988,7 +988,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1001,7 +1001,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1014,7 +1014,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1027,7 +1027,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1057,7 +1057,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1072,7 +1072,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1087,7 +1087,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1102,7 +1102,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1133,7 +1133,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1148,7 +1148,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1163,7 +1163,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1178,7 +1178,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1201,25 +1201,25 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.25
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.28
       dirs:
@@ -1248,7 +1248,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1263,7 +1263,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1278,7 +1278,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1293,7 +1293,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1331,7 +1331,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1346,7 +1346,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1361,7 +1361,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1376,7 +1376,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1412,7 +1412,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1429,7 +1429,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1448,7 +1448,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1467,7 +1467,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1511,7 +1511,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1532,7 +1532,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1555,7 +1555,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1578,7 +1578,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1628,7 +1628,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1651,7 +1651,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1676,7 +1676,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1701,7 +1701,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1739,7 +1739,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.25
@@ -1750,7 +1750,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1761,7 +1761,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1772,7 +1772,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1796,7 +1796,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1807,7 +1807,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1818,7 +1818,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1829,7 +1829,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1848,25 +1848,25 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.25
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     source:
       branch: release-1.28
       dirs:
@@ -1899,7 +1899,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.25
@@ -1926,7 +1926,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1955,7 +1955,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1980,7 +1980,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2030,7 +2030,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.25
@@ -2053,7 +2053,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2076,7 +2076,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2099,7 +2099,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2143,7 +2143,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.25
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.25
@@ -2160,7 +2160,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2179,7 +2179,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2198,7 +2198,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2240,7 +2240,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2257,7 +2257,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.27
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2274,7 +2274,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2311,7 +2311,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.28
-    go: 1.20.9
+    go: 1.20.10
     dependencies:
     - repository: api
       branch: release-1.28


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Update publishing-bot rules for active release branches that uses go1.20 to Go 1.20.10

#### Which issue(s) this PR fixes:

xref: https://github.com/kubernetes/release/issues/3311

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

/assign @saschagrunert @jeremyrickard  @liggitt @nikhita 
cc @kubernetes/release-engineering 