### PR TITLE
Add rundir folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,8 +91,9 @@ network_closure.sh
 /_tmp/
 /doc_tmp/
 
-# Test artifacts produced by Jenkins jobs
+# Test artifacts produced by Prow/kubetest2 jobs
 /_artifacts/
+/_rundir/
 
 # Go dependencies installed on Jenkins
 /_gopath/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubetest2 creates a rundir folder in the root of k/k for testing and this breaks the krel push logic as it expects clean tags on builds.

Example of kubetest2 writing rundir in the root of repos. https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/16018/pull-kops-e2e-k8s-aws-calico/1712521793329172480/build-log.txt look for rundir string

I'm working on getting kubetest2-kops to build k/k so we can use it in presubmits

https://github.com/kubernetes/kops/pull/16018

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```