### PR TITLE
Update busybox SHA based image to match tag - 1.36.1-1

### DIFF
--- a/test/e2e_node/image_id_test.go
+++ b/test/e2e_node/image_id_test.go
@@ -32,7 +32,7 @@ import (
 
 var _ = SIGDescribe("ImageID [NodeFeature: ImageID]", func() {
 
-	busyBoxImage := "registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff"
+	busyBoxImage := "registry.k8s.io/e2e-test-images/busybox@sha256:a9155b13325b2abef48e71de77bb8ac015412a566829f621d06bfae5c699b1b9"
 
 	f := framework.NewDefaultFramework("image-id-test")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -55,7 +55,7 @@ var NodePrePullImageList = sets.NewString(
 	"gcr.io/cadvisor/cadvisor:v0.47.2",
 	"registry.k8s.io/stress:v1",
 	busyboxImage,
-	"registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff",
+	"registry.k8s.io/e2e-test-images/busybox@sha256:a9155b13325b2abef48e71de77bb8ac015412a566829f621d06bfae5c699b1b9",
 	imageutils.GetE2EImage(imageutils.Nginx),
 	imageutils.GetE2EImage(imageutils.Perl),
 	imageutils.GetE2EImage(imageutils.Nonewprivs),


### PR DESCRIPTION
We use `registry.k8s.io/e2e-test-images/busybox:1.36.1-1` in most of our tests but the SHA based image is pointing to an old image SHA. Let's sync the two.

- https://explore.ggcr.dev/?image=registry.k8s.io%2Fe2e-test-images%2Fbusybox:1.36.1-1
- https://explore.ggcr.dev/?image=registry.k8s.io/e2e-test-images/busybox@sha256:a9155b13325b2abef48e71de77bb8ac015412a566829f621d06bfae5c699b1b9&mt=application%2Fvnd.docker.distribution.manifest.list.v2%2Bjson&size=2406

Why do we want to do this?

The older SHA based tag docker image has an old style manifest - https://explore.ggcr.dev/?image=registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff&mt=application%2Fvnd.docker.distribution.manifest.v1%2Bprettyjws&size=3205

and we want to get rid of this old style as it is going away in latest containerd. see [log](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/containerd_containerd/9152/pull-containerd-node-e2e/1712250336850219008/build-log.txt)
```
E1011 23:57:12.495117    1098 remote_image.go:180] "PullImage from image service failed" err="rpc error: code = Unknown desc = failed to pull and unpack image \"registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff\": application/vnd.docker.distribution.manifest.v1+prettyjws not supported" image="registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff"
  W1011 23:57:12.495196    1098 image_list.go:204] Failed to pull registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff as user "root", retrying in 1s (1 of 5): failed to pull and unpack image "registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff": application/vnd.docker.distribution.manifest.v1+prettyjws not supported
  E1011 23:57:13.771267    1098 remote_image.go:180] "PullImage from image service failed" err="rpc error: code = Unknown desc = failed to pull and unpack image \"registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff\": application/vnd.docker.distribution.manifest.v1+prettyjws not supported" image="registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff"
  W1011 23:57:13.771288    1098 image_list.go:204] Failed to pull registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff as user "root", retrying in 1s (2 of 5): failed to pull and unpack image "registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff": application/vnd.docker.distribution.manifest.v1+prettyjws not supported
  E1011 23:57:14.880379    1098 remote_image.go:180] "PullImage from image service failed" err="rpc error: code = Unknown desc = failed to pull and unpack image \"registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff\": application/vnd.docker.distribution.manifest.v1+prettyjws not supported" image="registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff"
  W1011 23:57:14.880399    1098 image_list.go:204] Failed to pull registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff as user "root", retrying in 1s (3 of 5): failed to pull and unpack image "registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff": application/vnd.docker.distribution.manifest.v1+prettyjws not supported
  E1011 23:57:16.289085    1098 remote_image.go:180] "PullImage from image service failed" err="rpc error: code = Unknown desc = failed to pull and unpack image \"registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff\": application/vnd.docker.distribution.manifest.v1+prettyjws not supported" image="registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff"
  W1011 23:57:16.289142    1098 image_list.go:204] Failed to pull registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff as user "root", retrying in 1s (4 of 5): failed to pull and unpack image "registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff": application/vnd.docker.distribution.manifest.v1+prettyjws not supported
  E1011 23:57:17.435658    1098 remote_image.go:180] "PullImage from image service failed" err="rpc error: code = Unknown desc = failed to pull and unpack image \"registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff\": application/vnd.docker.distribution.manifest.v1+prettyjws not supported" image="registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff"
  W1011 23:57:17.435678    1098 image_list.go:204] Failed to pull registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff as user "root", retrying in 1s (5 of 5): failed to pull and unpack image "registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff": application/vnd.docker.distribution.manifest.v1+prettyjws not supported
  W1011 23:57:17.435687    1098 image_list.go:208] Could not pre-pull image registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff failed to pull and unpack image "registry.k8s.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff": application/vnd.docker.distribution.manifest.v1+prettyjws not supported output:
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
