### PR TITLE
Stop StartupProbe explicity when successThrethold is reached

### DIFF
--- a/pkg/kubelet/prober/common_test.go
+++ b/pkg/kubelet/prober/common_test.go
@@ -46,6 +46,10 @@ func getTestRunningStatus() v1.PodStatus {
 	return getTestRunningStatusWithStarted(true)
 }
 
+func getTestNotRunningStatus() v1.PodStatus {
+	return getTestRunningStatusWithStarted(false)
+}
+
 func getTestRunningStatusWithStarted(started bool) v1.PodStatus {
 	containerStatus := v1.ContainerStatus{
 		Name:        testContainerName,

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -316,12 +316,12 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 
 	w.resultsManager.Set(w.containerID, result, w.pod)
 
-	if (w.probeType == liveness && result == results.Failure) || w.probeType == startup {
+	if (w.probeType == liveness && result == results.Failure) || (w.probeType == startup && (result == results.Success || result == results.Failure)) {
 		// The container fails a liveness/startup check, it will need to be restarted.
 		// Stop probing until we see a new container ID. This is to reduce the
 		// chance of hitting #21751, where running `docker exec` when a
 		// container is being stopped may lead to corrupted container state.
-		// In addition, if the container succeeds a startup probe, we should stop probing
+		// In addition, if the threshold for each result of a startup probe is exceeded, we should stop probing
 		// until the container is restarted.
 		// This is to prevent extra Probe executions #117153.
 		w.onHold = true

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -316,7 +316,7 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 
 	w.resultsManager.Set(w.containerID, result, w.pod)
 
-	if (w.probeType == liveness && result == results.Failure) || (w.probeType == startup && (result == results.Success || result == results.Failure)) {
+	if (w.probeType == liveness && result == results.Failure) || w.probeType == startup {
 		// The container fails a liveness/startup check, it will need to be restarted.
 		// Stop probing until we see a new container ID. This is to reduce the
 		// chance of hitting #21751, where running `docker exec` when a

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -275,14 +275,29 @@ func TestStartupProbeSuccessThreshold(t *testing.T) {
 	failureThreshold := 3
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: int32(successThreshold), FailureThreshold: int32(failureThreshold)})
 	m.statusManager.SetPodStatus(w.pod, getTestNotRunningStatus())
-
 	m.prober.exec = fakeExecProber{probe.Success, nil}
 
 	for i := 0; i < successThreshold+1; i++ {
+		if i < successThreshold {
+			// Probe should not be on hold and will continue to be excuted
+			// until successThreshold is met
+			if w.onHold {
+				t.Errorf("Prober should not be on hold")
+			}
+		} else {
+			// Probe should be on hold and will not be executed anymore
+			// when successThreshold is met
+			if !w.onHold {
+				t.Errorf("Prober should be on hold because successThreshold is exceeded")
+			}
+		}
 		msg := fmt.Sprintf("%d success", successThreshold)
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Success, msg)
-		expectResultRun(t, w, 0, msg)
+		// Meeting or exceeding successThreshold should cause resultRun to reset to 0
+		if w.resultRun != 0 {
+			t.Errorf("Prober resultRun should be 0, but %d", w.resultRun)
+		}
 	}
 }
 
@@ -293,19 +308,48 @@ func TestStartupProbeFailureThreshold(t *testing.T) {
 	failureThreshold := 3
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: int32(successThreshold), FailureThreshold: int32(failureThreshold)})
 	m.statusManager.SetPodStatus(w.pod, getTestNotRunningStatus())
-
 	m.prober.exec = fakeExecProber{probe.Failure, nil}
 
 	for i := 0; i < failureThreshold+1; i++ {
-		msg := fmt.Sprintf("%d failure", i+1)
-		expectContinue(t, w, w.doProbe(ctx), msg)
 		if i < failureThreshold-1 {
+			// Probe should not be on hold and will continue to be excuted
+			// until failureThreshold is met
+			if w.onHold {
+				t.Errorf("Prober should not be on hold")
+			}
+			msg := fmt.Sprintf("%d failure", i+1)
+			expectContinue(t, w, w.doProbe(ctx), msg)
 			expectResult(t, w, results.Unknown, msg)
-			expectResultRun(t, w, i+1, msg)
-		} else {
-			msg := fmt.Sprintf("%d failure", failureThreshold)
+			// resultRun should be incremented until failureThreshold is met
+			if w.resultRun != i+1 {
+				t.Errorf("Prober resultRun should be %d, but %d", i+1, w.resultRun)
+			}
+		} else if i < failureThreshold {
+			// Probe should not be on hold and will continue to be excuted
+			// until failureThreshold is met
+			if w.onHold {
+				t.Errorf("Prober should not be on hold")
+			}
+			msg := fmt.Sprintf("%d failure", i+1)
+			expectContinue(t, w, w.doProbe(ctx), msg)
 			expectResult(t, w, results.Failure, msg)
-			expectResultRun(t, w, 0, msg)
+			// Meeting failureThreshold should cause resultRun to reset to 0
+			if w.resultRun != 0 {
+				t.Errorf("Prober resultRun should be 0, but %d", w.resultRun)
+			}
+		} else {
+			// Probe should be on hold and will not be executed anymore
+			// when failureThreshold is met
+			if !w.onHold {
+				t.Errorf("Prober should be on hold because failureThreshold is exceeded")
+			}
+			msg := fmt.Sprintf("%d failure", failureThreshold)
+			expectContinue(t, w, w.doProbe(ctx), msg)
+			expectResult(t, w, results.Failure, msg)
+			// Exceeding failureThreshold should cause resultRun to reset to 0
+			if w.resultRun != 0 {
+				t.Errorf("Prober resultRun should be 0, but %d", w.resultRun)
+			}
 		}
 	}
 }
@@ -354,13 +398,6 @@ func expectResult(t *testing.T, w *worker, expectedResult results.Result, msg st
 	} else if result != expectedResult {
 		t.Errorf("[%s - %s] Expected result to be %v, but was %v",
 			w.probeType, msg, expectedResult, result)
-	}
-}
-
-func expectResultRun(t *testing.T, w *worker, expectedResultRun int, msg string) {
-	if w.resultRun != expectedResultRun {
-		t.Errorf("[%s - %s] Expected result to be %v, but was %v",
-			w.probeType, msg, expectedResultRun, w.resultRun)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`StartupProbe` is executed while container is starting and will update container status to `Started=true` if it succeeds.
When container status becomes to `Started=true`, `StartupProbe` will be stopped and Readiness/Liveness probe will be executed.
Probe and the main loop of kubelet that updates the container status are executed asynchronously, and the goroutine of the Probe requests the container status update to the main loop of kubelet via the channel.
Due to this asyncronicity, `StartupProbe` may be executed more than `successThrethold`.(#117153)

In this PR, `StartupProbe` is stopped explicity when `successThrethold` is reached.


#### Which issue(s) this PR fixes:

Fixes #117153

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`StartupProbe` is stopped explicity when `successThrethold` is reached. 
This eliminates the problem that `StartupProbe` is executed more than `successThrethold`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```