### PR TITLE
Automated cherry pick of #121203: Skip TestUnauthenticatedHTTP2ClientConnectionClose http1

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication_test.go
@@ -658,9 +658,10 @@ func TestUnauthenticatedHTTP2ClientConnectionClose(t *testing.T) {
 				f(t, http2.NextProtoTLS, tc.expectConnections)
 			})
 
-			t.Run("http/1.1", func(t *testing.T) {
-				f(t, "http/1.1", 1)
-			})
+			// http1 connection reuse occasionally flakes on CI, skipping for now
+			// t.Run("http/1.1", func(t *testing.T) {
+			// 	f(t, "http/1.1", 1)
+			// })
 		})
 	}
 }


### PR DESCRIPTION
Cherry pick of #121203 on release-1.28.

#121203: Skip TestUnauthenticatedHTTP2ClientConnectionClose http1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```